### PR TITLE
Fix partitioning preference derivation for UnionNode

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
@@ -40,6 +40,7 @@ import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.iterative.rule.PushPredicateIntoTableScan;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.ApplyNode;
+import io.trino.sql.planner.plan.AssignUniqueId;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.ChildReplacer;
 import io.trino.sql.planner.plan.CorrelatedJoinNode;
@@ -1305,6 +1306,14 @@ public class AddExchanges
             return withDerivedProperties(
                     ChildReplacer.replaceChildren(node, ImmutableList.of(child.getNode())),
                     child.getProperties());
+        }
+
+        @Override
+        public PlanWithProperties visitAssignUniqueId(AssignUniqueId node, PreferredProperties preferredProperties)
+        {
+            PreferredProperties translatedPreferred = preferredProperties.translate(symbol -> node.getIdColumn().equals(symbol) ? Optional.empty() : Optional.of(symbol));
+
+            return rebaseAndDeriveProperties(node, planChild(node, translatedPreferred));
         }
 
         private PlanWithProperties rebaseAndDeriveProperties(PlanNode node, List<PlanWithProperties> children)

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -3388,6 +3388,20 @@ public abstract class AbstractTestEngineOnlyQueries
                 "SELECT * FROM (SELECT custkey FROM orders ORDER BY orderkey LIMIT 1) CROSS JOIN (VALUES (10, 1), (20, 2), (30, 3))");
 
         assertQuery("SELECT * FROM orders, UNNEST(ARRAY[1])", "SELECT orders.*, 1 FROM orders");
+
+        assertQuery(
+                """
+                        WITH array_construct AS (
+                            SELECT ARRAY[1, 2, 3] AS array_actual, '[1,2,3]' AS expected
+                            UNION ALL
+                            SELECT NULL AS array_actual, '[]' AS expected)
+                        SELECT
+                            array_actual,
+                            '[' || (SELECT listagg(CAST(element AS varchar), ',') WITHIN GROUP(ORDER BY element) FROM UNNEST(array_actual) t(element)) || ']' AS actual,
+                            expected
+                        FROM array_construct
+                        """,
+                "VALUES (ARRAY[1, 2, 3], CAST('[1,2,3]' AS varchar), '[1,2,3]'), (null, null, '[]')");
     }
 
     @Test


### PR DESCRIPTION
## Description
In AddExchanges, when analyzing parent partitioning preference for UnionNode, filter out symbols which are not present in the UnionNode.

Not filtering the symbols out caused failures when trying to derive partitioning properties for the UnionNode or its children. The issue could be observed when the query involved correlated unioned UNNEST. In such case, a "unique" symbol was introduced in the parent node, and the inherited partitioning preference for the UnionNode contained that symbol.

fixes: https://github.com/trinodb/trino/issues/14472

```markdown
# General
* Fix potential planning failure of queries involving UNION. ({issue}`14472`)
```
