### PR TITLE
Add checkpoint for ORC UNION type

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/checkpoint/Checkpoints.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/checkpoint/Checkpoints.java
@@ -115,6 +115,9 @@ public final class Checkpoints
                 case STRUCT:
                     checkpoints.putAll(getStructColumnCheckpoints(columnId, compressed, availableStreams, columnPositionsList));
                     break;
+                case UNION:
+                    checkpoints.putAll(getUnionColumnCheckpoints(columnId, compressed, availableStreams, columnPositionsList));
+                    break;
                 case DECIMAL:
                     checkpoints.putAll(getDecimalColumnCheckpoints(columnId, columnEncoding, compressed, availableStreams, columnPositionsList));
                     break;
@@ -335,6 +338,25 @@ public final class Checkpoints
 
         if (availableStreams.contains(PRESENT)) {
             checkpoints.put(new StreamId(columnId, PRESENT), new BooleanStreamCheckpoint(compressed, positionsList));
+        }
+
+        return checkpoints.buildOrThrow();
+    }
+
+    private static Map<StreamId, StreamCheckpoint> getUnionColumnCheckpoints(
+            OrcColumnId columnId,
+            boolean compressed,
+            Set<StreamKind> availableStreams,
+            ColumnPositionsList positionsList)
+    {
+        ImmutableMap.Builder<StreamId, StreamCheckpoint> checkpoints = ImmutableMap.builder();
+
+        if (availableStreams.contains(PRESENT)) {
+            checkpoints.put(new StreamId(columnId, PRESENT), new BooleanStreamCheckpoint(compressed, positionsList));
+        }
+
+        if (availableStreams.contains(DATA)) {
+            checkpoints.put(new StreamId(columnId, DATA), new ByteStreamCheckpoint(compressed, positionsList));
         }
 
         return checkpoints.buildOrThrow();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
- When an ORC stripe has more than one ROW_GROUP, UNION type column will be failed to read.
- Tracked down to the case where UNION type data streams are not handled as part of stream checkpointing. 
- Added checkpointing for UNION type to fix the issue


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

() This is not user-visible or docs only and no release notes are required.
() Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
- Fix read failures for union type columns in ORC tables. ({issue}`#14532`)
```
