### PR TITLE
Add Azure to FTE exchange manager docs

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
@@ -326,8 +326,9 @@ Exchange manager
 
 Exchange spooling is responsible for storing and managing spooled data for
 fault-tolerant execution. You can configure a filesystem-based exchange manager
-that stores spooled data in a specified location, such as an S3-compatible
-storage system, Google Cloud Storage (GCS), or a local filesystem.
+that stores spooled data in a specified location, such as :ref:`AWS S3
+<fte-exchange-aws-s3>` and S3-compatible systems, :ref:`Azure Blob Storage
+<fte-exchange-azure-blob>`, or :ref:`Google Cloud Storage <fte-exchange-gcs>`.
 
 Configuration
 ^^^^^^^^^^^^^


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Adds Azure to the Exchange manager paragraph in the fault-tolerance execution docs.


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
