### PR TITLE
Hide Hive system schemas in Hudi

### DIFF
--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
@@ -89,7 +89,9 @@ public class HudiMetadata
     @Override
     public List<String> listSchemaNames(ConnectorSession session)
     {
-        return metastore.getAllDatabases();
+        return metastore.getAllDatabases().stream()
+                .filter(schemaName -> !isHiveSystemSchema(schemaName))
+                .collect(toImmutableList());
     }
 
     @Override

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/BaseHudiConnectorTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/BaseHudiConnectorTest.java
@@ -79,6 +79,13 @@ public abstract class BaseHudiConnectorTest
                         ")");
     }
 
+    @Test
+    public void testHideHiveSysSchema()
+    {
+        assertThat(computeActual("SHOW SCHEMAS").getOnlyColumnAsSet()).doesNotContain("sys");
+        assertQueryFails("SHOW TABLES IN hudi.sys", ".*Schema 'sys' does not exist");
+    }
+
     protected static String columnsToHide()
     {
         List<String> columns = new ArrayList<>(HOODIE_META_COLUMNS.size() + 1);

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiCopyOnWriteMinioConnectorTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiCopyOnWriteMinioConnectorTest.java
@@ -18,6 +18,7 @@ import io.trino.plugin.hive.containers.HiveMinioDataLake;
 import io.trino.plugin.hudi.testing.TpchHudiTablesInitializer;
 import io.trino.testing.QueryRunner;
 
+import static io.trino.plugin.hive.containers.HiveHadoop.HIVE3_IMAGE;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
 
@@ -29,7 +30,7 @@ public class TestHudiCopyOnWriteMinioConnectorTest
             throws Exception
     {
         String bucketName = "test-hudi-connector-" + randomTableSuffix();
-        hiveMinioDataLake = closeAfterClass(new HiveMinioDataLake(bucketName));
+        hiveMinioDataLake = closeAfterClass(new HiveMinioDataLake(bucketName, HIVE3_IMAGE));
         hiveMinioDataLake.start();
         hiveMinioDataLake.getMinioClient().ensureBucketExists(bucketName);
 

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiMergeOnReadMinioConnectorTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiMergeOnReadMinioConnectorTest.java
@@ -18,6 +18,7 @@ import io.trino.plugin.hive.containers.HiveMinioDataLake;
 import io.trino.plugin.hudi.testing.TpchHudiTablesInitializer;
 import io.trino.testing.QueryRunner;
 
+import static io.trino.plugin.hive.containers.HiveHadoop.HIVE3_IMAGE;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static org.apache.hudi.common.model.HoodieTableType.MERGE_ON_READ;
 
@@ -29,7 +30,7 @@ public class TestHudiMergeOnReadMinioConnectorTest
             throws Exception
     {
         String bucketName = "test-hudi-connector-" + randomTableSuffix();
-        hiveMinioDataLake = closeAfterClass(new HiveMinioDataLake(bucketName));
+        hiveMinioDataLake = closeAfterClass(new HiveMinioDataLake(bucketName, HIVE3_IMAGE));
         hiveMinioDataLake.start();
         hiveMinioDataLake.getMinioClient().ensureBucketExists(bucketName);
 


### PR DESCRIPTION
## Description

Hide Hive system schemas in Hudi.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Hudi
* Hide Hive system schemas. ({issue}`14510`)
```
