### PR TITLE
Fault Tolerant Execution for PostgreSQL and MySQL connectors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           set -x
           # Fake identity to tag rebased commits with.
-          # These commits will be discarded, but the important part is that `git rebase` executes commands between all commits. 
+          # These commits will be discarded, but the important part is that `git rebase` executes commands between all commits.
           git config user.name "Compile all commits builder"
           git config user.email "compile-all-commits@trino.io"
           # Show the entire PR branch and the base ref all the way to the fork point.
@@ -477,6 +477,8 @@ jobs:
             - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-hive-1 }
             - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-hive-2 }
             - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-iceberg }
+            - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-postgresql }
+            - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-mysql }
             - { modules: testing/trino-tests }
           EOF
           ./.github/bin/build-matrix-from-impacted.py -v -i gib-impacted.log -m .github/test-matrix.yaml -o matrix.json

--- a/core/trino-main/src/main/java/io/trino/operator/MergeWriterOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MergeWriterOperator.java
@@ -17,6 +17,7 @@ import io.trino.Session;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.connector.ConnectorMergeSink;
+import io.trino.split.PageSinkId;
 import io.trino.split.PageSinkManager;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.planner.plan.TableWriterNode.MergeTarget;
@@ -59,7 +60,7 @@ public class MergeWriterOperator
         {
             checkState(!closed, "Factory is already closed");
             OperatorContext context = driverContext.addOperatorContext(operatorId, planNodeId, MergeWriterOperator.class.getSimpleName());
-            ConnectorMergeSink mergeSink = pageSinkManager.createMergeSink(session, target.getMergeHandle().orElseThrow());
+            ConnectorMergeSink mergeSink = pageSinkManager.createMergeSink(session, target.getMergeHandle().orElseThrow(), PageSinkId.fromTaskId(driverContext.getTaskId()));
             return new MergeWriterOperator(context, mergeSink, pagePreprocessor);
         }
 

--- a/core/trino-main/src/main/java/io/trino/split/PageSinkId.java
+++ b/core/trino-main/src/main/java/io/trino/split/PageSinkId.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.split;
+
+import io.trino.execution.TaskId;
+import io.trino.spi.connector.ConnectorPageSinkId;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class PageSinkId
+        implements ConnectorPageSinkId
+{
+    private final long id;
+
+    public static PageSinkId fromTaskId(TaskId taskId)
+    {
+        long stageId = taskId.getStageId().getId();
+        long partitionId = taskId.getPartitionId();
+        checkArgument(partitionId == (partitionId & 0x00FFFFFF), "partitionId is out of allowable range");
+        long attemptId = taskId.getAttemptId();
+        checkArgument(attemptId == (attemptId & 0xFF), "attemptId is out of allowable range");
+        long id = (stageId << 32) + (partitionId << 8) + attemptId;
+        return new PageSinkId(id);
+    }
+
+    private PageSinkId(long id)
+    {
+        this.id = id;
+    }
+
+    @Override
+    public long getId()
+    {
+        return this.id;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/split/PageSinkManager.java
+++ b/core/trino-main/src/main/java/io/trino/split/PageSinkManager.java
@@ -23,6 +23,7 @@ import io.trino.metadata.TableExecuteHandle;
 import io.trino.metadata.TableHandle;
 import io.trino.spi.connector.ConnectorMergeSink;
 import io.trino.spi.connector.ConnectorPageSink;
+import io.trino.spi.connector.ConnectorPageSinkId;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorSession;
 
@@ -42,35 +43,35 @@ public class PageSinkManager
     }
 
     @Override
-    public ConnectorPageSink createPageSink(Session session, OutputTableHandle tableHandle)
+    public ConnectorPageSink createPageSink(Session session, OutputTableHandle tableHandle, ConnectorPageSinkId pageSinkId)
     {
         ConnectorSession connectorSession = session.toConnectorSession(tableHandle.getCatalogHandle());
-        return providerFor(tableHandle.getCatalogHandle()).createPageSink(tableHandle.getTransactionHandle(), connectorSession, tableHandle.getConnectorHandle());
+        return providerFor(tableHandle.getCatalogHandle()).createPageSink(tableHandle.getTransactionHandle(), connectorSession, tableHandle.getConnectorHandle(), pageSinkId);
     }
 
     @Override
-    public ConnectorPageSink createPageSink(Session session, InsertTableHandle tableHandle)
-    {
-        // assumes connectorId and catalog are the same
-        ConnectorSession connectorSession = session.toConnectorSession(tableHandle.getCatalogHandle());
-        return providerFor(tableHandle.getCatalogHandle()).createPageSink(tableHandle.getTransactionHandle(), connectorSession, tableHandle.getConnectorHandle());
-    }
-
-    @Override
-    public ConnectorPageSink createPageSink(Session session, TableExecuteHandle tableHandle)
+    public ConnectorPageSink createPageSink(Session session, InsertTableHandle tableHandle, ConnectorPageSinkId pageSinkId)
     {
         // assumes connectorId and catalog are the same
         ConnectorSession connectorSession = session.toConnectorSession(tableHandle.getCatalogHandle());
-        return providerFor(tableHandle.getCatalogHandle()).createPageSink(tableHandle.getTransactionHandle(), connectorSession, tableHandle.getConnectorHandle());
+        return providerFor(tableHandle.getCatalogHandle()).createPageSink(tableHandle.getTransactionHandle(), connectorSession, tableHandle.getConnectorHandle(), pageSinkId);
     }
 
     @Override
-    public ConnectorMergeSink createMergeSink(Session session, MergeHandle mergeHandle)
+    public ConnectorPageSink createPageSink(Session session, TableExecuteHandle tableHandle, ConnectorPageSinkId pageSinkId)
+    {
+        // assumes connectorId and catalog are the same
+        ConnectorSession connectorSession = session.toConnectorSession(tableHandle.getCatalogHandle());
+        return providerFor(tableHandle.getCatalogHandle()).createPageSink(tableHandle.getTransactionHandle(), connectorSession, tableHandle.getConnectorHandle(), pageSinkId);
+    }
+
+    @Override
+    public ConnectorMergeSink createMergeSink(Session session, MergeHandle mergeHandle, ConnectorPageSinkId pageSinkId)
     {
         // assumes connectorId and catalog are the same
         TableHandle tableHandle = mergeHandle.getTableHandle();
         ConnectorSession connectorSession = session.toConnectorSession(tableHandle.getCatalogHandle());
-        return providerFor(tableHandle.getCatalogHandle()).createMergeSink(tableHandle.getTransaction(), connectorSession, mergeHandle.getConnectorMergeHandle());
+        return providerFor(tableHandle.getCatalogHandle()).createMergeSink(tableHandle.getTransaction(), connectorSession, mergeHandle.getConnectorMergeHandle(), pageSinkId);
     }
 
     private ConnectorPageSinkProvider providerFor(CatalogHandle catalogHandle)

--- a/core/trino-main/src/main/java/io/trino/split/PageSinkProvider.java
+++ b/core/trino-main/src/main/java/io/trino/split/PageSinkProvider.java
@@ -20,23 +20,24 @@ import io.trino.metadata.OutputTableHandle;
 import io.trino.metadata.TableExecuteHandle;
 import io.trino.spi.connector.ConnectorMergeSink;
 import io.trino.spi.connector.ConnectorPageSink;
+import io.trino.spi.connector.ConnectorPageSinkId;
 
 public interface PageSinkProvider
 {
     /*
      * Used for CTAS
      */
-    ConnectorPageSink createPageSink(Session session, OutputTableHandle tableHandle);
+    ConnectorPageSink createPageSink(Session session, OutputTableHandle tableHandle, ConnectorPageSinkId pageSinkId);
 
     /*
      * Used to insert into an existing table
      */
-    ConnectorPageSink createPageSink(Session session, InsertTableHandle tableHandle);
+    ConnectorPageSink createPageSink(Session session, InsertTableHandle tableHandle, ConnectorPageSinkId pageSinkId);
 
-    ConnectorPageSink createPageSink(Session session, TableExecuteHandle tableHandle);
+    ConnectorPageSink createPageSink(Session session, TableExecuteHandle tableHandle, ConnectorPageSinkId pageSinkId);
 
     /*
      * Used to write the result of SQL MERGE to an existing table
      */
-    ConnectorMergeSink createMergeSink(Session session, MergeHandle mergeHandle);
+    ConnectorMergeSink createMergeSink(Session session, MergeHandle mergeHandle, ConnectorPageSinkId pageSinkId);
 }

--- a/core/trino-main/src/test/java/io/trino/split/TestPageSinkId.java
+++ b/core/trino-main/src/test/java/io/trino/split/TestPageSinkId.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.split;
+
+import io.trino.execution.StageId;
+import io.trino.execution.TaskId;
+import io.trino.spi.QueryId;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
+
+public class TestPageSinkId
+{
+    private PageSinkId fromTaskId(int stageId, int partitionId, int attemptId)
+    {
+        return PageSinkId.fromTaskId(new TaskId(new StageId(new QueryId("query"), stageId), partitionId, attemptId));
+    }
+
+    @Test
+    public void testFromTaskId()
+    {
+        PageSinkId pageSinkId = fromTaskId(1, 2, 3);
+        long expected = (1L << 32) + (2L << 8) + 3L;
+        assertEquals(pageSinkId.getId(), expected);
+    }
+
+    @Test
+    public void testFromTaskIdChecks()
+    {
+        assertThatThrownBy(() -> {
+            fromTaskId(1, 1 << 24, 3);
+        }).hasMessageContaining("partitionId is out of allowable range");
+
+        assertThatThrownBy(() -> {
+            fromTaskId(1, -1, 3);
+        }).hasMessageContaining("partitionId is negative");
+
+        assertThatThrownBy(() -> {
+            fromTaskId(1, 2, 256);
+        }).hasMessageContaining("attemptId is out of allowable range");
+
+        assertThatThrownBy(() -> {
+            fromTaskId(1, 2, -1);
+        }).hasMessageContaining("attemptId is negative");
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSinkId.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSinkId.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.connector;
+
+/**
+ * Represents an identifier for the associated {@link ConnectorPageSink}
+ * which will be unique within a particular query.
+ */
+public interface ConnectorPageSinkId
+{
+    /**
+     * @return An 8-byte representation of this identifier
+     */
+    long getId();
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSinkProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSinkProvider.java
@@ -19,17 +19,41 @@ import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 
 public interface ConnectorPageSinkProvider
 {
+    @Deprecated // TODO(Issue #14705): Remove
     ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle);
 
+    default ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle, ConnectorPageSinkId pageSinkId)
+    {
+        return createPageSink(transactionHandle, session, outputTableHandle);
+    }
+
+    @Deprecated // TODO(Issue #14705): Remove
     ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle);
 
+    default ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle, ConnectorPageSinkId pageSinkId)
+    {
+        return createPageSink(transactionHandle, session, insertTableHandle);
+    }
+
+    @Deprecated // TODO(Issue #14705): Remove
     default ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle)
     {
         throw new IllegalArgumentException("createPageSink not supported for tableExecuteHandle");
     }
 
+    default ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle, ConnectorPageSinkId pageSinkId)
+    {
+        return createPageSink(transactionHandle, session, tableExecuteHandle);
+    }
+
+    @Deprecated // TODO(Issue #14705): Remove
     default ConnectorMergeSink createMergeSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorMergeTableHandle mergeHandle)
     {
         throw new TrinoException(NOT_SUPPORTED, "This connector does not support SQL MERGE operations");
+    }
+
+    default ConnectorMergeSink createMergeSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorMergeTableHandle mergeHandle, ConnectorPageSinkId pageSinkId)
+    {
+        return createMergeSink(transactionHandle, session, mergeHandle);
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorPageSinkProvider.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorPageSinkProvider.java
@@ -19,6 +19,7 @@ import io.trino.spi.connector.ConnectorMergeSink;
 import io.trino.spi.connector.ConnectorMergeTableHandle;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorPageSink;
+import io.trino.spi.connector.ConnectorPageSinkId;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableExecuteHandle;
@@ -50,10 +51,26 @@ public final class ClassLoaderSafeConnectorPageSinkProvider
     }
 
     @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle, ConnectorPageSinkId pageSinkId)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return new ClassLoaderSafeConnectorPageSink(delegate.createPageSink(transactionHandle, session, outputTableHandle, pageSinkId), classLoader);
+        }
+    }
+
+    @Override
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return new ClassLoaderSafeConnectorPageSink(delegate.createPageSink(transactionHandle, session, insertTableHandle), classLoader);
+        }
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle, ConnectorPageSinkId pageSinkId)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return new ClassLoaderSafeConnectorPageSink(delegate.createPageSink(transactionHandle, session, insertTableHandle, pageSinkId), classLoader);
         }
     }
 
@@ -66,10 +83,26 @@ public final class ClassLoaderSafeConnectorPageSinkProvider
     }
 
     @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle, ConnectorPageSinkId pageSinkId)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return new ClassLoaderSafeConnectorPageSink(delegate.createPageSink(transactionHandle, session, tableExecuteHandle, pageSinkId), classLoader);
+        }
+    }
+
+    @Override
     public ConnectorMergeSink createMergeSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorMergeTableHandle mergeHandle)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return new ClassLoaderSafeConnectorMergeSink(delegate.createMergeSink(transactionHandle, session, mergeHandle), classLoader);
+        }
+    }
+
+    @Override
+    public ConnectorMergeSink createMergeSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorMergeTableHandle mergeHandle, ConnectorPageSinkId pageSinkId)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return new ClassLoaderSafeConnectorMergeSink(delegate.createMergeSink(transactionHandle, session, mergeHandle, pageSinkId), classLoader);
         }
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -300,9 +300,9 @@ public class CachingJdbcClient
     }
 
     @Override
-    public void commitCreateTable(ConnectorSession session, JdbcOutputTableHandle handle)
+    public void commitCreateTable(ConnectorSession session, JdbcOutputTableHandle handle, Set<Long> pageSinkIds)
     {
-        delegate.commitCreateTable(session, handle);
+        delegate.commitCreateTable(session, handle, pageSinkIds);
         invalidateTableCaches(new SchemaTableName(handle.getSchemaName(), handle.getTableName()));
     }
 
@@ -313,9 +313,9 @@ public class CachingJdbcClient
     }
 
     @Override
-    public void finishInsertTable(ConnectorSession session, JdbcOutputTableHandle handle)
+    public void finishInsertTable(ConnectorSession session, JdbcOutputTableHandle handle, Set<Long> pageSinkIds)
     {
-        delegate.finishInsertTable(session, handle);
+        delegate.finishInsertTable(session, handle, pageSinkIds);
         onDataChanged(new SchemaTableName(handle.getSchemaName(), handle.getTableName()));
     }
 
@@ -330,6 +330,12 @@ public class CachingJdbcClient
     public void rollbackCreateTable(ConnectorSession session, JdbcOutputTableHandle handle)
     {
         delegate.rollbackCreateTable(session, handle);
+    }
+
+    @Override
+    public boolean supportsRetries()
+    {
+        return delegate.supportsRetries();
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -191,9 +191,9 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
-    public void commitCreateTable(ConnectorSession session, JdbcOutputTableHandle handle)
+    public void commitCreateTable(ConnectorSession session, JdbcOutputTableHandle handle, Set<Long> pageSinkIds)
     {
-        delegate().commitCreateTable(session, handle);
+        delegate().commitCreateTable(session, handle, pageSinkIds);
     }
 
     @Override
@@ -203,9 +203,9 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
-    public void finishInsertTable(ConnectorSession session, JdbcOutputTableHandle handle)
+    public void finishInsertTable(ConnectorSession session, JdbcOutputTableHandle handle, Set<Long> pageSinkIds)
     {
-        delegate().finishInsertTable(session, handle);
+        delegate().finishInsertTable(session, handle, pageSinkIds);
     }
 
     @Override
@@ -218,6 +218,12 @@ public abstract class ForwardingJdbcClient
     public void rollbackCreateTable(ConnectorSession session, JdbcOutputTableHandle handle)
     {
         delegate().rollbackCreateTable(session, handle);
+    }
+
+    @Override
+    public boolean supportsRetries()
+    {
+        return delegate().supportsRetries();
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
@@ -158,15 +158,17 @@ public interface JdbcClient
 
     JdbcOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata);
 
-    void commitCreateTable(ConnectorSession session, JdbcOutputTableHandle handle);
+    void commitCreateTable(ConnectorSession session, JdbcOutputTableHandle handle, Set<Long> pageSinkIds);
 
     JdbcOutputTableHandle beginInsertTable(ConnectorSession session, JdbcTableHandle tableHandle, List<JdbcColumnHandle> columns);
 
-    void finishInsertTable(ConnectorSession session, JdbcOutputTableHandle handle);
+    void finishInsertTable(ConnectorSession session, JdbcOutputTableHandle handle, Set<Long> pageSinkIds);
 
     void dropTable(ConnectorSession session, JdbcTableHandle jdbcTableHandle);
 
     void rollbackCreateTable(ConnectorSession session, JdbcOutputTableHandle handle);
+
+    boolean supportsRetries();
 
     String buildInsertSql(JdbcOutputTableHandle handle, List<WriteFunction> columnWriters);
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcOutputTableHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcOutputTableHandle.java
@@ -40,6 +40,7 @@ public class JdbcOutputTableHandle
     private final List<Type> columnTypes;
     private final Optional<List<JdbcTypeHandle>> jdbcColumnTypes;
     private final Optional<String> temporaryTableName;
+    private final Optional<String> pageSinkIdColumnName;
 
     @JsonCreator
     public JdbcOutputTableHandle(
@@ -49,7 +50,8 @@ public class JdbcOutputTableHandle
             @JsonProperty("columnNames") List<String> columnNames,
             @JsonProperty("columnTypes") List<Type> columnTypes,
             @JsonProperty("jdbcColumnTypes") Optional<List<JdbcTypeHandle>> jdbcColumnTypes,
-            @JsonProperty("temporaryTableName") Optional<String> temporaryTableName)
+            @JsonProperty("temporaryTableName") Optional<String> temporaryTableName,
+            @JsonProperty("pageSinkIdColumnName") Optional<String> pageSinkIdColumnName)
     {
         this.catalogName = catalogName;
         this.schemaName = schemaName;
@@ -63,6 +65,7 @@ public class JdbcOutputTableHandle
         this.columnTypes = ImmutableList.copyOf(columnTypes);
         jdbcColumnTypes.ifPresent(jdbcTypeHandles -> checkArgument(jdbcTypeHandles.size() == columnNames.size(), "columnNames and jdbcColumnTypes sizes don't match"));
         this.jdbcColumnTypes = jdbcColumnTypes.map(ImmutableList::copyOf);
+        this.pageSinkIdColumnName = requireNonNull(pageSinkIdColumnName, "pageSinkIdColumnName is null");
     }
 
     @JsonProperty
@@ -109,6 +112,12 @@ public class JdbcOutputTableHandle
         return temporaryTableName;
     }
 
+    @JsonProperty
+    public Optional<String> getPageSinkIdColumnName()
+    {
+        return pageSinkIdColumnName;
+    }
+
     @Override
     public String toString()
     {
@@ -125,7 +134,8 @@ public class JdbcOutputTableHandle
                 columnNames,
                 columnTypes,
                 jdbcColumnTypes,
-                temporaryTableName);
+                temporaryTableName,
+                pageSinkIdColumnName);
     }
 
     @Override
@@ -144,6 +154,7 @@ public class JdbcOutputTableHandle
                 Objects.equals(this.columnNames, other.columnNames) &&
                 Objects.equals(this.columnTypes, other.columnTypes) &&
                 Objects.equals(this.jdbcColumnTypes, other.jdbcColumnTypes) &&
-                Objects.equals(this.temporaryTableName, other.temporaryTableName);
+                Objects.equals(this.temporaryTableName, other.temporaryTableName) &&
+                Objects.equals(this.pageSinkIdColumnName, other.pageSinkIdColumnName);
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSinkProvider.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSinkProvider.java
@@ -16,6 +16,7 @@ package io.trino.plugin.jdbc;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorPageSink;
+import io.trino.spi.connector.ConnectorPageSinkId;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTransactionHandle;
@@ -38,12 +39,24 @@ public class JdbcPageSinkProvider
     @Override
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle tableHandle)
     {
-        return new JdbcPageSink(session, (JdbcOutputTableHandle) tableHandle, jdbcClient);
+        throw new IllegalArgumentException("createPageSink not supported without ConnectorPageSinkId");
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle tableHandle, ConnectorPageSinkId pageSinkId)
+    {
+        return new JdbcPageSink(session, (JdbcOutputTableHandle) tableHandle, jdbcClient, pageSinkId);
     }
 
     @Override
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle tableHandle)
     {
-        return new JdbcPageSink(session, (JdbcOutputTableHandle) tableHandle, jdbcClient);
+        throw new IllegalArgumentException("createPageSink not supported without ConnectorPageSinkId");
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle tableHandle, ConnectorPageSinkId pageSinkId)
+    {
+        return new JdbcPageSink(session, (JdbcOutputTableHandle) tableHandle, jdbcClient, pageSinkId);
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -265,9 +265,9 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
-    public void commitCreateTable(ConnectorSession session, JdbcOutputTableHandle handle)
+    public void commitCreateTable(ConnectorSession session, JdbcOutputTableHandle handle, Set<Long> pageSinkIds)
     {
-        stats.getCommitCreateTable().wrap(() -> delegate().commitCreateTable(session, handle));
+        stats.getCommitCreateTable().wrap(() -> delegate().commitCreateTable(session, handle, pageSinkIds));
     }
 
     @Override
@@ -277,9 +277,9 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
-    public void finishInsertTable(ConnectorSession session, JdbcOutputTableHandle handle)
+    public void finishInsertTable(ConnectorSession session, JdbcOutputTableHandle handle, Set<Long> pageSinkIds)
     {
-        stats.getFinishInsertTable().wrap(() -> delegate().finishInsertTable(session, handle));
+        stats.getFinishInsertTable().wrap(() -> delegate().finishInsertTable(session, handle, pageSinkIds));
     }
 
     @Override
@@ -292,6 +292,12 @@ public final class StatisticsAwareJdbcClient
     public void rollbackCreateTable(ConnectorSession session, JdbcOutputTableHandle handle)
     {
         stats.getRollbackCreateTable().wrap(() -> delegate().rollbackCreateTable(session, handle));
+    }
+
+    @Override
+    public boolean supportsRetries()
+    {
+        return delegate().supportsRetries();
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcMetadata.java
@@ -25,10 +25,12 @@ import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
+import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.session.PropertyMetadata;
 import io.trino.testing.TestingConnectorSession;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -66,8 +68,43 @@ public class TestDefaultJdbcMetadata
             throws Exception
     {
         database = new TestingDatabase();
-        metadata = new DefaultJdbcMetadata(new GroupingSetsEnabledJdbcClient(database.getJdbcClient()), false);
+        metadata = new DefaultJdbcMetadata(new GroupingSetsEnabledJdbcClient(database.getJdbcClient(), Optional.empty()), false);
         tableHandle = metadata.getTableHandle(SESSION, new SchemaTableName("example", "numbers"));
+    }
+
+    @Test
+    public void testSupportsRetriesValidation()
+    {
+        metadata = new DefaultJdbcMetadata(new GroupingSetsEnabledJdbcClient(database.getJdbcClient(), Optional.of(false)), false);
+        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(new SchemaTableName("example", "numbers"), ImmutableList.of());
+
+        assertThatThrownBy(() -> {
+            metadata.beginCreateTable(SESSION, tableMetadata, Optional.empty(), RetryMode.RETRIES_ENABLED);
+        }).hasMessageContaining("This connector does not support query or task retries");
+
+        assertThatThrownBy(() -> {
+            metadata.beginInsert(SESSION, tableHandle, ImmutableList.of(), RetryMode.RETRIES_ENABLED);
+        }).hasMessageContaining("This connector does not support query or task retries");
+    }
+
+    @Test
+    public void testNonTransactionalInsertValidation()
+    {
+        metadata = new DefaultJdbcMetadata(new GroupingSetsEnabledJdbcClient(database.getJdbcClient(), Optional.of(true)), false);
+        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(new SchemaTableName("example", "numbers"), ImmutableList.of());
+
+        ConnectorSession session = TestingConnectorSession.builder()
+                .setPropertyMetadata(ImmutableList.of(
+                        PropertyMetadata.booleanProperty(JdbcWriteSessionProperties.NON_TRANSACTIONAL_INSERT, "description", true, false)))
+                .build();
+
+        assertThatThrownBy(() -> {
+            metadata.beginCreateTable(session, tableMetadata, Optional.empty(), RetryMode.RETRIES_ENABLED);
+        }).hasMessageContaining("Query and task retries are incompatible with non-transactional inserts");
+
+        assertThatThrownBy(() -> {
+            metadata.beginInsert(session, tableHandle, ImmutableList.of(), RetryMode.RETRIES_ENABLED);
+        }).hasMessageContaining("Query and task retries are incompatible with non-transactional inserts");
     }
 
     @AfterMethod(alwaysRun = true)
@@ -381,16 +418,24 @@ public class TestDefaultJdbcMetadata
             extends ForwardingJdbcClient
     {
         private final JdbcClient delegate;
+        private final Optional<Boolean> supportsRetriesOverride;
 
-        public GroupingSetsEnabledJdbcClient(JdbcClient jdbcClient)
+        public GroupingSetsEnabledJdbcClient(JdbcClient jdbcClient, Optional<Boolean> supportsRetriesOverride)
         {
             this.delegate = jdbcClient;
+            this.supportsRetriesOverride = supportsRetriesOverride;
         }
 
         @Override
         protected JdbcClient delegate()
         {
             return delegate;
+        }
+
+        @Override
+        public boolean supportsRetries()
+        {
+            return supportsRetriesOverride.orElseGet(super::supportsRetries);
         }
 
         @Override

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcOutputTableHandle.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcOutputTableHandle.java
@@ -35,7 +35,8 @@ public class TestJdbcOutputTableHandle
                 ImmutableList.of("abc", "xyz"),
                 ImmutableList.of(VARCHAR, VARCHAR),
                 Optional.empty(),
-                Optional.of("tmp_table"));
+                Optional.of("tmp_table"),
+                Optional.of("page_sink_id"));
 
         assertJsonRoundTrip(OUTPUT_TABLE_CODEC, handleForCreate);
 
@@ -46,7 +47,8 @@ public class TestJdbcOutputTableHandle
                 ImmutableList.of("abc", "xyz"),
                 ImmutableList.of(VARCHAR, VARCHAR),
                 Optional.of(ImmutableList.of(JDBC_VARCHAR, JDBC_VARCHAR)),
-                Optional.of("tmp_table"));
+                Optional.of("tmp_table"),
+                Optional.of("page_sink_id"));
 
         assertJsonRoundTrip(OUTPUT_TABLE_CODEC, handleForInsert);
     }

--- a/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
+++ b/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
@@ -66,6 +66,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.function.BiFunction;
 
@@ -462,7 +463,7 @@ public class DruidJdbcClient
     }
 
     @Override
-    public void commitCreateTable(ConnectorSession session, JdbcOutputTableHandle handle)
+    public void commitCreateTable(ConnectorSession session, JdbcOutputTableHandle handle, Set<Long> pageSinkIds)
     {
         throw new TrinoException(NOT_SUPPORTED, "This connector does not support creating tables");
     }

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -206,7 +206,7 @@ public class MySqlClient
             TypeManager typeManager,
             IdentifierMapping identifierMapping)
     {
-        super(config, "`", connectionFactory, queryBuilder, identifierMapping);
+        super(config, "`", connectionFactory, queryBuilder, identifierMapping, true);
         this.jsonType = typeManager.getType(new TypeSignature(StandardTypes.JSON));
         this.statisticsEnabled = statisticsConfig.isEnabled();
 

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/MySqlQueryRunner.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/MySqlQueryRunner.java
@@ -24,6 +24,7 @@ import io.trino.tpch.TpchTable;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
@@ -49,8 +50,22 @@ public final class MySqlQueryRunner
             Iterable<TpchTable<?>> tables)
             throws Exception
     {
+        return createMySqlQueryRunner(server, extraProperties, ImmutableMap.of(), connectorProperties, tables, runner -> {});
+    }
+
+    public static DistributedQueryRunner createMySqlQueryRunner(
+            TestingMySqlServer server,
+            Map<String, String> extraProperties,
+            Map<String, String> coordinatorProperties,
+            Map<String, String> connectorProperties,
+            Iterable<TpchTable<?>> tables,
+            Consumer<QueryRunner> moreSetup)
+            throws Exception
+    {
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(createSession())
                 .setExtraProperties(extraProperties)
+                .setCoordinatorProperties(coordinatorProperties)
+                .setAdditionalSetup(moreSetup)
                 .build();
         try {
             queryRunner.installPlugin(new TpchPlugin());

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixOutputTableHandle.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixOutputTableHandle.java
@@ -40,7 +40,7 @@ public class PhoenixOutputTableHandle
             @JsonProperty("jdbcColumnTypes") Optional<List<JdbcTypeHandle>> jdbcColumnTypes,
             @JsonProperty("rowkeyColumn") Optional<String> rowkeyColumn)
     {
-        super("", schemaName, tableName, columnNames, columnTypes, jdbcColumnTypes, Optional.empty());
+        super("", schemaName, tableName, columnNames, columnTypes, jdbcColumnTypes, Optional.empty(), Optional.empty());
         this.rowkeyColumn = requireNonNull(rowkeyColumn, "rowkeyColumn is null");
     }
 

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -284,7 +284,7 @@ public class PostgreSqlClient
             TypeManager typeManager,
             IdentifierMapping identifierMapping)
     {
-        super(config, "\"", connectionFactory, queryBuilder, identifierMapping);
+        super(config, "\"", connectionFactory, queryBuilder, identifierMapping, true);
         this.jsonType = typeManager.getType(new TypeSignature(JSON));
         this.uuidType = typeManager.getType(new TypeSignature(StandardTypes.UUID));
         this.varcharMapType = (MapType) typeManager.getType(mapType(VARCHAR.getTypeSignature(), VARCHAR.getTypeSignature()));

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
@@ -19,10 +19,12 @@ import io.trino.Session;
 import io.trino.plugin.jmx.JmxPlugin;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
@@ -42,10 +44,24 @@ public final class PostgreSqlQueryRunner
             Iterable<TpchTable<?>> tables)
             throws Exception
     {
+        return createPostgreSqlQueryRunner(server, extraProperties, Map.of(), connectorProperties, tables, runner -> {});
+    }
+
+    public static DistributedQueryRunner createPostgreSqlQueryRunner(
+            TestingPostgreSqlServer server,
+            Map<String, String> extraProperties,
+            Map<String, String> coordinatorProperties,
+            Map<String, String> connectorProperties,
+            Iterable<TpchTable<?>> tables,
+            Consumer<QueryRunner> moreSetup)
+            throws Exception
+    {
         DistributedQueryRunner queryRunner = null;
         try {
             queryRunner = DistributedQueryRunner.builder(createSession())
                     .setExtraProperties(extraProperties)
+                    .setCoordinatorProperties(coordinatorProperties)
+                    .setAdditionalSetup(moreSetup)
                     .build();
 
             queryRunner.installPlugin(new TpchPlugin());

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -928,17 +928,9 @@ public class SqlServerClient
     }
 
     @Override
-    protected String buildInsertSql(ConnectorSession session, RemoteTableName targetTable, RemoteTableName sourceTable, List<String> columnNames)
+    protected String postProcessInsertTableNameClause(ConnectorSession session, String tableName)
     {
-        String columns = columnNames.stream()
-                .map(this::quoted)
-                .collect(joining(", "));
-        return format("INSERT INTO %s %s (%s) SELECT %s FROM %s",
-                targetTable,
-                isTableLockNeeded(session) ? "WITH (TABLOCK)" : "", // TABLOCK is a prerequisite for minimal logging in SQL Server
-                columns,
-                columns,
-                sourceTable);
+        return tableName + (isTableLockNeeded(session) ? " WITH (TABLOCK)" : "");
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -442,6 +442,13 @@
 
             <dependency>
                 <groupId>io.trino</groupId>
+                <artifactId>trino-mysql</artifactId>
+                <type>test-jar</type>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
                 <artifactId>trino-orc</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -499,6 +506,19 @@
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-plugin-toolkit</artifactId>
+                <type>test-jar</type>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
+                <artifactId>trino-postgresql</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
+                <artifactId>trino-postgresql</artifactId>
                 <type>test-jar</type>
                 <version>${project.version}</version>
             </dependency>

--- a/testing/trino-faulttolerant-tests/pom.xml
+++ b/testing/trino-faulttolerant-tests/pom.xml
@@ -255,7 +255,33 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-mysql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-mysql</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-postgresql</artifactId>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
 
@@ -361,6 +387,24 @@
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -480,6 +524,42 @@
                             <threadCount>4</threadCount>
                             <includes>
                                 <include>**/io/trino/faulttolerant/iceberg/Test*.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>test-fault-tolerant-postgresql</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <threadCount>4</threadCount>
+                            <includes>
+                                <include>**/io/trino/faulttolerant/postgresql/Test*FailureRecoveryTest.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>test-fault-tolerant-mysql</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <threadCount>4</threadCount>
+                            <includes>
+                                <include>**/io/trino/faulttolerant/mysql/Test*FailureRecoveryTest.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/BaseFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/BaseFailureRecoveryTest.java
@@ -252,7 +252,7 @@ public abstract class BaseFailureRecoveryTest
     public void testUserFailure()
     {
         assertThatThrownBy(() -> getQueryRunner().execute("SELECT * FROM nation WHERE regionKey / nationKey - 1 = 0"))
-                .hasMessageContaining("Division by zero");
+                .hasMessageMatching("(?i).*Division by zero.*"); // some errors come back with different casing.
 
         assertThatQuery("SELECT * FROM nation")
                 .experiencing(TASK_FAILURE, Optional.of(ErrorType.USER_ERROR))

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/BaseFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/BaseFailureRecoveryTest.java
@@ -501,7 +501,7 @@ public abstract class BaseFailureRecoveryTest
     {
         private final String query;
         private Session session = getQueryRunner().getDefaultSession();
-        private Optional<Function<MaterializedResult, Integer>> stageSelector;
+        private Optional<Function<MaterializedResult, Integer>> stageSelector = Optional.empty();
         private Optional<InjectedFailureType> failureType = Optional.empty();
         private Optional<ErrorType> errorType = Optional.empty();
         private Optional<String> setup = Optional.empty();
@@ -630,6 +630,17 @@ public abstract class BaseFailureRecoveryTest
             }
 
             return new ExecutionResult(resultWithQueryId, updatedTableContent, updatedTableStatistics);
+        }
+
+        public void isCoordinatorOnly()
+        {
+            verifyFailureTypeAndStageSelector();
+            ExecutionResult result = executeExpected();
+            StageStats rootStage = result.getQueryResult().getStatementStats().get().getRootStage();
+            List<StageStats> subStages = rootStage.getSubStages();
+
+            assertThat(rootStage.isCoordinatorOnly()).isTrue();
+            assertThat(subStages).isEmpty();
         }
 
         public void finishesSuccessfully()

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/jdbc/BaseJdbcFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/jdbc/BaseJdbcFailureRecoveryTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.faulttolerant.jdbc;
+
+import io.trino.faulttolerant.BaseFailureRecoveryTest;
+import io.trino.operator.RetryPolicy;
+import org.testng.SkipException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public abstract class BaseJdbcFailureRecoveryTest
+        extends BaseFailureRecoveryTest
+{
+    public BaseJdbcFailureRecoveryTest(RetryPolicy retryPolicy)
+    {
+        super(retryPolicy);
+    }
+
+    @Override
+    protected void createPartitionedLineitemTable(String tableName, List<String> columns, String partitionColumn)
+    {
+    }
+
+    @Override
+    public void testJoinDynamicFilteringDisabled()
+    {
+        assertThatThrownBy(super::testJoinDynamicFilteringDisabled)
+                .hasMessageContaining("partitioned_lineitem' does not exist");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    public void testJoinDynamicFilteringEnabled()
+    {
+        assertThatThrownBy(super::testJoinDynamicFilteringEnabled)
+                .hasMessageContaining("partitioned_lineitem' does not exist");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    public void testAnalyzeTable()
+    {
+        assertThatThrownBy(super::testAnalyzeTable).hasMessageMatching("This connector does not support analyze");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    public void testDelete()
+    {
+        // This simple delete on JDBC ends up as a very simple, single-fragment, coordinator-only plan,
+        // which has no ability to recover from errors. This test simply verifies that's still the case.
+        Optional<String> setupQuery = Optional.of("CREATE TABLE <table> AS SELECT * FROM orders");
+        String testQuery = "DELETE FROM <table> WHERE orderkey = 1";
+        Optional<String> cleanupQuery = Optional.of("DROP TABLE <table>");
+
+        assertThatQuery(testQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .isCoordinatorOnly();
+    }
+
+    @Override
+    public void testDeleteWithSubquery()
+    {
+        assertThatThrownBy(super::testDeleteWithSubquery).hasMessageContaining("Unsupported delete");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    public void testRefreshMaterializedView()
+    {
+        assertThatThrownBy(super::testRefreshMaterializedView)
+                .hasMessageContaining("This connector does not support creating materialized views");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    public void testUpdate()
+    {
+        assertThatThrownBy(super::testUpdate).hasMessageContaining("This connector does not support updates");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    public void testUpdateWithSubquery()
+    {
+        assertThatThrownBy(super::testUpdateWithSubquery).hasMessageContaining("This connector does not support updates");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    public void testMerge()
+    {
+        assertThatThrownBy(super::testMerge).hasMessageContaining("This connector does not support merges");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    protected boolean areWriteRetriesSupported()
+    {
+        return true;
+    }
+}

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/mysql/BaseMySqlFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/mysql/BaseMySqlFailureRecoveryTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.faulttolerant.mysql;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.faulttolerant.jdbc.BaseJdbcFailureRecoveryTest;
+import io.trino.operator.RetryPolicy;
+import io.trino.plugin.exchange.filesystem.FileSystemExchangePlugin;
+import io.trino.plugin.mysql.TestingMySqlServer;
+import io.trino.testing.QueryRunner;
+import io.trino.tpch.TpchTable;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
+
+public abstract class BaseMySqlFailureRecoveryTest
+        extends BaseJdbcFailureRecoveryTest
+{
+    public BaseMySqlFailureRecoveryTest(RetryPolicy retryPolicy)
+    {
+        super(retryPolicy);
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner(
+            List<TpchTable<?>> requiredTpchTables,
+            Map<String, String> configProperties,
+            Map<String, String> coordinatorProperties)
+            throws Exception
+    {
+        return createMySqlQueryRunner(
+                closeAfterClass(new TestingMySqlServer()),
+                configProperties,
+                coordinatorProperties,
+                Map.of(),
+                requiredTpchTables,
+                runner -> {
+                    runner.installPlugin(new FileSystemExchangePlugin());
+                    runner.loadExchangeManager("filesystem", ImmutableMap.<String, String>builder()
+                            .put("exchange.base-directories", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager")
+                            .buildOrThrow());
+                });
+    }
+}

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/mysql/TestMySqlQueryFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/mysql/TestMySqlQueryFailureRecoveryTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.faulttolerant.mysql;
+
+import io.trino.operator.RetryPolicy;
+
+public class TestMySqlQueryFailureRecoveryTest
+        extends BaseMySqlFailureRecoveryTest
+{
+    public TestMySqlQueryFailureRecoveryTest()
+    {
+        super(RetryPolicy.QUERY);
+    }
+}

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/mysql/TestMySqlTaskFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/mysql/TestMySqlTaskFailureRecoveryTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.faulttolerant.mysql;
+
+import io.trino.operator.RetryPolicy;
+
+public class TestMySqlTaskFailureRecoveryTest
+        extends BaseMySqlFailureRecoveryTest
+{
+    public TestMySqlTaskFailureRecoveryTest()
+    {
+        super(RetryPolicy.TASK);
+    }
+}

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/postgresql/BasePostgresFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/postgresql/BasePostgresFailureRecoveryTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.faulttolerant.postgresql;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.faulttolerant.jdbc.BaseJdbcFailureRecoveryTest;
+import io.trino.operator.RetryPolicy;
+import io.trino.plugin.exchange.filesystem.FileSystemExchangePlugin;
+import io.trino.plugin.postgresql.TestingPostgreSqlServer;
+import io.trino.testing.QueryRunner;
+import io.trino.tpch.TpchTable;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.trino.plugin.postgresql.PostgreSqlQueryRunner.createPostgreSqlQueryRunner;
+
+public abstract class BasePostgresFailureRecoveryTest
+        extends BaseJdbcFailureRecoveryTest
+{
+    public BasePostgresFailureRecoveryTest(RetryPolicy retryPolicy)
+    {
+        super(retryPolicy);
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner(
+            List<TpchTable<?>> requiredTpchTables,
+            Map<String, String> configProperties,
+            Map<String, String> coordinatorProperties)
+            throws Exception
+    {
+        return createPostgreSqlQueryRunner(
+                closeAfterClass(new TestingPostgreSqlServer()),
+                configProperties,
+                coordinatorProperties,
+                Map.of(),
+                requiredTpchTables,
+                runner -> {
+                    runner.installPlugin(new FileSystemExchangePlugin());
+                    runner.loadExchangeManager("filesystem", ImmutableMap.<String, String>builder()
+                            .put("exchange.base-directories", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager")
+                            .buildOrThrow());
+                });
+    }
+}

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/postgresql/TestPostgresQueryFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/postgresql/TestPostgresQueryFailureRecoveryTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.faulttolerant.postgresql;
+
+import io.trino.operator.RetryPolicy;
+
+public class TestPostgresQueryFailureRecoveryTest
+        extends BasePostgresFailureRecoveryTest
+{
+    public TestPostgresQueryFailureRecoveryTest()
+    {
+        super(RetryPolicy.QUERY);
+    }
+}

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/postgresql/TestPostgresTaskFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/postgresql/TestPostgresTaskFailureRecoveryTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.faulttolerant.postgresql;
+
+import io.trino.operator.RetryPolicy;
+
+public class TestPostgresTaskFailureRecoveryTest
+        extends BasePostgresFailureRecoveryTest
+{
+    public TestPostgresTaskFailureRecoveryTest()
+    {
+        super(RetryPolicy.TASK);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This PR primarily introduces fault tolerant writes for Postgres and MySQL. To do this, the write process is changed thusly:

1. Add a `ConstructorPageSinkId` to trino-spi. The implementation of this is `PageSinkId`.
    1. The JdbcPageSink takes a ConstructorPageSinkId to use as a `long` identifier. We chose `long` instead of a string for the fast joins.
    2. The identifier (see `fromTaskId` in `PageSinkId`), is calculated thusly:
        1. The 4 bytes from the StageId's `id`
        2. The bottom 3 bytes of the `partitionId` - this affords us ~16 million partitions
        3. The bottom byte of the `attemptId` - this affords us 256 attempts
4. When creating the temporary staging table the JdbcPageSinks write to, we subsequently add a `trino_page_sink_id` column to that temporary table.
5. The PageSink will include its identifier for that column in the insert.
6. The PageSink, in `finish`, will return its identifier in the fragment slice passed back to the coordinator.
7. The coordinator will then insert all the successful page sink ID fragments from the successful PageSinks into an additional temporary helper table.
8. In the final `insert into ... select from`, we do a semi-join to that helper table created in step 7, thereby including only the rows inserted by successful tasks.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

This guarantees the ability to only include data from successful tasks. There is no additional necessary cleanup of data from failed tasks. This PR avoids changing any behavior of existing JDBC clients, including in 3rd party plugins, unless you opt-in by extending `FaultTolerantJdbcClient`. I have opted in for the `PostgreSqlClient`, and the `MySqlClient`.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:
PostgreSQL and MySQL connectors now fault tolerant and only include data from successful tasks, automatically discarding any data from retried tasks.
```markdown
# Section
* Allow writes to PostgreSQL and MySQL connectors when fault tolerant execution is enabled (`retry-policy` is set to `TASK` or `QUERY`). (https://github.com/starburstdata/stargate/issues/3877)
```
