### PR TITLE
Cache short decimal type instances

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/type/DecimalType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/DecimalType.java
@@ -41,7 +41,7 @@ public abstract class DecimalType
         }
 
         if (precision <= MAX_SHORT_PRECISION) {
-            return new ShortDecimalType(precision, scale);
+            return ShortDecimalType.getInstance(precision, scale);
         }
         return new LongDecimalType(precision, scale);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortDecimalType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortDecimalType.java
@@ -34,6 +34,7 @@ import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
+import static io.trino.spi.type.Decimals.MAX_SHORT_PRECISION;
 import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
 import static java.lang.invoke.MethodHandles.lookup;
 
@@ -42,7 +43,23 @@ final class ShortDecimalType
 {
     private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(ShortDecimalType.class, lookup(), long.class);
 
-    ShortDecimalType(int precision, int scale)
+    private static final ShortDecimalType[][] INSTANCES;
+
+    static {
+        INSTANCES = new ShortDecimalType[MAX_SHORT_PRECISION][MAX_SHORT_PRECISION + 1];
+        for (int precision = 1; precision <= MAX_SHORT_PRECISION; precision++) {
+            for (int scale = 0; scale <= precision; scale++) {
+                INSTANCES[precision - 1][scale] = new ShortDecimalType(precision, scale);
+            }
+        }
+    }
+
+    static ShortDecimalType getInstance(int precision, int scale)
+    {
+        return INSTANCES[precision - 1][scale];
+    }
+
+    private ShortDecimalType(int precision, int scale)
     {
         super(precision, scale, long.class);
         checkArgument(0 < precision && precision <= Decimals.MAX_SHORT_PRECISION, "Invalid precision: %s", precision);


### PR DESCRIPTION
When profiling Iceberg planning on TPC-DS data set, it was found out that 10% of time spend inside `TableStatisticsMaker` is actually spent inside `ShortDecimalType` constructor.

<img width="892" alt="image" src="https://user-images.githubusercontent.com/144328/194586896-6c54275e-2678-48d3-9fbc-3fc4d310134f.png">
