### PR TITLE
Support `TRUNCATE TABLE` statement in BigQuery

### DIFF
--- a/docs/src/main/sphinx/connector/bigquery.rst
+++ b/docs/src/main/sphinx/connector/bigquery.rst
@@ -298,6 +298,7 @@ BigQuery database. In addition to the
 the following features:
 
 * :doc:`/sql/insert`
+* :doc:`/sql/truncate`
 * :doc:`/sql/create-table`
 * :doc:`/sql/create-table-as`
 * :doc:`/sql/drop-table`

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -481,6 +481,21 @@ public class BigQueryMetadata
     }
 
     @Override
+    public void truncateTable(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        BigQueryTableHandle table = (BigQueryTableHandle) tableHandle;
+        BigQueryClient client = bigQueryClientFactory.createBigQueryClient(session);
+
+        RemoteTableName remoteTableName = table.asPlainTable().getRemoteTableName();
+        String sql = format(
+                "TRUNCATE TABLE %s.%s.%s",
+                quote(remoteTableName.getProjectId()),
+                quote(remoteTableName.getDatasetName()),
+                quote(remoteTableName.getTableName()));
+        client.executeUpdate(QueryJobConfiguration.of(sql));
+    }
+
+    @Override
     public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> columns, RetryMode retryMode)
     {
         if (retryMode != RetryMode.NO_RETRIES) {

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
@@ -84,6 +84,9 @@ public class TestBigQueryConnectorTest
             case SUPPORTS_NOT_NULL_CONSTRAINT:
                 return false;
 
+            case SUPPORTS_TRUNCATE:
+                return true;
+
             case SUPPORTS_NEGATIVE_DATE:
                 return false;
 


### PR DESCRIPTION
## Description

Support `TRUNCATE TABLE` statement in BigQuery

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# BigQuery
* Add support for [truncating tables](/sql/truncate). ({issue}`14494`)
```
