### PR TITLE
Allow creating tables with avro.schema.literal

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableProperties.java
@@ -56,6 +56,7 @@ public class HiveTableProperties
     public static final String ORC_BLOOM_FILTER_COLUMNS = "orc_bloom_filter_columns";
     public static final String ORC_BLOOM_FILTER_FPP = "orc_bloom_filter_fpp";
     public static final String AVRO_SCHEMA_URL = "avro_schema_url";
+    public static final String AVRO_SCHEMA_LITERAL = "avro_schema_literal";
     public static final String TEXTFILE_FIELD_SEPARATOR = "textfile_field_separator";
     public static final String TEXTFILE_FIELD_SEPARATOR_ESCAPE = "textfile_field_separator_escape";
     public static final String NULL_FORMAT_PROPERTY = "null_format";
@@ -143,6 +144,7 @@ public class HiveTableProperties
                 integerProperty(BUCKETING_VERSION, "Bucketing version", null, false),
                 integerProperty(BUCKET_COUNT_PROPERTY, "Number of buckets", 0, false),
                 stringProperty(AVRO_SCHEMA_URL, "URI pointing to Avro schema for the table", null, false),
+                stringProperty(AVRO_SCHEMA_LITERAL, "JSON-encoded Avro schema for the table", null, false),
                 integerProperty(SKIP_HEADER_LINE_COUNT, "Number of header lines", null, false),
                 integerProperty(SKIP_FOOTER_LINE_COUNT, "Number of footer lines", null, false),
                 stringProperty(TEXTFILE_FIELD_SEPARATOR, "TEXTFILE field separator character", null, false),
@@ -183,6 +185,11 @@ public class HiveTableProperties
     public static String getAvroSchemaUrl(Map<String, Object> tableProperties)
     {
         return (String) tableProperties.get(AVRO_SCHEMA_URL);
+    }
+
+    public static String getAvroSchemaLiteral(Map<String, Object> tableProperties)
+    {
+        return (String) tableProperties.get(AVRO_SCHEMA_LITERAL);
     }
 
     public static Optional<Integer> getHeaderSkipCount(Map<String, Object> tableProperties)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/MetastoreUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/MetastoreUtil.java
@@ -59,6 +59,7 @@ import java.util.concurrent.TimeUnit;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.hive.HiveMetadata.AVRO_SCHEMA_LITERAL_KEY;
 import static io.trino.plugin.hive.HiveMetadata.AVRO_SCHEMA_URL_KEY;
 import static io.trino.plugin.hive.HiveSplitManager.PRESTO_OFFLINE;
 import static io.trino.plugin.hive.HiveStorageFormat.AVRO;
@@ -217,8 +218,10 @@ public final class MetastoreUtil
     public static boolean isAvroTableWithSchemaSet(Table table)
     {
         return AVRO.getSerde().equals(table.getStorage().getStorageFormat().getSerDeNullable()) &&
-                (table.getParameters().get(AVRO_SCHEMA_URL_KEY) != null ||
-                        (table.getStorage().getSerdeParameters().get(AVRO_SCHEMA_URL_KEY) != null));
+                ((table.getParameters().get(AVRO_SCHEMA_URL_KEY) != null ||
+                        (table.getStorage().getSerdeParameters().get(AVRO_SCHEMA_URL_KEY) != null)) ||
+                 (table.getParameters().get(AVRO_SCHEMA_LITERAL_KEY) != null ||
+                         (table.getStorage().getSerdeParameters().get(AVRO_SCHEMA_LITERAL_KEY) != null)));
     }
 
     public static String makePartitionName(Table table, Partition partition)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -102,6 +102,7 @@ import static io.trino.plugin.hive.HiveColumnStatisticType.NUMBER_OF_NON_NULL_VA
 import static io.trino.plugin.hive.HiveColumnStatisticType.NUMBER_OF_TRUE_VALUES;
 import static io.trino.plugin.hive.HiveColumnStatisticType.TOTAL_SIZE_IN_BYTES;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_INVALID_METADATA;
+import static io.trino.plugin.hive.HiveMetadata.AVRO_SCHEMA_LITERAL_KEY;
 import static io.trino.plugin.hive.HiveMetadata.AVRO_SCHEMA_URL_KEY;
 import static io.trino.plugin.hive.HiveStorageFormat.AVRO;
 import static io.trino.plugin.hive.HiveStorageFormat.CSV;
@@ -415,8 +416,10 @@ public final class ThriftMetastoreUtil
         SerDeInfo serdeInfo = getSerdeInfo(table);
 
         return serdeInfo.getSerializationLib() != null &&
-                (table.getParameters().get(AVRO_SCHEMA_URL_KEY) != null ||
-                        (serdeInfo.getParameters() != null && serdeInfo.getParameters().get(AVRO_SCHEMA_URL_KEY) != null)) &&
+                ((table.getParameters().get(AVRO_SCHEMA_URL_KEY) != null ||
+                        (serdeInfo.getParameters() != null && serdeInfo.getParameters().get(AVRO_SCHEMA_URL_KEY) != null)) ||
+                 (table.getParameters().get(AVRO_SCHEMA_LITERAL_KEY) != null ||
+                         (serdeInfo.getParameters() != null && serdeInfo.getParameters().get(AVRO_SCHEMA_LITERAL_KEY) != null))) &&
                 serdeInfo.getSerializationLib().equals(AVRO.getSerde());
     }
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestAvroSchemaEvolution.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestAvroSchemaEvolution.java
@@ -21,6 +21,10 @@ import io.trino.tempto.ProductTest;
 import io.trino.tempto.assertions.QueryAssert.Row;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -46,21 +50,24 @@ public abstract class BaseTestAvroSchemaEvolution
     private static final String CHANGE_COLUMN_TYPE_SCHEMA = "file:///docker/presto-product-tests/avro/change_column_type_schema.avsc";
     private static final String INCOMPATIBLE_TYPE_SCHEMA = "file:///docker/presto-product-tests/avro/incompatible_type_schema.avsc";
 
-    private final String tableName;
+    private final String tableWithSchemaUrl;
+    private final String tableWithSchemaLiteral;
     private final String columnsInTableStatement;
     private final String selectStarStatement;
     private final List<String> varcharPartitionColumns;
 
     protected BaseTestAvroSchemaEvolution(String tableName, String... varcharPartitionColumns)
     {
-        this.tableName = tableName;
-        this.columnsInTableStatement = "SHOW COLUMNS IN " + tableName;
-        this.selectStarStatement = "SELECT * FROM " + tableName;
+        this.tableWithSchemaLiteral = tableName + "_with_schema_literal";
+        this.tableWithSchemaUrl = tableName + "_with_schema_url";
+        this.columnsInTableStatement = "SHOW COLUMNS IN %s";
+        this.selectStarStatement = "SELECT * FROM %s";
         this.varcharPartitionColumns = ImmutableList.copyOf(varcharPartitionColumns);
     }
 
     @BeforeTestWithContext
     public void createAndLoadTable()
+            throws IOException
     {
         onTrino().executeQuery(format(
                 "CREATE TABLE %s (" +
@@ -72,34 +79,57 @@ public abstract class BaseTestAvroSchemaEvolution
                         "  avro_schema_url='%s'" +
                         (varcharPartitionColumns.isEmpty() ? "" : ", partitioned_by=ARRAY[" + getPartitionsAsListString(partitionColumns -> "'" + partitionColumns + "'") + "]") +
                         ")",
-                tableName,
+                tableWithSchemaUrl,
                 ORIGINAL_SCHEMA));
-        insertData(tableName, 0, "'stringA0'", "0");
+        insertData(tableWithSchemaUrl, 0, "'stringA0'", "0");
+        onTrino().executeQuery(format(
+                "CREATE TABLE %s (" +
+                        "  dummy_col VARCHAR" +
+                        (varcharPartitionColumns.isEmpty() ? "" : ", " + getPartitionsAsListString(partitionColumns -> partitionColumns + " varchar")) +
+                        ")" +
+                        "WITH (" +
+                        "  format='AVRO', " +
+                        "  avro_schema_literal='%s'" +
+                        (varcharPartitionColumns.isEmpty() ? "" : ", partitioned_by=ARRAY[" + getPartitionsAsListString(partitionColumns -> "'" + partitionColumns + "'") + "]") +
+                        ")",
+                tableWithSchemaLiteral,
+                readSchemaLiteralFromUrl(ORIGINAL_SCHEMA)));
+        insertData(tableWithSchemaLiteral, 0, "'stringA0'", "0");
     }
 
     @AfterTestWithContext
     public void dropTestTable()
     {
-        onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
+        onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", tableWithSchemaUrl));
+        onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", tableWithSchemaLiteral));
     }
 
     @Test(groups = AVRO)
     public void testSelectTable()
     {
-        assertThat(onTrino().executeQuery(format("SELECT string_col FROM %s", tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT string_col FROM %s", tableWithSchemaUrl)))
+                .containsExactlyInOrder(row("stringA0"));
+        assertThat(onTrino().executeQuery(format("SELECT string_col FROM %s", tableWithSchemaLiteral)))
                 .containsExactlyInOrder(row("stringA0"));
     }
 
     @Test(groups = AVRO)
     public void testInsertAfterSchemaEvolution()
+            throws IOException
     {
-        assertThat(onTrino().executeQuery(selectStarStatement))
-                .containsOnly(
-                        createRow(0, "stringA0", 0));
+        assertUnmodified();
 
-        alterTableSchemaTo(ADDED_COLUMN_SCHEMA);
-        insertData(tableName, 1, "'stringA1'", "1", "101");
-        assertThat(onTrino().executeQuery(selectStarStatement))
+        alterTableSchemaUrl(ADDED_COLUMN_SCHEMA);
+        alterTableSchemaLiteral(readSchemaLiteralFromUrl(ADDED_COLUMN_SCHEMA));
+
+        insertData(tableWithSchemaUrl, 1, "'stringA1'", "1", "101");
+        insertData(tableWithSchemaLiteral, 1, "'stringA1'", "1", "101");
+
+        assertThat(onTrino().executeQuery(format(selectStarStatement, tableWithSchemaUrl)))
+                .containsOnly(
+                        createRow(0, "stringA0", 0, 100),
+                        createRow(1, "stringA1", 1, 101));
+        assertThat(onTrino().executeQuery(format(selectStarStatement, tableWithSchemaLiteral)))
                 .containsOnly(
                         createRow(0, "stringA0", 0, 100),
                         createRow(1, "stringA1", 1, 101));
@@ -107,72 +137,136 @@ public abstract class BaseTestAvroSchemaEvolution
 
     @Test(groups = AVRO)
     public void testSchemaEvolutionWithIncompatibleType()
+            throws IOException
     {
-        assertThat(onTrino().executeQuery(columnsInTableStatement))
+        assertThat(onTrino().executeQuery(format(columnsInTableStatement, tableWithSchemaUrl)))
                 .containsExactlyInOrder(
                         prepareShowColumnsResultRows(
                                 row("string_col", "varchar", "", ""),
                                 row("int_col", "integer", "", "")));
-        assertThat(onTrino().executeQuery(selectStarStatement))
+        assertThat(onTrino().executeQuery(format(columnsInTableStatement, tableWithSchemaLiteral)))
                 .containsExactlyInOrder(
-                        createRow(0, "stringA0", 0));
+                        prepareShowColumnsResultRows(
+                                row("string_col", "varchar", "", ""),
+                                row("int_col", "integer", "", "")));
+        assertUnmodified();
 
-        alterTableSchemaTo(INCOMPATIBLE_TYPE_SCHEMA);
-        assertQueryFailure(() -> onTrino().executeQuery(selectStarStatement))
+        alterTableSchemaUrl(INCOMPATIBLE_TYPE_SCHEMA);
+        alterTableSchemaLiteral(readSchemaLiteralFromUrl(INCOMPATIBLE_TYPE_SCHEMA));
+
+        assertQueryFailure(() -> onTrino().executeQuery(format(selectStarStatement, tableWithSchemaUrl)))
+                .hasMessageContaining("Found int, expecting string");
+        assertQueryFailure(() -> onTrino().executeQuery(format(selectStarStatement, tableWithSchemaLiteral)))
                 .hasMessageContaining("Found int, expecting string");
     }
 
     @Test(groups = AVRO)
-    public void testSchemaEvolution()
+    public void testSchemaEvolutionWithUrl()
     {
-        assertThat(onTrino().executeQuery(columnsInTableStatement))
+        assertThat(onTrino().executeQuery(format(columnsInTableStatement, tableWithSchemaUrl)))
                 .containsExactlyInOrder(
                         prepareShowColumnsResultRows(
                                 row("string_col", "varchar", "", ""),
                                 row("int_col", "integer", "", "")));
 
-        assertThat(onTrino().executeQuery(selectStarStatement))
+        assertThat(onTrino().executeQuery(format(selectStarStatement, tableWithSchemaUrl)))
                 .containsExactlyInOrder(
                         createRow(0, "stringA0", 0));
 
-        alterTableSchemaTo(CHANGE_COLUMN_TYPE_SCHEMA);
-        assertThat(onTrino().executeQuery(columnsInTableStatement))
+        alterTableSchemaUrl(CHANGE_COLUMN_TYPE_SCHEMA);
+        assertThat(onTrino().executeQuery(format(columnsInTableStatement, tableWithSchemaUrl)))
                 .containsExactlyInOrder(
                         prepareShowColumnsResultRows(
                                 row("string_col", "varchar", "", ""),
                                 row("int_col", "bigint", "", "")));
-        assertThat(onTrino().executeQuery(selectStarStatement))
+        assertThat(onTrino().executeQuery(format(selectStarStatement, tableWithSchemaUrl)))
                 .containsExactlyInOrder(
                         createRow(0, "stringA0", 0));
 
-        alterTableSchemaTo(ADDED_COLUMN_SCHEMA);
-        assertThat(onTrino().executeQuery(columnsInTableStatement))
+        alterTableSchemaUrl(ADDED_COLUMN_SCHEMA);
+        assertThat(onTrino().executeQuery(format(columnsInTableStatement, tableWithSchemaUrl)))
                 .containsExactlyInOrder(
                         prepareShowColumnsResultRows(
                                 row("string_col", "varchar", "", ""),
                                 row("int_col", "integer", "", ""),
                                 row("int_col_added", "integer", "", "")));
-        assertThat(onTrino().executeQuery(selectStarStatement))
+        assertThat(onTrino().executeQuery(format(selectStarStatement, tableWithSchemaUrl)))
                 .containsExactlyInOrder(
                         createRow(0, "stringA0", 0, 100));
 
-        alterTableSchemaTo(REMOVED_COLUMN_SCHEMA);
-        assertThat(onTrino().executeQuery(columnsInTableStatement))
+        alterTableSchemaUrl(REMOVED_COLUMN_SCHEMA);
+        assertThat(onTrino().executeQuery(format(columnsInTableStatement, tableWithSchemaUrl)))
                 .containsExactlyInOrder(
                         prepareShowColumnsResultRows(
                                 row("int_col", "integer", "", "")));
-        assertThat(onTrino().executeQuery(selectStarStatement))
+        assertThat(onTrino().executeQuery(format(selectStarStatement, tableWithSchemaUrl)))
                 .containsExactlyInOrder(
                         createRow(0, 0));
 
-        alterTableSchemaTo(RENAMED_COLUMN_SCHEMA);
-        assertThat(onTrino().executeQuery(columnsInTableStatement))
+        alterTableSchemaUrl(RENAMED_COLUMN_SCHEMA);
+        assertThat(onTrino().executeQuery(format(columnsInTableStatement, tableWithSchemaUrl)))
                 .containsExactlyInOrder(
                         prepareShowColumnsResultRows(
                                 row("string_col", "varchar", "", ""),
                                 row("int_col_renamed", "integer", "", "")));
 
-        assertThat(onTrino().executeQuery(selectStarStatement))
+        assertThat(onTrino().executeQuery(format(selectStarStatement, tableWithSchemaUrl)))
+                .containsExactlyInOrder(
+                        createRow(0, "stringA0", null));
+    }
+
+    @Test(groups = AVRO)
+    public void testSchemaEvolutionWithLiteral()
+            throws IOException
+    {
+        assertThat(onTrino().executeQuery(format(columnsInTableStatement, tableWithSchemaLiteral)))
+                .containsExactlyInOrder(
+                        prepareShowColumnsResultRows(
+                                row("string_col", "varchar", "", ""),
+                                row("int_col", "integer", "", "")));
+
+        assertThat(onTrino().executeQuery(format(selectStarStatement, tableWithSchemaLiteral)))
+                .containsExactlyInOrder(
+                        createRow(0, "stringA0", 0));
+
+        alterTableSchemaLiteral(readSchemaLiteralFromUrl(CHANGE_COLUMN_TYPE_SCHEMA));
+        assertThat(onTrino().executeQuery(format(columnsInTableStatement, tableWithSchemaLiteral)))
+                .containsExactlyInOrder(
+                        prepareShowColumnsResultRows(
+                                row("string_col", "varchar", "", ""),
+                                row("int_col", "bigint", "", "")));
+        assertThat(onTrino().executeQuery(format(selectStarStatement, tableWithSchemaLiteral)))
+                .containsExactlyInOrder(
+                        createRow(0, "stringA0", 0));
+
+        alterTableSchemaLiteral(readSchemaLiteralFromUrl(ADDED_COLUMN_SCHEMA));
+        assertThat(onTrino().executeQuery(format(columnsInTableStatement, tableWithSchemaLiteral)))
+                .containsExactlyInOrder(
+                        prepareShowColumnsResultRows(
+                                row("string_col", "varchar", "", ""),
+                                row("int_col", "integer", "", ""),
+                                row("int_col_added", "integer", "", "")));
+        assertThat(onTrino().executeQuery(format(selectStarStatement, tableWithSchemaLiteral)))
+                .containsExactlyInOrder(
+                        createRow(0, "stringA0", 0, 100));
+
+        alterTableSchemaLiteral(readSchemaLiteralFromUrl(REMOVED_COLUMN_SCHEMA));
+        assertThat(onTrino().executeQuery(format(columnsInTableStatement, tableWithSchemaLiteral)))
+                .containsExactlyInOrder(
+                        prepareShowColumnsResultRows(
+                                row("int_col", "integer", "", "")));
+        assertThat(onTrino().executeQuery(format(selectStarStatement, tableWithSchemaLiteral)))
+                .containsExactlyInOrder(
+                        createRow(0, 0));
+
+        alterTableSchemaLiteral(readSchemaLiteralFromUrl(RENAMED_COLUMN_SCHEMA));
+        assertThat(onTrino().executeQuery(format(columnsInTableStatement, tableWithSchemaLiteral)))
+                .containsExactlyInOrder(
+                        prepareShowColumnsResultRows(
+                                row("string_col", "varchar", "", ""),
+                                row("int_col_renamed", "integer", "", "")));
+
+        assertThat(onTrino().executeQuery(format(selectStarStatement, tableWithSchemaLiteral)))
                 .containsExactlyInOrder(
                         createRow(0, "stringA0", null));
     }
@@ -180,17 +274,36 @@ public abstract class BaseTestAvroSchemaEvolution
     @Test(groups = AVRO)
     public void testSchemaWhenUrlIsUnset()
     {
-        assertThat(onTrino().executeQuery(columnsInTableStatement))
+        assertThat(onTrino().executeQuery(format(columnsInTableStatement, tableWithSchemaUrl)))
                 .containsExactlyInOrder(
                         prepareShowColumnsResultRows(
                                 row("string_col", "varchar", "", ""),
                                 row("int_col", "integer", "", "")));
-        assertThat(onTrino().executeQuery(selectStarStatement))
+        assertThat(onTrino().executeQuery(format(selectStarStatement, tableWithSchemaUrl)))
                 .containsExactlyInOrder(
                         createRow(0, "stringA0", 0));
 
-        onHive().executeQuery(format("ALTER TABLE %s UNSET TBLPROPERTIES('avro.schema.url')", tableName));
-        assertThat(onTrino().executeQuery(columnsInTableStatement))
+        onHive().executeQuery(format("ALTER TABLE %s UNSET TBLPROPERTIES('avro.schema.url')", tableWithSchemaUrl));
+        assertThat(onTrino().executeQuery(format(columnsInTableStatement, tableWithSchemaUrl)))
+                .containsExactlyInOrder(
+                        prepareShowColumnsResultRows(
+                                row("dummy_col", "varchar", "", "")));
+    }
+
+    @Test(groups = AVRO)
+    public void testSchemaWhenLiteralIsUnset()
+    {
+        assertThat(onTrino().executeQuery(format(columnsInTableStatement, tableWithSchemaLiteral)))
+                .containsExactlyInOrder(
+                        prepareShowColumnsResultRows(
+                                row("string_col", "varchar", "", ""),
+                                row("int_col", "integer", "", "")));
+        assertThat(onTrino().executeQuery(format(selectStarStatement, tableWithSchemaLiteral)))
+                .containsExactlyInOrder(
+                        createRow(0, "stringA0", 0));
+
+        onHive().executeQuery(format("ALTER TABLE %s UNSET TBLPROPERTIES('avro.schema.literal')", tableWithSchemaLiteral));
+        assertThat(onTrino().executeQuery(format(columnsInTableStatement, tableWithSchemaLiteral)))
                 .containsExactlyInOrder(
                         prepareShowColumnsResultRows(
                                 row("dummy_col", "varchar", "", "")));
@@ -199,22 +312,58 @@ public abstract class BaseTestAvroSchemaEvolution
     @Test(groups = AVRO)
     public void testCreateTableLike()
     {
-        String createTableLikeName = tableName + "_avro_like";
+        String createTableLikeWithSchemaUrl = tableWithSchemaUrl + "_avro_like";
+        String createTableLikeWithSchemaLiteral = tableWithSchemaLiteral + "_avro_like";
+
         onTrino().executeQuery(format(
                 "CREATE TABLE %s (LIKE %s INCLUDING PROPERTIES)",
-                createTableLikeName,
-                tableName));
+                createTableLikeWithSchemaUrl,
+                tableWithSchemaUrl));
 
-        insertData(createTableLikeName, 0, "'stringA0'", "0");
+        onTrino().executeQuery(format(
+                "CREATE TABLE %s (LIKE %s INCLUDING PROPERTIES)",
+                createTableLikeWithSchemaLiteral,
+                tableWithSchemaLiteral));
 
-        assertThat(onTrino().executeQuery(format("SELECT string_col FROM %s", createTableLikeName)))
+        insertData(createTableLikeWithSchemaUrl, 0, "'stringA0'", "0");
+        insertData(createTableLikeWithSchemaLiteral, 0, "'stringA0'", "0");
+
+        assertThat(onTrino().executeQuery(format("SELECT string_col FROM %s", createTableLikeWithSchemaUrl)))
                 .containsExactlyInOrder(row("stringA0"));
-        onTrino().executeQuery("DROP TABLE IF EXISTS " + createTableLikeName);
+        assertThat(onTrino().executeQuery(format("SELECT string_col FROM %s", createTableLikeWithSchemaLiteral)))
+                .containsExactlyInOrder(row("stringA0"));
+
+        onTrino().executeQuery("DROP TABLE IF EXISTS " + createTableLikeWithSchemaUrl);
+        onTrino().executeQuery("DROP TABLE IF EXISTS " + createTableLikeWithSchemaLiteral);
     }
 
-    private void alterTableSchemaTo(String schema)
+    private void assertUnmodified()
     {
-        onHive().executeQuery(format("ALTER TABLE %s SET TBLPROPERTIES('avro.schema.url'='%s')", tableName, schema));
+        assertThat(onTrino().executeQuery(format(columnsInTableStatement, tableWithSchemaUrl)))
+                .containsExactlyInOrder(
+                        prepareShowColumnsResultRows(
+                                row("string_col", "varchar", "", ""),
+                                row("int_col", "integer", "", "")));
+        assertThat(onTrino().executeQuery(format(columnsInTableStatement, tableWithSchemaLiteral)))
+                .containsExactlyInOrder(
+                        prepareShowColumnsResultRows(
+                                row("string_col", "varchar", "", ""),
+                                row("int_col", "integer", "", "")));
+
+        assertThat(onTrino().executeQuery(format(selectStarStatement, tableWithSchemaUrl)))
+                .containsOnly(createRow(0, "stringA0", 0));
+        assertThat(onTrino().executeQuery(format(selectStarStatement, tableWithSchemaLiteral)))
+                .containsOnly(createRow(0, "stringA0", 0));
+    }
+
+    private void alterTableSchemaUrl(String newUrl)
+    {
+        onHive().executeQuery(format("ALTER TABLE %s SET TBLPROPERTIES('avro.schema.url'='%s')", tableWithSchemaUrl, newUrl));
+    }
+
+    private void alterTableSchemaLiteral(String newLiteral)
+    {
+        onHive().executeQuery(format("ALTER TABLE %s SET TBLPROPERTIES('avro.schema.literal'='%s')", tableWithSchemaLiteral, newLiteral));
     }
 
     private void insertData(String tableName, int rowNumber, String... sqlValues)
@@ -246,5 +395,11 @@ public abstract class BaseTestAvroSchemaEvolution
         return varcharPartitionColumns.stream()
                 .map(partitionMapper)
                 .collect(Collectors.joining(", "));
+    }
+
+    private static String readSchemaLiteralFromUrl(String url)
+            throws IOException
+    {
+        return Files.readString(Path.of(URI.create(url)));
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaLiteral.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaLiteral.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.hive;
+
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertThat;
+import static io.trino.tests.product.TestGroups.AVRO;
+import static io.trino.tests.product.utils.QueryExecutors.onHive;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+import static java.lang.String.format;
+
+public class TestAvroSchemaLiteral
+        extends HiveProductTest
+{
+    @Language("JSON")
+    private static final String SCHEMA_LITERAL = "{\n" +
+            "  \"namespace\": \"io.trino.test\",\n" +
+            "  \"name\": \"product_tests_avro_table\",\n" +
+            "  \"type\": \"record\",\n" +
+            "  \"fields\": [\n" +
+            "    { \"name\":\"string_col\", \"type\":\"string\"},\n" +
+            "    { \"name\":\"int_col\", \"type\":\"int\" }\n" +
+            "]}";
+
+    @Test(groups = AVRO)
+    public void testHiveCreatedTable()
+    {
+        onHive().executeQuery("DROP TABLE IF EXISTS test_avro_schema_literal_hive");
+        onHive().executeQuery(format("" +
+                        "CREATE TABLE test_avro_schema_literal_hive " +
+                        "ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.avro.AvroSerDe' " +
+                        "STORED AS " +
+                        "INPUTFORMAT 'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat' " +
+                        "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat' " +
+                        "TBLPROPERTIES ('avro.schema.literal'='%s')",
+                SCHEMA_LITERAL));
+        onHive().executeQuery("INSERT INTO test_avro_schema_literal_hive VALUES ('some text', 123042)");
+
+        assertThat(onHive().executeQuery("SELECT * FROM test_avro_schema_literal_hive")).containsExactlyInOrder(row("some text", 123042));
+        assertThat(onTrino().executeQuery("SELECT * FROM test_avro_schema_literal_hive")).containsExactlyInOrder(row("some text", 123042));
+
+        onHive().executeQuery("DROP TABLE test_avro_schema_literal_hive");
+    }
+
+    @Test(groups = AVRO)
+    public void testTrinoCreatedTable()
+    {
+        onTrino().executeQuery("DROP TABLE IF EXISTS test_avro_schema_literal_trino");
+        onTrino().executeQuery(format("CREATE TABLE test_avro_schema_literal_trino (dummy_col VARCHAR) WITH (format='AVRO', avro_schema_literal='%s')", SCHEMA_LITERAL));
+        onTrino().executeQuery("INSERT INTO test_avro_schema_literal_trino VALUES ('some text', 123042)");
+
+        assertThat(onHive().executeQuery("SELECT * FROM test_avro_schema_literal_trino")).containsExactlyInOrder(row("some text", 123042));
+        assertThat(onTrino().executeQuery("SELECT * FROM test_avro_schema_literal_trino")).containsExactlyInOrder(row("some text", 123042));
+
+        onTrino().executeQuery("DROP TABLE test_avro_schema_literal_trino");
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR aims to address the following
* Add support for creating Avro-backed Hive table with `avro.schema.literal`.
* Add product tests to cover following cases
    1. Creating table by Hive with `avro.schema.literal` and querying from Trino (`TestAvroSchemaLiteral`)
    2. Creating table by Trino with `avro.schema.literal` and querying from Trino (`TestAvroSchemaLiteral`)
    3. Schema evolution on partitioned/non-partitioned tables with `avro.schema.literal` (Captured in `BaseTestAvroSchemaEvolution`)

Update also needed in https://github.com/trinodb/trino/blob/master/docs/src/main/sphinx/connector/hive.rst 


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
With this change, Trino users will be able to create Hive table using `avro.schema.literal` to define the schema.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
