### PR TITLE
Remove redundant modifier strictfp on Java 17

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/DoubleOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/DoubleOperators.java
@@ -212,7 +212,7 @@ public final class DoubleOperators
 
     @ScalarOperator(SATURATED_FLOOR_CAST)
     @SqlType(StandardTypes.REAL)
-    public static strictfp long saturatedFloorCastToFloat(@SqlType(StandardTypes.DOUBLE) double value)
+    public static long saturatedFloorCastToFloat(@SqlType(StandardTypes.DOUBLE) double value)
     {
         if (Double.isNaN(value)) {
             return floatToIntBits(Float.NaN);


### PR DESCRIPTION
Since Intel and AMD have both long supported SSE2 and later extensions
which allow natural support for strict floating-point semantics, the
technical motivation for having a default floating-point semantics
different than strict is no longer present.

See https://bugs.openjdk.org/browse/JDK-8175916

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
