### PR TITLE
Remove redundant repetition in Iceberg docs

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -575,8 +575,8 @@ the state of the table to a previous snapshot id::
 Schema evolution
 ----------------
 
-Iceberg and the Iceberg connector support schema evolution, with safe
-column add, drop, reorder and rename operations, including in nested structures.
+Iceberg supports schema evolution, with safe column add, drop, reorder
+and rename operations, including in nested structures.
 Table partitioning can also be changed and the connector can still
 query data created before the partitioning change.
 


### PR DESCRIPTION
Technically "Iceberg" and "Iceberg connector" refer to different things, but it's unlikely that user will appreciate the distinction.

For now, replacing with just "Iceberg" and not "the connector". The operations are safe from the connector perspective, but not all are possible via the connector.
