### PR TITLE
Avoid reading Iceberg column stats when they are not needed

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -484,8 +484,7 @@ public class IcebergMetadata
             Supplier<List<FileScanTask>> lazyFiles = Suppliers.memoize(() -> {
                 TableScan tableScan = icebergTable.newScan()
                         .useSnapshot(table.getSnapshotId().get())
-                        .filter(toIcebergExpression(enforcedPredicate))
-                        .includeColumnStats();
+                        .filter(toIcebergExpression(enforcedPredicate));
 
                 try (CloseableIterable<FileScanTask> iterator = tableScan.planFiles()) {
                     return ImmutableList.copyOf(iterator);


### PR DESCRIPTION
## Description

Fixes: https://github.com/trinodb/trino/issues/14004

The column statistics in Iceberg can be large when there are many files or many columns with statistics collected. Avoid reading these stats if they are not used.

## Non-technical explanation

Reduce memory and I/O of Iceberg metadata reads.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Reduce overhead of some Iceberg metadata reads by selectively reading data file statistics. ({issue}`14004`)
```
