### PR TITLE
Unwrap casts in `BETWEEN` predicate

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/TestUnwrapCastInComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestUnwrapCastInComparison.java
@@ -77,6 +77,14 @@ public class TestUnwrapCastInComparison
                     validate(operator, fromType, from, "DOUBLE", to);
                 }
             }
+
+            for (Number to : asList(null, Byte.MIN_VALUE - 1, Byte.MIN_VALUE, 0, 1, Byte.MAX_VALUE, Byte.MAX_VALUE + 1)) {
+                validateBetween(fromType, from, "SMALLINT", to, to);
+                validateBetween(fromType, from, "INTEGER", to, to);
+                validateBetween(fromType, from, "BIGINT", to, to);
+                validateBetween(fromType, from, "REAL", to, to);
+                validateBetween(fromType, from, "DOUBLE", to, to);
+            }
         }
     }
 
@@ -102,6 +110,13 @@ public class TestUnwrapCastInComparison
                     validate(operator, fromType, from, "DOUBLE", to);
                 }
             }
+
+            for (Number to : asList(null, Short.MIN_VALUE - 1, Short.MIN_VALUE, 0, 1, Short.MAX_VALUE, Short.MAX_VALUE + 1)) {
+                validateBetween(fromType, from, "INTEGER", to, to);
+                validateBetween(fromType, from, "BIGINT", to, to);
+                validateBetween(fromType, from, "REAL", to, to);
+                validateBetween(fromType, from, "DOUBLE", to, to);
+            }
         }
     }
 
@@ -123,6 +138,16 @@ public class TestUnwrapCastInComparison
                     validate(operator, fromType, from, "REAL", to);
                 }
             }
+
+            for (Number to : asList(null, Integer.MIN_VALUE - 1L, Integer.MIN_VALUE, 0, 1, Integer.MAX_VALUE, Integer.MAX_VALUE + 1L)) {
+                validateBetween(fromType, from, "BIGINT", to, to);
+            }
+            for (Number to : asList(null, Integer.MIN_VALUE - 1L, Integer.MIN_VALUE, 0, 0.1, 0.9, 1, Integer.MAX_VALUE, Integer.MAX_VALUE + 1L)) {
+                validateBetween(fromType, from, "DOUBLE", to, to);
+            }
+            for (Number to : asList(null, Integer.MIN_VALUE - 1L, Integer.MIN_VALUE, -1L << 23 + 1, 0, 0.1, 0.9, 1, 1L << 23 - 1, Integer.MAX_VALUE, Integer.MAX_VALUE + 1L)) {
+                validateBetween(fromType, from, "REAL", to, to);
+            }
         }
     }
 
@@ -140,6 +165,13 @@ public class TestUnwrapCastInComparison
                     validate(operator, fromType, from, "REAL", to);
                 }
             }
+
+            for (Number to : asList(null, Long.MIN_VALUE, Long.MIN_VALUE + 1, -1L << 53 + 1, 0, 0.1, 0.9, 1, 1L << 53 - 1, Long.MAX_VALUE - 1, Long.MAX_VALUE)) {
+                validateBetween(fromType, from, "DOUBLE", to, to);
+            }
+            for (Number to : asList(null, Long.MIN_VALUE, Long.MIN_VALUE + 1, -1L << 23 + 1, 0, 0.1, 0.9, 1, 1L << 23 - 1, Long.MAX_VALUE - 1, Long.MAX_VALUE)) {
+                validateBetween(fromType, from, "REAL", to, to);
+            }
         }
     }
 
@@ -155,6 +187,9 @@ public class TestUnwrapCastInComparison
                     validate(operator, fromType, from, toType, to);
                 }
             }
+            for (String to : toLiteral(toType, asList(null, Double.NEGATIVE_INFINITY, Math.nextDown((double) -Float.MIN_VALUE), (double) -Float.MIN_VALUE, 0, 0.1, 0.9, 1, (double) Float.MAX_VALUE, Math.nextUp((double) Float.MAX_VALUE), Double.POSITIVE_INFINITY, Double.NaN))) {
+                validateBetween(fromType, from, toType, to, to);
+            }
         }
     }
 
@@ -169,6 +204,9 @@ public class TestUnwrapCastInComparison
                     validate(operator, "DECIMAL(15, 0)", from, "DOUBLE", Double.valueOf(to));
                 }
             }
+            for (String to : values) {
+                validateBetween("DECIMAL(15, 0)", from, "DOUBLE", Double.valueOf(to), Double.valueOf(to));
+            }
         }
 
         // decimal(16) -> double
@@ -178,6 +216,9 @@ public class TestUnwrapCastInComparison
                 for (String to : values) {
                     validate(operator, "DECIMAL(16, 0)", from, "DOUBLE", Double.valueOf(to));
                 }
+            }
+            for (String to : values) {
+                validateBetween("DECIMAL(16, 0)", from, "DOUBLE", Double.valueOf(to), Double.valueOf(to));
             }
         }
 
@@ -189,6 +230,9 @@ public class TestUnwrapCastInComparison
                     validate(operator, "DECIMAL(7, 0)", from, "REAL", Double.valueOf(to));
                 }
             }
+            for (String to : values) {
+                validateBetween("DECIMAL(7, 0)", from, "REAL", Double.valueOf(to), Double.valueOf(to));
+            }
         }
 
         // decimal(8) -> real
@@ -198,6 +242,9 @@ public class TestUnwrapCastInComparison
                 for (String to : values) {
                     validate(operator, "DECIMAL(8, 0)", from, "REAL", Double.valueOf(to));
                 }
+            }
+            for (String to : values) {
+                validateBetween("DECIMAL(8, 0)", from, "REAL", Double.valueOf(to), Double.valueOf(to));
             }
         }
     }
@@ -211,6 +258,9 @@ public class TestUnwrapCastInComparison
                     validate(operator, "VARCHAR(1)", from, "VARCHAR(2)", to);
                 }
             }
+            for (String to : asList(null, "''", "'a'", "'aa'", "'b'", "'bb'")) {
+                validateBetween("VARCHAR(1)", from, "VARCHAR(2)", to, to);
+            }
         }
 
         // type with no range
@@ -218,6 +268,9 @@ public class TestUnwrapCastInComparison
             for (String to : asList("'" + "a".repeat(200) + "'", "'" + "b".repeat(200) + "'")) {
                 validate(operator, "VARCHAR(200)", "'" + "a".repeat(200) + "'", "VARCHAR(300)", to);
             }
+        }
+        for (String to : asList("'" + "a".repeat(200) + "'", "'" + "b".repeat(200) + "'")) {
+            validateBetween("VARCHAR(200)", "'" + "a".repeat(200) + "'", "VARCHAR(300)", to, to);
         }
     }
 
@@ -239,6 +292,15 @@ public class TestUnwrapCastInComparison
             validate(session, operator, "timestamp(12)", "TIMESTAMP '2020-07-03 01:23:45.123456789123'", "timestamp(12) with time zone", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'");
             validate(session, operator, "timestamp(12)", "TIMESTAMP '2020-07-03 01:23:45.123456789123'", "timestamp(12) with time zone", "TIMESTAMP '2020-07-03 01:23:45 UTC'");
         }
+
+        validateBetween(session, "timestamp(3)", "TIMESTAMP '2020-07-03 01:23:45.123'", "timestamp(3) with time zone", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'");
+        validateBetween(session, "timestamp(3)", "TIMESTAMP '2020-07-03 01:23:45.123'", "timestamp(3) with time zone", "TIMESTAMP '2020-07-03 01:23:45 UTC'", "TIMESTAMP '2020-07-03 01:23:45 UTC'");
+        validateBetween(session, "timestamp(6)", "TIMESTAMP '2020-07-03 01:23:45.123456'", "timestamp(6) with time zone", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'");
+        validateBetween(session, "timestamp(6)", "TIMESTAMP '2020-07-03 01:23:45.123456'", "timestamp(6) with time zone", "TIMESTAMP '2020-07-03 01:23:45 UTC'", "TIMESTAMP '2020-07-03 01:23:45 UTC'");
+        validateBetween(session, "timestamp(9)", "TIMESTAMP '2020-07-03 01:23:45.123456789'", "timestamp(9) with time zone", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'");
+        validateBetween(session, "timestamp(9)", "TIMESTAMP '2020-07-03 01:23:45.123456789'", "timestamp(9) with time zone", "TIMESTAMP '2020-07-03 01:23:45 UTC'", "TIMESTAMP '2020-07-03 01:23:45 UTC'");
+        validateBetween(session, "timestamp(12)", "TIMESTAMP '2020-07-03 01:23:45.123456789123'", "timestamp(12) with time zone", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'");
+        validateBetween(session, "timestamp(12)", "TIMESTAMP '2020-07-03 01:23:45.123456789123'", "timestamp(12) with time zone", "TIMESTAMP '2020-07-03 01:23:45 UTC'", "TIMESTAMP '2020-07-03 01:23:45 UTC'");
 
         // DST forward change (2017-09-24 03:00 -> 2017-09-24 04:00)
         List<LocalTime> fromLocalTimes = asList(
@@ -340,6 +402,30 @@ public class TestUnwrapCastInComparison
                         "FROM (VALUES CAST(%s AS %s)) t(v)",
                 toType, operator, toValue, toType,
                 fromValue, toType, operator, toValue, toType,
+                fromValue, fromType);
+
+        boolean result = (boolean) assertions.execute(session, query)
+                .getMaterializedRows()
+                .get(0)
+                .getField(0);
+
+        assertTrue(result, "Query evaluated to false: " + query);
+    }
+
+    private void validateBetween(String fromType, Object fromValue, String toType, Object minValue, Object maxValue)
+    {
+        validateBetween(assertions.getDefaultSession(), fromType, fromValue, toType, minValue, maxValue);
+    }
+
+    private void validateBetween(Session session, String fromType, Object fromValue, String toType, Object minValue, Object maxValue)
+    {
+        String query = format(
+                "SELECT (CAST(v AS %s) BETWEEN CAST(%s AS %s) AND CAST(%s AS %s)) " +
+                        "IS NOT DISTINCT FROM " +
+                        "(CAST(%s AS %s) BETWEEN CAST(%s AS %s) AND CAST(%s AS %s)) " +
+                        "FROM (VALUES CAST(%s AS %s)) t(v)",
+                toType, minValue, toType, maxValue, toType,
+                fromValue, toType, minValue, toType, maxValue, toType,
                 fromValue, fromType);
 
         boolean result = (boolean) assertions.execute(session, query)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -1399,18 +1399,32 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE CAST(d AS date) >= DATE '2015-05-15'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE CAST(d AS DATE) BETWEEN DATE '2015-05-15' AND DATE '2015-06-15'"))
+                .isFullyPushedDown();
 
         assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE d >= TIMESTAMP '2015-05-15 12:00:00'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE d BETWEEN TIMESTAMP '2015-05-15 12:00:00' AND TIMESTAMP '2015-06-15 11:59:59.999999'"))
+                .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE d >= TIMESTAMP '2015-05-15 12:00:00.000001'"))
+                .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE d BETWEEN TIMESTAMP '2015-05-15 12:00:00.000001' AND TIMESTAMP '2015-06-15 11:59:59.999999'"))
+                .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE d BETWEEN TIMESTAMP '2015-05-15 12:00:00' AND TIMESTAMP '2015-06-15 12:00:00.00000'"))
                 .isNotFullyPushedDown(FilterNode.class);
 
         // date()
         assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE date(d) = DATE '2015-05-15'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE date(d) BETWEEN DATE '2015-05-15' AND DATE '2015-06-15'"))
+                .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE date(d) BETWEEN TIMESTAMP '2015-05-15 12:00:00' AND TIMESTAMP '2015-06-15 12:00:00.00000'"))
+                .isFullyPushedDown();
 
         // year()
         assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE year(d) = 2015"))
+                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+        assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE year(d) BETWEEN 2015 AND 2016"))
                 .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
 
         // date_trunc
@@ -1505,6 +1519,8 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_hour_transform_timestamptz WHERE CAST(d AS date) >= DATE '2015-05-15'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_hour_transform_timestamptz WHERE CAST(d AS date) BETWEEN DATE '2015-05-15' AND DATE '2015-06-15'"))
+                .isFullyPushedDown();
 
         assertThat(query("SELECT * FROM test_hour_transform_timestamptz WHERE d >= TIMESTAMP '2015-05-15 12:00:00 UTC'"))
                 .isFullyPushedDown();
@@ -1514,9 +1530,13 @@ public abstract class BaseIcebergConnectorTest
         // date()
         assertThat(query("SELECT * FROM test_hour_transform_timestamptz WHERE date(d) = DATE '2015-05-15'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_hour_transform_timestamptz WHERE date(d) BETWEEN DATE '2015-05-15' AND DATE '2015-06-15'"))
+                .isFullyPushedDown();
 
         // year()
         assertThat(query("SELECT * FROM test_hour_transform_timestamptz WHERE year(d) = 2015"))
+                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+        assertThat(query("SELECT * FROM test_hour_transform_timestamptz WHERE year(d) BETWEEN 2015 AND 2016"))
                 .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
 
         // date_trunc
@@ -1645,6 +1665,8 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_day_transform_date WHERE CAST(d AS date) >= DATE '2015-01-13'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_day_transform_date WHERE d BETWEEN DATE '2015-01-13' AND DATE '2015-01-14'"))
+                .isFullyPushedDown();
 
         // d comparison with TIMESTAMP can be unwrapped
         assertThat(query("SELECT * FROM test_day_transform_date WHERE d >= TIMESTAMP '2015-01-13 00:00:00'"))
@@ -1658,6 +1680,8 @@ public abstract class BaseIcebergConnectorTest
 
         // year()
         assertThat(query("SELECT * FROM test_day_transform_date WHERE year(d) = 2015"))
+                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+        assertThat(query("SELECT * FROM test_day_transform_date WHERE year(d) BETWEEN 2015 AND 2016"))
                 .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
 
         // date_trunc
@@ -1758,18 +1782,28 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE CAST(d AS date) >= DATE '2015-05-15'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE d BETWEEN DATE '2015-05-15' AND DATE '2015-05-16'"))
+                .isNotFullyPushedDown(FilterNode.class);
 
         assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE d >= TIMESTAMP '2015-05-15 00:00:00'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE d BETWEEN TIMESTAMP '2015-05-15 00:00:00' AND TIMESTAMP '2015-05-16 23:59:59.999999'"))
+                .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE d >= TIMESTAMP '2015-05-15 00:00:00.000001'"))
+                .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE d BETWEEN TIMESTAMP '2015-05-15 00:00:00' AND TIMESTAMP '2015-05-16 00:00:00'"))
                 .isNotFullyPushedDown(FilterNode.class);
 
         // date()
         assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE date(d) = DATE '2015-05-15'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE date(d) BETWEEN DATE '2015-05-15' AND DATE '2015-06-15'"))
+                .isFullyPushedDown();
 
         // year()
         assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE year(d) = 2015"))
+                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+        assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE year(d) BETWEEN 2015 AND 2016"))
                 .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
 
         // date_trunc
@@ -1885,6 +1919,8 @@ public abstract class BaseIcebergConnectorTest
         // year()
         assertThat(query("SELECT * FROM test_day_transform_timestamptz WHERE year(d) = 2015"))
                 .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+        assertThat(query("SELECT * FROM test_day_transform_timestamptz WHERE year(d) BETWEEN 2015 AND 2016"))
+                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
 
         // date_trunc
         assertThat(query("SELECT * FROM test_day_transform_timestamptz WHERE date_trunc('day', d) = TIMESTAMP '2015-05-15 00:00:00.000000 UTC'"))
@@ -1981,15 +2017,21 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_month_transform_date WHERE CAST(d AS date) >= DATE '2020-06-02'"))
                 .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_month_transform_date WHERE d BETWEEN DATE '2020-06-01' AND DATE '2020-07-31'"))
+                .isFullyPushedDown();
 
         // d comparison with TIMESTAMP can be unwrapped
         assertThat(query("SELECT * FROM test_month_transform_date WHERE d >= TIMESTAMP '2015-06-01 00:00:00'"))
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_month_transform_date WHERE d >= TIMESTAMP '2015-05-01 00:00:00.000001'"))
                 .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_month_transform_date WHERE d BETWEEN TIMESTAMP '2015-05-01 00:00:00' AND TIMESTAMP '2015-06-30 00:00:00'"))
+                .isFullyPushedDown();
 
         // year()
         assertThat(query("SELECT * FROM test_month_transform_date WHERE year(d) = 2015"))
+                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+        assertThat(query("SELECT * FROM test_month_transform_date WHERE year(d) BETWEEN 2015 AND 2016"))
                 .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
 
         // date_trunc
@@ -2112,8 +2154,15 @@ public abstract class BaseIcebergConnectorTest
         assertThat(query("SELECT * FROM test_month_transform_timestamp WHERE d >= TIMESTAMP '2015-05-01 00:00:00.000001'"))
                 .isNotFullyPushedDown(FilterNode.class);
 
+        assertThat(query("SELECT * FROM test_month_transform_timestamp WHERE d BETWEEN DATE '2015-05-01' AND DATE '2015-06-01'"))
+                .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_month_transform_timestamp WHERE d BETWEEN DATE '2015-05-01' AND TIMESTAMP '2015-05-31 23:59:59.999999'"))
+                .isFullyPushedDown();
+
         // year()
         assertThat(query("SELECT * FROM test_month_transform_timestamp WHERE year(d) = 2015"))
+                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+        assertThat(query("SELECT * FROM test_month_transform_timestamp WHERE year(d) BETWEEN 2015 AND 2016"))
                 .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
 
         // date_trunc
@@ -2224,6 +2273,8 @@ public abstract class BaseIcebergConnectorTest
         // year()
         assertThat(query("SELECT * FROM test_month_transform_timestamptz WHERE year(d) = 2015"))
                 .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+        assertThat(query("SELECT * FROM test_month_transform_timestamptz WHERE year(d) BETWEEN 2015 AND 2016"))
+                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
 
         // date_trunc
         assertThat(query("SELECT * FROM test_month_transform_timestamptz WHERE date_trunc('month', d) = TIMESTAMP '2015-05-01 00:00:00.000000 UTC'"))
@@ -2316,6 +2367,10 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_year_transform_date WHERE CAST(d AS date) >= DATE '2015-01-02'"))
                 .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_year_transform_date WHERE d BETWEEN DATE '2015-01-01' AND DATE '2016-01-01'"))
+                .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_year_transform_date WHERE d BETWEEN DATE '2015-01-01' AND TIMESTAMP '2015-12-31 23:59:59.999999'"))
+                .isFullyPushedDown();
 
         // d comparison with TIMESTAMP can be unwrapped
         assertThat(query("SELECT * FROM test_year_transform_date WHERE d >= TIMESTAMP '2015-01-01 00:00:00'"))
@@ -2325,6 +2380,8 @@ public abstract class BaseIcebergConnectorTest
 
         // year()
         assertThat(query("SELECT * FROM test_year_transform_date WHERE year(d) = 2015"))
+                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+        assertThat(query("SELECT * FROM test_year_transform_date WHERE year(d) BETWEEN 2015 AND 2016"))
                 .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
 
         // date_trunc
@@ -2436,6 +2493,8 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_year_transform_timestamp WHERE CAST(d AS date) >= DATE '2015-01-02'"))
                 .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_year_transform_timestamp WHERE CAST(d AS date) BETWEEN DATE '2015-01-01' AND DATE '2016-12-31'"))
+                .isFullyPushedDown();
 
         assertThat(query("SELECT * FROM test_year_transform_timestamp WHERE d >= TIMESTAMP '2015-01-01 00:00:00'"))
                 .isFullyPushedDown();
@@ -2444,6 +2503,8 @@ public abstract class BaseIcebergConnectorTest
 
         // year()
         assertThat(query("SELECT * FROM test_year_transform_timestamp WHERE year(d) = 2015"))
+                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+        assertThat(query("SELECT * FROM test_year_transform_timestamp WHERE year(d) BETWEEN 2015 AND 2016"))
                 .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
 
         // date_trunc
@@ -2531,6 +2592,10 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE d >= with_timezone(DATE '2015-01-02', 'UTC')"))
                 .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE d BETWEEN DATE '2015-01-01' AND DATE '2016-01-01'"))
+                .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE d BETWEEN with_timezone(DATE '2015-01-01', 'UTC') AND with_timezone(TIMESTAMP '2016-12-31 23:59:59.999999', 'UTC')"))
+                .isFullyPushedDown();
 
         assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE CAST(d AS date) >= DATE '2015-01-01'"))
                 .isFullyPushedDown();
@@ -2540,6 +2605,8 @@ public abstract class BaseIcebergConnectorTest
                 // Engine can eliminate the table scan after connector accepts the filter pushdown
                 .hasPlan(node(OutputNode.class, node(ValuesNode.class)))
                 .returnsEmptyResult();
+        assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE CAST(d AS date) BETWEEN DATE '2015-01-01' AND DATE '2016-12-31'"))
+                .isFullyPushedDown();
 
         assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE d >= TIMESTAMP '2015-01-01 00:00:00 UTC'"))
                 .isFullyPushedDown();
@@ -2548,6 +2615,8 @@ public abstract class BaseIcebergConnectorTest
 
         // year()
         assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE year(d) = 2015"))
+                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+        assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE year(d) BETWEEN 2015 AND 2016"))
                 .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
 
         // date_trunc

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q13.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q13.plan.txt
@@ -3,24 +3,24 @@ final aggregation over ()
         remote exchange (GATHER, SINGLE, [])
             partial aggregation over ()
                 join (INNER, REPLICATED):
-                    join (INNER, PARTITIONED):
-                        remote exchange (REPARTITION, HASH, ["cd_demo_sk"])
-                            scan customer_demographics
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ss_cdemo_sk"])
-                                join (INNER, REPLICATED):
+                    scan customer_demographics
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPLICATE, BROADCAST, [])
+                            join (INNER, PARTITIONED):
+                                remote exchange (REPARTITION, HASH, ["ss_hdemo_sk"])
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            scan store_sales
+                                            join (INNER, REPLICATED):
+                                                scan store_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan customer_address
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     scan date_dim
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan customer_address
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
-                                            scan household_demographics
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPLICATE, BROADCAST, [])
-                            scan store
+                                                scan store
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPARTITION, HASH, ["hd_demo_sk"])
+                                        scan household_demographics

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q85.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q85.plan.txt
@@ -4,35 +4,35 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["r_reason_desc"])
                     partial aggregation over (r_reason_desc)
-                        join (INNER, REPLICATED):
-                            scan customer_demographics
+                        join (INNER, PARTITIONED):
+                            remote exchange (REPARTITION, HASH, ["wp_web_page_sk"])
+                                scan web_page
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPLICATE, BROADCAST, [])
+                                remote exchange (REPARTITION, HASH, ["ws_web_page_sk"])
                                     join (INNER, REPLICATED):
-                                        join (INNER, REPLICATED):
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                    scan customer_address
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["wr_refunded_addr_sk"])
-                                                        join (INNER, PARTITIONED):
-                                                            remote exchange (REPARTITION, HASH, ["wr_refunded_cdemo_sk"])
-                                                                join (INNER, PARTITIONED):
-                                                                    remote exchange (REPARTITION, HASH, ["wr_item_sk", "wr_order_number"])
-                                                                        scan web_returns
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPARTITION, HASH, ["ws_item_sk", "ws_order_number"])
-                                                                            join (INNER, REPLICATED):
-                                                                                scan web_sales
-                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                        scan date_dim
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPARTITION, HASH, ["cd_demo_sk"])
-                                                                    scan customer_demographics
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan web_page
+                                        scan customer_demographics
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan reason
+                                                join (INNER, REPLICATED):
+                                                    scan customer_demographics
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            join (INNER, REPLICATED):
+                                                                join (INNER, PARTITIONED):
+                                                                    remote exchange (REPARTITION, HASH, ["wr_refunded_addr_sk"])
+                                                                        join (INNER, PARTITIONED):
+                                                                            remote exchange (REPARTITION, HASH, ["wr_item_sk", "wr_order_number"])
+                                                                                scan web_returns
+                                                                            local exchange (GATHER, SINGLE, [])
+                                                                                remote exchange (REPARTITION, HASH, ["ws_item_sk", "ws_order_number"])
+                                                                                    join (INNER, REPLICATED):
+                                                                                        scan web_sales
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                scan date_dim
+                                                                    local exchange (GATHER, SINGLE, [])
+                                                                        remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                                            scan customer_address
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                        scan reason

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q13.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q13.plan.txt
@@ -3,23 +3,24 @@ final aggregation over ()
         remote exchange (GATHER, SINGLE, [])
             partial aggregation over ()
                 join (INNER, REPLICATED):
-                    join (INNER, REPLICATED):
-                        join (INNER, REPLICATED):
-                            join (INNER, REPLICATED):
+                    join (INNER, PARTITIONED):
+                        remote exchange (REPARTITION, HASH, ["cd_demo_sk"])
+                            scan customer_demographics
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ss_cdemo_sk"])
                                 join (INNER, REPLICATED):
-                                    scan store_sales
+                                    join (INNER, REPLICATED):
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan customer_address
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan customer_address
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        scan date_dim
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPLICATE, BROADCAST, [])
-                                    scan household_demographics
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPLICATE, BROADCAST, [])
-                                scan customer_demographics
+                                            scan household_demographics
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPLICATE, BROADCAST, [])
                             scan store

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q85.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q85.plan.txt
@@ -4,35 +4,35 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["r_reason_desc"])
                     partial aggregation over (r_reason_desc)
-                        join (INNER, REPLICATED):
-                            join (INNER, REPLICATED):
-                                scan customer_demographics
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        join (INNER, REPLICATED):
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                    scan customer_address
+                        join (INNER, PARTITIONED):
+                            remote exchange (REPARTITION, HASH, ["wr_reason_sk"])
+                                join (INNER, REPLICATED):
+                                    scan customer_demographics
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            join (INNER, REPLICATED):
+                                                scan customer_demographics
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["wr_refunded_addr_sk"])
-                                                        join (INNER, PARTITIONED):
-                                                            remote exchange (REPARTITION, HASH, ["wr_refunded_cdemo_sk"])
-                                                                join (INNER, PARTITIONED):
-                                                                    remote exchange (REPARTITION, HASH, ["ws_item_sk", "ws_order_number"])
-                                                                        join (INNER, REPLICATED):
-                                                                            scan web_sales
-                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan date_dim
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPARTITION, HASH, ["wr_item_sk", "wr_order_number"])
-                                                                            scan web_returns
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        join (INNER, REPLICATED):
+                                                            join (INNER, PARTITIONED):
+                                                                remote exchange (REPARTITION, HASH, ["wr_refunded_addr_sk"])
+                                                                    join (INNER, PARTITIONED):
+                                                                        remote exchange (REPARTITION, HASH, ["ws_item_sk", "ws_order_number"])
+                                                                            join (INNER, REPLICATED):
+                                                                                scan web_sales
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                                        scan date_dim
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPARTITION, HASH, ["wr_item_sk", "wr_order_number"])
+                                                                                scan web_returns
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                                        scan customer_address
                                                             local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPARTITION, HASH, ["cd_demo_sk"])
-                                                                    scan customer_demographics
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan web_page
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan web_page
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPLICATE, BROADCAST, [])
+                                remote exchange (REPARTITION, HASH, ["r_reason_sk"])
                                     scan reason

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/partitioned/q13.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/partitioned/q13.plan.txt
@@ -4,24 +4,24 @@ final aggregation over ()
             partial aggregation over ()
                 join (INNER, REPLICATED):
                     join (INNER, PARTITIONED):
-                        remote exchange (REPARTITION, HASH, ["ss_cdemo_sk"])
-                            join (INNER, REPLICATED):
-                                join (INNER, PARTITIONED):
-                                    remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
-                                        join (INNER, REPLICATED):
-                                            scan store_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                            scan customer_address
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        scan household_demographics
+                        remote exchange (REPARTITION, HASH, ["cd_demo_sk"])
+                            scan customer_demographics
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["cd_demo_sk"])
-                                scan customer_demographics
+                            remote exchange (REPARTITION, HASH, ["ss_cdemo_sk"])
+                                join (INNER, REPLICATED):
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
+                                            join (INNER, REPLICATED):
+                                                scan store_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                scan customer_address
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            scan household_demographics
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPLICATE, BROADCAST, [])
                             scan store

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/partitioned/q85.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/partitioned/q85.plan.txt
@@ -4,35 +4,35 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["r_reason_desc"])
                     partial aggregation over (r_reason_desc)
-                        join (INNER, REPLICATED):
-                            join (INNER, REPLICATED):
-                                scan customer_address
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        join (INNER, REPLICATED):
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["cd_demo_sk_6", "cd_education_status_9", "cd_marital_status_8"])
-                                                    scan customer_demographics
+                        join (INNER, PARTITIONED):
+                            remote exchange (REPARTITION, HASH, ["wr_reason_sk"])
+                                join (INNER, REPLICATED):
+                                    scan customer_demographics
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            join (INNER, REPLICATED):
+                                                scan customer_demographics
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["cd_education_status", "cd_marital_status", "wr_returning_cdemo_sk"])
-                                                        join (INNER, PARTITIONED):
-                                                            remote exchange (REPARTITION, HASH, ["wr_refunded_cdemo_sk"])
-                                                                join (INNER, PARTITIONED):
-                                                                    remote exchange (REPARTITION, HASH, ["ws_item_sk", "ws_order_number"])
-                                                                        join (INNER, REPLICATED):
-                                                                            scan web_sales
-                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan date_dim
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPARTITION, HASH, ["wr_item_sk", "wr_order_number"])
-                                                                            scan web_returns
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        join (INNER, REPLICATED):
+                                                            join (INNER, PARTITIONED):
+                                                                remote exchange (REPARTITION, HASH, ["wr_refunded_addr_sk"])
+                                                                    join (INNER, PARTITIONED):
+                                                                        remote exchange (REPARTITION, HASH, ["ws_item_sk", "ws_order_number"])
+                                                                            join (INNER, REPLICATED):
+                                                                                scan web_sales
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                                        scan date_dim
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPARTITION, HASH, ["wr_item_sk", "wr_order_number"])
+                                                                                scan web_returns
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                                        scan customer_address
                                                             local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPARTITION, HASH, ["cd_demo_sk"])
-                                                                    scan customer_demographics
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan web_page
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan web_page
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPLICATE, BROADCAST, [])
+                                remote exchange (REPARTITION, HASH, ["r_reason_sk"])
                                     scan reason

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/unpartitioned/q13.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/unpartitioned/q13.plan.txt
@@ -4,24 +4,24 @@ final aggregation over ()
             partial aggregation over ()
                 join (INNER, REPLICATED):
                     join (INNER, PARTITIONED):
-                        remote exchange (REPARTITION, HASH, ["ss_cdemo_sk"])
-                            join (INNER, REPLICATED):
-                                join (INNER, PARTITIONED):
-                                    remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
-                                        join (INNER, REPLICATED):
-                                            scan store_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                            scan customer_address
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        scan household_demographics
+                        remote exchange (REPARTITION, HASH, ["cd_demo_sk"])
+                            scan customer_demographics
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["cd_demo_sk"])
-                                scan customer_demographics
+                            remote exchange (REPARTITION, HASH, ["ss_cdemo_sk"])
+                                join (INNER, REPLICATED):
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
+                                            join (INNER, REPLICATED):
+                                                scan store_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                scan customer_address
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            scan household_demographics
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPLICATE, BROADCAST, [])
                             scan store

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/unpartitioned/q85.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/unpartitioned/q85.plan.txt
@@ -4,35 +4,35 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["r_reason_desc"])
                     partial aggregation over (r_reason_desc)
-                        join (INNER, REPLICATED):
-                            join (INNER, REPLICATED):
-                                scan customer_address
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        join (INNER, REPLICATED):
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["cd_demo_sk_6", "cd_education_status_9", "cd_marital_status_8"])
-                                                    scan customer_demographics
+                        join (INNER, PARTITIONED):
+                            remote exchange (REPARTITION, HASH, ["wr_reason_sk"])
+                                join (INNER, REPLICATED):
+                                    scan customer_demographics
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            join (INNER, REPLICATED):
+                                                scan customer_demographics
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["cd_education_status", "cd_marital_status", "wr_returning_cdemo_sk"])
-                                                        join (INNER, PARTITIONED):
-                                                            remote exchange (REPARTITION, HASH, ["wr_refunded_cdemo_sk"])
-                                                                join (INNER, PARTITIONED):
-                                                                    remote exchange (REPARTITION, HASH, ["ws_item_sk", "ws_order_number"])
-                                                                        join (INNER, REPLICATED):
-                                                                            scan web_sales
-                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan date_dim
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPARTITION, HASH, ["wr_item_sk", "wr_order_number"])
-                                                                            scan web_returns
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        join (INNER, REPLICATED):
+                                                            join (INNER, PARTITIONED):
+                                                                remote exchange (REPARTITION, HASH, ["wr_refunded_addr_sk"])
+                                                                    join (INNER, PARTITIONED):
+                                                                        remote exchange (REPARTITION, HASH, ["ws_item_sk", "ws_order_number"])
+                                                                            join (INNER, REPLICATED):
+                                                                                scan web_sales
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                                        scan date_dim
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPARTITION, HASH, ["wr_item_sk", "wr_order_number"])
+                                                                                scan web_returns
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                                        scan customer_address
                                                             local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPARTITION, HASH, ["cd_demo_sk"])
-                                                                    scan customer_demographics
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan web_page
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan web_page
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPLICATE, BROADCAST, [])
+                                remote exchange (REPARTITION, HASH, ["r_reason_sk"])
                                     scan reason


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This change allows the engine to infer that, for instance, given t::timestamp(6)

    cast(t as date) BETWEEN DATE '2022-01-01' AND DATE '2022-01-02'

can be rewritten as

     t BETWEEN TIMESTAMP '2022-01-01 00:00:00' AND TIMESTAMP '2022-01-02 23:59:59.999999'

The change applies for the temporal types:
- date
- timestamp
- timestamp with time zone

Range predicate BetweenPredicate can be transformed into a `TupleDomain` and thus help with predicate pushdown.
Range-based `TupleDomain` representation is critical for connectors which have min/max-based metadata (like Iceberg manifests lists which play a key role in partition pruning or Iceberg data files), as ranges allow for intersection tests, something that is hard
to do in a generic manner for `ConnectorExpression`.


This is a spin-off from https://github.com/trinodb/trino/pull/14390

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Main
* Improve partition and data pruning when comparing casts with ranges in `BETWEEN` predicate
```