### PR TITLE
When access denied add cause

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
@@ -227,14 +227,14 @@ public class CreateTableTask
                                     .collect(toImmutableSet()));
                 }
                 catch (AccessDeniedException e) {
-                    throw new AccessDeniedException("Cannot reference columns of table " + likeTableName);
+                    throw new AccessDeniedException("Cannot reference columns of table " + likeTableName, e);
                 }
                 if (propertiesOption == INCLUDING) {
                     try {
                         accessControl.checkCanShowCreateTable(session.toSecurityContext(), likeTableName);
                     }
                     catch (AccessDeniedException e) {
-                        throw new AccessDeniedException("Cannot reference properties of table " + likeTableName);
+                        throw new AccessDeniedException("Cannot reference properties of table " + likeTableName, e);
                     }
                 }
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -835,7 +835,7 @@ class StatementAnalyzer
                 accessControl.checkCanInsertIntoTable(session.toSecurityContext(), tableName);
             }
             catch (AccessDeniedException exception) {
-                throw new AccessDeniedException(format("Cannot ANALYZE (missing insert privilege) table %s", tableName));
+                throw new AccessDeniedException(format("Cannot ANALYZE (missing insert privilege) table %s", tableName), exception);
             }
 
             return createAndAssignScope(node, scope, Field.newUnqualified("rows", BIGINT));


### PR DESCRIPTION
In 3 cases in which AccessDeniedExeception is thrown inside a catch of AccessDeniedException, add the cause to the new exception thrown.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
