### PR TITLE
Implement the v1.1 Trino protocol in trino-client and trino-jdbc

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/ClientSession.java
+++ b/client/trino-client/src/main/java/io/trino/client/ClientSession.java
@@ -53,6 +53,7 @@ public class ClientSession
     private final String transactionId;
     private final Duration clientRequestTimeout;
     private final boolean compressionDisabled;
+    private final boolean multiThread;
 
     public static Builder builder()
     {
@@ -91,7 +92,8 @@ public class ClientSession
             Map<String, String> extraCredentials,
             String transactionId,
             Duration clientRequestTimeout,
-            boolean compressionDisabled)
+            boolean compressionDisabled,
+            boolean multiThread)
     {
         this.server = requireNonNull(server, "server is null");
         this.principal = requireNonNull(principal, "principal is null");
@@ -113,6 +115,7 @@ public class ClientSession
         this.extraCredentials = ImmutableMap.copyOf(requireNonNull(extraCredentials, "extraCredentials is null"));
         this.clientRequestTimeout = clientRequestTimeout;
         this.compressionDisabled = compressionDisabled;
+        this.multiThread = multiThread;
 
         for (String clientTag : clientTags) {
             checkArgument(!clientTag.contains(","), "client tag cannot contain ','");
@@ -251,6 +254,11 @@ public class ClientSession
         return compressionDisabled;
     }
 
+    public boolean isMultiThread()
+    {
+        return multiThread;
+    }
+
     @Override
     public String toString()
     {
@@ -294,6 +302,7 @@ public class ClientSession
         private String transactionId;
         private Duration clientRequestTimeout;
         private boolean compressionDisabled;
+        private boolean multiThread;
 
         private Builder() {}
 
@@ -320,6 +329,7 @@ public class ClientSession
             transactionId = clientSession.getTransactionId();
             clientRequestTimeout = clientSession.getClientRequestTimeout();
             compressionDisabled = clientSession.isCompressionDisabled();
+            multiThread = clientSession.isMultiThread();
         }
 
         public Builder server(URI server)
@@ -442,6 +452,12 @@ public class ClientSession
             return this;
         }
 
+        public Builder multiThread(boolean multiThread)
+        {
+            this.multiThread = multiThread;
+            return this;
+        }
+
         public ClientSession build()
         {
             return new ClientSession(
@@ -464,7 +480,8 @@ public class ClientSession
                     credentials,
                     transactionId,
                     clientRequestTimeout,
-                    compressionDisabled);
+                    compressionDisabled,
+                    multiThread);
         }
     }
 }

--- a/client/trino-client/src/main/java/io/trino/client/MultiThreadedQuery.java
+++ b/client/trino-client/src/main/java/io/trino/client/MultiThreadedQuery.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client;
+
+import okhttp3.ConnectionPool;
+import okhttp3.Headers;
+import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.net.HttpHeaders.USER_AGENT;
+import static io.trino.client.JsonCodec.jsonCodec;
+
+public class MultiThreadedQuery
+        implements Runnable
+{
+    private static final String USER_AGENT_VALUE = StatementClientV1.class.getSimpleName() +
+            "/" +
+            firstNonNull(StatementClientV1.class.getPackage().getImplementationVersion(), "unknown");
+    private static final String HEADER_NEXTURI = "X-Trino-NextUri";
+    private static final JsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class);
+    StatementClient client;
+    ClientSession session;
+    Results results;
+    Results currentResults;
+    Semaphore allResultsReady;
+    LocalDateTime start;
+    String nextUri;
+    Optional<String> user;
+
+    public MultiThreadedQuery(ClientSession session, Headers headers, StatementClient caller, Optional<String> user)
+    {
+        this.start = LocalDateTime.now();
+        this.client = caller;
+        this.session = session;
+        this.user = user;
+        this.nextUri = headers.get(HEADER_NEXTURI);
+//        System.out.println("DEBUG: " + nextUri);
+        this.allResultsReady = new Semaphore(1);
+        try {
+            this.allResultsReady.acquire();
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        Results newResults = new Results(0);
+        newResults.nextUriReady(nextUri);
+        this.results = newResults;
+        this.currentResults = newResults;
+
+        Thread thread = new Thread(this);
+        thread.start();
+    }
+
+    /**
+     * Starts creating a Results linked list
+     */
+    @Override
+    public void run()
+    {
+        ExecutorService executorService = Executors.newFixedThreadPool(8);
+        ConnectionPool pool = new ConnectionPool(10, 5, TimeUnit.SECONDS);
+
+        String nextUri = this.nextUri;
+        Results newResults = this.results;
+        int counter = 1;
+
+        while (nextUri != null) {
+            try {
+                counter++;
+
+                String urlToDownload = nextUri;
+                Results res = newResults;
+                LocalDateTime start = LocalDateTime.now();
+                executorService.submit(() -> downloadData(urlToDownload, res));
+                res.waitForNextUri();
+                nextUri = res.nextUri;
+                if (nextUri != null) {
+                    newResults = new Results(counter);
+                    newResults.nextUri = nextUri;
+                    results.next = newResults;
+                    results = newResults;
+                }
+            }
+            catch (Exception e) {
+                e.printStackTrace();
+                nextUri = null;
+            }
+        }
+
+        LocalDateTime end = LocalDateTime.now();
+        Duration duration = Duration.between(start, end);
+        System.out.printf("NextUri trail completed in %2d.%06ds (%d result sets)\n", duration.getSeconds(), duration.getNano() / 1000, counter);
+
+        executorService.shutdown();
+        end = LocalDateTime.now();
+        duration = Duration.between(start, end);
+        System.out.printf("Fetch data completed in %2d.%06ds\n", duration.getSeconds(), duration.getNano() / 1000);
+    }
+
+    /**
+     * Downloads a given URI, parse it and store the results
+     * @param nextUri the URI to download
+     * @param results the Results object where to store the results
+     */
+    private void downloadData(String nextUri, Results results)
+    {
+        try {
+            HttpUrl url = HttpUrl.get(nextUri);
+            OkHttpClient client = new OkHttpClient.Builder()
+                    .addNetworkInterceptor(new HeadersInterceptor(results))
+                    .build();
+
+            Request.Builder builder = new Request.Builder()
+                    .addHeader(USER_AGENT, USER_AGENT_VALUE);
+//                    .addHeader(ACCEPT_ENCODING, "gzip");
+
+            if (this.user.isPresent()) {
+                builder = builder.addHeader("X-Trino-User", user.get());
+            }
+
+            Request request = builder
+                    .url(url)
+                    .build();
+
+            results.content = JsonResponse.execute(QUERY_RESULTS_CODEC, client, request, OptionalLong.empty());
+            results.dataReady();
+        }
+        catch (Exception e) {
+            System.out.printf("ERROR FOR %s\n", results.nextUri);
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Called when ResultSet.next() is called
+     *
+     * @return the QueryResults representing the data returned by a URI
+     */
+    public JsonResponse<QueryResults> getNextResults()
+    {
+        if (currentResults == null) {
+            return null;
+        }
+        boolean acquired = false;
+
+        while (!acquired) {
+            try {
+//            System.out.printf("Check [%d] %s\n", currentResults.nb, currentResults.nextUri);
+                currentResults.waitForData();
+                acquired = true;
+//            System.out.printf("Check [%d] %s DONE\n", currentResults.nb, currentResults.nextUri);
+            }
+            catch (Exception e) {
+                acquired = false;
+            }
+        }
+
+        JsonResponse<QueryResults> results = currentResults.content;
+        if (results.getStatusCode() != 200) {
+            System.out.printf("Problem [%d]: HTTP error code %d\n", currentResults.nb, results.getStatusCode());
+        }
+        currentResults = currentResults.next;
+        return results;
+    }
+
+    /**
+     * Element of a chained list which contains QueryResults data
+     * (QueryResults is what is the Trino client expecting)
+     */
+    public static class Results
+    {
+        Results next;
+        int nb;
+        String nextUri;
+        JsonResponse<QueryResults> content;
+        int index;
+        private final Semaphore dataLock;
+        private final Semaphore nextUriLock;
+
+        public Results(int nb)
+        {
+            this.nb = nb;
+            this.dataLock = new Semaphore(1);
+            this.nextUriLock = new Semaphore(1);
+            try {
+                this.dataLock.acquire();
+                this.nextUriLock.acquire();
+            }
+            catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+        public void waitForNextUri()
+                throws InterruptedException
+        {
+            this.nextUriLock.acquire();
+        }
+
+        public void nextUriReady(String nextUri)
+        {
+            this.nextUri = nextUri;
+            this.nextUriLock.release();
+        }
+
+        public void waitForData()
+                throws InterruptedException
+        {
+            this.dataLock.acquire();
+        }
+
+        public void dataReady()
+        {
+            this.dataLock.release();
+        }
+    }
+
+    /**
+     * OkHttp hook
+     */
+    static class HeadersInterceptor
+            implements Interceptor
+    {
+        private final Results results;
+
+        public HeadersInterceptor(Results results)
+        {
+            this.results = results;
+        }
+
+        @Override public Response intercept(Interceptor.Chain chain) throws IOException
+        {
+            Request request = chain.request();
+            Response response = chain.proceed(request);
+            String nextUri = response.header(HEADER_NEXTURI);
+            results.nextUriReady(nextUri);
+
+            return response;
+        }
+    }
+}

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
@@ -88,6 +88,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<String> TRACE_TOKEN = new TraceToken();
     public static final ConnectionProperty<Map<String, String>> SESSION_PROPERTIES = new SessionProperties();
     public static final ConnectionProperty<String> SOURCE = new Source();
+    public static final ConnectionProperty<Boolean> MULTI_THREAD = new MultiThread();
 
     private static final Set<ConnectionProperty<?>> ALL_PROPERTIES = ImmutableSet.<ConnectionProperty<?>>builder()
             .add(USER)
@@ -128,6 +129,7 @@ final class ConnectionProperties
             .add(EXTERNAL_AUTHENTICATION_TIMEOUT)
             .add(EXTERNAL_AUTHENTICATION_TOKEN_CACHE)
             .add(EXTERNAL_AUTHENTICATION_REDIRECT_HANDLERS)
+            .add(MULTI_THREAD)
             .build();
 
     private static final Map<String, ConnectionProperty<?>> KEY_LOOKUP = unmodifiableMap(ALL_PROPERTIES.stream()
@@ -610,6 +612,15 @@ final class ConnectionProperties
         public Source()
         {
             super("source", NOT_REQUIRED, ALLOWED, STRING_CONVERTER);
+        }
+    }
+
+    private static class MultiThread
+            extends AbstractConnectionProperty<Boolean>
+    {
+        public MultiThread()
+        {
+            super("multithread", Optional.of("false"), NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
         }
     }
 

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
@@ -112,6 +112,7 @@ public class TrinoConnection
     private final AtomicReference<String> transactionId = new AtomicReference<>();
     private final OkHttpClient httpClient;
     private final Set<TrinoStatement> statements = newSetFromMap(new ConcurrentHashMap<>());
+    private final Boolean multiThread;
 
     TrinoConnection(TrinoDriverUri uri, OkHttpClient httpClient)
             throws SQLException
@@ -127,6 +128,8 @@ public class TrinoConnection
         this.source = uri.getSource();
         this.extraCredentials = uri.getExtraCredentials();
         this.compressionDisabled = uri.isCompressionDisabled();
+        this.multiThread = uri.isMultiThread();
+
         this.assumeLiteralNamesInMetadataCallsForNonConformingClients = uri.isAssumeLiteralNamesInMetadataCallsForNonConformingClients();
 
         if (this.assumeLiteralNamesInMetadataCallsForNonConformingClients) {
@@ -753,6 +756,7 @@ public class TrinoConnection
                 .transactionId(transactionId.get())
                 .clientRequestTimeout(timeout)
                 .compressionDisabled(compressionDisabled)
+                .multiThread(multiThread)
                 .build();
 
         return newStatementClient(httpClient, session, sql);

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
@@ -72,6 +72,7 @@ import static io.trino.jdbc.ConnectionProperties.KERBEROS_PRINCIPAL;
 import static io.trino.jdbc.ConnectionProperties.KERBEROS_REMOTE_SERVICE_NAME;
 import static io.trino.jdbc.ConnectionProperties.KERBEROS_SERVICE_PRINCIPAL_PATTERN;
 import static io.trino.jdbc.ConnectionProperties.KERBEROS_USE_CANONICAL_HOSTNAME;
+import static io.trino.jdbc.ConnectionProperties.MULTI_THREAD;
 import static io.trino.jdbc.ConnectionProperties.PASSWORD;
 import static io.trino.jdbc.ConnectionProperties.ROLES;
 import static io.trino.jdbc.ConnectionProperties.SESSION_PROPERTIES;
@@ -256,6 +257,12 @@ public final class TrinoDriverUri
             throws SQLException
     {
         return ASSUME_LITERAL_UNDERSCORE_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS.getValue(properties).orElse(false);
+    }
+
+    public boolean isMultiThread()
+            throws SQLException
+    {
+        return MULTI_THREAD.getValue(properties).orElse(false);
     }
 
     public void setupClient(OkHttpClient.Builder builder)

--- a/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
@@ -82,6 +82,7 @@ import static io.airlift.jaxrs.AsyncResponseHandler.bindAsyncResponse;
 import static io.trino.execution.QueryState.FAILED;
 import static io.trino.execution.QueryState.QUEUED;
 import static io.trino.server.HttpRequestSessionContextFactory.AUTHENTICATED_IDENTITY;
+import static io.trino.server.InternalHeaders.TRINO_NEXT_URI;
 import static io.trino.server.protocol.QueryInfoUrlFactory.getQueryInfoUri;
 import static io.trino.server.protocol.Slug.Context.EXECUTING_QUERY;
 import static io.trino.server.protocol.Slug.Context.QUEUED_QUERY;
@@ -248,6 +249,7 @@ public class QueuedStatementResource
         if (!compressionEnabled) {
             builder.encoding("identity");
         }
+        builder.header(TRINO_NEXT_URI, results.getNextUri());
         return builder.build();
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/InternalHeaders.java
+++ b/core/trino-main/src/main/java/io/trino/server/InternalHeaders.java
@@ -23,6 +23,7 @@ public final class InternalHeaders
     public static final String TRINO_PAGE_NEXT_TOKEN = "X-Trino-Page-End-Sequence-Id";
     public static final String TRINO_BUFFER_COMPLETE = "X-Trino-Buffer-Complete";
     public static final String TRINO_TASK_FAILED = "X-Trino-Task-Failed";
+    public static final String TRINO_NEXT_URI = "X-Trino-NextUri";
 
     private InternalHeaders() {}
 }

--- a/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
@@ -60,6 +60,7 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.Threads.threadsNamed;
 import static io.airlift.jaxrs.AsyncResponseHandler.bindAsyncResponse;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.trino.server.InternalHeaders.TRINO_NEXT_URI;
 import static io.trino.server.protocol.Slug.Context.EXECUTING_QUERY;
 import static io.trino.server.security.ResourceSecurity.AccessType.PUBLIC;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -278,6 +279,7 @@ public class ExecutingStatementResource
             response.encoding("identity");
         }
 
+        response.header(TRINO_NEXT_URI, queryResults.getNextUri());
         return response.build();
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR implements the Trino 1.1 client protocol by performing the following:

- On the server side, each query response (whether queued or executing statements) returns a new `X-Trino-NextUri` HTTP header
- The `trino-client` module is using the new HTTP header to parallelize downloads:
  - A new `multiThread` property is added to the `ClientSession` and `TrinoConnection` classes to indicate when to use the 1.1 protocol
  - When set, a new `MultiThreadedQuery` class is used to downloads the query results in parallel. When it downloads a URI, it starts downloading the next URI in a separate threads as soon as the `X-Trino-NextUri` header is available
  - It creates a linked lists of `MultiThreadedQuery.Results` objects
  - The `trino-client` calls `advanceMultithreaded()` instead of `advance()` when it needs to retrieve data
- The `trino-jdbc` module has a new `multithread=true` JDBC option to take advantage of the Trino 1.1 protocol.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
This PR implements the Trino 1.1 client protocol whose goal is to parallelize results download


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(X) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
