### PR TITLE
Add link to Databricks type support in Delta Lake connector docs

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.rst
+++ b/docs/src/main/sphinx/connector/delta-lake.rst
@@ -294,6 +294,11 @@ writing data. Data types may not map the same way in both directions between
 Trino and the data source. Refer to the following sections for type mapping in
 each direction.
 
+See the `Delta Transaction Log specification
+<https://github.com/delta-io/delta/blob/master/PROTOCOL.md#primitive-types>`_
+for more information about supported data types in the Delta Lake table format
+specification.
+
 Delta Lake to Trino type mapping
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The list of supported types in the Delta Lake connector is directly affected by what's supported in the Delta protocol. This PR links out to the Delta Transaction Log protocol's specification for more information about data type support.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Provide link out to the Delta protocol documentation for more information about supported types in Delta Lake.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
