### PR TITLE
Fix session property documentation for writer scaling

### DIFF
--- a/docs/src/main/sphinx/admin/properties-writer-scaling.rst
+++ b/docs/src/main/sphinx/admin/properties-writer-scaling.rst
@@ -35,7 +35,7 @@ Enable scaling the number of concurrent writers within a task. The maximum write
 count per task for scaling is ``task.scale-writers.max-writer-count``. Additional
 writers are added only when the average amount of physical data written per writer
 is above the minimum threshold of ``writer-min-size`` and query is bottlenecked on
-writing. This can be specified on a per-query basis using the ``task_scale_writers``
+writing. This can be specified on a per-query basis using the ``task_scale_writers_enabled``
 session property.
 
 .. _prop-task-scale-writers-max-writer-count:


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
The correct session property name for
`task.scale-writers.enabled`
is `task_scale_writers_enabled`


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
Simple documentation fix


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
