### PR TITLE
Support RLE Pages in JoinProbe

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/TrinoOperatorFactories.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TrinoOperatorFactories.java
@@ -60,7 +60,7 @@ public class TrinoOperatorFactories
                 probeOutputChannelTypes,
                 lookupSourceFactory.getBuildOutputTypes(),
                 joinType,
-                new JoinProbe.JoinProbeFactory(probeOutputChannels, probeJoinChannel, probeHashChannel),
+                new JoinProbe.JoinProbeFactory(probeOutputChannels, probeJoinChannel, probeHashChannel, hasFilter),
                 blockTypeOperators,
                 probeJoinChannel,
                 probeHashChannel);

--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinOperatorInfo.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinOperatorInfo.java
@@ -33,8 +33,10 @@ public class JoinOperatorInfo
     private final long[] logHistogramProbes;
     private final long[] logHistogramOutput;
     private final Optional<Long> lookupSourcePositions;
+    private final long rleProbes;
+    private final long totalProbes;
 
-    public static JoinOperatorInfo createJoinOperatorInfo(JoinType joinType, long[] logHistogramCounters, Optional<Long> lookupSourcePositions)
+    public static JoinOperatorInfo createJoinOperatorInfo(JoinType joinType, long[] logHistogramCounters, Optional<Long> lookupSourcePositions, long rleProbes, long totalProbes)
     {
         long[] logHistogramProbes = new long[HISTOGRAM_BUCKETS];
         long[] logHistogramOutput = new long[HISTOGRAM_BUCKETS];
@@ -42,7 +44,7 @@ public class JoinOperatorInfo
             logHistogramProbes[i] = logHistogramCounters[2 * i];
             logHistogramOutput[i] = logHistogramCounters[2 * i + 1];
         }
-        return new JoinOperatorInfo(joinType, logHistogramProbes, logHistogramOutput, lookupSourcePositions);
+        return new JoinOperatorInfo(joinType, logHistogramProbes, logHistogramOutput, lookupSourcePositions, rleProbes, totalProbes);
     }
 
     @JsonCreator
@@ -50,7 +52,9 @@ public class JoinOperatorInfo
             @JsonProperty("joinType") JoinType joinType,
             @JsonProperty("logHistogramProbes") long[] logHistogramProbes,
             @JsonProperty("logHistogramOutput") long[] logHistogramOutput,
-            @JsonProperty("lookupSourcePositions") Optional<Long> lookupSourcePositions)
+            @JsonProperty("lookupSourcePositions") Optional<Long> lookupSourcePositions,
+            @JsonProperty("rleProbes") long rleProbes,
+            @JsonProperty("totalProbes") long totalProbes)
     {
         checkArgument(logHistogramProbes.length == HISTOGRAM_BUCKETS);
         checkArgument(logHistogramOutput.length == HISTOGRAM_BUCKETS);
@@ -58,6 +62,8 @@ public class JoinOperatorInfo
         this.logHistogramProbes = logHistogramProbes;
         this.logHistogramOutput = logHistogramOutput;
         this.lookupSourcePositions = lookupSourcePositions;
+        this.rleProbes = rleProbes;
+        this.totalProbes = totalProbes;
     }
 
     @JsonProperty
@@ -87,6 +93,18 @@ public class JoinOperatorInfo
         return lookupSourcePositions;
     }
 
+    @JsonProperty
+    public long getRleProbes()
+    {
+        return rleProbes;
+    }
+
+    @JsonProperty
+    public long getTotalProbes()
+    {
+        return totalProbes;
+    }
+
     @Override
     public String toString()
     {
@@ -95,6 +113,8 @@ public class JoinOperatorInfo
                 .add("logHistogramProbes", logHistogramProbes)
                 .add("logHistogramOutput", logHistogramOutput)
                 .add("lookupSourcePositions", lookupSourcePositions)
+                .add("rleProbes", rleProbes)
+                .add("totalProbes", totalProbes)
                 .toString();
     }
 
@@ -114,7 +134,7 @@ public class JoinOperatorInfo
             mergedSourcePositions = Optional.of(this.lookupSourcePositions.orElse(0L) + other.lookupSourcePositions.orElse(0L));
         }
 
-        return new JoinOperatorInfo(this.joinType, logHistogramProbes, logHistogramOutput, mergedSourcePositions);
+        return new JoinOperatorInfo(this.joinType, logHistogramProbes, logHistogramOutput, mergedSourcePositions, this.rleProbes + other.rleProbes, this.totalProbes + other.totalProbes);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinStatisticsCounter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinStatisticsCounter.java
@@ -37,6 +37,9 @@ public class JoinStatisticsCounter
     //      [2*bucket + 1]  total count of rows that were produces by probe rows in this bucket.
     private final long[] logHistogramCounters = new long[HISTOGRAM_BUCKETS * 2];
 
+    private long rleProbes;
+    private long totalProbes;
+
     /**
      * Estimated number of positions in on the build side
      */
@@ -71,9 +74,19 @@ public class JoinStatisticsCounter
         logHistogramCounters[2 * bucket + 1] += numSourcePositions;
     }
 
+    public void recordRleProbe()
+    {
+        rleProbes++;
+    }
+
+    public void recordCreateProbe()
+    {
+        totalProbes++;
+    }
+
     @Override
     public JoinOperatorInfo get()
     {
-        return createJoinOperatorInfo(joinType, logHistogramCounters, lookupSourcePositions);
+        return createJoinOperatorInfo(joinType, logHistogramCounters, lookupSourcePositions, rleProbes, totalProbes);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/join/unspilled/LookupJoinPageBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/unspilled/LookupJoinPageBuilder.java
@@ -17,6 +17,7 @@ import io.trino.operator.join.LookupSource;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.block.Block;
+import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.Type;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 
@@ -43,6 +44,7 @@ public class LookupJoinPageBuilder
     private int estimatedProbeRowSize = -1;
     private int previousPosition = -1;
     private boolean isSequentialProbeIndices = true;
+    private boolean repeatBuildRow;
 
     public LookupJoinPageBuilder(List<Type> buildTypes)
     {
@@ -62,6 +64,13 @@ public class LookupJoinPageBuilder
         return probeIndexBuilder.isEmpty() && buildPageBuilder.isEmpty();
     }
 
+    public int getPositionCount()
+    {
+        // when build rows are repeated then position count is equal to probe position count
+        verify(!repeatBuildRow);
+        return probeIndexBuilder.size();
+    }
+
     public void reset()
     {
         // be aware that probeIndexBuilder will not clear its capacity
@@ -71,6 +80,7 @@ public class LookupJoinPageBuilder
         estimatedProbeRowSize = -1;
         previousPosition = -1;
         isSequentialProbeIndices = true;
+        repeatBuildRow = false;
     }
 
     /**
@@ -101,8 +111,17 @@ public class LookupJoinPageBuilder
         }
     }
 
+    public void repeatBuildRow()
+    {
+        repeatBuildRow = true;
+    }
+
     public Page build(JoinProbe probe)
     {
+        if (repeatBuildRow) {
+            return buildRepeatedPage(probe);
+        }
+
         int outputPositions = probeIndexBuilder.size();
         verify(buildPageBuilder.getPositionCount() == outputPositions);
 
@@ -138,6 +157,32 @@ public class LookupJoinPageBuilder
             verify(blocks[offset + i].getPositionCount() == outputPositions);
         }
         return new Page(outputPositions, blocks);
+    }
+
+    private Page buildRepeatedPage(JoinProbe probe)
+    {
+        // Build match can be repeated only if there is a single build row match
+        // and probe join channels are run length encoded.
+        verify(probe.areProbeJoinChannelsRunLengthEncoded());
+        verify(buildPageBuilder.getPositionCount() == 1);
+        verify(probeIndexBuilder.size() == 1);
+        verify(probeIndexBuilder.getInt(0) == 0);
+
+        int positionCount = probe.getPage().getPositionCount();
+        int[] probeOutputChannels = probe.getOutputChannels();
+        Block[] blocks = new Block[probeOutputChannels.length + buildOutputChannelCount];
+
+        for (int i = 0; i < probeOutputChannels.length; i++) {
+            blocks[i] = probe.getPage().getBlock(probeOutputChannels[i]);
+        }
+
+        int offset = probeOutputChannels.length;
+        for (int i = 0; i < buildOutputChannelCount; i++) {
+            Block buildBlock = buildPageBuilder.getBlockBuilder(i).build();
+            blocks[offset + i] = RunLengthEncodedBlock.create(buildBlock, positionCount);
+        }
+
+        return new Page(positionCount, blocks);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/join/unspilled/PageJoiner.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/unspilled/PageJoiner.java
@@ -110,6 +110,7 @@ public class PageJoiner
         }
         if (probe == null) {
             probe = joinProbeFactory.createJoinProbe(probePage, lookupSource);
+            statisticsCounter.recordCreateProbe();
         }
 
         processProbe(lookupSource);
@@ -147,11 +148,50 @@ public class PageJoiner
                 }
                 statisticsCounter.recordProbe(joinSourcePositions);
             }
+
+            if (handleRleProbe()) {
+                break;
+            }
+
             if (!advanceProbePosition()) {
                 break;
             }
         }
         while (!yieldSignal.isSet());
+    }
+
+    /**
+     * @return true if run length encoded probe has been handled and probe page processing is now finished
+     */
+    private boolean handleRleProbe()
+    {
+        if (!probe.areProbeJoinChannelsRunLengthEncoded()) {
+            return false;
+        }
+
+        if (probe.getPosition() != 0) {
+            // RLE probe can be handled only after first row is processed
+            return false;
+        }
+
+        if (pageBuilder.getPositionCount() == 0) {
+            // skip matching of other probe rows since first
+            // row from RLE probe did not produce any matches
+            probe.finish();
+            statisticsCounter.recordRleProbe();
+            return true;
+        }
+
+        if (pageBuilder.getPositionCount() == 1) {
+            // repeat probe join key match
+            pageBuilder.repeatBuildRow();
+            probe.finish();
+            statisticsCounter.recordRleProbe();
+            return true;
+        }
+
+        // process probe row by row since there are multiple matches per probe join key
+        return false;
     }
 
     /**

--- a/core/trino-main/src/test/java/io/trino/operator/join/TestJoinOperatorInfo.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/TestJoinOperatorInfo.java
@@ -30,17 +30,23 @@ public class TestJoinOperatorInfo
                 INNER,
                 makeHistogramArray(10, 20, 30, 40, 50, 60, 70, 80),
                 makeHistogramArray(12, 22, 32, 42, 52, 62, 72, 82),
-                Optional.of(1L));
+                Optional.of(1L),
+                2,
+                3);
         JoinOperatorInfo other = new JoinOperatorInfo(
                 INNER,
                 makeHistogramArray(11, 21, 31, 41, 51, 61, 71, 81),
                 makeHistogramArray(15, 25, 35, 45, 55, 65, 75, 85),
-                Optional.of(2L));
+                Optional.of(2L),
+                4,
+                7);
 
         JoinOperatorInfo merged = base.mergeWith(other);
         assertEquals(makeHistogramArray(21, 41, 61, 81, 101, 121, 141, 161), merged.getLogHistogramProbes());
         assertEquals(makeHistogramArray(27, 47, 67, 87, 107, 127, 147, 167), merged.getLogHistogramOutput());
         assertEquals(merged.getLookupSourcePositions(), Optional.of(3L));
+        assertEquals(merged.getRleProbes(), 6);
+        assertEquals(merged.getTotalProbes(), 10);
     }
 
     private long[] makeHistogramArray(long... longArray)

--- a/core/trino-main/src/test/java/io/trino/operator/join/unspilled/TestHashJoinOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/unspilled/TestHashJoinOperator.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.primitives.Ints;
+import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
 import io.trino.ExceededMemoryLimitException;
 import io.trino.RowPagesBuilder;
@@ -39,11 +40,14 @@ import io.trino.operator.WorkProcessorOperator;
 import io.trino.operator.WorkProcessorOperatorFactory;
 import io.trino.operator.join.InternalJoinFilterFunction;
 import io.trino.operator.join.JoinBridgeManager;
+import io.trino.operator.join.JoinOperatorInfo;
 import io.trino.operator.join.unspilled.JoinTestUtils.BuildSideSetup;
 import io.trino.operator.join.unspilled.JoinTestUtils.TestInternalJoinFilterFunction;
 import io.trino.spi.Page;
 import io.trino.spi.block.LazyBlock;
+import io.trino.spi.block.LongArrayBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.block.VariableWidthBlock;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
 import io.trino.sql.planner.NodePartitioningManager;
@@ -71,7 +75,11 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.RowPagesBuilder.rowPagesBuilder;
 import static io.trino.SessionTestUtils.TEST_SESSION;
+import static io.trino.block.BlockAssertions.createLongsBlock;
 import static io.trino.operator.OperatorAssertion.assertOperatorEquals;
+import static io.trino.operator.OperatorAssertion.dropChannel;
+import static io.trino.operator.OperatorAssertion.toMaterializedResult;
+import static io.trino.operator.OperatorAssertion.toPages;
 import static io.trino.operator.OperatorFactories.JoinOperatorType.fullOuterJoin;
 import static io.trino.operator.OperatorFactories.JoinOperatorType.innerJoin;
 import static io.trino.operator.OperatorFactories.JoinOperatorType.probeOuterJoin;
@@ -85,9 +93,12 @@ import static io.trino.operator.join.unspilled.JoinTestUtils.setupBuildSide;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.testing.DataProviders.cartesianProduct;
+import static io.trino.testing.DataProviders.trueFalse;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -191,41 +202,79 @@ public class TestHashJoinOperator
         assertOperatorEquals(joinOperatorFactory, taskContext.addPipelineContext(0, true, true, false).addDriverContext(), probeInput, expected, true, getHashChannels(probePages, buildPages));
     }
 
-    @Test(dataProvider = "singleBigintLookupSourceProvider")
-    public void testInnerJoinWithRunLengthEncodedProbe(boolean singleBigintLookupSource)
+    @Test(dataProvider = "hashJoinRleProbeTestValues")
+    public void testInnerJoinWithRunLengthEncodedProbe(boolean withFilter, boolean probeHashEnabled, boolean singleBigintLookupSource)
     {
         TaskContext taskContext = createTaskContext();
 
         // build factory
-        RowPagesBuilder buildPages = rowPagesBuilder(false, Ints.asList(0), ImmutableList.of(BIGINT))
-                .addSequencePage(10, 20)
-                .addSequencePage(10, 21);
+        RowPagesBuilder buildPages = rowPagesBuilder(false, Ints.asList(0), ImmutableList.of(VARCHAR, BIGINT))
+                .row("20", 1L)
+                .row("21", 2L)
+                .row("21", 3L);
         BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, false, taskContext, buildPages, Optional.empty(), singleBigintLookupSource);
         JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactory = buildSideSetup.getLookupSourceFactoryManager();
 
         // probe factory
-        RowPagesBuilder probePages = rowPagesBuilder(false, Ints.asList(0), ImmutableList.of(BIGINT));
-        List<Page> probeInput = ImmutableList.of(
-                new Page(RunLengthEncodedBlock.create(BIGINT, 20L, 2)),
-                new Page(RunLengthEncodedBlock.create(BIGINT, -1L, 2)),
-                new Page(RunLengthEncodedBlock.create(BIGINT, 21L, 2)));
-        OperatorFactory joinOperatorFactory = innerJoinOperatorFactory(operatorFactories, lookupSourceFactory, probePages, false);
+        RowPagesBuilder probePagesBuilder = rowPagesBuilder(probeHashEnabled, Ints.asList(0), ImmutableList.of(VARCHAR, BIGINT))
+                .addBlocksPage(
+                        RunLengthEncodedBlock.create(VARCHAR, Slices.utf8Slice("20"), 2),
+                        createLongsBlock(42, 43))
+                .addBlocksPage(
+                        RunLengthEncodedBlock.create(VARCHAR, Slices.utf8Slice("-1"), 2),
+                        createLongsBlock(52, 53))
+                .addBlocksPage(
+                        RunLengthEncodedBlock.create(VARCHAR, Slices.utf8Slice("21"), 2),
+                        createLongsBlock(62, 63));
+        OperatorFactory joinOperatorFactory = innerJoinOperatorFactory(operatorFactories, lookupSourceFactory, probePagesBuilder, withFilter);
 
         // build drivers and operators
         instantiateBuildDrivers(buildSideSetup, taskContext);
         buildLookupSource(executor, buildSideSetup);
 
-        // expected
-        MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probePages.getTypesWithoutHash(), buildPages.getTypesWithoutHash()))
-                .row(20L, 20L)
-                .row(20L, 20L)
-                .row(21L, 21L)
-                .row(21L, 21L)
-                .row(21L, 21L)
-                .row(21L, 21L)
-                .build();
+        DriverContext driverContext = taskContext.addPipelineContext(0, true, true, false).addDriverContext();
+        List<Page> pages = toPages(joinOperatorFactory, driverContext, probePagesBuilder.build(), true, true);
+        if (probeHashEnabled) {
+            // Drop the hashChannel for all pages
+            pages = dropChannel(pages, getHashChannels(probePagesBuilder, buildPages));
+        }
 
-        assertOperatorEquals(joinOperatorFactory, taskContext.addPipelineContext(0, true, true, false).addDriverContext(), probeInput, expected, true, getHashChannels(probePages, buildPages));
+        assertThat(pages.size()).isEqualTo(2);
+        if (withFilter) {
+            assertThat(pages.get(0).getBlock(2)).isInstanceOf(VariableWidthBlock.class);
+            assertThat(pages.get(0).getBlock(3)).isInstanceOf(LongArrayBlock.class);
+        }
+        else {
+            assertThat(pages.get(0).getBlock(2)).isInstanceOf(RunLengthEncodedBlock.class);
+            assertThat(pages.get(0).getBlock(3)).isInstanceOf(RunLengthEncodedBlock.class);
+        }
+        assertThat(pages.get(1).getBlock(2)).isInstanceOf(VariableWidthBlock.class);
+
+        assertThat(getJoinOperatorInfo(driverContext).getRleProbes()).isEqualTo(withFilter ? 0 : 2);
+        assertThat(getJoinOperatorInfo(driverContext).getTotalProbes()).isEqualTo(3);
+
+        // expected
+        MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probePagesBuilder.getTypesWithoutHash(), buildPages.getTypesWithoutHash()))
+                .row("20", 42L, "20", 1L)
+                .row("20", 43L, "20", 1L)
+                .row("21", 62L, "21", 3L)
+                .row("21", 62L, "21", 2L)
+                .row("21", 63L, "21", 3L)
+                .row("21", 63L, "21", 2L)
+                .build();
+        MaterializedResult actual = toMaterializedResult(driverContext.getSession(), expected.getTypes(), pages);
+        assertThat(actual).containsExactlyElementsOf(expected);
+    }
+
+    private JoinOperatorInfo getJoinOperatorInfo(DriverContext driverContext)
+    {
+        return (JoinOperatorInfo) getOnlyElement(driverContext.getOperatorStats()).getInfo();
+    }
+
+    @DataProvider(name = "hashJoinRleProbeTestValues")
+    public static Object[][] hashJoinRleProbeTestValuesProvider()
+    {
+        return cartesianProduct(trueFalse(), trueFalse(), trueFalse());
     }
 
     @Test(dataProvider = "singleBigintLookupSourceProvider")

--- a/core/trino-main/src/test/java/io/trino/operator/join/unspilled/TestLookupJoinPageBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/unspilled/TestLookupJoinPageBuilder.java
@@ -45,7 +45,7 @@ public class TestLookupJoinPageBuilder
         Block block = blockBuilder.build();
         Page page = new Page(block, block);
 
-        JoinProbeFactory joinProbeFactory = new JoinProbeFactory(ImmutableList.of(0, 1), ImmutableList.of(0, 1), OptionalInt.empty());
+        JoinProbeFactory joinProbeFactory = new JoinProbeFactory(ImmutableList.of(0, 1), ImmutableList.of(0, 1), OptionalInt.empty(), false);
         LookupSource lookupSource = new TestLookupSource(ImmutableList.of(BIGINT, BIGINT), page);
         JoinProbe probe = joinProbeFactory.createJoinProbe(page, lookupSource);
         LookupJoinPageBuilder lookupJoinPageBuilder = new LookupJoinPageBuilder(ImmutableList.of(BIGINT, BIGINT));
@@ -93,7 +93,7 @@ public class TestLookupJoinPageBuilder
         }
         Block block = blockBuilder.build();
         Page page = new Page(block);
-        JoinProbeFactory joinProbeFactory = new JoinProbeFactory(ImmutableList.of(0), ImmutableList.of(0), OptionalInt.empty());
+        JoinProbeFactory joinProbeFactory = new JoinProbeFactory(ImmutableList.of(0), ImmutableList.of(0), OptionalInt.empty(), false);
         LookupSource lookupSource = new TestLookupSource(ImmutableList.of(BIGINT), page);
         LookupJoinPageBuilder lookupJoinPageBuilder = new LookupJoinPageBuilder(ImmutableList.of(BIGINT));
 
@@ -165,7 +165,7 @@ public class TestLookupJoinPageBuilder
 
         // nothing on the build side so we don't append anything
         LookupSource lookupSource = new TestLookupSource(ImmutableList.of(), page);
-        JoinProbe probe = (new JoinProbeFactory(ImmutableList.of(0), ImmutableList.of(0), OptionalInt.empty())).createJoinProbe(page, lookupSource);
+        JoinProbe probe = (new JoinProbeFactory(ImmutableList.of(0), ImmutableList.of(0), OptionalInt.empty(), false)).createJoinProbe(page, lookupSource);
         LookupJoinPageBuilder lookupJoinPageBuilder = new LookupJoinPageBuilder(ImmutableList.of(BIGINT));
 
         // append the same row many times should also flush in the end


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
JoinProbe will now perform only a single row join when parsing an RLE page


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
Optimize joins performance for RLE pages.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Improve performance of joins on partitioned columns. ({issue}`14493`)
```
