### PR TITLE
Add context appender to sql based connectors

### DIFF
--- a/core/trino-main/src/main/java/io/trino/testing/TestingConnectorSession.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingConnectorSession.java
@@ -151,10 +151,10 @@ public class TestingConnectorSession
     public static class Builder
     {
         private ConnectorIdentity identity = ConnectorIdentity.ofUser("user");
-        private final Optional<String> source = Optional.of("test");
+        private Optional<String> source = Optional.of("test");
         private TimeZoneKey timeZoneKey = UTC_KEY;
         private final Locale locale = ENGLISH;
-        private final Optional<String> traceToken = Optional.empty();
+        private Optional<String> traceToken = Optional.empty();
         private Optional<Instant> start = Optional.empty();
         private List<PropertyMetadata<?>> propertyMetadatas = ImmutableList.of();
         private Map<String, Object> propertyValues = ImmutableMap.of();
@@ -174,6 +174,18 @@ public class TestingConnectorSession
         public Builder setStart(Instant start)
         {
             this.start = Optional.of(start);
+            return this;
+        }
+
+        public Builder setSource(String source)
+        {
+            this.source = Optional.of(source);
+            return this;
+        }
+
+        public Builder setTraceToken(String token)
+        {
+            this.traceToken = Optional.of(token);
             return this;
         }
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.io.Closer;
 import io.airlift.log.Logger;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnHandle;
@@ -104,6 +105,7 @@ public abstract class BaseJdbcClient
     protected final String identifierQuote;
     protected final Set<String> jdbcTypesMappedToVarchar;
     private final IdentifierMapping identifierMapping;
+    private final RemoteQueryModifier queryModifier;
 
     private final boolean supportsRetries;
 
@@ -112,7 +114,8 @@ public abstract class BaseJdbcClient
             String identifierQuote,
             ConnectionFactory connectionFactory,
             QueryBuilder queryBuilder,
-            IdentifierMapping identifierMapping)
+            IdentifierMapping identifierMapping,
+            RemoteQueryModifier remoteQueryModifier)
     {
         this(
                 identifierQuote,
@@ -120,6 +123,7 @@ public abstract class BaseJdbcClient
                 queryBuilder,
                 config.getJdbcTypesMappedToVarchar(),
                 identifierMapping,
+                remoteQueryModifier,
                 false);
     }
 
@@ -129,6 +133,7 @@ public abstract class BaseJdbcClient
             QueryBuilder queryBuilder,
             Set<String> jdbcTypesMappedToVarchar,
             IdentifierMapping identifierMapping,
+            RemoteQueryModifier remoteQueryModifier,
             boolean supportsRetries)
     {
         this.identifierQuote = requireNonNull(identifierQuote, "identifierQuote is null");
@@ -138,6 +143,7 @@ public abstract class BaseJdbcClient
                 .addAll(requireNonNull(jdbcTypesMappedToVarchar, "jdbcTypesMappedToVarchar is null"))
                 .build();
         this.identifierMapping = requireNonNull(identifierMapping, "identifierMapping is null");
+        this.queryModifier = requireNonNull(remoteQueryModifier, "remoteQueryModifier is null");
         this.supportsRetries = supportsRetries;
     }
 
@@ -610,7 +616,7 @@ public abstract class BaseJdbcClient
 
             RemoteTableName remoteTableName = new RemoteTableName(Optional.ofNullable(catalog), Optional.ofNullable(remoteSchema), remoteTargetTableName);
             String sql = createTableSql(remoteTableName, columnList.build(), tableMetadata);
-            execute(connection, sql);
+            execute(session, connection, sql);
 
             return new JdbcOutputTableHandle(
                     catalog,
@@ -682,7 +688,7 @@ public abstract class BaseJdbcClient
             }
 
             String remoteTemporaryTableName = identifierMapping.toRemoteTableName(identity, connection, remoteSchema, generateTemporaryTableName());
-            copyTableSchema(connection, catalog, remoteSchema, remoteTable, remoteTemporaryTableName, columnNames.build());
+            copyTableSchema(session, connection, catalog, remoteSchema, remoteTable, remoteTemporaryTableName, columnNames.build());
 
             Optional<ColumnMetadata> pageSinkIdColumn = Optional.empty();
             if (shouldUseFaultTolerantExecution(session)) {
@@ -709,7 +715,7 @@ public abstract class BaseJdbcClient
         }
     }
 
-    protected void copyTableSchema(Connection connection, String catalogName, String schemaName, String tableName, String newTableName, List<String> columnNames)
+    protected void copyTableSchema(ConnectorSession session, Connection connection, String catalogName, String schemaName, String tableName, String newTableName, List<String> columnNames)
     {
         String sql = format(
                 "CREATE TABLE %s AS SELECT %s FROM %s WHERE 0 = 1",
@@ -719,7 +725,7 @@ public abstract class BaseJdbcClient
                         .collect(joining(", ")),
                 quoted(catalogName, schemaName, tableName));
         try {
-            execute(connection, sql);
+            execute(session, connection, sql);
         }
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);
@@ -774,7 +780,7 @@ public abstract class BaseJdbcClient
     protected void renameTable(ConnectorSession session, Connection connection, String catalogName, String remoteSchemaName, String remoteTableName, String newRemoteSchemaName, String newRemoteTableName)
             throws SQLException
     {
-        execute(connection, format(
+        execute(session, connection, format(
                 "ALTER TABLE %s RENAME TO %s",
                 quoted(catalogName, remoteSchemaName, remoteTableName),
                 quoted(catalogName, newRemoteSchemaName, newRemoteTableName)));
@@ -800,9 +806,10 @@ public abstract class BaseJdbcClient
         String pageSinkInsertSql = format("INSERT INTO %s (%s) VALUES (?)",
                 quoted(pageSinkTable),
                 pageSinkIdColumnName);
+        pageSinkInsertSql = queryModifier.apply(session, pageSinkInsertSql);
         LongWriteFunction pageSinkIdWriter = (LongWriteFunction) toWriteMapping(session, TRINO_PAGE_SINK_ID_COLUMN_TYPE).getWriteFunction();
 
-        execute(connection, pageSinkTableSql);
+        execute(session, connection, pageSinkTableSql);
 
         try (PreparedStatement statement = connection.prepareStatement(pageSinkInsertSql)) {
             int batchSize = 0;
@@ -868,7 +875,7 @@ public abstract class BaseJdbcClient
                         handle.getPageSinkIdColumnName().get());
             }
 
-            execute(connection, insertSql);
+            execute(session, connection, insertSql);
         }
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);
@@ -919,7 +926,7 @@ public abstract class BaseJdbcClient
                 "ALTER TABLE %s ADD %s",
                 quoted(table),
                 getColumnDefinitionSql(session, column, remoteColumnName));
-        execute(connection, sql);
+        execute(session, connection, sql);
     }
 
     @Override
@@ -939,7 +946,7 @@ public abstract class BaseJdbcClient
     protected void renameColumn(ConnectorSession session, Connection connection, RemoteTableName remoteTableName, String remoteColumnName, String newRemoteColumnName)
             throws SQLException
     {
-        execute(connection, format(
+        execute(session, connection, format(
                 "ALTER TABLE %s RENAME COLUMN %s TO %s",
                 quoted(remoteTableName),
                 quoted(remoteColumnName),
@@ -956,7 +963,7 @@ public abstract class BaseJdbcClient
                     "ALTER TABLE %s DROP COLUMN %s",
                     quoted(handle.asPlainTable().getRemoteTableName()),
                     quoted(remoteColumnName));
-            execute(connection, sql);
+            execute(session, connection, sql);
         }
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);
@@ -1076,7 +1083,7 @@ public abstract class BaseJdbcClient
     protected void createSchema(ConnectorSession session, Connection connection, String remoteSchemaName)
             throws SQLException
     {
-        execute(connection, "CREATE SCHEMA " + quoted(remoteSchemaName));
+        execute(session, connection, "CREATE SCHEMA " + quoted(remoteSchemaName));
     }
 
     @Override
@@ -1096,7 +1103,7 @@ public abstract class BaseJdbcClient
     protected void dropSchema(ConnectorSession session, Connection connection, String remoteSchemaName)
             throws SQLException
     {
-        execute(connection, "DROP SCHEMA " + quoted(remoteSchemaName));
+        execute(session, connection, "DROP SCHEMA " + quoted(remoteSchemaName));
     }
 
     @Override
@@ -1118,25 +1125,26 @@ public abstract class BaseJdbcClient
     protected void renameSchema(ConnectorSession session, Connection connection, String remoteSchemaName, String newRemoteSchemaName)
             throws SQLException
     {
-        execute(connection, "ALTER SCHEMA " + quoted(remoteSchemaName) + " RENAME TO " + quoted(newRemoteSchemaName));
+        execute(session, connection, "ALTER SCHEMA " + quoted(remoteSchemaName) + " RENAME TO " + quoted(newRemoteSchemaName));
     }
 
     protected void execute(ConnectorSession session, String query)
     {
         try (Connection connection = connectionFactory.openConnection(session)) {
-            execute(connection, query);
+            execute(session, connection, query);
         }
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);
         }
     }
 
-    protected void execute(Connection connection, String query)
+    protected void execute(ConnectorSession session, Connection connection, String query)
             throws SQLException
     {
         try (Statement statement = connection.createStatement()) {
-            log.debug("Execute: %s", query);
-            statement.execute(query);
+            String modifiedQuery = queryModifier.apply(session, query);
+            log.debug("Execute: %s", modifiedQuery);
+            statement.execute(modifiedQuery);
         }
         catch (SQLException e) {
             e.addSuppressed(new RuntimeException("Query: " + query));

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
@@ -16,8 +16,10 @@ package io.trino.plugin.jdbc;
 import com.google.common.base.Joiner;
 import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.JoinType;
@@ -42,6 +44,7 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
 import static java.util.Collections.nCopies;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
 public class DefaultQueryBuilder
@@ -52,6 +55,19 @@ public class DefaultQueryBuilder
     // not all databases support booleans, so use 1=1 and 1=0 instead
     private static final String ALWAYS_TRUE = "1=1";
     private static final String ALWAYS_FALSE = "1=0";
+
+    private final RemoteQueryModifier queryModifier;
+
+    public DefaultQueryBuilder()
+    {
+        this(RemoteQueryModifier.NONE);
+    }
+
+    @Inject
+    public DefaultQueryBuilder(RemoteQueryModifier queryModifier)
+    {
+        this.queryModifier = requireNonNull(queryModifier, "queryModifier is null");
+    }
 
     @Override
     public PreparedQuery prepareSelectQuery(
@@ -163,8 +179,9 @@ public class DefaultQueryBuilder
             PreparedQuery preparedQuery)
             throws SQLException
     {
-        log.debug("Preparing query: %s", preparedQuery.getQuery());
-        PreparedStatement statement = client.getPreparedStatement(connection, preparedQuery.getQuery());
+        String modifiedQuery = queryModifier.apply(session, preparedQuery.getQuery());
+        log.debug("Preparing query: %s", modifiedQuery);
+        PreparedStatement statement = client.getPreparedStatement(connection, modifiedQuery);
 
         List<QueryParameter> parameters = preparedQuery.getParameters();
         for (int i = 0; i < parameters.size(); i++) {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcModule.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcModule.java
@@ -21,6 +21,7 @@ import com.google.inject.multibindings.Multibinder;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.plugin.base.CatalogName;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifierModule;
 import io.trino.plugin.jdbc.mapping.IdentifierMappingModule;
 import io.trino.plugin.jdbc.procedure.FlushJdbcMetadataCacheProcedure;
 import io.trino.spi.connector.ConnectorAccessControl;
@@ -49,6 +50,7 @@ public class JdbcModule
     {
         install(new JdbcDiagnosticModule());
         install(new IdentifierMappingModule());
+        install(new RemoteQueryModifierModule());
 
         newOptionalBinder(binder, ConnectorAccessControl.class);
         newOptionalBinder(binder, QueryBuilder.class).setDefault().to(DefaultQueryBuilder.class).in(Scopes.SINGLETON);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSinkProvider.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSinkProvider.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.jdbc;
 
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorPageSink;
@@ -29,22 +30,24 @@ public class JdbcPageSinkProvider
         implements ConnectorPageSinkProvider
 {
     private final JdbcClient jdbcClient;
+    private RemoteQueryModifier queryModifier;
 
     @Inject
-    public JdbcPageSinkProvider(JdbcClient jdbcClient)
+    public JdbcPageSinkProvider(JdbcClient jdbcClient, RemoteQueryModifier remoteQueryModifier)
     {
         this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
+        this.queryModifier = requireNonNull(remoteQueryModifier, "remoteQueryModifier is null");
     }
 
     @Override
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle tableHandle, ConnectorPageSinkId pageSinkId)
     {
-        return new JdbcPageSink(session, (JdbcOutputTableHandle) tableHandle, jdbcClient, pageSinkId);
+        return new JdbcPageSink(session, (JdbcOutputTableHandle) tableHandle, jdbcClient, pageSinkId, queryModifier);
     }
 
     @Override
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle tableHandle, ConnectorPageSinkId pageSinkId)
     {
-        return new JdbcPageSink(session, (JdbcOutputTableHandle) tableHandle, jdbcClient, pageSinkId);
+        return new JdbcPageSink(session, (JdbcOutputTableHandle) tableHandle, jdbcClient, pageSinkId, queryModifier);
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/logging/FormatBasedRemoteQueryModifier.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/logging/FormatBasedRemoteQueryModifier.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.logging;
+
+import com.google.inject.Inject;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_NON_TRANSIENT_ERROR;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class FormatBasedRemoteQueryModifier
+        implements RemoteQueryModifier
+{
+    private final String commentFormat;
+
+    @Inject
+    public FormatBasedRemoteQueryModifier(FormatBasedRemoteQueryModifierConfig config)
+    {
+        this.commentFormat = requireNonNull(config, "config is null").getFormat();
+        checkState(!commentFormat.isBlank(), "comment format is blank");
+    }
+
+    @Override
+    public String apply(ConnectorSession session, String query)
+    {
+        String message = commentFormat;
+        for (PredefinedValue predefinedValue : PredefinedValue.values()) {
+            message = message.replaceAll(predefinedValue.getMatchCase(), predefinedValue.value(session));
+        }
+        return query + " /*" + message + "*/";
+    }
+
+    enum PredefinedValue
+    {
+        QUERY_ID(ConnectorSession::getQueryId),
+        SOURCE(new SanitizedValuesProvider(session -> session.getSource().orElse(""), "$SOURCE")),
+        USER(ConnectorSession::getUser),
+        TRACE_TOKEN(new SanitizedValuesProvider(session -> session.getTraceToken().orElse(""), "$TRACE_TOKEN"));
+
+        private final Function<ConnectorSession, String> valueProvider;
+
+        PredefinedValue(Function<ConnectorSession, String> valueProvider)
+        {
+            this.valueProvider = valueProvider;
+        }
+
+        String getMatchCase()
+        {
+            return "\\$" + this.name();
+        }
+
+        String getPredefinedValueCode()
+        {
+            return "$" + this.name();
+        }
+
+        String value(ConnectorSession session)
+        {
+            return valueProvider.apply(session);
+        }
+    }
+
+    private static class SanitizedValuesProvider
+            implements Function<ConnectorSession, String>
+    {
+        private static final Predicate<String> VALIDATION_MATCHER = Pattern.compile("^[\\w_]*$").asMatchPredicate();
+        private final Function<ConnectorSession, String> valueProvider;
+        private final String name;
+
+        private SanitizedValuesProvider(Function<ConnectorSession, String> valueProvider, String name)
+        {
+            this.valueProvider = requireNonNull(valueProvider, "valueProvider is null");
+            this.name = requireNonNull(name, "name is null");
+        }
+
+        @Override
+        public String apply(ConnectorSession session)
+        {
+            String value = valueProvider.apply(session);
+            if (VALIDATION_MATCHER.test(value)) {
+                return value;
+            }
+            throw new TrinoException(JDBC_NON_TRANSIENT_ERROR, format("Passed value %s as %s does not meet security criteria. It can contain only letters, digits and underscores", value, name));
+        }
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/logging/FormatBasedRemoteQueryModifierConfig.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/logging/FormatBasedRemoteQueryModifierConfig.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.logging;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.trino.plugin.jdbc.logging.FormatBasedRemoteQueryModifier.PredefinedValue;
+
+import javax.validation.constraints.AssertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.stream.Collectors.joining;
+
+public class FormatBasedRemoteQueryModifierConfig
+{
+    private static final List<String> PREDEFINED_MATCHES = Arrays.stream(PredefinedValue.values()).map(PredefinedValue::getMatchCase).toList();
+    private static final Pattern VALIDATION_PATTERN = Pattern.compile("[\\w ,=]|" + String.join("|", PREDEFINED_MATCHES));
+    private String format = "";
+
+    @Config("query.comment-format")
+    @ConfigDescription("Format in which logs about query execution context should be added as comments sent through jdbc driver.")
+    public FormatBasedRemoteQueryModifierConfig setFormat(String format)
+    {
+        this.format = format;
+        return this;
+    }
+
+    public String getFormat()
+    {
+        return format;
+    }
+
+    @AssertTrue(message = "Incorrect format it may consist of only letters, digits, underscores, commas, spaces, equal signs and predefined values")
+    boolean isFormatValid()
+    {
+        Matcher matcher = VALIDATION_PATTERN.matcher(format);
+        return matcher.results()
+                .map(MatchResult::group)
+                .collect(joining())
+                .equals(format);
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/logging/RemoteQueryModifier.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/logging/RemoteQueryModifier.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.logging;
+
+import io.trino.spi.connector.ConnectorSession;
+
+public interface RemoteQueryModifier
+{
+    RemoteQueryModifier NONE = (session, query) -> query;
+
+    String apply(ConnectorSession session, String query);
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/logging/RemoteQueryModifierModule.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/logging/RemoteQueryModifierModule.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.logging;
+
+import com.google.inject.Binder;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class RemoteQueryModifierModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        configBinder(binder).bindConfig(FormatBasedRemoteQueryModifierConfig.class);
+        install(conditionalModule(
+                FormatBasedRemoteQueryModifierConfig.class,
+                config -> config.getFormat().isBlank(),
+                innerBinder -> innerBinder.bind(RemoteQueryModifier.class).toInstance(RemoteQueryModifier.NONE),
+                innerBinder -> innerBinder.bind(RemoteQueryModifier.class).to(FormatBasedRemoteQueryModifier.class).in(SINGLETON)));
+    }
+}

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcClient.java
@@ -19,6 +19,7 @@ import io.trino.plugin.base.aggregation.AggregateFunctionRewriter;
 import io.trino.plugin.jdbc.aggregation.ImplementCountAll;
 import io.trino.plugin.jdbc.expression.JdbcConnectorExpressionRewriterBuilder;
 import io.trino.plugin.jdbc.expression.RewriteVariable;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.plugin.jdbc.mapping.DefaultIdentifierMapping;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
 import io.trino.spi.TrinoException;
@@ -89,7 +90,7 @@ class TestingH2JdbcClient
 
     public TestingH2JdbcClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, IdentifierMapping identifierMapping)
     {
-        super(config, "\"", connectionFactory, new DefaultQueryBuilder(), identifierMapping);
+        super(config, "\"", connectionFactory, new DefaultQueryBuilder(), identifierMapping, RemoteQueryModifier.NONE);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/logging/TestFormatBasedRemoteQueryModifier.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/logging/TestFormatBasedRemoteQueryModifier.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.logging;
+
+import io.trino.spi.TrinoException;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.testing.TestingConnectorSession;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestFormatBasedRemoteQueryModifier
+{
+    @Test
+    public void testCreatingCommentToAppendBasedOnFormatAndConnectorSession()
+    {
+        TestingConnectorSession connectorSession = TestingConnectorSession.builder()
+                .setTraceToken("trace_token")
+                .setSource("source")
+                .setIdentity(ConnectorIdentity.ofUser("Alice"))
+                .build();
+
+        FormatBasedRemoteQueryModifier modifier = createRemoteQueryModifier("Query=$QUERY_ID Execution for user=$USER with source=$SOURCE ttoken=$TRACE_TOKEN");
+        String modifiedQuery = modifier.apply(connectorSession, "SELECT * from USERS");
+
+        assertThat(modifiedQuery)
+                .isEqualTo("SELECT * from USERS /*Query=%s Execution for user=%s with source=%s ttoken=%s*/", connectorSession.getQueryId(), "Alice", "source", "trace_token");
+    }
+
+    @Test
+    public void testCreatingCommentWithDuplicatedPredefinedValues()
+    {
+        TestingConnectorSession connectorSession = TestingConnectorSession.builder()
+                .setTraceToken("trace_token")
+                .setSource("source")
+                .setIdentity(ConnectorIdentity.ofUser("Alice"))
+                .build();
+
+        FormatBasedRemoteQueryModifier modifier = createRemoteQueryModifier("$QUERY_ID, $QUERY_ID, $QUERY_ID, $QUERY_ID, $USER, $USER, $SOURCE, $SOURCE, $SOURCE, $TRACE_TOKEN, $TRACE_TOKEN");
+        String modifiedQuery = modifier.apply(connectorSession, "SELECT * from USERS");
+
+        assertThat(modifiedQuery)
+                .isEqualTo("SELECT * from USERS /*%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s*/",
+                        connectorSession.getQueryId(),
+                        connectorSession.getQueryId(),
+                        connectorSession.getQueryId(),
+                        connectorSession.getQueryId(),
+                        "Alice",
+                        "Alice",
+                        "source",
+                        "source",
+                        "source",
+                        "trace_token",
+                        "trace_token");
+    }
+
+    @Test
+    public void testForSQLInjectionsByTraceToken()
+    {
+        TestingConnectorSession connectorSession = TestingConnectorSession.builder()
+                .setTraceToken("*/; DROP TABLE TABLE_A; /*")
+                .setSource("source")
+                .setIdentity(ConnectorIdentity.ofUser("Alice"))
+                .build();
+
+        FormatBasedRemoteQueryModifier modifier = createRemoteQueryModifier("Query=$QUERY_ID Execution for user=$USER with source=$SOURCE ttoken=$TRACE_TOKEN");
+
+        assertThatThrownBy(() -> modifier.apply(connectorSession, "SELECT * from USERS"))
+                .isInstanceOf(TrinoException.class)
+                .hasMessage("Passed value */; DROP TABLE TABLE_A; /* as $TRACE_TOKEN does not meet security criteria. It can contain only letters, digits and underscores");
+    }
+
+    @Test
+    public void testForSQLInjectionsBySource()
+    {
+        TestingConnectorSession connectorSession = TestingConnectorSession.builder()
+                .setTraceToken("trace_token")
+                .setSource("*/; DROP TABLE TABLE_A; /*")
+                .setIdentity(ConnectorIdentity.ofUser("Alice"))
+                .build();
+
+        FormatBasedRemoteQueryModifier modifier = createRemoteQueryModifier("Query=$QUERY_ID Execution for user=$USER with source=$SOURCE ttoken=$TRACE_TOKEN");
+
+        assertThatThrownBy(() -> modifier.apply(connectorSession, "SELECT * from USERS"))
+                .isInstanceOf(TrinoException.class)
+                .hasMessage("Passed value */; DROP TABLE TABLE_A; /* as $SOURCE does not meet security criteria. It can contain only letters, digits and underscores");
+    }
+
+    @Test
+    public void testFormatWithEmptyValues()
+    {
+        TestingConnectorSession connectorSession = TestingConnectorSession.builder()
+                .setIdentity(ConnectorIdentity.ofUser("Alice"))
+                .setSource("")
+                .build();
+
+        FormatBasedRemoteQueryModifier modifier = createRemoteQueryModifier("source=$SOURCE ttoken=$TRACE_TOKEN");
+
+        String modifiedQuery = modifier.apply(connectorSession, "SELECT * FROM USERS");
+
+        assertThat(modifiedQuery)
+                .isEqualTo("SELECT * FROM USERS /*source= ttoken=*/");
+    }
+
+    private static FormatBasedRemoteQueryModifier createRemoteQueryModifier(String commentFormat)
+    {
+        return new FormatBasedRemoteQueryModifier(new FormatBasedRemoteQueryModifierConfig().setFormat(commentFormat));
+    }
+}

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/logging/TestFormatBasedRemoteQueryModifierConfig.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/logging/TestFormatBasedRemoteQueryModifierConfig.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.logging;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Arrays.array;
+
+public class TestFormatBasedRemoteQueryModifierConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(FormatBasedRemoteQueryModifierConfig.class).setFormat(""));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder().put("query.comment-format", "format").buildOrThrow();
+
+        FormatBasedRemoteQueryModifierConfig expected = new FormatBasedRemoteQueryModifierConfig().setFormat("format");
+
+        assertFullMapping(properties, expected);
+    }
+
+    @Test(dataProvider = "getForbiddenValuesInFormat")
+    public void testInvalidFormatValue(String incorrectValue)
+    {
+        assertThat(new FormatBasedRemoteQueryModifierConfig().setFormat(incorrectValue).isFormatValid())
+                .isFalse();
+    }
+
+    @DataProvider
+    public static Object[][] getForbiddenValuesInFormat()
+    {
+        return array(
+                array("*"),
+                array("("),
+                array(")"),
+                array("["),
+                array("]"),
+                array("{"),
+                array("}"),
+                array("&"),
+                array("@"),
+                array("!"),
+                array("#"),
+                array("%"),
+                array("^"),
+                array("$"),
+                array("\\"),
+                array("/"),
+                array("?"),
+                array(">"),
+                array("<"),
+                array(";"),
+                array("\""),
+                array(":"),
+                array("|"));
+    }
+
+    @Test
+    public void testValidFormatWithPredefinedValues()
+    {
+        assertThat(new FormatBasedRemoteQueryModifierConfig().setFormat("$QUERY_ID $USER $SOURCE $TRACE_TOKEN").isFormatValid()).isTrue();
+    }
+
+    @Test
+    public void testValidFormatWithDuplicatedPredefinedValues()
+    {
+        assertThat(new FormatBasedRemoteQueryModifierConfig().setFormat("$QUERY_ID $QUERY_ID $USER $USER $SOURCE $SOURCE $TRACE_TOKEN $TRACE_TOKEN").isFormatValid()).isTrue();
+    }
+}

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/logging/TestFormatBasedRemoteQueryModifierModule.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/logging/TestFormatBasedRemoteQueryModifierModule.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.logging;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.bootstrap.Bootstrap;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestFormatBasedRemoteQueryModifierModule
+{
+    @Test
+    public void testRemoteQueryModifierAvailableByDefault()
+    {
+        RemoteQueryModifier remoteQueryModifier = new Bootstrap(new RemoteQueryModifierModule())
+                .initialize()
+                .getInstance(RemoteQueryModifier.class);
+
+        assertThat(remoteQueryModifier)
+                .isEqualTo(RemoteQueryModifier.NONE);
+    }
+
+    @Test
+    public void testNonEmptyFormatProducingNonDefaultRemoteQueryModifier()
+    {
+        RemoteQueryModifier remoteQueryModifier = new Bootstrap(new RemoteQueryModifierModule())
+                .setRequiredConfigurationProperties(ImmutableMap.of("query.comment-format", "valid format"))
+                .initialize()
+                .getInstance(RemoteQueryModifier.class);
+
+        assertThat(remoteQueryModifier)
+                .isNotEqualTo(RemoteQueryModifier.NONE);
+    }
+}

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -48,6 +48,7 @@ import io.trino.plugin.jdbc.aggregation.ImplementCountAll;
 import io.trino.plugin.jdbc.aggregation.ImplementMinMax;
 import io.trino.plugin.jdbc.aggregation.ImplementSum;
 import io.trino.plugin.jdbc.expression.JdbcConnectorExpressionRewriterBuilder;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.AggregateFunction;
@@ -204,9 +205,10 @@ public class ClickHouseClient
             ConnectionFactory connectionFactory,
             QueryBuilder queryBuilder,
             TypeManager typeManager,
-            IdentifierMapping identifierMapping)
+            IdentifierMapping identifierMapping,
+            RemoteQueryModifier queryModifier)
     {
-        super(config, "\"", connectionFactory, queryBuilder, identifierMapping);
+        super(config, "\"", connectionFactory, queryBuilder, identifierMapping, queryModifier);
         this.uuidType = typeManager.getType(new TypeSignature(StandardTypes.UUID));
         this.ipAddressType = typeManager.getType(new TypeSignature(StandardTypes.IPADDRESS));
         JdbcTypeHandle bigintTypeHandle = new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
@@ -256,7 +258,7 @@ public class ClickHouseClient
     }
 
     @Override
-    protected void copyTableSchema(Connection connection, String catalogName, String schemaName, String tableName, String newTableName, List<String> columnNames)
+    protected void copyTableSchema(ConnectorSession session, Connection connection, String catalogName, String schemaName, String tableName, String newTableName, List<String> columnNames)
     {
         // ClickHouse does not support `create table tbl as select * from tbl2 where 0=1`
         // ClickHouse supports the following two methods to copy schema
@@ -267,7 +269,7 @@ public class ClickHouseClient
                 quoted(null, schemaName, newTableName),
                 quoted(null, schemaName, tableName));
         try {
-            execute(connection, sql);
+            execute(session, connection, sql);
         }
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);
@@ -368,7 +370,7 @@ public class ClickHouseClient
                     "ALTER TABLE %s MODIFY %s",
                     quoted(handle.asPlainTable().getRemoteTableName()),
                     join(" ", tableOptions.build()));
-            execute(connection, sql);
+            execute(session, connection, sql);
         }
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);
@@ -399,21 +401,21 @@ public class ClickHouseClient
     protected void createSchema(ConnectorSession session, Connection connection, String remoteSchemaName)
             throws SQLException
     {
-        execute(connection, "CREATE DATABASE " + quoted(remoteSchemaName));
+        execute(session, connection, "CREATE DATABASE " + quoted(remoteSchemaName));
     }
 
     @Override
     protected void dropSchema(ConnectorSession session, Connection connection, String remoteSchemaName)
             throws SQLException
     {
-        execute(connection, "DROP DATABASE " + quoted(remoteSchemaName));
+        execute(session, connection, "DROP DATABASE " + quoted(remoteSchemaName));
     }
 
     @Override
     protected void renameSchema(ConnectorSession session, Connection connection, String remoteSchemaName, String newRemoteSchemaName)
             throws SQLException
     {
-        execute(connection, "RENAME DATABASE " + quoted(remoteSchemaName) + " TO " + quoted(newRemoteSchemaName));
+        execute(session, connection, "RENAME DATABASE " + quoted(remoteSchemaName) + " TO " + quoted(newRemoteSchemaName));
     }
 
     @Override
@@ -425,7 +427,7 @@ public class ClickHouseClient
                     "ALTER TABLE %s ADD COLUMN %s",
                     quoted(handle.asPlainTable().getRemoteTableName()),
                     getColumnDefinitionSql(session, column, remoteColumnName));
-            execute(connection, sql);
+            execute(session, connection, sql);
         }
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);
@@ -469,7 +471,7 @@ public class ClickHouseClient
     protected void renameTable(ConnectorSession session, Connection connection, String catalogName, String remoteSchemaName, String remoteTableName, String newRemoteSchemaName, String newRemoteTableName)
             throws SQLException
     {
-        execute(connection, format("RENAME TABLE %s.%s TO %s.%s",
+        execute(session, connection, format("RENAME TABLE %s.%s TO %s.%s",
                 quoted(remoteSchemaName),
                 quoted(remoteTableName),
                 quoted(newRemoteSchemaName),

--- a/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
+++ b/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
@@ -30,6 +30,7 @@ import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.plugin.jdbc.WriteFunction;
 import io.trino.plugin.jdbc.WriteMapping;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnMetadata;
@@ -150,9 +151,9 @@ public class DruidJdbcClient
             .withChronology(IsoChronology.INSTANCE);
 
     @Inject
-    public DruidJdbcClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, QueryBuilder queryBuilder, IdentifierMapping identifierMapping)
+    public DruidJdbcClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, QueryBuilder queryBuilder, IdentifierMapping identifierMapping, RemoteQueryModifier queryModifier)
     {
-        super(config, "\"", connectionFactory, queryBuilder, identifierMapping);
+        super(config, "\"", connectionFactory, queryBuilder, identifierMapping, queryModifier);
     }
 
     @Override

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbClient.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbClient.java
@@ -20,6 +20,7 @@ import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.plugin.jdbc.mapping.DefaultIdentifierMapping;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.ColumnHandle;
@@ -62,7 +63,8 @@ public class TestMariaDbClient
                 throw new UnsupportedOperationException();
             },
             new DefaultQueryBuilder(),
-            new DefaultIdentifierMapping());
+            new DefaultIdentifierMapping(),
+            RemoteQueryModifier.NONE);
 
     @Test
     public void testImplementCount()

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -49,6 +49,7 @@ import io.trino.plugin.jdbc.aggregation.ImplementSum;
 import io.trino.plugin.jdbc.aggregation.ImplementVariancePop;
 import io.trino.plugin.jdbc.aggregation.ImplementVarianceSamp;
 import io.trino.plugin.jdbc.expression.JdbcConnectorExpressionRewriterBuilder;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.AggregateFunction;
@@ -204,9 +205,10 @@ public class MySqlClient
             ConnectionFactory connectionFactory,
             QueryBuilder queryBuilder,
             TypeManager typeManager,
-            IdentifierMapping identifierMapping)
+            IdentifierMapping identifierMapping,
+            RemoteQueryModifier queryModifier)
     {
-        super("`", connectionFactory, queryBuilder, config.getJdbcTypesMappedToVarchar(), identifierMapping, true);
+        super("`", connectionFactory, queryBuilder, config.getJdbcTypesMappedToVarchar(), identifierMapping, queryModifier, true);
         this.jsonType = typeManager.getType(new TypeSignature(StandardTypes.JSON));
         this.statisticsEnabled = statisticsConfig.isEnabled();
 
@@ -589,7 +591,7 @@ public class MySqlClient
                 quoted(remoteTableName.getCatalogName().orElse(null), remoteTableName.getSchemaName().orElse(null), remoteTableName.getTableName()),
                 quoted(remoteColumnName),
                 quoted(newRemoteColumnName));
-        execute(connection, sql);
+        execute(session, connection, sql);
     }
 
     @Override
@@ -599,7 +601,7 @@ public class MySqlClient
     }
 
     @Override
-    protected void copyTableSchema(Connection connection, String catalogName, String schemaName, String tableName, String newTableName, List<String> columnNames)
+    protected void copyTableSchema(ConnectorSession session, Connection connection, String catalogName, String schemaName, String tableName, String newTableName, List<String> columnNames)
     {
         String tableCopyFormat = "CREATE TABLE %s AS SELECT * FROM %s WHERE 0 = 1";
         if (isGtidMode(connection)) {
@@ -610,7 +612,7 @@ public class MySqlClient
                 quoted(catalogName, schemaName, newTableName),
                 quoted(catalogName, schemaName, tableName));
         try {
-            execute(connection, sql);
+            execute(session, connection, sql);
         }
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlClient.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlClient.java
@@ -21,6 +21,7 @@ import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.plugin.jdbc.JdbcStatisticsConfig;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.plugin.jdbc.mapping.DefaultIdentifierMapping;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.ColumnHandle;
@@ -66,7 +67,8 @@ public class TestMySqlClient
             },
             new DefaultQueryBuilder(),
             TESTING_TYPE_MANAGER,
-            new DefaultIdentifierMapping());
+            new DefaultIdentifierMapping(),
+            RemoteQueryModifier.NONE);
 
     @Test
     public void testImplementCount()

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
@@ -49,6 +49,7 @@ import io.trino.plugin.jdbc.aggregation.ImplementSum;
 import io.trino.plugin.jdbc.aggregation.ImplementVariancePop;
 import io.trino.plugin.jdbc.aggregation.ImplementVarianceSamp;
 import io.trino.plugin.jdbc.expression.JdbcConnectorExpressionRewriterBuilder;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.AggregateFunction;
@@ -206,9 +207,10 @@ public class OracleClient
             OracleConfig oracleConfig,
             ConnectionFactory connectionFactory,
             QueryBuilder queryBuilder,
-            IdentifierMapping identifierMapping)
+            IdentifierMapping identifierMapping,
+            RemoteQueryModifier queryModifier)
     {
-        super(config, "\"", connectionFactory, queryBuilder, identifierMapping);
+        super(config, "\"", connectionFactory, queryBuilder, identifierMapping, queryModifier);
 
         this.synonymsEnabled = oracleConfig.isSynonymsEnabled();
 
@@ -279,7 +281,7 @@ public class OracleClient
         }
 
         String newTableName = newRemoteTableName.toUpperCase(ENGLISH);
-        execute(connection, format(
+        execute(session, connection, format(
                 "ALTER TABLE %s RENAME TO %s",
                 quoted(catalogName, remoteSchemaName, remoteTableName),
                 quoted(newTableName)));

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleClient.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleClient.java
@@ -18,6 +18,7 @@ import io.trino.plugin.jdbc.DefaultQueryBuilder;
 import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.WriteFunction;
 import io.trino.plugin.jdbc.WriteMapping;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.plugin.jdbc.mapping.DefaultIdentifierMapping;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.Type;
@@ -58,7 +59,8 @@ public class TestOracleClient
                 throw new UnsupportedOperationException();
             },
             new DefaultQueryBuilder(),
-            new DefaultIdentifierMapping());
+            new DefaultIdentifierMapping(),
+            RemoteQueryModifier.NONE);
 
     private static final ConnectorSession SESSION = TestingConnectorSession.SESSION;
 

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -35,6 +35,7 @@ import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.plugin.jdbc.WriteFunction;
 import io.trino.plugin.jdbc.WriteMapping;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
@@ -212,7 +213,7 @@ public class PhoenixClient
     private final Configuration configuration;
 
     @Inject
-    public PhoenixClient(PhoenixConfig config, ConnectionFactory connectionFactory, QueryBuilder queryBuilder, IdentifierMapping identifierMapping)
+    public PhoenixClient(PhoenixConfig config, ConnectionFactory connectionFactory, QueryBuilder queryBuilder, IdentifierMapping identifierMapping, RemoteQueryModifier queryModifier)
             throws SQLException
     {
         super(
@@ -221,6 +222,7 @@ public class PhoenixClient
                 queryBuilder,
                 ImmutableSet.of(),
                 identifierMapping,
+                queryModifier,
                 false);
         this.configuration = newEmptyConfiguration();
         getConnectionProperties(config).forEach((k, v) -> configuration.set((String) k, (String) v));

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClientModule.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClientModule.java
@@ -53,6 +53,7 @@ import io.trino.plugin.jdbc.StatsCollecting;
 import io.trino.plugin.jdbc.TypeHandlingJdbcConfig;
 import io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties;
 import io.trino.plugin.jdbc.credential.EmptyCredentialProvider;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifierModule;
 import io.trino.plugin.jdbc.mapping.IdentifierMappingModule;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorMetadata;
@@ -97,6 +98,7 @@ public class PhoenixClientModule
     @Override
     protected void setup(Binder binder)
     {
+        install(new RemoteQueryModifierModule());
         binder.bind(ConnectorSplitManager.class).annotatedWith(ForJdbcDynamicFiltering.class).to(PhoenixSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorSplitManager.class).annotatedWith(ForClassLoaderSafe.class).to(JdbcDynamicFilteringSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorSplitManager.class).to(ClassLoaderSafeConnectorSplitManager.class).in(Scopes.SINGLETON);

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/CollationAwareQueryBuilder.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/CollationAwareQueryBuilder.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.postgresql;
 
+import com.google.inject.Inject;
 import io.trino.plugin.jdbc.DefaultQueryBuilder;
 import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
@@ -20,6 +21,7 @@ import io.trino.plugin.jdbc.JdbcJoinCondition;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
 import io.trino.plugin.jdbc.QueryParameter;
 import io.trino.plugin.jdbc.WriteFunction;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.Type;
 
@@ -34,6 +36,12 @@ import static java.lang.String.format;
 public class CollationAwareQueryBuilder
         extends DefaultQueryBuilder
 {
+    @Inject
+    public CollationAwareQueryBuilder(RemoteQueryModifier queryModifier)
+    {
+        super(queryModifier);
+    }
+
     @Override
     protected String formatJoinCondition(JdbcClient client, String leftRelationAlias, String rightRelationAlias, JdbcJoinCondition condition)
     {

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -67,6 +67,7 @@ import io.trino.plugin.jdbc.aggregation.ImplementVarianceSamp;
 import io.trino.plugin.jdbc.expression.JdbcConnectorExpressionRewriterBuilder;
 import io.trino.plugin.jdbc.expression.RewriteComparison;
 import io.trino.plugin.jdbc.expression.RewriteIn;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
 import io.trino.plugin.postgresql.PostgreSqlConfig.ArrayMapping;
 import io.trino.spi.TrinoException;
@@ -282,9 +283,10 @@ public class PostgreSqlClient
             ConnectionFactory connectionFactory,
             QueryBuilder queryBuilder,
             TypeManager typeManager,
-            IdentifierMapping identifierMapping)
+            IdentifierMapping identifierMapping,
+            RemoteQueryModifier queryModifier)
     {
-        super("\"", connectionFactory, queryBuilder, config.getJdbcTypesMappedToVarchar(), identifierMapping, true);
+        super("\"", connectionFactory, queryBuilder, config.getJdbcTypesMappedToVarchar(), identifierMapping, queryModifier, true);
         this.jsonType = typeManager.getType(new TypeSignature(JSON));
         this.uuidType = typeManager.getType(new TypeSignature(StandardTypes.UUID));
         this.varcharMapType = (MapType) typeManager.getType(mapType(VARCHAR.getTypeSignature(), VARCHAR.getTypeSignature()));
@@ -369,7 +371,7 @@ public class PostgreSqlClient
             throw new TrinoException(NOT_SUPPORTED, "This connector does not support renaming tables across schemas");
         }
 
-        execute(connection, format(
+        execute(session, connection, format(
                 "ALTER TABLE %s RENAME TO %s",
                 quoted(catalogName, remoteSchemaName, remoteTableName),
                 quoted(newRemoteTableName)));

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
@@ -24,6 +24,7 @@ import io.trino.plugin.jdbc.JdbcMetadataConfig;
 import io.trino.plugin.jdbc.JdbcMetadataSessionProperties;
 import io.trino.plugin.jdbc.JdbcStatisticsConfig;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.plugin.jdbc.mapping.DefaultIdentifierMapping;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.ColumnHandle;
@@ -112,7 +113,8 @@ public class TestPostgreSqlClient
             session -> { throw new UnsupportedOperationException(); },
             new DefaultQueryBuilder(),
             TESTING_TYPE_MANAGER,
-            new DefaultIdentifierMapping());
+            new DefaultIdentifierMapping(),
+            RemoteQueryModifier.NONE);
 
     private static final LiteralEncoder LITERAL_ENCODER = new LiteralEncoder(PLANNER_CONTEXT);
 

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestRemoteQueryCommentLogging.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestRemoteQueryCommentLogging.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.postgresql;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.Test;
+
+import static io.trino.plugin.postgresql.PostgreSqlQueryRunner.createPostgreSqlQueryRunner;
+import static io.trino.tpch.TpchTable.CUSTOMER;
+import static io.trino.tpch.TpchTable.NATION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test(singleThreaded = true)
+public class TestRemoteQueryCommentLogging
+        extends AbstractTestQueryFramework
+{
+    private TestingPostgreSqlServer postgreSqlServer;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        postgreSqlServer = closeAfterClass(new TestingPostgreSqlServer());
+        DistributedQueryRunner distributedQueryRunner = createPostgreSqlQueryRunner(
+                postgreSqlServer,
+                ImmutableMap.of(),
+                ImmutableMap.of("query.comment-format", "query executed by $USER"),
+                ImmutableList.of(CUSTOMER, NATION));
+
+        return distributedQueryRunner;
+    }
+
+    @Test
+    public void testShouldLogContextInComment()
+    {
+        assertThat(postgreSqlServer.recordEventsForOperations(() -> getQueryRunner().execute("CREATE TABLE postgresql.tpch.log_nation_test_table AS (SELECT * FROM postgresql.tpch.nation)"))
+                .stopEventsRecording()
+                .streamQueriesContaining("\"tpch\".\"tpch\".\"tmp_trino_"))
+                .allMatch(query -> query.endsWith("/*query executed by user*/"))
+                .size()
+                .isGreaterThanOrEqualTo(3); //Depending on whether fault tolerancy is enabled or not, this might vary and we don't want to over-specify
+
+        assertThat(postgreSqlServer.recordEventsForOperations(() -> getQueryRunner().execute("SELECT * FROM postgresql.tpch.log_nation_test_table"))
+                .stopEventsRecording()
+                .streamQueriesContaining("log_nation_test_table"))
+                .allMatch(query -> query.endsWith("/*query executed by user*/"))
+                .size()
+                .isEqualTo(1);
+
+        assertThat(postgreSqlServer.recordEventsForOperations(() -> getQueryRunner().execute("DELETE FROM postgresql.tpch.log_nation_test_table"))
+                .stopEventsRecording()
+                .streamQueriesContaining("log_nation_test_table"))
+                .allMatch(query -> query.endsWith("/*query executed by user*/"))
+                .size()
+                .isEqualTo(1);
+
+        assertThat(postgreSqlServer.recordEventsForOperations(() -> getQueryRunner().execute("INSERT INTO postgresql.tpch.log_nation_test_table VALUES (1, 'nation', 1, 'nation')"))
+                .stopEventsRecording()
+                .streamQueriesContaining("log_nation_test_table", "\"tpch\".\"tpch\".\"tmp_trino_"))
+                .allMatch(query -> query.endsWith("/*query executed by user*/"))
+                .size()
+                .isGreaterThanOrEqualTo(1); //Depending on whether fault tolerancy is enabled or not, this might vary and we don't want to over-specify
+
+        assertThat(postgreSqlServer.recordEventsForOperations(() -> getQueryRunner().execute("DROP TABLE postgresql.tpch.log_nation_test_table"))
+                .stopEventsRecording()
+                .streamQueriesContaining("log_nation_test_table"))
+                .allMatch(query -> query.endsWith("/*query executed by user*/"))
+                .size()
+                .isEqualTo(1);
+    }
+
+    @Test
+    public void testShouldLogContextInCommentForTableFunctionsQueryPassthrough()
+    {
+        assertThat(postgreSqlServer.recordEventsForOperations(() -> getQueryRunner().execute("SELECT * FROM TABLE( postgresql.system.query(query => 'SELECT name FROM tpch.nation WHERE nationkey = 0'))"))
+                .stopEventsRecording()
+                .streamQueriesContaining("tpch.nation"))
+                .allMatch(query -> query.contains("SELECT name FROM tpch.nation WHERE nationkey = 0"))
+                .allMatch(query -> query.endsWith("/*query executed by user*/"))
+                .size()
+                .isEqualTo(1);
+    }
+}

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestRemoteQueryCommentLoggingDisabledByDefault.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestRemoteQueryCommentLoggingDisabledByDefault.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.postgresql;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.Test;
+
+import static io.trino.plugin.postgresql.PostgreSqlQueryRunner.createPostgreSqlQueryRunner;
+import static io.trino.tpch.TpchTable.CUSTOMER;
+import static io.trino.tpch.TpchTable.NATION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test(singleThreaded = true)
+public class TestRemoteQueryCommentLoggingDisabledByDefault
+        extends AbstractTestQueryFramework
+{
+    private TestingPostgreSqlServer postgreSqlServer;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        postgreSqlServer = closeAfterClass(new TestingPostgreSqlServer());
+        DistributedQueryRunner distributedQueryRunner = createPostgreSqlQueryRunner(
+                postgreSqlServer,
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableList.of(CUSTOMER, NATION));
+
+        return distributedQueryRunner;
+    }
+
+    @Test
+    public void testShouldNotLogContextInComments()
+    {
+        assertThat(postgreSqlServer.recordEventsForOperations(() -> getQueryRunner().execute("CREATE TABLE postgresql.tpch.log_nation_test_table AS (SELECT * FROM postgresql.tpch.nation)"))
+                .stopEventsRecording()
+                .streamQueriesContaining("*/"))
+                .size()
+                .isEqualTo(0);
+
+        assertThat(postgreSqlServer.recordEventsForOperations(() -> getQueryRunner().execute("SELECT * FROM postgresql.tpch.log_nation_test_table"))
+                .stopEventsRecording()
+                .streamQueriesContaining("*/"))
+                .size()
+                .isEqualTo(0);
+
+        assertThat(postgreSqlServer.recordEventsForOperations(() -> getQueryRunner().execute("DELETE FROM postgresql.tpch.log_nation_test_table"))
+                .stopEventsRecording()
+                .streamQueriesContaining("*/"))
+                .size()
+                .isEqualTo(0);
+
+        assertThat(postgreSqlServer.recordEventsForOperations(() -> getQueryRunner().execute("INSERT INTO postgresql.tpch.log_nation_test_table VALUES (1, 'nation', 1, 'nation')"))
+                .stopEventsRecording()
+                .streamQueriesContaining("*/"))
+                .size()
+                .isGreaterThanOrEqualTo(0); //Depending on whether fault tolerancy is enabled or not, this might vary and we don't want to over-specify
+
+        assertThat(postgreSqlServer.recordEventsForOperations(() -> getQueryRunner().execute("DROP TABLE postgresql.tpch.log_nation_test_table"))
+                .stopEventsRecording()
+                .streamQueriesContaining("*/"))
+                .size()
+                .isEqualTo(0);
+    }
+
+    @Test
+    public void testShouldNotLogContextInCommentForTableFunctionsQueryPassthrough()
+    {
+        assertThat(postgreSqlServer.recordEventsForOperations(() -> getQueryRunner().execute("SELECT * FROM TABLE( postgresql.system.query(query => 'SELECT name FROM tpch.nation WHERE nationkey = 0'))"))
+                .stopEventsRecording()
+                .streamQueriesContaining("*/"))
+                .size()
+                .isEqualTo(0);
+    }
+}

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlServer.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlServer.java
@@ -26,6 +26,9 @@ import java.sql.Statement;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -33,6 +36,7 @@ import static io.trino.plugin.jdbc.RemoteDatabaseEvent.Status.CANCELLED;
 import static io.trino.plugin.jdbc.RemoteDatabaseEvent.Status.RUNNING;
 import static io.trino.testing.containers.TestContainers.exposeFixedPorts;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static java.util.function.Predicate.not;
 import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 
@@ -44,8 +48,10 @@ public class TestingPostgreSqlServer
     private static final String DATABASE = "tpch";
 
     private static final String LOG_PREFIX_REGEXP = "^([-:0-9. ]+UTC \\[[0-9]+\\] )";
-    private static final String LOG_RUNNING_STATEMENT_PREFIX = "LOG:  execute <unnamed>: ";
+    private static final String LOG_RUNNING_STATEMENT_PREFIX = "LOG:  execute <unnamed>";
     private static final String LOG_CANCELLATION_EVENT = "ERROR:  canceling statement due to user request";
+
+    private static final Pattern SQL_QUERY_FIND_PATTERN = Pattern.compile("^(: |/C_\\d: )(.*)"); //In PgSQL cursor queries and non-cursor queries are logged differently
     private static final String LOG_CANCELLED_STATEMENT_PREFIX = "STATEMENT:  ";
 
     private final PostgreSQLContainer<?> dockerContainer;
@@ -88,6 +94,13 @@ public class TestingPostgreSqlServer
         }
     }
 
+    DatabaseEventsRecorder recordEventsForOperations(Runnable operation)
+    {
+        DatabaseEventsRecorder events = DatabaseEventsRecorder.startRecording(this);
+        operation.run();
+        return events;
+    }
+
     protected List<RemoteDatabaseEvent> getRemoteDatabaseEvents()
     {
         List<String> logs = getLogs();
@@ -96,7 +109,11 @@ public class TestingPostgreSqlServer
         while (logsIterator.hasNext()) {
             String logLine = logsIterator.next().replaceAll(LOG_PREFIX_REGEXP, "");
             if (logLine.startsWith(LOG_RUNNING_STATEMENT_PREFIX)) {
-                events.add(new RemoteDatabaseEvent(logLine.substring(LOG_RUNNING_STATEMENT_PREFIX.length()), RUNNING));
+                Matcher matcher = SQL_QUERY_FIND_PATTERN.matcher(logLine.substring(LOG_RUNNING_STATEMENT_PREFIX.length()));
+                if (matcher.find()) {
+                    String sqlStatement = matcher.group(2);
+                    events.add(new RemoteDatabaseEvent(sqlStatement, RUNNING));
+                }
             }
             if (logLine.equals(LOG_CANCELLATION_EVENT)) {
                 // next line must be present
@@ -145,5 +162,40 @@ public class TestingPostgreSqlServer
     public void close()
     {
         dockerContainer.close();
+    }
+
+    public static class DatabaseEventsRecorder
+    {
+        private final Supplier<Stream<String>> loggedQueriesSource;
+
+        private DatabaseEventsRecorder(Supplier<Stream<String>> loggedQueriesSource)
+        {
+            this.loggedQueriesSource = requireNonNull(loggedQueriesSource, "loggedQueriesSource is null");
+        }
+
+        static DatabaseEventsRecorder startRecording(TestingPostgreSqlServer server)
+        {
+            int startingEventsCount = server.getRemoteDatabaseEvents().size();
+            return new DatabaseEventsRecorder(() ->
+                    server.getRemoteDatabaseEvents().stream()
+                            .skip(startingEventsCount)
+                            .map(RemoteDatabaseEvent::getQuery));
+        }
+
+        public DatabaseEventsRecorder stopEventsRecording()
+        {
+            List<String> queries = loggedQueriesSource.get().collect(toImmutableList());
+            return new DatabaseEventsRecorder(queries::stream);
+        }
+
+        public Stream<String> streamQueriesContaining(String queryPart, String... alternativeQueryParts)
+        {
+            ImmutableList<String> queryParts = ImmutableList.<String>builder()
+                    .add(queryPart)
+                    .addAll(ImmutableList.copyOf(alternativeQueryParts))
+                    .build();
+            return loggedQueriesSource.get()
+                    .filter(query -> queryParts.stream().anyMatch(query::contains));
+        }
     }
 }

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
@@ -22,6 +22,7 @@ import io.trino.plugin.jdbc.JdbcTableHandle;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
 import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.WriteMapping;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
@@ -90,9 +91,9 @@ public class RedshiftClient
         extends BaseJdbcClient
 {
     @Inject
-    public RedshiftClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, QueryBuilder queryBuilder, IdentifierMapping identifierMapping)
+    public RedshiftClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, QueryBuilder queryBuilder, IdentifierMapping identifierMapping, RemoteQueryModifier queryModifier)
     {
-        super(config, "\"", connectionFactory, queryBuilder, identifierMapping);
+        super(config, "\"", connectionFactory, queryBuilder, identifierMapping, queryModifier);
     }
 
     @Override
@@ -110,7 +111,7 @@ public class RedshiftClient
             throw new TrinoException(NOT_SUPPORTED, "This connector does not support renaming tables across schemas");
         }
 
-        execute(connection, format(
+        execute(session, connection, format(
                 "ALTER TABLE %s RENAME TO %s",
                 quoted(catalogName, remoteSchemaName, remoteTableName),
                 quoted(newRemoteTableName)));

--- a/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreClient.java
+++ b/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreClient.java
@@ -29,6 +29,7 @@ import io.trino.plugin.jdbc.PreparedQuery;
 import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.plugin.jdbc.WriteMapping;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.AggregateFunction;
@@ -152,9 +153,9 @@ public class SingleStoreClient
     private final Type jsonType;
 
     @Inject
-    public SingleStoreClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, QueryBuilder queryBuilder, TypeManager typeManager, IdentifierMapping identifierMapping)
+    public SingleStoreClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, QueryBuilder queryBuilder, TypeManager typeManager, IdentifierMapping identifierMapping, RemoteQueryModifier queryModifier)
     {
-        super(config, "`", connectionFactory, queryBuilder, identifierMapping);
+        super(config, "`", connectionFactory, queryBuilder, identifierMapping, queryModifier);
         requireNonNull(typeManager, "typeManager is null");
         this.jsonType = typeManager.getType(new TypeSignature(StandardTypes.JSON));
     }
@@ -340,7 +341,7 @@ public class SingleStoreClient
             throws SQLException
     {
         // SingleStore versions earlier than 5.7 do not support the CHANGE syntax
-        execute(connection, format(
+        execute(session, connection, format(
                 "ALTER TABLE %s CHANGE %s %s",
                 quoted(remoteTableName.getCatalogName().orElse(null), remoteTableName.getSchemaName().orElse(null), remoteTableName.getTableName()),
                 quoted(remoteColumnName),

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerClient.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerClient.java
@@ -21,6 +21,7 @@ import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.plugin.jdbc.JdbcStatisticsConfig;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.plugin.jdbc.mapping.DefaultIdentifierMapping;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.ColumnHandle;
@@ -64,7 +65,8 @@ public class TestSqlServerClient
                 throw new UnsupportedOperationException();
             },
             new DefaultQueryBuilder(),
-            new DefaultIdentifierMapping());
+            new DefaultIdentifierMapping(),
+            RemoteQueryModifier.NONE);
 
     @Test
     public void testImplementCount()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Add context appender to sql based connectors

This is a first iteration for SELECT Queries of a mechanism
that will allow to send to the actual database a bit more
information, that might be available only in Trino. It's for the 
purpose of these other systems to be able to capture this info and
log it for its own purposes. For now we are sending it as a comments 
added at the end of a query.


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
This pr adds an ability to add additional context of query execution and send it to external database,
like pgsql, oracle etc. 


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Add context comments to SELECT queries in sql based connectors.
```
