### PR TITLE
Introduce batched parquet column readers for flat types

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.rst
+++ b/docs/src/main/sphinx/connector/delta-lake.rst
@@ -219,6 +219,12 @@ connector.
         The equivalent catalog session property is
         ``parquet_optimized_writer_enabled``.
       - ``true``
+    * - ``parquet.optimized-reader.enabled``
+      - Whether batched column readers should be used when reading Parquet files
+        for improved performance. Set this property to ``false`` to disable the
+        optimized parquet reader by default. The equivalent catalog session
+        property is ``parquet_optimized_reader_enabled``.
+      - ``true``
 
 The following table describes :ref:`catalog session properties
 <session-properties-definition>` supported by the Delta Lake connector to
@@ -233,6 +239,10 @@ configure processing of Parquet files.
       - Default
     * - ``parquet_optimized_writer_enabled``
       - Whether the optimized writer should be used when writing Parquet files.
+      - ``true``
+    * - ``parquet_optimized_reader_enabled``
+      - Whether batched column readers should be used when reading Parquet files
+        for improved performance.
       - ``true``
     * - ``parquet_max_read_block_size``
       - The maximum block size used when reading Parquet files.

--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -525,6 +525,12 @@ with Parquet files performed by the Hive connector.
         definition. The equivalent catalog session property is
         ``parquet_use_column_names``.
       - ``true``
+    * - ``parquet.optimized-reader.enabled``
+      - Whether batched column readers should be used when reading Parquet files
+        for improved performance. Set this property to ``false`` to disable the
+        optimized parquet reader by default. The equivalent catalog session
+        property is ``parquet_optimized_reader_enabled``.
+      - ``true``
     * - ``parquet.optimized-writer.enabled``
       - Whether the optimized writer should be used when writing Parquet files.
         Set this property to ``true`` to use the optimized parquet writer by

--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -179,6 +179,26 @@ with ORC files performed by the Iceberg connector.
     - Enable bloom filters for predicate pushdown.
     - ``false``
 
+Parquet format configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following properties are used to configure the read and write operations
+with Parquet files performed by the Iceberg connector.
+
+.. list-table:: Parquet format configuration properties
+    :widths: 30, 50, 20
+    :header-rows: 1
+
+    * - Property Name
+      - Description
+      - Default
+    * - ``parquet.optimized-reader.enabled``
+      - Whether batched column readers should be used when reading Parquet files
+        for improved performance. Set this property to ``false`` to disable the
+        optimized parquet reader by default. The equivalent catalog session
+        property is ``parquet_optimized_reader_enabled``.
+      - ``true``
+
 .. _iceberg-authorization:
 
 Authorization checks

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderOptions.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderOptions.java
@@ -29,6 +29,7 @@ public class ParquetReaderOptions
     private final DataSize maxMergeDistance;
     private final DataSize maxBufferSize;
     private final boolean useColumnIndex;
+    private final boolean useBatchColumnReaders;
 
     public ParquetReaderOptions()
     {
@@ -37,6 +38,7 @@ public class ParquetReaderOptions
         maxMergeDistance = DEFAULT_MAX_MERGE_DISTANCE;
         maxBufferSize = DEFAULT_MAX_BUFFER_SIZE;
         useColumnIndex = true;
+        useBatchColumnReaders = true;
     }
 
     private ParquetReaderOptions(
@@ -44,13 +46,15 @@ public class ParquetReaderOptions
             DataSize maxReadBlockSize,
             DataSize maxMergeDistance,
             DataSize maxBufferSize,
-            boolean useColumnIndex)
+            boolean useColumnIndex,
+            boolean useBatchColumnReaders)
     {
         this.ignoreStatistics = ignoreStatistics;
         this.maxReadBlockSize = requireNonNull(maxReadBlockSize, "maxReadBlockSize is null");
         this.maxMergeDistance = requireNonNull(maxMergeDistance, "maxMergeDistance is null");
         this.maxBufferSize = requireNonNull(maxBufferSize, "maxBufferSize is null");
         this.useColumnIndex = useColumnIndex;
+        this.useBatchColumnReaders = useBatchColumnReaders;
     }
 
     public boolean isIgnoreStatistics()
@@ -73,6 +77,11 @@ public class ParquetReaderOptions
         return useColumnIndex;
     }
 
+    public boolean useBatchColumnReaders()
+    {
+        return useBatchColumnReaders;
+    }
+
     public DataSize getMaxBufferSize()
     {
         return maxBufferSize;
@@ -85,7 +94,8 @@ public class ParquetReaderOptions
                 maxReadBlockSize,
                 maxMergeDistance,
                 maxBufferSize,
-                useColumnIndex);
+                useColumnIndex,
+                useBatchColumnReaders);
     }
 
     public ParquetReaderOptions withMaxReadBlockSize(DataSize maxReadBlockSize)
@@ -95,7 +105,8 @@ public class ParquetReaderOptions
                 maxReadBlockSize,
                 maxMergeDistance,
                 maxBufferSize,
-                useColumnIndex);
+                useColumnIndex,
+                useBatchColumnReaders);
     }
 
     public ParquetReaderOptions withMaxMergeDistance(DataSize maxMergeDistance)
@@ -105,7 +116,8 @@ public class ParquetReaderOptions
                 maxReadBlockSize,
                 maxMergeDistance,
                 maxBufferSize,
-                useColumnIndex);
+                useColumnIndex,
+                useBatchColumnReaders);
     }
 
     public ParquetReaderOptions withMaxBufferSize(DataSize maxBufferSize)
@@ -115,7 +127,8 @@ public class ParquetReaderOptions
                 maxReadBlockSize,
                 maxMergeDistance,
                 maxBufferSize,
-                useColumnIndex);
+                useColumnIndex,
+                useBatchColumnReaders);
     }
 
     public ParquetReaderOptions withUseColumnIndex(boolean useColumnIndex)
@@ -125,6 +138,18 @@ public class ParquetReaderOptions
                 maxReadBlockSize,
                 maxMergeDistance,
                 maxBufferSize,
-                useColumnIndex);
+                useColumnIndex,
+                useBatchColumnReaders);
+    }
+
+    public ParquetReaderOptions withBatchColumnReaders(boolean useBatchColumnReaders)
+    {
+        return new ParquetReaderOptions(
+                ignoreStatistics,
+                maxReadBlockSize,
+                maxMergeDistance,
+                maxBufferSize,
+                useColumnIndex,
+                useBatchColumnReaders);
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderUtils.java
@@ -14,7 +14,11 @@
 package io.trino.parquet;
 
 import io.airlift.slice.Slice;
+import io.trino.parquet.reader.SimpleSliceInputStream;
 import org.apache.parquet.bytes.ByteBufferInputStream;
+
+import static com.google.common.base.Verify.verify;
+import static java.lang.String.format;
 
 public final class ParquetReaderUtils
 {
@@ -28,5 +32,98 @@ public final class ParquetReaderUtils
     public static ByteBufferInputStream toInputStream(DictionaryPage page)
     {
         return toInputStream(page.getSlice());
+    }
+
+    /**
+     * Reads an integer formatted in ULEB128 variable-width format described in
+     * <a href="https://en.wikipedia.org/wiki/LEB128">...</a>
+     */
+    public static int readUleb128Int(SimpleSliceInputStream input)
+    {
+        byte[] inputBytes = input.getByteArray();
+        int offset = input.getByteArrayOffset();
+        // Manual loop unrolling shows improvements in BenchmarkReadUleb128Int
+        int inputByte = inputBytes[offset];
+        int value = inputByte & 0x7F;
+        if ((inputByte & 0x80) == 0) {
+            input.skip(1);
+            return value;
+        }
+        inputByte = inputBytes[offset + 1];
+        value |= (inputByte & 0x7F) << 7;
+        if ((inputByte & 0x80) == 0) {
+            input.skip(2);
+            return value;
+        }
+        inputByte = inputBytes[offset + 2];
+        value |= (inputByte & 0x7F) << 14;
+        if ((inputByte & 0x80) == 0) {
+            input.skip(3);
+            return value;
+        }
+        inputByte = inputBytes[offset + 3];
+        value |= (inputByte & 0x7F) << 21;
+        if ((inputByte & 0x80) == 0) {
+            input.skip(4);
+            return value;
+        }
+        inputByte = inputBytes[offset + 4];
+        verify((inputByte & 0x80) == 0, "ULEB128 variable-width integer should not be longer than 5 bytes");
+        input.skip(5);
+        return value | inputByte << 28;
+    }
+
+    /**
+     * Method simulates a cast from boolean to byte value. Despite using
+     * a ternary (?) operator, the just-in-time compiler usually figures out
+     * that this is a cast and turns that into a no-op.
+     * <p>
+     * Method may be used to avoid branches that may be CPU costly due to
+     * branch misprediction.
+     * The following code:
+     * <pre>
+     *      boolean[] flags = ...
+     *      int sum = 0;
+     *      for (int i = 0; i &lt; length; i++){
+     *          if (flags[i])
+     *              sum++;
+     *      }
+     * </pre>
+     * will perform better when rewritten to
+     * <pre>
+     *      boolean[] flags = ...
+     *      int sum = 0;
+     *      for (int i = 0; i &lt; length; i++){
+     *          sum += castToByte(flags[i]);
+     *      }
+     * </pre>
+     */
+    public static byte castToByte(boolean value)
+    {
+        return (byte) (value ? 1 : 0);
+    }
+
+    /**
+     * Works the same as {@link io.trino.parquet.ParquetReaderUtils#castToByte(boolean)} and negates the boolean value
+     */
+    public static byte castToByteNegate(boolean value)
+    {
+        return (byte) (value ? 0 : 1);
+    }
+
+    public static short toShortExact(int value)
+    {
+        if ((short) value != value) {
+            throw new ArithmeticException(format("Value %d exceeds short range", value));
+        }
+        return (short) value;
+    }
+
+    public static byte toByteExact(int value)
+    {
+        if ((byte) value != value) {
+            throw new ArithmeticException(format("Value %d exceeds byte range", value));
+        }
+        return (byte) value;
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
@@ -33,6 +33,7 @@ import org.apache.parquet.schema.MessageType;
 
 import javax.annotation.Nullable;
 
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -282,6 +283,20 @@ public final class ParquetTypeUtils
         }
         value = value >> ((8 - length) * 8);
         return value;
+    }
+
+    public static byte[] paddingBigInteger(BigInteger bigInteger, int numBytes)
+    {
+        byte[] bytes = bigInteger.toByteArray();
+        if (bytes.length == numBytes) {
+            return bytes;
+        }
+        byte[] result = new byte[numBytes];
+        if (bigInteger.signum() < 0) {
+            Arrays.fill(result, 0, numBytes - bytes.length, (byte) 0xFF);
+        }
+        System.arraycopy(bytes, 0, result, numBytes - bytes.length, bytes.length);
+        return result;
     }
 
     public static Optional<Field> constructField(Type type, ColumnIO columnIO)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReader.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import org.apache.parquet.internal.filter2.columnindex.RowRanges;
+
+public interface ColumnReader
+{
+    boolean hasPageReader();
+
+    void setPageReader(PageReader pageReader, RowRanges rowRanges);
+
+    void prepareNextRead(int batchSize);
+
+    ColumnChunk readPrimitive();
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
@@ -14,42 +14,119 @@
 package io.trino.parquet.reader;
 
 import io.trino.parquet.PrimitiveField;
+import io.trino.parquet.reader.decoders.ValueDecoders;
+import io.trino.parquet.reader.flat.FlatColumnReader;
 import io.trino.spi.TrinoException;
+import io.trino.spi.type.AbstractIntType;
+import io.trino.spi.type.AbstractLongType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Type;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.DateLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.IntLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.LogicalTypeAnnotationVisitor;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimeLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
-import org.apache.parquet.schema.PrimitiveType;
 import org.joda.time.DateTimeZone;
 
 import java.util.Optional;
 
 import static io.trino.parquet.ParquetTypeUtils.createDecimalType;
+import static io.trino.parquet.reader.flat.BooleanColumnAdapter.BOOLEAN_ADAPTER;
+import static io.trino.parquet.reader.flat.ByteColumnAdapter.BYTE_ADAPTER;
+import static io.trino.parquet.reader.flat.IntColumnAdapter.INT_ADAPTER;
+import static io.trino.parquet.reader.flat.LongColumnAdapter.LONG_ADAPTER;
+import static io.trino.parquet.reader.flat.ShortColumnAdapter.SHORT_ADAPTER;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
+import static java.lang.String.format;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit.MICROS;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit.MILLIS;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit.NANOS;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 
 public final class ColumnReaderFactory
 {
     private ColumnReaderFactory() {}
 
-    public static ColumnReader create(PrimitiveField field, DateTimeZone timeZone)
+    public static ColumnReader create(PrimitiveField field, DateTimeZone timeZone, boolean useBatchedColumnReaders)
     {
-        PrimitiveType primitiveType = field.getDescriptor().getPrimitiveType();
-        return switch (primitiveType.getPrimitiveTypeName()) {
+        Type type = field.getType();
+        PrimitiveTypeName primitiveType = field.getDescriptor().getPrimitiveType().getPrimitiveTypeName();
+        LogicalTypeAnnotation annotation = field.getDescriptor().getPrimitiveType().getLogicalTypeAnnotation();
+        if (useBatchedColumnReaders && field.getDescriptor().getPath().length == 1) {
+            if (BOOLEAN.equals(type) && primitiveType == PrimitiveTypeName.BOOLEAN) {
+                return new FlatColumnReader<>(field, ValueDecoders::getBooleanDecoder, BOOLEAN_ADAPTER);
+            }
+            if (TINYINT.equals(type) && primitiveType == INT32) {
+                if (isIntegerAnnotation(annotation)) {
+                    return new FlatColumnReader<>(field, ValueDecoders::getByteDecoder, BYTE_ADAPTER);
+                }
+                throw unsupportedException(type, field);
+            }
+            if (SMALLINT.equals(type) && primitiveType == INT32) {
+                if (isIntegerAnnotation(annotation)) {
+                    return new FlatColumnReader<>(field, ValueDecoders::getShortDecoder, SHORT_ADAPTER);
+                }
+                throw unsupportedException(type, field);
+            }
+            if (DATE.equals(type) && primitiveType == INT32) {
+                if (annotation == null || annotation instanceof DateLogicalTypeAnnotation) {
+                    return new FlatColumnReader<>(field, ValueDecoders::getIntDecoder, INT_ADAPTER);
+                }
+                throw unsupportedException(type, field);
+            }
+            if (type instanceof AbstractIntType && primitiveType == INT32) {
+                if (isIntegerAnnotation(annotation)) {
+                    return new FlatColumnReader<>(field, ValueDecoders::getIntDecoder, INT_ADAPTER);
+                }
+                throw unsupportedException(type, field);
+            }
+            if (type instanceof AbstractLongType && primitiveType == INT64) {
+                if (BIGINT.equals(type) && annotation instanceof TimestampLogicalTypeAnnotation) {
+                    return new FlatColumnReader<>(field, ValueDecoders::getLongDecoder, LONG_ADAPTER);
+                }
+                if (isIntegerAnnotation(annotation)) {
+                    return new FlatColumnReader<>(field, ValueDecoders::getLongDecoder, LONG_ADAPTER);
+                }
+            }
+            if (REAL.equals(type) && primitiveType == FLOAT) {
+                return new FlatColumnReader<>(field, ValueDecoders::getRealDecoder, INT_ADAPTER);
+            }
+            if (DOUBLE.equals(type) && primitiveType == PrimitiveTypeName.DOUBLE) {
+                return new FlatColumnReader<>(field, ValueDecoders::getDoubleDecoder, LONG_ADAPTER);
+            }
+            if (type instanceof DecimalType decimalType && decimalType.isShort() && (primitiveType == INT32 || primitiveType == INT64)) {
+                if (annotation instanceof DecimalLogicalTypeAnnotation decimalAnnotation && !isDecimalRescaled(decimalAnnotation, decimalType)) {
+                    return new FlatColumnReader<>(field, ValueDecoders::getShortDecimalDecoder, LONG_ADAPTER);
+                }
+            }
+        }
+
+        return switch (primitiveType) {
             case BOOLEAN -> new BooleanColumnReader(field);
             case INT32 -> createDecimalColumnReader(field).orElse(new IntColumnReader(field));
             case INT64 -> {
-                if (primitiveType.getLogicalTypeAnnotation() instanceof TimeLogicalTypeAnnotation timeAnnotation) {
+                if (annotation instanceof TimeLogicalTypeAnnotation timeAnnotation) {
                     if (timeAnnotation.getUnit() == MICROS) {
                         yield new TimeMicrosColumnReader(field);
                     }
-                    throw new TrinoException(NOT_SUPPORTED, "Unsupported column: " + field.getDescriptor());
+                    throw unsupportedException(type, field);
                 }
-                if (primitiveType.getLogicalTypeAnnotation() instanceof TimestampLogicalTypeAnnotation timestampAnnotation) {
+                if (annotation instanceof TimestampLogicalTypeAnnotation timestampAnnotation) {
                     if (timestampAnnotation.getUnit() == MILLIS) {
                         yield new Int64TimestampMillisColumnReader(field);
                     }
@@ -59,7 +136,7 @@ public final class ColumnReaderFactory
                     if (timestampAnnotation.getUnit() == NANOS) {
                         yield new Int64TimestampNanosColumnReader(field);
                     }
-                    throw new TrinoException(NOT_SUPPORTED, "Unsupported column: " + field.getDescriptor());
+                    throw unsupportedException(type, field);
                 }
                 yield createDecimalColumnReader(field).orElse(new LongColumnReader(field));
             }
@@ -72,22 +149,22 @@ public final class ColumnReaderFactory
                 if (decimalColumnReader.isPresent()) {
                     yield decimalColumnReader.get();
                 }
-                if (isLogicalUuid(primitiveType)) {
+                if (isLogicalUuid(annotation)) {
                     yield new UuidColumnReader(field);
                 }
-                if (primitiveType.getLogicalTypeAnnotation() == null) {
+                if (annotation == null) {
                     // Iceberg 0.11.1 writes UUID as FIXED_LEN_BYTE_ARRAY without logical type annotation (see https://github.com/apache/iceberg/pull/2913)
                     // To support such files, we bet on the type to be UUID, which gets verified later, when reading the column data.
                     yield new UuidColumnReader(field);
                 }
-                throw new TrinoException(NOT_SUPPORTED, "Unsupported column: " + field.getDescriptor());
+                throw unsupportedException(type, field);
             }
         };
     }
 
-    private static boolean isLogicalUuid(PrimitiveType primitiveType)
+    private static boolean isLogicalUuid(LogicalTypeAnnotation annotation)
     {
-        return Optional.ofNullable(primitiveType.getLogicalTypeAnnotation())
+        return Optional.ofNullable(annotation)
                 .flatMap(logicalTypeAnnotation -> logicalTypeAnnotation.accept(new LogicalTypeAnnotationVisitor<Boolean>()
                 {
                     @Override
@@ -103,5 +180,27 @@ public final class ColumnReaderFactory
     {
         return createDecimalType(field)
                 .map(decimalType -> DecimalColumnReaderFactory.createReader(field, decimalType));
+    }
+
+    private static boolean isDecimalRescaled(DecimalLogicalTypeAnnotation decimalAnnotation, DecimalType trinoType)
+    {
+        return decimalAnnotation.getPrecision() != trinoType.getPrecision()
+                || decimalAnnotation.getScale() != trinoType.getScale();
+    }
+
+    private static boolean isIntegerAnnotation(LogicalTypeAnnotation typeAnnotation)
+    {
+        return typeAnnotation == null || typeAnnotation instanceof IntLogicalTypeAnnotation || isZeroScaleDecimalAnnotation(typeAnnotation);
+    }
+
+    private static boolean isZeroScaleDecimalAnnotation(LogicalTypeAnnotation typeAnnotation)
+    {
+        return typeAnnotation instanceof DecimalLogicalTypeAnnotation
+                && ((DecimalLogicalTypeAnnotation) typeAnnotation).getScale() == 0;
+    }
+
+    private static TrinoException unsupportedException(Type type, PrimitiveField field)
+    {
+        return new TrinoException(NOT_SUPPORTED, format("Unsupported Trino column type (%s) for Parquet column (%s)", type, field.getDescriptor()));
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.trino.parquet.PrimitiveField;
+import io.trino.spi.TrinoException;
+import org.apache.parquet.schema.LogicalTypeAnnotation.LogicalTypeAnnotationVisitor;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimeLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.joda.time.DateTimeZone;
+
+import java.util.Optional;
+
+import static io.trino.parquet.ParquetTypeUtils.createDecimalType;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit.MICROS;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit.MILLIS;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit.NANOS;
+
+public final class ColumnReaderFactory
+{
+    private ColumnReaderFactory() {}
+
+    public static ColumnReader create(PrimitiveField field, DateTimeZone timeZone)
+    {
+        PrimitiveType primitiveType = field.getDescriptor().getPrimitiveType();
+        return switch (primitiveType.getPrimitiveTypeName()) {
+            case BOOLEAN -> new BooleanColumnReader(field);
+            case INT32 -> createDecimalColumnReader(field).orElse(new IntColumnReader(field));
+            case INT64 -> {
+                if (primitiveType.getLogicalTypeAnnotation() instanceof TimeLogicalTypeAnnotation timeAnnotation) {
+                    if (timeAnnotation.getUnit() == MICROS) {
+                        yield new TimeMicrosColumnReader(field);
+                    }
+                    throw new TrinoException(NOT_SUPPORTED, "Unsupported column: " + field.getDescriptor());
+                }
+                if (primitiveType.getLogicalTypeAnnotation() instanceof TimestampLogicalTypeAnnotation timestampAnnotation) {
+                    if (timestampAnnotation.getUnit() == MILLIS) {
+                        yield new Int64TimestampMillisColumnReader(field);
+                    }
+                    if (timestampAnnotation.getUnit() == MICROS) {
+                        yield new TimestampMicrosColumnReader(field);
+                    }
+                    if (timestampAnnotation.getUnit() == NANOS) {
+                        yield new Int64TimestampNanosColumnReader(field);
+                    }
+                    throw new TrinoException(NOT_SUPPORTED, "Unsupported column: " + field.getDescriptor());
+                }
+                yield createDecimalColumnReader(field).orElse(new LongColumnReader(field));
+            }
+            case INT96 -> new TimestampColumnReader(field, timeZone);
+            case FLOAT -> new FloatColumnReader(field);
+            case DOUBLE -> new DoubleColumnReader(field);
+            case BINARY -> createDecimalColumnReader(field).orElse(new BinaryColumnReader(field));
+            case FIXED_LEN_BYTE_ARRAY -> {
+                Optional<PrimitiveColumnReader> decimalColumnReader = createDecimalColumnReader(field);
+                if (decimalColumnReader.isPresent()) {
+                    yield decimalColumnReader.get();
+                }
+                if (isLogicalUuid(primitiveType)) {
+                    yield new UuidColumnReader(field);
+                }
+                if (primitiveType.getLogicalTypeAnnotation() == null) {
+                    // Iceberg 0.11.1 writes UUID as FIXED_LEN_BYTE_ARRAY without logical type annotation (see https://github.com/apache/iceberg/pull/2913)
+                    // To support such files, we bet on the type to be UUID, which gets verified later, when reading the column data.
+                    yield new UuidColumnReader(field);
+                }
+                throw new TrinoException(NOT_SUPPORTED, "Unsupported column: " + field.getDescriptor());
+            }
+        };
+    }
+
+    private static boolean isLogicalUuid(PrimitiveType primitiveType)
+    {
+        return Optional.ofNullable(primitiveType.getLogicalTypeAnnotation())
+                .flatMap(logicalTypeAnnotation -> logicalTypeAnnotation.accept(new LogicalTypeAnnotationVisitor<Boolean>()
+                {
+                    @Override
+                    public Optional<Boolean> visit(UUIDLogicalTypeAnnotation uuidLogicalType)
+                    {
+                        return Optional.of(TRUE);
+                    }
+                }))
+                .orElse(FALSE);
+    }
+
+    private static Optional<PrimitiveColumnReader> createDecimalColumnReader(PrimitiveField field)
+    {
+        return createDecimalType(field)
+                .map(decimalType -> DecimalColumnReaderFactory.createReader(field, decimalType));
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/FilteredRowRanges.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/FilteredRowRanges.java
@@ -13,15 +13,28 @@
  */
 package io.trino.parquet.reader;
 
-import java.util.Optional;
+import org.apache.parquet.internal.filter2.columnindex.RowRanges;
 
-public interface ColumnReader
+import static java.util.Objects.requireNonNull;
+
+public class FilteredRowRanges
 {
-    boolean hasPageReader();
+    private final RowRanges parquetRowRanges;
+    private final long rowCount;
 
-    void setPageReader(PageReader pageReader, Optional<FilteredRowRanges> rowRanges);
+    public FilteredRowRanges(RowRanges parquetRowRanges)
+    {
+        this.parquetRowRanges = requireNonNull(parquetRowRanges, "parquetRowRanges is null");
+        this.rowCount = parquetRowRanges.rowCount();
+    }
 
-    void prepareNextRead(int batchSize);
+    public RowRanges getParquetRowRanges()
+    {
+        return parquetRowRanges;
+    }
 
-    ColumnChunk readPrimitive();
+    public long getRowCount()
+    {
+        return rowCount;
+    }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/FilteredRowRanges.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/FilteredRowRanges.java
@@ -15,16 +15,23 @@ package io.trino.parquet.reader;
 
 import org.apache.parquet.internal.filter2.columnindex.RowRanges;
 
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
+// PrimitiveColumnReader iterates over RowRanges value-by-value
+// FlatColumnReader iterates over range of values using FilteredRowRangesIterator
 public class FilteredRowRanges
 {
     private final RowRanges parquetRowRanges;
+    private final List<RowRange> rowRanges;
     private final long rowCount;
 
     public FilteredRowRanges(RowRanges parquetRowRanges)
     {
         this.parquetRowRanges = requireNonNull(parquetRowRanges, "parquetRowRanges is null");
+        this.rowRanges = constructRanges(parquetRowRanges);
         this.rowCount = parquetRowRanges.rowCount();
     }
 
@@ -33,8 +40,30 @@ public class FilteredRowRanges
         return parquetRowRanges;
     }
 
+    public List<RowRange> getRowRanges()
+    {
+        return rowRanges;
+    }
+
     public long getRowCount()
     {
         return rowCount;
     }
+
+    /**
+     * Construct a list of row ranges from the given `rowRanges`. For example, suppose the
+     * `rowRanges` are `[0, 1, 2, 4, 5, 7, 8, 9]`, it will be converted into 3 row ranges:
+     * `[0-2], [4-5], [7-9]`.
+     */
+    private static List<RowRange> constructRanges(RowRanges rowRanges)
+    {
+        return rowRanges.getRanges().stream()
+                .map(range -> new RowRange(range.from, range.to))
+                .collect(toImmutableList());
+    }
+
+    /**
+     * Helper struct to represent a range of row indexes `[start, end]`.
+     */
+    public record RowRange(long start, long end) {}
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PageReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PageReader.java
@@ -109,4 +109,19 @@ public final class PageReader
             throw new RuntimeException("Error reading dictionary page", e);
         }
     }
+
+    public DataPage getNextPage()
+    {
+        return compressedPages.getFirst();
+    }
+
+    public boolean hasNext()
+    {
+        return !compressedPages.isEmpty();
+    }
+
+    public void skipNextPage()
+    {
+        compressedPages.removeFirst();
+    }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PageReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PageReader.java
@@ -28,6 +28,7 @@ public final class PageReader
 {
     private final CompressionCodecName codec;
     private final long valueCount;
+    private final boolean hasNoNulls;
     private final LinkedList<DataPage> compressedPages;
     private final DictionaryPage compressedDictionaryPage;
 
@@ -38,17 +39,24 @@ public final class PageReader
     public PageReader(CompressionCodecName codec,
                       LinkedList<DataPage> compressedPages,
                       DictionaryPage compressedDictionaryPage,
-                      long valueCount)
+                      long valueCount,
+                      boolean hasNoNulls)
     {
         this.codec = codec;
         this.compressedPages = compressedPages;
         this.compressedDictionaryPage = compressedDictionaryPage;
         this.valueCount = valueCount;
+        this.hasNoNulls = hasNoNulls;
     }
 
     public long getTotalValueCount()
     {
         return valueCount;
+    }
+
+    public boolean hasNoNulls()
+    {
+        return hasNoNulls;
     }
 
     public DataPage readPage()

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PageReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PageReader.java
@@ -24,7 +24,7 @@ import java.util.LinkedList;
 
 import static io.trino.parquet.ParquetCompressionUtils.decompress;
 
-final class PageReader
+public final class PageReader
 {
     private final CompressionCodecName codec;
     private final long valueCount;

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
@@ -120,7 +120,7 @@ public class ParquetReader
     private long nextRowInGroup;
     private int batchSize;
     private int nextBatchSize = INITIAL_BATCH_SIZE;
-    private final Map<Integer, PrimitiveColumnReader> columnReaders;
+    private final Map<Integer, ColumnReader> columnReaders;
     private final Map<Integer, Long> maxBytesPerCell;
     private long maxCombinedBytesPerRow;
     private final ParquetReaderOptions options;
@@ -437,7 +437,7 @@ public class ParquetReader
     {
         ColumnDescriptor columnDescriptor = field.getDescriptor();
         int fieldId = field.getId();
-        PrimitiveColumnReader columnReader = columnReaders.get(fieldId);
+        ColumnReader columnReader = columnReaders.get(fieldId);
         if (!columnReader.hasPageReader()) {
             validateParquet(currentBlockMetadata.getRowCount() > 0, "Row group has 0 rows");
             ColumnChunkMetaData metadata = getColumnChunkMetaData(currentBlockMetadata, columnDescriptor);
@@ -506,7 +506,7 @@ public class ParquetReader
     private void initializeColumnReaders()
     {
         for (PrimitiveField field : primitiveFields) {
-            columnReaders.put(field.getId(), PrimitiveColumnReader.createReader(field, timeZone));
+            columnReaders.put(field.getId(), ColumnReaderFactory.create(field, timeZone));
         }
     }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
@@ -59,22 +59,22 @@ import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.parquet.internal.column.columnindex.OffsetIndex;
 import org.apache.parquet.internal.filter2.columnindex.ColumnIndexFilter;
 import org.apache.parquet.internal.filter2.columnindex.ColumnIndexStore;
-import org.apache.parquet.internal.filter2.columnindex.RowRanges;
 import org.joda.time.DateTimeZone;
+
+import javax.annotation.Nullable;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.parquet.ParquetValidationUtils.validateParquet;
 import static io.trino.parquet.ParquetWriteValidation.StatisticsValidation;
 import static io.trino.parquet.ParquetWriteValidation.StatisticsValidation.createStatisticsValidationBuilder;
@@ -84,6 +84,7 @@ import static io.trino.parquet.reader.ListColumnReader.calculateCollectionOffset
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
 import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
 
@@ -104,7 +105,6 @@ public class ParquetReader
     private final ParquetDataSource dataSource;
     private final DateTimeZone timeZone;
     private final AggregatedMemoryContext memoryContext;
-    private final Optional<FilterPredicate> filter;
 
     private int currentRowGroup = -1;
     private BlockMetaData currentBlockMetadata;
@@ -116,7 +116,6 @@ public class ParquetReader
     /**
      * Index in the current group of the next row
      */
-    private RowRanges currentGroupRowRanges;
     private long nextRowInGroup;
     private int batchSize;
     private int nextBatchSize = INITIAL_BATCH_SIZE;
@@ -132,8 +131,7 @@ public class ParquetReader
     private final Optional<ParquetWriteValidation> writeValidation;
     private final Optional<WriteChecksumBuilder> writeChecksumBuilder;
     private final Optional<StatisticsValidation> rowGroupStatisticsValidation;
-    private final List<RowRanges> blockRowRanges;
-    private final Map<ColumnPath, ColumnDescriptor> paths = new HashMap<>();
+    private final FilteredRowRanges[] blockRowRanges;
     private final ParquetBlockFactory blockFactory;
     private final Map<String, Metric<?>> codecMetrics;
 
@@ -195,20 +193,14 @@ public class ParquetReader
         this.writeChecksumBuilder = writeValidation.map(validation -> createWriteChecksumBuilder(validation.getTypes()));
         this.rowGroupStatisticsValidation = writeValidation.map(validation -> createStatisticsValidationBuilder(validation.getTypes()));
 
-        this.blockRowRanges = listWithNulls(this.blocks.size());
-        for (PrimitiveField field : primitiveFields) {
-            ColumnDescriptor columnDescriptor = field.getDescriptor();
-            this.paths.put(ColumnPath.get(columnDescriptor.getPath()), columnDescriptor);
-        }
-
         requireNonNull(parquetPredicate, "parquetPredicate is null");
         this.columnIndexStore = requireNonNull(columnIndexStore, "columnIndexStore is null");
+        Optional<FilterPredicate> filter = Optional.empty();
         if (parquetPredicate.isPresent() && options.isUseColumnIndex()) {
-            this.filter = parquetPredicate.get().toParquetFilter(timeZone);
+            filter = parquetPredicate.get().toParquetFilter(timeZone);
         }
-        else {
-            this.filter = Optional.empty();
-        }
+        this.blockRowRanges = calculateFilteredRowRanges(blocks, filter, columnIndexStore, primitiveFields);
+
         this.blockFactory = new ParquetBlockFactory(exceptionTransform);
         ListMultimap<ChunkKey, DiskRange> ranges = ArrayListMultimap.create();
         Map<String, LongCount> codecMetrics = new HashMap<>();
@@ -222,7 +214,10 @@ public class ParquetReader
                 long startingPosition = chunkMetadata.getStartingPos();
                 long totalLength = chunkMetadata.getTotalSize();
                 long totalDataSize = 0;
-                FilteredOffsetIndex filteredOffsetIndex = getFilteredOffsetIndex(rowGroup, rowGroupRowCount, columnPath);
+                FilteredOffsetIndex filteredOffsetIndex = null;
+                if (blockRowRanges[rowGroup] != null) {
+                    filteredOffsetIndex = getFilteredOffsetIndex(blockRowRanges[rowGroup], rowGroup, rowGroupRowCount, columnPath);
+                }
                 if (filteredOffsetIndex == null) {
                     DiskRange range = new DiskRange(startingPosition, toIntExact(totalLength));
                     totalDataSize = range.getLength();
@@ -326,16 +321,14 @@ public class ParquetReader
         currentBlockMetadata = blocks.get(currentRowGroup);
         firstRowIndexInGroup = firstRowsOfBlocks.get(currentRowGroup);
         currentGroupRowCount = currentBlockMetadata.getRowCount();
-        if (filter.isPresent() && options.isUseColumnIndex()) {
-            if (columnIndexStore.get(currentRowGroup).isPresent()) {
-                currentGroupRowRanges = getRowRanges(filter.get(), currentRowGroup);
-                long rowCount = currentGroupRowRanges.rowCount();
-                columnIndexRowsFiltered += currentGroupRowCount - rowCount;
-                if (rowCount == 0) {
-                    return false;
-                }
-                currentGroupRowCount = rowCount;
+        FilteredRowRanges currentGroupRowRanges = blockRowRanges[currentRowGroup];
+        if (currentGroupRowRanges != null) {
+            long rowCount = currentGroupRowRanges.getRowCount();
+            columnIndexRowsFiltered += currentGroupRowCount - rowCount;
+            if (rowCount == 0) {
+                return false;
             }
+            currentGroupRowCount = rowCount;
         }
         nextRowInGroup = 0L;
         initializeColumnReaders();
@@ -415,21 +408,19 @@ public class ParquetReader
         return new ColumnChunk(rowBlock, columnChunk.getDefinitionLevels(), columnChunk.getRepetitionLevels());
     }
 
-    private FilteredOffsetIndex getFilteredOffsetIndex(int rowGroup, long rowGroupRowCount, ColumnPath columnPath)
+    @Nullable
+    private FilteredOffsetIndex getFilteredOffsetIndex(FilteredRowRanges rowRanges, int rowGroup, long rowGroupRowCount, ColumnPath columnPath)
     {
-        if (filter.isPresent()) {
-            RowRanges rowRanges = getRowRanges(filter.get(), rowGroup);
-            if (rowRanges != null && rowRanges.rowCount() < rowGroupRowCount) {
-                Optional<ColumnIndexStore> columnIndexStore = this.columnIndexStore.get(rowGroup);
-                if (columnIndexStore.isPresent()) {
-                    OffsetIndex offsetIndex = columnIndexStore.get().getOffsetIndex(columnPath);
-                    if (offsetIndex != null) {
-                        return FilteredOffsetIndex.filterOffsetIndex(offsetIndex, rowRanges, rowGroupRowCount);
-                    }
-                }
-            }
+        Optional<ColumnIndexStore> rowGroupColumnIndexStore = this.columnIndexStore.get(rowGroup);
+        if (rowGroupColumnIndexStore.isEmpty()) {
+            return null;
         }
-        return null;
+        // We have a selective rowRanges for the rowGroup, every column must have a valid offset index
+        // to figure out which rows need to be read from the required parquet pages
+        OffsetIndex offsetIndex = requireNonNull(
+                rowGroupColumnIndexStore.get().getOffsetIndex(columnPath),
+                format("Missing OffsetIndex for column %s", columnPath));
+        return FilteredOffsetIndex.filterOffsetIndex(offsetIndex, rowRanges.getParquetRowRanges(), rowGroupRowCount);
     }
 
     private ColumnChunk readPrimitive(PrimitiveField field)
@@ -441,9 +432,13 @@ public class ParquetReader
         if (!columnReader.hasPageReader()) {
             validateParquet(currentBlockMetadata.getRowCount() > 0, "Row group has 0 rows");
             ColumnChunkMetaData metadata = getColumnChunkMetaData(currentBlockMetadata, columnDescriptor);
-            OffsetIndex offsetIndex = getFilteredOffsetIndex(currentRowGroup, currentBlockMetadata.getRowCount(), metadata.getPath());
+            FilteredRowRanges rowRanges = blockRowRanges[currentRowGroup];
+            OffsetIndex offsetIndex = null;
+            if (rowRanges != null) {
+                offsetIndex = getFilteredOffsetIndex(rowRanges, currentRowGroup, currentBlockMetadata.getRowCount(), metadata.getPath());
+            }
             List<Slice> slices = allocateBlock(fieldId);
-            columnReader.setPageReader(createPageReader(slices, metadata, columnDescriptor, offsetIndex), currentGroupRowRanges);
+            columnReader.setPageReader(createPageReader(slices, metadata, columnDescriptor, offsetIndex), Optional.ofNullable(rowRanges));
         }
         ColumnChunk columnChunk = columnReader.readPrimitive();
 
@@ -565,30 +560,36 @@ public class ParquetReader
         return memoryContext;
     }
 
-    private static <T> List<T> listWithNulls(int size)
+    private static FilteredRowRanges[] calculateFilteredRowRanges(
+            List<BlockMetaData> blocks,
+            Optional<FilterPredicate> filter,
+            List<Optional<ColumnIndexStore>> columnIndexStore,
+            List<PrimitiveField> primitiveFields)
     {
-        return Stream.generate(() -> (T) null)
-                .limit(size)
-                .collect(Collectors.toCollection(ArrayList<T>::new));
-    }
-
-    private RowRanges getRowRanges(FilterPredicate filter, int blockIndex)
-    {
-        requireNonNull(filter, "filter is null");
-
-        RowRanges rowRanges = blockRowRanges.get(blockIndex);
-        if (rowRanges == null) {
-            Optional<ColumnIndexStore> columnIndexStore = this.columnIndexStore.get(blockIndex);
-            if (columnIndexStore.isPresent()) {
-                rowRanges = ColumnIndexFilter.calculateRowRanges(
-                        FilterCompat.get(filter),
-                        columnIndexStore.get(),
-                        paths.keySet(),
-                        blocks.get(blockIndex).getRowCount());
-                blockRowRanges.set(blockIndex, rowRanges);
+        FilteredRowRanges[] blockRowRanges = new FilteredRowRanges[blocks.size()];
+        if (filter.isEmpty()) {
+            return blockRowRanges;
+        }
+        Set<ColumnPath> paths = primitiveFields.stream()
+                .map(field -> ColumnPath.get(field.getDescriptor().getPath()))
+                .collect(toImmutableSet());
+        for (int rowGroup = 0; rowGroup < blocks.size(); rowGroup++) {
+            Optional<ColumnIndexStore> rowGroupColumnIndexStore = columnIndexStore.get(rowGroup);
+            if (rowGroupColumnIndexStore.isEmpty()) {
+                continue;
+            }
+            BlockMetaData metadata = blocks.get(rowGroup);
+            long rowGroupRowCount = metadata.getRowCount();
+            FilteredRowRanges rowRanges = new FilteredRowRanges(ColumnIndexFilter.calculateRowRanges(
+                    FilterCompat.get(filter.get()),
+                    rowGroupColumnIndexStore.get(),
+                    paths,
+                    rowGroupRowCount));
+            if (rowRanges.getRowCount() < rowGroupRowCount) {
+                blockRowRanges[rowGroup] = rowRanges;
             }
         }
-        return rowRanges;
+        return blockRowRanges;
     }
 
     private void validateWritePageChecksum(Page page)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
@@ -501,7 +501,7 @@ public class ParquetReader
     private void initializeColumnReaders()
     {
         for (PrimitiveField field : primitiveFields) {
-            columnReaders.put(field.getId(), ColumnReaderFactory.create(field, timeZone));
+            columnReaders.put(field.getId(), ColumnReaderFactory.create(field, timeZone, options.useBatchColumnReaders()));
         }
     }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
@@ -438,7 +438,7 @@ public class ParquetReader
         ColumnDescriptor columnDescriptor = field.getDescriptor();
         int fieldId = field.getId();
         PrimitiveColumnReader columnReader = columnReaders.get(fieldId);
-        if (columnReader.getPageReader() == null) {
+        if (!columnReader.hasPageReader()) {
             validateParquet(currentBlockMetadata.getRowCount() > 0, "Row group has 0 rows");
             ColumnChunkMetaData metadata = getColumnChunkMetaData(currentBlockMetadata, columnDescriptor);
             OffsetIndex offsetIndex = getFilteredOffsetIndex(currentRowGroup, currentBlockMetadata.getRowCount(), metadata.getPath());

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PrimitiveColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PrimitiveColumnReader.java
@@ -176,9 +176,9 @@ public abstract class PrimitiveColumnReader
         this.indexIterator = null;
     }
 
-    public PageReader getPageReader()
+    public boolean hasPageReader()
     {
-        return pageReader;
+        return pageReader != null;
     }
 
     public void setPageReader(PageReader pageReader, RowRanges rowRanges)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PrimitiveColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PrimitiveColumnReader.java
@@ -30,12 +30,12 @@ import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.BytesUtils;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
-import org.apache.parquet.internal.filter2.columnindex.RowRanges;
 import org.apache.parquet.io.ParquetDecodingException;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.PrimitiveIterator;
 
@@ -101,7 +101,7 @@ public abstract class PrimitiveColumnReader
     }
 
     @Override
-    public void setPageReader(PageReader pageReader, RowRanges rowRanges)
+    public void setPageReader(PageReader pageReader, Optional<FilteredRowRanges> rowRanges)
     {
         this.pageReader = requireNonNull(pageReader, "pageReader");
         DictionaryPage dictionaryPage = pageReader.readDictionaryPage();
@@ -119,8 +119,8 @@ public abstract class PrimitiveColumnReader
         }
         checkArgument(pageReader.getTotalValueCount() > 0, "page is empty");
         totalValueCount = pageReader.getTotalValueCount();
-        if (rowRanges != null) {
-            indexIterator = rowRanges.iterator();
+        if (rowRanges.isPresent()) {
+            indexIterator = rowRanges.get().getParquetRowRanges().iterator();
             // If rowRanges is empty for a row-group, then no page needs to be read, and we should not reach here
             checkArgument(indexIterator.hasNext(), "rowRanges is empty");
             targetRow = indexIterator.next();

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/SimpleSliceInputStream.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/SimpleSliceInputStream.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.airlift.slice.Slice;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Basic input stream based on a given Slice object.
+ * This is a simpler version of BasicSliceInput with a few additional methods.
+ * <p>
+ * Note that methods starting with 'read' modify the underlying offset, while 'get' methods return
+ * value without modifying the state
+ */
+public final class SimpleSliceInputStream
+{
+    private final Slice slice;
+    private int offset;
+
+    public SimpleSliceInputStream(Slice slice)
+    {
+        this(slice, 0);
+    }
+
+    public SimpleSliceInputStream(Slice slice, int offset)
+    {
+        this.slice = requireNonNull(slice, "slice is null");
+        checkArgument(slice.length() == 0 || slice.hasByteArray(), "SimpleSliceInputStream supports only slices backed by byte array");
+        this.offset = offset;
+    }
+
+    public byte readByte()
+    {
+        return slice.getByte(offset++);
+    }
+
+    public long readLong()
+    {
+        long value = slice.getLong(offset);
+        offset += Long.BYTES;
+        return value;
+    }
+
+    public byte[] readBytes()
+    {
+        byte[] bytes = slice.getBytes();
+        offset = slice.length();
+        return bytes;
+    }
+
+    public void skip(int n)
+    {
+        offset += n;
+    }
+
+    public Slice asSlice()
+    {
+        return slice.slice(offset, slice.length() - offset);
+    }
+
+    /**
+     * Returns the byte array wrapped by this Slice.
+     * Callers should take care to use {@link SimpleSliceInputStream#getByteArrayOffset()}
+     * since the contents of this Slice may not start at array index 0.
+     */
+    public byte[] getByteArray()
+    {
+        return slice.byteArray();
+    }
+
+    /**
+     * Returns the start index the content of this slice within the byte array wrapped by this slice.
+     */
+    public int getByteArrayOffset()
+    {
+        return offset + slice.byteArrayOffset();
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ApacheParquetValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ApacheParquetValueDecoders.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.column.values.ValuesReader;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+
+import static io.trino.parquet.ParquetReaderUtils.castToByte;
+import static io.trino.parquet.ParquetReaderUtils.toByteExact;
+import static io.trino.parquet.ParquetReaderUtils.toShortExact;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This is a set of proxy value decoders that use a delegated value reader from apache lib.
+ */
+public class ApacheParquetValueDecoders
+{
+    private ApacheParquetValueDecoders() {}
+
+    public static final class IntApacheParquetValueDecoder
+            implements ValueDecoder<int[]>
+    {
+        private final ValuesReader delegate;
+
+        public IntApacheParquetValueDecoder(ValuesReader delegate)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            initialize(input, delegate);
+        }
+
+        @Override
+        public void read(int[] values, int offset, int length)
+        {
+            for (int i = offset; i < offset + length; i++) {
+                values[i] = delegate.readInteger();
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            delegate.skip(n);
+        }
+    }
+
+    public static final class ShortApacheParquetValueDecoder
+            implements ValueDecoder<short[]>
+    {
+        private final ValuesReader delegate;
+
+        public ShortApacheParquetValueDecoder(ValuesReader delegate)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            initialize(input, delegate);
+        }
+
+        @Override
+        public void read(short[] values, int offset, int length)
+        {
+            for (int i = offset; i < offset + length; i++) {
+                values[i] = toShortExact(delegate.readInteger());
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            delegate.skip(n);
+        }
+    }
+
+    public static final class ByteApacheParquetValueDecoder
+            implements ValueDecoder<byte[]>
+    {
+        private final ValuesReader delegate;
+
+        public ByteApacheParquetValueDecoder(ValuesReader delegate)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            initialize(input, delegate);
+        }
+
+        @Override
+        public void read(byte[] values, int offset, int length)
+        {
+            for (int i = offset; i < offset + length; i++) {
+                values[i] = toByteExact(delegate.readInteger());
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            delegate.skip(n);
+        }
+    }
+
+    public static final class IntToLongApacheParquetValueDecoder
+            implements ValueDecoder<long[]>
+    {
+        private final ValuesReader delegate;
+
+        public IntToLongApacheParquetValueDecoder(ValuesReader delegate)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            initialize(input, delegate);
+        }
+
+        @Override
+        public void read(long[] values, int offset, int length)
+        {
+            for (int i = offset; i < offset + length; i++) {
+                values[i] = delegate.readInteger();
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            delegate.skip(n);
+        }
+    }
+
+    public static final class LongApacheParquetValueDecoder
+            implements ValueDecoder<long[]>
+    {
+        private final ValuesReader delegate;
+
+        public LongApacheParquetValueDecoder(ValuesReader delegate)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            initialize(input, delegate);
+        }
+
+        @Override
+        public void read(long[] values, int offset, int length)
+        {
+            for (int i = offset; i < offset + length; i++) {
+                values[i] = delegate.readLong();
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            delegate.skip(n);
+        }
+    }
+
+    public static final class DoubleApacheParquetValueDecoder
+            implements ValueDecoder<long[]>
+    {
+        private final ValuesReader delegate;
+
+        public DoubleApacheParquetValueDecoder(ValuesReader delegate)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            initialize(input, delegate);
+        }
+
+        @Override
+        public void read(long[] values, int offset, int length)
+        {
+            for (int i = offset; i < offset + length; i++) {
+                values[i] = Double.doubleToLongBits(delegate.readDouble());
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            delegate.skip(n);
+        }
+    }
+
+    public static final class FloatApacheParquetValueDecoder
+            implements ValueDecoder<int[]>
+    {
+        private final ValuesReader delegate;
+
+        public FloatApacheParquetValueDecoder(ValuesReader delegate)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            initialize(input, delegate);
+        }
+
+        @Override
+        public void read(int[] values, int offset, int length)
+        {
+            for (int i = offset; i < offset + length; i++) {
+                values[i] = Float.floatToIntBits(delegate.readFloat());
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            delegate.skip(n);
+        }
+    }
+
+    public static final class BooleanApacheParquetValueDecoder
+            implements ValueDecoder<byte[]>
+    {
+        private final ValuesReader delegate;
+
+        public BooleanApacheParquetValueDecoder(ValuesReader delegate)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            byte[] buffer = input.readBytes();
+            try {
+                // Deprecated PLAIN boolean decoder from Apache lib is the only one that actually
+                // uses the valueCount argument to allocate memory so we simulate it here.
+                int valueCount = buffer.length * Byte.SIZE;
+                delegate.initFromPage(valueCount, ByteBufferInputStream.wrap(ByteBuffer.wrap(buffer, 0, buffer.length)));
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public void read(byte[] values, int offset, int length)
+        {
+            for (int i = offset; i < offset + length; i++) {
+                values[i] = castToByte(delegate.readBoolean());
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            delegate.skip(n);
+        }
+    }
+
+    private static void initialize(SimpleSliceInputStream input, ValuesReader reader)
+    {
+        byte[] buffer = input.readBytes();
+        try {
+            reader.initFromPage(0, ByteBufferInputStream.wrap(ByteBuffer.wrap(buffer, 0, buffer.length)));
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoder.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoder.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.trino.parquet.ParquetEncoding;
+import io.trino.parquet.PrimitiveField;
+import io.trino.parquet.dictionary.Dictionary;
+import io.trino.parquet.reader.SimpleSliceInputStream;
+
+import javax.annotation.Nullable;
+
+public interface ValueDecoder<T>
+{
+    void init(SimpleSliceInputStream input);
+
+    void read(T values, int offset, int length);
+
+    void skip(int n);
+
+    interface ValueDecodersProvider<T>
+    {
+        ValueDecoder<T> create(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary);
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.trino.parquet.ParquetEncoding;
+import io.trino.parquet.PrimitiveField;
+import io.trino.parquet.dictionary.Dictionary;
+import org.apache.parquet.column.values.ValuesReader;
+
+import javax.annotation.Nullable;
+
+import static io.trino.parquet.ParquetEncoding.PLAIN_DICTIONARY;
+import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
+import static io.trino.parquet.ValuesType.VALUES;
+import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.BooleanApacheParquetValueDecoder;
+import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ByteApacheParquetValueDecoder;
+import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.DoubleApacheParquetValueDecoder;
+import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.FloatApacheParquetValueDecoder;
+import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.IntApacheParquetValueDecoder;
+import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.IntToLongApacheParquetValueDecoder;
+import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.LongApacheParquetValueDecoder;
+import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortApacheParquetValueDecoder;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This class provides static API for creating value decoders for given fields and encodings.
+ * If no suitable decoder is found the Apache Parquet fallback is used.
+ * Not all types are supported since this class is at this point used only by flat readers
+ * <p>
+ * This class is to replace most of the logic contained in ParquetEncoding enum
+ */
+public final class ValueDecoders
+{
+    private ValueDecoders() {}
+
+    public static ValueDecoder<long[]> getDoubleDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    {
+        return switch (encoding) {
+            case PLAIN, PLAIN_DICTIONARY, RLE_DICTIONARY -> new DoubleApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
+            default -> throw wrongEncoding(encoding, field);
+        };
+    }
+
+    public static ValueDecoder<int[]> getRealDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    {
+        return switch (encoding) {
+            case PLAIN, PLAIN_DICTIONARY, RLE_DICTIONARY -> new FloatApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
+            default -> throw wrongEncoding(encoding, field);
+        };
+    }
+
+    public static ValueDecoder<long[]> getShortDecimalDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    {
+        return switch (field.getDescriptor().getPrimitiveType().getPrimitiveTypeName()) {
+            case INT64 -> getLongDecoder(encoding, field, dictionary);
+            case INT32 -> getIntToLongDecoder(encoding, field, dictionary);
+            default -> throw wrongEncoding(encoding, field);
+        };
+    }
+
+    public static ValueDecoder<long[]> getLongDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    {
+        return switch (encoding) {
+            case PLAIN, DELTA_BINARY_PACKED, RLE, BIT_PACKED, PLAIN_DICTIONARY, RLE_DICTIONARY ->
+                    new LongApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
+            default -> throw wrongEncoding(encoding, field);
+        };
+    }
+
+    public static ValueDecoder<long[]> getIntToLongDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    {
+        // We need to produce LongArrayBlock from the decoded integers for INT32 backed decimals
+        return switch (encoding) {
+            case PLAIN, DELTA_BINARY_PACKED, RLE, BIT_PACKED, PLAIN_DICTIONARY, RLE_DICTIONARY ->
+                    new IntToLongApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
+            default -> throw wrongEncoding(encoding, field);
+        };
+    }
+
+    public static ValueDecoder<int[]> getIntDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    {
+        return switch (encoding) {
+            case PLAIN, DELTA_BINARY_PACKED, RLE, BIT_PACKED, PLAIN_DICTIONARY, RLE_DICTIONARY ->
+                    new IntApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
+            default -> throw wrongEncoding(encoding, field);
+        };
+    }
+
+    public static ValueDecoder<byte[]> getByteDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    {
+        return switch (encoding) {
+            case PLAIN, DELTA_BINARY_PACKED, RLE, BIT_PACKED, PLAIN_DICTIONARY, RLE_DICTIONARY ->
+                    new ByteApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
+            default -> throw wrongEncoding(encoding, field);
+        };
+    }
+
+    public static ValueDecoder<short[]> getShortDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    {
+        return switch (encoding) {
+            case PLAIN, DELTA_BINARY_PACKED, RLE, BIT_PACKED, PLAIN_DICTIONARY, RLE_DICTIONARY ->
+                    new ShortApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
+            default -> throw wrongEncoding(encoding, field);
+        };
+    }
+
+    public static ValueDecoder<byte[]> getBooleanDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    {
+        return switch (encoding) {
+            case PLAIN, RLE, BIT_PACKED -> new BooleanApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
+            default -> throw wrongEncoding(encoding, field);
+        };
+    }
+
+    private static ValuesReader getApacheParquetReader(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    {
+        if (encoding == RLE_DICTIONARY || encoding == PLAIN_DICTIONARY) {
+            return encoding.getDictionaryBasedValuesReader(field.getDescriptor(), VALUES, requireNonNull(dictionary, "dictionary is null"));
+        }
+        return encoding.getValuesReader(field.getDescriptor(), VALUES);
+    }
+
+    private static IllegalArgumentException wrongEncoding(ParquetEncoding encoding, PrimitiveField field)
+    {
+        return new IllegalArgumentException("Wrong encoding " + encoding + " for column type " + field.getDescriptor().getPrimitiveType().getPrimitiveTypeName());
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/BitPackingUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/BitPackingUtils.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import static io.trino.parquet.ParquetReaderUtils.castToByteNegate;
+
+public class BitPackingUtils
+{
+    private BitPackingUtils() {}
+
+    /**
+     * @return number of bits equal to 0 (non-nulls)
+     */
+    public static int unpack(boolean[] values, int offset, byte packedByte, int startBit, int endBit)
+    {
+        int nonNullCount = 0;
+        for (int i = 0; i < endBit - startBit; i++) {
+            // We need to negate the value as we convert the "does exist" to "is null", hence '== 0' instead of '== 1'
+            boolean value = (((packedByte >>> (startBit + i)) & 1) == 1);
+            nonNullCount += castToByteNegate(value);
+            values[offset + i] = value;
+        }
+
+        return nonNullCount;
+    }
+
+    /**
+     * @return number of bits equal to 0 (non-nulls)
+     */
+    public static int unpack(boolean[] values, int offset, byte packedByte)
+    {
+        values[offset] = (packedByte & 1) == 1;
+        values[offset + 1] = ((packedByte >>> 1) & 1) == 1;
+        values[offset + 2] = ((packedByte >>> 2) & 1) == 1;
+        values[offset + 3] = ((packedByte >>> 3) & 1) == 1;
+        values[offset + 4] = ((packedByte >>> 4) & 1) == 1;
+        values[offset + 5] = ((packedByte >>> 5) & 1) == 1;
+        values[offset + 6] = ((packedByte >>> 6) & 1) == 1;
+        values[offset + 7] = ((packedByte >>> 7) & 1) == 1;
+
+        return Byte.SIZE - bitCount(packedByte);
+    }
+
+    /**
+     * @return number of bits equal to 0 (non-nulls)
+     */
+    public static int unpack(boolean[] values, int offset, long packedValue)
+    {
+        values[offset] = (packedValue & 1) == 1;
+        values[offset + 1] = ((packedValue >>> 1) & 1) == 1;
+        values[offset + 2] = ((packedValue >>> 2) & 1) == 1;
+        values[offset + 3] = ((packedValue >>> 3) & 1) == 1;
+        values[offset + 4] = ((packedValue >>> 4) & 1) == 1;
+        values[offset + 5] = ((packedValue >>> 5) & 1) == 1;
+        values[offset + 6] = ((packedValue >>> 6) & 1) == 1;
+        values[offset + 7] = ((packedValue >>> 7) & 1) == 1;
+        values[offset + 8] = ((packedValue >>> 8) & 1) == 1;
+        values[offset + 9] = ((packedValue >>> 9) & 1) == 1;
+
+        values[offset + 10] = ((packedValue >>> 10) & 1) == 1;
+        values[offset + 11] = ((packedValue >>> 11) & 1) == 1;
+        values[offset + 12] = ((packedValue >>> 12) & 1) == 1;
+        values[offset + 13] = ((packedValue >>> 13) & 1) == 1;
+        values[offset + 14] = ((packedValue >>> 14) & 1) == 1;
+        values[offset + 15] = ((packedValue >>> 15) & 1) == 1;
+        values[offset + 16] = ((packedValue >>> 16) & 1) == 1;
+        values[offset + 17] = ((packedValue >>> 17) & 1) == 1;
+        values[offset + 18] = ((packedValue >>> 18) & 1) == 1;
+        values[offset + 19] = ((packedValue >>> 19) & 1) == 1;
+
+        values[offset + 20] = ((packedValue >>> 20) & 1) == 1;
+        values[offset + 21] = ((packedValue >>> 21) & 1) == 1;
+        values[offset + 22] = ((packedValue >>> 22) & 1) == 1;
+        values[offset + 23] = ((packedValue >>> 23) & 1) == 1;
+        values[offset + 24] = ((packedValue >>> 24) & 1) == 1;
+        values[offset + 25] = ((packedValue >>> 25) & 1) == 1;
+        values[offset + 26] = ((packedValue >>> 26) & 1) == 1;
+        values[offset + 27] = ((packedValue >>> 27) & 1) == 1;
+        values[offset + 28] = ((packedValue >>> 28) & 1) == 1;
+        values[offset + 29] = ((packedValue >>> 29) & 1) == 1;
+
+        values[offset + 30] = ((packedValue >>> 30) & 1) == 1;
+        values[offset + 31] = ((packedValue >>> 31) & 1) == 1;
+        values[offset + 32] = ((packedValue >>> 32) & 1) == 1;
+        values[offset + 33] = ((packedValue >>> 33) & 1) == 1;
+        values[offset + 34] = ((packedValue >>> 34) & 1) == 1;
+        values[offset + 35] = ((packedValue >>> 35) & 1) == 1;
+        values[offset + 36] = ((packedValue >>> 36) & 1) == 1;
+        values[offset + 37] = ((packedValue >>> 37) & 1) == 1;
+        values[offset + 38] = ((packedValue >>> 38) & 1) == 1;
+        values[offset + 39] = ((packedValue >>> 39) & 1) == 1;
+
+        values[offset + 40] = ((packedValue >>> 40) & 1) == 1;
+        values[offset + 41] = ((packedValue >>> 41) & 1) == 1;
+        values[offset + 42] = ((packedValue >>> 42) & 1) == 1;
+        values[offset + 43] = ((packedValue >>> 43) & 1) == 1;
+        values[offset + 44] = ((packedValue >>> 44) & 1) == 1;
+        values[offset + 45] = ((packedValue >>> 45) & 1) == 1;
+        values[offset + 46] = ((packedValue >>> 46) & 1) == 1;
+        values[offset + 47] = ((packedValue >>> 47) & 1) == 1;
+        values[offset + 48] = ((packedValue >>> 48) & 1) == 1;
+        values[offset + 49] = ((packedValue >>> 49) & 1) == 1;
+
+        values[offset + 50] = ((packedValue >>> 50) & 1) == 1;
+        values[offset + 51] = ((packedValue >>> 51) & 1) == 1;
+        values[offset + 52] = ((packedValue >>> 52) & 1) == 1;
+        values[offset + 53] = ((packedValue >>> 53) & 1) == 1;
+        values[offset + 54] = ((packedValue >>> 54) & 1) == 1;
+        values[offset + 55] = ((packedValue >>> 55) & 1) == 1;
+        values[offset + 56] = ((packedValue >>> 56) & 1) == 1;
+        values[offset + 57] = ((packedValue >>> 57) & 1) == 1;
+        values[offset + 58] = ((packedValue >>> 58) & 1) == 1;
+        values[offset + 59] = ((packedValue >>> 59) & 1) == 1;
+
+        values[offset + 60] = ((packedValue >>> 60) & 1) == 1;
+        values[offset + 61] = ((packedValue >>> 61) & 1) == 1;
+        values[offset + 62] = ((packedValue >>> 62) & 1) == 1;
+        values[offset + 63] = ((packedValue >>> 63) & 1) == 1;
+
+        return Long.SIZE - Long.bitCount(packedValue);
+    }
+
+    public static int bitCount(byte value)
+    {
+        return Integer.bitCount(value & 0xFF);
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/BooleanColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/BooleanColumnAdapter.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.block.ByteArrayBlock;
+
+import java.util.Optional;
+
+public class BooleanColumnAdapter
+        implements ColumnAdapter<byte[]>
+{
+    public static final BooleanColumnAdapter BOOLEAN_ADAPTER = new BooleanColumnAdapter();
+
+    @Override
+    public byte[] createBuffer(int size)
+    {
+        return new byte[size];
+    }
+
+    @Override
+    public Block createNonNullBlock(int size, byte[] values)
+    {
+        return new ByteArrayBlock(size, Optional.empty(), values);
+    }
+
+    @Override
+    public Block createNullableBlock(int size, boolean[] nulls, byte[] values)
+    {
+        return new ByteArrayBlock(size, Optional.of(nulls), values);
+    }
+
+    @Override
+    public void copyValue(byte[] source, int sourceIndex, byte[] destination, int destinationIndex)
+    {
+        destination[destinationIndex] = source[sourceIndex];
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ByteColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ByteColumnAdapter.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.block.ByteArrayBlock;
+
+import java.util.Optional;
+
+public class ByteColumnAdapter
+        implements ColumnAdapter<byte[]>
+{
+    public static final ByteColumnAdapter BYTE_ADAPTER = new ByteColumnAdapter();
+
+    @Override
+    public byte[] createBuffer(int size)
+    {
+        return new byte[size];
+    }
+
+    @Override
+    public Block createNonNullBlock(int size, byte[] values)
+    {
+        return new ByteArrayBlock(size, Optional.empty(), values);
+    }
+
+    @Override
+    public Block createNullableBlock(int size, boolean[] nulls, byte[] values)
+    {
+        return new ByteArrayBlock(size, Optional.of(nulls), values);
+    }
+
+    @Override
+    public void copyValue(byte[] source, int sourceIndex, byte[] destination, int destinationIndex)
+    {
+        destination[destinationIndex] = source[sourceIndex];
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ColumnAdapter.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import io.trino.spi.block.Block;
+
+import static io.trino.parquet.ParquetReaderUtils.castToByteNegate;
+
+public interface ColumnAdapter<BufferType>
+{
+    /**
+     * Temporary buffer used for null unpacking
+     */
+    default BufferType createTemporaryBuffer(int size)
+    {
+        return createBuffer(size);
+    }
+
+    BufferType createBuffer(int size);
+
+    void copyValue(BufferType source, int sourceIndex, BufferType destination, int destinationIndex);
+
+    Block createNullableBlock(int size, boolean[] nulls, BufferType values);
+
+    Block createNonNullBlock(int size, BufferType values);
+
+    default void unpackNullValues(BufferType source, BufferType destination, boolean[] isNull, int destOffset, int nonNullCount)
+    {
+        int srcOffset = 0;
+        while (srcOffset < nonNullCount) {
+            copyValue(source, srcOffset, destination, destOffset);
+            // Avoid branching
+            srcOffset += castToByteNegate(isNull[destOffset]);
+            destOffset++;
+        }
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/FilteredRowRangesIterator.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/FilteredRowRangesIterator.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import io.trino.parquet.reader.FilteredRowRanges;
+
+import java.util.Iterator;
+import java.util.OptionalLong;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static io.trino.parquet.reader.FilteredRowRanges.RowRange;
+import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * When filtering using column indexes we might skip reading some pages for different columns. Because the rows are
+ * not aligned between the pages of the different columns it might be required to skip some values. The values (and the
+ * related rl and dl) are skipped based on the iterator of the required row indexes and the first row index of each
+ * page.
+ * For example:
+ *
+ * <pre>
+ * rows   col1   col2   col3
+ *      ┌──────┬──────┬──────┐
+ *   0  │  p0  │      │      │
+ *      ╞══════╡  p0  │  p0  │
+ *  20  │ p1(X)│------│------│
+ *      ╞══════╪══════╡      │
+ *  40  │ p2(X)│      │------│
+ *      ╞══════╡ p1(X)╞══════╡
+ *  60  │ p3(X)│      │------│
+ *      ╞══════╪══════╡      │
+ *  80  │  p4  │      │  p1  │
+ *      ╞══════╡  p2  │      │
+ * 100  │  p5  │      │      │
+ *      └──────┴──────┴──────┘
+ * </pre>
+ *
+ * The pages 1, 2, 3 in col1 are skipped, so we have to skip the rows [20, 79]. Because page 1 in col2 contains values
+ * only for the rows [40, 79] we skip this entire page as well. To synchronize the row reading we have to skip the
+ * values (and the related rl and dl) for the rows [20, 39] in the end of the page 0 for col2. Similarly, we have to
+ * skip values while reading page0 and page1 for col3.
+ */
+public class FilteredRowRangesIterator
+        implements RowRangesIterator
+{
+    private final Iterator<RowRange> rowRangeIterator;
+
+    // The current row range
+    private RowRange currentRange;
+
+    private long pageFirstRowIndex = -1;
+    private int pageValuesConsumed;
+
+    public FilteredRowRangesIterator(FilteredRowRanges rowRanges)
+    {
+        requireNonNull(rowRanges, "rowRanges is null");
+        this.rowRangeIterator = rowRanges.getRowRanges().iterator();
+        // We don't handle the empty rowRanges case because that should result in all pages getting eliminated
+        // and nothing should be read from file for that particular row group
+        checkArgument(this.rowRangeIterator.hasNext(), "rowRanges is empty");
+        nextRange();
+    }
+
+    /**
+     * @return Size of the next read within current range, bounded by chunkSize.
+     * When all the rows of the current range have been read, advance to the next range.
+     */
+    @Override
+    public int advanceRange(int chunkSize)
+    {
+        checkState(pageFirstRowIndex >= 0, "pageFirstRowIndex %s cannot be negative", pageFirstRowIndex);
+        long rangeEnd = currentRange.end();
+        int rowsLeftInRange = toIntExact(rangeEnd - pageFirstRowIndex) - pageValuesConsumed + 1;
+        if (rowsLeftInRange > chunkSize) {
+            pageValuesConsumed += chunkSize;
+            return chunkSize;
+        }
+        pageValuesConsumed += rowsLeftInRange;
+        if (rowRangeIterator.hasNext()) {
+            nextRange();
+        }
+        else {
+            checkState(
+                    rowsLeftInRange == chunkSize,
+                    "Reached end of filtered rowRanges with chunkSize %s, rowsLeftInRange %s, pageFirstRowIndex %s, pageValuesConsumed %s",
+                    chunkSize,
+                    rowsLeftInRange,
+                    pageFirstRowIndex,
+                    pageValuesConsumed);
+        }
+        return rowsLeftInRange;
+    }
+
+    /**
+     * Seek forward in the page by chunkSize.
+     * Advance rowRanges if we seek beyond currentRange.
+     * @return number of values skipped within rowRanges
+     */
+    @Override
+    public int seekForward(int chunkSize)
+    {
+        checkState(pageFirstRowIndex >= 0, "pageFirstRowIndex %s cannot be negative", pageFirstRowIndex);
+        long currentIndex = pageFirstRowIndex + pageValuesConsumed;
+        int skippedInRange = 0;
+        while (chunkSize > 0) {
+            // Before currentRange
+            if (currentIndex < currentRange.start()) {
+                int stepSize = min(chunkSize, toIntExact(currentRange.start() - currentIndex));
+                currentIndex += stepSize;
+                pageValuesConsumed += stepSize;
+                chunkSize -= stepSize;
+            }
+            // Within currentRange
+            else if (currentIndex <= currentRange.end()) {
+                int stepSize = min(chunkSize, toIntExact(currentRange.end() - currentIndex) + 1);
+                currentIndex += stepSize;
+                skippedInRange += stepSize;
+                pageValuesConsumed += stepSize;
+                chunkSize -= stepSize;
+            }
+            // After currentRange
+            else {
+                // chunkSize can never go beyond rowRanges end
+                checkState(
+                        rowRangeIterator.hasNext(),
+                        "Reached end of filtered rowRanges with chunkSize %s, currentIndex %s, pageFirstRowIndex %s, pageValuesConsumed %s",
+                        chunkSize,
+                        currentIndex,
+                        pageFirstRowIndex,
+                        pageValuesConsumed);
+                nextRange();
+            }
+        }
+        return skippedInRange;
+    }
+
+    /**
+     * @return Count of values to be skipped when current range start
+     * is after current position in the page
+     */
+    @Override
+    public long skipToRangeStart()
+    {
+        checkState(pageFirstRowIndex >= 0, "pageFirstRowIndex %s cannot be negative", pageFirstRowIndex);
+        long rangeStart = currentRange.start();
+        long currentIndex = pageFirstRowIndex + pageValuesConsumed;
+        if (rangeStart <= currentIndex) {
+            return 0;
+        }
+        long skipCount = rangeStart - currentIndex;
+        pageValuesConsumed += skipCount;
+        return skipCount;
+    }
+
+    /**
+     * Must be called at the beginning of reading a new page.
+     * Advances rowRanges if current range has no overlap with the new page.
+     */
+    @Override
+    public void resetForNewPage(OptionalLong firstRowIndex)
+    {
+        checkArgument(firstRowIndex.isPresent(), "Missing firstRowIndex for selecting rowRanges");
+        checkArgument(firstRowIndex.getAsLong() >= 0, "firstRowIndex %s cannot be negative", firstRowIndex.getAsLong());
+        checkArgument(
+                firstRowIndex.getAsLong() >= pageFirstRowIndex,
+                "firstRowIndex %s cannot be less than current pageFirstRowIndex %s",
+                firstRowIndex.getAsLong(),
+                pageFirstRowIndex);
+
+        pageFirstRowIndex = firstRowIndex.getAsLong();
+        pageValuesConsumed = 0;
+        long rangeEnd = currentRange.end();
+        if (pageFirstRowIndex > rangeEnd) {
+            nextRange();
+            rangeEnd = currentRange.end();
+        }
+        // We only read pages which contain some rows matched by rowRanges.
+        // At the end of reading previous page, one of 2 cases can happen:
+        // 1. Current range was not fully read, so firstRowIndex must be <= rangeEnd.
+        // 2. Current range was fully read, the next range must have some overlap with new page.
+        verify(pageFirstRowIndex <= rangeEnd);
+    }
+
+    private void nextRange()
+    {
+        currentRange = rowRangeIterator.next();
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/FilteredRowRangesIterator.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/FilteredRowRangesIterator.java
@@ -196,6 +196,17 @@ public class FilteredRowRangesIterator
         verify(pageFirstRowIndex <= rangeEnd);
     }
 
+    /**
+     * Returns whether the current page with the provided value count
+     * is fully contained within the current row range.
+     */
+    @Override
+    public boolean isPageFullyConsumed(int pageValueCount)
+    {
+        return pageFirstRowIndex >= currentRange.start()
+                && (pageFirstRowIndex + pageValueCount) <= currentRange.end() + 1;
+    }
+
     private void nextRange()
     {
         currentRange = rowRangeIterator.next();

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/FlatColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/FlatColumnReader.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.airlift.slice.Slice;
+import io.trino.parquet.DataPage;
+import io.trino.parquet.DataPageV1;
+import io.trino.parquet.DataPageV2;
+import io.trino.parquet.DictionaryPage;
+import io.trino.parquet.ParquetEncoding;
+import io.trino.parquet.PrimitiveField;
+import io.trino.parquet.dictionary.Dictionary;
+import io.trino.parquet.reader.ColumnChunk;
+import io.trino.parquet.reader.ColumnReader;
+import io.trino.parquet.reader.FilteredRowRanges;
+import io.trino.parquet.reader.PageReader;
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import io.trino.parquet.reader.decoders.ValueDecoder;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import org.apache.parquet.io.ParquetDecodingException;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.parquet.ParquetEncoding.RLE;
+import static io.trino.parquet.reader.decoders.ValueDecoder.ValueDecodersProvider;
+import static io.trino.parquet.reader.flat.RowRangesIterator.createRowRangesIterator;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class FlatColumnReader<BufferType>
+        implements ColumnReader
+{
+    private static final int[] EMPTY_DEFINITION_LEVELS = new int[0];
+    private static final int[] EMPTY_REPETITION_LEVELS = new int[0];
+
+    private final PrimitiveField field;
+    private final ValueDecodersProvider<BufferType> decodersProvider;
+    private final ColumnAdapter<BufferType> columnAdapter;
+    private PageReader pageReader;
+    private RowRangesIterator rowRanges;
+
+    private int readOffset;
+    private int remainingPageValueCount;
+    @Nullable
+    private Dictionary dictionary;
+    private FlatDefinitionLevelDecoder definitionLevelDecoder;
+    private ValueDecoder<BufferType> valueDecoder;
+
+    private int nextBatchSize;
+
+    public FlatColumnReader(PrimitiveField field, ValueDecodersProvider<BufferType> decodersProvider, ColumnAdapter<BufferType> columnAdapter)
+    {
+        this.field = requireNonNull(field, "field is null");
+        this.decodersProvider = requireNonNull(decodersProvider, "decoders is null");
+        this.columnAdapter = requireNonNull(columnAdapter, "columnAdapter is null");
+    }
+
+    private void seek()
+    {
+        int remainingInBatch = readOffset;
+        while (remainingInBatch > 0) {
+            if (remainingPageValueCount == 0) {
+                if (!readNextPage()) {
+                    throwEndOfBatchException(remainingInBatch);
+                }
+            }
+
+            int chunkSize = Math.min(remainingPageValueCount, remainingInBatch);
+            int nonNullCount;
+            if (field.isRequired()) {
+                nonNullCount = chunkSize;
+            }
+            else {
+                nonNullCount = definitionLevelDecoder.skip(chunkSize);
+            }
+            valueDecoder.skip(nonNullCount);
+            remainingInBatch -= rowRanges.seekForward(chunkSize);
+            remainingPageValueCount -= chunkSize;
+        }
+    }
+
+    @VisibleForTesting
+    ColumnChunk readNullable()
+    {
+        BufferType values = columnAdapter.createBuffer(nextBatchSize);
+        boolean[] isNull = new boolean[nextBatchSize];
+
+        int totalNonNullCount = 0;
+        int remainingInBatch = nextBatchSize;
+        int offset = 0;
+        while (remainingInBatch > 0) {
+            if (remainingPageValueCount == 0) {
+                if (!readNextPage()) {
+                    throwEndOfBatchException(remainingInBatch);
+                }
+            }
+
+            if (skipToRowRangesStart()) {
+                continue;
+            }
+            int chunkSize = rowRanges.advanceRange(Math.min(remainingPageValueCount, remainingInBatch));
+            int nonNullCount = definitionLevelDecoder.readNext(isNull, offset, chunkSize);
+            totalNonNullCount += nonNullCount;
+
+            if (nonNullCount > 0) {
+                if (nonNullCount < chunkSize) {
+                    // Read to a temporary array and unpack the nulls to the actual destination
+                    BufferType tmpBuffer = columnAdapter.createTemporaryBuffer(nonNullCount);
+                    valueDecoder.read(tmpBuffer, 0, nonNullCount);
+                    columnAdapter.unpackNullValues(tmpBuffer, values, isNull, offset, nonNullCount);
+                }
+                else {
+                    valueDecoder.read(values, offset, nonNullCount);
+                }
+            }
+
+            offset += chunkSize;
+            remainingInBatch -= chunkSize;
+            remainingPageValueCount -= chunkSize;
+        }
+
+        if (totalNonNullCount == 0) {
+            Block block = RunLengthEncodedBlock.create(field.getType(), null, nextBatchSize);
+            return new ColumnChunk(block, EMPTY_DEFINITION_LEVELS, EMPTY_REPETITION_LEVELS);
+        }
+
+        boolean hasNoNulls = totalNonNullCount == nextBatchSize;
+        Block block;
+        if (hasNoNulls) {
+            block = columnAdapter.createNonNullBlock(nextBatchSize, values);
+        }
+        else {
+            block = columnAdapter.createNullableBlock(nextBatchSize, isNull, values);
+        }
+        return new ColumnChunk(block, EMPTY_DEFINITION_LEVELS, EMPTY_REPETITION_LEVELS);
+    }
+
+    @VisibleForTesting
+    ColumnChunk readNoNull()
+    {
+        BufferType values = columnAdapter.createBuffer(nextBatchSize);
+        int remainingInBatch = nextBatchSize;
+        int offset = 0;
+        while (remainingInBatch > 0) {
+            if (remainingPageValueCount == 0) {
+                if (!readNextPage()) {
+                    throwEndOfBatchException(remainingInBatch);
+                }
+            }
+
+            if (skipToRowRangesStart()) {
+                continue;
+            }
+            int chunkSize = rowRanges.advanceRange(Math.min(remainingPageValueCount, remainingInBatch));
+
+            valueDecoder.read(values, offset, chunkSize);
+            offset += chunkSize;
+            remainingInBatch -= chunkSize;
+            remainingPageValueCount -= chunkSize;
+        }
+
+        Block block = columnAdapter.createNonNullBlock(nextBatchSize, values);
+        return new ColumnChunk(block, EMPTY_DEFINITION_LEVELS, EMPTY_REPETITION_LEVELS);
+    }
+
+    /**
+     * Finds the number of values to be skipped in the current page to reach
+     * the start of the current row range and uses that to skip ValueDecoder
+     * and DefinitionLevelDecoder to the appropriate position.
+     *
+     * @return Whether to skip the entire remaining page
+     */
+    private boolean skipToRowRangesStart()
+    {
+        int skipCount = toIntExact(rowRanges.skipToRangeStart());
+        if (skipCount >= remainingPageValueCount) {
+            remainingPageValueCount = 0;
+            return true;
+        }
+        if (skipCount > 0) {
+            int nonNullsCount;
+            if (field.isRequired()) {
+                nonNullsCount = skipCount;
+            }
+            else {
+                nonNullsCount = definitionLevelDecoder.skip(skipCount);
+            }
+            valueDecoder.skip(nonNullsCount);
+            remainingPageValueCount -= skipCount;
+        }
+        return false;
+    }
+
+    private boolean readNextPage()
+    {
+        DataPage page = pageReader.readPage();
+        if (page == null) {
+            return false;
+        }
+
+        if (page instanceof DataPageV1) {
+            readFlatPageV1((DataPageV1) page);
+        }
+        else if (page instanceof DataPageV2) {
+            readFlatPageV2((DataPageV2) page);
+        }
+
+        remainingPageValueCount = page.getValueCount();
+        rowRanges.resetForNewPage(page.getFirstRowIndex());
+        return true;
+    }
+
+    private void readFlatPageV1(DataPageV1 page)
+    {
+        Slice buffer = page.getSlice();
+        ParquetEncoding definitionEncoding = page.getDefinitionLevelEncoding();
+
+        checkArgument(field.isRequired() || definitionEncoding == RLE, "Invalid definition level encoding: " + definitionEncoding);
+        int alreadyRead = 0;
+        if (definitionEncoding == RLE) {
+            // Definition levels are skipped from file when the max definition level is 0 as the bit-width required to store them is 0.
+            // This can happen for non-null (required) fields or nullable fields where all values are null.
+            // See org.apache.parquet.column.Encoding.RLE.getValuesReader for reference.
+            if (field.getDescriptor().getMaxDefinitionLevel() == 0) {
+                definitionLevelDecoder = new ZeroDefinitionLevelDecoder();
+            }
+            else {
+                int bufferSize = buffer.getInt(0); //  We need to read the size even if nulls are absent
+                definitionLevelDecoder = new NullsDecoder(buffer.slice(Integer.BYTES, bufferSize));
+                alreadyRead = bufferSize + Integer.BYTES;
+            }
+        }
+
+        valueDecoder = decodersProvider.create(page.getValueEncoding(), field, dictionary);
+        valueDecoder.init(new SimpleSliceInputStream(buffer.slice(alreadyRead, buffer.length() - alreadyRead)));
+    }
+
+    private void readFlatPageV2(DataPageV2 page)
+    {
+        int maxDefinitionLevel = field.getDescriptor().getMaxDefinitionLevel();
+        checkArgument(maxDefinitionLevel >= 0 && maxDefinitionLevel <= 1, "Invalid max definition level: " + maxDefinitionLevel);
+
+        definitionLevelDecoder = new NullsDecoder(page.getDefinitionLevels());
+
+        valueDecoder = decodersProvider.create(page.getDataEncoding(), field, dictionary);
+        valueDecoder.init(new SimpleSliceInputStream(page.getSlice()));
+    }
+
+    @Override
+    public boolean hasPageReader()
+    {
+        return pageReader != null;
+    }
+
+    @Override
+    public void setPageReader(PageReader pageReader, Optional<FilteredRowRanges> rowRanges)
+    {
+        this.pageReader = requireNonNull(pageReader, "pageReader");
+        DictionaryPage dictionaryPage = pageReader.readDictionaryPage();
+
+        // For dictionary based encodings - https://github.com/apache/parquet-format/blob/master/Encodings.md
+        if (dictionaryPage != null) {
+            try {
+                dictionary = dictionaryPage.getEncoding().initDictionary(field.getDescriptor(), dictionaryPage);
+            }
+            catch (IOException e) {
+                throw new ParquetDecodingException("could not decode the dictionary for " + field.getDescriptor(), e);
+            }
+        }
+        else {
+            dictionary = null;
+        }
+        checkArgument(pageReader.getTotalValueCount() > 0, "page is empty");
+        this.rowRanges = createRowRangesIterator(rowRanges);
+    }
+
+    @Override
+    public void prepareNextRead(int batchSize)
+    {
+        readOffset += nextBatchSize;
+        nextBatchSize = batchSize;
+    }
+
+    @Override
+    public ColumnChunk readPrimitive()
+    {
+        ColumnChunk columnChunk;
+        seek();
+        if (field.isRequired()) {
+            columnChunk = readNoNull();
+        }
+        else {
+            columnChunk = readNullable();
+        }
+
+        readOffset = 0;
+        nextBatchSize = 0;
+        return columnChunk;
+    }
+
+    private static void throwEndOfBatchException(int remainingInBatch)
+    {
+        throw new ParquetDecodingException(format("Corrupted Parquet file: extra %d values to be consumed when scanning current batch", remainingInBatch));
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/FlatDefinitionLevelDecoder.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/FlatDefinitionLevelDecoder.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+public interface FlatDefinitionLevelDecoder
+{
+    /**
+     * Populate 'values' with true for nulls and return the number of non-nulls encountered.
+     * 'values' array is assumed to be empty at the start of reading a batch, i.e. contain only false values.
+     */
+    int readNext(boolean[] values, int offset, int length);
+
+    /**
+     * Skip 'length' values and return the number of non-nulls encountered
+     */
+    int skip(int length);
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/IntColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/IntColumnAdapter.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.block.IntArrayBlock;
+
+import java.util.Optional;
+
+public class IntColumnAdapter
+        implements ColumnAdapter<int[]>
+{
+    public static final IntColumnAdapter INT_ADAPTER = new IntColumnAdapter();
+
+    @Override
+    public int[] createBuffer(int size)
+    {
+        return new int[size];
+    }
+
+    @Override
+    public Block createNonNullBlock(int size, int[] values)
+    {
+        return new IntArrayBlock(size, Optional.empty(), values);
+    }
+
+    @Override
+    public Block createNullableBlock(int size, boolean[] nulls, int[] values)
+    {
+        return new IntArrayBlock(size, Optional.of(nulls), values);
+    }
+
+    @Override
+    public void copyValue(int[] source, int sourceIndex, int[] destination, int destinationIndex)
+    {
+        destination[destinationIndex] = source[sourceIndex];
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/LongColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/LongColumnAdapter.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.block.LongArrayBlock;
+
+import java.util.Optional;
+
+public class LongColumnAdapter
+        implements ColumnAdapter<long[]>
+{
+    public static final LongColumnAdapter LONG_ADAPTER = new LongColumnAdapter();
+
+    @Override
+    public long[] createBuffer(int size)
+    {
+        return new long[size];
+    }
+
+    @Override
+    public Block createNonNullBlock(int size, long[] values)
+    {
+        return new LongArrayBlock(size, Optional.empty(), values);
+    }
+
+    @Override
+    public Block createNullableBlock(int size, boolean[] nulls, long[] values)
+    {
+        return new LongArrayBlock(size, Optional.of(nulls), values);
+    }
+
+    @Override
+    public void copyValue(long[] source, int sourceIndex, long[] destination, int destinationIndex)
+    {
+        destination[destinationIndex] = source[sourceIndex];
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/NullsDecoder.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/NullsDecoder.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import io.airlift.slice.Slice;
+import io.trino.parquet.reader.SimpleSliceInputStream;
+
+import java.util.Arrays;
+
+import static io.trino.parquet.ParquetReaderUtils.castToByteNegate;
+import static io.trino.parquet.ParquetReaderUtils.readUleb128Int;
+import static io.trino.parquet.reader.flat.BitPackingUtils.bitCount;
+import static io.trino.parquet.reader.flat.BitPackingUtils.unpack;
+import static java.lang.Math.min;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * The hybrid RLE/bit-packing encoding consists of multiple groups.
+ * Each group is either encoded as RLE or bit-packed
+ * <p>
+ * For a primitive column, the definition level is always either 0 (null) or 1 (non-null).
+ * Therefore, every value is decoded from a single bit and stored into a boolean array
+ * which stores false for non-null and true for null.
+ */
+public class NullsDecoder
+        implements FlatDefinitionLevelDecoder
+{
+    private final SimpleSliceInputStream input;
+
+    // Encoding type if decoding stopped in the middle of the group
+    private boolean isRle;
+    // Values left to decode in the current group
+    private int valuesLeftInGroup;
+    // With RLE encoding - the current value
+    private boolean rleValue;
+    // With bit-packing - the byte that has been partially read
+    private byte bitPackedValue;
+    // Number of bits already read in the current byte while reading bit-packed values
+    private int bitPackedValueOffset;
+
+    public NullsDecoder(Slice input)
+    {
+        this.input = new SimpleSliceInputStream(requireNonNull(input, "input is null"));
+    }
+
+    /**
+     * 'values' array needs to be empty, i.e. contain only false values.
+     */
+    @Override
+    public int readNext(boolean[] values, int offset, int length)
+    {
+        int nonNullCount = 0;
+        while (length > 0) {
+            if (valuesLeftInGroup == 0) {
+                readGroupHeader();
+            }
+
+            if (isRle) {
+                int chunkSize = min(length, valuesLeftInGroup);
+                // The contract of the method requires values array to be empty (i.e. filled with false)
+                // so action is required only if the value is equal to true
+                if (rleValue) {
+                    Arrays.fill(values, offset, offset + chunkSize, true);
+                }
+                nonNullCount += castToByteNegate(rleValue) * chunkSize;
+                valuesLeftInGroup -= chunkSize;
+
+                length -= chunkSize;
+                offset += chunkSize;
+            }
+            else if (bitPackedValueOffset != 0) { // bit-packed - read remaining bits of current byte
+                int remainingBits = Byte.SIZE - bitPackedValueOffset;
+                int chunkSize = min(remainingBits, length);
+                nonNullCount += unpack(values, offset, bitPackedValue, bitPackedValueOffset, bitPackedValueOffset + chunkSize);
+                valuesLeftInGroup -= chunkSize;
+                bitPackedValueOffset = (bitPackedValueOffset + chunkSize) % Byte.SIZE;
+
+                offset += chunkSize;
+                length -= chunkSize;
+            }
+            else { // bit-packed
+                // At this point we have only full bytes to read and valuesLeft is a multiplication of 8
+                int chunkSize = min(length, valuesLeftInGroup);
+                int leftToRead = chunkSize;
+                // All values read from input are inverted as Trino uses 1 for null but Parquet uses 1 for non-null value
+                while (leftToRead >= Long.SIZE) {
+                    nonNullCount += unpack(values, offset, ~input.readLong());
+                    offset += Long.SIZE;
+                    leftToRead -= Long.SIZE;
+                }
+                while (leftToRead >= Byte.SIZE) {
+                    nonNullCount += unpack(values, offset, (byte) ~input.readByte());
+                    offset += Byte.SIZE;
+                    leftToRead -= Byte.SIZE;
+                }
+                if (leftToRead > 0) {
+                    bitPackedValue = (byte) ~input.readByte();
+                    nonNullCount += unpack(values, offset, bitPackedValue, 0, leftToRead);
+                    bitPackedValueOffset += leftToRead;
+                    offset += leftToRead;
+                }
+                valuesLeftInGroup -= chunkSize;
+                length -= chunkSize;
+            }
+        }
+        return nonNullCount;
+    }
+
+    /**
+     * Skip 'length' values and return the number of non-nulls encountered
+     */
+    @Override
+    public int skip(int length)
+    {
+        int nonNullCount = 0;
+        while (length > 0) {
+            if (valuesLeftInGroup == 0) {
+                readGroupHeader();
+            }
+
+            if (isRle) {
+                int chunkSize = min(length, valuesLeftInGroup);
+                nonNullCount += castToByteNegate(rleValue) * chunkSize;
+                valuesLeftInGroup -= chunkSize;
+
+                length -= chunkSize;
+            }
+            else if (bitPackedValueOffset != 0) { // bit-packed - read remaining bits of current byte
+                int remainingBits = Byte.SIZE - bitPackedValueOffset;
+                int chunkSize = min(remainingBits, length);
+                int remainingPackedValue = (bitPackedValue & 0xff) >>> bitPackedValueOffset;
+                // In bitPackedValue 1's are nulls, so the number of non-nulls is
+                // chunkSize - bitCount(remainingBits up to chunkSize)
+                nonNullCount += chunkSize - bitCount((byte) (remainingPackedValue & ((1 << chunkSize) - 1)));
+                valuesLeftInGroup -= chunkSize;
+                bitPackedValueOffset = (bitPackedValueOffset + chunkSize) % Byte.SIZE;
+
+                length -= chunkSize;
+            }
+            else { // bit-packed
+                // At this point we have only full bytes to read and valuesLeft is a multiplication of 8
+                int chunkSize = min(length, valuesLeftInGroup);
+                int leftToRead = chunkSize;
+                // Parquet uses 1 for non-null value
+                while (leftToRead >= Long.SIZE) {
+                    nonNullCount += Long.bitCount(input.readLong());
+                    leftToRead -= Long.SIZE;
+                }
+                while (leftToRead >= Byte.SIZE) {
+                    nonNullCount += bitCount(input.readByte());
+                    leftToRead -= Byte.SIZE;
+                }
+                if (leftToRead > 0) {
+                    byte packedValue = input.readByte();
+                    nonNullCount += bitCount((byte) (packedValue & ((1 << leftToRead) - 1)));
+
+                    // Inverting packedValue as readNext expects 1 for null
+                    bitPackedValue = (byte) ~packedValue;
+                    bitPackedValueOffset += leftToRead;
+                }
+                valuesLeftInGroup -= chunkSize;
+                length -= chunkSize;
+            }
+        }
+        return nonNullCount;
+    }
+
+    private void readGroupHeader()
+    {
+        int header = readUleb128Int(input);
+        isRle = (header & 1) == 0;
+        valuesLeftInGroup = header >>> 1;
+        if (isRle) {
+            // We need to negate the value as we convert the "does exist" to "is null", hence "== 0"
+            rleValue = input.readByte() == 0;
+        }
+        else {
+            // Only full bytes are encoded
+            valuesLeftInGroup *= Byte.SIZE;
+        }
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/RowRangesIterator.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/RowRangesIterator.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import io.trino.parquet.reader.FilteredRowRanges;
+
+import java.util.Optional;
+import java.util.OptionalLong;
+
+public interface RowRangesIterator
+{
+    RowRangesIterator ALL_ROW_RANGES_ITERATOR = new AllRowRangesIterator();
+
+    int advanceRange(int chunkSize);
+
+    int seekForward(int chunkSize);
+
+    long skipToRangeStart();
+
+    void resetForNewPage(OptionalLong firstRowIndex);
+
+    class AllRowRangesIterator
+            implements RowRangesIterator
+    {
+        @Override
+        public int advanceRange(int chunkSize)
+        {
+            return chunkSize;
+        }
+
+        @Override
+        public int seekForward(int chunkSize)
+        {
+            return chunkSize;
+        }
+
+        @Override
+        public long skipToRangeStart()
+        {
+            return 0;
+        }
+
+        @Override
+        public void resetForNewPage(OptionalLong firstRowIndex) {}
+    }
+
+    static RowRangesIterator createRowRangesIterator(Optional<FilteredRowRanges> filteredRowRanges)
+    {
+        if (filteredRowRanges.isEmpty()) {
+            return ALL_ROW_RANGES_ITERATOR;
+        }
+        return new FilteredRowRangesIterator(filteredRowRanges.get());
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/RowRangesIterator.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/RowRangesIterator.java
@@ -30,6 +30,8 @@ public interface RowRangesIterator
 
     void resetForNewPage(OptionalLong firstRowIndex);
 
+    boolean isPageFullyConsumed(int pageValueCount);
+
     class AllRowRangesIterator
             implements RowRangesIterator
     {
@@ -53,6 +55,12 @@ public interface RowRangesIterator
 
         @Override
         public void resetForNewPage(OptionalLong firstRowIndex) {}
+
+        @Override
+        public boolean isPageFullyConsumed(int pageValueCount)
+        {
+            return true;
+        }
     }
 
     static RowRangesIterator createRowRangesIterator(Optional<FilteredRowRanges> filteredRowRanges)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ShortColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ShortColumnAdapter.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.block.ShortArrayBlock;
+
+import java.util.Optional;
+
+public class ShortColumnAdapter
+        implements ColumnAdapter<short[]>
+{
+    public static final ShortColumnAdapter SHORT_ADAPTER = new ShortColumnAdapter();
+
+    @Override
+    public short[] createBuffer(int size)
+    {
+        return new short[size];
+    }
+
+    @Override
+    public Block createNonNullBlock(int size, short[] values)
+    {
+        return new ShortArrayBlock(size, Optional.empty(), values);
+    }
+
+    @Override
+    public Block createNullableBlock(int size, boolean[] nulls, short[] values)
+    {
+        return new ShortArrayBlock(size, Optional.of(nulls), values);
+    }
+
+    @Override
+    public void copyValue(short[] source, int sourceIndex, short[] destination, int destinationIndex)
+    {
+        destination[destinationIndex] = source[sourceIndex];
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ZeroDefinitionLevelDecoder.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ZeroDefinitionLevelDecoder.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+public class ZeroDefinitionLevelDecoder
+        implements FlatDefinitionLevelDecoder
+{
+    @Override
+    public int readNext(boolean[] values, int offset, int length)
+    {
+        return 0;
+    }
+
+    @Override
+    public int skip(int length)
+    {
+        return 0;
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -89,6 +89,7 @@ public class ParquetWriter
     private final int chunkMaxLogicalBytes;
     private final Map<List<String>, Type> primitiveTypes;
     private final CompressionCodecName compressionCodecName;
+    private final boolean useBatchColumnReadersForVerification;
     private final Optional<DateTimeZone> parquetTimeZone;
 
     private final ImmutableList.Builder<RowGroup> rowGroupBuilder = ImmutableList.builder();
@@ -109,6 +110,7 @@ public class ParquetWriter
             ParquetWriterOptions writerOption,
             CompressionCodecName compressionCodecName,
             String trinoVersion,
+            boolean useBatchColumnReadersForVerification,
             Optional<DateTimeZone> parquetTimeZone,
             Optional<ParquetWriteValidationBuilder> validationBuilder)
     {
@@ -118,6 +120,7 @@ public class ParquetWriter
         this.primitiveTypes = requireNonNull(primitiveTypes, "primitiveTypes is null");
         this.writerOption = requireNonNull(writerOption, "writerOption is null");
         this.compressionCodecName = requireNonNull(compressionCodecName, "compressionCodecName is null");
+        this.useBatchColumnReadersForVerification = useBatchColumnReadersForVerification;
         this.parquetTimeZone = requireNonNull(parquetTimeZone, "parquetTimeZone is null");
         this.createdBy = formatCreatedBy(requireNonNull(trinoVersion, "trinoVersion is null"));
 
@@ -268,7 +271,7 @@ public class ParquetWriter
                 input,
                 parquetTimeZone.orElseThrow(),
                 newSimpleAggregatedMemoryContext(),
-                new ParquetReaderOptions(),
+                new ParquetReaderOptions().withBatchColumnReaders(useBatchColumnReadersForVerification),
                 exception -> {
                     throwIfUnchecked(exception);
                     return new RuntimeException(exception);

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkReadUleb128Int.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkReadUleb128Int.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.parquet.ParquetReaderUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.jmh.Benchmarks.benchmark;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.parquet.bytes.BytesUtils.writeUnsignedVarInt;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Measurement(iterations = 15, time = 500, timeUnit = MILLISECONDS)
+@Warmup(iterations = 10, time = 500, timeUnit = MILLISECONDS)
+@Fork(3)
+public class BenchmarkReadUleb128Int
+{
+    @Param({
+            "100",
+            "1000"
+    })
+    private int size;
+
+    @Param({
+            "20000",
+            "4000000"
+    })
+    private int maxValue;
+
+    private Slice[] inputValues;
+
+    public BenchmarkReadUleb128Int()
+    {
+        maxValue = Integer.MAX_VALUE;
+    }
+
+    public BenchmarkReadUleb128Int(int size, int maxValue)
+    {
+        this.size = size;
+        this.maxValue = maxValue;
+    }
+
+    @Setup
+    public void setUp()
+            throws IOException
+    {
+        inputValues = new Slice[size];
+        Random random = new Random(1);
+        for (int i = 0; i < size; i++) {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            writeUnsignedVarInt(random.nextInt(maxValue), bos);
+            inputValues[i] = Slices.wrappedBuffer(bos.toByteArray());
+        }
+    }
+
+    @Benchmark
+    public void readUleb128Int()
+    {
+        for (Slice input : inputValues) {
+            sink(ParquetReaderUtils.readUleb128Int(new SimpleSliceInputStream(input)));
+        }
+    }
+
+    @Benchmark
+    public void readUleb128IntLoop()
+    {
+        for (Slice input : inputValues) {
+            sink(readUleb128IntLoop(new SimpleSliceInputStream(input)));
+        }
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static void sink(int value)
+    {
+        // IT IS VERY IMPORTANT TO MATCH THE SIGNATURE TO AVOID AUTOBOXING.
+        // The method intentionally does nothing.
+    }
+
+    private static int readUleb128IntLoop(SimpleSliceInputStream input)
+    {
+        int value = 0;
+        int i = 0;
+        int b = input.readByte();
+        while ((b & 0x80) != 0) {
+            value |= (b & 0x7F) << i;
+            i += 7;
+            b = input.readByte();
+        }
+        return value | (b << i);
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        benchmark(BenchmarkReadUleb128Int.class)
+                .withOptions(optionsBuilder -> optionsBuilder.jvmArgsAppend("-Xmx4g", "-Xms4g"))
+                .run();
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkShortDecimalColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkShortDecimalColumnReader.java
@@ -124,7 +124,7 @@ public class BenchmarkShortDecimalColumnReader
     public int read()
             throws IOException
     {
-        PrimitiveColumnReader columnReader = PrimitiveColumnReader.createReader(field, UTC);
+        ColumnReader columnReader = ColumnReaderFactory.create(field, UTC);
         columnReader.setPageReader(new PageReader(UNCOMPRESSED, new LinkedList<>(dataPages), null, MAX_VALUES), null);
         int rowsRead = 0;
         while (rowsRead < MAX_VALUES) {

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkShortDecimalColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkShortDecimalColumnReader.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.OptionalLong;
 
 import static io.trino.jmh.Benchmarks.benchmark;
@@ -124,8 +125,8 @@ public class BenchmarkShortDecimalColumnReader
     public int read()
             throws IOException
     {
-        ColumnReader columnReader = ColumnReaderFactory.create(field, UTC);
-        columnReader.setPageReader(new PageReader(UNCOMPRESSED, new LinkedList<>(dataPages), null, MAX_VALUES), null);
+        ColumnReader columnReader = ColumnReaderFactory.create(field, UTC, true);
+        columnReader.setPageReader(new PageReader(UNCOMPRESSED, new LinkedList<>(dataPages), null, MAX_VALUES), Optional.empty());
         int rowsRead = 0;
         while (rowsRead < MAX_VALUES) {
             int remaining = MAX_VALUES - rowsRead;

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkShortDecimalColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkShortDecimalColumnReader.java
@@ -126,7 +126,7 @@ public class BenchmarkShortDecimalColumnReader
             throws IOException
     {
         ColumnReader columnReader = ColumnReaderFactory.create(field, UTC, true);
-        columnReader.setPageReader(new PageReader(UNCOMPRESSED, new LinkedList<>(dataPages), null, MAX_VALUES), Optional.empty());
+        columnReader.setPageReader(new PageReader(UNCOMPRESSED, new LinkedList<>(dataPages), null, MAX_VALUES, false), Optional.empty());
         int rowsRead = 0;
         while (rowsRead < MAX_VALUES) {
             int remaining = MAX_VALUES - rowsRead;

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReader.java
@@ -91,7 +91,7 @@ public class TestColumnReader
         List<TestingPage> testingPages = getTestingPages(nullPositionsProvider, pageRowRanges);
         reader.setPageReader(
                 getPageReader(testingPages, columnReaderInput.dictionaryEncoded()),
-                selectedRows.orElse(null));
+                selectedRows.map(FilteredRowRanges::new));
 
         int rowCount = selectedRows.map(ranges -> toIntExact(ranges.rowCount()))
                 .orElseGet(() -> pagesRowCount(testingPages));

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReader.java
@@ -359,7 +359,8 @@ public class TestColumnReader
                 UNCOMPRESSED,
                 inputPages,
                 dictionaryPage,
-                pagesRowCount(testingPages));
+                pagesRowCount(testingPages),
+                false);
     }
 
     private static List<DataPage> createDataPages(List<TestingPage> testingPage, ValuesWriter encoder)

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReaderFactory.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReaderFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.trino.parquet.PrimitiveField;
+import io.trino.parquet.reader.flat.FlatColumnReader;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.schema.PrimitiveType;
+import org.testng.annotations.Test;
+
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.joda.time.DateTimeZone.UTC;
+
+public class TestColumnReaderFactory
+{
+    @Test
+    public void testUseBatchedColumnReaders()
+    {
+        PrimitiveField field = new PrimitiveField(
+                INTEGER,
+                false,
+                new ColumnDescriptor(new String[] {"test"}, new PrimitiveType(OPTIONAL, INT32, "test"), 0, 1),
+                0);
+        assertThat(ColumnReaderFactory.create(field, UTC, false))
+                .isNotInstanceOf(FlatColumnReader.class);
+        assertThat(ColumnReaderFactory.create(field, UTC, true))
+                .isInstanceOf(FlatColumnReader.class);
+    }
+
+    @Test
+    public void testNestedColumnReaders()
+    {
+        PrimitiveField field = new PrimitiveField(
+                INTEGER,
+                false,
+                new ColumnDescriptor(new String[] {"level1", "level2"}, new PrimitiveType(OPTIONAL, INT32, "test"), 1, 2),
+                0);
+        assertThat(ColumnReaderFactory.create(field, UTC, false))
+                .isNotInstanceOf(FlatColumnReader.class);
+        assertThat(ColumnReaderFactory.create(field, UTC, true))
+                .isNotInstanceOf(FlatColumnReader.class);
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestData.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestData.java
@@ -14,7 +14,11 @@
 package io.trino.parquet.reader;
 
 import io.trino.spi.type.Decimals;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 import java.util.function.IntFunction;
 
@@ -48,6 +52,66 @@ public final class TestData
             value >>= Byte.SIZE;
         }
         return result;
+    }
+
+    public static boolean[] generateMixedData(Random r, int size, int maxGroupSize)
+    {
+        List<Boolean> mixedList = new ArrayList<>();
+        while (mixedList.size() < size) {
+            boolean isGroup = r.nextBoolean();
+            int groupSize = r.nextInt(maxGroupSize);
+            if (isGroup) {
+                boolean value = r.nextBoolean();
+                for (int i = 0; i < groupSize; i++) {
+                    mixedList.add(value);
+                }
+            }
+            else {
+                for (int i = 0; i < groupSize; i++) {
+                    mixedList.add(r.nextBoolean());
+                }
+            }
+        }
+        boolean[] result = new boolean[size];
+        for (int i = 0; i < size; i++) {
+            result[i] = mixedList.get(i);
+        }
+        return result;
+    }
+
+    public static int[] generateMixedData(Random r, int size, int maxGroupSize, int bitWidth)
+    {
+        IntList mixedList = new IntArrayList();
+        while (mixedList.size() < size) {
+            boolean isGroup = r.nextBoolean();
+            int groupSize = r.nextInt(maxGroupSize);
+            if (isGroup) {
+                int value = randomInt(r, bitWidth);
+                for (int i = 0; i < groupSize; i++) {
+                    mixedList.add(value);
+                }
+            }
+            else {
+                for (int i = 0; i < groupSize; i++) {
+                    mixedList.add(randomInt(r, bitWidth));
+                }
+            }
+        }
+        int[] result = new int[size];
+        mixedList.getElements(0, result, 0, size);
+        return result;
+    }
+
+    public static int randomInt(Random r, int bitWidth)
+    {
+        checkArgument(bitWidth <= 32 && bitWidth >= 0, "bit width must be in range 0 - 32 inclusive");
+        if (bitWidth == 32) {
+            return r.nextInt();
+        }
+        else if (bitWidth == 31) {
+            return r.nextInt() & ((1 << 31) - 1);
+        }
+        return r.nextInt(1 << bitWidth);
     }
 
     private static long randomLong(Random r, int bitWidth)

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReaderUtils.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReaderUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.airlift.slice.Slices;
+import org.apache.parquet.bytes.BytesUtils;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Random;
+
+import static io.trino.parquet.ParquetReaderUtils.readUleb128Int;
+import static io.trino.parquet.reader.TestData.randomInt;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestParquetReaderUtils
+{
+    @Test
+    public void testReadUleb128Int()
+            throws IOException
+    {
+        Random random = new Random(1);
+        for (int bitWidth = 1; bitWidth <= 32; bitWidth++) {
+            for (int i = 0; i < 10; i++) {
+                int value = randomInt(random, bitWidth);
+                SimpleSliceInputStream sliceInputStream = getSliceInputStream(BytesUtils::writeUnsignedVarInt, value);
+                assertThat(readUleb128Int(sliceInputStream))
+                        .isEqualTo(value);
+                assertThat(sliceInputStream.asSlice().length())
+                        .isEqualTo(0);
+            }
+        }
+    }
+
+    private static <T> SimpleSliceInputStream getSliceInputStream(ValuesWriter<T> writer, T value)
+            throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        writer.write(value, out);
+        return new SimpleSliceInputStream(Slices.wrappedBuffer(out.toByteArray()));
+    }
+
+    private interface ValuesWriter<T>
+    {
+        void write(T value, OutputStream out)
+                throws IOException;
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestingColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestingColumnReader.java
@@ -1,0 +1,875 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.math.IntMath;
+import com.google.common.math.LongMath;
+import com.google.common.primitives.Longs;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.parquet.DictionaryPage;
+import io.trino.plugin.base.type.DecodedTimestamp;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.ByteArrayBlock;
+import io.trino.spi.block.DictionaryBlock;
+import io.trino.spi.block.Int128ArrayBlock;
+import io.trino.spi.block.Int96ArrayBlock;
+import io.trino.spi.block.IntArrayBlock;
+import io.trino.spi.block.LongArrayBlock;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.block.ShortArrayBlock;
+import io.trino.spi.block.VariableWidthBlock;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.DoubleType;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.LongTimestampWithTimeZone;
+import io.trino.spi.type.TimeType;
+import io.trino.spi.type.TimeZoneKey;
+import io.trino.spi.type.Timestamps;
+import io.trino.spi.type.Type;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter;
+import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainBinaryDictionaryValuesWriter;
+import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainDoubleDictionaryValuesWriter;
+import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainFixedLenArrayDictionaryValuesWriter;
+import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainFloatDictionaryValuesWriter;
+import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainIntegerDictionaryValuesWriter;
+import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainLongDictionaryValuesWriter;
+import org.apache.parquet.column.values.plain.BooleanPlainValuesWriter;
+import org.apache.parquet.column.values.plain.FixedLenByteArrayPlainValuesWriter;
+import org.apache.parquet.column.values.plain.PlainValuesWriter;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.testng.annotations.DataProvider;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.math.BigInteger;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.IntFunction;
+import java.util.stream.Stream;
+
+import static io.trino.parquet.ParquetTypeUtils.getParquetEncoding;
+import static io.trino.parquet.ParquetTypeUtils.paddingBigInteger;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
+import static io.trino.spi.type.DateTimeEncoding.unpackZoneKey;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.Decimals.longTenToNth;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeType.TIME_MILLIS;
+import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_NANOS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_PICOS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_NANOS;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.UuidType.UUID;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.testing.DataProviders.cartesianProduct;
+import static io.trino.testing.DataProviders.toDataProvider;
+import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.max;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.ZoneOffset.UTC;
+import static java.time.temporal.ChronoField.NANO_OF_DAY;
+import static java.time.temporal.JulianFields.JULIAN_DAY;
+import static java.util.Objects.requireNonNull;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit.MICROS;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit.MILLIS;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit.NANOS;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.decimalType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.timeType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.timestampType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.uuidType;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT96;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestingColumnReader
+{
+    private static final Map<Type, Class<? extends Block>> BLOCK_CLASSES = ImmutableMap.<Type, Class<? extends Block>>builder()
+            .put(BooleanType.BOOLEAN, ByteArrayBlock.class)
+            .put(BIGINT, LongArrayBlock.class)
+            .put(INTEGER, IntArrayBlock.class)
+            .put(SMALLINT, ShortArrayBlock.class)
+            .put(TINYINT, ByteArrayBlock.class)
+            .put(REAL, IntArrayBlock.class)
+            .put(DoubleType.DOUBLE, LongArrayBlock.class)
+            .put(VARCHAR, VariableWidthBlock.class)
+            .put(DecimalType.createDecimalType(8, 0), LongArrayBlock.class)
+            .put(DecimalType.createDecimalType(38, 2), Int128ArrayBlock.class)
+            .put(TIME_MILLIS, LongArrayBlock.class)
+            .put(TIMESTAMP_MILLIS, LongArrayBlock.class)
+            .put(TIMESTAMP_TZ_MILLIS, LongArrayBlock.class)
+            .put(TIMESTAMP_TZ_NANOS, Int96ArrayBlock.class)
+            .put(TIMESTAMP_PICOS, Int96ArrayBlock.class)
+            .put(UUID, Int128ArrayBlock.class)
+            .buildOrThrow();
+
+    private static final IntFunction<DictionaryValuesWriter> DICTIONARY_INT_WRITER =
+            length -> new PlainIntegerDictionaryValuesWriter(Integer.MAX_VALUE, Encoding.RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
+    private static final IntFunction<DictionaryValuesWriter> DICTIONARY_LONG_WRITER =
+            length -> new PlainLongDictionaryValuesWriter(Integer.MAX_VALUE, Encoding.RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
+    private static final IntFunction<DictionaryValuesWriter> DICTIONARY_FIXED_LENGTH_WRITER =
+            length -> new PlainFixedLenArrayDictionaryValuesWriter(Integer.MAX_VALUE, length, Encoding.RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
+    private static final IntFunction<DictionaryValuesWriter> DICTIONARY_FLOAT_WRITER =
+            length -> new PlainFloatDictionaryValuesWriter(Integer.MAX_VALUE, Encoding.RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
+    private static final IntFunction<DictionaryValuesWriter> DICTIONARY_DOUBLE_WRITER =
+            length -> new PlainDoubleDictionaryValuesWriter(Integer.MAX_VALUE, Encoding.RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
+    private static final IntFunction<DictionaryValuesWriter> DICTIONARY_BINARY_WRITER =
+            length -> new PlainBinaryDictionaryValuesWriter(Integer.MAX_VALUE, Encoding.RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
+
+    private static final IntFunction<ValuesWriter> BOOLEAN_WRITER = length -> new BooleanPlainValuesWriter();
+    private static final IntFunction<ValuesWriter> FIXED_LENGTH_WRITER =
+            length -> new FixedLenByteArrayPlainValuesWriter(length, 1024, 1024, HeapByteBufferAllocator.getInstance());
+    public static final IntFunction<ValuesWriter> PLAIN_WRITER =
+            length -> new PlainValuesWriter(1024, 1024, HeapByteBufferAllocator.getInstance());
+    private static final Writer<Number> WRITE_BOOLEAN = (writer, values) -> {
+        Number[] result = new Number[values.length];
+        for (int i = 0; i < values.length; i++) {
+            if (values[i] != null) {
+                boolean value = values[i] % 2 == 1;
+                writer.writeBoolean(value);
+                result[i] = (byte) (value ? 1 : 0);
+            }
+        }
+        return result;
+    };
+    private static final Writer<Number> WRITE_BYTE = (writer, values) -> {
+        Number[] result = new Number[values.length];
+        for (int i = 0; i < values.length; i++) {
+            if (values[i] != null) {
+                writer.writeInteger(values[i]);
+                result[i] = values[i].byteValue();
+            }
+        }
+        return result;
+    };
+    private static final Writer<Number> WRITE_SHORT = (writer, values) -> {
+        Number[] result = new Number[values.length];
+        for (int i = 0; i < values.length; i++) {
+            if (values[i] != null) {
+                writer.writeInteger(values[i]);
+                result[i] = values[i].shortValue();
+            }
+        }
+        return result;
+    };
+    private static final Writer<Number> WRITE_INT = (writer, values) -> {
+        for (int i = 0; i < values.length; i++) {
+            if (values[i] != null) {
+                // 1001 work well for testing timestamp related types
+                values[i] *= 1001;
+                writer.writeInteger(values[i]);
+            }
+        }
+        return values;
+    };
+    private static final Writer<Number> WRITE_LONG = (writer, values) -> {
+        Number[] result = new Number[values.length];
+        for (int i = 0; i < values.length; i++) {
+            if (values[i] != null) {
+                // 1001001 work well for testing timestamp related types
+                long value = values[i].longValue();
+                writer.writeLong(value);
+                result[i] = value;
+            }
+        }
+        return result;
+    };
+    private static final Writer<Number> WRITE_LONG_TIMESTAMP = (writer, values) -> {
+        Number[] result = new Number[values.length];
+        for (int i = 0; i < values.length; i++) {
+            if (values[i] != null) {
+                // 1001001 work well for testing timestamp related types
+                long value = values[i].longValue() * 1001001;
+                writer.writeLong(value);
+                result[i] = value;
+            }
+        }
+        return result;
+    };
+    private static final Writer<Float> WRITE_FLOAT = (writer, values) -> {
+        Float[] result = new Float[values.length];
+        for (int i = 0; i < values.length; i++) {
+            if (values[i] != null) {
+                writer.writeFloat(values[i]);
+                result[i] = values[i].floatValue();
+            }
+        }
+        return result;
+    };
+    private static final Writer<Double> WRITE_DOUBLE = (writer, values) -> {
+        Double[] result = new Double[values.length];
+        for (int i = 0; i < values.length; i++) {
+            if (values[i] != null) {
+                writer.writeDouble(values[i]);
+                result[i] = values[i].doubleValue();
+            }
+        }
+        return result;
+    };
+    private static final Writer<Number> WRITE_SHORT_DECIMAL = (writer, values) -> {
+        for (Integer value : values) {
+            if (value != null) {
+                writer.writeBytes(Binary.fromConstantByteArray(Longs.toByteArray(value.longValue())));
+            }
+        }
+        return values;
+    };
+    private static final Writer<String> WRITE_BINARY = (writer, values) -> {
+        String[] result = new String[values.length];
+        for (int i = 0; i < values.length; i++) {
+            if (values[i] != null) {
+                String stringValue = Integer.toString(values[i]);
+                writer.writeBytes(Binary.fromCharSequence(stringValue));
+                result[i] = stringValue;
+            }
+        }
+        return result;
+    };
+    private static final Writer<Number> WRITE_BINARY_DECIMAL = (writer, values) -> {
+        Number[] result = new Number[values.length];
+        for (int i = 0; i < values.length; i++) {
+            if (values[i] != null) {
+                writer.writeBytes(Binary.fromConstantByteArray(BigInteger.valueOf(values[i]).toByteArray()));
+                result[i] = values[i];
+            }
+        }
+        return result;
+    };
+    private static final Writer<Number> WRITE_BINARY_LONG_DECIMAL = (writer, values) -> {
+        Number[] result = new Number[values.length * 2];
+        for (int i = 0; i < values.length; i++) {
+            if (values[i] != null) {
+                writer.writeBytes(Binary.fromConstantByteArray(BigInteger.valueOf(values[i]).toByteArray()));
+                result[2 * i] = 0;
+                result[2 * i + 1] = values[i];
+            }
+        }
+        return result;
+    };
+    private static final Writer<DecodedTimestamp> WRITE_INT96 = (writer, values) -> {
+        DecodedTimestamp[] result = new DecodedTimestamp[values.length];
+        for (int i = 0; i < values.length; i++) {
+            if (values[i] != null) {
+                // 1001001 work well for testing timestamp related types
+                long seconds = values[i].longValue() * 1001001;
+                int nanos = (int) (values[i].longValue() * 1111);
+                writer.writeBytes(encodeInt96Timestamp(seconds, nanos));
+                result[i] = new DecodedTimestamp(seconds, nanos);
+            }
+        }
+        return result;
+    };
+    private static final Writer<Number> WRITE_UUID = (writer, values) -> {
+        Number[] result = new Long[values.length * 2];
+        for (int i = 0; i < values.length; i++) {
+            if (values[i] != null) {
+                byte[] uuid = new byte[16];
+                byte value = values[i].byteValue();
+                for (int j = 0; j < 16; j++) {
+                    uuid[j] = (byte) (value + j);
+                }
+
+                result[2 * i] = Long.reverseBytes(Longs.fromByteArray(Arrays.copyOfRange(uuid, 0, 8)));
+                result[2 * i + 1] = Long.reverseBytes(Longs.fromByteArray(Arrays.copyOfRange(uuid, 8, 16)));
+                writer.writeBytes(Binary.fromConstantByteArray(uuid));
+            }
+        }
+        return result;
+    };
+
+    private static Writer<Number> writeLongDecimal(int typeLength)
+    {
+        return (writer, values) -> {
+            Number[] result = new Number[values.length * 2];
+            for (int i = 0; i < values.length; i++) {
+                if (values[i] != null) {
+                    writer.writeBytes(Binary.fromConstantByteArray(paddingBigInteger(BigInteger.valueOf(values[i]), typeLength)));
+                    Int128 longDecimal = Int128.valueOf(values[i]);
+                    result[2 * i] = longDecimal.getHigh();
+                    result[2 * i + 1] = longDecimal.getLow();
+                }
+            }
+            return result;
+        };
+    }
+
+    private static final Assertion<Number> ASSERT_BYTE = (values, block, offset, blockOffset) -> assertThat(block.getByte(blockOffset, 0)).isEqualTo(values[offset].byteValue());
+    private static final Assertion<Number> ASSERT_SHORT = (values, block, offset, blockOffset) -> assertThat(block.getShort(blockOffset, 0)).isEqualTo(values[offset].shortValue());
+    private static final Assertion<Number> ASSERT_INT = (values, block, offset, blockOffset) -> assertThat(block.getInt(blockOffset, 0)).isEqualTo(values[offset].intValue());
+    private static final Assertion<Float> ASSERT_FLOAT = (values, block, offset, blockOffset) -> assertThat(intBitsToFloat(block.getInt(blockOffset, 0))).isEqualTo(values[offset].floatValue());
+    private static final Assertion<Number> ASSERT_LONG = (values, block, offset, blockOffset) -> assertThat(block.getLong(blockOffset, 0)).isEqualTo(values[offset].longValue());
+    private static final Assertion<Double> ASSERT_DOUBLE = (values, block, offset, blockOffset) -> assertThat(Double.longBitsToDouble(block.getLong(blockOffset, 0))).isEqualTo(values[offset].doubleValue());
+    private static final Assertion<Number> ASSERT_INT_128 = new Assertion<>()
+    {
+        @Override
+        public void assertPosition(Number[] expected, Block block, int index, int blockIndex)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void assertBlock(Number[] expected, Block block, int offset, int blockOffset, int length)
+        {
+            for (int i = 0; i < length; i++) {
+                if (block.isNull(blockOffset + i)) {
+                    assertThat(expected[2 * (offset + i)]).isNull();
+                    assertThat(expected[2 * (offset + i) + 1]).isNull();
+                }
+                else {
+                    assertThat(block.getLong(blockOffset + i, 0)).isEqualTo(expected[2 * (offset + i)].longValue());
+                    assertThat(block.getLong(blockOffset + i, 8)).isEqualTo(expected[2 * (offset + i) + 1].longValue());
+                }
+            }
+        }
+
+        @Override
+        public void assertBlock(Number[] expected, Block block)
+        {
+            assertThat(expected.length).isEqualTo(block.getPositionCount() * 2);
+            assertBlock(expected, block, 0, 0, block.getPositionCount());
+        }
+    };
+
+    private static Assertion<Number> assertRescaled(int scale)
+    {
+        return (expected, block, index, blockIndex) -> {
+            long multiplier = longTenToNth(scale);
+            assertThat(block.getLong(blockIndex, 0)).isEqualTo(expected[index].longValue() * multiplier);
+        };
+    }
+
+    private static Assertion<Number> assertShortToLongRescaled(int scale)
+    {
+        long multiplier = longTenToNth(scale);
+        return (expected, block, index, blockIndex) -> {
+            assertThat(block.getLong(blockIndex, 0)).isEqualTo(0);
+            assertThat(block.getLong(blockIndex, 8)).isEqualTo(expected[index].longValue() * multiplier);
+        };
+    }
+
+    private static Assertion<Number> assertLongToShortRescaled(int scale)
+    {
+        long multiplier = longTenToNth(scale);
+        return new Assertion<>()
+        {
+            @Override
+            public void assertBlock(Number[] expected, Block block, int offset, int blockOffset, int length)
+            {
+                for (int i = 0; i < length; i++) {
+                    if (block.isNull(blockOffset + i)) {
+                        assertThat(expected[2 * (offset + i)]).isNull();
+                        assertThat(expected[2 * (offset + i) + 1]).isNull();
+                    }
+                    else {
+                        assertPosition(expected, block, offset + i, blockOffset + i);
+                    }
+                }
+            }
+
+            @Override
+            public void assertPosition(Number[] expected, Block block, int index, int blockIndex)
+            {
+                assertThat(block.getLong(blockIndex, 0)).isEqualTo(expected[2 * index + 1].longValue() * multiplier);
+            }
+
+            @Override
+            public void assertBlock(Number[] expected, Block block)
+            {
+                assertThat(expected.length).isEqualTo(block.getPositionCount() * 2);
+                assertBlock(expected, block, 0, 0, block.getPositionCount());
+            }
+        };
+    }
+
+    private static Assertion<Number> assertLongRescaled(int scale)
+    {
+        long multiplier = longTenToNth(scale);
+        return new Assertion<>()
+        {
+            @Override
+            public void assertBlock(Number[] expected, Block block, int offset, int blockOffset, int length)
+            {
+                for (int i = 0; i < length; i++) {
+                    if (block.isNull(blockOffset + i)) {
+                        assertThat(expected[2 * (offset + i)]).isNull();
+                        assertThat(expected[2 * (offset + i) + 1]).isNull();
+                    }
+                    else {
+                        assertPosition(expected, block, offset + i, blockOffset + i);
+                    }
+                }
+            }
+
+            @Override
+            public void assertPosition(Number[] expected, Block block, int index, int blockIndex)
+            {
+                assertThat(block.getLong(blockIndex, 0)).isEqualTo(0);
+                assertThat(block.getLong(blockIndex, 8)).isEqualTo(expected[2 * index + 1].longValue() * multiplier);
+            }
+
+            @Override
+            public void assertBlock(Number[] expected, Block block)
+            {
+                assertThat(expected.length).isEqualTo(block.getPositionCount() * 2);
+                assertBlock(expected, block, 0, 0, block.getPositionCount());
+            }
+        };
+    }
+
+    private static final Assertion<String> ASSERT_BINARY = (values, block, offset, blockOffset) -> {
+        int positionLength = block.getSliceLength(blockOffset);
+        assertThat(block.getSlice(blockOffset, 0, positionLength).getBytes()).isEqualTo(values[offset].getBytes(UTF_8));
+    };
+
+    private static Assertion<Number> assertTime(int precision)
+    {
+        return assertTime(precision, -precision);
+    }
+
+    private static Assertion<Number> assertTime(int precision, int rounding)
+    {
+        long multiplier = LongMath.pow(10, max(0, precision));
+        return (values, block, offset, blockOffset) -> {
+            long value = values[offset].longValue();
+            if (rounding > 0 | precision < 0) {
+                value = Timestamps.round(value, rounding) / LongMath.pow(10, -precision);
+            }
+            assertThat(block.getLong(blockOffset, 0)).isEqualTo(value * multiplier);
+        };
+    }
+
+    private static Assertion<DecodedTimestamp> assertInt96Short(int rounding)
+    {
+        return (values, block, offset, blockOffset) -> {
+            long epochSeconds = values[offset].getEpochSeconds();
+            int nanos = values[offset].getNanosOfSecond();
+            long epochNanos = epochSeconds * Timestamps.NANOSECONDS_PER_SECOND + nanos;
+            long expectedMicros = Timestamps.round(epochNanos, rounding) / 1000;
+
+            assertThat(block.getLong(blockOffset, 0)).isEqualTo(expectedMicros);
+        };
+    }
+
+    private static Assertion<DecodedTimestamp> assertInt96Long()
+    {
+        return (values, block, offset, blockOffset) -> {
+            long epochSeconds = values[offset].getEpochSeconds();
+            int nanos = values[offset].getNanosOfSecond();
+            long epochNanos = epochSeconds * Timestamps.NANOSECONDS_PER_SECOND + nanos;
+
+            long actualEpochMicros = block.getLong(blockOffset, 0);
+            long actualNanos = block.getInt(blockOffset, 8) / 1000;
+            long actualEpochNanos = actualEpochMicros * 1000 + actualNanos;
+            assertThat(actualEpochNanos).isEqualTo(epochNanos);
+        };
+    }
+
+    private static Assertion<DecodedTimestamp> assertInt96ShortWithTimezone()
+    {
+        return (values, block, offset, blockOffset) -> {
+            long epochSeconds = values[offset].getEpochSeconds();
+            int nanos = values[offset].getNanosOfSecond();
+            long epochNanos = epochSeconds * Timestamps.NANOSECONDS_PER_SECOND + nanos;
+            long expectedMillis = Timestamps.round(epochNanos, 6) / 1000000;
+
+            long packed = block.getLong(blockOffset, 0);
+            long blockMillis = unpackMillisUtc(packed);
+            TimeZoneKey timeZoneKey = unpackZoneKey(packed);
+            assertThat(timeZoneKey).isEqualTo(UTC_KEY);
+
+            assertThat(blockMillis).isEqualTo(expectedMillis);
+        };
+    }
+
+    private static Assertion<Number> assertLongTimestamp(int precision)
+    {
+        int multiplier = IntMath.pow(10, precision);
+        return (values, block, offset, blockOffset) ->
+        {
+            LongTimestamp value = (LongTimestamp) TIMESTAMP_PICOS.getObject(block, blockOffset);
+            // We ignore higher bits of long timestamp as we only test on small numbers
+            long longValue = (value.getEpochMicros() * 1_000_000) + value.getPicosOfMicro();
+            assertThat(longValue).isEqualTo(values[offset].longValue() * multiplier);
+        };
+    }
+
+    private static Assertion<Number> assertTimestampWithTimeZone(int precision)
+    {
+        return assertTimestampWithTimeZone(precision, -precision);
+    }
+
+    private static Assertion<Number> assertTimestampWithTimeZone(int precision, int rounding)
+    {
+        long multiplier = LongMath.pow(10, max(0, precision));
+        return (values, block, offset, blockOffset) ->
+        {
+            long packed = block.getLong(blockOffset, 0);
+            long millisUtc = unpackMillisUtc(packed);
+            TimeZoneKey timeZoneKey = unpackZoneKey(packed);
+            long value = values[offset].longValue();
+            if (rounding > 0 | precision < 0) {
+                value = Timestamps.round(value, rounding) / LongMath.pow(10, -precision);
+            }
+            assertThat(timeZoneKey).isEqualTo(UTC_KEY);
+            assertThat(millisUtc).isEqualTo(value * multiplier);
+        };
+    }
+
+    private static Assertion<Number> assertLongTimestampWithTimeZone(int precision)
+    {
+        long multiplier = LongMath.pow(10, precision);
+        return (values, block, offset, blockOffset) ->
+        {
+            LongTimestampWithTimeZone packed = (LongTimestampWithTimeZone) TIMESTAMP_TZ_NANOS.getObject(block, blockOffset);
+            long longValue = (packed.getEpochMillis() * 1_000_000_000) + packed.getPicosOfMilli();
+            TimeZoneKey timeZoneKey = TimeZoneKey.getTimeZoneKey(packed.getTimeZoneKey());
+            long value = values[offset].longValue();
+            assertThat(timeZoneKey).isEqualTo(UTC_KEY);
+            assertThat(longValue).isEqualTo(value * multiplier);
+        };
+    }
+
+    private TestingColumnReader() {}
+
+    public enum DataPageVersion
+    {
+        V1, V2
+    }
+
+    public static DictionaryPage getDictionaryPage(DictionaryValuesWriter dictionaryWriter)
+    {
+        org.apache.parquet.column.page.DictionaryPage apacheDictionaryPage = dictionaryWriter.toDictPageAndClose();
+        return toTrinoDictionaryPage(apacheDictionaryPage);
+    }
+
+    public static DictionaryPage toTrinoDictionaryPage(org.apache.parquet.column.page.DictionaryPage dictionary)
+    {
+        try {
+            return new DictionaryPage(
+                    Slices.wrappedBuffer(dictionary.getBytes().toByteArray()),
+                    dictionary.getDictionarySize(),
+                    getParquetEncoding(dictionary.getEncoding()));
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @DataProvider(name = "readersWithPageVersions")
+    public static Object[][] readersWithPageVersions()
+    {
+        return cartesianProduct(
+                Stream.of(DataPageVersion.V1, DataPageVersion.V2).collect(toDataProvider()),
+                Stream.of(TestingColumnReader.columnReaders()).collect(toDataProvider()));
+    }
+
+    @DataProvider(name = "dictionaryReadersWithPageVersions")
+    public static Object[][] dictionaryReadersWithPageVersions()
+    {
+        return cartesianProduct(
+                Stream.of(DataPageVersion.V1, DataPageVersion.V2).collect(toDataProvider()),
+                Arrays.stream(TestingColumnReader.columnReaders())
+                        .filter(reader -> reader.dictionaryWriterProvider != null)
+                        .collect(toDataProvider()));
+    }
+
+    private static Binary encodeInt96Timestamp(long epochSeconds, int nanos)
+    {
+        LocalDateTime javaTime = LocalDateTime.ofEpochSecond(epochSeconds, nanos, UTC);
+        Slice slice = Slices.allocate(12);
+        slice.setLong(0, NANO_OF_DAY.getFrom(javaTime));
+        slice.setInt(8, (int) JULIAN_DAY.getFrom(javaTime));
+
+        return Binary.fromConstantByteArray(slice.getBytes());
+    }
+
+    /**
+     * These types should correspond to the column readers in {@link ColumnReaderFactory} class.
+     * This method is a de-facto definition of all supported types and coercions of the optimized Parquet Reader.
+     * All supported types should be added here.
+     */
+    private static ColumnReaderFormat<?>[] columnReaders()
+    {
+        return new ColumnReaderFormat[] {
+                new ColumnReaderFormat<>(BOOLEAN, BooleanType.BOOLEAN, BOOLEAN_WRITER, null, WRITE_BOOLEAN, ASSERT_BYTE),
+                new ColumnReaderFormat<>(FLOAT, REAL, PLAIN_WRITER, DICTIONARY_FLOAT_WRITER, WRITE_FLOAT, ASSERT_FLOAT),
+                new ColumnReaderFormat<>(DOUBLE, DoubleType.DOUBLE, PLAIN_WRITER, DICTIONARY_DOUBLE_WRITER, WRITE_DOUBLE, ASSERT_DOUBLE),
+                new ColumnReaderFormat<>(INT32, decimalType(0, 8), createDecimalType(8), PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, ASSERT_INT),
+                new ColumnReaderFormat<>(INT32, BIGINT, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, ASSERT_LONG),
+                new ColumnReaderFormat<>(INT32, INTEGER, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, ASSERT_INT),
+                new ColumnReaderFormat<>(INT32, SMALLINT, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_SHORT, ASSERT_SHORT),
+                new ColumnReaderFormat<>(INT32, TINYINT, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_BYTE, ASSERT_BYTE),
+                new ColumnReaderFormat<>(BINARY, VARCHAR, PLAIN_WRITER, DICTIONARY_BINARY_WRITER, WRITE_BINARY, ASSERT_BINARY),
+                new ColumnReaderFormat<>(INT64, decimalType(0, 16), createDecimalType(16), PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, ASSERT_LONG),
+                new ColumnReaderFormat<>(INT64, BIGINT, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, ASSERT_LONG),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 2), createDecimalType(2), FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_SHORT_DECIMAL, ASSERT_LONG),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 16, decimalType(2, 38), createDecimalType(38, 2), FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, writeLongDecimal(16), ASSERT_INT_128),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 16, uuidType(), UUID, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_UUID, ASSERT_INT_128),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 16, null, UUID, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_UUID, ASSERT_INT_128),
+                // Trino type precision is irrelevant since the data is always stored as picoseconds
+                new ColumnReaderFormat<>(INT64, timeType(false, MICROS), TimeType.TIME_MICROS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, assertTime(6)),
+                // Short decimals
+                new ColumnReaderFormat<>(INT32, decimalType(0, 8), createDecimalType(8), PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, ASSERT_INT),
+                new ColumnReaderFormat<>(INT32, createDecimalType(9), PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, ASSERT_INT),
+                new ColumnReaderFormat<>(INT32, decimalType(0, 8), BIGINT, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, ASSERT_LONG),
+                new ColumnReaderFormat<>(INT32, decimalType(0, 8), INTEGER, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, ASSERT_INT),
+                new ColumnReaderFormat<>(INT32, decimalType(0, 8), SMALLINT, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_SHORT, ASSERT_SHORT),
+                new ColumnReaderFormat<>(INT32, decimalType(0, 8), TINYINT, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_BYTE, ASSERT_BYTE),
+                new ColumnReaderFormat<>(INT64, decimalType(0, 8), createDecimalType(8), PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, ASSERT_LONG),
+                new ColumnReaderFormat<>(INT64, decimalType(0, 8), BIGINT, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, ASSERT_LONG),
+                new ColumnReaderFormat<>(INT64, decimalType(0, 8), INTEGER, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, ASSERT_INT),
+                new ColumnReaderFormat<>(INT64, decimalType(0, 8), SMALLINT, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, ASSERT_SHORT),
+                new ColumnReaderFormat<>(INT64, decimalType(0, 8), TINYINT, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, ASSERT_BYTE),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 2), createDecimalType(2), FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_SHORT_DECIMAL, ASSERT_LONG),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 2), BIGINT, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_SHORT_DECIMAL, ASSERT_LONG),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 2), INTEGER, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_SHORT_DECIMAL, ASSERT_INT),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 2), SMALLINT, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_SHORT_DECIMAL, ASSERT_SHORT),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 2), TINYINT, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_SHORT_DECIMAL, ASSERT_BYTE),
+                new ColumnReaderFormat<>(BINARY, decimalType(0, 8), createDecimalType(8), PLAIN_WRITER, DICTIONARY_BINARY_WRITER, WRITE_BINARY_DECIMAL, ASSERT_LONG),
+                new ColumnReaderFormat<>(BINARY, decimalType(0, 8), BIGINT, PLAIN_WRITER, DICTIONARY_BINARY_WRITER, WRITE_BINARY_DECIMAL, ASSERT_LONG),
+                new ColumnReaderFormat<>(BINARY, decimalType(0, 8), INTEGER, PLAIN_WRITER, DICTIONARY_BINARY_WRITER, WRITE_BINARY_DECIMAL, ASSERT_INT),
+                new ColumnReaderFormat<>(BINARY, decimalType(0, 8), SMALLINT, PLAIN_WRITER, DICTIONARY_BINARY_WRITER, WRITE_BINARY_DECIMAL, ASSERT_SHORT),
+                new ColumnReaderFormat<>(BINARY, decimalType(0, 8), TINYINT, PLAIN_WRITER, DICTIONARY_BINARY_WRITER, WRITE_BINARY_DECIMAL, ASSERT_BYTE),
+                // Long decimals
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 16, decimalType(2, 38), createDecimalType(38, 2), FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, writeLongDecimal(16), ASSERT_INT_128),
+                new ColumnReaderFormat<>(BINARY, 16, decimalType(2, 38), createDecimalType(38, 2), PLAIN_WRITER, DICTIONARY_BINARY_WRITER, WRITE_BINARY_LONG_DECIMAL, ASSERT_INT_128),
+                // Rescaled decimals
+                new ColumnReaderFormat<>(INT32, decimalType(0, 7), createDecimalType(8, 1), PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, assertRescaled(1)),
+                new ColumnReaderFormat<>(INT64, decimalType(0, 7), createDecimalType(8, 2), PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, assertRescaled(2)),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 7), createDecimalType(8, 3), FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_SHORT_DECIMAL, assertRescaled(3)),
+                new ColumnReaderFormat<>(INT32, decimalType(0, 7), createDecimalType(30, 1), PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, assertShortToLongRescaled(1)),
+                new ColumnReaderFormat<>(INT64, decimalType(0, 7), createDecimalType(30, 2), PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, assertShortToLongRescaled(2)),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 7), createDecimalType(30, 3), FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_SHORT_DECIMAL, assertShortToLongRescaled(3)),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 16, decimalType(0, 38), createDecimalType(8, 1), FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, writeLongDecimal(16), assertLongToShortRescaled(1)),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 16, decimalType(0, 38), createDecimalType(37, 2), FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, writeLongDecimal(16), assertLongRescaled(2)),
+                // Timestamps.
+                //  The `precision` and `rounding` arguments at the end of every assertion may be difficult to understand. They are a direct
+                // consequence of various Trino timestamp representations.
+                new ColumnReaderFormat<>(INT64, timestampType(false, MILLIS), TIMESTAMP_MICROS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertTime(3)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, MILLIS), TIMESTAMP_PICOS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertLongTimestamp(9)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, MILLIS), TIMESTAMP_TZ_MILLIS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertTimestampWithTimeZone(0)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, MICROS), TIMESTAMP_MILLIS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertTime(0, 3)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, MICROS), TIMESTAMP_MICROS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertTime(0)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, MICROS), TIMESTAMP_NANOS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertLongTimestamp(6)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, MICROS), TIMESTAMP_TZ_MILLIS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertTimestampWithTimeZone(-3, 3)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, MICROS), TIMESTAMP_TZ_NANOS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertLongTimestampWithTimeZone(6)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, NANOS), TIMESTAMP_MILLIS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertTime(-3, 6)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, NANOS), TIMESTAMP_MICROS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertTime(-3)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, NANOS), TIMESTAMP_NANOS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertLongTimestamp(3)),
+                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_MILLIS, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_INT96, assertInt96Short(6)),
+                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_MICROS, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_INT96, assertInt96Short(3)),
+                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_NANOS, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_INT96, assertInt96Long()),
+                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_PICOS, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_INT96, assertInt96Long()),
+                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_TZ_MILLIS, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_INT96, assertInt96ShortWithTimezone()),
+                // timestamps read as bigint
+                new ColumnReaderFormat<>(INT64, timestampType(false, MILLIS), BIGINT, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, ASSERT_LONG),
+                new ColumnReaderFormat<>(INT64, timestampType(false, MICROS), BIGINT, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, ASSERT_LONG),
+                new ColumnReaderFormat<>(INT64, timestampType(false, NANOS), BIGINT, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, ASSERT_LONG)};
+    }
+
+    // Simple helper interface that writes given data into the parquet writer
+    // and returns buffer that can be used for asserting the results
+    // The values are always int, and they should be somehow "mapped" to the resulting
+    // type e.g. 1 -> "1" for varchar type
+    private interface Writer<BUFFER>
+    {
+        BUFFER[] write(ValuesWriter parquetWriter, Integer[] values);
+
+        default BUFFER[] resetAndWrite(ValuesWriter parquetWriter, Integer[] values)
+        {
+            parquetWriter.reset();
+            return write(parquetWriter, values);
+        }
+    }
+
+    private interface Assertion<BUFFER>
+    {
+        void assertPosition(BUFFER[] expected, Block block, int index, int blockIndex);
+
+        default void assertBlock(BUFFER[] expected, Block block, int offset, int blockOffset, int length)
+        {
+            for (int i = 0; i < length; i++) {
+                if (block.isNull(blockOffset + i)) {
+                    assertThat(expected[offset + i]).isNull();
+                }
+                else {
+                    assertPosition(expected, block, offset + i, blockOffset + i);
+                }
+            }
+        }
+
+        default void assertBlock(BUFFER[] expected, Block block)
+        {
+            assertThat(expected.length).isEqualTo(block.getPositionCount());
+            assertBlock(expected, block, 0, 0, block.getPositionCount());
+        }
+    }
+
+    public static class ColumnReaderFormat<T>
+            implements Assertion<T>, Writer<T>
+    {
+        private final PrimitiveTypeName typeName;
+        private final int typeLengthInBytes;
+        @Nullable
+        private final LogicalTypeAnnotation logicalTypeAnnotation;
+        private final Type trinoType;
+        private final IntFunction<ValuesWriter> plainWriterProvider;
+        @Nullable
+        private final IntFunction<DictionaryValuesWriter> dictionaryWriterProvider;
+        private final Writer<T> writerFunction;
+        private final Assertion<T> assertion;
+
+        public ColumnReaderFormat(
+                PrimitiveTypeName typeName,
+                Type trinoType,
+                IntFunction<ValuesWriter> plainWriterProvider,
+                @Nullable IntFunction<DictionaryValuesWriter> dictionaryWriterProvider,
+                Writer<T> writerFunction,
+                Assertion<T> assertion)
+        {
+            this(typeName, null, trinoType, plainWriterProvider, dictionaryWriterProvider, writerFunction, assertion);
+        }
+
+        public ColumnReaderFormat(
+                PrimitiveTypeName typeName,
+                @Nullable LogicalTypeAnnotation logicalTypeAnnotation,
+                Type trinoType,
+                IntFunction<ValuesWriter> plainWriterProvider,
+                @Nullable IntFunction<DictionaryValuesWriter> dictionaryWriterProvider,
+                Writer<T> writerFunction,
+                Assertion<T> assertion)
+        {
+            this(typeName, -1, logicalTypeAnnotation, trinoType, plainWriterProvider, dictionaryWriterProvider, writerFunction, assertion);
+        }
+
+        public ColumnReaderFormat(
+                PrimitiveTypeName typeName,
+                int typeLengthInBytes,
+                @Nullable LogicalTypeAnnotation logicalTypeAnnotation,
+                Type trinoType,
+                IntFunction<ValuesWriter> plainWriterProvider,
+                @Nullable IntFunction<DictionaryValuesWriter> dictionaryWriterProvider,
+                Writer<T> writerFunction,
+                Assertion<T> assertion)
+        {
+            this.typeName = requireNonNull(typeName, "typeName is null");
+            this.typeLengthInBytes = typeLengthInBytes;
+            this.logicalTypeAnnotation = logicalTypeAnnotation;
+            this.trinoType = requireNonNull(trinoType, "trinoType is null");
+            this.plainWriterProvider = requireNonNull(plainWriterProvider, "plainWriterSupplier is null");
+            this.dictionaryWriterProvider = dictionaryWriterProvider;
+            this.writerFunction = requireNonNull(writerFunction, "writerFunction is null");
+            this.assertion = requireNonNull(assertion, "assertion is null");
+        }
+
+        public PrimitiveTypeName getTypeName()
+        {
+            return typeName;
+        }
+
+        public int getTypeLengthInBytes()
+        {
+            return typeLengthInBytes;
+        }
+
+        @Nullable
+        public LogicalTypeAnnotation getLogicalTypeAnnotation()
+        {
+            return logicalTypeAnnotation;
+        }
+
+        public Type getTrinoType()
+        {
+            return trinoType;
+        }
+
+        public ValuesWriter getPlainWriter()
+        {
+            return plainWriterProvider.apply(typeLengthInBytes);
+        }
+
+        public DictionaryValuesWriter getDictionaryWriter()
+        {
+            return requireNonNull(dictionaryWriterProvider, "dictionaryWriterProvider is null").apply(typeLengthInBytes);
+        }
+
+        @Override
+        public T[] write(ValuesWriter parquetWriter, Integer[] values)
+        {
+            return writerFunction.write(parquetWriter, values);
+        }
+
+        @Override
+        public void assertPosition(T[] expected, Block block, int index, int blockIndex)
+        {
+            assertion.assertPosition(expected, block, index, blockIndex);
+        }
+
+        @Override
+        public void assertBlock(T[] expected, Block block)
+        {
+            Class<? extends Block> blockClass = BLOCK_CLASSES.entrySet().stream()
+                    .filter(entry -> entry.getKey().getClass().isAssignableFrom(trinoType.getClass()))
+                    .map(Entry::getValue)
+                    .findFirst()
+                    .orElseThrow();
+            if (block.getClass() != RunLengthEncodedBlock.class && block.getClass() != DictionaryBlock.class) {
+                assertThat(block).isInstanceOf(blockClass);
+            }
+            assertion.assertBlock(expected, block);
+        }
+
+        @Override
+        public void assertBlock(T[] expected, Block block, int offset, int blockOffset, int length)
+        {
+            assertion.assertBlock(expected, block, offset, blockOffset, length);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "ColumnReaderFormat{" +
+                    "typeName=" + typeName +
+                    ", typeLengthInBytes=" + typeLengthInBytes +
+                    ", logicalTypeAnnotation=" + logicalTypeAnnotation +
+                    ", trinoType=" + trinoType +
+                    '}';
+        }
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/BenchmarkFlatDefinitionLevelDecoder.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/BenchmarkFlatDefinitionLevelDecoder.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import io.airlift.slice.Slices;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridEncoder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.parquet.reader.TestData.generateMixedData;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Measurement(iterations = 20, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+public class BenchmarkFlatDefinitionLevelDecoder
+{
+    public static final int BATCH_SIZE = 1024;
+
+    @Param({
+            "1000",
+            "10000",
+            "100000",
+    })
+    private int size;
+
+    @Param({
+            "RANDOM",
+            "ONLY_NULLS",
+            "ONLY_NON_NULLS",
+            "MIXED_RANDOM_AND_SMALL_GROUPS",
+            "MIXED_RANDOM_AND_BIG_GROUPS",
+    })
+    private DataGenerator dataGenerator;
+
+    private byte[] data;
+    // Dummy output array
+    private boolean[] output;
+
+    public BenchmarkFlatDefinitionLevelDecoder()
+    {
+    }
+
+    public BenchmarkFlatDefinitionLevelDecoder(int size, DataGenerator dataGenerator)
+    {
+        this.size = size;
+        this.dataGenerator = dataGenerator;
+    }
+
+    @Setup
+    public void setup()
+            throws IOException
+    {
+        data = dataGenerator.getData(size);
+        output = new boolean[size];
+    }
+
+    @Benchmark
+    public int read()
+            throws IOException
+    {
+        NullsDecoder decoder = new NullsDecoder(Slices.wrappedBuffer(data));
+        int nonNullCount = 0;
+        for (int i = 0; i < size; i += BATCH_SIZE) {
+            nonNullCount += decoder.readNext(output, i, Math.min(BATCH_SIZE, size - i));
+        }
+        return nonNullCount;
+    }
+
+    public enum DataGenerator
+    {
+        RANDOM {
+            @Override
+            public void generate(RunLengthBitPackingHybridEncoder encoder, Random random, int size)
+                    throws IOException
+            {
+                for (int i = 0; i < size; i++) {
+                    encoder.writeInt(random.nextBoolean() ? 1 : 0);
+                }
+            }
+        },
+        ONLY_NULLS {
+            @Override
+            public void generate(RunLengthBitPackingHybridEncoder encoder, Random random, int size)
+                    throws IOException
+            {
+                for (int i = 0; i < size; i++) {
+                    encoder.writeInt(0);
+                }
+            }
+        },
+        ONLY_NON_NULLS {
+            @Override
+            public void generate(RunLengthBitPackingHybridEncoder encoder, Random random, int size)
+                    throws IOException
+            {
+                for (int i = 0; i < size; i++) {
+                    encoder.writeInt(1);
+                }
+            }
+        },
+        MIXED_RANDOM_AND_SMALL_GROUPS {
+            @Override
+            public void generate(RunLengthBitPackingHybridEncoder encoder, Random random, int size)
+                    throws IOException
+            {
+                boolean[] data = generateMixedData(random, size, 23);
+                for (int i = 0; i < size; i++) {
+                    encoder.writeInt(data[i] ? 1 : 0);
+                }
+            }
+        },
+        MIXED_RANDOM_AND_BIG_GROUPS {
+            @Override
+            public void generate(RunLengthBitPackingHybridEncoder encoder, Random random, int size)
+                    throws IOException
+            {
+                boolean[] data = generateMixedData(random, size, 127);
+                for (int i = 0; i < size; i++) {
+                    encoder.writeInt(data[i] ? 1 : 0);
+                }
+            }
+        },
+        /**/;
+
+        public abstract void generate(RunLengthBitPackingHybridEncoder encoder, Random random, int size)
+                throws IOException;
+
+        public byte[] getData(int size)
+                throws IOException
+        {
+            Random random = new Random(1);
+            RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(1, size, size, HeapByteBufferAllocator.getInstance());
+            generate(encoder, random, size);
+            return encoder.toBytes().toByteArray();
+        }
+
+        DataGenerator()
+        {
+        }
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        benchmark(BenchmarkFlatDefinitionLevelDecoder.class)
+                .withOptions(optionsBuilder -> optionsBuilder.jvmArgsAppend("-Xmx4g", "-Xms4g"))
+                .run();
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/TestBitPackingUtils.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/TestBitPackingUtils.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import org.testng.annotations.Test;
+
+import java.util.Random;
+
+import static io.trino.parquet.reader.flat.BitPackingUtils.bitCount;
+import static io.trino.parquet.reader.flat.BitPackingUtils.unpack;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestBitPackingUtils
+{
+    @Test
+    public void testBitCount()
+    {
+        for (int i = 0; i < 256; i++) {
+            int count = bitCount((byte) i);
+            assertThat(count).isEqualTo(Integer.bitCount(i));
+        }
+    }
+
+    @Test
+    public void testUnpack()
+    {
+        Random random = new Random(0);
+        boolean[] values = new boolean[100 + 8];
+        for (int packedByte = 0; packedByte < 256; packedByte++) {
+            for (int start = 0; start < 8; start++) {
+                for (int end = start + 1; end <= 8; end++) {
+                    int offset = random.nextInt(100);
+                    int nonNullCount = unpack(values, offset, (byte) packedByte, start, end);
+                    assertThat(nonNullCount).isEqualTo((end - start) - Integer.bitCount(selectBits(packedByte, start, end)));
+
+                    for (int bit = start; bit < end; bit++) {
+                        assertThat(values[offset + bit - start]).isEqualTo(((packedByte >>> bit) & 1) == 1);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testUnpack8()
+    {
+        Random random = new Random(0);
+        boolean[] values = new boolean[100 + 8];
+        for (int packedByte = 0; packedByte < 256; packedByte++) {
+            int offset = random.nextInt(100);
+            int nonNullCount = unpack(values, offset, (byte) packedByte);
+            assertThat(nonNullCount).isEqualTo(8 - Integer.bitCount(packedByte));
+
+            for (int bit = 0; bit < 8; bit++) {
+                assertThat(values[offset + bit]).isEqualTo(((packedByte >>> bit) & 1) == 1);
+            }
+        }
+    }
+
+    @Test
+    public void testUnpack64()
+    {
+        Random random = new Random(1);
+        boolean[] values = new boolean[100 + 64];
+        for (int i = 0; i < 100_000; i++) {
+            int offset = random.nextInt(100);
+            long packedValue = random.nextLong();
+            int nonNullCount = unpack(values, offset, packedValue);
+            assertThat(nonNullCount).isEqualTo(64 - Long.bitCount(packedValue));
+
+            for (int bit = 0; bit < 64; bit++) {
+                assertThat(values[offset + bit]).isEqualTo(((packedValue >>> bit) & 1) == 1);
+            }
+        }
+    }
+
+    private static int selectBits(int packedByte, int start, int end)
+    {
+        return (packedByte >>> start) & ((1 << (end - start)) - 1);
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/TestFlatColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/TestFlatColumnReader.java
@@ -1,0 +1,558 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.parquet.DataPage;
+import io.trino.parquet.DataPageV1;
+import io.trino.parquet.DataPageV2;
+import io.trino.parquet.DictionaryPage;
+import io.trino.parquet.ParquetEncoding;
+import io.trino.parquet.PrimitiveField;
+import io.trino.parquet.reader.ColumnReader;
+import io.trino.parquet.reader.ColumnReaderFactory;
+import io.trino.parquet.reader.PageReader;
+import io.trino.parquet.reader.TestingColumnReader;
+import io.trino.parquet.reader.TestingColumnReader.ColumnReaderFormat;
+import io.trino.parquet.reader.TestingColumnReader.DataPageVersion;
+import io.trino.parquet.reader.decoders.ValueDecoders;
+import io.trino.spi.block.Block;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesWriter;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.apache.parquet.schema.Types.PrimitiveBuilder;
+import org.testng.annotations.Test;
+
+import javax.annotation.Nullable;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static io.airlift.slice.Slices.EMPTY_SLICE;
+import static io.trino.parquet.ParquetEncoding.BIT_PACKED;
+import static io.trino.parquet.ParquetEncoding.PLAIN;
+import static io.trino.parquet.ParquetEncoding.RLE;
+import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
+import static io.trino.parquet.reader.TestingColumnReader.DataPageVersion.V1;
+import static io.trino.parquet.reader.TestingColumnReader.PLAIN_WRITER;
+import static io.trino.parquet.reader.TestingColumnReader.getDictionaryPage;
+import static io.trino.parquet.reader.flat.IntColumnAdapter.INT_ADAPTER;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static java.util.Objects.requireNonNull;
+import static org.apache.parquet.hadoop.metadata.CompressionCodecName.UNCOMPRESSED;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.joda.time.DateTimeZone.UTC;
+
+/**
+ * The purpose of this class is to cover all code paths of FlatColumnReader with all supported data types.
+ * Many methods have the same signature, even though they do not use some arguments. This is for the
+ * purpose of reusing the testng data providers.
+ */
+public class TestFlatColumnReader
+{
+    private static final PrimitiveType TYPE = new PrimitiveType(REQUIRED, INT32, "");
+    private static final PrimitiveField NULLABLE_FIELD = new PrimitiveField(INTEGER, false, new ColumnDescriptor(new String[] {}, TYPE, 0, 0), 0);
+    private static final PrimitiveField FIELD = new PrimitiveField(INTEGER, true, new ColumnDescriptor(new String[] {}, TYPE, 0, 0), 0);
+
+    private final String[] fieldPath;
+
+    public TestFlatColumnReader(String[] fieldPath)
+    {
+        this.fieldPath = requireNonNull(fieldPath, "fieldPath is null");
+    }
+
+    @Test
+    public void testReadPageV1BitPacked()
+            throws IOException
+    {
+        FlatColumnReader<int[]> reader = new FlatColumnReader<>(NULLABLE_FIELD, ValueDecoders::getIntDecoder, INT_ADAPTER);
+        reader.setPageReader(getSimplePageReaderMock(BIT_PACKED), Optional.empty());
+        reader.prepareNextRead(1);
+
+        assertThatThrownBy(reader::readNullable)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid definition level encoding: BIT_PACKED");
+    }
+
+    @Test
+    public void testReadPageV1BitPackedNoNulls()
+            throws IOException
+    {
+        FlatColumnReader<int[]> reader = new FlatColumnReader<>(FIELD, ValueDecoders::getIntDecoder, INT_ADAPTER);
+        reader.setPageReader(getSimplePageReaderMock(BIT_PACKED), Optional.empty());
+        reader.prepareNextRead(1);
+
+        reader.readNoNull();
+    }
+
+    @Test
+    public void testReadPageV1RleNoNulls()
+            throws IOException
+    {
+        FlatColumnReader<int[]> reader = new FlatColumnReader<>(FIELD, ValueDecoders::getIntDecoder, INT_ADAPTER);
+        assertThat(FIELD.isRequired()).isTrue();
+        assertThat(FIELD.getDescriptor().getMaxDefinitionLevel()).isEqualTo(0);
+        reader.setPageReader(getSimplePageReaderMock(RLE), Optional.empty());
+        reader.prepareNextRead(1);
+
+        Block block = reader.readNoNull().getBlock();
+        assertThat(block.getPositionCount()).isEqualTo(1);
+        assertThat(block.getInt(0, 0)).isEqualTo(42);
+    }
+
+    @Test
+    public void testReadPageV1RleOnlyNulls()
+            throws IOException
+    {
+        FlatColumnReader<int[]> reader = new FlatColumnReader<>(NULLABLE_FIELD, ValueDecoders::getIntDecoder, INT_ADAPTER);
+        assertThat(NULLABLE_FIELD.isRequired()).isFalse();
+        assertThat(NULLABLE_FIELD.getDescriptor().getMaxDefinitionLevel()).isEqualTo(0);
+        reader.setPageReader(getNullOnlyPageReaderMock(), Optional.empty());
+        reader.prepareNextRead(1);
+
+        Block block = reader.readNullable().getBlock();
+        assertThat(block.getPositionCount()).isEqualTo(1);
+        assertThat(block.isNull(0)).isTrue();
+    }
+
+    @Test(dataProvider = "dictionaryReadersWithPageVersions", dataProviderClass = TestingColumnReader.class)
+    public <T> void testSingleValueDictionary(DataPageVersion version, ColumnReaderFormat<T> format)
+            throws IOException
+    {
+        // Create reader
+        PrimitiveField field = createField(format, true);
+        ColumnReader reader = createColumnReader(field);
+        // Write data
+        DictionaryValuesWriter dictionaryWriter = format.getDictionaryWriter();
+        T[] values = format.write(dictionaryWriter, new Integer[] {1, 1});
+        DataPage page = createDataPage(version, RLE_DICTIONARY, dictionaryWriter, 2);
+        DictionaryPage dictionaryPage = getDictionaryPage(dictionaryWriter);
+        // Read and assert
+        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page)), dictionaryPage), Optional.empty());
+        reader.prepareNextRead(2);
+        Block actual = reader.readPrimitive().getBlock();
+        format.assertBlock(values, actual);
+    }
+
+    @Test(dataProvider = "dictionaryReadersWithPageVersions", dataProviderClass = TestingColumnReader.class)
+    public <T> void testSingleValueDictionaryNullable(DataPageVersion version, ColumnReaderFormat<T> format)
+            throws IOException
+    {
+        // Create reader
+        PrimitiveField field = createField(format, false);
+        ColumnReader reader = createColumnReader(field);
+        // Write data
+        DictionaryValuesWriter dictionaryWriter = format.getDictionaryWriter();
+        T[] values = format.write(dictionaryWriter, new Integer[] {1, null});
+        DataPage page = createNullableDataPage(version, RLE_DICTIONARY, dictionaryWriter, false, true);
+        DictionaryPage dictionaryPage = getDictionaryPage(dictionaryWriter);
+        // Read and assert
+        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page)), dictionaryPage), Optional.empty());
+        reader.prepareNextRead(2);
+        Block actual = reader.readPrimitive().getBlock();
+        format.assertBlock(values, actual);
+    }
+
+    @Test(dataProvider = "dictionaryReadersWithPageVersions", dataProviderClass = TestingColumnReader.class)
+    public <T> void testSingleValueDictionaryNullableWithNoNulls(DataPageVersion version, ColumnReaderFormat<T> format)
+            throws IOException
+    {
+        // Create reader
+        PrimitiveField field = createField(format, false);
+        ColumnReader reader = createColumnReader(field);
+        // Write data
+        DictionaryValuesWriter dictionaryWriter = format.getDictionaryWriter();
+        T[] values = format.write(dictionaryWriter, new Integer[] {1, 1});
+        DataPage page = createNullableDataPage(version, RLE_DICTIONARY, dictionaryWriter, false, false);
+        DictionaryPage dictionaryPage = getDictionaryPage(dictionaryWriter);
+        // Read and assert
+        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page)), dictionaryPage), Optional.empty());
+        reader.prepareNextRead(2);
+        Block actual = reader.readPrimitive().getBlock();
+        format.assertBlock(values, actual);
+    }
+
+    @Test(dataProvider = "dictionaryReadersWithPageVersions", dataProviderClass = TestingColumnReader.class)
+    public <T> void testSingleValueDictionaryNullableWithOnlyNulls(DataPageVersion version, ColumnReaderFormat<T> format)
+            throws IOException
+    {
+        // Create reader
+        PrimitiveField field = createField(format, false);
+        ColumnReader reader = createColumnReader(field);
+        // Write data
+        DictionaryValuesWriter dictionaryWriter = format.getDictionaryWriter();
+        // Write dummy value. Without it dictionary would end up null.
+        format.write(dictionaryWriter, new Integer[] {42});
+        T[] values = format.resetAndWrite(dictionaryWriter, new Integer[] {null, null});
+        DataPage page = createNullableDataPage(version, RLE_DICTIONARY, dictionaryWriter, true, true);
+        DictionaryPage dictionaryPage = getDictionaryPage(dictionaryWriter);
+        // Read and assert
+        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page)), dictionaryPage), Optional.empty());
+        reader.prepareNextRead(2);
+        Block actual = reader.readPrimitive().getBlock();
+        format.assertBlock(values, actual);
+    }
+
+    @Test(dataProvider = "readersWithPageVersions", dataProviderClass = TestingColumnReader.class)
+    public <T> void testReadNoNull(DataPageVersion version, ColumnReaderFormat<T> format)
+            throws IOException
+    {
+        // Create reader
+        PrimitiveField field = createField(format, true);
+        ColumnReader reader = createColumnReader(field);
+        // Write data
+        ValuesWriter writer = format.getPlainWriter();
+        T[] values1 = format.write(writer, new Integer[] {1});
+        DataPage page1 = createDataPage(version, PLAIN, writer, 1);
+        T[] values2 = format.resetAndWrite(writer, new Integer[] {2, 3});
+        DataPage page2 = createDataPage(version, PLAIN, writer, 2);
+        T[] values3 = format.resetAndWrite(writer, new Integer[] {4});
+        DataPage page3 = createDataPage(version, PLAIN, writer, 1);
+        // Read and assert
+        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page1, page2, page3)), null), Optional.empty());
+        Block actual1 = readBlock(reader, 1); // Parquet/Trino page size the same
+        Block actual2 = readBlock(reader, 1); // Parquet page bigger than Trino
+        Block actual3 = readBlock(reader, 2); // Parquet page smaller than Trino
+
+        format.assertBlock(values1, actual1);
+        format.assertBlock(values2, actual2, 0, 0, 1);
+        format.assertBlock(values2, actual3, 1, 0, 1);
+        format.assertBlock(values3, actual3, 0, 1, 1);
+    }
+
+    @Test(dataProvider = "dictionaryReadersWithPageVersions", dataProviderClass = TestingColumnReader.class)
+    public <T> void testSingleValueDictionaryAndNonDictionaryInASingleChunk(DataPageVersion version, ColumnReaderFormat<T> format)
+            throws IOException
+    {
+        // Create reader
+        PrimitiveField field = createField(format, true);
+        ColumnReader reader = createColumnReader(field);
+        // Write data
+        DictionaryValuesWriter dictionaryWriter = format.getDictionaryWriter();
+        ValuesWriter writer = format.getPlainWriter();
+        T[] values1 = format.write(dictionaryWriter, new Integer[] {1, 1});
+        DataPage page1 = createDataPage(version, RLE_DICTIONARY, dictionaryWriter, 2);
+        T[] values2 = format.write(writer, new Integer[] {2});
+        DataPage page2 = createDataPage(version, PLAIN, writer, 1);
+        DictionaryPage dictionaryPage = getDictionaryPage(dictionaryWriter);
+        // Read and assert
+        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page1, page2)), dictionaryPage), Optional.empty());
+        reader.prepareNextRead(3);
+        Block actual = reader.readPrimitive().getBlock();
+        format.assertBlock(values1, actual, 0, 0, 2);
+        format.assertBlock(values2, actual, 0, 2, 1);
+    }
+
+    @Test(dataProvider = "readersWithPageVersions", dataProviderClass = TestingColumnReader.class)
+    public <T> void testReadOnlyNulls(DataPageVersion version, ColumnReaderFormat<T> format)
+            throws IOException
+    {
+        // Create reader
+        PrimitiveField field = createField(format, false);
+        ColumnReader reader = createColumnReader(field);
+        // Write data
+        ValuesWriter writer = format.getPlainWriter();
+        T[] values1 = format.write(writer, new Integer[] {null});
+        DataPage page1 = createNullableDataPage(version, PLAIN, writer, true);
+        T[] values2 = format.write(writer, new Integer[] {null, null});
+        DataPage page2 = createNullableDataPage(version, PLAIN, writer, true, true);
+        // Read and assert
+        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page1, page2)), null), Optional.empty());
+        // Deliberate mismatch between Trino/Parquet page sizes
+        Block actual1 = readBlock(reader, 2);
+        Block actual2 = readBlock(reader, 1);
+
+        format.assertBlock(values1, actual1, 0, 0, 1);
+        format.assertBlock(values2, actual1, 0, 1, 1);
+        format.assertBlock(values2, actual2, 1, 0, 1);
+    }
+
+    @Test(dataProvider = "readersWithPageVersions", dataProviderClass = TestingColumnReader.class)
+    public <T> void testReadNullable(DataPageVersion version, ColumnReaderFormat<T> format)
+            throws IOException
+    {
+        // Create reader
+        PrimitiveField field = createField(format, false);
+        ColumnReader reader = createColumnReader(field);
+        // Write data
+        ValuesWriter writer = format.getPlainWriter();
+        T[] values1 = format.write(writer, new Integer[] {null, 1});
+        DataPage page1 = createNullableDataPage(version, PLAIN, writer, true, false);
+        T[] values2 = format.resetAndWrite(writer, new Integer[] {null, 2, null});
+        DataPage page2 = createNullableDataPage(version, PLAIN, writer, true, false, true);
+        T[] values3 = format.resetAndWrite(writer, new Integer[] {3, null, 4});
+        DataPage page3 = createNullableDataPage(version, PLAIN, writer, false, true, false);
+        // Read and assert
+        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page1, page2, page3)), null), Optional.empty());
+        // Deliberate mismatch between Trino/Parquet page sizes
+        Block actual1 = readBlock(reader, 2);
+        Block actual2 = readBlock(reader, 2);
+        Block actual3 = readBlock(reader, 4);
+
+        format.assertBlock(values1, actual1);
+        format.assertBlock(values2, actual2, 0, 0, 2);
+        format.assertBlock(values2, actual3, 2, 0, 1);
+        format.assertBlock(values3, actual3, 0, 1, 3);
+    }
+
+    @Test(dataProvider = "readersWithPageVersions", dataProviderClass = TestingColumnReader.class)
+    public <T> void testReadNullableWithNoNulls(DataPageVersion version, ColumnReaderFormat<T> format)
+            throws IOException
+    {
+        // Create reader
+        PrimitiveField field = createField(format, false);
+        ColumnReader reader = createColumnReader(field);
+        // Write data
+        ValuesWriter writer = format.getPlainWriter();
+        T[] values1 = format.write(writer, new Integer[] {1, 2});
+        DataPage page1 = createNullableDataPage(version, PLAIN, writer, false, false);
+        // Read and assert
+        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page1)), null), Optional.empty());
+        // Deliberate mismatch between Trino/Parquet page sizes
+        Block actual1 = readBlock(reader, 2);
+
+        format.assertBlock(values1, actual1);
+    }
+
+    @Test(dataProvider = "dictionaryReadersWithPageVersions", dataProviderClass = TestingColumnReader.class)
+    public <T> void testMixedDictionaryAndOrdinary(DataPageVersion version, ColumnReaderFormat<T> format)
+            throws IOException
+    {
+        // Create reader
+        PrimitiveField field = createField(format, true);
+        ColumnReader reader = createColumnReader(field);
+        // Write data
+        DictionaryValuesWriter dictionaryWriter = format.getDictionaryWriter();
+        T[] values1 = format.write(dictionaryWriter, new Integer[] {1, 2, 3});
+        DataPage page1 = createDataPage(version, RLE_DICTIONARY, dictionaryWriter, 3);
+        ValuesWriter writer = format.getPlainWriter();
+        T[] values2 = format.resetAndWrite(writer, new Integer[] {4, 5, 6});
+        DataPage page2 = createDataPage(version, PLAIN, writer, 3);
+        DictionaryPage dictionaryPage = getDictionaryPage(dictionaryWriter);
+        // Read and assert
+        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page1, page2)), dictionaryPage), Optional.empty());
+        // Deliberate mismatch between Trino/Parquet page sizes
+        Block actual1 = readBlock(reader, 2); // Only dictionary
+        Block actual2 = readBlock(reader, 2); // Mixed
+        Block actual3 = readBlock(reader, 2); // Only non-dictionary
+
+        format.assertBlock(values1, actual1, 0, 0, 2);
+        format.assertBlock(values1, actual2, 2, 0, 1);
+        format.assertBlock(values2, actual2, 0, 1, 1);
+        format.assertBlock(values2, actual3, 1, 0, 2);
+    }
+
+    @Test(dataProvider = "readersWithPageVersions", dataProviderClass = TestingColumnReader.class)
+    public <T> void testOnlyNullParquetPage(DataPageVersion version, ColumnReaderFormat<T> format)
+            throws IOException
+    {
+        // Create reader
+        PrimitiveField field = createField(format, false);
+        ColumnReader reader = createColumnReader(field);
+        // Write data
+        ValuesWriter writer = format.getPlainWriter();
+        T[] values1 = format.write(writer, new Integer[] {1});
+        DataPage page1 = createNullableDataPage(version, PLAIN, writer, false);
+        T[] values2 = format.resetAndWrite(writer, new Integer[] {null});
+        DataPage page2 = createNullableDataPage(version, PLAIN, writer, true);
+        T[] values3 = format.resetAndWrite(writer, new Integer[] {2});
+        DataPage page3 = createNullableDataPage(version, PLAIN, writer, false);
+        // Read and assert
+        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page1, page2, page3)), null), Optional.empty());
+        // Deliberate mismatch between Trino/Parquet page sizes
+        Block actual = readBlock(reader, 3);
+
+        format.assertBlock(values1, actual, 0, 0, 1);
+        format.assertBlock(values2, actual, 0, 1, 1);
+        format.assertBlock(values3, actual, 0, 2, 1);
+    }
+
+    @Test(dataProvider = "dictionaryReadersWithPageVersions", dataProviderClass = TestingColumnReader.class)
+    public <T> void testSkip(DataPageVersion version, ColumnReaderFormat<T> format)
+            throws IOException
+    {
+        // Create reader
+        PrimitiveField field = createField(format, true);
+        ColumnReader reader = createColumnReader(field);
+        // Write data
+        ValuesWriter writer = format.getPlainWriter();
+        DictionaryValuesWriter dictionaryWriter = format.getDictionaryWriter();
+        T[] values1 = format.write(writer, new Integer[] {1, 2, 3});
+        DataPage page1 = createDataPage(version, PLAIN, writer, 3);
+        T[] values2 = format.resetAndWrite(dictionaryWriter, new Integer[] {4, 5, 6});
+        DataPage page2 = createDataPage(version, RLE_DICTIONARY, dictionaryWriter, 3);
+        DictionaryPage dictionaryPage = getDictionaryPage(dictionaryWriter);
+        // Read and assert
+        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page1, page2)), dictionaryPage), Optional.empty());
+        reader.prepareNextRead(1); // skip
+        Block actual = readBlock(reader, 2);
+        reader.prepareNextRead(1); // skip
+        Block actual2 = readBlock(reader, 2);
+
+        format.assertBlock(values1, actual, 1, 0, 2);
+        format.assertBlock(values2, actual2, 1, 0, 2);
+    }
+
+    private Block readBlock(ColumnReader reader, int valueCount)
+    {
+        reader.prepareNextRead(valueCount);
+        Block block = reader.readPrimitive().getBlock();
+        assertThat(block.getPositionCount()).isEqualTo(valueCount);
+        return block;
+    }
+
+    private DataPage createDataPage(DataPageVersion version, ParquetEncoding encoding, ValuesWriter writer, int valueCount)
+            throws IOException
+    {
+        Slice slice = Slices.wrappedBuffer(writer.getBytes().toByteArray());
+        if (version == V1) {
+            return new DataPageV1(slice, valueCount, slice.length(), OptionalLong.empty(), RLE, BIT_PACKED, encoding);
+        }
+        else {
+            return new DataPageV2(
+                    valueCount,
+                    0,
+                    valueCount,
+                    EMPTY_SLICE,
+                    EMPTY_SLICE,
+                    encoding,
+                    slice,
+                    slice.length(),
+                    OptionalLong.empty(),
+                    null,
+                    false);
+        }
+    }
+
+    private DataPage createNullableDataPage(DataPageVersion version, ParquetEncoding encoding, ValuesWriter writer, boolean... isNull)
+            throws IOException
+    {
+        int valueCount = isNull.length;
+        RunLengthBitPackingHybridValuesWriter nullsWriter = new RunLengthBitPackingHybridValuesWriter(1, valueCount, valueCount, HeapByteBufferAllocator.getInstance());
+        int nullCount = 0;
+        for (int i = 0; i < valueCount; i++) {
+            nullsWriter.writeInteger(isNull[i] ? 0 : 1);
+            nullCount += isNull[i] ? 1 : 0;
+        }
+        byte[] nullBytes = nullsWriter.getBytes().toByteArray();
+        byte[] valueBytes = writer.getBytes().toByteArray();
+
+        if (version == V1) {
+            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+            bytes.write(nullBytes);
+            bytes.write(valueBytes);
+
+            return new DataPageV1(Slices.wrappedBuffer(bytes.toByteArray()), valueCount, 4, OptionalLong.empty(), RLE, RLE, encoding);
+        }
+        else {
+            return new DataPageV2(
+                    valueCount,
+                    nullCount,
+                    valueCount,
+                    EMPTY_SLICE,
+                    Slices.wrappedBuffer(nullBytes, Integer.BYTES, nullBytes.length - Integer.BYTES), // Skip length
+                    encoding,
+                    Slices.wrappedBuffer(valueBytes),
+                    nullBytes.length + valueBytes.length,
+                    OptionalLong.empty(),
+                    null,
+                    false);
+        }
+    }
+
+    private PrimitiveField createField(ColumnReaderFormat<?> format, boolean required)
+    {
+        PrimitiveBuilder<PrimitiveType> builder;
+        if (required) {
+            builder = Types.required(format.getTypeName());
+        }
+        else {
+            builder = Types.optional(format.getTypeName());
+        }
+        builder = builder.length(format.getTypeLengthInBytes());
+        if (format.getLogicalTypeAnnotation() != null) {
+            builder = builder.as(format.getLogicalTypeAnnotation());
+        }
+        PrimitiveType primitiveType = builder.named("dummy");
+        return new PrimitiveField(
+                format.getTrinoType(),
+                required,
+                new ColumnDescriptor(fieldPath, primitiveType, 0, required ? 0 : 1),
+                0);
+    }
+
+    private static PageReader getSimplePageReaderMock(ParquetEncoding encoding)
+            throws IOException
+    {
+        LinkedList<DataPage> pages = new LinkedList<>();
+        ValuesWriter writer = PLAIN_WRITER.apply(1);
+        writer.writeInteger(42);
+        byte[] valueBytes = writer.getBytes().toByteArray();
+        pages.add(new DataPageV1(
+                Slices.wrappedBuffer(valueBytes),
+                1,
+                valueBytes.length,
+                OptionalLong.empty(),
+                encoding,
+                encoding,
+                PLAIN));
+        return new PageReader(UNCOMPRESSED, pages, null, 1);
+    }
+
+    private static PageReader getNullOnlyPageReaderMock()
+            throws IOException
+    {
+        LinkedList<DataPage> pages = new LinkedList<>();
+        RunLengthBitPackingHybridValuesWriter nullsWriter = new RunLengthBitPackingHybridValuesWriter(1, 1, 1, HeapByteBufferAllocator.getInstance());
+        nullsWriter.writeInteger(0);
+        byte[] nullBytes = nullsWriter.getBytes().toByteArray();
+        pages.add(new DataPageV1(
+                Slices.wrappedBuffer(nullBytes),
+                1,
+                nullBytes.length,
+                OptionalLong.empty(),
+                RLE,
+                RLE,
+                PLAIN));
+        return new PageReader(UNCOMPRESSED, pages, null, 1);
+    }
+
+    private static PageReader getPageReaderMock(LinkedList<DataPage> dataPages, @Nullable DictionaryPage dictionaryPage)
+    {
+        return new PageReader(
+                UNCOMPRESSED,
+                dataPages,
+                dictionaryPage,
+                dataPages.stream()
+                        .mapToInt(DataPage::getValueCount)
+                        .sum());
+    }
+
+    private static ColumnReader createColumnReader(PrimitiveField field)
+    {
+        return ColumnReaderFactory.create(field, UTC, true);
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/TestNullsDecoder.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/TestNullsDecoder.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import io.airlift.slice.Slices;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridEncoder;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.stream.Stream;
+
+import static io.trino.parquet.reader.TestData.generateMixedData;
+import static io.trino.testing.DataProviders.cartesianProduct;
+import static io.trino.testing.DataProviders.toDataProvider;
+import static java.lang.Math.min;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestNullsDecoder
+{
+    private static final int N = 1000;
+    private static final int MAX_MIXED_GROUP_SIZE = 23;
+    private static final boolean[] ALL_NON_NULLS_ARRAY = new boolean[N];
+    private static final boolean[] RANDOM_ARRAY = new boolean[N];
+    private static final boolean[] MIXED_RANDOM_AND_GROUPED_ARRAY;
+
+    static {
+        Arrays.fill(ALL_NON_NULLS_ARRAY, true);
+        Random r = new Random(0);
+        for (int i = 0; i < N; i++) {
+            RANDOM_ARRAY[i] = r.nextBoolean();
+        }
+
+        MIXED_RANDOM_AND_GROUPED_ARRAY = generateMixedData(r, N, MAX_MIXED_GROUP_SIZE);
+    }
+
+    @Test(dataProvider = "dataSets")
+    public void testDecoding(NullValuesProvider nullValuesProvider, int batchSize)
+            throws IOException
+    {
+        boolean[] values = nullValuesProvider.getPositions();
+        byte[] encoded = encode(values);
+        NullsDecoder decoder = new NullsDecoder(Slices.wrappedBuffer(encoded));
+        boolean[] result = new boolean[N];
+        int nonNullCount = 0;
+        for (int i = 0; i < N; i += batchSize) {
+            nonNullCount += decoder.readNext(result, i, min(batchSize, N - i));
+        }
+        // Parquet encodes whether value exists, Trino whether value is null
+        boolean[] byteResult = flip(result);
+        assertThat(byteResult).containsExactly(values);
+
+        int expectedNonNull = nonNullCount(values);
+        assertThat(nonNullCount).isEqualTo(expectedNonNull);
+    }
+
+    @Test(dataProvider = "dataSets")
+    public void testSkippedDecoding(NullValuesProvider nullValuesProvider, int batchSize)
+            throws IOException
+    {
+        boolean[] values = nullValuesProvider.getPositions();
+        byte[] encoded = encode(values);
+        NullsDecoder decoder = new NullsDecoder(Slices.wrappedBuffer(encoded));
+        int nonNullCount = 0;
+        int numberOfBatches = (N + batchSize - 1) / batchSize;
+        Random random = new Random(batchSize * 0xFFFFFFFFL * N);
+        int skippedBatches = random.nextInt(numberOfBatches);
+        int alreadyRead = 0;
+        for (int i = 0; i < skippedBatches; i++) {
+            int chunkSize = min(batchSize, N - alreadyRead);
+            nonNullCount += decoder.skip(chunkSize);
+            alreadyRead += chunkSize;
+        }
+        assertThat(nonNullCount).isEqualTo(nonNullCount(values, alreadyRead));
+
+        boolean[] result = new boolean[N - alreadyRead];
+        boolean[] expected = Arrays.copyOfRange(values, alreadyRead, values.length);
+        int offset = 0;
+        while (alreadyRead < N) {
+            int chunkSize = min(batchSize, N - alreadyRead);
+            nonNullCount += decoder.readNext(result, offset, chunkSize);
+            alreadyRead += chunkSize;
+            offset += chunkSize;
+        }
+        // Parquet encodes whether value exists, Trino whether value is null
+        boolean[] byteResult = flip(result);
+        assertThat(byteResult).containsExactly(expected);
+
+        assertThat(nonNullCount).isEqualTo(nonNullCount(values));
+    }
+
+    @DataProvider(name = "dataSets")
+    public static Object[][] dataSets()
+    {
+        return cartesianProduct(
+                Arrays.stream(NullValuesProvider.values()).collect(toDataProvider()),
+                Stream.of(1, 3, 16, 100, 1000).collect(toDataProvider()));
+    }
+
+    private enum NullValuesProvider
+    {
+        ALL_NULLS {
+            @Override
+            boolean[] getPositions()
+            {
+                return new boolean[N];
+            }
+        },
+        ALL_NON_NULLS {
+            @Override
+            boolean[] getPositions()
+            {
+                return ALL_NON_NULLS_ARRAY;
+            }
+        },
+        RANDOM {
+            @Override
+            boolean[] getPositions()
+            {
+                return RANDOM_ARRAY;
+            }
+        },
+        MIXED_RANDOM_AND_GROUPED {
+            @Override
+            boolean[] getPositions()
+            {
+                return MIXED_RANDOM_AND_GROUPED_ARRAY;
+            }
+        };
+
+        abstract boolean[] getPositions();
+    }
+
+    private static byte[] encode(boolean[] values)
+            throws IOException
+    {
+        RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(1, N, N, HeapByteBufferAllocator.getInstance());
+        for (int i = 0; i < N; i++) {
+            encoder.writeInt(values[i] ? 1 : 0);
+        }
+        return encoder.toBytes().toByteArray();
+    }
+
+    private static boolean[] flip(boolean[] values)
+    {
+        boolean[] result = new boolean[values.length];
+        for (int i = 0; i < values.length; i++) {
+            result[i] = !values[i];
+        }
+        return result;
+    }
+
+    private static int nonNullCount(boolean[] values)
+    {
+        return nonNullCount(values, values.length);
+    }
+
+    private static int nonNullCount(boolean[] values, int length)
+    {
+        int nonNullCount = 0;
+        for (int i = 0; i < length; i++) {
+            nonNullCount += values[i] ? 1 : 0;
+        }
+        return nonNullCount;
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/TestNullsDecoderBenchmark.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/TestNullsDecoderBenchmark.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import io.trino.parquet.reader.flat.BenchmarkFlatDefinitionLevelDecoder.DataGenerator;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+public class TestNullsDecoderBenchmark
+{
+    @Test
+    public void testDataGenerators()
+            throws IOException
+    {
+        for (DataGenerator generator : DataGenerator.values()) {
+            BenchmarkFlatDefinitionLevelDecoder benchmark = new BenchmarkFlatDefinitionLevelDecoder(10000, generator);
+            benchmark.setup();
+            benchmark.read();
+        }
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/TestRowRangesIterator.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/TestRowRangesIterator.java
@@ -36,6 +36,7 @@ public class TestRowRangesIterator
         assertThat(ranges.skipToRangeStart()).isEqualTo(0);
         assertThat(ranges.advanceRange(100)).isEqualTo(100);
         assertThat(ranges.seekForward(100)).isEqualTo(100);
+        assertThat(ranges.isPageFullyConsumed(100)).isTrue();
     }
 
     @Test
@@ -75,6 +76,25 @@ public class TestRowRangesIterator
         assertThatThrownBy(() -> createRowRangesIterator(range(20, 30), range(50, 99))
                 .resetForNewPage(OptionalLong.of(100)))
                 .isInstanceOf(VerifyException.class);
+    }
+
+    @Test
+    public void testIsPageFullyConsumed()
+    {
+        RowRangesIterator ranges = createRowRangesIterator(range(20, 30), range(50, 99));
+        ranges.resetForNewPage(OptionalLong.of(0));
+        assertThat(ranges.isPageFullyConsumed(5)).isFalse();
+        assertThat(ranges.isPageFullyConsumed(31)).isFalse();
+
+        ranges = createRowRangesIterator(range(20, 30), range(50, 99));
+        ranges.resetForNewPage(OptionalLong.of(20));
+        assertThat(ranges.isPageFullyConsumed(11)).isTrue();
+        assertThat(ranges.isPageFullyConsumed(12)).isFalse();
+
+        ranges = createRowRangesIterator(range(20, 30), range(50, 99));
+        ranges.resetForNewPage(OptionalLong.of(25));
+        assertThat(ranges.isPageFullyConsumed(6)).isTrue();
+        assertThat(ranges.isPageFullyConsumed(7)).isFalse();
     }
 
     @Test

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/TestRowRangesIterator.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/TestRowRangesIterator.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import com.google.common.base.VerifyException;
+import io.trino.parquet.reader.FilteredRowRanges;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static io.trino.parquet.reader.FilteredRowRanges.RowRange;
+import static org.apache.parquet.internal.filter2.columnindex.TestingRowRanges.toRowRange;
+import static org.apache.parquet.internal.filter2.columnindex.TestingRowRanges.toRowRanges;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestRowRangesIterator
+{
+    @Test
+    public void testNullRowRanges()
+    {
+        RowRangesIterator ranges = RowRangesIterator.createRowRangesIterator(Optional.empty());
+        ranges.resetForNewPage(OptionalLong.empty());
+        assertThat(ranges.skipToRangeStart()).isEqualTo(0);
+        assertThat(ranges.advanceRange(100)).isEqualTo(100);
+        assertThat(ranges.seekForward(100)).isEqualTo(100);
+    }
+
+    @Test
+    public void testRowRangesWithoutFirstPageIndex()
+    {
+        RowRangesIterator ranges = RowRangesIterator.createRowRangesIterator(Optional.of(new FilteredRowRanges(toRowRange(50))));
+        assertThatThrownBy(() -> ranges.resetForNewPage(OptionalLong.empty()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testSkipToRangeStart()
+    {
+        RowRangesIterator ranges = createRowRangesIterator(range(20, 30), range(50, 99));
+        ranges.resetForNewPage(OptionalLong.of(0));
+        assertThat(ranges.skipToRangeStart()).isEqualTo(20);
+        assertThat(ranges.skipToRangeStart()).isEqualTo(0);
+
+        ranges = createRowRangesIterator(range(20, 30), range(50, 99));
+        ranges.resetForNewPage(OptionalLong.of(10));
+        assertThat(ranges.skipToRangeStart()).isEqualTo(10);
+        assertThat(ranges.skipToRangeStart()).isEqualTo(0);
+
+        ranges = createRowRangesIterator(range(20, 30), range(50, 99));
+        ranges.resetForNewPage(OptionalLong.of(25));
+        assertThat(ranges.skipToRangeStart()).isEqualTo(0);
+
+        ranges = createRowRangesIterator(range(20, 30), range(50, 99));
+        ranges.resetForNewPage(OptionalLong.of(35));
+        assertThat(ranges.skipToRangeStart()).isEqualTo(15);
+        assertThat(ranges.skipToRangeStart()).isEqualTo(0);
+
+        ranges = createRowRangesIterator(range(20, 30), range(50, 99));
+        ranges.resetForNewPage(OptionalLong.of(75));
+        assertThat(ranges.skipToRangeStart()).isEqualTo(0);
+
+        assertThatThrownBy(() -> createRowRangesIterator(range(20, 30), range(50, 99))
+                .resetForNewPage(OptionalLong.of(100)))
+                .isInstanceOf(VerifyException.class);
+    }
+
+    @Test
+    public void testAdvanceRange()
+    {
+        RowRangesIterator ranges = createRowRangesIterator(range(20, 30), range(50, 99));
+        ranges.resetForNewPage(OptionalLong.of(0));
+        assertThat(ranges.skipToRangeStart()).isEqualTo(20);
+        assertThat(ranges.advanceRange(10)).isEqualTo(10);
+        assertThat(ranges.advanceRange(15)).isEqualTo(1);
+        assertThat(ranges.skipToRangeStart()).isEqualTo(19);
+
+        ranges = createRowRangesIterator(range(20, 30), range(50, 99));
+        ranges.resetForNewPage(OptionalLong.of(20));
+        assertThat(ranges.advanceRange(11)).isEqualTo(11);
+        assertThat(ranges.skipToRangeStart()).isEqualTo(19);
+        assertThat(ranges.advanceRange(10)).isEqualTo(10);
+        assertThat(ranges.advanceRange(40)).isEqualTo(40);
+        RowRangesIterator consumedRange = ranges;
+        assertThatThrownBy(() -> consumedRange.advanceRange(1))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void testSeekForward()
+    {
+        RowRangesIterator ranges = createRowRangesIterator(range(20, 30), range(50, 99));
+        ranges.resetForNewPage(OptionalLong.of(5));
+        assertThat(ranges.seekForward(95)).isEqualTo(61);
+
+        ranges = createRowRangesIterator(range(20, 30), range(50, 99));
+        ranges.resetForNewPage(OptionalLong.of(0));
+        assertThat(ranges.seekForward(90)).isEqualTo(51);
+
+        ranges = createRowRangesIterator(range(20, 30), range(50, 99));
+        ranges.resetForNewPage(OptionalLong.of(0));
+        assertThat(ranges.seekForward(90)).isEqualTo(51);
+
+        ranges = createRowRangesIterator(range(20, 30), range(50, 99));
+        ranges.resetForNewPage(OptionalLong.of(0));
+        assertThat(ranges.seekForward(40)).isEqualTo(11);
+
+        ranges = createRowRangesIterator(range(20, 30), range(50, 99));
+        ranges.resetForNewPage(OptionalLong.of(10));
+        assertThat(ranges.seekForward(5)).isEqualTo(0);
+        assertThat(ranges.seekForward(5)).isEqualTo(0);
+        assertThat(ranges.seekForward(5)).isEqualTo(5);
+        assertThat(ranges.seekForward(5)).isEqualTo(5);
+        assertThat(ranges.seekForward(5)).isEqualTo(1);
+        assertThat(ranges.seekForward(65)).isEqualTo(50);
+        RowRangesIterator consumedRange = ranges;
+        assertThatThrownBy(() -> consumedRange.seekForward(1))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    private static RowRangesIterator createRowRangesIterator(RowRange... ranges)
+    {
+        return RowRangesIterator.createRowRangesIterator(Optional.of(new FilteredRowRanges(toRowRanges(ranges))));
+    }
+
+    private static RowRange range(long start, long end)
+    {
+        return new RowRange(start, end);
+    }
+}

--- a/lib/trino-parquet/src/test/java/org/apache/parquet/internal/filter2/columnindex/TestingRowRanges.java
+++ b/lib/trino-parquet/src/test/java/org/apache/parquet/internal/filter2/columnindex/TestingRowRanges.java
@@ -15,10 +15,9 @@ package org.apache.parquet.internal.filter2.columnindex;
 
 import org.apache.parquet.internal.column.columnindex.OffsetIndex;
 
-import java.util.Objects;
 import java.util.stream.IntStream;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.trino.parquet.reader.FilteredRowRanges.RowRange;
 import static java.util.Objects.requireNonNull;
 
 public class TestingRowRanges
@@ -66,68 +65,13 @@ public class TestingRowRanges
         @Override
         public long getFirstRowIndex(int pageIndex)
         {
-            return rowRanges[pageIndex].getStart();
+            return rowRanges[pageIndex].start();
         }
 
         @Override
         public long getLastRowIndex(int pageIndex, long rowGroupRowCount)
         {
-            return rowRanges[pageIndex].getEnd();
-        }
-    }
-
-    public static RowRange range(long start, long end)
-    {
-        return new RowRange(start, end);
-    }
-
-    public static class RowRange
-    {
-        private final long start;
-        private final long end;
-
-        private RowRange(long start, long end)
-        {
-            this.start = start;
-            this.end = end;
-        }
-
-        public long getStart()
-        {
-            return start;
-        }
-
-        public long getEnd()
-        {
-            return end;
-        }
-
-        @Override
-        public boolean equals(Object o)
-        {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            RowRange rowRange = (RowRange) o;
-            return start == rowRange.start && end == rowRange.end;
-        }
-
-        @Override
-        public int hashCode()
-        {
-            return Objects.hash(start, end);
-        }
-
-        @Override
-        public String toString()
-        {
-            return toStringHelper(this)
-                    .add("start", start)
-                    .add("end", end)
-                    .toString();
+            return rowRanges[pageIndex].end();
         }
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -237,6 +237,7 @@ public class DeltaLakeMergeSink
                     IntStream.range(0, dataColumns.size()).toArray(),
                     compressionCodecName,
                     trinoVersion,
+                    false,
                     Optional.empty(),
                     Optional.empty());
         }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
@@ -491,6 +491,7 @@ public class DeltaLakePageSink
                     identityMapping,
                     compressionCodecName,
                     trinoVersion,
+                    false,
                     Optional.empty(),
                     Optional.empty());
         }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
@@ -68,6 +68,7 @@ import static io.trino.plugin.deltalake.DeltaHiveTypeTranslator.toHiveType;
 import static io.trino.plugin.deltalake.DeltaLakeColumnHandle.ROW_ID_COLUMN_NAME;
 import static io.trino.plugin.deltalake.DeltaLakeColumnType.REGULAR;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetMaxReadBlockSize;
+import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.isParquetOptimizedReaderEnabled;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.extractSchema;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.getColumnMappingMode;
 import static io.trino.plugin.hive.HiveSessionProperties.isParquetUseColumnIndex;
@@ -152,7 +153,8 @@ public class DeltaLakePageSourceProvider
 
         TrinoInputFile inputFile = fileSystemFactory.create(session).newInputFile(split.getPath(), split.getFileSize());
         ParquetReaderOptions options = parquetReaderOptions.withMaxReadBlockSize(getParquetMaxReadBlockSize(session))
-                .withUseColumnIndex(isParquetUseColumnIndex(session));
+                .withUseColumnIndex(isParquetUseColumnIndex(session))
+                .withBatchColumnReaders(isParquetOptimizedReaderEnabled(session));
 
         ColumnMappingMode columnMappingMode = getColumnMappingMode(table.getMetadataEntry());
         Map<Integer, String> parquetFieldIdToName = columnMappingMode == ColumnMappingMode.ID ? loadParquetIdAndNameMapping(inputFile, options) : ImmutableMap.of();

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
@@ -45,6 +45,7 @@ public final class DeltaLakeSessionProperties
     private static final String HIVE_CATALOG_NAME = "hive_catalog_name";
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
     private static final String PARQUET_USE_COLUMN_INDEX = "parquet_use_column_index";
+    private static final String PARQUET_OPTIMIZED_READER_ENABLED = "parquet_optimized_reader_enabled";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
     private static final String TARGET_MAX_FILE_SIZE = "target_max_file_size";
@@ -97,6 +98,11 @@ public final class DeltaLakeSessionProperties
                         PARQUET_USE_COLUMN_INDEX,
                         "Use Parquet column index",
                         parquetReaderConfig.isUseColumnIndex(),
+                        false),
+                booleanProperty(
+                        PARQUET_OPTIMIZED_READER_ENABLED,
+                        "Use optimized Parquet reader",
+                        parquetReaderConfig.isOptimizedReaderEnabled(),
                         false),
                 dataSizeProperty(
                         PARQUET_WRITER_BLOCK_SIZE,
@@ -182,6 +188,11 @@ public final class DeltaLakeSessionProperties
     public static boolean isParquetUseColumnIndex(ConnectorSession session)
     {
         return session.getProperty(PARQUET_USE_COLUMN_INDEX, Boolean.class);
+    }
+
+    public static boolean isParquetOptimizedReaderEnabled(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_OPTIMIZED_READER_ENABLED, Boolean.class);
     }
 
     public static boolean isParquetOptimizedWriterEnabled(ConnectorSession session)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeUpdatablePageSource.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeUpdatablePageSource.java
@@ -70,6 +70,7 @@ import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_BAD_WRITE;
 import static io.trino.plugin.deltalake.DeltaLakePageSink.createPartitionValues;
 import static io.trino.plugin.deltalake.DeltaLakeSchemaProperties.buildHiveSchema;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetMaxReadBlockSize;
+import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.isParquetOptimizedReaderEnabled;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.isParquetUseColumnIndex;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.extractSchema;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogParser.deserializePartitionValue;
@@ -578,7 +579,8 @@ public class DeltaLakeUpdatablePageSource
                 parquetDateTimeZone,
                 new FileFormatDataSourceStats(),
                 parquetReaderOptions.withMaxReadBlockSize(getParquetMaxReadBlockSize(this.session))
-                        .withUseColumnIndex(isParquetUseColumnIndex(this.session)),
+                        .withUseColumnIndex(isParquetUseColumnIndex(this.session))
+                        .withBatchColumnReaders(isParquetOptimizedReaderEnabled(this.session)),
                 Optional.empty());
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
@@ -86,6 +86,7 @@ public final class HiveSessionProperties
     private static final String PARQUET_IGNORE_STATISTICS = "parquet_ignore_statistics";
     private static final String PARQUET_USE_COLUMN_INDEX = "parquet_use_column_index";
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
+    private static final String PARQUET_OPTIMIZED_READER_ENABLED = "parquet_optimized_reader_enabled";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
     private static final String PARQUET_WRITER_BATCH_SIZE = "parquet_writer_batch_size";
@@ -323,6 +324,11 @@ public final class HiveSessionProperties
                         PARQUET_MAX_READ_BLOCK_SIZE,
                         "Parquet: Maximum size of a block to read",
                         parquetReaderConfig.getMaxReadBlockSize(),
+                        false),
+                booleanProperty(
+                        PARQUET_OPTIMIZED_READER_ENABLED,
+                        "Use optimized Parquet reader",
+                        parquetReaderConfig.isOptimizedReaderEnabled(),
                         false),
                 dataSizeProperty(
                         PARQUET_WRITER_BLOCK_SIZE,
@@ -686,6 +692,11 @@ public final class HiveSessionProperties
     public static DataSize getParquetMaxReadBlockSize(ConnectorSession session)
     {
         return session.getProperty(PARQUET_MAX_READ_BLOCK_SIZE, DataSize.class);
+    }
+
+    public static boolean isParquetOptimizedReaderEnabled(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_OPTIMIZED_READER_ENABLED, Boolean.class);
     }
 
     public static DataSize getParquetWriterBlockSize(ConnectorSession session)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
@@ -73,6 +73,7 @@ public class ParquetFileWriter
             int[] fileInputColumnIndexes,
             CompressionCodecName compressionCodecName,
             String trinoVersion,
+            boolean useBatchColumnReadersForVerification,
             Optional<DateTimeZone> parquetTimeZone,
             Optional<Supplier<ParquetDataSource>> validationInputFactory)
             throws IOException
@@ -88,6 +89,7 @@ public class ParquetFileWriter
                 parquetWriterOptions,
                 compressionCodecName,
                 trinoVersion,
+                useBatchColumnReadersForVerification,
                 parquetTimeZone,
                 validationInputFactory.isPresent()
                         ? Optional.of(new ParquetWriteValidationBuilder(fileColumnTypes, fileColumnNames))

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
@@ -57,6 +57,7 @@ import static io.trino.parquet.writer.ParquetSchemaConverter.HIVE_PARQUET_USE_LE
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_OPEN_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITE_VALIDATION_FAILED;
 import static io.trino.plugin.hive.HiveSessionProperties.getTimestampPrecision;
+import static io.trino.plugin.hive.HiveSessionProperties.isParquetOptimizedReaderEnabled;
 import static io.trino.plugin.hive.HiveSessionProperties.isParquetOptimizedWriterValidate;
 import static io.trino.plugin.hive.util.HiveUtil.getColumnNames;
 import static io.trino.plugin.hive.util.HiveUtil.getColumnTypes;
@@ -161,6 +162,7 @@ public class ParquetFileWriterFactory
                     fileInputColumnIndexes,
                     compressionCodecName,
                     nodeVersion.toString(),
+                    isParquetOptimizedReaderEnabled(session),
                     Optional.of(parquetTimeZone),
                     validationInputFactory));
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -92,6 +92,7 @@ import static io.trino.plugin.hive.HivePageSourceProvider.projectBaseColumns;
 import static io.trino.plugin.hive.HivePageSourceProvider.projectSufficientColumns;
 import static io.trino.plugin.hive.HiveSessionProperties.getParquetMaxReadBlockSize;
 import static io.trino.plugin.hive.HiveSessionProperties.isParquetIgnoreStatistics;
+import static io.trino.plugin.hive.HiveSessionProperties.isParquetOptimizedReaderEnabled;
 import static io.trino.plugin.hive.HiveSessionProperties.isParquetUseColumnIndex;
 import static io.trino.plugin.hive.HiveSessionProperties.isUseParquetColumnNames;
 import static io.trino.plugin.hive.parquet.ParquetPageSource.handleException;
@@ -178,7 +179,8 @@ public class ParquetPageSourceFactory
                 stats,
                 options.withIgnoreStatistics(isParquetIgnoreStatistics(session))
                         .withMaxReadBlockSize(getParquetMaxReadBlockSize(session))
-                        .withUseColumnIndex(isParquetUseColumnIndex(session)),
+                        .withUseColumnIndex(isParquetUseColumnIndex(session))
+                        .withBatchColumnReaders(isParquetOptimizedReaderEnabled(session)),
                 Optional.empty()));
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetReaderConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetReaderConfig.java
@@ -98,6 +98,19 @@ public class ParquetReaderConfig
         return options.isUseColumnIndex();
     }
 
+    @Config("parquet.optimized-reader.enabled")
+    @ConfigDescription("Use optimized Parquet reader")
+    public ParquetReaderConfig setOptimizedReaderEnabled(boolean optimizedReaderEnabled)
+    {
+        options = options.withBatchColumnReaders(optimizedReaderEnabled);
+        return this;
+    }
+
+    public boolean isOptimizedReaderEnabled()
+    {
+        return options.useBatchColumnReaders();
+    }
+
     public ParquetReaderOptions toParquetReaderOptions()
     {
         return options;

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestParquetPageSkipping.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestParquetPageSkipping.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import io.trino.Session;
+import io.trino.execution.QueryStats;
+import io.trino.operator.OperatorStats;
+import io.trino.spi.QueryId;
+import io.trino.spi.metrics.Count;
+import io.trino.spi.metrics.Metric;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.MaterializedResult;
+import io.trino.testing.MaterializedResultWithQueryId;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.google.common.collect.MoreCollectors.onlyElement;
+import static io.trino.parquet.reader.ParquetReader.COLUMN_INDEX_ROWS_FILTERED;
+import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class AbstractTestParquetPageSkipping
+        extends AbstractTestQueryFramework
+{
+    private void buildSortedTables(String tableName, String sortByColumnName, String sortByColumnType)
+    {
+        String createTableTemplate =
+                "CREATE TABLE %s ( " +
+                        "   orderkey bigint, " +
+                        "   custkey bigint, " +
+                        "   orderstatus varchar(1), " +
+                        "   totalprice double, " +
+                        "   orderdate date, " +
+                        "   orderpriority varchar(15), " +
+                        "   clerk varchar(15), " +
+                        "   shippriority integer, " +
+                        "   comment varchar(79), " +
+                        "   rvalues double array " +
+                        ") " +
+                        "WITH ( " +
+                        "   format = 'PARQUET', " +
+                        "   bucketed_by = array['orderstatus'], " +
+                        "   bucket_count = 1, " +
+                        "   sorted_by = array['%s'] " +
+                        ")";
+        createTableTemplate = createTableTemplate.replaceFirst(sortByColumnName + "[ ]+([^,]*)", sortByColumnName + " " + sortByColumnType);
+
+        assertUpdate(format(
+                createTableTemplate,
+                tableName,
+                sortByColumnName));
+        String catalog = getSession().getCatalog().orElseThrow();
+        assertUpdate(
+                Session.builder(getSession())
+                        .setCatalogSessionProperty(catalog, "parquet_writer_page_size", "10000B")
+                        .setCatalogSessionProperty(catalog, "parquet_writer_block_size", "100GB")
+                        .build(),
+                format("INSERT INTO %s SELECT *, ARRAY[rand(), rand(), rand()] FROM tpch.tiny.orders", tableName),
+                15000);
+    }
+
+    @Test
+    public void testAndPredicates()
+    {
+        String tableName = "test_and_predicate_" + randomNameSuffix();
+        buildSortedTables(tableName, "totalprice", "double");
+        int rowCount = assertColumnIndexResults("SELECT * FROM " + tableName + " WHERE totalprice BETWEEN 100000 AND 131280 AND clerk = 'Clerk#000000624'");
+        assertThat(rowCount).isGreaterThan(0);
+
+        // `totalprice BETWEEN 51890 AND 51900` is chosen to lie between min/max values of row group
+        // but outside page level min/max boundaries to trigger pruning of row group using column index
+        assertRowGroupPruning("SELECT * FROM " + tableName + " WHERE totalprice BETWEEN 51890 AND 51900 AND orderkey > 0");
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testPageSkippingWithNonSequentialOffsets()
+    {
+        String tableName = "test_random_" + randomNameSuffix();
+        int updateCount = 8192;
+        assertUpdate(
+                "CREATE TABLE " + tableName + " (col) WITH (format = 'PARQUET') AS " +
+                        "SELECT * FROM unnest(transform(repeat(1, 8192), x -> rand()))",
+                updateCount);
+        for (int i = 0; i < 8; i++) {
+            assertUpdate(
+                    "INSERT INTO " + tableName + " SELECT rand() FROM " + tableName,
+                    updateCount);
+            updateCount += updateCount;
+        }
+        // These queries select a subset of pages which are stored at non-sequential offsets
+        // This reproduces the issue identified in https://github.com/trinodb/trino/issues/9097
+        for (double i = 0; i < 1; i += 0.1) {
+            assertColumnIndexResults(format("SELECT * FROM %s WHERE col BETWEEN %f AND %f", tableName, i - 0.00001, i + 0.00001));
+        }
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testFilteringOnColumnNameWithDot()
+    {
+        String nameInSql = "\"a.dot\"";
+        String tableName = "test_column_name_with_dot_" + randomNameSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName + "(key varchar(50), " + nameInSql + " varchar(50)) WITH (format = 'PARQUET')");
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('null value', NULL), ('sample value', 'abc'), ('other value', 'xyz')", 3);
+
+        assertQuery("SELECT key FROM " + tableName + " WHERE " + nameInSql + " IS NULL", "VALUES ('null value')");
+        assertQuery("SELECT key FROM " + tableName + " WHERE " + nameInSql + " = 'abc'", "VALUES ('sample value')");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test(dataProvider = "dataType")
+    public void testPageSkipping(String sortByColumn, String sortByColumnType, Object[][] valuesArray)
+    {
+        String tableName = "test_page_skipping_" + randomNameSuffix();
+        buildSortedTables(tableName, sortByColumn, sortByColumnType);
+        for (Object[] values : valuesArray) {
+            Object lowValue = values[0];
+            Object middleLowValue = values[1];
+            Object middleHighValue = values[2];
+            Object highValue = values[3];
+            assertColumnIndexResults(format("SELECT %s FROM %s WHERE %s = %s", sortByColumn, tableName, sortByColumn, middleLowValue));
+            assertThat(assertColumnIndexResults(format("SELECT %s FROM %s WHERE %s < %s", sortByColumn, tableName, sortByColumn, lowValue))).isGreaterThan(0);
+            assertThat(assertColumnIndexResults(format("SELECT %s FROM %s WHERE %s > %s", sortByColumn, tableName, sortByColumn, highValue))).isGreaterThan(0);
+            assertThat(assertColumnIndexResults(format("SELECT %s FROM %s WHERE %s BETWEEN %s AND %s", sortByColumn, tableName, sortByColumn, middleLowValue, middleHighValue))).isGreaterThan(0);
+            // Tests synchronization of reading values across columns
+            assertColumnIndexResults(format("SELECT * FROM %s WHERE %s = %s", tableName, sortByColumn, middleLowValue));
+            assertThat(assertColumnIndexResults(format("SELECT * FROM %s WHERE %s < %s", tableName, sortByColumn, lowValue))).isGreaterThan(0);
+            assertThat(assertColumnIndexResults(format("SELECT * FROM %s WHERE %s > %s", tableName, sortByColumn, highValue))).isGreaterThan(0);
+            assertThat(assertColumnIndexResults(format("SELECT * FROM %s WHERE %s BETWEEN %s AND %s", tableName, sortByColumn, middleLowValue, middleHighValue))).isGreaterThan(0);
+            // Nested data
+            assertColumnIndexResults(format("SELECT rvalues FROM %s WHERE %s IN (%s, %s, %s, %s)", tableName, sortByColumn, lowValue, middleLowValue, middleHighValue, highValue));
+            // Without nested data
+            assertColumnIndexResults(format("SELECT orderkey, orderdate FROM %s WHERE %s IN (%s, %s, %s, %s)", tableName, sortByColumn, lowValue, middleLowValue, middleHighValue, highValue));
+        }
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testFilteringWithColumnIndex()
+    {
+        String tableName = "test_page_filtering_" + randomNameSuffix();
+        String catalog = getSession().getCatalog().orElseThrow();
+        assertUpdate(
+                Session.builder(getSession())
+                        .setCatalogSessionProperty(catalog, "parquet_writer_page_size", "32kB")
+                        .build(),
+                "CREATE TABLE " + tableName + " " +
+                        "WITH (format = 'PARQUET', bucket_count = 1, bucketed_by = ARRAY['suppkey'], sorted_by = ARRAY['suppkey']) AS " +
+                        "SELECT suppkey, extendedprice, shipmode, comment FROM tpch.tiny.lineitem",
+                60175);
+
+        verifyFilteringWithColumnIndex("SELECT * FROM " + tableName + " WHERE suppkey = 10");
+        verifyFilteringWithColumnIndex("SELECT * FROM " + tableName + " WHERE suppkey BETWEEN 25 AND 35");
+        verifyFilteringWithColumnIndex("SELECT * FROM " + tableName + " WHERE suppkey >= 60");
+        verifyFilteringWithColumnIndex("SELECT * FROM " + tableName + " WHERE suppkey <= 40");
+        verifyFilteringWithColumnIndex("SELECT * FROM " + tableName + " WHERE suppkey IN (25, 35, 50, 80)");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    private void verifyFilteringWithColumnIndex(@Language("SQL") String query)
+    {
+        DistributedQueryRunner queryRunner = getDistributedQueryRunner();
+        MaterializedResultWithQueryId resultWithoutColumnIndex = queryRunner.executeWithQueryId(
+                noParquetColumnIndexFiltering(getSession()),
+                query);
+        QueryStats queryStatsWithoutColumnIndex = getQueryStats(resultWithoutColumnIndex.getQueryId());
+        assertThat(queryStatsWithoutColumnIndex.getPhysicalInputPositions()).isGreaterThan(0);
+        Map<String, Metric<?>> metricsWithoutColumnIndex = getScanOperatorStats(resultWithoutColumnIndex.getQueryId())
+                .getConnectorMetrics()
+                .getMetrics();
+        assertThat(metricsWithoutColumnIndex).doesNotContainKey(COLUMN_INDEX_ROWS_FILTERED);
+
+        MaterializedResultWithQueryId resultWithColumnIndex = queryRunner.executeWithQueryId(getSession(), query);
+        QueryStats queryStatsWithColumnIndex = getQueryStats(resultWithColumnIndex.getQueryId());
+        assertThat(queryStatsWithColumnIndex.getPhysicalInputPositions()).isGreaterThan(0);
+        assertThat(queryStatsWithColumnIndex.getPhysicalInputPositions())
+                .isLessThan(queryStatsWithoutColumnIndex.getPhysicalInputPositions());
+        Map<String, Metric<?>> metricsWithColumnIndex = getScanOperatorStats(resultWithColumnIndex.getQueryId())
+                .getConnectorMetrics()
+                .getMetrics();
+        assertThat(metricsWithColumnIndex).containsKey(COLUMN_INDEX_ROWS_FILTERED);
+        assertThat(((Count<?>) metricsWithColumnIndex.get(COLUMN_INDEX_ROWS_FILTERED)).getTotal())
+                .isGreaterThan(0);
+
+        assertEqualsIgnoreOrder(resultWithColumnIndex.getResult(), resultWithoutColumnIndex.getResult());
+    }
+
+    private int assertColumnIndexResults(String query)
+    {
+        MaterializedResult withColumnIndexing = computeActual(query);
+        MaterializedResult withoutColumnIndexing = computeActual(noParquetColumnIndexFiltering(getSession()), query);
+        assertEqualsIgnoreOrder(withColumnIndexing, withoutColumnIndexing);
+        return withoutColumnIndexing.getRowCount();
+    }
+
+    private void assertRowGroupPruning(@Language("SQL") String sql)
+    {
+        assertQueryStats(
+                noParquetColumnIndexFiltering(getSession()),
+                sql,
+                queryStats -> {
+                    assertThat(queryStats.getPhysicalInputPositions()).isGreaterThan(0);
+                    assertThat(queryStats.getProcessedInputPositions()).isEqualTo(queryStats.getPhysicalInputPositions());
+                },
+                results -> assertThat(results.getRowCount()).isEqualTo(0));
+
+        assertQueryStats(
+                getSession(),
+                sql,
+                queryStats -> {
+                    assertThat(queryStats.getPhysicalInputPositions()).isEqualTo(0);
+                    assertThat(queryStats.getProcessedInputPositions()).isEqualTo(0);
+                },
+                results -> assertThat(results.getRowCount()).isEqualTo(0));
+    }
+
+    @DataProvider
+    public Object[][] dataType()
+    {
+        return new Object[][] {
+                {"orderkey", "bigint", new Object[][] {{2, 7520, 7523, 14950}}},
+                {"totalprice", "double", new Object[][] {{974.04, 131094.34, 131279.97, 406938.36}}},
+                {"totalprice", "real", new Object[][] {{974.04, 131094.34, 131279.97, 406938.36}}},
+                {"totalprice", "decimal(12,2)", new Object[][] {
+                        {974.04, 131094.34, 131279.97, 406938.36},
+                        {973, 131095, 131280, 406950},
+                        {974.04123, 131094.34123, 131279.97012, 406938.36555}}},
+                {"totalprice", "decimal(12,0)", new Object[][] {
+                        {973, 131095, 131280, 406950}}},
+                {"totalprice", "decimal(35,2)", new Object[][] {
+                        {974.04, 131094.34, 131279.97, 406938.36},
+                        {973, 131095, 131280, 406950},
+                        {974.04123, 131094.34123, 131279.97012, 406938.36555}}},
+                {"orderdate", "date", new Object[][] {{"DATE '1992-01-05'", "DATE '1995-10-13'", "DATE '1995-10-13'", "DATE '1998-07-29'"}}},
+                {"orderdate", "timestamp", new Object[][] {{"TIMESTAMP '1992-01-05'", "TIMESTAMP '1995-10-13'", "TIMESTAMP '1995-10-14'", "TIMESTAMP '1998-07-29'"}}},
+                {"clerk", "varchar(15)", new Object[][] {{"'Clerk#000000006'", "'Clerk#000000508'", "'Clerk#000000513'", "'Clerk#000000996'"}}},
+                {"custkey", "integer", new Object[][] {{4, 634, 640, 1493}}},
+                {"custkey", "smallint", new Object[][] {{4, 634, 640, 1493}}}
+        };
+    }
+
+    private Session noParquetColumnIndexFiltering(Session session)
+    {
+        return Session.builder(session)
+                .setCatalogSessionProperty(session.getCatalog().orElseThrow(), "parquet_use_column_index", "false")
+                .build();
+    }
+
+    private QueryStats getQueryStats(QueryId queryId)
+    {
+        return getDistributedQueryRunner().getCoordinator()
+                .getQueryManager()
+                .getFullQueryInfo(queryId)
+                .getQueryStats();
+    }
+
+    private OperatorStats getScanOperatorStats(QueryId queryId)
+    {
+        return getQueryStats(queryId)
+                .getOperatorSummaries()
+                .stream()
+                .filter(summary -> summary.getOperatorType().startsWith("TableScan") || summary.getOperatorType().startsWith("Scan"))
+                .collect(onlyElement());
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveTestUtils.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveTestUtils.java
@@ -118,6 +118,13 @@ public final class HiveTestUtils
                 .build();
     }
 
+    public static TestingConnectorSession getHiveSession(HiveConfig hiveConfig, ParquetReaderConfig parquetReaderConfig)
+    {
+        return TestingConnectorSession.builder()
+                .setPropertyMetadata(getHiveSessionProperties(hiveConfig, parquetReaderConfig).getSessionProperties())
+                .build();
+    }
+
     public static HiveSessionProperties getHiveSessionProperties(HiveConfig hiveConfig)
     {
         return getHiveSessionProperties(hiveConfig, new OrcReaderConfig());
@@ -146,6 +153,16 @@ public final class HiveTestUtils
                 new OrcWriterConfig(),
                 new ParquetReaderConfig(),
                 parquetWriterConfig);
+    }
+
+    public static HiveSessionProperties getHiveSessionProperties(HiveConfig hiveConfig, ParquetReaderConfig parquetReaderConfig)
+    {
+        return new HiveSessionProperties(
+                hiveConfig,
+                new OrcReaderConfig(),
+                new OrcWriterConfig(),
+                parquetReaderConfig,
+                new ParquetWriterConfig());
     }
 
     public static Set<HivePageSourceFactory> getDefaultHivePageSourceFactories(HdfsEnvironment hdfsEnvironment, HiveConfig hiveConfig)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestParquetPageSkippingWithOptimizedReader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestParquetPageSkippingWithOptimizedReader.java
@@ -16,7 +16,7 @@ package io.trino.plugin.hive;
 import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
 
-public class TestParquetPageSkipping
+public class TestParquetPageSkippingWithOptimizedReader
         extends AbstractTestParquetPageSkipping
 {
     @Override
@@ -29,7 +29,7 @@ public class TestParquetPageSkipping
                                 "parquet.use-column-index", "true",
                                 // Small max-buffer-size allows testing mix of small and large ranges in HdfsParquetDataSource#planRead
                                 "parquet.max-buffer-size", "400B",
-                                "parquet.optimized-reader.enabled", "false"))
+                                "parquet.optimized-reader.enabled", "true"))
                 .build();
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/BenchmarkFileFormat.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/BenchmarkFileFormat.java
@@ -22,6 +22,7 @@ public enum BenchmarkFileFormat
     TRINO_RCTEXT(StandardFileFormats.TRINO_RCTEXT),
     TRINO_ORC(StandardFileFormats.TRINO_ORC),
     TRINO_PARQUET(StandardFileFormats.TRINO_PARQUET),
+    TRINO_OPTIMIZED_PARQUET(StandardFileFormats.TRINO_PARQUET),
     HIVE_RCBINARY(StandardFileFormats.HIVE_RCBINARY),
     HIVE_RCTEXT(StandardFileFormats.HIVE_RCTEXT),
     HIVE_ORC(StandardFileFormats.HIVE_ORC),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/StandardFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/StandardFileFormats.java
@@ -320,6 +320,7 @@ public final class StandardFileFormats
                     ParquetWriterOptions.builder().build(),
                     compressionCodec.getParquetCompressionCodec(),
                     "test-version",
+                    false,
                     Optional.of(DateTimeZone.getDefault()),
                     Optional.empty());
         }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/TestHiveFileFormatBenchmark.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/TestHiveFileFormatBenchmark.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 
 import static io.trino.plugin.hive.HiveCompressionCodec.SNAPPY;
 import static io.trino.plugin.hive.benchmark.BenchmarkFileFormat.HIVE_RCBINARY;
+import static io.trino.plugin.hive.benchmark.BenchmarkFileFormat.TRINO_OPTIMIZED_PARQUET;
 import static io.trino.plugin.hive.benchmark.BenchmarkFileFormat.TRINO_ORC;
 import static io.trino.plugin.hive.benchmark.BenchmarkFileFormat.TRINO_RCBINARY;
 import static io.trino.plugin.hive.benchmark.BenchmarkHiveFileFormat.DataSet.LARGE_MAP_VARCHAR_DOUBLE;
@@ -37,6 +38,7 @@ public class TestHiveFileFormatBenchmark
         executeBenchmark(LINEITEM, SNAPPY, TRINO_RCBINARY);
         executeBenchmark(LINEITEM, SNAPPY, TRINO_ORC);
         executeBenchmark(LINEITEM, SNAPPY, HIVE_RCBINARY);
+        executeBenchmark(LINEITEM, SNAPPY, TRINO_OPTIMIZED_PARQUET);
         executeBenchmark(MAP_VARCHAR_DOUBLE, SNAPPY, TRINO_RCBINARY);
         executeBenchmark(MAP_VARCHAR_DOUBLE, SNAPPY, TRINO_ORC);
         executeBenchmark(MAP_VARCHAR_DOUBLE, SNAPPY, HIVE_RCBINARY);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
@@ -1105,6 +1105,36 @@ public abstract class AbstractTestParquetReader
                 .isInstanceOf(TrinoException.class);
     }
 
+    @Test
+    public void testParquetShortDecimalWriteToTrinoIntegerBlockWithNonZeroScale()
+    {
+        assertThatThrownBy(() -> {
+            MessageType parquetSchema = parseMessageType(format("message hive_decimal { optional INT32 test (DECIMAL(%d, %d)); }", 8, 1));
+            tester.testRoundTrip(javaIntObjectInspector, ImmutableList.of(1), ImmutableList.of(1), INTEGER, Optional.of(parquetSchema));
+        }).hasMessage("Unsupported Trino column type (integer) for Parquet column ([test] optional int32 test (DECIMAL(8,1)))")
+                .isInstanceOf(TrinoException.class);
+    }
+
+    @Test
+    public void testParquetShortDecimalWriteToTrinoSmallBlockWithNonZeroScale()
+    {
+        assertThatThrownBy(() -> {
+            MessageType parquetSchema = parseMessageType(format("message hive_decimal { optional INT32 test (DECIMAL(%d, %d)); }", 8, 1));
+            tester.testRoundTrip(javaShortObjectInspector, ImmutableList.of((short) 1), ImmutableList.of((short) 1), SMALLINT, Optional.of(parquetSchema));
+        }).hasMessage("Unsupported Trino column type (smallint) for Parquet column ([test] optional int32 test (DECIMAL(8,1)))")
+                .isInstanceOf(TrinoException.class);
+    }
+
+    @Test
+    public void testParquetShortDecimalWriteToTrinoTinyBlockWithNonZeroScale()
+    {
+        assertThatThrownBy(() -> {
+            MessageType parquetSchema = parseMessageType(format("message hive_decimal { optional INT32 test (DECIMAL(%d, %d)); }", 8, 1));
+            tester.testRoundTrip(javaByteObjectInspector, ImmutableList.of((byte) 1), ImmutableList.of((byte) 1), TINYINT, Optional.of(parquetSchema));
+        }).hasMessage("Unsupported Trino column type (tinyint) for Parquet column ([test] optional int32 test (DECIMAL(8,1)))")
+                .isInstanceOf(TrinoException.class);
+    }
+
     @Test(dataProvider = "timestampPrecision")
     public void testTimestamp(HiveTimestampPrecision precision)
             throws Exception

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
@@ -158,8 +158,14 @@ public class ParquetTester
 {
     private static final int MAX_PRECISION_INT64 = toIntExact(maxPrecision(8));
 
-    public static final ConnectorSession SESSION = getHiveSession(createHiveConfig(false));
-    public static final ConnectorSession SESSION_USE_NAME = getHiveSession(createHiveConfig(true));
+    private static final ConnectorSession SESSION = getHiveSession(
+            createHiveConfig(false), new ParquetReaderConfig().setOptimizedReaderEnabled(false));
+
+    private static final ConnectorSession SESSION_OPTIMIZED_READER = getHiveSession(
+            createHiveConfig(false), new ParquetReaderConfig().setOptimizedReaderEnabled(true));
+
+    private static final ConnectorSession SESSION_USE_NAME = getHiveSession(createHiveConfig(true));
+
     public static final List<String> TEST_COLUMN = singletonList("test");
 
     private final Set<CompressionCodecName> compressions;
@@ -182,13 +188,23 @@ public class ParquetTester
                 StandardFileFormats.TRINO_PARQUET);
     }
 
+    public static ParquetTester quickOptimizedParquetTester()
+    {
+        return new ParquetTester(
+                ImmutableSet.of(GZIP),
+                ImmutableSet.of(GZIP),
+                ImmutableSet.of(PARQUET_1_0),
+                ImmutableSet.of(SESSION_OPTIMIZED_READER),
+                StandardFileFormats.TRINO_PARQUET);
+    }
+
     public static ParquetTester fullParquetTester()
     {
         return new ParquetTester(
                 ImmutableSet.of(GZIP, UNCOMPRESSED, SNAPPY, LZO, LZ4, ZSTD),
                 ImmutableSet.of(GZIP, UNCOMPRESSED, SNAPPY, ZSTD),
                 ImmutableSet.copyOf(WriterVersion.values()),
-                ImmutableSet.of(SESSION, SESSION_USE_NAME),
+                ImmutableSet.of(SESSION, SESSION_USE_NAME, SESSION_OPTIMIZED_READER),
                 StandardFileFormats.TRINO_PARQUET);
     }
 
@@ -414,48 +430,51 @@ public class ParquetTester
             throws Exception
     {
         CompressionCodecName compressionCodecName = UNCOMPRESSED;
-        HiveSessionProperties hiveSessionProperties = new HiveSessionProperties(
-                new HiveConfig()
-                        .setHiveStorageFormat(HiveStorageFormat.PARQUET)
-                        .setUseParquetColumnNames(false),
-                new OrcReaderConfig(),
-                new OrcWriterConfig(),
-                new ParquetReaderConfig()
-                        .setMaxReadBlockSize(maxReadBlockSize),
-                new ParquetWriterConfig());
-        ConnectorSession session = TestingConnectorSession.builder()
-                .setPropertyMetadata(hiveSessionProperties.getSessionProperties())
-                .build();
+        for (boolean optimizedReaderEnabled : ImmutableList.of(true, false)) {
+            HiveSessionProperties hiveSessionProperties = new HiveSessionProperties(
+                    new HiveConfig()
+                            .setHiveStorageFormat(HiveStorageFormat.PARQUET)
+                            .setUseParquetColumnNames(false),
+                    new OrcReaderConfig(),
+                    new OrcWriterConfig(),
+                    new ParquetReaderConfig()
+                            .setMaxReadBlockSize(maxReadBlockSize)
+                            .setOptimizedReaderEnabled(optimizedReaderEnabled),
+                    new ParquetWriterConfig());
+            ConnectorSession session = TestingConnectorSession.builder()
+                    .setPropertyMetadata(hiveSessionProperties.getSessionProperties())
+                    .build();
 
-        try (TempFile tempFile = new TempFile("test", "parquet")) {
-            JobConf jobConf = new JobConf(newEmptyConfiguration());
-            jobConf.setEnum(COMPRESSION, compressionCodecName);
-            jobConf.setBoolean(ENABLE_DICTIONARY, true);
-            jobConf.setEnum(WRITER_VERSION, PARQUET_1_0);
-            writeParquetColumn(
-                    jobConf,
-                    tempFile.getFile(),
-                    compressionCodecName,
-                    createTableProperties(columnNames, objectInspectors),
-                    getStandardStructObjectInspector(columnNames, objectInspectors),
-                    getIterators(writeValues),
-                    parquetSchema,
-                    false,
-                    DateTimeZone.getDefault());
+            try (TempFile tempFile = new TempFile("test", "parquet")) {
+                JobConf jobConf = new JobConf(newEmptyConfiguration());
+                jobConf.setEnum(COMPRESSION, compressionCodecName);
+                jobConf.setBoolean(ENABLE_DICTIONARY, true);
+                jobConf.setEnum(WRITER_VERSION, PARQUET_1_0);
+                writeParquetColumn(
+                        jobConf,
+                        tempFile.getFile(),
+                        compressionCodecName,
+                        createTableProperties(columnNames, objectInspectors),
+                        getStandardStructObjectInspector(columnNames, objectInspectors),
+                        getIterators(writeValues),
+                        parquetSchema,
+                        false,
+                        DateTimeZone.getDefault());
 
-            Iterator<?>[] expectedValues = getIterators(readValues);
-            try (ConnectorPageSource pageSource = fileFormat.createFileFormatReader(
-                    session,
-                    HDFS_ENVIRONMENT,
-                    tempFile.getFile(),
-                    columnNames,
-                    columnTypes)) {
-                assertPageSource(
-                        columnTypes,
-                        expectedValues,
-                        pageSource,
-                        Optional.of(getParquetMaxReadBlockSize(session).toBytes()));
-                assertFalse(stream(expectedValues).allMatch(Iterator::hasNext));
+                Iterator<?>[] expectedValues = getIterators(readValues);
+                try (ConnectorPageSource pageSource = fileFormat.createFileFormatReader(
+                        session,
+                        HDFS_ENVIRONMENT,
+                        tempFile.getFile(),
+                        columnNames,
+                        columnTypes)) {
+                    assertPageSource(
+                            columnTypes,
+                            expectedValues,
+                            pageSource,
+                            Optional.of(getParquetMaxReadBlockSize(session).toBytes()));
+                    assertFalse(stream(expectedValues).allMatch(Iterator::hasNext));
+                }
             }
         }
     }
@@ -759,6 +778,7 @@ public class ParquetTester
                         .build(),
                 compressionCodecName,
                 "test-version",
+                false,
                 Optional.of(DateTimeZone.getDefault()),
                 Optional.of(new ParquetWriteValidationBuilder(types, columnNames)));
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestOptimizedParquetReader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestOptimizedParquetReader.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.parquet;
+
+import org.testng.annotations.Test;
+
+// Failing on multiple threads because of org.apache.hadoop.hive.ql.io.parquet.write.ParquetRecordWriterWrapper
+// uses a single record writer across all threads.
+@Test(singleThreaded = true)
+public class TestOptimizedParquetReader
+        extends AbstractTestParquetReader
+{
+    public TestOptimizedParquetReader()
+    {
+        super(ParquetTester.quickOptimizedParquetTester());
+    }
+
+    @Test
+    public void forceTestNgToRespectSingleThreaded()
+    {
+        // TODO: Remove after updating TestNG to 7.4.0+ (https://github.com/trinodb/trino/issues/8571)
+        // TestNG doesn't enforce @Test(singleThreaded = true) when tests are defined in base class. According to
+        // https://github.com/cbeust/testng/issues/2361#issuecomment-688393166 a workaround it to add a dummy test to the leaf test class.
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetDecimalScaling.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetDecimalScaling.java
@@ -15,6 +15,7 @@ package io.trino.plugin.hive.parquet;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import io.trino.Session;
 import io.trino.plugin.hive.HiveQueryRunner;
 import io.trino.plugin.hive.parquet.write.TestMapredParquetOutputFormat;
 import io.trino.testing.AbstractTestQueryFramework;
@@ -34,6 +35,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.parquet.schema.MessageType;
+import org.intellij.lang.annotations.Language;
 import org.joda.time.DateTimeZone;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -300,7 +302,11 @@ public class TestParquetDecimalScaling
                 ImmutableList.of(new ParquetDecimalInsert("value", forceFixedLengthArray, precision, scale, values)),
                 writerVersion);
 
-        assertQueryFails(format("SELECT * FROM tpch.%s", tableName), format("Cannot cast DECIMAL\\(%d, %d\\) '.*' to DECIMAL\\(%d, %d\\)", precision, scale, schemaPrecision, schemaScale));
+        @Language("SQL") String query = format("SELECT * FROM tpch.%s", tableName);
+        @Language("RegExp") String expectedMessage = format("Cannot cast DECIMAL\\(%d, %d\\) '.*' to DECIMAL\\(%d, %d\\)", precision, scale, schemaPrecision, schemaScale);
+
+        assertQueryFails(optimizedParquetReaderEnabled(false), query, expectedMessage);
+        assertQueryFails(optimizedParquetReaderEnabled(true), query, expectedMessage);
 
         dropTable(tableName);
     }
@@ -349,9 +355,11 @@ public class TestParquetDecimalScaling
                 writerVersion);
 
         if (overflows(new BigDecimal(writeValue).unscaledValue(), schemaPrecision)) {
-            assertQueryFails(
-                    format("SELECT * FROM tpch.%s", tableName),
-                    format("Could not read fixed_len_byte_array\\(%d\\) value %s into decimal\\(%d,%d\\)", byteArrayLength, writeValue, schemaPrecision, schemaScale));
+            @Language("SQL") String query = format("SELECT * FROM tpch.%s", tableName);
+            @Language("RegExp") String expectedMessage = format("Could not read fixed_len_byte_array\\(%d\\) value %s into decimal\\(%d,%d\\)", byteArrayLength, writeValue, schemaPrecision, schemaScale);
+
+            assertQueryFails(optimizedParquetReaderEnabled(false), query, expectedMessage);
+            assertQueryFails(optimizedParquetReaderEnabled(true), query, expectedMessage);
         }
         else {
             assertValues(tableName, schemaScale, ImmutableList.of(writeValue));
@@ -386,9 +394,15 @@ public class TestParquetDecimalScaling
         assertUpdate(format("DROP TABLE %s", tableName));
     }
 
-    protected void assertValues(String tableName, int scale, List<String> expected)
+    private void assertValues(String tableName, int scale, List<String> expected)
     {
-        MaterializedResult materializedRows = computeActual(format("SELECT value FROM tpch.%s", tableName));
+        assertValues(optimizedParquetReaderEnabled(false), tableName, scale, expected);
+        assertValues(optimizedParquetReaderEnabled(true), tableName, scale, expected);
+    }
+
+    private void assertValues(Session session, String tableName, int scale, List<String> expected)
+    {
+        MaterializedResult materializedRows = computeActual(session, format("SELECT value FROM tpch.%s", tableName));
 
         List<BigDecimal> actualValues = materializedRows.getMaterializedRows().stream()
                 .map(row -> row.getField(0))
@@ -402,9 +416,15 @@ public class TestParquetDecimalScaling
         assertThat(actualValues).containsExactlyInAnyOrder(expectedValues);
     }
 
-    protected void assertRoundedValues(String tableName, int scale, List<String> expected)
+    private void assertRoundedValues(String tableName, int scale, List<String> expected)
     {
-        MaterializedResult materializedRows = computeActual(format("SELECT value FROM tpch.%s", tableName));
+        assertRoundedValues(optimizedParquetReaderEnabled(false), tableName, scale, expected);
+        assertRoundedValues(optimizedParquetReaderEnabled(true), tableName, scale, expected);
+    }
+
+    private void assertRoundedValues(Session session, String tableName, int scale, List<String> expected)
+    {
+        MaterializedResult materializedRows = computeActual(session, format("SELECT value FROM tpch.%s", tableName));
 
         List<BigDecimal> actualValues = materializedRows.getMaterializedRows().stream()
                 .map(row -> row.getField(0))
@@ -515,6 +535,14 @@ public class TestParquetDecimalScaling
         Object[][] versions = Stream.of(WriterVersion.values())
                 .collect(toDataProvider());
         return cartesianProduct(args, versions);
+    }
+
+    private Session optimizedParquetReaderEnabled(boolean enabled)
+    {
+        Session session = getSession();
+        return Session.builder(session)
+                .setCatalogSessionProperty(session.getCatalog().orElseThrow(), "parquet_optimized_reader_enabled", Boolean.toString(enabled))
+                .build();
     }
 
     protected static class ParquetDecimalInsert

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetReaderConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetReaderConfig.java
@@ -35,7 +35,8 @@ public class TestParquetReaderConfig
                 .setMaxReadBlockSize(DataSize.of(16, MEGABYTE))
                 .setMaxMergeDistance(DataSize.of(1, MEGABYTE))
                 .setMaxBufferSize(DataSize.of(8, MEGABYTE))
-                .setUseColumnIndex(true));
+                .setUseColumnIndex(true)
+                .setOptimizedReaderEnabled(true));
     }
 
     @Test
@@ -47,6 +48,7 @@ public class TestParquetReaderConfig
                 .put("parquet.max-buffer-size", "1431kB")
                 .put("parquet.max-merge-distance", "342kB")
                 .put("parquet.use-column-index", "false")
+                .put("parquet.optimized-reader.enabled", "false")
                 .buildOrThrow();
 
         ParquetReaderConfig expected = new ParquetReaderConfig()
@@ -54,7 +56,8 @@ public class TestParquetReaderConfig
                 .setMaxReadBlockSize(DataSize.of(66, KILOBYTE))
                 .setMaxBufferSize(DataSize.of(1431, KILOBYTE))
                 .setMaxMergeDistance(DataSize.of(342, KILOBYTE))
-                .setUseColumnIndex(false);
+                .setUseColumnIndex(false)
+                .setOptimizedReaderEnabled(false);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestTimestamp.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestTimestamp.java
@@ -18,6 +18,7 @@ import com.google.common.collect.DiscreteDomain;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import io.trino.plugin.hive.HiveConfig;
+import io.trino.plugin.hive.HiveTimestampPrecision;
 import io.trino.plugin.hive.benchmark.StandardFileFormats;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
@@ -30,18 +31,26 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.schema.MessageType;
 import org.joda.time.DateTimeZone;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.plugin.hive.HiveTestUtils.getHiveSession;
 import static io.trino.spi.type.BigintType.BIGINT;
-import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static io.trino.testing.DataProviders.toDataProvider;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
 import static java.util.Collections.singletonList;
 import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardStructObjectInspector;
 import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaLongObjectInspector;
@@ -54,23 +63,37 @@ import static org.testng.Assert.assertTrue;
 
 public class TestTimestamp
 {
-    @Test
-    public void testTimestampBackedByInt64()
+    @DataProvider
+    public static Object[][] timestampPrecisionProvider()
+    {
+        return Arrays.stream(HiveTimestampPrecision.values()).collect(toDataProvider());
+    }
+
+    @Test(dataProvider = "timestampPrecisionProvider")
+    public void testTimestampBackedByInt64(HiveTimestampPrecision timestamp)
             throws Exception
     {
-        MessageType parquetSchema = parseMessageType("message hive_timestamp { optional int64 test (TIMESTAMP_MILLIS); }");
-        ContiguousSet<Long> epochMillisValues = ContiguousSet.create(Range.closedOpen((long) -1_000, (long) 1_000), DiscreteDomain.longs());
-        ImmutableList.Builder<SqlTimestamp> timestampsMillis = ImmutableList.builder();
-        ImmutableList.Builder<Long> bigints = ImmutableList.builder();
-        for (long value : epochMillisValues) {
-            timestampsMillis.add(SqlTimestamp.fromMillis(3, value));
-            bigints.add(value);
-        }
+        String logicalAnnotation = switch (timestamp) {
+            case MILLISECONDS -> "TIMESTAMP(MILLIS,true)";
+            case MICROSECONDS -> "TIMESTAMP(MICROS,true)";
+            case NANOSECONDS -> "TIMESTAMP(NANOS,true)";
+        };
+        MessageType parquetSchema = parseMessageType("message hive_timestamp { optional int64 test (" + logicalAnnotation + "); }");
+        List<Long> writeValues = ContiguousSet.create(Range.closedOpen((long) -1_000, (long) 1_000), DiscreteDomain.longs()).stream()
+                .collect(toImmutableList());
+        List<SqlTimestamp> timestampReadValues = writeValues.stream()
+                .map(value -> switch (timestamp) {
+                    case MILLISECONDS -> SqlTimestamp.fromMillis(timestamp.getPrecision(), value);
+                    case MICROSECONDS -> SqlTimestamp.newInstance(timestamp.getPrecision(), value, 0);
+                    case NANOSECONDS -> SqlTimestamp.newInstance(
+                            timestamp.getPrecision(),
+                            floorDiv(value, NANOSECONDS_PER_MICROSECOND),
+                            floorMod(value, NANOSECONDS_PER_MICROSECOND) * PICOSECONDS_PER_NANOSECOND);
+                })
+                .collect(toImmutableList());
 
         List<ObjectInspector> objectInspectors = singletonList(javaLongObjectInspector);
         List<String> columnNames = ImmutableList.of("test");
-
-        ConnectorSession session = getHiveSession(new HiveConfig());
 
         try (ParquetTester.TempFile tempFile = new ParquetTester.TempFile("test", "parquet")) {
             JobConf jobConf = new JobConf(newEmptyConfiguration());
@@ -82,17 +105,22 @@ public class TestTimestamp
                     CompressionCodecName.SNAPPY,
                     ParquetTester.createTableProperties(columnNames, objectInspectors),
                     getStandardStructObjectInspector(columnNames, objectInspectors),
-                    new Iterator<?>[] {epochMillisValues.iterator()},
+                    new Iterator<?>[] {writeValues.iterator()},
                     Optional.of(parquetSchema),
                     false,
                     DateTimeZone.getDefault());
 
-            testReadingAs(TIMESTAMP_MILLIS, session, tempFile, columnNames, timestampsMillis.build());
-            testReadingAs(BIGINT, session, tempFile, columnNames, bigints.build());
+            ConnectorSession session = getHiveSession(new HiveConfig(), new ParquetReaderConfig().setOptimizedReaderEnabled(false));
+            testReadingAs(createTimestampType(timestamp.getPrecision()), session, tempFile, columnNames, timestampReadValues);
+            testReadingAs(BIGINT, session, tempFile, columnNames, writeValues);
+
+            session = getHiveSession(new HiveConfig(), new ParquetReaderConfig().setOptimizedReaderEnabled(true));
+            testReadingAs(createTimestampType(timestamp.getPrecision()), session, tempFile, columnNames, timestampReadValues);
+            testReadingAs(BIGINT, session, tempFile, columnNames, writeValues);
         }
     }
 
-    private void testReadingAs(Type type, ConnectorSession session, ParquetTester.TempFile tempFile, List<String> columnNames, List<?> expectedValues)
+    private static void testReadingAs(Type type, ConnectorSession session, ParquetTester.TempFile tempFile, List<String> columnNames, List<?> expectedValues)
              throws IOException
     {
         Iterator<?> expected = expectedValues.iterator();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestTimestampMicros.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestTimestampMicros.java
@@ -48,6 +48,7 @@ import static io.trino.plugin.hive.HiveTestUtils.getHiveSession;
 import static io.trino.plugin.hive.HiveType.HIVE_TIMESTAMP;
 import static io.trino.spi.type.TimestampType.createTimestampType;
 import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
+import static io.trino.testing.DataProviders.cartesianProduct;
 import static io.trino.testing.MaterializedResult.materializeSourceDataStream;
 import static org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_LIB;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,11 +56,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestTimestampMicros
 {
     @Test(dataProvider = "testTimestampMicrosDataProvider")
-    public void testTimestampMicros(HiveTimestampPrecision timestampPrecision, LocalDateTime expected)
+    public void testTimestampMicros(HiveTimestampPrecision timestampPrecision, LocalDateTime expected, boolean useOptimizedParquetReader)
             throws Exception
     {
-        ConnectorSession session = getHiveSession(new HiveConfig()
-                .setTimestampPrecision(timestampPrecision));
+        ConnectorSession session = getHiveSession(
+                new HiveConfig().setTimestampPrecision(timestampPrecision),
+                new ParquetReaderConfig().setOptimizedReaderEnabled(useOptimizedParquetReader));
 
         File parquetFile = new File(Resources.getResource("issue-5483.parquet").toURI());
         Type columnType = createTimestampType(timestampPrecision.getPrecision());
@@ -72,11 +74,12 @@ public class TestTimestampMicros
     }
 
     @Test(dataProvider = "testTimestampMicrosDataProvider")
-    public void testTimestampMicrosAsTimestampWithTimeZone(HiveTimestampPrecision timestampPrecision, LocalDateTime expected)
+    public void testTimestampMicrosAsTimestampWithTimeZone(HiveTimestampPrecision timestampPrecision, LocalDateTime expected, boolean useOptimizedParquetReader)
             throws Exception
     {
-        ConnectorSession session = getHiveSession(new HiveConfig()
-                .setTimestampPrecision(timestampPrecision));
+        ConnectorSession session = getHiveSession(
+                new HiveConfig().setTimestampPrecision(timestampPrecision),
+                new ParquetReaderConfig().setOptimizedReaderEnabled(useOptimizedParquetReader));
 
         File parquetFile = new File(Resources.getResource("issue-5483.parquet").toURI());
         Type columnType = createTimestampWithTimeZoneType(timestampPrecision.getPrecision());
@@ -91,11 +94,13 @@ public class TestTimestampMicros
     @DataProvider
     public static Object[][] testTimestampMicrosDataProvider()
     {
-        return new Object[][] {
-                {HiveTimestampPrecision.MILLISECONDS, LocalDateTime.parse("2020-10-12T16:26:02.907")},
-                {HiveTimestampPrecision.MICROSECONDS, LocalDateTime.parse("2020-10-12T16:26:02.906668")},
-                {HiveTimestampPrecision.NANOSECONDS, LocalDateTime.parse("2020-10-12T16:26:02.906668")},
-        };
+        return cartesianProduct(
+                new Object[][] {
+                        {HiveTimestampPrecision.MILLISECONDS, LocalDateTime.parse("2020-10-12T16:26:02.907")},
+                        {HiveTimestampPrecision.MICROSECONDS, LocalDateTime.parse("2020-10-12T16:26:02.906668")},
+                        {HiveTimestampPrecision.NANOSECONDS, LocalDateTime.parse("2020-10-12T16:26:02.906668")},
+                },
+                new Object[][] {{true}, {false}});
     }
 
     private ConnectorPageSource createPageSource(ConnectorSession session, File parquetFile, String columnName, HiveType columnHiveType, Type columnType)

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPageSourceProvider.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPageSourceProvider.java
@@ -90,6 +90,7 @@ import static io.trino.plugin.hudi.HudiErrorCode.HUDI_CURSOR_ERROR;
 import static io.trino.plugin.hudi.HudiErrorCode.HUDI_INVALID_PARTITION_VALUE;
 import static io.trino.plugin.hudi.HudiErrorCode.HUDI_MISSING_DATA;
 import static io.trino.plugin.hudi.HudiErrorCode.HUDI_UNSUPPORTED_FILE_FORMAT;
+import static io.trino.plugin.hudi.HudiSessionProperties.isParquetOptimizedReaderEnabled;
 import static io.trino.plugin.hudi.HudiSessionProperties.shouldUseParquetColumnNames;
 import static io.trino.plugin.hudi.HudiUtil.getHudiFileFormat;
 import static io.trino.spi.predicate.Utils.nativeValueToBlock;
@@ -239,7 +240,7 @@ public class HudiPageSourceProvider
                     dataSource,
                     timeZone,
                     newSimpleAggregatedMemoryContext(),
-                    options,
+                    options.withBatchColumnReaders(isParquetOptimizedReaderEnabled(session)),
                     exception -> handleException(dataSourceId, exception),
                     Optional.of(parquetPredicate),
                     columnIndexes.build(),

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSessionProperties.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSessionProperties.java
@@ -16,6 +16,7 @@ package io.trino.plugin.hudi;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
+import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.session.PropertyMetadata;
@@ -42,6 +43,7 @@ public class HudiSessionProperties
     private static final String COLUMNS_TO_HIDE = "columns_to_hide";
     private static final String METADATA_ENABLED = "metadata_enabled";
     private static final String USE_PARQUET_COLUMN_NAMES = "use_parquet_column_names";
+    private static final String PARQUET_OPTIMIZED_READER_ENABLED = "parquet_optimized_reader_enabled";
     private static final String MIN_PARTITION_BATCH_SIZE = "min_partition_batch_size";
     private static final String MAX_PARTITION_BATCH_SIZE = "max_partition_batch_size";
     private static final String SIZE_BASED_SPLIT_WEIGHTS_ENABLED = "size_based_split_weights_enabled";
@@ -51,7 +53,7 @@ public class HudiSessionProperties
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
-    public HudiSessionProperties(HudiConfig hudiConfig)
+    public HudiSessionProperties(HudiConfig hudiConfig, ParquetReaderConfig parquetReaderConfig)
     {
         sessionProperties = ImmutableList.of(
                 new PropertyMetadata<>(
@@ -74,6 +76,11 @@ public class HudiSessionProperties
                         USE_PARQUET_COLUMN_NAMES,
                         "Access parquet columns using names from the file. If disabled, then columns are accessed using index.",
                         hudiConfig.getUseParquetColumnNames(),
+                        false),
+                booleanProperty(
+                        PARQUET_OPTIMIZED_READER_ENABLED,
+                        "Use optimized Parquet reader",
+                        parquetReaderConfig.isOptimizedReaderEnabled(),
                         false),
                 integerProperty(
                         MIN_PARTITION_BATCH_SIZE,
@@ -127,6 +134,11 @@ public class HudiSessionProperties
     public static boolean shouldUseParquetColumnNames(ConnectorSession session)
     {
         return session.getProperty(USE_PARQUET_COLUMN_NAMES, Boolean.class);
+    }
+
+    public static boolean isParquetOptimizedReaderEnabled(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_OPTIMIZED_READER_ENABLED, Boolean.class);
     }
 
     public static int getMinPartitionBatchSize(ConnectorSession session)

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiSessionProperties.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiSessionProperties.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.hudi;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.testing.TestingConnectorSession;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ public class TestHudiSessionProperties
     {
         HudiConfig config = new HudiConfig()
                 .setColumnsToHide("col1, col2");
-        HudiSessionProperties sessionProperties = new HudiSessionProperties(config);
+        HudiSessionProperties sessionProperties = new HudiSessionProperties(config, new ParquetReaderConfig());
         ConnectorSession session = TestingConnectorSession.builder()
                 .setPropertyMetadata(sessionProperties.getSessionProperties())
                 .build();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -159,6 +159,7 @@ import static io.trino.plugin.iceberg.IcebergSessionProperties.getOrcTinyStripeT
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetMaxReadBlockSize;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isOrcBloomFiltersEnabled;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isOrcNestedLazy;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.isParquetOptimizedReaderEnabled;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isUseFileSizeFromMetadata;
 import static io.trino.plugin.iceberg.IcebergSplitManager.ICEBERG_DOMAIN_COMPACTION_THRESHOLD;
 import static io.trino.plugin.iceberg.IcebergUtil.deserializePartitionValue;
@@ -562,7 +563,8 @@ public class IcebergPageSourceProvider
                         partitionData,
                         dataColumns,
                         parquetReaderOptions
-                                .withMaxReadBlockSize(getParquetMaxReadBlockSize(session)),
+                                .withMaxReadBlockSize(getParquetMaxReadBlockSize(session))
+                                .withBatchColumnReaders(isParquetOptimizedReaderEnabled(session)),
                         predicate,
                         fileFormatDataSourceStats,
                         nameMapping,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetFileWriter.java
@@ -67,6 +67,7 @@ public class IcebergParquetFileWriter
                 fileInputColumnIndexes,
                 compressionCodecName,
                 trinoVersion,
+                false,
                 Optional.empty(),
                 Optional.empty());
         this.metricsConfig = requireNonNull(metricsConfig, "metricsConfig is null");

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -66,6 +66,7 @@ public final class IcebergSessionProperties
     private static final String ORC_WRITER_MAX_STRIPE_ROWS = "orc_writer_max_stripe_rows";
     private static final String ORC_WRITER_MAX_DICTIONARY_MEMORY = "orc_writer_max_dictionary_memory";
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
+    private static final String PARQUET_OPTIMIZED_READER_ENABLED = "parquet_optimized_reader_enabled";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
     private static final String PARQUET_WRITER_BATCH_SIZE = "parquet_writer_batch_size";
@@ -189,6 +190,11 @@ public final class IcebergSessionProperties
                         PARQUET_MAX_READ_BLOCK_SIZE,
                         "Parquet: Maximum size of a block to read",
                         parquetReaderConfig.getMaxReadBlockSize(),
+                        false))
+                .add(booleanProperty(
+                        PARQUET_OPTIMIZED_READER_ENABLED,
+                        "Use optimized Parquet reader",
+                        parquetReaderConfig.isOptimizedReaderEnabled(),
                         false))
                 .add(dataSizeProperty(
                         PARQUET_WRITER_BLOCK_SIZE,
@@ -356,6 +362,11 @@ public final class IcebergSessionProperties
     public static DataSize getParquetMaxReadBlockSize(ConnectorSession session)
     {
         return session.getProperty(PARQUET_MAX_READ_BLOCK_SIZE, DataSize.class);
+    }
+
+    public static boolean isParquetOptimizedReaderEnabled(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_OPTIMIZED_READER_ENABLED, Boolean.class);
     }
 
     public static DataSize getParquetWriterPageSize(ConnectorSession session)


### PR DESCRIPTION
## Description

    FlatDefinitionLevelDecoder implements an optimized decoder for primitive
    columns where the definition level is either 0 or 1.
    ApacheParquetValueDecoder provides implementations of batched decoders
    which are wrappers over existing parquet-mr ValuesReader implementations.
    More optimized implementations of ValueDecoder will be added to ValueDecoders
    in subsequent chnages.
    FilteredRowRangesIterator providers a way to iterate over rows selected by column
    index in a batch of positions at a time.
    FlatColumnReader makes use of the batched decoders and row-ranges iterator to
    implement an optimized ColumnReader with dedicated code paths for nullable and
    non-nullable types.
    ColumnReaderFactory is updated to use the optimized implementations for
    boolean, tinyint, short, int, long, float, double and short decimals.
    ColumnReaderFactory falls back to existing implementations where optimized
    implementations are not yet available or the flag
    parquet.optimized-reader.enabled is disabled.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Improve performance of reading Parquet files for boolean, tinyint, short, int, long, float, double and short decimal data types.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Iceberg, Delta, Hudi
* Improve performance of reading Parquet files for boolean, tinyint, short, int, long, float, double and short decimal data types. The catalog configuration property `parquet.optimized-reader.enabled` can be set to `false` to disable the optimized implementation. ({issue}`14423`)
```
