### PR TITLE
Disallow writing to Delta Lake tables with generated columns

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
@@ -415,6 +415,18 @@ public final class DeltaLakeSchemaSupport
         return invariants == null ? null : invariants.asText();
     }
 
+    public static Map<String, String> getGeneratedColumnExpressions(MetadataEntry metadataEntry)
+    {
+        return getColumnProperties(metadataEntry, DeltaLakeSchemaSupport::getGeneratedColumnExpressions);
+    }
+
+    @Nullable
+    private static String getGeneratedColumnExpressions(JsonNode node)
+    {
+        JsonNode invariants = node.get("metadata").get("delta.generationExpression");
+        return invariants == null ? null : invariants.asText();
+    }
+
     public static Map<String, String> getCheckConstraints(MetadataEntry metadataEntry)
     {
         return metadataEntry.getConfiguration().entrySet().stream()


### PR DESCRIPTION
## Description

Disallow writing to Delta Lake tables with generated columns explicitly.
Note that such writing was already prevented by the writer version check. 
Relates to #12637

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
