### PR TITLE
Fix support for window aggregates from plugins

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AccumulatorCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AccumulatorCompiler.java
@@ -219,6 +219,9 @@ public final class AccumulatorCompiler
             AggregationImplementation implementation,
             FunctionNullability functionNullability)
     {
+        // change types used in Aggregation methods to types used in the core Trino engine to simplify code generation
+        implementation = normalizeAggregationMethods(implementation);
+
         DynamicClassLoader classLoader = new DynamicClassLoader(AccumulatorCompiler.class.getClassLoader());
 
         List<Boolean> argumentNullable = functionNullability.getArgumentNullable()


### PR DESCRIPTION
Change window accumulator compiler to not reference classes from the plugin class loader.

Fixes #14486

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix support for aggregations used in window expressions when the function loaded from a plugin. ({issue}`14486`)
```
