### PR TITLE
Use table-level SerDe parameter for Avro partitions

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/MetastoreUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/MetastoreUtil.java
@@ -44,6 +44,7 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.metastore.ProtectMode;
+import org.apache.hadoop.hive.serde2.avro.AvroSerDe;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 
@@ -58,6 +59,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.hive.HiveMetadata.AVRO_SCHEMA_URL_KEY;
 import static io.trino.plugin.hive.HiveSplitManager.PRESTO_OFFLINE;
@@ -96,6 +98,7 @@ public final class MetastoreUtil
         // Mimics function in Hive: MetaStoreUtils.getTableMetadata(Table)
         return getHiveSchema(
                 table.getStorage(),
+                Optional.empty(),
                 table.getDataColumns(),
                 table.getDataColumns(),
                 table.getParameters(),
@@ -109,6 +112,7 @@ public final class MetastoreUtil
         // Mimics function in Hive: MetaStoreUtils.getSchema(Partition, Table)
         return getHiveSchema(
                 partition.getStorage(),
+                Optional.of(table.getStorage()),
                 partition.getColumns(),
                 table.getDataColumns(),
                 table.getParameters(),
@@ -119,6 +123,7 @@ public final class MetastoreUtil
 
     private static Properties getHiveSchema(
             Storage sd,
+            Optional<Storage> tableSd,
             List<Column> dataColumns,
             List<Column> tableDataColumns,
             Map<String, String> parameters,
@@ -148,6 +153,13 @@ public final class MetastoreUtil
         for (Map.Entry<String, String> param : sd.getSerdeParameters().entrySet()) {
             schema.setProperty(param.getKey(), (param.getValue() != null) ? param.getValue() : "");
         }
+
+        if (sd.getStorageFormat().getSerde().equals(AvroSerDe.class.getName()) && tableSd.isPresent()) {
+            for (Map.Entry<String, String> param : tableSd.get().getSerdeParameters().entrySet()) {
+                schema.setProperty(param.getKey(), nullToEmpty(param.getValue()));
+            }
+        }
+
         schema.setProperty(SERIALIZATION_LIB, sd.getStorageFormat().getSerde());
 
         StringBuilder columnNameBuilder = new StringBuilder();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Currently, `MetastoreUtil::getHiveSchema(Partition, Table)` does not include the table's storage descriptor when computing for partitioned tables. We have encountered some cases where Avro table only has schema properties (e.g. `avro.schema.literal`) stored in the table-level storage descriptor.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
