### PR TITLE
Typo in authentication

### DIFF
--- a/docs/src/main/sphinx/security/certificate.rst
+++ b/docs/src/main/sphinx/security/certificate.rst
@@ -97,7 +97,7 @@ The following configuration properties are also available:
      - The path to a JSON file that contains a set of :doc:`user mapping
        rules </security/user-mapping>` for this authentication type.
 
-Use certificate authencation with clients
+Use certificate authentication with clients
 -----------------------------------------
 
 When using the Trino :doc:`CLI </client/cli>`, specify the

--- a/docs/src/main/sphinx/security/certificate.rst
+++ b/docs/src/main/sphinx/security/certificate.rst
@@ -98,7 +98,7 @@ The following configuration properties are also available:
        rules </security/user-mapping>` for this authentication type.
 
 Use certificate authentication with clients
------------------------------------------
+-------------------------------------------
 
 When using the Trino :doc:`CLI </client/cli>`, specify the
 ``--keystore-path`` and ``--keystore-password`` options as described


### PR DESCRIPTION
## Description
It says "authencation" rather than "authentication"

## Non-technical explanation
NA

## Release notes

(X ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: