### PR TITLE
Enable reading Parquet's bloomfilter statistics for hive connector

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -531,6 +531,12 @@ with Parquet files performed by the Hive connector.
         optimized parquet reader by default. The equivalent catalog session
         property is ``parquet_optimized_reader_enabled``.
       - ``true``
+    * - ``parquet.use-bloom-filter``
+      - Whether bloom filters are used for predicate pushdown when reading
+        Parquet files. Set this property to ``false`` to disable the usage of
+        bloom filters by default. The equivalent catalog session property is
+        ``parquet_use_bloom_filter``.
+      - ``true``
     * - ``parquet.optimized-writer.enabled``
       - Whether the optimized writer should be used when writing Parquet files.
         Set this property to ``true`` to use the optimized parquet writer by

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/BloomFilterStore.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/BloomFilterStore.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.BasicSliceInput;
+import io.airlift.slice.Slice;
+import org.apache.parquet.column.values.bloomfilter.BlockSplitBloomFilter;
+import org.apache.parquet.column.values.bloomfilter.BloomFilter;
+import org.apache.parquet.format.BloomFilterHeader;
+import org.apache.parquet.format.Util;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.io.ParquetDecodingException;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.Verify.verify;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.apache.parquet.column.values.bloomfilter.BlockSplitBloomFilter.UPPER_BOUND_BYTES;
+
+public class BloomFilterStore
+{
+    // since bloomfilter header is relatively small(18 bytes when testing) we can read in a larger buffer(BlockSplitBloomFilter.HEADER_SIZE*4 in this case)
+    // and get actual bytes used when deserializing header in order to calculate the correct offset for bloomfilter data.
+    private static final int MAX_HEADER_LENGTH = BlockSplitBloomFilter.HEADER_SIZE * 4;
+
+    private final ParquetDataSource dataSource;
+    private final Map<ColumnPath, Long> bloomFilterOffsets;
+
+    public BloomFilterStore(ParquetDataSource dataSource, BlockMetaData block, Set<ColumnPath> columnsFiltered)
+    {
+        this.dataSource = requireNonNull(dataSource, "dataSource is null");
+        requireNonNull(block, "block is null");
+        requireNonNull(columnsFiltered, "columnsFiltered is null");
+
+        ImmutableMap.Builder<ColumnPath, Long> bloomFilterOffsetBuilder = ImmutableMap.builder();
+        for (ColumnChunkMetaData column : block.getColumns()) {
+            ColumnPath path = column.getPath();
+            if (hasBloomFilter(column) && columnsFiltered.contains(path)) {
+                bloomFilterOffsetBuilder.put(path, column.getBloomFilterOffset());
+            }
+        }
+        this.bloomFilterOffsets = bloomFilterOffsetBuilder.buildOrThrow();
+    }
+
+    public Optional<BloomFilter> getBloomFilter(ColumnPath columnPath)
+    {
+        BloomFilterHeader bloomFilterHeader;
+        long bloomFilterDataOffset;
+        try {
+            Long columnBloomFilterOffset = bloomFilterOffsets.get(columnPath);
+            if (columnBloomFilterOffset == null) {
+                return Optional.empty();
+            }
+            BasicSliceInput headerSliceInput = dataSource.readFully(columnBloomFilterOffset, MAX_HEADER_LENGTH).getInput();
+            bloomFilterHeader = Util.readBloomFilterHeader(headerSliceInput);
+            bloomFilterDataOffset = columnBloomFilterOffset + headerSliceInput.position();
+        }
+        catch (IOException exception) {
+            throw new UncheckedIOException("Failed to read Bloom filter header", exception);
+        }
+
+        if (!bloomFilterSupported(columnPath, bloomFilterHeader)) {
+            return Optional.empty();
+        }
+
+        try {
+            Slice bloomFilterData = dataSource.readFully(bloomFilterDataOffset, bloomFilterHeader.getNumBytes());
+            verify(bloomFilterData.length() > 0, "Read empty bloom filter %s", bloomFilterHeader);
+            return Optional.of(new BlockSplitBloomFilter(bloomFilterData.getBytes()));
+        }
+        catch (IOException exception) {
+            throw new UncheckedIOException("Failed to read Bloom filter data", exception);
+        }
+    }
+
+    public static boolean hasBloomFilter(ColumnChunkMetaData columnMetaData)
+    {
+        return columnMetaData.getBloomFilterOffset() > 0;
+    }
+
+    private static boolean bloomFilterSupported(ColumnPath columnPath, BloomFilterHeader bloomFilterHeader)
+    {
+        int numBytes = bloomFilterHeader.getNumBytes();
+        if (numBytes <= 0 || numBytes > UPPER_BOUND_BYTES) {
+            throw new ParquetDecodingException(format("Column: %s has bloom filter number of bytes value of %d, which is out of bound of lower limit: %d and upper limit: %d", columnPath, numBytes, 0, UPPER_BOUND_BYTES));
+        }
+        return bloomFilterHeader.getHash().isSetXXHASH() && bloomFilterHeader.getAlgorithm().isSetBLOCK() && bloomFilterHeader.getCompression().isSetUNCOMPRESSED();
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderOptions.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderOptions.java
@@ -33,6 +33,7 @@ public class ParquetReaderOptions
     private final DataSize maxBufferSize;
     private final boolean useColumnIndex;
     private final boolean useBatchColumnReaders;
+    private final boolean useBloomFilter;
 
     public ParquetReaderOptions()
     {
@@ -43,6 +44,7 @@ public class ParquetReaderOptions
         maxBufferSize = DEFAULT_MAX_BUFFER_SIZE;
         useColumnIndex = true;
         useBatchColumnReaders = true;
+        useBloomFilter = true;
     }
 
     private ParquetReaderOptions(
@@ -52,7 +54,8 @@ public class ParquetReaderOptions
             DataSize maxMergeDistance,
             DataSize maxBufferSize,
             boolean useColumnIndex,
-            boolean useBatchColumnReaders)
+            boolean useBatchColumnReaders,
+            boolean useBloomFilter)
     {
         this.ignoreStatistics = ignoreStatistics;
         this.maxReadBlockSize = requireNonNull(maxReadBlockSize, "maxReadBlockSize is null");
@@ -62,6 +65,7 @@ public class ParquetReaderOptions
         this.maxBufferSize = requireNonNull(maxBufferSize, "maxBufferSize is null");
         this.useColumnIndex = useColumnIndex;
         this.useBatchColumnReaders = useBatchColumnReaders;
+        this.useBloomFilter = useBloomFilter;
     }
 
     public boolean isIgnoreStatistics()
@@ -89,6 +93,11 @@ public class ParquetReaderOptions
         return useBatchColumnReaders;
     }
 
+    public boolean useBloomFilter()
+    {
+        return useBloomFilter;
+    }
+
     public DataSize getMaxBufferSize()
     {
         return maxBufferSize;
@@ -108,7 +117,8 @@ public class ParquetReaderOptions
                 maxMergeDistance,
                 maxBufferSize,
                 useColumnIndex,
-                useBatchColumnReaders);
+                useBatchColumnReaders,
+                useBloomFilter);
     }
 
     public ParquetReaderOptions withMaxReadBlockSize(DataSize maxReadBlockSize)
@@ -120,7 +130,8 @@ public class ParquetReaderOptions
                 maxMergeDistance,
                 maxBufferSize,
                 useColumnIndex,
-                useBatchColumnReaders);
+                useBatchColumnReaders,
+                useBloomFilter);
     }
 
     public ParquetReaderOptions withMaxReadBlockRowCount(int maxReadBlockRowCount)
@@ -132,7 +143,8 @@ public class ParquetReaderOptions
                 maxMergeDistance,
                 maxBufferSize,
                 useColumnIndex,
-                useBatchColumnReaders);
+                useBatchColumnReaders,
+                useBloomFilter);
     }
 
     public ParquetReaderOptions withMaxMergeDistance(DataSize maxMergeDistance)
@@ -144,7 +156,8 @@ public class ParquetReaderOptions
                 maxMergeDistance,
                 maxBufferSize,
                 useColumnIndex,
-                useBatchColumnReaders);
+                useBatchColumnReaders,
+                useBloomFilter);
     }
 
     public ParquetReaderOptions withMaxBufferSize(DataSize maxBufferSize)
@@ -156,7 +169,8 @@ public class ParquetReaderOptions
                 maxMergeDistance,
                 maxBufferSize,
                 useColumnIndex,
-                useBatchColumnReaders);
+                useBatchColumnReaders,
+                useBloomFilter);
     }
 
     public ParquetReaderOptions withUseColumnIndex(boolean useColumnIndex)
@@ -168,7 +182,8 @@ public class ParquetReaderOptions
                 maxMergeDistance,
                 maxBufferSize,
                 useColumnIndex,
-                useBatchColumnReaders);
+                useBatchColumnReaders,
+                useBloomFilter);
     }
 
     public ParquetReaderOptions withBatchColumnReaders(boolean useBatchColumnReaders)
@@ -180,6 +195,20 @@ public class ParquetReaderOptions
                 maxMergeDistance,
                 maxBufferSize,
                 useColumnIndex,
-                useBatchColumnReaders);
+                useBatchColumnReaders,
+                useBloomFilter);
+    }
+
+    public ParquetReaderOptions withBloomFilter(boolean useBloomFilter)
+    {
+        return new ParquetReaderOptions(
+                ignoreStatistics,
+                maxReadBlockSize,
+                maxReadBlockRowCount,
+                maxMergeDistance,
+                maxBufferSize,
+                useColumnIndex,
+                useBatchColumnReaders,
+                useBloomFilter);
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/PredicateUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/PredicateUtils.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceInput;
+import io.trino.parquet.BloomFilterStore;
 import io.trino.parquet.DictionaryPage;
 import io.trino.parquet.ParquetDataSource;
 import io.trino.parquet.ParquetEncoding;
@@ -64,7 +65,7 @@ public final class PredicateUtils
 {
     // Maximum size of dictionary that we will read for row-group pruning.
     // Reading larger dictionaries is typically not beneficial. Before checking
-    // the dictionary, the row-group and page indexes have already been checked
+    // the dictionary, the row-group, page indexes and bloomfilters have already been checked
     // and when the dictionary does not eliminate a row-group, the work done to
     // decode the dictionary and match it with predicates is wasted.
     private static final int MAX_DICTIONARY_SIZE = 8096;
@@ -131,7 +132,9 @@ public final class PredicateUtils
             Map<List<String>, ColumnDescriptor> descriptorsByPath,
             TupleDomain<ColumnDescriptor> parquetTupleDomain,
             Optional<ColumnIndexStore> columnIndexStore,
-            DateTimeZone timeZone)
+            Optional<BloomFilterStore> bloomFilterStore,
+            DateTimeZone timeZone,
+            int domainCompactionThreshold)
             throws IOException
     {
         if (block.getRowCount() == 0) {
@@ -146,13 +149,17 @@ public final class PredicateUtils
         if (candidateColumns.get().isEmpty()) {
             return true;
         }
-        // Perform column index and dictionary lookups only for the subset of columns where it can be useful.
+        // Perform column index, bloom filter checks and dictionary lookups only for the subset of columns where it can be useful.
         // This prevents unnecessary filesystem reads and decoding work when the predicate on a column comes from
         // file-level min/max stats or more generally when the predicate selects a range equal to or wider than row-group min/max.
         TupleDomainParquetPredicate indexPredicate = new TupleDomainParquetPredicate(parquetTupleDomain, candidateColumns.get(), timeZone);
 
         // Page stats is finer grained but relatively more expensive, so we do the filtering after above block filtering.
         if (columnIndexStore.isPresent() && !indexPredicate.matches(columnValueCounts, columnIndexStore.get(), dataSource.getId())) {
+            return false;
+        }
+
+        if (bloomFilterStore.isPresent() && !indexPredicate.matches(bloomFilterStore.get(), domainCompactionThreshold)) {
             return false;
         }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/MetadataReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/MetadataReader.java
@@ -155,6 +155,7 @@ public final class MetadataReader
                             metaData.total_uncompressed_size);
                     column.setColumnIndexReference(toColumnIndexReference(columnChunk));
                     column.setOffsetIndexReference(toOffsetIndexReference(columnChunk));
+                    column.setBloomFilterOffset(metaData.bloom_filter_offset);
                     blockMetaData.addColumn(column);
                 }
                 blockMetaData.setPath(filePath);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -92,6 +92,7 @@ public class DeltaLakeMergeSink
     private final ConnectorPageSink insertPageSink;
     private final List<DeltaLakeColumnHandle> dataColumns;
     private final int tableColumnCount;
+    private final int domainCompactionThreshold;
     private final Map<Slice, FileDeletion> fileDeletions = new HashMap<>();
 
     public DeltaLakeMergeSink(
@@ -104,7 +105,8 @@ public class DeltaLakeMergeSink
             DeltaLakeWriterStats writerStats,
             String rootTableLocation,
             ConnectorPageSink insertPageSink,
-            List<DeltaLakeColumnHandle> tableColumns)
+            List<DeltaLakeColumnHandle> tableColumns,
+            int domainCompactionThreshold)
     {
         this.session = requireNonNull(session, "session is null");
         this.fileSystem = fileSystemFactory.create(session);
@@ -120,6 +122,7 @@ public class DeltaLakeMergeSink
         this.dataColumns = tableColumns.stream()
                 .filter(column -> column.getColumnType() == REGULAR)
                 .collect(toImmutableList());
+        this.domainCompactionThreshold = domainCompactionThreshold;
     }
 
     @Override
@@ -313,7 +316,8 @@ public class DeltaLakeMergeSink
                 parquetDateTimeZone,
                 new FileFormatDataSourceStats(),
                 new ParquetReaderOptions(),
-                Optional.empty());
+                Optional.empty(),
+                domainCompactionThreshold);
     }
 
     private static class FileDeletion

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -315,7 +315,7 @@ public class DeltaLakeMergeSink
                 true,
                 parquetDateTimeZone,
                 new FileFormatDataSourceStats(),
-                new ParquetReaderOptions(),
+                new ParquetReaderOptions().withBloomFilter(false),
                 Optional.empty(),
                 domainCompactionThreshold);
     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSinkProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSinkProvider.java
@@ -50,6 +50,7 @@ public class DeltaLakePageSinkProvider
     private final DateTimeZone parquetDateTimeZone;
     private final TypeManager typeManager;
     private final String trinoVersion;
+    private final int domainCompactionThreshold;
 
     @Inject
     public DeltaLakePageSinkProvider(
@@ -71,6 +72,7 @@ public class DeltaLakePageSinkProvider
         this.stats = stats;
         this.maxPartitionsPerWriter = deltaLakeConfig.getMaxPartitionsPerWriter();
         this.parquetDateTimeZone = deltaLakeConfig.getParquetDateTimeZone();
+        this.domainCompactionThreshold = deltaLakeConfig.getDomainCompactionThreshold();
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.trinoVersion = nodeVersion.toString();
     }
@@ -155,6 +157,7 @@ public class DeltaLakePageSinkProvider
                 stats,
                 tableHandle.getLocation(),
                 pageSink,
-                tableHandle.getInputColumns());
+                tableHandle.getInputColumns(),
+                domainCompactionThreshold);
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
@@ -197,7 +197,8 @@ public class DeltaLakePageSourceProvider
                     parquetReaderOptions,
                     parquetPredicate,
                     typeManager,
-                    updateResultJsonCodec);
+                    updateResultJsonCodec,
+                    domainCompactionThreshold);
         }
 
         ReaderPageSource pageSource = ParquetPageSourceFactory.createPageSource(
@@ -210,7 +211,8 @@ public class DeltaLakePageSourceProvider
                 parquetDateTimeZone,
                 fileFormatDataSourceStats,
                 options,
-                Optional.empty());
+                Optional.empty(),
+                domainCompactionThreshold);
 
         verify(pageSource.getReaderColumns().isEmpty(), "All columns expected to be base columns");
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
@@ -103,7 +103,7 @@ public class DeltaLakePageSourceProvider
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.fileFormatDataSourceStats = requireNonNull(fileFormatDataSourceStats, "fileFormatDataSourceStats is null");
-        this.parquetReaderOptions = parquetReaderConfig.toParquetReaderOptions();
+        this.parquetReaderOptions = parquetReaderConfig.toParquetReaderOptions().withBloomFilter(false);
         this.domainCompactionThreshold = deltaLakeConfig.getDomainCompactionThreshold();
         this.parquetDateTimeZone = deltaLakeConfig.getParquetDateTimeZone();
         this.executorService = requireNonNull(executorService, "executorService is null");

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeUpdatablePageSource.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeUpdatablePageSource.java
@@ -108,6 +108,7 @@ public class DeltaLakeUpdatablePageSource
     private final HdfsEnvironment hdfsEnvironment;
     private final DateTimeZone parquetDateTimeZone;
     private final ParquetReaderOptions parquetReaderOptions;
+    private final int domainCompactionThreshold;
     private final TypeManager typeManager;
     private final JsonCodec<DeltaLakeUpdateResult> updateResultJsonCodec;
     private final BitSet rowsToDelete;
@@ -141,7 +142,8 @@ public class DeltaLakeUpdatablePageSource
             ParquetReaderOptions parquetReaderOptions,
             TupleDomain<HiveColumnHandle> parquetPredicate,
             TypeManager typeManager,
-            JsonCodec<DeltaLakeUpdateResult> updateResultJsonCodec)
+            JsonCodec<DeltaLakeUpdateResult> updateResultJsonCodec,
+            int domainCompactionThreshold)
     {
         this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
         this.queryColumns = requireNonNull(queryColumns, "queryColumns is null");
@@ -156,6 +158,7 @@ public class DeltaLakeUpdatablePageSource
         this.parquetReaderOptions = requireNonNull(parquetReaderOptions, "parquetReaderOptions is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.updateResultJsonCodec = requireNonNull(updateResultJsonCodec, "deleteResultJsonCodec is null");
+        this.domainCompactionThreshold = domainCompactionThreshold;
 
         List<DeltaLakeColumnMetadata> columnMetadata = extractSchema(tableHandle.getMetadataEntry(), typeManager);
         List<DeltaLakeColumnHandle> allColumns = columnMetadata.stream()
@@ -583,7 +586,8 @@ public class DeltaLakeUpdatablePageSource
                         .withMaxReadBlockRowCount(getParquetMaxReadBlockRowCount(session))
                         .withUseColumnIndex(isParquetUseColumnIndex(this.session))
                         .withBatchColumnReaders(isParquetOptimizedReaderEnabled(this.session)),
-                Optional.empty());
+                Optional.empty(),
+                domainCompactionThreshold);
     }
 
     private DeltaLakeWriter createWriter(Path targetFile, List<DeltaLakeColumnMetadata> allColumns, List<DeltaLakeColumnHandle> dataColumns)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeUpdatablePageSource.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeUpdatablePageSource.java
@@ -155,7 +155,7 @@ public class DeltaLakeUpdatablePageSource
         this.fileSystem = fileSystemFactory.create(session);
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.parquetDateTimeZone = requireNonNull(parquetDateTimeZone, "parquetDateTimeZone is null");
-        this.parquetReaderOptions = requireNonNull(parquetReaderOptions, "parquetReaderOptions is null");
+        this.parquetReaderOptions = requireNonNull(parquetReaderOptions, "parquetReaderOptions is null").withBloomFilter(false);
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.updateResultJsonCodec = requireNonNull(updateResultJsonCodec, "deleteResultJsonCodec is null");
         this.domainCompactionThreshold = domainCompactionThreshold;

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TableSnapshot.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TableSnapshot.java
@@ -58,6 +58,7 @@ public class TableSnapshot
     private final Path tableLocation;
     private final ParquetReaderOptions parquetReaderOptions;
     private final boolean checkpointRowStatisticsWritingEnabled;
+    private final int domainCompactionThreshold;
 
     private Optional<MetadataEntry> cachedMetadata = Optional.empty();
 
@@ -67,7 +68,8 @@ public class TableSnapshot
             TransactionLogTail logTail,
             Path tableLocation,
             ParquetReaderOptions parquetReaderOptions,
-            boolean checkpointRowStatisticsWritingEnabled)
+            boolean checkpointRowStatisticsWritingEnabled,
+            int domainCompactionThreshold)
     {
         this.table = requireNonNull(table, "table is null");
         this.lastCheckpoint = requireNonNull(lastCheckpoint, "lastCheckpoint is null");
@@ -75,6 +77,7 @@ public class TableSnapshot
         this.tableLocation = requireNonNull(tableLocation, "tableLocation is null");
         this.parquetReaderOptions = requireNonNull(parquetReaderOptions, "parquetReaderOptions is null");
         this.checkpointRowStatisticsWritingEnabled = checkpointRowStatisticsWritingEnabled;
+        this.domainCompactionThreshold = domainCompactionThreshold;
     }
 
     public static TableSnapshot load(
@@ -82,7 +85,8 @@ public class TableSnapshot
             TrinoFileSystem fileSystem,
             Path tableLocation,
             ParquetReaderOptions parquetReaderOptions,
-            boolean checkpointRowStatisticsWritingEnabled)
+            boolean checkpointRowStatisticsWritingEnabled,
+            int domainCompactionThreshold)
             throws IOException
     {
         Optional<LastCheckpoint> lastCheckpoint = readLastCheckpoint(fileSystem, tableLocation);
@@ -95,7 +99,8 @@ public class TableSnapshot
                 transactionLogTail,
                 tableLocation,
                 parquetReaderOptions,
-                checkpointRowStatisticsWritingEnabled);
+                checkpointRowStatisticsWritingEnabled,
+                domainCompactionThreshold);
     }
 
     public Optional<TableSnapshot> getUpdatedSnapshot(TrinoFileSystem fileSystem)
@@ -119,7 +124,8 @@ public class TableSnapshot
                 transactionLogTail,
                 tableLocation,
                 parquetReaderOptions,
-                checkpointRowStatisticsWritingEnabled));
+                checkpointRowStatisticsWritingEnabled,
+                domainCompactionThreshold));
     }
 
     public long getVersion()
@@ -229,7 +235,8 @@ public class TableSnapshot
                 metadataEntry,
                 stats,
                 parquetReaderOptions,
-                checkpointRowStatisticsWritingEnabled));
+                checkpointRowStatisticsWritingEnabled,
+                domainCompactionThreshold));
     }
 
     private MetadataEntry getCheckpointMetadataEntry(

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
@@ -93,6 +93,7 @@ public class TransactionLogAccess
     private final Cache<String /* table location */, TableSnapshot> tableSnapshots;
     private final Cache<String /* table location */, DeltaLakeDataFileCacheEntry> activeDataFileCache;
     private final boolean checkpointRowStatisticsWritingEnabled;
+    private final int domainCompactionThreshold;
 
     @Inject
     public TransactionLogAccess(
@@ -109,6 +110,7 @@ public class TransactionLogAccess
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.parquetReaderOptions = parquetReaderConfig.toParquetReaderOptions();
         this.checkpointRowStatisticsWritingEnabled = deltaLakeConfig.isCheckpointRowStatisticsWritingEnabled();
+        this.domainCompactionThreshold = deltaLakeConfig.getDomainCompactionThreshold();
 
         tableSnapshots = EvictableCacheBuilder.newBuilder()
                 .expireAfterWrite(deltaLakeConfig.getMetadataCacheTtl().toMillis(), TimeUnit.MILLISECONDS)
@@ -154,7 +156,8 @@ public class TransactionLogAccess
                                 fileSystem,
                                 tableLocation,
                                 parquetReaderOptions,
-                                checkpointRowStatisticsWritingEnabled));
+                                checkpointRowStatisticsWritingEnabled,
+                                domainCompactionThreshold));
             }
             catch (UncheckedExecutionException | ExecutionException e) {
                 throwIfUnchecked(e.getCause());

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
@@ -108,7 +108,7 @@ public class TransactionLogAccess
         this.checkpointSchemaManager = requireNonNull(checkpointSchemaManager, "checkpointSchemaManager is null");
         this.fileFormatDataSourceStats = requireNonNull(fileFormatDataSourceStats, "fileFormatDataSourceStats is null");
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
-        this.parquetReaderOptions = parquetReaderConfig.toParquetReaderOptions();
+        this.parquetReaderOptions = parquetReaderConfig.toParquetReaderOptions().withBloomFilter(false);
         this.checkpointRowStatisticsWritingEnabled = deltaLakeConfig.isCheckpointRowStatisticsWritingEnabled();
         this.domainCompactionThreshold = deltaLakeConfig.getDomainCompactionThreshold();
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
@@ -142,7 +142,8 @@ public class CheckpointEntryIterator
             Optional<MetadataEntry> metadataEntry,
             FileFormatDataSourceStats stats,
             ParquetReaderOptions parquetReaderOptions,
-            boolean checkpointRowStatisticsWritingEnabled)
+            boolean checkpointRowStatisticsWritingEnabled,
+            int domainCompactionThreshold)
     {
         this.checkpointPath = checkpoint.location();
         this.session = requireNonNull(session, "session is null");
@@ -183,7 +184,8 @@ public class CheckpointEntryIterator
                 DateTimeZone.UTC,
                 stats,
                 parquetReaderOptions,
-                Optional.empty());
+                Optional.empty(),
+                domainCompactionThreshold);
 
         verify(pageSource.getReaderColumns().isEmpty(), "All columns expected to be base columns");
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestTableSnapshot.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestTableSnapshot.java
@@ -50,6 +50,7 @@ import static org.testng.Assert.assertEquals;
 public class TestTableSnapshot
 {
     private final ParquetReaderOptions parquetReaderOptions = new ParquetReaderConfig().toParquetReaderOptions();
+    private final int domainCompactionThreshold = 32;
 
     private CheckpointSchemaManager checkpointSchemaManager;
     private AccessTrackingFileSystemFactory accessTrackingFileSystemFactory;
@@ -74,7 +75,7 @@ public class TestTableSnapshot
     {
         Map<String, Integer> expectedFileAccess = new HashMap<>();
         TableSnapshot tableSnapshot = TableSnapshot.load(
-                new SchemaTableName("schema", "person"), accessTrackingFileSystem, tableLocation, parquetReaderOptions, true);
+                new SchemaTableName("schema", "person"), accessTrackingFileSystem, tableLocation, parquetReaderOptions, true, domainCompactionThreshold);
         expectedFileAccess.put("_last_checkpoint", 1);
         expectedFileAccess.put("00000000000000000011.json", 1);
         expectedFileAccess.put("00000000000000000012.json", 1);
@@ -92,7 +93,7 @@ public class TestTableSnapshot
             throws IOException
     {
         TableSnapshot tableSnapshot = TableSnapshot.load(
-                new SchemaTableName("schema", "person"), accessTrackingFileSystem, tableLocation, parquetReaderOptions, true);
+                new SchemaTableName("schema", "person"), accessTrackingFileSystem, tableLocation, parquetReaderOptions, true, domainCompactionThreshold);
         tableSnapshot.setCachedMetadata(Optional.of(new MetadataEntry("id", "name", "description", null, "schema", ImmutableList.of(), ImmutableMap.of(), 0)));
         try (Stream<DeltaLakeTransactionLogEntry> stream = tableSnapshot.getCheckpointTransactionLogEntries(
                 SESSION, ImmutableSet.of(ADD), checkpointSchemaManager, TESTING_TYPE_MANAGER, accessTrackingFileSystem, new FileFormatDataSourceStats())) {
@@ -181,7 +182,7 @@ public class TestTableSnapshot
             throws IOException
     {
         TableSnapshot tableSnapshot = TableSnapshot.load(
-                new SchemaTableName("schema", "person"), accessTrackingFileSystem, tableLocation, parquetReaderOptions, true);
+                new SchemaTableName("schema", "person"), accessTrackingFileSystem, tableLocation, parquetReaderOptions, true, domainCompactionThreshold);
         assertEquals(tableSnapshot.getVersion(), 13L);
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointEntryIterator.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Iterators;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
+import io.trino.plugin.deltalake.DeltaLakeConfig;
 import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
 import io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
@@ -227,6 +228,7 @@ public class TestCheckpointEntryIterator
                 metadataEntry,
                 new FileFormatDataSourceStats(),
                 new ParquetReaderConfig().toParquetReaderOptions(),
-                true);
+                true,
+                new DeltaLakeConfig().getDomainCompactionThreshold());
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointWriter.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointWriter.java
@@ -20,6 +20,7 @@ import io.airlift.slice.Slice;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
+import io.trino.plugin.deltalake.DeltaLakeConfig;
 import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
 import io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
@@ -490,7 +491,8 @@ public class TestCheckpointWriter
                 Optional.of(metadataEntry),
                 new FileFormatDataSourceStats(),
                 new ParquetReaderConfig().toParquetReaderOptions(),
-                rowStatisticsEnabled);
+                rowStatisticsEnabled,
+                new DeltaLakeConfig().getDomainCompactionThreshold());
 
         CheckpointBuilder checkpointBuilder = new CheckpointBuilder();
         while (checkpointEntryIterator.hasNext()) {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/TestDeltaLakeFileStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/TestDeltaLakeFileStatistics.java
@@ -20,6 +20,7 @@ import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
 import io.trino.plugin.deltalake.DeltaLakeColumnHandle;
+import io.trino.plugin.deltalake.DeltaLakeConfig;
 import io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointEntryIterator;
@@ -105,7 +106,8 @@ public class TestDeltaLakeFileStatistics
                 Optional.empty(),
                 new FileFormatDataSourceStats(),
                 new ParquetReaderConfig().toParquetReaderOptions(),
-                true);
+                true,
+                new DeltaLakeConfig().getDomainCompactionThreshold());
         MetadataEntry metadataEntry = getOnlyElement(metadataEntryIterator).getMetaData();
 
         CheckpointEntryIterator checkpointEntryIterator = new CheckpointEntryIterator(
@@ -118,7 +120,8 @@ public class TestDeltaLakeFileStatistics
                 Optional.of(metadataEntry),
                 new FileFormatDataSourceStats(),
                 new ParquetReaderConfig().toParquetReaderOptions(),
-                true);
+                true,
+                new DeltaLakeConfig().getDomainCompactionThreshold());
         DeltaLakeTransactionLogEntry matchingAddFileEntry = null;
         while (checkpointEntryIterator.hasNext()) {
             DeltaLakeTransactionLogEntry entry = checkpointEntryIterator.next();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
@@ -85,6 +85,7 @@ public final class HiveSessionProperties
     private static final String PARQUET_USE_COLUMN_NAME = "parquet_use_column_names";
     private static final String PARQUET_IGNORE_STATISTICS = "parquet_ignore_statistics";
     private static final String PARQUET_USE_COLUMN_INDEX = "parquet_use_column_index";
+    private static final String PARQUET_USE_BLOOM_FILTER = "parquet_use_bloom_filter";
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
     private static final String PARQUET_MAX_READ_BLOCK_ROW_COUNT = "parquet_max_read_block_row_count";
     private static final String PARQUET_OPTIMIZED_READER_ENABLED = "parquet_optimized_reader_enabled";
@@ -320,6 +321,11 @@ public final class HiveSessionProperties
                         PARQUET_USE_COLUMN_INDEX,
                         "Use Parquet column index",
                         parquetReaderConfig.isUseColumnIndex(),
+                        false),
+                booleanProperty(
+                        PARQUET_USE_BLOOM_FILTER,
+                        "Use Parquet bloomfilter",
+                        parquetReaderConfig.isUseBloomFilter(),
                         false),
                 dataSizeProperty(
                         PARQUET_MAX_READ_BLOCK_SIZE,
@@ -700,6 +706,11 @@ public final class HiveSessionProperties
     public static boolean isParquetUseColumnIndex(ConnectorSession session)
     {
         return session.getProperty(PARQUET_USE_COLUMN_INDEX, Boolean.class);
+    }
+
+    public static boolean useParquetBloomFilter(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_USE_BLOOM_FILTER, Boolean.class);
     }
 
     public static DataSize getParquetMaxReadBlockSize(ConnectorSession session)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableSet;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.TrinoInputFile;
+import io.trino.parquet.BloomFilterStore;
 import io.trino.parquet.ParquetCorruptionException;
 import io.trino.parquet.ParquetDataSource;
 import io.trino.parquet.ParquetDataSourceId;
@@ -96,6 +97,7 @@ import static io.trino.plugin.hive.HiveSessionProperties.isParquetIgnoreStatisti
 import static io.trino.plugin.hive.HiveSessionProperties.isParquetOptimizedReaderEnabled;
 import static io.trino.plugin.hive.HiveSessionProperties.isParquetUseColumnIndex;
 import static io.trino.plugin.hive.HiveSessionProperties.isUseParquetColumnNames;
+import static io.trino.plugin.hive.HiveSessionProperties.useParquetBloomFilter;
 import static io.trino.plugin.hive.parquet.ParquetPageSource.handleException;
 import static io.trino.plugin.hive.util.HiveUtil.getDeserializerClassName;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -131,6 +133,7 @@ public class ParquetPageSourceFactory
     private final FileFormatDataSourceStats stats;
     private final ParquetReaderOptions options;
     private final DateTimeZone timeZone;
+    private final int domainCompactionThreshold;
 
     @Inject
     public ParquetPageSourceFactory(
@@ -143,6 +146,7 @@ public class ParquetPageSourceFactory
         this.stats = requireNonNull(stats, "stats is null");
         options = config.toParquetReaderOptions();
         timeZone = hiveConfig.getParquetDateTimeZone();
+        domainCompactionThreshold = hiveConfig.getDomainCompactionThreshold();
     }
 
     public static Properties stripUnnecessaryProperties(Properties schema)
@@ -193,8 +197,10 @@ public class ParquetPageSourceFactory
                         .withMaxReadBlockSize(getParquetMaxReadBlockSize(session))
                         .withMaxReadBlockRowCount(getParquetMaxReadBlockRowCount(session))
                         .withUseColumnIndex(isParquetUseColumnIndex(session))
+                        .withBloomFilter(useParquetBloomFilter(session))
                         .withBatchColumnReaders(isParquetOptimizedReaderEnabled(session)),
-                Optional.empty()));
+                Optional.empty(),
+                domainCompactionThreshold));
     }
 
     /**
@@ -210,7 +216,8 @@ public class ParquetPageSourceFactory
             DateTimeZone timeZone,
             FileFormatDataSourceStats stats,
             ParquetReaderOptions options,
-            Optional<ParquetWriteValidation> parquetWriteValidation)
+            Optional<ParquetWriteValidation> parquetWriteValidation,
+            int domainCompactionThreshold)
     {
         // Ignore predicates on partial columns for now.
         effectivePredicate = effectivePredicate.filter((column, domain) -> column.isBaseColumn());
@@ -245,8 +252,19 @@ public class ParquetPageSourceFactory
             for (BlockMetaData block : parquetMetadata.getBlocks()) {
                 long firstDataPage = block.getColumns().get(0).getFirstDataPageOffset();
                 Optional<ColumnIndexStore> columnIndex = getColumnIndexStore(dataSource, block, descriptorsByPath, parquetTupleDomain, options);
+                Optional<BloomFilterStore> bloomFilterStore = getBloomFilterStore(dataSource, block, parquetTupleDomain, options);
+
                 if (start <= firstDataPage && firstDataPage < start + length
-                        && predicateMatches(parquetPredicate, block, dataSource, descriptorsByPath, parquetTupleDomain, columnIndex, timeZone)) {
+                        && predicateMatches(
+                        parquetPredicate,
+                        block,
+                        dataSource,
+                        descriptorsByPath,
+                        parquetTupleDomain,
+                        columnIndex,
+                        bloomFilterStore,
+                        timeZone,
+                        domainCompactionThreshold)) {
                     blocks.add(block);
                     blockStarts.add(nextStart);
                     columnIndexes.add(columnIndex);
@@ -397,6 +415,30 @@ public class ParquetPageSourceFactory
                 .collect(toImmutableSet());
 
         return Optional.of(new TrinoColumnIndexStore(dataSource, blockMetadata, columnsReadPaths, columnsFilteredPaths));
+    }
+
+    public static Optional<BloomFilterStore> getBloomFilterStore(
+            ParquetDataSource dataSource,
+            BlockMetaData blockMetadata,
+            TupleDomain<ColumnDescriptor> parquetTupleDomain,
+            ParquetReaderOptions options)
+    {
+        if (!options.useBloomFilter() || parquetTupleDomain.isAll() || parquetTupleDomain.isNone()) {
+            return Optional.empty();
+        }
+
+        boolean hasBloomFilter = blockMetadata.getColumns().stream().anyMatch(BloomFilterStore::hasBloomFilter);
+        if (!hasBloomFilter) {
+            return Optional.empty();
+        }
+
+        Map<ColumnDescriptor, Domain> parquetDomains = parquetTupleDomain.getDomains()
+                .orElseThrow(() -> new IllegalStateException("Predicate other than none should have domains"));
+        Set<ColumnPath> columnsFilteredPaths = parquetDomains.keySet().stream()
+                .map(column -> ColumnPath.get(column.getPath()))
+                .collect(toImmutableSet());
+
+        return Optional.of(new BloomFilterStore(dataSource, blockMetadata, columnsFilteredPaths));
     }
 
     public static TupleDomain<ColumnDescriptor> getParquetTupleDomain(

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetReaderConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetReaderConfig.java
@@ -130,6 +130,19 @@ public class ParquetReaderConfig
         return options.useBatchColumnReaders();
     }
 
+    @Config("parquet.use-bloom-filter")
+    @ConfigDescription("Enable using Parquet bloom filter")
+    public ParquetReaderConfig setUseBloomFilter(boolean useBloomFilter)
+    {
+        options = options.withBloomFilter(useBloomFilter);
+        return this;
+    }
+
+    public boolean isUseBloomFilter()
+    {
+        return options.useBloomFilter();
+    }
+
     public ParquetReaderOptions toParquetReaderOptions()
     {
         return options;

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestBloomFilterStore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestBloomFilterStore.java
@@ -1,0 +1,366 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.parquet;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
+import io.trino.parquet.BloomFilterStore;
+import io.trino.parquet.ParquetReaderOptions;
+import io.trino.parquet.predicate.TupleDomainParquetPredicate;
+import io.trino.parquet.reader.MetadataReader;
+import io.trino.plugin.hive.FileFormatDataSourceStats;
+import io.trino.plugin.hive.HiveConfig;
+import io.trino.plugin.hive.HiveStorageFormat;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.SortedRangeSet;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.UuidType;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.values.bloomfilter.BloomFilter;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.joda.time.DateTimeZone;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
+import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
+import static io.trino.plugin.hive.HiveTestUtils.getHiveSession;
+import static io.trino.plugin.hive.HiveTestUtils.toNativeContainerValue;
+import static io.trino.spi.predicate.Domain.multipleValues;
+import static io.trino.spi.predicate.TupleDomain.withColumnDomains;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static java.util.Objects.requireNonNull;
+import static org.apache.hadoop.hive.common.type.Date.ofEpochDay;
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardStructObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaByteArrayObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaByteObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaDateObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaDoubleObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaFloatObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaIntObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaShortObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_1_0;
+import static org.apache.parquet.hadoop.ParquetOutputFormat.BLOOM_FILTER_ENABLED;
+import static org.apache.parquet.hadoop.ParquetOutputFormat.WRITER_VERSION;
+import static org.apache.parquet.hadoop.metadata.ColumnPath.fromDotString;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+import static org.joda.time.DateTimeZone.UTC;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestBloomFilterStore
+{
+    private static final String COLUMN_NAME = "test_column";
+    private static final int DOMAIN_COMPACTION_THRESHOLD = 32;
+
+    // here PrimitiveType#getPrimitiveTypeName is dummy, since predicate matches is via column name
+    ColumnDescriptor columnDescriptor = new ColumnDescriptor(new String[] {COLUMN_NAME}, new PrimitiveType(REQUIRED, BINARY, COLUMN_NAME), 0, 0);
+
+    @DataProvider
+    public Object[][] bloomFilterTypeTests()
+    {
+        return new Object[][] {
+                {
+                        // varchar test case
+                        new BloomFilterTypeTestCase(
+                                Arrays.asList("hello", "parquet", "bloom", "filter"),
+                                Arrays.asList("NotExist", "fdsvit"),
+                                createVarcharType(255),
+                                javaStringObjectInspector)
+                },
+                {
+                        // integer test case, 32-bit signed two’s complement integer, between -2^31 and 2^31 - 1
+                        new BloomFilterTypeTestCase(
+                                Arrays.asList(12321, 3344, 72334, 321, Integer.MAX_VALUE, Integer.MIN_VALUE),
+                                Arrays.asList(89899, 897773),
+                                INTEGER,
+                                javaIntObjectInspector)
+                },
+                {
+                        // double test case, 64-bit inexact
+                        new BloomFilterTypeTestCase(
+                                Arrays.asList(892.22d, 341112.2222d, 43232.222121d, 99988.22d, Double.MAX_VALUE, Double.POSITIVE_INFINITY, Double.MIN_VALUE, Double.NEGATIVE_INFINITY),
+                                Arrays.asList(321.44d, 776541.3214d, Double.MAX_VALUE / 2),
+                                DOUBLE,
+                                javaDoubleObjectInspector)
+                },
+                {
+                        // real test case, 32-bit inexact
+                        new BloomFilterTypeTestCase(
+                                Arrays.asList(32.22f, 341112.2222f, 43232.222121f, 32322.22f, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.MIN_VALUE, Float.MAX_VALUE),
+                                Arrays.asList(321.44f, 321.3214f, Float.MIN_VALUE / 2),
+                                REAL,
+                                javaFloatObjectInspector)
+                },
+                {
+                        // tinyint test case, 8 bits signed integer, between -2^7 and 2^7 - 1
+                        new BloomFilterTypeTestCase(
+                                Arrays.asList((byte) 32, (byte) 67, Byte.MAX_VALUE, Byte.MAX_VALUE, (byte) 89),
+                                Arrays.asList((byte) 0, (byte) 33, (byte) 75),
+                                TINYINT,
+                                javaByteObjectInspector)
+                },
+                {
+                        // smallint test case, 16 bits signed integer, between -2^15 and 2^15 - 1
+                        new BloomFilterTypeTestCase(
+                                Arrays.asList((short) 32, (short) 3000, Short.MIN_VALUE, Short.MAX_VALUE),
+                                Arrays.asList((short) 0, (short) 33, (short) 43),
+                                SMALLINT,
+                                javaShortObjectInspector)
+                },
+                {
+                        // date test case
+                        new BloomFilterTypeTestCase(
+                                Arrays.asList(ofEpochDay(0), ofEpochDay(325), ofEpochDay(99875553), ofEpochDay(2456524)),
+                                Arrays.asList(ofEpochDay(45), ofEpochDay(67439216)),
+                                DATE,
+                                javaDateObjectInspector)
+                },
+                {
+                        // varbinary test case, variable length binary data.
+                        new BloomFilterTypeTestCase(
+                                Arrays.asList("hello".getBytes(StandardCharsets.UTF_8), "parquet  ".getBytes(StandardCharsets.UTF_8), "bloom".getBytes(StandardCharsets.UTF_8), "filter".getBytes(StandardCharsets.UTF_8)),
+                                Arrays.asList("not".getBytes(StandardCharsets.UTF_8), "exist".getBytes(StandardCharsets.UTF_8), "testcaseX".getBytes(StandardCharsets.UTF_8), "parquet".getBytes(StandardCharsets.UTF_8)),
+                                VARBINARY,
+                                javaByteArrayObjectInspector)
+                },
+                {
+                        // uuid test case, represents a UUID
+                        new BloomFilterTypeTestCase(
+                                Arrays.asList(uuidToBytes(UUID.fromString("783176de-b6c5-4c5a-905d-0460ae103050")), uuidToBytes(UUID.fromString("b1a71c78-bd96-4117-a91a-18671530196a"))),
+                                Arrays.asList(uuidToBytes(UUID.fromString("98a5f99c-7adb-4a92-ae10-6d2469d59423")), uuidToBytes(UUID.fromString("19fd9aed-7a93-4ada-8966-f89014f499ec"))),
+                                UuidType.UUID,
+                                javaByteArrayObjectInspector)
+                }
+        };
+    }
+
+    @Test(dataProvider = "bloomFilterTypeTests")
+    public void testReadBloomFilter(BloomFilterTypeTestCase typeTestCase)
+            throws Exception
+    {
+        try (ParquetTester.TempFile tempFile = new ParquetTester.TempFile("testbloomfilter", ".parquet")) {
+            BloomFilterStore bloomFilterEnabled = generateBloomFilterStore(tempFile, true, typeTestCase.writeValues, typeTestCase.objectInspector);
+            assertTrue(bloomFilterEnabled.getBloomFilter(fromDotString(COLUMN_NAME)).isPresent());
+            BloomFilter bloomFilter = bloomFilterEnabled.getBloomFilter(fromDotString(COLUMN_NAME)).get();
+
+            for (Object data : typeTestCase.matchingValues) {
+                assertTrue(TupleDomainParquetPredicate.checkInBloomFilter(bloomFilter, data, typeTestCase.sqlType));
+            }
+            for (Object data : typeTestCase.nonMatchingValues) {
+                assertFalse(TupleDomainParquetPredicate.checkInBloomFilter(bloomFilter, data, typeTestCase.sqlType));
+            }
+        }
+
+        try (ParquetTester.TempFile tempFile = new ParquetTester.TempFile("testbloomfilter", ".parquet")) {
+            BloomFilterStore bloomFilterNotEnabled = generateBloomFilterStore(tempFile, false, typeTestCase.writeValues, typeTestCase.objectInspector);
+            assertTrue(bloomFilterNotEnabled.getBloomFilter(fromDotString(COLUMN_NAME)).isEmpty());
+        }
+    }
+
+    @Test(dataProvider = "bloomFilterTypeTests")
+    public void testMatchesWithBloomFilter(BloomFilterTypeTestCase typeTestCase)
+            throws Exception
+    {
+        try (ParquetTester.TempFile tempFile = new ParquetTester.TempFile("testbloomfilter", ".parquet")) {
+            BloomFilterStore bloomFilterStore = generateBloomFilterStore(tempFile, true, typeTestCase.writeValues, typeTestCase.objectInspector);
+
+            TupleDomain<ColumnDescriptor> domain = withColumnDomains(singletonMap(columnDescriptor, multipleValues(typeTestCase.sqlType, typeTestCase.matchingValues)));
+            TupleDomainParquetPredicate parquetPredicate = new TupleDomainParquetPredicate(domain, singletonList(columnDescriptor), UTC);
+            // bloomfilter store has the column, and values match
+            assertTrue(parquetPredicate.matches(bloomFilterStore, DOMAIN_COMPACTION_THRESHOLD));
+
+            TupleDomain<ColumnDescriptor> domainWithoutMatch = withColumnDomains(singletonMap(columnDescriptor, multipleValues(typeTestCase.sqlType, typeTestCase.nonMatchingValues)));
+            TupleDomainParquetPredicate parquetPredicateWithoutMatch = new TupleDomainParquetPredicate(domainWithoutMatch, singletonList(columnDescriptor), UTC);
+            // bloomfilter store has the column, but values not match
+            assertFalse(parquetPredicateWithoutMatch.matches(bloomFilterStore, DOMAIN_COMPACTION_THRESHOLD));
+
+            ColumnDescriptor columnDescriptor = new ColumnDescriptor(new String[] {"non_exist_path"}, Types.optional(BINARY).named("Test column"), 0, 0);
+            TupleDomain<ColumnDescriptor> domainForColumnWithoutBloomFilter = withColumnDomains(singletonMap(columnDescriptor, multipleValues(typeTestCase.sqlType, typeTestCase.nonMatchingValues)));
+            TupleDomainParquetPredicate predicateForColumnWithoutBloomFilter = new TupleDomainParquetPredicate(domainForColumnWithoutBloomFilter, singletonList(columnDescriptor), UTC);
+            // bloomfilter store does not have the column
+            assertTrue(predicateForColumnWithoutBloomFilter.matches(bloomFilterStore, DOMAIN_COMPACTION_THRESHOLD));
+        }
+    }
+
+    @Test
+    public void testMatchesWithBloomFilterExpand()
+            throws Exception
+    {
+        try (ParquetTester.TempFile tempFile = new ParquetTester.TempFile("testbloomfilter", ".parquet")) {
+            BloomFilterStore bloomFilterStore = generateBloomFilterStore(tempFile, true, Arrays.asList(60, 61, 62, 63, 64, 65), javaIntObjectInspector);
+
+            // case 1, bloomfilter store has the column, and ranges expanded successfully and overlap
+            TupleDomain<ColumnDescriptor> domain = TupleDomain.withColumnDomains(singletonMap(columnDescriptor, Domain.create(SortedRangeSet.copyOf(INTEGER,
+                    ImmutableList.of(Range.range(INTEGER, 60L, true, 68L, true))), false)));
+            TupleDomainParquetPredicate parquetPredicate = new TupleDomainParquetPredicate(domain, singletonList(columnDescriptor), UTC);
+            assertTrue(parquetPredicate.matches(bloomFilterStore, DOMAIN_COMPACTION_THRESHOLD));
+
+            // case 2, bloomfilter store does not have the column, but ranges exceeded DOMAIN_COMPACTION_THRESHOLD
+            domain = TupleDomain.withColumnDomains(singletonMap(columnDescriptor, Domain.create(SortedRangeSet.copyOf(INTEGER,
+                    ImmutableList.of(Range.range(INTEGER, -68L, true, 0L, true))), false)));
+            parquetPredicate = new TupleDomainParquetPredicate(domain, singletonList(columnDescriptor), UTC);
+            assertTrue(parquetPredicate.matches(bloomFilterStore, DOMAIN_COMPACTION_THRESHOLD));
+
+            // case 3, bloomfilter store has the column, and ranges expanded successfully but does not overlap
+            domain = TupleDomain.withColumnDomains(singletonMap(columnDescriptor, Domain.create(SortedRangeSet.copyOf(INTEGER,
+                    ImmutableList.of(Range.range(INTEGER, -68L, true, -60L, true))), false)));
+            parquetPredicate = new TupleDomainParquetPredicate(domain, singletonList(columnDescriptor), UTC);
+            assertFalse(parquetPredicate.matches(bloomFilterStore, DOMAIN_COMPACTION_THRESHOLD));
+        }
+    }
+
+    @Test
+    public void testMatchesWithBloomFilterNullValues()
+            throws Exception
+    {
+        // null values in parquet will only update column's repetition level and definition level, bloomfilter matching will be based on non-null values
+        try (ParquetTester.TempFile tempFile = new ParquetTester.TempFile("testbloomfilter", ".parquet")) {
+            BloomFilterStore bloomFilterStore = generateBloomFilterStore(tempFile, true, Arrays.asList(null, null, 62, 63, 64, 65), javaIntObjectInspector);
+
+            TupleDomain<ColumnDescriptor> domain = TupleDomain.withColumnDomains(singletonMap(columnDescriptor, Domain.create(SortedRangeSet.copyOf(INTEGER,
+                    ImmutableList.of(Range.range(INTEGER, 60L, true, 68L, true))), false)));
+            TupleDomainParquetPredicate parquetPredicate = new TupleDomainParquetPredicate(domain, singletonList(columnDescriptor), UTC);
+            // bloomfilter store has the column, and ranges overlap
+            assertTrue(parquetPredicate.matches(bloomFilterStore, DOMAIN_COMPACTION_THRESHOLD));
+
+            TupleDomain<ColumnDescriptor> domainWithoutMatch = TupleDomain.withColumnDomains(singletonMap(columnDescriptor, Domain.create(SortedRangeSet.copyOf(INTEGER,
+                    ImmutableList.of(Range.range(INTEGER, -68L, true, -60L, true))), false)));
+            // bloomfilter store has the column, but ranges not overlap
+            TupleDomainParquetPredicate parquetPredicateWithoutMatch = new TupleDomainParquetPredicate(domainWithoutMatch, singletonList(columnDescriptor), UTC);
+            assertFalse(parquetPredicateWithoutMatch.matches(bloomFilterStore, DOMAIN_COMPACTION_THRESHOLD));
+        }
+    }
+
+    @Test
+    public void testMatchesWithBloomFilterNullPredicate()
+            throws Exception
+    {
+        // if the predicate contains null values, bloomfilter matches will return true, since the bloom filter bitset contains only non-null values
+        try (ParquetTester.TempFile tempFile = new ParquetTester.TempFile("testbloomfilter", ".parquet")) {
+            BloomFilterStore bloomFilterStore = generateBloomFilterStore(tempFile, true, Arrays.asList(62, 63, 64, 65), javaIntObjectInspector);
+
+            TupleDomain<ColumnDescriptor> domainWithoutMatch = TupleDomain.withColumnDomains(singletonMap(columnDescriptor, Domain.create(SortedRangeSet.copyOf(INTEGER,
+                    ImmutableList.of(Range.range(INTEGER, -68L, true, -60L, true))), true)));
+            TupleDomainParquetPredicate parquetPredicateWithoutMatch = new TupleDomainParquetPredicate(domainWithoutMatch, singletonList(columnDescriptor), UTC);
+            assertTrue(parquetPredicateWithoutMatch.matches(bloomFilterStore, DOMAIN_COMPACTION_THRESHOLD));
+        }
+    }
+
+    private static BloomFilterStore generateBloomFilterStore(ParquetTester.TempFile tempFile, boolean enableBloomFilter, List<Object> testValues, ObjectInspector objectInspector)
+            throws Exception
+    {
+        List<ObjectInspector> objectInspectors = singletonList(objectInspector);
+        List<String> columnNames = ImmutableList.of(COLUMN_NAME);
+
+        JobConf jobConf = new JobConf(newEmptyConfiguration());
+        jobConf.setEnum(WRITER_VERSION, PARQUET_1_0);
+        jobConf.setBoolean(BLOOM_FILTER_ENABLED, enableBloomFilter);
+
+        ParquetTester.writeParquetColumn(
+                jobConf,
+                tempFile.getFile(),
+                CompressionCodecName.SNAPPY,
+                ParquetTester.createTableProperties(columnNames, objectInspectors),
+                getStandardStructObjectInspector(columnNames, objectInspectors),
+                new Iterator<?>[] {testValues.iterator()},
+                Optional.empty(),
+                false,
+                DateTimeZone.getDefault());
+
+        TrinoFileSystemFactory fileSystemFactory = new HdfsFileSystemFactory(HDFS_ENVIRONMENT);
+        TrinoFileSystem fileSystem = fileSystemFactory.create(getHiveSession(new HiveConfig().setHiveStorageFormat(HiveStorageFormat.PARQUET)));
+        TrinoInputFile inputFile = fileSystem.newInputFile(tempFile.getFile().getPath());
+        TrinoParquetDataSource dataSource = new TrinoParquetDataSource(inputFile, new ParquetReaderOptions(), new FileFormatDataSourceStats());
+
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        ColumnChunkMetaData columnChunkMetaData = getOnlyElement(getOnlyElement(parquetMetadata.getBlocks()).getColumns());
+
+        return new BloomFilterStore(dataSource, getOnlyElement(parquetMetadata.getBlocks()), Set.of(columnChunkMetaData.getPath()));
+    }
+
+    private static class BloomFilterTypeTestCase
+    {
+        private final List<Object> matchingValues;
+        private final List<Object> nonMatchingValues;
+        private final List<Object> writeValues;
+        private final Type sqlType;
+        private final ObjectInspector objectInspector;
+
+        private BloomFilterTypeTestCase(List<Object> writeValues, List<Object> nonMatchingValues, Type sqlType, ObjectInspector objectInspector)
+        {
+            this.sqlType = requireNonNull(sqlType);
+            this.objectInspector = requireNonNull(objectInspector);
+            this.writeValues = requireNonNull(writeValues);
+
+            this.matchingValues = writeValues.stream()
+                    .map(data -> toNativeContainerValue(sqlType, data))
+                    .collect(toImmutableList());
+            this.nonMatchingValues = nonMatchingValues.stream()
+                    .map(data -> toNativeContainerValue(sqlType, data))
+                    .collect(toImmutableList());
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("writeValues", writeValues)
+                    .add("sqlType", sqlType)
+                    .toString();
+        }
+    }
+
+    private static byte[] uuidToBytes(UUID uuid)
+    {
+        return ByteBuffer.allocate(16)
+                .putLong(uuid.getMostSignificantBits())
+                .putLong(uuid.getLeastSignificantBits())
+                .array();
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetReaderConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetReaderConfig.java
@@ -37,7 +37,8 @@ public class TestParquetReaderConfig
                 .setMaxMergeDistance(DataSize.of(1, MEGABYTE))
                 .setMaxBufferSize(DataSize.of(8, MEGABYTE))
                 .setUseColumnIndex(true)
-                .setOptimizedReaderEnabled(true));
+                .setOptimizedReaderEnabled(true)
+                .setUseBloomFilter(true));
     }
 
     @Test
@@ -51,6 +52,7 @@ public class TestParquetReaderConfig
                 .put("parquet.max-merge-distance", "342kB")
                 .put("parquet.use-column-index", "false")
                 .put("parquet.optimized-reader.enabled", "false")
+                .put("parquet.use-bloom-filter", "false")
                 .buildOrThrow();
 
         ParquetReaderConfig expected = new ParquetReaderConfig()
@@ -60,7 +62,8 @@ public class TestParquetReaderConfig
                 .setMaxBufferSize(DataSize.of(1431, KILOBYTE))
                 .setMaxMergeDistance(DataSize.of(342, KILOBYTE))
                 .setUseColumnIndex(false)
-                .setOptimizedReaderEnabled(false);
+                .setOptimizedReaderEnabled(false)
+                .setUseBloomFilter(false);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPageSourceProvider.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPageSourceProvider.java
@@ -125,6 +125,7 @@ public class HudiPageSourceProvider
     private final FileFormatDataSourceStats dataSourceStats;
     private final ParquetReaderOptions options;
     private final DateTimeZone timeZone;
+    private static final int DOMAIN_COMPACTION_THRESHOLD = 1000;
 
     @Inject
     public HudiPageSourceProvider(
@@ -216,7 +217,7 @@ public class HudiPageSourceProvider
                 long firstDataPage = block.getColumns().get(0).getFirstDataPageOffset();
                 Optional<ColumnIndexStore> columnIndex = getColumnIndexStore(dataSource, block, descriptorsByPath, parquetTupleDomain, options);
                 if (start <= firstDataPage && firstDataPage < start + length
-                        && predicateMatches(parquetPredicate, block, dataSource, descriptorsByPath, parquetTupleDomain, columnIndex, timeZone)) {
+                        && predicateMatches(parquetPredicate, block, dataSource, descriptorsByPath, parquetTupleDomain, columnIndex, Optional.empty(), timeZone, DOMAIN_COMPACTION_THRESHOLD)) {
                     blocks.add(block);
                     blockStarts.add(nextStart);
                     columnIndexes.add(columnIndex);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -984,7 +984,7 @@ public class IcebergPageSourceProvider
             for (BlockMetaData block : parquetMetadata.getBlocks()) {
                 long firstDataPage = block.getColumns().get(0).getFirstDataPageOffset();
                 if (start <= firstDataPage && firstDataPage < start + length &&
-                        predicateMatches(parquetPredicate, block, dataSource, descriptorsByPath, parquetTupleDomain, Optional.empty(), UTC)) {
+                        predicateMatches(parquetPredicate, block, dataSource, descriptorsByPath, parquetTupleDomain, Optional.empty(), Optional.empty(), UTC, ICEBERG_DOMAIN_COMPACTION_THRESHOLD)) {
                     blocks.add(block);
                     blockStarts.add(nextStart);
                     if (startRowPosition.isEmpty()) {


### PR DESCRIPTION
## Description
Enable hive connector to read parquet file's bloomfilter statistics. Related RB: https://github.com/apache/parquet-mr/commit/806037c080dc477798d157cd4a54a81240a85d37#diff-8da24c84aef62e6e836d073938f7843d289785baaeddf446f3afeae6d4ef4b10.

This feature can be controlled via hive config: "parquet.use-bloom-filter"

Implementation limitations:
1. Limited types supported: Will add more trino types once this merged in.
2. Only support Hive connector. hudi, delta-lake and iceberg can be supported after this merged in.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
Enable hive connector to read parquet file's bloomfilter statistics. For more details: https://github.com/apache/parquet-format/blob/master/BloomFilter.md. 


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Improve performance of queries with filters when bloom filter indexes are present in parquet files. Usage of bloom filters from parquet files can be disabled using the catalog configuration property `parquet.use-bloom-filter` or the catalog session property `parquet_use_bloom_filter`. ({issue}`9471`)
```
