### PR TITLE
Fix product test filtering on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -787,6 +787,7 @@ jobs:
     runs-on: ubuntu-latest
     # explicitly define the name to avoid adding the value of the `ignore exclusion if` matrix item
     name: pt (${{ matrix.config }}, ${{ matrix.suite }}, ${{ matrix.jdk }})
+    if: needs.build-pt.outputs.matrix != '{}'
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.build-pt.outputs.matrix) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -728,7 +728,7 @@ jobs:
             #   actual value of the property, and will therefore not be excluded.
             # - If the expression evaluates to false, it will match the actual
             #   value of the property, and the exclusion will apply normally.
-            - false
+            - "false"
           include:
             # this suite is not meant to be run with different configs
             - config: default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -771,6 +771,22 @@ jobs:
           ./.github/bin/build-pt-matrix-from-impacted-connectors.py -v -m .github/test-pt-matrix.yaml -o matrix.json
       - name: Build PT matrix (impacted-features)
         if: steps.filter.outputs.product-tests == 'false' && !contains(github.event.pull_request.labels.*.name, 'tests:all') && !contains(github.event.pull_request.labels.*.name, 'product-tests:all')
+        # all these envs are required to be set by some product test environments
+        env:
+          ABFS_CONTAINER:
+          ABFS_ACCOUNT:
+          ABFS_ACCESS_KEY:
+          S3_BUCKET:
+          AWS_REGION:
+          DATABRICKS_AWS_ACCESS_KEY_ID:
+          DATABRICKS_AWS_SECRET_ACCESS_KEY:
+          DATABRICKS_73_JDBC_URL:
+          DATABRICKS_91_JDBC_URL:
+          DATABRICKS_104_JDBC_URL:
+          DATABRICKS_LOGIN:
+          DATABRICKS_TOKEN:
+          GCP_CREDENTIALS_KEY:
+          GCP_STORAGE_BUCKET:
         run: |
           # converts filtered YAML file into JSON
           ./.github/bin/build-pt-matrix-from-impacted-connectors.py -v -m .github/test-pt-matrix.yaml -i impacted-features.log -o matrix.json


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The product tests job currently fails on master because when building the matrix we try to describe all environments and some require specific environmental variables to be set. This PR sets them to empty strings but also makes the script more robust by:
* not processing the matrix at all if the impacted features list is not provided
* raising an exception when the call to the product tests launcher fails, instead of silently ignoring it
* producing an empty matrix if all matrix items are excluded

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

n/a

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
