### PR TITLE
Use helper for getting Stream from Iterable

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
@@ -29,12 +29,12 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.StreamSupport;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Maps.immutableEntry;
+import static com.google.common.collect.Streams.stream;
 import static io.trino.client.ClientSelectedRole.Type.ALL;
 import static io.trino.client.ClientSelectedRole.Type.NONE;
 import static io.trino.jdbc.AbstractConnectionProperty.checkedPredicate;
@@ -539,7 +539,7 @@ final class ConnectionProperties
 
         public static List<ExternalRedirectStrategy> parse(String value)
         {
-            return StreamSupport.stream(ENUM_SPLITTER.split(value).spliterator(), false)
+            return stream(ENUM_SPLITTER.split(value))
                     .map(ExternalRedirectStrategy::valueOf)
                     .collect(toImmutableList());
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/StaticMetastoreConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/StaticMetastoreConfig.java
@@ -21,9 +21,9 @@ import javax.validation.constraints.NotNull;
 
 import java.net.URI;
 import java.util.List;
-import java.util.stream.StreamSupport;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Streams.stream;
 
 public class StaticMetastoreConfig
 {
@@ -49,7 +49,7 @@ public class StaticMetastoreConfig
             return this;
         }
 
-        this.metastoreUris = StreamSupport.stream(SPLITTER.split(uris).spliterator(), false)
+        this.metastoreUris = stream(SPLITTER.split(uris))
                 .map(URI::create)
                 .collect(toImmutableList());
 

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConfig.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConfig.java
@@ -32,10 +32,10 @@ import javax.validation.constraints.Size;
 import java.io.File;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.StreamSupport;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Streams.stream;
 
 @DefunctConfig("kafka.connect-timeout")
 public class KafkaConfig
@@ -122,7 +122,7 @@ public class KafkaConfig
     private static ImmutableSet<HostAddress> parseNodes(String nodes)
     {
         Splitter splitter = Splitter.on(',').omitEmptyStrings().trimResults();
-        return StreamSupport.stream(splitter.split(nodes).spliterator(), false)
+        return stream(splitter.split(nodes))
                 .map(KafkaConfig::toHostAddress)
                 .collect(toImmutableSet());
     }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentSchemaRegistryConfig.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentSchemaRegistryConfig.java
@@ -28,9 +28,9 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.Size;
 
 import java.util.Set;
-import java.util.stream.StreamSupport;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Streams.stream;
 import static io.trino.plugin.kafka.schema.confluent.AvroSchemaConverter.EmptyFieldStrategy.IGNORE;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -101,7 +101,7 @@ public class ConfluentSchemaRegistryConfig
     private static ImmutableSet<HostAddress> parseNodes(String nodes)
     {
         Splitter splitter = Splitter.on(',').omitEmptyStrings().trimResults();
-        return StreamSupport.stream(splitter.split(nodes).spliterator(), false)
+        return stream(splitter.split(nodes))
                 .map(ConfluentSchemaRegistryConfig::toHostAddress)
                 .collect(toImmutableSet());
     }

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisConnectorConfig.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisConnectorConfig.java
@@ -29,9 +29,9 @@ import javax.validation.constraints.Size;
 
 import java.io.File;
 import java.util.Set;
-import java.util.stream.StreamSupport;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Streams.stream;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
@@ -250,7 +250,7 @@ public class RedisConnectorConfig
     {
         Splitter splitter = Splitter.on(',').omitEmptyStrings().trimResults();
 
-        return StreamSupport.stream(splitter.split(nodes).spliterator(), false)
+        return stream(splitter.split(nodes))
                 .map(RedisConnectorConfig::toHostAddress)
                 .collect(toImmutableSet());
     }


### PR DESCRIPTION
The `StreamSupport.stream` API requires getting a spliterator and this is less readable than Guava's `Streams.stream(Iterable)` replacement.
