### PR TITLE
Include dictionaryLookBack size in MultiChannelGroupByHash size

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/MultiChannelGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MultiChannelGroupByHash.java
@@ -174,7 +174,8 @@ public class MultiChannelGroupByHash
                 currentPageBuilder.getRetainedSizeInBytes() +
                 sizeOf(groupIdsByHash) +
                 sizeOf(rawHashByHashPosition) +
-                preallocatedMemoryInBytes;
+                preallocatedMemoryInBytes +
+                (dictionaryLookBack != null ? dictionaryLookBack.getRetainedSizeInBytes() : 0);
     }
 
     @Override
@@ -543,6 +544,7 @@ public class MultiChannelGroupByHash
 
     private static final class DictionaryLookBack
     {
+        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DictionaryLookBack.class).instanceSize());
         private final Block dictionary;
         private final int[] processed;
 
@@ -571,6 +573,13 @@ public class MultiChannelGroupByHash
         public void setProcessed(int position, int groupId)
         {
             processed[position] = groupId;
+        }
+
+        public long getRetainedSizeInBytes()
+        {
+            return INSTANCE_SIZE +
+                    sizeOf(processed) +
+                    dictionary.getRetainedSizeInBytes();
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

MultiChannelGroupByHash getEstimatedSize will include the size of DictionaryLookBack. DictionaryLookBack is  preserved across input pages.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Better memory utilization when using GroupBy.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

