### PR TITLE
Remove PlanMatchPattern join overloading by builder

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDereferencePushDown.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDereferencePushDown.java
@@ -52,9 +52,10 @@ public class TestDereferencePushDown
                                         "a_msg_x", PlanMatchPattern.expression("a_msg[1]"),
                                         "a_msg", PlanMatchPattern.expression("a_msg"),
                                         "b_msg_y", PlanMatchPattern.expression("b_msg_y")),
-                                join(INNER, ImmutableList.of(),
-                                        values("a_msg"),
-                                        values(ImmutableList.of("b_msg_y"), ImmutableList.of(ImmutableList.of(new DoubleLiteral("2e0")), ImmutableList.of(new DoubleLiteral("4e0"))))))));
+                                join(INNER, builder -> builder
+                                        .left(values("a_msg"))
+                                        .right(
+                                                values(ImmutableList.of("b_msg_y"), ImmutableList.of(ImmutableList.of(new DoubleLiteral("2e0")), ImmutableList.of(new DoubleLiteral("4e0")))))))));
     }
 
     @Test
@@ -82,22 +83,24 @@ public class TestDereferencePushDown
                         "FROM t a JOIN t b ON a.msg.y = b.msg.y " +
                         "WHERE a.msg.x > BIGINT '5'",
                 output(ImmutableList.of("a_y"),
-                                values("a_y")));
+                        values("a_y")));
 
         assertPlan("WITH t(msg) AS (VALUES ROW(CAST(ROW(1, 2.0) AS ROW(x BIGINT, y DOUBLE))))" +
                         "SELECT b.msg.x " +
                         "FROM t a JOIN t b ON a.msg.y = b.msg.y " +
                         "WHERE a.msg.x + b.msg.x < BIGINT '10'",
                 output(ImmutableList.of("b_x"),
-                        join(INNER, ImmutableList.of(),
-                                project(filter(
-                                        "a_y = 2e0",
-                                        values(ImmutableList.of("a_y"), ImmutableList.of(ImmutableList.of(new DoubleLiteral("2e0")))))),
-                                project(filter(
-                                        "b_y = 2e0",
-                                        values(
-                                                ImmutableList.of("b_x", "b_y"),
-                                                ImmutableList.of(ImmutableList.of(new GenericLiteral("BIGINT", "1"), new DoubleLiteral("2e0")))))))));
+                        join(INNER, builder -> builder
+                                .left(
+                                        project(filter(
+                                                "a_y = 2e0",
+                                                values(ImmutableList.of("a_y"), ImmutableList.of(ImmutableList.of(new DoubleLiteral("2e0")))))))
+                                .right(
+                                        project(filter(
+                                                "b_y = 2e0",
+                                                values(
+                                                        ImmutableList.of("b_x", "b_y"),
+                                                        ImmutableList.of(ImmutableList.of(new GenericLiteral("BIGINT", "1"), new DoubleLiteral("2e0"))))))))));
     }
 
     @Test
@@ -234,15 +237,18 @@ public class TestDereferencePushDown
                         "FROM t a JOIN t b ON a.msg.y = b.msg.y " +
                         "WHERE a.msg.x + b.msg.x < BIGINT '10' " +
                         "LIMIT 100",
-                anyTree(join(INNER, ImmutableList.of(),
-                        project(filter(
-                                "a_y = 2e0",
-                                values(ImmutableList.of("a_y"), ImmutableList.of(ImmutableList.of(new DoubleLiteral("2e0")))))),
-                        project(filter(
-                                "b_y = 2e0",
-                                values(
-                                        ImmutableList.of("b_x", "b_y"),
-                                        ImmutableList.of(ImmutableList.of(new GenericLiteral("BIGINT", "1"), new DoubleLiteral("2e0")))))))));
+                anyTree(
+                        join(INNER, builder -> builder
+                                .left(
+                                        project(filter(
+                                                "a_y = 2e0",
+                                                values(ImmutableList.of("a_y"), ImmutableList.of(ImmutableList.of(new DoubleLiteral("2e0")))))))
+                                .right(
+                                        project(filter(
+                                                "b_y = 2e0",
+                                                values(
+                                                        ImmutableList.of("b_x", "b_y"),
+                                                        ImmutableList.of(ImmutableList.of(new GenericLiteral("BIGINT", "1"), new DoubleLiteral("2e0"))))))))));
     }
 
     @Test
@@ -256,14 +262,16 @@ public class TestDereferencePushDown
                 output(ImmutableList.of("expr"),
                         strictProject(ImmutableMap.of("expr", expression("a_x")),
                                 unnest(
-                                        join(INNER, ImmutableList.of(),
-                                                project(
-                                                        filter(
-                                                                "a_y = 2e0",
-                                                                values("array", "a_x", "a_y"))),
-                                                project(
-                                                        filter(
-                                                                "b_y = 2e0",
-                                                                values(ImmutableList.of("b_y"), ImmutableList.of(ImmutableList.of(new DoubleLiteral("2e0")))))))))));
+                                        join(INNER, builder -> builder
+                                                .left(
+                                                        project(
+                                                                filter(
+                                                                        "a_y = 2e0",
+                                                                        values("array", "a_x", "a_y"))))
+                                                .right(
+                                                        project(
+                                                                filter(
+                                                                        "b_y = 2e0",
+                                                                        values(ImmutableList.of("b_y"), ImmutableList.of(ImmutableList.of(new DoubleLiteral("2e0"))))))))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDynamicFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDynamicFilter.java
@@ -82,15 +82,13 @@ public class TestDynamicFilter
     {
         assertPlan("SELECT o.orderkey FROM orders o LEFT JOIN lineitem l ON l.orderkey = o.orderkey",
                 anyTree(
-                        join(
-                                LEFT,
-                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
-                                ImmutableMap.of(),
-                                project(
-                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
-                                exchange(
-                                        project(
-                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
+                        join(LEFT, builder -> builder
+                                .equiCriteria("ORDERS_OK", "LINEITEM_OK")
+                                .left(
+                                        project(tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))
+                                .right(
+                                        exchange(
+                                                project(tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))))));
     }
 
     @Test
@@ -98,15 +96,15 @@ public class TestDynamicFilter
     {
         assertPlan("SELECT o.orderkey FROM orders o FULL JOIN lineitem l ON l.orderkey = o.orderkey",
                 anyTree(
-                        join(
-                                FULL,
-                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
-                                ImmutableMap.of(),
-                                project(
-                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
-                                exchange(
+                        join(FULL, builder -> builder
+                                .equiCriteria("ORDERS_OK", "LINEITEM_OK")
+                                .left(
                                         project(
-                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))
+                                .right(
+                                        exchange(
+                                                project(
+                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))))));
     }
 
     @Test
@@ -114,15 +112,16 @@ public class TestDynamicFilter
     {
         assertPlan("SELECT o.orderkey FROM orders o RIGHT JOIN lineitem l ON l.orderkey = o.orderkey",
                 anyTree(
-                        join(
-                                RIGHT,
-                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
-                                ImmutableMap.of("ORDERS_OK", "LINEITEM_OK"),
-                                anyTree(
-                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
-                                exchange(
-                                        project(
-                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
+                        join(RIGHT, builder -> builder
+                                .equiCriteria("ORDERS_OK", "LINEITEM_OK")
+                                .dynamicFilter("ORDERS_OK", "LINEITEM_OK")
+                                .left(
+                                        anyTree(
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))
+                                .right(
+                                        exchange(
+                                                project(
+                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))))));
     }
 
     @Test
@@ -130,16 +129,17 @@ public class TestDynamicFilter
     {
         assertPlan("SELECT o.orderkey FROM orders o RIGHT JOIN lineitem l ON l.orderkey + 1 = o.orderkey",
                 output(
-                        join(
-                                RIGHT,
-                                ImmutableList.of(equiJoinClause("ORDERS_OK", "expr")),
-                                ImmutableMap.of("ORDERS_OK", "expr"),
-                                anyTree(
-                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
-                                anyTree(
-                                        project(
-                                                ImmutableMap.of("expr", expression("LINEITEM_OK + BIGINT '1'")),
-                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
+                        join(RIGHT, builder -> builder
+                                .equiCriteria("ORDERS_OK", "expr")
+                                .dynamicFilter("ORDERS_OK", "expr")
+                                .left(
+                                        anyTree(
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))
+                                .right(
+                                        anyTree(
+                                                project(
+                                                        ImmutableMap.of("expr", expression("LINEITEM_OK + BIGINT '1'")),
+                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))))));
     }
 
     @Test
@@ -147,18 +147,16 @@ public class TestDynamicFilter
     {
         assertPlan("SELECT o.orderkey FROM orders o RIGHT JOIN lineitem l ON l.orderkey < o.orderkey",
                 anyTree(
-                        join(
-                                RIGHT,
-                                ImmutableList.of(),
-                                Optional.of("LINEITEM_OK < ORDERS_OK"),
-                                Optional.of(ImmutableList.of(new DynamicFilterPattern("ORDERS_OK", GREATER_THAN, "LINEITEM_OK"))),
-                                Optional.empty(),
-                                Optional.empty(),
-                                filter(
-                                        TRUE_LITERAL,
-                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
-                                exchange(
-                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))));
+                        join(RIGHT, builder -> builder
+                                .left(
+                                        filter(
+                                                TRUE_LITERAL,
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))
+                                .right(
+                                        exchange(
+                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))
+                                .filter("LINEITEM_OK < ORDERS_OK")
+                                .dynamicFilter(ImmutableList.of(new DynamicFilterPattern("ORDERS_OK", GREATER_THAN, "LINEITEM_OK"))))));
     }
 
     @Test
@@ -166,13 +164,11 @@ public class TestDynamicFilter
     {
         assertPlan("SELECT o.orderkey FROM orders o CROSS JOIN lineitem l",
                 anyTree(
-                        join(
-                                INNER,
-                                ImmutableList.of(),
-                                ImmutableMap.of(),
-                                tableScan("orders"),
-                                exchange(
-                                        tableScan("lineitem")))));
+                        join(INNER, builder -> builder
+                                .left(
+                                        tableScan("orders"))
+                                .right(
+                                        exchange(tableScan("lineitem"))))));
     }
 
     @Test
@@ -180,15 +176,15 @@ public class TestDynamicFilter
     {
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey > l.orderkey",
                 anyTree(filter("O_ORDERKEY > L_ORDERKEY",
-                        join(
-                                INNER,
-                                ImmutableList.of(),
-                                ImmutableList.of(new DynamicFilterPattern("O_ORDERKEY", GREATER_THAN, "L_ORDERKEY")),
-                                filter(
-                                        TRUE_LITERAL,
-                                        tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))),
-                                exchange(
-                                        tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey")))))));
+                        join(INNER, builder -> builder
+                                .dynamicFilter(ImmutableList.of(new DynamicFilterPattern("O_ORDERKEY", GREATER_THAN, "L_ORDERKEY")))
+                                .left(
+                                        filter(
+                                                TRUE_LITERAL,
+                                                tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))))
+                                .right(
+                                        exchange(
+                                                tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey"))))))));
     }
 
     @Test
@@ -196,15 +192,15 @@ public class TestDynamicFilter
     {
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey < o.orderkey",
                 anyTree(filter("O_ORDERKEY > L_ORDERKEY",
-                        join(
-                                INNER,
-                                ImmutableList.of(),
-                                ImmutableList.of(new DynamicFilterPattern("O_ORDERKEY", GREATER_THAN, "L_ORDERKEY")),
-                                filter(
-                                        TRUE_LITERAL,
-                                        tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))),
-                                exchange(
-                                        tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey")))))));
+                        join(INNER, builder -> builder
+                                .dynamicFilter(ImmutableList.of(new DynamicFilterPattern("O_ORDERKEY", GREATER_THAN, "L_ORDERKEY")))
+                                .left(
+                                        filter(
+                                                TRUE_LITERAL,
+                                                tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))))
+                                .right(
+                                        exchange(
+                                                tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey"))))))));
     }
 
     @Test
@@ -212,43 +208,43 @@ public class TestDynamicFilter
     {
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey BETWEEN l.orderkey AND l.partkey",
                 anyTree(filter("O_ORDERKEY BETWEEN L_ORDERKEY AND L_PARTKEY",
-                        join(
-                                INNER,
-                                ImmutableList.of(),
-                                ImmutableList.of(
-                                        new DynamicFilterPattern("O_ORDERKEY", GREATER_THAN_OR_EQUAL, "L_ORDERKEY"),
-                                        new DynamicFilterPattern("O_ORDERKEY", LESS_THAN_OR_EQUAL, "L_PARTKEY")),
-                                filter(
-                                        TRUE_LITERAL,
-                                        tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))),
-                                exchange(
-                                        tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey", "L_PARTKEY", "partkey")))))));
+                        join(INNER, builder -> builder
+                                .dynamicFilter(
+                                        ImmutableList.of(
+                                                new DynamicFilterPattern("O_ORDERKEY", GREATER_THAN_OR_EQUAL, "L_ORDERKEY"),
+                                                new DynamicFilterPattern("O_ORDERKEY", LESS_THAN_OR_EQUAL, "L_PARTKEY")))
+                                .left(
+                                        filter(
+                                                TRUE_LITERAL,
+                                                tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))))
+                                .right(
+                                        exchange(
+                                                tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey", "L_PARTKEY", "partkey"))))))));
 
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey BETWEEN l.orderkey AND l.partkey - 1",
                 anyTree(filter("O_ORDERKEY BETWEEN L_ORDERKEY AND L_PARTKEY - BIGINT '1'",
-                        join(
-                                INNER,
-                                ImmutableList.of(),
-                                ImmutableList.of(
-                                        new DynamicFilterPattern("O_ORDERKEY", GREATER_THAN_OR_EQUAL, "L_ORDERKEY")),
-                                filter(
-                                        TRUE_LITERAL,
-                                        tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))),
-                                exchange(
-                                        tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey", "L_PARTKEY", "partkey")))))));
+                        join(INNER, builder -> builder
+                                .dynamicFilter(ImmutableList.of(new DynamicFilterPattern("O_ORDERKEY", GREATER_THAN_OR_EQUAL, "L_ORDERKEY")))
+                                .left(
+                                        filter(
+                                                TRUE_LITERAL,
+                                                tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))))
+                                .right(
+                                        exchange(
+                                                tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey", "L_PARTKEY", "partkey"))))))));
 
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey BETWEEN l.orderkey + 1 AND l.partkey",
                 anyTree(filter("O_ORDERKEY BETWEEN L_ORDERKEY + BIGINT '1' AND L_PARTKEY",
-                        join(
-                                INNER,
-                                ImmutableList.of(),
-                                ImmutableList.of(
-                                        new DynamicFilterPattern("O_ORDERKEY", LESS_THAN_OR_EQUAL, "L_PARTKEY")),
-                                filter(
-                                        TRUE_LITERAL,
-                                        tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))),
-                                exchange(
-                                        tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey", "L_PARTKEY", "partkey")))))));
+                        join(INNER, builder -> builder
+                                .dynamicFilter(ImmutableList.of(
+                                        new DynamicFilterPattern("O_ORDERKEY", LESS_THAN_OR_EQUAL, "L_PARTKEY")))
+                                .left(
+                                        filter(
+                                                TRUE_LITERAL,
+                                                tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))))
+                                .right(
+                                        exchange(
+                                                tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey", "L_PARTKEY", "partkey"))))))));
     }
 
     @Test
@@ -256,19 +252,15 @@ public class TestDynamicFilter
     {
         assertPlan("SELECT o.comment, l.comment FROM lineitem l, orders o WHERE o.comment < l.comment",
                 anyTree(filter("CAST(L_COMMENT AS varchar(79)) > O_COMMENT",
-                        join(
-                                INNER,
-                                ImmutableList.of(),
-                                ImmutableList.of(
-                                        new DynamicFilterPattern(
-                                                typeOnlyCast("L_COMMENT", varchar(79)),
-                                                GREATER_THAN,
-                                                "O_COMMENT",
-                                                false)),
-                                filter(TRUE_LITERAL,
-                                        tableScan("lineitem", ImmutableMap.of("L_COMMENT", "comment"))),
-                                exchange(
-                                        tableScan("orders", ImmutableMap.of("O_COMMENT", "comment")))))));
+                        join(INNER, builder -> builder
+                                .dynamicFilter(ImmutableList.of(
+                                        new DynamicFilterPattern(typeOnlyCast("L_COMMENT", varchar(79)), GREATER_THAN, "O_COMMENT", false)))
+                                .left(
+                                        filter(TRUE_LITERAL,
+                                                tableScan("lineitem", ImmutableMap.of("L_COMMENT", "comment"))))
+                                .right(
+                                        exchange(
+                                                tableScan("orders", ImmutableMap.of("O_COMMENT", "comment"))))))));
     }
 
     private DataType varchar(int size)
@@ -293,18 +285,18 @@ public class TestDynamicFilter
                 anyTree(
                         project(
                                 filter("O_COMMENT < expr",
-                                        join(
-                                                INNER,
-                                                ImmutableList.of(),
-                                                ImmutableList.of(new DynamicFilterPattern("O_COMMENT", LESS_THAN, "expr")),
-                                                filter(
-                                                        TRUE_LITERAL,
-                                                        tableScan("orders", ImmutableMap.of("O_COMMENT", "comment"))),
-                                                anyTree(
-                                                        project(
-                                                                ImmutableMap.of("expr", expression("CAST(L_COMMENT AS varchar(79))")),
-                                                                tableScan("lineitem",
-                                                                        ImmutableMap.of("L_COMMENT", "comment")))))))));
+                                        join(INNER, builder -> builder
+                                                .dynamicFilter(ImmutableList.of(new DynamicFilterPattern("O_COMMENT", LESS_THAN, "expr")))
+                                                .left(
+                                                        filter(
+                                                                TRUE_LITERAL,
+                                                                tableScan("orders", ImmutableMap.of("O_COMMENT", "comment"))))
+                                                .right(
+                                                        anyTree(
+                                                                project(
+                                                                        ImmutableMap.of("expr", expression("CAST(L_COMMENT AS varchar(79))")),
+                                                                        tableScan("lineitem",
+                                                                                ImmutableMap.of("L_COMMENT", "comment"))))))))));
     }
 
     @Test
@@ -312,15 +304,16 @@ public class TestDynamicFilter
     {
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey = o.orderkey",
                 anyTree(
-                        join(
-                                INNER,
-                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
-                                ImmutableMap.of("ORDERS_OK", "LINEITEM_OK"),
-                                anyTree(
-                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
-                                exchange(
-                                        project(
-                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("ORDERS_OK", "LINEITEM_OK")
+                                .dynamicFilter("ORDERS_OK", "LINEITEM_OK")
+                                .left(
+                                        anyTree(
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))
+                                .right(
+                                        exchange(
+                                                project(
+                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))))));
     }
 
     @Test
@@ -328,15 +321,16 @@ public class TestDynamicFilter
     {
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey = l.orderkey",
                 anyTree(
-                        join(
-                                INNER,
-                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
-                                ImmutableMap.of("ORDERS_OK", "LINEITEM_OK"),
-                                anyTree(
-                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
-                                exchange(
-                                        project(
-                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("ORDERS_OK", "LINEITEM_OK")
+                                .dynamicFilter("ORDERS_OK", "LINEITEM_OK")
+                                .left(
+                                        anyTree(
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))
+                                .right(
+                                        exchange(
+                                                project(
+                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))))));
     }
 
     @Test
@@ -344,37 +338,35 @@ public class TestDynamicFilter
     {
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey IS NOT DISTINCT FROM o.orderkey",
                 anyTree(filter("O_ORDERKEY IS NOT DISTINCT FROM L_ORDERKEY",
-                        join(
-                                INNER,
-                                ImmutableList.of(),
-                                ImmutableList.of(new DynamicFilterPattern("O_ORDERKEY", EQUAL, "L_ORDERKEY", true)),
-                                filter(
-                                        TRUE_LITERAL,
-                                        tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))),
-                                exchange(
-                                        tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey")))))));
+                        join(INNER, builder -> builder
+                                .dynamicFilter(ImmutableList.of(new DynamicFilterPattern("O_ORDERKEY", EQUAL, "L_ORDERKEY", true)))
+                                .left(
+                                        filter(
+                                                TRUE_LITERAL,
+                                                tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))))
+                                .right(
+                                        exchange(
+                                                tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey"))))))));
 
         // Dynamic filter is not supported for IS DISTINCT FROM
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey IS DISTINCT FROM o.orderkey",
                 anyTree(filter("O_ORDERKEY IS DISTINCT FROM L_ORDERKEY",
-                        join(
-                                INNER,
-                                ImmutableList.of(),
-                                ImmutableList.of(),
-                                tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey")),
-                                exchange(
-                                        tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey")))))));
+                        join(INNER, builder -> builder
+                                .left(
+                                        tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey")))
+                                .right(
+                                        exchange(
+                                                tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey"))))))));
 
         // extendedprice and totalprice are of DOUBLE type, dynamic filter is not supported with IS NOT DISTINCT FROM clause on DOUBLE or REAL types
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE l.extendedprice IS NOT DISTINCT FROM o.totalprice",
                 anyTree(filter("O_TOTALPRICE IS NOT DISTINCT FROM L_EXTENDEDPRICE",
-                        join(
-                                INNER,
-                                ImmutableList.of(),
-                                ImmutableList.of(),
-                                tableScan("orders", ImmutableMap.of("O_TOTALPRICE", "totalprice")),
-                                exchange(
-                                        tableScan("lineitem", ImmutableMap.of("L_EXTENDEDPRICE", "extendedprice")))))));
+                        join(INNER, builder -> builder
+                                .left(
+                                        tableScan("orders", ImmutableMap.of("O_TOTALPRICE", "totalprice")))
+                                .right(
+                                        exchange(
+                                                tableScan("lineitem", ImmutableMap.of("L_EXTENDEDPRICE", "extendedprice"))))))));
     }
 
     @Test
@@ -382,33 +374,38 @@ public class TestDynamicFilter
     {
         // IS NOT DISTINCT FROM condition does not promote LEFT to INNER
         assertPlan("SELECT 1 FROM (SELECT o.orderkey FROM nation n LEFT JOIN orders o ON n.nationkey = o.orderkey) o JOIN lineitem l ON o.orderkey IS NOT DISTINCT FROM l.orderkey",
-                anyTree(join(
-                        INNER,
-                        ImmutableList.of(),
-                        join(
-                                LEFT,
-                                ImmutableList.of(equiJoinClause("nationkey", "ORDERS_OK")),
-                                anyTree(
-                                        tableScan("nation", ImmutableMap.of("nationkey", "nationkey"))),
-                                anyTree(
-                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))),
-                        anyTree(
-                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))));
+                anyTree(
+                        join(INNER, builder -> builder
+                                .left(
+                                        join(LEFT, leftJoinBuilder -> leftJoinBuilder
+                                                .equiCriteria("nationkey", "ORDERS_OK")
+                                                .left(
+                                                        anyTree(
+                                                                tableScan("nation", ImmutableMap.of("nationkey", "nationkey"))))
+                                                .right(
+                                                        anyTree(
+                                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))))
+                                .right(
+                                        anyTree(
+                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
 
         // equi condition promotes LEFT to INNER
         assertPlan("SELECT 1 FROM (SELECT o.orderkey FROM nation n LEFT JOIN orders o ON n.nationkey = o.orderkey) o JOIN lineitem l ON o.orderkey = l.orderkey",
-                anyTree(join(
-                        INNER,
-                        ImmutableList.of(equiJoinClause("nationkey", "LINEITEM_OK")),
-                        join(
-                                INNER,
-                                ImmutableList.of(equiJoinClause("nationkey", "ORDERS_OK")),
-                                anyTree(
-                                        tableScan("nation", ImmutableMap.of("nationkey", "nationkey"))),
-                                anyTree(
-                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))),
-                        anyTree(
-                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))));
+                anyTree(
+                        join(INNER, builder -> builder
+                                .equiCriteria("nationkey", "LINEITEM_OK")
+                                .left(
+                                        join(INNER, leftJoinBuilder -> leftJoinBuilder
+                                                .equiCriteria("nationkey", "ORDERS_OK")
+                                                .left(
+                                                        anyTree(
+                                                                tableScan("nation", ImmutableMap.of("nationkey", "nationkey"))))
+                                                .right(
+                                                        anyTree(
+                                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))))
+                                .right(
+                                        anyTree(
+                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
     }
 
     @Test
@@ -416,33 +413,33 @@ public class TestDynamicFilter
     {
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE cast(l.orderkey as int) = cast(o.orderkey as int)",
                 anyTree(
-                        join(
-                                INNER,
-                                ImmutableList.of(equiJoinClause("expr_orders", "expr_lineitem")),
-                                ImmutableMap.of(),
-                                anyTree(
-                                        project(
-                                                ImmutableMap.of("expr_orders", expression("CAST(ORDERS_OK AS int)")),
-                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))),
-                                anyTree(
-                                        project(
-                                                ImmutableMap.of("expr_lineitem", expression("CAST(LINEITEM_OK AS int)")),
-                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("expr_orders", "expr_lineitem")
+                                .left(
+                                        anyTree(
+                                                project(
+                                                        ImmutableMap.of("expr_orders", expression("CAST(ORDERS_OK AS int)")),
+                                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))))
+                                .right(
+                                        anyTree(
+                                                project(
+                                                        ImmutableMap.of("expr_lineitem", expression("CAST(LINEITEM_OK AS int)")),
+                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))))));
 
         // Dynamic filter is removed due to double cast on orders.orderkey
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey = cast(o.orderkey as int)",
                 anyTree(
-                        join(
-                                INNER,
-                                ImmutableList.of(equiJoinClause("expr_orders", "LINEITEM_OK")),
-                                ImmutableMap.of(),
-                                anyTree(
-                                        project(
-                                                ImmutableMap.of("expr_orders", expression("CAST(CAST(ORDERS_OK AS int) AS bigint)")),
-                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))),
-                                anyTree(
-                                        project(
-                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("expr_orders", "LINEITEM_OK")
+                                .left(
+                                        anyTree(
+                                                project(
+                                                        ImmutableMap.of("expr_orders", expression("CAST(CAST(ORDERS_OK AS int) AS bigint)")),
+                                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))))
+                                .right(
+                                        anyTree(
+                                                project(
+                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))))));
     }
 
     @Test
@@ -451,18 +448,19 @@ public class TestDynamicFilter
         // linenumber is integer and orderkey is bigint
         assertPlan("SELECT o.orderkey FROM lineitem l, orders o WHERE l.linenumber = o.orderkey",
                 anyTree(
-                        join(
-                                INNER,
-                                ImmutableList.of(equiJoinClause("expr_linenumber", "ORDERS_OK")),
-                                anyTree(
-                                        project(
-                                                ImmutableMap.of("expr_linenumber", expression("CAST(LINEITEM_LN AS bigint)")),
-                                                node(FilterNode.class,
-                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_LN", "linenumber")))
-                                                        .with(numberOfDynamicFilters(1)))),
-                                exchange(
-                                        project(
-                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("expr_linenumber", "ORDERS_OK")
+                                .left(
+                                        anyTree(
+                                                project(
+                                                        ImmutableMap.of("expr_linenumber", expression("CAST(LINEITEM_LN AS bigint)")),
+                                                        node(FilterNode.class,
+                                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_LN", "linenumber")))
+                                                                .with(numberOfDynamicFilters(1)))))
+                                .right(
+                                        exchange(
+                                                project(
+                                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))))));
     }
 
     @Test
@@ -470,17 +468,18 @@ public class TestDynamicFilter
     {
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey = o.orderkey AND l.partkey = o.custkey",
                 anyTree(
-                        join(
-                                INNER,
-                                ImmutableList.of(
+                        join(INNER, builder -> builder
+                                .equiCriteria(ImmutableList.of(
                                         equiJoinClause("ORDERS_OK", "LINEITEM_OK"),
-                                        equiJoinClause("ORDERS_CK", "LINEITEM_PK")),
-                                ImmutableMap.of("ORDERS_OK", "LINEITEM_OK", "ORDERS_CK", "LINEITEM_PK"),
-                                anyTree(
-                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey", "ORDERS_CK", "custkey"))),
-                                exchange(
-                                        project(
-                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey", "LINEITEM_PK", "partkey")))))));
+                                        equiJoinClause("ORDERS_CK", "LINEITEM_PK")))
+                                .dynamicFilter(ImmutableMap.of("ORDERS_OK", "LINEITEM_OK", "ORDERS_CK", "LINEITEM_PK"))
+                                .left(
+                                        anyTree(
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey", "ORDERS_CK", "custkey"))))
+                                .right(
+                                        exchange(
+                                                project(
+                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey", "LINEITEM_PK", "partkey"))))))));
     }
 
     @Test
@@ -488,15 +487,16 @@ public class TestDynamicFilter
     {
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey = o.orderkey ORDER BY l.orderkey ASC, o.orderkey ASC",
                 anyTree(
-                        join(
-                                INNER,
-                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
-                                ImmutableMap.of("ORDERS_OK", "LINEITEM_OK"),
-                                anyTree(
-                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
-                                exchange(
-                                        project(
-                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("ORDERS_OK", "LINEITEM_OK")
+                                .dynamicFilter("ORDERS_OK", "LINEITEM_OK")
+                                .left(
+                                        anyTree(
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))
+                                .right(
+                                        exchange(
+                                                project(
+                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))))));
     }
 
     @Test
@@ -504,17 +504,18 @@ public class TestDynamicFilter
     {
         assertPlan("SELECT * FROM orders WHERE orderkey = (SELECT orderkey FROM lineitem ORDER BY orderkey LIMIT 1)",
                 anyTree(
-                        join(
-                                INNER,
-                                ImmutableList.of(equiJoinClause("X", "Y")),
-                                ImmutableMap.of("X", "Y"),
-                                anyTree(
-                                        tableScan("orders", ImmutableMap.of("X", "orderkey"))),
-                                project(
-                                        node(
-                                                EnforceSingleRowNode.class,
-                                                anyTree(
-                                                        tableScan("lineitem", ImmutableMap.of("Y", "orderkey"))))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("X", "Y")
+                                .dynamicFilter("X", "Y")
+                                .left(
+                                        anyTree(
+                                                tableScan("orders", ImmutableMap.of("X", "orderkey"))))
+                                .right(
+                                        project(
+                                                node(
+                                                        EnforceSingleRowNode.class,
+                                                        anyTree(
+                                                                tableScan("lineitem", ImmutableMap.of("Y", "orderkey")))))))));
     }
 
     @Test
@@ -524,21 +525,20 @@ public class TestDynamicFilter
                 anyTree(
                         anyNot(
                                 FilterNode.class,
-                                join(
-                                        INNER,
-                                        ImmutableList.of(equiJoinClause("O_SHIPPRIORITY", "L_LINENUMBER")),
-                                        Optional.of("O_ORDERKEY < L_ORDERKEY"),
-                                        Optional.of(ImmutableList.of(
+                                join(INNER, builder -> builder
+                                        .equiCriteria("O_SHIPPRIORITY", "L_LINENUMBER")
+                                        .filter("O_ORDERKEY < L_ORDERKEY")
+                                        .dynamicFilter(ImmutableList.of(
                                                 new DynamicFilterPattern("O_SHIPPRIORITY", EQUAL, "L_LINENUMBER"),
-                                                new DynamicFilterPattern("O_ORDERKEY", LESS_THAN, "L_ORDERKEY"))),
-                                        Optional.empty(),
-                                        Optional.empty(),
-                                        anyTree(tableScan("orders", ImmutableMap.of(
-                                                "O_SHIPPRIORITY", "shippriority",
-                                                "O_ORDERKEY", "orderkey"))),
-                                        anyTree(tableScan("lineitem", ImmutableMap.of(
-                                                "L_LINENUMBER", "linenumber",
-                                                "L_ORDERKEY", "orderkey")))))));
+                                                new DynamicFilterPattern("O_ORDERKEY", LESS_THAN, "L_ORDERKEY")))
+                                        .left(
+                                                anyTree(tableScan("orders", ImmutableMap.of(
+                                                        "O_SHIPPRIORITY", "shippriority",
+                                                        "O_ORDERKEY", "orderkey"))))
+                                        .right(
+                                                anyTree(tableScan("lineitem", ImmutableMap.of(
+                                                        "L_LINENUMBER", "linenumber",
+                                                        "L_ORDERKEY", "orderkey"))))))));
     }
 
     @Test
@@ -547,21 +547,22 @@ public class TestDynamicFilter
         assertPlan(
                 "SELECT part.partkey from part JOIN (lineitem JOIN orders ON lineitem.orderkey = orders.orderkey) ON part.partkey = lineitem.orderkey",
                 anyTree(
-                        join(
-                                INNER,
-                                ImmutableList.of(equiJoinClause("PART_PK", "LINEITEM_OK")),
-                                ImmutableMap.of("PART_PK", "LINEITEM_OK"),
-                                anyTree(
-                                        tableScan("part", ImmutableMap.of("PART_PK", "partkey"))),
-                                anyTree(
-                                        join(
-                                                INNER,
-                                                ImmutableList.of(equiJoinClause("LINEITEM_OK", "ORDERS_OK")),
-                                                ImmutableMap.of("LINEITEM_OK", "ORDERS_OK"),
-                                                anyTree(
-                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))),
-                                                exchange(
-                                                        project(tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("PART_PK", "LINEITEM_OK")
+                                .dynamicFilter("PART_PK", "LINEITEM_OK")
+                                .left(
+                                        anyTree(tableScan("part", ImmutableMap.of("PART_PK", "partkey"))))
+                                .right(
+                                        anyTree(
+                                                join(INNER, rightJoinBuilder -> rightJoinBuilder
+                                                        .equiCriteria("LINEITEM_OK", "ORDERS_OK")
+                                                        .dynamicFilter("LINEITEM_OK", "ORDERS_OK")
+                                                        .left(
+                                                                anyTree(
+                                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))
+                                                        .right(
+                                                                exchange(
+                                                                        project(tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))))))))));
     }
 
     @Test
@@ -570,22 +571,24 @@ public class TestDynamicFilter
         assertPlan(
                 "SELECT part.partkey from (lineitem JOIN orders ON lineitem.orderkey = orders.orderkey) JOIN part ON lineitem.orderkey = part.partkey",
                 anyTree(
-                        join(
-                                INNER,
-                                ImmutableList.of(equiJoinClause("LINEITEM_OK", "PART_PK")),
-                                ImmutableMap.of("LINEITEM_OK", "PART_PK", "ORDERS_OK", "PART_PK"),
-                                join(
-                                        INNER,
-                                        ImmutableList.of(equiJoinClause("LINEITEM_OK", "ORDERS_OK")),
-                                        ImmutableMap.of("LINEITEM_OK", "ORDERS_OK"),
-                                        anyTree(node(FilterNode.class,
-                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))
-                                                .with(numberOfDynamicFilters(2))),
-                                        anyTree(node(FilterNode.class,
-                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))
-                                                .with(numberOfDynamicFilters(1)))),
-                                exchange(
-                                        project(tableScan("part", ImmutableMap.of("PART_PK", "partkey")))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("LINEITEM_OK", "PART_PK")
+                                .dynamicFilter(ImmutableMap.of("LINEITEM_OK", "PART_PK", "ORDERS_OK", "PART_PK"))
+                                .left(
+                                        join(INNER, leftJoinBuilder -> leftJoinBuilder
+                                                .equiCriteria("LINEITEM_OK", "ORDERS_OK")
+                                                .dynamicFilter("LINEITEM_OK", "ORDERS_OK")
+                                                .left(
+                                                        anyTree(node(FilterNode.class,
+                                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))
+                                                                .with(numberOfDynamicFilters(2))))
+                                                .right(
+                                                        anyTree(node(FilterNode.class,
+                                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))
+                                                                .with(numberOfDynamicFilters(1))))))
+                                .right(
+                                        exchange(
+                                                project(tableScan("part", ImmutableMap.of("PART_PK", "partkey"))))))));
     }
 
     @Test
@@ -600,27 +603,30 @@ public class TestDynamicFilter
                         "SELECT t.clerk " +
                         "FROM orders o3 JOIN t ON t.clerk = o3.clerk",
                 anyTree(
-                        join(
-                                INNER,
-                                ImmutableList.of(equiJoinClause("ORDERS_CK", "ORDERS_CK6")),
-                                ImmutableMap.of("ORDERS_CK", "ORDERS_CK6"),
-                                anyTree(
-                                        tableScan("orders", ImmutableMap.of("ORDERS_CK", "clerk"))),
-                                anyTree(
-                                        join(
-                                                LEFT,
-                                                ImmutableList.of(equiJoinClause("ORDERS_CK16", "ORDERS_CK27")),
-                                                anyTree(
-                                                        join(
-                                                                LEFT,
-                                                                ImmutableList.of(equiJoinClause("ORDERS_CK6", "ORDERS_CK16")),
-                                                                project(
-                                                                        tableScan("orders", ImmutableMap.of("ORDERS_CK6", "clerk"))),
-                                                                exchange(
-                                                                        project(
-                                                                                tableScan("orders", ImmutableMap.of("ORDERS_CK16", "clerk")))))),
-                                                anyTree(
-                                                        tableScan("orders", ImmutableMap.of("ORDERS_CK27", "clerk"))))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("ORDERS_CK", "ORDERS_CK6")
+                                .dynamicFilter("ORDERS_CK", "ORDERS_CK6")
+                                .left(
+                                        anyTree(
+                                                tableScan("orders", ImmutableMap.of("ORDERS_CK", "clerk"))))
+                                .right(
+                                        anyTree(
+                                                join(LEFT, rightJoinBuilder -> rightJoinBuilder
+                                                        .equiCriteria("ORDERS_CK16", "ORDERS_CK27")
+                                                        .left(
+                                                                anyTree(
+                                                                        join(LEFT, leftJoinBuilder -> leftJoinBuilder
+                                                                                .equiCriteria("ORDERS_CK6", "ORDERS_CK16")
+                                                                                .left(
+                                                                                        project(
+                                                                                                tableScan("orders", ImmutableMap.of("ORDERS_CK6", "clerk"))))
+                                                                                .right(
+                                                                                        exchange(
+                                                                                                project(
+                                                                                                        tableScan("orders", ImmutableMap.of("ORDERS_CK16", "clerk"))))))))
+                                                        .right(
+                                                                anyTree(
+                                                                        tableScan("orders", ImmutableMap.of("ORDERS_CK27", "clerk"))))))))));
     }
 
     @Test
@@ -631,31 +637,33 @@ public class TestDynamicFilter
                         "WHERE t0.partkey = t1.partkey AND t0.partkey = t2.partkey " +
                         "AND t0.size + t1.size = t2.size",
                 anyTree(
-                        join(
-                                INNER,
-                                ImmutableList.of(equiJoinClause("K0", "K2"), equiJoinClause("S", "V2")),
-                                Optional.empty(), // Should be ImmutableMap.of("K0", "K2", "K1", "K2") but K1 symbol is not available when matching current join node
-                                project(
+                        // Expected filter should be ImmutableMap.of("K0", "K2", "K1", "K2") but K1 symbol is not available when matching current join node
+                        join(INNER, builder -> builder
+                                .equiCriteria(ImmutableList.of(equiJoinClause("K0", "K2"), equiJoinClause("S", "V2")))
+                                .left(
                                         project(
-                                                ImmutableMap.of("S", expression("V0 + V1")),
-                                                join(
-                                                        INNER,
-                                                        ImmutableList.of(equiJoinClause("K0", "K1")),
-                                                        ImmutableMap.of("K0", "K1"),
-                                                        project(
-                                                                node(
-                                                                        FilterNode.class,
-                                                                        tableScan("part", ImmutableMap.of("K0", "partkey", "V0", "size")))
-                                                                        .with(numberOfDynamicFilters(2))),
-                                                        exchange(
-                                                                project(
-                                                                        node(
-                                                                                FilterNode.class,
-                                                                                tableScan("part", ImmutableMap.of("K1", "partkey", "V1", "size")))
-                                                                                .with(numberOfDynamicFilters(1))))))),
-                                exchange(
-                                        project(
-                                                tableScan("part", ImmutableMap.of("K2", "partkey", "V2", "size")))))));
+                                                project(
+                                                        ImmutableMap.of("S", expression("V0 + V1")),
+                                                        join(INNER, leftJoinBuilder -> leftJoinBuilder
+                                                                .equiCriteria("K0", "K1")
+                                                                .dynamicFilter("K0", "K1")
+                                                                .left(
+                                                                        project(
+                                                                                node(
+                                                                                        FilterNode.class,
+                                                                                        tableScan("part", ImmutableMap.of("K0", "partkey", "V0", "size")))
+                                                                                        .with(numberOfDynamicFilters(2))))
+                                                                .right(
+                                                                        exchange(
+                                                                                project(
+                                                                                        node(
+                                                                                                FilterNode.class,
+                                                                                                tableScan("part", ImmutableMap.of("K1", "partkey", "V1", "size")))
+                                                                                                .with(numberOfDynamicFilters(1)))))))))
+                                .right(
+                                        exchange(
+                                                project(
+                                                        tableScan("part", ImmutableMap.of("K2", "partkey", "V2", "size"))))))));
     }
 
     @Test
@@ -764,14 +772,14 @@ public class TestDynamicFilter
         assertPlan("SELECT o.orderkey FROM orders o JOIN lineitem l ON o.orderkey + 1 < l.orderkey",
                 anyTree(
                         filter("expr < LINEITEM_OK",
-                                join(
-                                        INNER,
-                                        ImmutableList.of(),
-                                        project(
-                                                ImmutableMap.of("expr", expression("ORDERS_OK + BIGINT '1'")),
-                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
-                                        anyTree(
-                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
+                                join(INNER, builder -> builder
+                                        .left(
+                                                project(
+                                                        ImmutableMap.of("expr", expression("ORDERS_OK + BIGINT '1'")),
+                                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))
+                                        .right(
+                                                anyTree(
+                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))))));
     }
 
     @Test
@@ -780,16 +788,16 @@ public class TestDynamicFilter
         assertPlan("SELECT o.orderkey FROM orders o JOIN lineitem l ON o.orderkey < l.orderkey + 1",
                 anyTree(
                         filter("ORDERS_OK < expr",
-                                join(
-                                        INNER,
-                                        ImmutableList.of(),
-                                        ImmutableList.of(new DynamicFilterPattern("ORDERS_OK", LESS_THAN, "expr")),
-                                        filter(TRUE_LITERAL,
-                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
-                                        anyTree(
-                                                project(
-                                                        ImmutableMap.of("expr", expression("LINEITEM_OK + BIGINT '1'")),
-                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))))));
+                                join(INNER, builder -> builder
+                                        .dynamicFilter(ImmutableList.of(new DynamicFilterPattern("ORDERS_OK", LESS_THAN, "expr")))
+                                        .left(
+                                                filter(TRUE_LITERAL,
+                                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))
+                                        .right(
+                                                anyTree(
+                                                        project(
+                                                                ImmutableMap.of("expr", expression("LINEITEM_OK + BIGINT '1'")),
+                                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))))));
     }
 
     @Test
@@ -797,12 +805,10 @@ public class TestDynamicFilter
     {
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey + 1 < l.orderkey",
                 anyTree(filter("ORDERS_OK + BIGINT '1' < LINEITEM_OK",
-                        join(
-                                INNER,
-                                ImmutableList.of(),
-                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")),
-                                exchange(
-                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
+                        join(INNER, builder -> builder
+                                .left(tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))
+                                .right(exchange(
+                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))))));
     }
 
     @Test
@@ -811,17 +817,17 @@ public class TestDynamicFilter
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey < l.orderkey + 1",
                 anyTree(
                         filter("ORDERS_OK < expr",
-                                join(
-                                        INNER,
-                                        ImmutableList.of(),
-                                        ImmutableList.of(new DynamicFilterPattern("ORDERS_OK", LESS_THAN, "expr")),
-                                        filter(
-                                                TRUE_LITERAL,
-                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
-                                        anyTree(
-                                                project(
-                                                        ImmutableMap.of("expr", expression("LINEITEM_OK + BIGINT '1'")),
-                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))))));
+                                join(INNER, builder -> builder
+                                        .dynamicFilter(ImmutableList.of(new DynamicFilterPattern("ORDERS_OK", LESS_THAN, "expr")))
+                                        .left(
+                                                filter(
+                                                        TRUE_LITERAL,
+                                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))
+                                        .right(
+                                                anyTree(
+                                                        project(
+                                                                ImmutableMap.of("expr", expression("LINEITEM_OK + BIGINT '1'")),
+                                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))))));
     }
 
     @Test
@@ -833,17 +839,19 @@ public class TestDynamicFilter
                         "WHERE f.nationkey >= mod(d.nationkey, 2) AND f.suppkey >= mod(d.nationkey, 2)",
                 anyTree(
                         filter("(nationkey >= mod) AND (suppkey >= mod)",
-                                join(INNER,
-                                        ImmutableList.of(),
-                                        ImmutableList.of(
-                                                new DynamicFilterPattern("nationkey", GREATER_THAN_OR_EQUAL, "mod"),
-                                                new DynamicFilterPattern("suppkey", GREATER_THAN_OR_EQUAL, "mod")),
-                                        anyTree(
-                                                tableScan("supplier", ImmutableMap.of("nationkey", "nationkey", "suppkey", "suppkey"))),
-                                        anyTree(
-                                                project(
-                                                        ImmutableMap.of("mod", expression("mod(n_nationkey, BIGINT '2')")),
-                                                        tableScan("nation", ImmutableMap.of("n_nationkey", "nationkey"))))))));
+                                join(INNER, builder -> builder
+                                        .dynamicFilter(
+                                                ImmutableList.of(
+                                                        new DynamicFilterPattern("nationkey", GREATER_THAN_OR_EQUAL, "mod"),
+                                                        new DynamicFilterPattern("suppkey", GREATER_THAN_OR_EQUAL, "mod")))
+                                        .left(
+                                                anyTree(
+                                                        tableScan("supplier", ImmutableMap.of("nationkey", "nationkey", "suppkey", "suppkey"))))
+                                        .right(
+                                                anyTree(
+                                                        project(
+                                                                ImmutableMap.of("mod", expression("mod(n_nationkey, BIGINT '2')")),
+                                                                tableScan("nation", ImmutableMap.of("n_nationkey", "nationkey")))))))));
     }
 
     private Matcher numberOfDynamicFilters(int numberOfDynamicFilters)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestPlanMatchingFramework.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestPlanMatchingFramework.java
@@ -28,7 +28,6 @@ import static io.trino.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.columnReference;
-import static io.trino.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.functionCall;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
@@ -149,11 +148,14 @@ public class TestPlanMatchingFramework
                 "SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey = o.orderkey",
                 noJoinReordering(),
                 anyTree(
-                        join(INNER, ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
-                                anyTree(
-                                        tableScan("orders").withAlias("ORDERS_OK", columnReference("orders", "orderkey"))),
-                                anyTree(
-                                        tableScan("lineitem").withAlias("LINEITEM_OK", columnReference("lineitem", "orderkey"))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("ORDERS_OK", "LINEITEM_OK")
+                                .left(
+                                        anyTree(
+                                                tableScan("orders").withAlias("ORDERS_OK", columnReference("orders", "orderkey"))))
+                                .right(
+                                        anyTree(
+                                                tableScan("lineitem").withAlias("LINEITEM_OK", columnReference("lineitem", "orderkey")))))));
     }
 
     @Test
@@ -161,11 +163,14 @@ public class TestPlanMatchingFramework
     {
         assertPlan("SELECT l.orderkey FROM orders l, orders r WHERE l.orderkey = r.orderkey",
                 anyTree(
-                        join(INNER, ImmutableList.of(equiJoinClause("L_ORDERS_OK", "R_ORDERS_OK")),
-                                anyTree(
-                                        tableScan("orders").withAlias("L_ORDERS_OK", columnReference("orders", "orderkey"))),
-                                anyTree(
-                                        tableScan("orders").withAlias("R_ORDERS_OK", columnReference("orders", "orderkey"))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("L_ORDERS_OK", "R_ORDERS_OK")
+                                .left(
+                                        anyTree(
+                                                tableScan("orders").withAlias("L_ORDERS_OK", columnReference("orders", "orderkey"))))
+                                .right(
+                                        anyTree(
+                                                tableScan("orders").withAlias("R_ORDERS_OK", columnReference("orders", "orderkey")))))));
     }
 
     @Test
@@ -244,11 +249,14 @@ public class TestPlanMatchingFramework
                 "SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey = o.orderkey",
                 noJoinReordering(),
                 anyTree(
-                        join(INNER, ImmutableList.of(equiJoinClause("LINEITEM_OK", "ORDERS_OK")),
-                                anyTree(
-                                        tableScan("orders").withAlias("ORDERS_OK", columnReference("orders", "orderkey"))),
-                                anyTree(
-                                        tableScan("lineitem").withAlias("ORDERS_OK", columnReference("lineitem", "orderkey")))))))
+                        join(INNER, builder -> builder
+                                .equiCriteria("LINEITEM_OK", "ORDERS_OK")
+                                .left(
+                                        anyTree(
+                                                tableScan("orders").withAlias("ORDERS_OK", columnReference("orders", "orderkey"))))
+                                .right(
+                                        anyTree(
+                                                tableScan("lineitem").withAlias("ORDERS_OK", columnReference("lineitem", "orderkey"))))))))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageMatching(".*already bound to expression.*");
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestPredicatePushdownWithoutDynamicFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestPredicatePushdownWithoutDynamicFilter.java
@@ -13,12 +13,10 @@
  */
 package io.trino.sql.planner;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
-import static io.trino.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
@@ -49,16 +47,19 @@ public class TestPredicatePushdownWithoutDynamicFilter
                         "FROM t JOIN u ON t.k = u.k AND t.v = u.v " +
                         "WHERE t.v = 'x'",
                 anyTree(
-                        join(INNER, ImmutableList.of(equiJoinClause("t_k", "u_k")),
-                                project(
-                                        filter(
-                                                "CAST('x' AS varchar(4)) = CAST(t_v AS varchar(4))",
-                                                tableScan("nation", ImmutableMap.of("t_k", "nationkey", "t_v", "name")))),
-                                anyTree(
+                        join(INNER, builder -> builder
+                                .equiCriteria("t_k", "u_k")
+                                .left(
                                         project(
                                                 filter(
-                                                        "CAST('x' AS varchar(4)) = CAST(u_v AS varchar(4))",
-                                                        tableScan("nation", ImmutableMap.of("u_k", "nationkey", "u_v", "name"))))))));
+                                                        "CAST('x' AS varchar(4)) = CAST(t_v AS varchar(4))",
+                                                        tableScan("nation", ImmutableMap.of("t_k", "nationkey", "t_v", "name")))))
+                                .right(
+                                        anyTree(
+                                                project(
+                                                        filter(
+                                                                "CAST('x' AS varchar(4)) = CAST(u_v AS varchar(4))",
+                                                                tableScan("nation", ImmutableMap.of("u_k", "nationkey", "u_v", "name")))))))));
 
         // values have different types (varchar(4) vs varchar(5)) in each table
         assertPlan(
@@ -69,15 +70,17 @@ public class TestPredicatePushdownWithoutDynamicFilter
                         "FROM t JOIN u ON t.k = u.k AND t.v = u.v " +
                         "WHERE t.v = 'x'",
                 anyTree(
-                        join(INNER, ImmutableList.of(equiJoinClause("t_k", "u_k")),
-                                project(
-                                        filter(
-                                                "CAST('x' AS varchar(4)) = CAST(t_v AS varchar(4))",
-                                                tableScan("nation", ImmutableMap.of("t_k", "nationkey", "t_v", "name")))),
-                                anyTree(
+                        join(INNER, builder -> builder
+                                .equiCriteria("t_k", "u_k")
+                                .left(
                                         project(
-                                                filter(
-                                                        "CAST('x' AS varchar(5)) = CAST(u_v AS varchar(5))",
-                                                        tableScan("nation", ImmutableMap.of("u_k", "nationkey", "u_v", "name"))))))));
+                                                filter("CAST('x' AS varchar(4)) = CAST(t_v AS varchar(4))",
+                                                        tableScan("nation", ImmutableMap.of("t_k", "nationkey", "t_v", "name")))))
+                                .right(
+                                        anyTree(
+                                                project(
+                                                        filter(
+                                                                "CAST('x' AS varchar(5)) = CAST(u_v AS varchar(5))",
+                                                                tableScan("nation", ImmutableMap.of("u_k", "nationkey", "u_v", "name")))))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestQuantifiedComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestQuantifiedComparison.java
@@ -13,7 +13,6 @@
  */
 package io.trino.sql.planner;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.sql.planner.assertions.BasePlanTest;
 import io.trino.sql.planner.plan.AggregationNode;
@@ -22,7 +21,6 @@ import io.trino.sql.planner.plan.ValuesNode;
 import org.testng.annotations.Test;
 
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
-import static io.trino.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
@@ -40,11 +38,10 @@ public class TestQuantifiedComparison
     {
         String query = "SELECT orderkey, custkey FROM orders WHERE orderkey = ANY (VALUES ROW(CAST(5 as BIGINT)), ROW(CAST(3 as BIGINT)))";
         assertPlan(query, anyTree(
-                join(
-                        INNER,
-                        ImmutableList.of(equiJoinClause("Y", "X")),
-                        anyTree(values(ImmutableMap.of("Y", 0))),
-                        anyTree(tableScan("orders", ImmutableMap.of("X", "orderkey"))))));
+                join(INNER, builder -> builder
+                        .equiCriteria("Y", "X")
+                        .left(anyTree(values(ImmutableMap.of("Y", 0))))
+                        .right(anyTree(tableScan("orders", ImmutableMap.of("X", "orderkey")))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/JoinMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/JoinMatcher.java
@@ -13,12 +13,14 @@
  */
 package io.trino.sql.planner.assertions;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.cost.StatsProvider;
 import io.trino.metadata.Metadata;
 import io.trino.sql.DynamicFilters;
 import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
 import io.trino.sql.planner.plan.DynamicFilterId;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.JoinNode;
@@ -43,11 +45,14 @@ import static io.trino.sql.DynamicFilters.extractDynamicFilters;
 import static io.trino.sql.planner.ExpressionExtractor.extractExpressions;
 import static io.trino.sql.planner.assertions.MatchResult.NO_MATCH;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.DynamicFilterPattern;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
 import static io.trino.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
+import static io.trino.sql.tree.ComparisonExpression.Operator.EQUAL;
 import static io.trino.sql.tree.ComparisonExpression.Operator.IS_DISTINCT_FROM;
 import static java.util.Objects.requireNonNull;
 
-final class JoinMatcher
+public final class JoinMatcher
         implements Matcher
 {
     private final JoinNode.Type joinType;
@@ -187,5 +192,109 @@ final class JoinMatcher
                 .add("distributionType", distributionType)
                 .add("dynamicFilter", expectedDynamicFilter)
                 .toString();
+    }
+
+    public static class Builder
+    {
+        private JoinNode.Type joinType;
+        private Optional<List<ExpectedValueProvider<JoinNode.EquiJoinClause>>> equiCriteria = Optional.empty();
+        private Optional<List<PlanMatchPattern.DynamicFilterPattern>> dynamicFilter = Optional.empty();
+        private Optional<DistributionType> distributionType = Optional.empty();
+        private Optional<Boolean> expectedSpillable = Optional.empty();
+        private PlanMatchPattern left;
+        private PlanMatchPattern right;
+        private Optional<String> filter = Optional.empty();
+
+        public Builder type(JoinNode.Type joinType)
+        {
+            this.joinType = joinType;
+
+            return this;
+        }
+
+        public Builder equiCriteria(List<ExpectedValueProvider<JoinNode.EquiJoinClause>> expectedEquiCriteria)
+        {
+            this.equiCriteria = Optional.of(expectedEquiCriteria);
+
+            return this;
+        }
+
+        public Builder equiCriteria(String left, String right)
+        {
+            this.equiCriteria = Optional.of(ImmutableList.of(equiJoinClause(left, right)));
+
+            return this;
+        }
+
+        public Builder filter(String expectedFilter)
+        {
+            this.filter = Optional.of(expectedFilter);
+
+            return this;
+        }
+
+        public Builder dynamicFilter(Map<String, String> expectedDynamicFilter)
+        {
+            this.dynamicFilter = Optional.of(expectedDynamicFilter.entrySet().stream()
+                    .map(entry -> new PlanMatchPattern.DynamicFilterPattern(entry.getKey(), EQUAL, entry.getValue()))
+                    .collect(toImmutableList()));
+
+            return this;
+        }
+
+        public Builder dynamicFilter(String key, String value)
+        {
+            this.dynamicFilter = Optional.of(ImmutableList.of(new PlanMatchPattern.DynamicFilterPattern(key, EQUAL, value)));
+
+            return this;
+        }
+
+        public Builder dynamicFilter(List<PlanMatchPattern.DynamicFilterPattern> expectedDynamicFilter)
+        {
+            this.dynamicFilter = Optional.of(expectedDynamicFilter);
+
+            return this;
+        }
+
+        public Builder distributionType(DistributionType expectedDistributionType)
+        {
+            this.distributionType = Optional.of(expectedDistributionType);
+
+            return this;
+        }
+
+        public Builder spillable(Boolean expectedSpillable)
+        {
+            this.expectedSpillable = Optional.of(expectedSpillable);
+
+            return this;
+        }
+
+        public Builder left(PlanMatchPattern left)
+        {
+            this.left = left;
+
+            return this;
+        }
+
+        public Builder right(PlanMatchPattern right)
+        {
+            this.right = right;
+
+            return this;
+        }
+
+        public PlanMatchPattern build()
+        {
+            return node(JoinNode.class, left, right)
+                    .with(
+                            new JoinMatcher(
+                                    joinType,
+                                    equiCriteria.orElse(ImmutableList.of()),
+                                    filter.map(PlanBuilder::expression),
+                                    distributionType,
+                                    expectedSpillable,
+                                    dynamicFilter));
+        }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushDownDereferencesRules.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushDownDereferencesRules.java
@@ -157,20 +157,22 @@ public class TestPushDownDereferencesRules
                                         .put("right_y", PlanMatchPattern.expression("y"))
                                         .put("z", PlanMatchPattern.expression("z"))
                                         .buildOrThrow(),
-                                join(INNER, ImmutableList.of(),
-                                        strictProject(
-                                                ImmutableMap.of(
-                                                        "x", PlanMatchPattern.expression("msg1[1]"),
-                                                        "msg1", PlanMatchPattern.expression("msg1"),
-                                                        "unreferenced_symbol", PlanMatchPattern.expression("unreferenced_symbol")),
-                                                values("msg1", "unreferenced_symbol")),
-                                        strictProject(
-                                                ImmutableMap.<String, ExpressionMatcher>builder()
-                                                        .put("y", PlanMatchPattern.expression("msg2[2]"))
-                                                        .put("z", PlanMatchPattern.expression("z"))
-                                                        .put("msg2", PlanMatchPattern.expression("msg2"))
-                                                        .buildOrThrow(),
-                                                values("msg2", "z")))));
+                                join(INNER, builder -> builder
+                                        .left(
+                                                strictProject(
+                                                        ImmutableMap.of(
+                                                                "x", PlanMatchPattern.expression("msg1[1]"),
+                                                                "msg1", PlanMatchPattern.expression("msg1"),
+                                                                "unreferenced_symbol", PlanMatchPattern.expression("unreferenced_symbol")),
+                                                        values("msg1", "unreferenced_symbol")))
+                                        .right(
+                                                strictProject(
+                                                        ImmutableMap.<String, ExpressionMatcher>builder()
+                                                                .put("y", PlanMatchPattern.expression("msg2[2]"))
+                                                                .put("z", PlanMatchPattern.expression("z"))
+                                                                .put("msg2", PlanMatchPattern.expression("msg2"))
+                                                                .buildOrThrow(),
+                                                        values("msg2", "z"))))));
 
         // Verify pushdown for filters
         tester().assertThat(new PushDownDereferenceThroughJoin(tester().getTypeAnalyzer()))
@@ -188,13 +190,15 @@ public class TestPushDownDereferencesRules
                                 ImmutableMap.of(
                                         "expr", PlanMatchPattern.expression("msg1_x"),
                                         "expr_2", PlanMatchPattern.expression("msg2")),
-                                join(INNER, ImmutableList.of(), Optional.of("msg1_x + msg2[2] > BIGINT '10'"),
-                                        strictProject(
-                                                ImmutableMap.of(
-                                                        "msg1_x", PlanMatchPattern.expression("msg1[1]"),
-                                                        "msg1", PlanMatchPattern.expression("msg1")),
-                                                values("msg1")),
-                                        values("msg2"))));
+                                join(INNER, builder -> builder
+                                        .filter("msg1_x + msg2[2] > BIGINT '10'")
+                                        .left(
+                                                strictProject(
+                                                        ImmutableMap.of(
+                                                                "msg1_x", PlanMatchPattern.expression("msg1[1]"),
+                                                                "msg1", PlanMatchPattern.expression("msg1")),
+                                                        values("msg1")))
+                                        .right(values("msg2")))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushInequalityFilterExpressionBelowJoinRuleSet.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushInequalityFilterExpressionBelowJoinRuleSet.java
@@ -13,7 +13,6 @@
  */
 package io.trino.sql.planner.iterative.rule;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
@@ -23,8 +22,6 @@ import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.GenericLiteral;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import java.util.Optional;
 
 import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
@@ -80,14 +77,12 @@ public class TestPushInequalityFilterExpressionBelowJoinRuleSet
                             comparison(LESS_THAN, add(b, 1), a.toSymbolReference()));
                 })
                 .matches(
-                        join(
-                                INNER,
-                                ImmutableList.of(),
-                                Optional.of("expr < a"),
-                                values("a"),
-                                project(
+                        join(INNER, builder -> builder
+                                .filter("expr < a")
+                                .left(values("a"))
+                                .right(project(
                                         ImmutableMap.of("expr", expression("b + BIGINT '1'")),
-                                        values("b"))));
+                                        values("b")))));
     }
 
     @Test
@@ -106,16 +101,15 @@ public class TestPushInequalityFilterExpressionBelowJoinRuleSet
                                     comparison(GREATER_THAN, add(b, 10), a.toSymbolReference())));
                 })
                 .matches(
-                        join(
-                                INNER,
-                                ImmutableList.of(),
-                                Optional.of("expr_less < a and expr_greater > a"),
-                                values("a"),
-                                project(
-                                        ImmutableMap.of(
-                                                "expr_less", expression("b + BIGINT '1'"),
-                                                "expr_greater", expression("b + BIGINT '10'")),
-                                        values("b"))));
+                        join(INNER, builder -> builder
+                                .filter("expr_less < a and expr_greater > a")
+                                .left(values("a"))
+                                .right(
+                                        project(
+                                                ImmutableMap.of(
+                                                        "expr_less", expression("b + BIGINT '1'"),
+                                                        "expr_greater", expression("b + BIGINT '10'")),
+                                                values("b")))));
     }
 
     @Test
@@ -132,14 +126,13 @@ public class TestPushInequalityFilterExpressionBelowJoinRuleSet
                             comparison(LESS_THAN, add(b, 1), add(a, 2)));
                 })
                 .matches(
-                        join(
-                                INNER,
-                                ImmutableList.of(),
-                                Optional.of("expr < a + BIGINT '2'"),
-                                values("a"),
-                                project(
-                                        ImmutableMap.of("expr", expression("b + BIGINT '1'")),
-                                        values("b"))));
+                        join(INNER, builder -> builder
+                                .filter("expr < a + BIGINT '2'")
+                                .left(values("a"))
+                                .right(
+                                        project(
+                                                ImmutableMap.of("expr", expression("b + BIGINT '1'")),
+                                                values("b")))));
     }
 
     @Test
@@ -176,13 +169,13 @@ public class TestPushInequalityFilterExpressionBelowJoinRuleSet
                 .matches(
                         project(
                                 filter("expr < a",
-                                        join(
-                                                INNER,
-                                                ImmutableList.of(),
-                                                values("a"),
-                                                project(
-                                                        ImmutableMap.of("expr", expression("b + BIGINT '1'")),
-                                                        values("b"))))));
+                                        join(INNER, builder -> builder
+                                                .left(
+                                                        values("a"))
+                                                .right(
+                                                        project(
+                                                                ImmutableMap.of("expr", expression("b + BIGINT '1'")),
+                                                                values("b")))))));
     }
 
     @Test
@@ -204,15 +197,14 @@ public class TestPushInequalityFilterExpressionBelowJoinRuleSet
                 .matches(
                         project(
                                 filter("expr_less < a and expr_greater > a",
-                                        join(
-                                                INNER,
-                                                ImmutableList.of(),
-                                                values("a"),
-                                                project(
-                                                        ImmutableMap.of(
-                                                                "expr_less", expression("b + BIGINT '1'"),
-                                                                "expr_greater", expression("b + BIGINT '10'")),
-                                                        values("b"))))));
+                                        join(INNER, builder -> builder
+                                                .left(values("a"))
+                                                .right(
+                                                        project(
+                                                                ImmutableMap.of(
+                                                                        "expr_less", expression("b + BIGINT '1'"),
+                                                                        "expr_greater", expression("b + BIGINT '10'")),
+                                                                values("b")))))));
     }
 
     @Test
@@ -233,16 +225,15 @@ public class TestPushInequalityFilterExpressionBelowJoinRuleSet
                 .matches(
                         project(
                                 filter("parent_expression < a",
-                                        join(
-                                                INNER,
-                                                ImmutableList.of(),
-                                                Optional.of("join_expression < a"),
-                                                values("a"),
-                                                project(
-                                                        ImmutableMap.of(
-                                                                "join_expression", expression("b + BIGINT '2'"),
-                                                                "parent_expression", expression("b + BIGINT '1'")),
-                                                        values("b")))
+                                        join(INNER, builder -> builder
+                                                .filter("join_expression < a")
+                                                .left(values("a"))
+                                                .right(
+                                                        project(
+                                                                ImmutableMap.of(
+                                                                        "join_expression", expression("b + BIGINT '2'"),
+                                                                        "parent_expression", expression("b + BIGINT '1'")),
+                                                                values("b"))))
                                                 .withExactOutputs("a", "b", "parent_expression"))));
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushLimitThroughOuterJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushLimitThroughOuterJoin.java
@@ -19,7 +19,6 @@ import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.plan.JoinNode.EquiJoinClause;
 import org.testng.annotations.Test;
 
-import static io.trino.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.limit;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
@@ -46,11 +45,10 @@ public class TestPushLimitThroughOuterJoin
                 })
                 .matches(
                         limit(1,
-                                join(
-                                        LEFT,
-                                        ImmutableList.of(equiJoinClause("leftKey", "rightKey")),
-                                        limit(1, ImmutableList.of(), true, values("leftKey")),
-                                        values("rightKey"))));
+                               join(LEFT, builder -> builder
+                                        .equiCriteria("leftKey", "rightKey")
+                                        .left(limit(1, ImmutableList.of(), true, values("leftKey")))
+                                        .right(values("rightKey")))));
     }
 
     @Test
@@ -69,11 +67,10 @@ public class TestPushLimitThroughOuterJoin
                 })
                 .matches(
                         limit(1,
-                                join(
-                                        RIGHT,
-                                        ImmutableList.of(equiJoinClause("leftKey", "rightKey")),
-                                        values("leftKey"),
-                                        limit(1, ImmutableList.of(), true, values("rightKey")))));
+                                join(RIGHT, builder -> builder
+                                        .equiCriteria("leftKey", "rightKey")
+                                        .left(values("leftKey"))
+                                        .right(limit(1, ImmutableList.of(), true, values("rightKey"))))));
     }
 
     @Test
@@ -164,11 +161,10 @@ public class TestPushLimitThroughOuterJoin
                 })
                 .matches(
                         limit(1, ImmutableList.of(), false, ImmutableList.of("leftKey"),
-                                join(
-                                        LEFT,
-                                        ImmutableList.of(equiJoinClause("leftKey", "rightKey")),
-                                        limit(1, ImmutableList.of(), true, ImmutableList.of("leftKey"), values("leftKey")),
-                                        values("rightKey"))));
+                               join(LEFT, builder -> builder
+                                        .equiCriteria("leftKey", "rightKey")
+                                        .left(limit(1, ImmutableList.of(), true, ImmutableList.of("leftKey"), values("leftKey")))
+                                        .right(values("rightKey")))));
     }
 
     @Test
@@ -206,10 +202,9 @@ public class TestPushLimitThroughOuterJoin
                 })
                 .matches(
                         limit(1, ImmutableList.of(), false, ImmutableList.of("rightKey"),
-                                join(
-                                        RIGHT,
-                                        ImmutableList.of(equiJoinClause("leftKey", "rightKey")),
-                                        values("leftKey"),
-                                        limit(1, ImmutableList.of(), true, ImmutableList.of("rightKey"), values("rightKey")))));
+                                join(RIGHT, builder -> builder
+                                        .equiCriteria("leftKey", "rightKey")
+                                        .left(values("leftKey"))
+                                        .right(limit(1, ImmutableList.of(), true, ImmutableList.of("rightKey"), values("rightKey"))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushProjectionThroughJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushProjectionThroughJoin.java
@@ -98,20 +98,21 @@ public class TestPushProjectionThroughJoin
                 createTestingFunctionManager(),
                 node -> unknown(),
                 new Plan(rewritten.get(), p.getTypes(), empty()), noLookup(),
-                join(
-                        INNER,
-                        ImmutableList.of(aliases -> new JoinNode.EquiJoinClause(new Symbol("a1"), new Symbol("b1"))),
-                        strictProject(ImmutableMap.of(
-                                "a3", expression("-(+a0)"),
-                                "a1", expression("a1")),
+                join(INNER, builder -> builder
+                        .equiCriteria(ImmutableList.of(aliases -> new JoinNode.EquiJoinClause(new Symbol("a1"), new Symbol("b1"))))
+                        .left(
                                 strictProject(ImmutableMap.of(
-                                        "a0", expression("a0"),
-                                        "a1", expression("a1")),
-                                        PlanMatchPattern.values("a0", "a1"))),
-                        strictProject(ImmutableMap.of(
-                                "b2", expression("+b1"),
-                                "b1", expression("b1")),
-                                PlanMatchPattern.values("b0", "b1")))
+                                                "a3", expression("-(+a0)"),
+                                                "a1", expression("a1")),
+                                        strictProject(ImmutableMap.of(
+                                                        "a0", expression("a0"),
+                                                        "a1", expression("a1")),
+                                                PlanMatchPattern.values("a0", "a1"))))
+                        .right(
+                                strictProject(ImmutableMap.of(
+                                                "b2", expression("+b1"),
+                                                "b1", expression("b1")),
+                                        PlanMatchPattern.values("b0", "b1"))))
                         .withExactOutputs("a3", "b2"));
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushTopNThroughOuterJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushTopNThroughOuterJoin.java
@@ -19,7 +19,6 @@ import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.plan.JoinNode;
 import org.testng.annotations.Test;
 
-import static io.trino.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.sort;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.topN;
@@ -53,11 +52,10 @@ public class TestPushTopNThroughOuterJoin
                                     new JoinNode.EquiJoinClause(leftKey, rightKey)));
                 })
                 .matches(
-                        join(
-                                LEFT,
-                                ImmutableList.of(equiJoinClause("leftKey", "rightKey")),
-                                topN(1, ImmutableList.of(sort("leftKey", ASCENDING, FIRST)), PARTIAL, values("leftKey")),
-                                values("rightKey")));
+                        join(LEFT, builder -> builder
+                                .equiCriteria("leftKey", "rightKey")
+                                .left(topN(1, ImmutableList.of(sort("leftKey", ASCENDING, FIRST)), PARTIAL, values("leftKey")))
+                                .right(values("rightKey"))));
     }
 
     @Test
@@ -78,11 +76,10 @@ public class TestPushTopNThroughOuterJoin
                                     new JoinNode.EquiJoinClause(leftKey, rightKey)));
                 })
                 .matches(
-                        join(
-                                RIGHT,
-                                ImmutableList.of(equiJoinClause("leftKey", "rightKey")),
-                                values("leftKey"),
-                                topN(1, ImmutableList.of(sort("rightKey", ASCENDING, FIRST)), PARTIAL, values("rightKey"))));
+                        join(RIGHT, builder -> builder
+                                .equiCriteria("leftKey", "rightKey")
+                                .left(values("leftKey"))
+                                .right(topN(1, ImmutableList.of(sort("rightKey", ASCENDING, FIRST)), PARTIAL, values("rightKey")))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedDistinctAggregationWithProjection.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedDistinctAggregationWithProjection.java
@@ -86,15 +86,14 @@ public class TestTransformCorrelatedDistinctAggregationWithProjection
                                         ImmutableMap.of(),
                                         Optional.empty(),
                                         SINGLE,
-                                        join(
-                                                LEFT,
-                                                ImmutableList.of(),
-                                                Optional.of("b > corr"),
-                                                assignUniqueId(
-                                                        "unique",
-                                                        values("corr")),
-                                                filter(
+                                        join(LEFT, builder -> builder
+                                                .filter("b > corr")
+                                                .left(
+                                                        assignUniqueId(
+                                                                "unique",
+                                                                values("corr")))
+                                                .right(filter(
                                                         "true",
-                                                        values("a", "b"))))));
+                                                        values("a", "b")))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedDistinctAggregationWithoutProjection.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedDistinctAggregationWithoutProjection.java
@@ -81,15 +81,15 @@ public class TestTransformCorrelatedDistinctAggregationWithoutProjection
                                         ImmutableMap.of(),
                                         Optional.empty(),
                                         SINGLE,
-                                        join(
-                                                LEFT,
-                                                ImmutableList.of(),
-                                                Optional.of("b > corr"),
-                                                assignUniqueId(
-                                                        "unique",
-                                                        values("corr")),
-                                                filter(
-                                                        "true",
-                                                        values("a", "b"))))));
+                                        join(LEFT, builder -> builder
+                                                .filter("b > corr")
+                                                .left(
+                                                        assignUniqueId(
+                                                                "unique",
+                                                                values("corr")))
+                                                .right(
+                                                        filter(
+                                                                "true",
+                                                                values("a", "b")))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedGlobalAggregationWithProjection.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedGlobalAggregationWithProjection.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
 import io.trino.sql.planner.plan.Assignments;
-import io.trino.sql.planner.plan.JoinNode;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
@@ -130,12 +129,11 @@ public class TestTransformCorrelatedGlobalAggregationWithProjection
                 .matches(
                         project(ImmutableMap.of("corr", expression("corr"), "expr", expression("(\"sum_1\" + 1)")),
                                 aggregation(ImmutableMap.of("sum_1", functionCall("sum", ImmutableList.of("a"))),
-                                        join(JoinNode.Type.LEFT,
-                                                ImmutableList.of(),
-                                                assignUniqueId("unique",
-                                                        values(ImmutableMap.of("corr", 0))),
-                                                project(ImmutableMap.of("non_null", expression("true")),
-                                                        values(ImmutableMap.of("a", 0, "b", 1)))))));
+                                        join(LEFT, builder -> builder
+                                                .left(assignUniqueId("unique",
+                                                        values(ImmutableMap.of("corr", 0))))
+                                                .right(project(ImmutableMap.of("non_null", expression("true")),
+                                                        values(ImmutableMap.of("a", 0, "b", 1))))))));
     }
 
     @Test
@@ -170,18 +168,18 @@ public class TestTransformCorrelatedGlobalAggregationWithProjection
                                                 ImmutableMap.of(),
                                                 Optional.empty(),
                                                 SINGLE,
-                                                join(
-                                                        LEFT,
-                                                        ImmutableList.of(),
-                                                        Optional.of("b > corr"),
-                                                        assignUniqueId(
-                                                                "unique",
-                                                                values("corr")),
-                                                        project(
-                                                                ImmutableMap.of("non_null", expression("true")),
-                                                                filter(
-                                                                        "true",
-                                                                        values("a", "b"))))))));
+                                                join(LEFT, builder -> builder
+                                                        .filter("b > corr")
+                                                        .left(
+                                                                assignUniqueId(
+                                                                        "unique",
+                                                                        values("corr")))
+                                                        .right(
+                                                                project(
+                                                                        ImmutableMap.of("non_null", expression("true")),
+                                                                        filter(
+                                                                                "true",
+                                                                                values("a", "b")))))))));
     }
 
     @Test
@@ -213,23 +211,23 @@ public class TestTransformCorrelatedGlobalAggregationWithProjection
                                         ImmutableList.of("non_null"),
                                         Optional.empty(),
                                         SINGLE,
-                                        join(
-                                                LEFT,
-                                                ImmutableList.of(),
-                                                Optional.of("b = corr"),
-                                                assignUniqueId(
-                                                        "unique",
-                                                        values("corr")),
-                                                project(
-                                                        ImmutableMap.of("non_null", expression("true")),
-                                                        aggregation(
-                                                                singleGroupingSet("a", "b"),
-                                                                ImmutableMap.of(),
-                                                                Optional.empty(),
-                                                                SINGLE,
-                                                                filter(
-                                                                        "true",
-                                                                        values("a", "b"))))))));
+                                        join(LEFT, builder -> builder
+                                                .filter("b = corr")
+                                                .left(
+                                                        assignUniqueId(
+                                                                "unique",
+                                                                values("corr")))
+                                                .right(
+                                                        project(
+                                                                ImmutableMap.of("non_null", expression("true")),
+                                                                aggregation(
+                                                                        singleGroupingSet("a", "b"),
+                                                                        ImmutableMap.of(),
+                                                                        Optional.empty(),
+                                                                        SINGLE,
+                                                                        filter(
+                                                                                "true",
+                                                                                values("a", "b")))))))));
     }
 
     @Test
@@ -255,11 +253,10 @@ public class TestTransformCorrelatedGlobalAggregationWithProjection
                                         SINGLE,
                                         project(
                                                 ImmutableMap.of("new_mask", expression("mask AND non_null")),
-                                                join(JoinNode.Type.LEFT,
-                                                        ImmutableList.of(),
-                                                        assignUniqueId("unique",
-                                                                values(ImmutableMap.of("corr", 0))),
-                                                        project(ImmutableMap.of("non_null", expression("true")),
-                                                                values(ImmutableMap.of("a", 0, "mask", 1))))))));
+                                                join(LEFT, builder -> builder
+                                                        .left(assignUniqueId("unique",
+                                                                values(ImmutableMap.of("corr", 0))))
+                                                        .right(project(ImmutableMap.of("non_null", expression("true")),
+                                                                values(ImmutableMap.of("a", 0, "mask", 1)))))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedGlobalAggregationWithoutProjection.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedGlobalAggregationWithoutProjection.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
 import io.trino.sql.planner.plan.Assignments;
-import io.trino.sql.planner.plan.JoinNode;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
@@ -115,12 +114,11 @@ public class TestTransformCorrelatedGlobalAggregationWithoutProjection
                 .matches(
                         project(ImmutableMap.of("sum_1", expression("sum_1"), "corr", expression("corr")),
                                 aggregation(ImmutableMap.of("sum_1", functionCall("sum", ImmutableList.of("a"))),
-                                        join(JoinNode.Type.LEFT,
-                                                ImmutableList.of(),
-                                                assignUniqueId("unique",
-                                                        values(ImmutableMap.of("corr", 0))),
-                                                project(ImmutableMap.of("non_null", expression("true")),
-                                                        values(ImmutableMap.of("a", 0, "b", 1)))))));
+                                        join(LEFT, builder -> builder
+                                                .left(assignUniqueId("unique",
+                                                        values(ImmutableMap.of("corr", 0))))
+                                                .right(project(ImmutableMap.of("non_null", expression("true")),
+                                                        values(ImmutableMap.of("a", 0, "b", 1))))))));
     }
 
     @Test
@@ -155,12 +153,11 @@ public class TestTransformCorrelatedGlobalAggregationWithoutProjection
                                 aggregation(ImmutableMap.of(
                                         "count_rows", functionCall("count", ImmutableList.of()),
                                         "count_non_null_values", functionCall("count", ImmutableList.of("a"))),
-                                        join(JoinNode.Type.LEFT,
-                                                ImmutableList.of(),
-                                                assignUniqueId("unique",
-                                                        values(ImmutableMap.of("corr", 0))),
-                                                project(ImmutableMap.of("non_null", expression("true")),
-                                                        values(ImmutableMap.of("a", 0, "b", 1)))))));
+                                        join(LEFT, builder -> builder
+                                                .left(assignUniqueId("unique",
+                                                        values(ImmutableMap.of("corr", 0))))
+                                                .right(project(ImmutableMap.of("non_null", expression("true")),
+                                                        values(ImmutableMap.of("a", 0, "b", 1))))))));
     }
 
     @Test
@@ -193,18 +190,18 @@ public class TestTransformCorrelatedGlobalAggregationWithoutProjection
                                                 ImmutableMap.of(),
                                                 Optional.empty(),
                                                 SINGLE,
-                                                join(
-                                                        LEFT,
-                                                        ImmutableList.of(),
-                                                        Optional.of("b > corr"),
-                                                        assignUniqueId(
-                                                                "unique",
-                                                                values("corr")),
-                                                        project(
-                                                                ImmutableMap.of("non_null", expression("true")),
-                                                                filter(
-                                                                        "true",
-                                                                        values("a", "b"))))))));
+                                                join(LEFT, builder -> builder
+                                                        .filter("b > corr")
+                                                        .left(
+                                                                assignUniqueId(
+                                                                        "unique",
+                                                                        values("corr")))
+                                                        .right(
+                                                                project(
+                                                                        ImmutableMap.of("non_null", expression("true")),
+                                                                        filter(
+                                                                                "true",
+                                                                                values("a", "b")))))))));
     }
 
     @Test
@@ -234,23 +231,23 @@ public class TestTransformCorrelatedGlobalAggregationWithoutProjection
                                         ImmutableList.of("non_null"),
                                         Optional.empty(),
                                         SINGLE,
-                                        join(
-                                                LEFT,
-                                                ImmutableList.of(),
-                                                Optional.of("b = corr"),
-                                                assignUniqueId(
-                                                        "unique",
-                                                        values("corr")),
-                                                project(
-                                                        ImmutableMap.of("non_null", expression("true")),
-                                                        aggregation(
-                                                                singleGroupingSet("a", "b"),
-                                                                ImmutableMap.of(),
-                                                                Optional.empty(),
-                                                                SINGLE,
-                                                                filter(
-                                                                        "true",
-                                                                        values("a", "b"))))))));
+                                        join(LEFT, builder -> builder
+                                                .filter("b = corr")
+                                                .left(
+                                                        assignUniqueId(
+                                                                "unique",
+                                                                values("corr")))
+                                                .right(
+                                                        project(
+                                                                ImmutableMap.of("non_null", expression("true")),
+                                                                aggregation(
+                                                                        singleGroupingSet("a", "b"),
+                                                                        ImmutableMap.of(),
+                                                                        Optional.empty(),
+                                                                        SINGLE,
+                                                                        filter(
+                                                                                "true",
+                                                                                values("a", "b")))))))));
     }
 
     @Test
@@ -275,11 +272,10 @@ public class TestTransformCorrelatedGlobalAggregationWithoutProjection
                                         SINGLE,
                                         project(
                                                 ImmutableMap.of("new_mask", expression("mask AND non_null")),
-                                                join(JoinNode.Type.LEFT,
-                                                        ImmutableList.of(),
-                                                        assignUniqueId("unique",
-                                                                values(ImmutableMap.of("corr", 0))),
-                                                        project(ImmutableMap.of("non_null", expression("true")),
-                                                                values(ImmutableMap.of("a", 0, "mask", 1))))))));
+                                                join(LEFT, builder -> builder
+                                                        .left(assignUniqueId("unique",
+                                                                values(ImmutableMap.of("corr", 0))))
+                                                        .right(project(ImmutableMap.of("non_null", expression("true")),
+                                                                values(ImmutableMap.of("a", 0, "mask", 1)))))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedGroupedAggregationWithProjection.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedGroupedAggregationWithProjection.java
@@ -18,7 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
 import io.trino.sql.planner.plan.Assignments;
-import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.JoinNode.Type;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
@@ -91,16 +91,16 @@ public class TestTransformCorrelatedGroupedAggregationWithProjection
                                         ImmutableMap.of(Optional.of("sum_agg"), functionCall("sum", ImmutableList.of("a")), Optional.of("count_agg"), functionCall("count", ImmutableList.of())),
                                         Optional.empty(),
                                         SINGLE,
-                                        join(
-                                                JoinNode.Type.INNER,
-                                                ImmutableList.of(),
-                                                Optional.of("b > corr"),
-                                                assignUniqueId(
-                                                        "unique",
-                                                        values("corr")),
-                                                filter(
-                                                        "true",
-                                                        values("a", "b"))))));
+                                        join(Type.INNER, builder -> builder
+                                                .filter("b > corr")
+                                                .left(
+                                                        assignUniqueId(
+                                                                "unique",
+                                                                values("corr")))
+                                                .right(
+                                                        filter(
+                                                                "true",
+                                                                values("a", "b")))))));
     }
 
     @Test
@@ -135,16 +135,16 @@ public class TestTransformCorrelatedGroupedAggregationWithProjection
                                                 ImmutableMap.of(),
                                                 Optional.empty(),
                                                 SINGLE,
-                                                join(
-                                                        JoinNode.Type.INNER,
-                                                        ImmutableList.of(),
-                                                        Optional.of("b > corr"),
-                                                        assignUniqueId(
-                                                                "unique",
-                                                                values("corr")),
-                                                        filter(
-                                                                "true",
-                                                                values("a", "b")))))));
+                                                join(Type.INNER, builder -> builder
+                                                        .filter("b > corr")
+                                                        .left(
+                                                                assignUniqueId(
+                                                                        "unique",
+                                                                        values("corr")))
+                                                        .right(
+                                                                filter(
+                                                                        "true",
+                                                                        values("a", "b"))))))));
     }
 
     @Test
@@ -176,20 +176,20 @@ public class TestTransformCorrelatedGroupedAggregationWithProjection
                                         ImmutableMap.of(Optional.of("sum_agg"), functionCall("sum", ImmutableList.of("a")), Optional.of("count_agg"), functionCall("count", ImmutableList.of())),
                                         Optional.empty(),
                                         SINGLE,
-                                        join(
-                                                JoinNode.Type.INNER,
-                                                ImmutableList.of(),
-                                                Optional.of("b = corr"),
-                                                assignUniqueId(
-                                                        "unique",
-                                                        values("corr")),
-                                                aggregation(
-                                                        singleGroupingSet("a", "b"),
-                                                        ImmutableMap.of(),
-                                                        Optional.empty(),
-                                                        SINGLE,
-                                                        filter(
-                                                                "true",
-                                                                values("a", "b")))))));
+                                        join(Type.INNER, builder -> builder
+                                                .filter("b = corr")
+                                                .left(
+                                                        assignUniqueId(
+                                                                "unique",
+                                                                values("corr")))
+                                                .right(
+                                                        aggregation(
+                                                                singleGroupingSet("a", "b"),
+                                                                ImmutableMap.of(),
+                                                                Optional.empty(),
+                                                                SINGLE,
+                                                                filter(
+                                                                        "true",
+                                                                        values("a", "b"))))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedGroupedAggregationWithoutProjection.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedGroupedAggregationWithoutProjection.java
@@ -17,7 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
-import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.JoinNode.Type;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
@@ -86,16 +86,16 @@ public class TestTransformCorrelatedGroupedAggregationWithoutProjection
                                         ImmutableMap.of(Optional.of("sum_agg"), functionCall("sum", ImmutableList.of("a")), Optional.of("count_agg"), functionCall("count", ImmutableList.of())),
                                         Optional.empty(),
                                         SINGLE,
-                                        join(
-                                                JoinNode.Type.INNER,
-                                                ImmutableList.of(),
-                                                Optional.of("b > corr"),
-                                                assignUniqueId(
-                                                        "unique",
-                                                        values("corr")),
-                                                filter(
-                                                        "true",
-                                                        values("a", "b"))))));
+                                        join(Type.INNER, builder -> builder
+                                                .filter("b > corr")
+                                                .left(
+                                                        assignUniqueId(
+                                                                "unique",
+                                                                values("corr")))
+                                                .right(
+                                                        filter(
+                                                                "true",
+                                                                values("a", "b")))))));
     }
 
     @Test
@@ -128,16 +128,16 @@ public class TestTransformCorrelatedGroupedAggregationWithoutProjection
                                                 ImmutableMap.of(),
                                                 Optional.empty(),
                                                 SINGLE,
-                                                join(
-                                                        JoinNode.Type.INNER,
-                                                        ImmutableList.of(),
-                                                        Optional.of("b > corr"),
-                                                        assignUniqueId(
-                                                                "unique",
-                                                                values("corr")),
-                                                        filter(
-                                                                "true",
-                                                                values("a", "b")))))));
+                                                join(Type.INNER, builder -> builder
+                                                        .filter("b > corr")
+                                                        .left(
+                                                                assignUniqueId(
+                                                                        "unique",
+                                                                        values("corr")))
+                                                        .right(
+                                                                filter(
+                                                                        "true",
+                                                                        values("a", "b"))))))));
     }
 
     @Test
@@ -167,20 +167,20 @@ public class TestTransformCorrelatedGroupedAggregationWithoutProjection
                                         ImmutableMap.of(Optional.of("sum_agg"), functionCall("sum", ImmutableList.of("a")), Optional.of("count_agg"), functionCall("count", ImmutableList.of())),
                                         Optional.empty(),
                                         SINGLE,
-                                        join(
-                                                JoinNode.Type.INNER,
-                                                ImmutableList.of(),
-                                                Optional.of("b = corr"),
-                                                assignUniqueId(
-                                                        "unique",
-                                                        values("corr")),
-                                                aggregation(
-                                                        singleGroupingSet("a", "b"),
-                                                        ImmutableMap.of(),
-                                                        Optional.empty(),
-                                                        SINGLE,
-                                                        filter(
-                                                                "true",
-                                                                values("a", "b")))))));
+                                        join(Type.INNER, builder -> builder
+                                                .filter("b = corr")
+                                                .left(
+                                                        assignUniqueId(
+                                                                "unique",
+                                                                values("corr")))
+                                                .right(
+                                                        aggregation(
+                                                                singleGroupingSet("a", "b"),
+                                                                ImmutableMap.of(),
+                                                                Optional.empty(),
+                                                                SINGLE,
+                                                                filter(
+                                                                        "true",
+                                                                        values("a", "b"))))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedJoinToJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedJoinToJoin.java
@@ -16,12 +16,10 @@ package io.trino.sql.planner.iterative.rule;
 import com.google.common.collect.ImmutableList;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
-import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.JoinNode.Type;
 import io.trino.sql.tree.ComparisonExpression;
 import io.trino.sql.tree.LongLiteral;
 import org.testng.annotations.Test;
-
-import java.util.Optional;
 
 import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
@@ -53,14 +51,13 @@ public class TestTransformCorrelatedJoinToJoin
                                     p.values(b)));
                 })
                 .matches(
-                        join(
-                                JoinNode.Type.INNER,
-                                ImmutableList.of(),
-                                Optional.of("b > a"),
-                                values("a"),
-                                filter(
-                                        TRUE_LITERAL,
-                                        values("b"))));
+                        join(Type.INNER, builder -> builder
+                                .filter("b > a")
+                                .left(values("a"))
+                                .right(
+                                        filter(
+                                                TRUE_LITERAL,
+                                                values("b")))));
 
         tester().assertThat(new TransformCorrelatedJoinToJoin(tester().getPlannerContext()))
                 .on(p -> {
@@ -82,14 +79,13 @@ public class TestTransformCorrelatedJoinToJoin
                                     p.values(b)));
                 })
                 .matches(
-                        join(
-                                JoinNode.Type.INNER,
-                                ImmutableList.of(),
-                                Optional.of("b > a AND b < 3"),
-                                values("a"),
-                                filter(
-                                        TRUE_LITERAL,
-                                        values("b"))));
+                        join(Type.INNER, builder -> builder
+                                .filter("b > a AND b < 3")
+                                .left(values("a"))
+                                .right(
+                                        filter(
+                                                TRUE_LITERAL,
+                                                values("b")))));
     }
 
     @Test
@@ -112,14 +108,13 @@ public class TestTransformCorrelatedJoinToJoin
                                     p.values(b)));
                 })
                 .matches(
-                        join(
-                                JoinNode.Type.LEFT,
-                                ImmutableList.of(),
-                                Optional.of("b > a"),
-                                values("a"),
-                                filter(
-                                        TRUE_LITERAL,
-                                        values("b"))));
+                        join(Type.LEFT, builder -> builder
+                                .filter("b > a")
+                                .left(values("a"))
+                                .right(
+                                        filter(
+                                                TRUE_LITERAL,
+                                                values("b")))));
 
         tester().assertThat(new TransformCorrelatedJoinToJoin(tester().getPlannerContext()))
                 .on(p -> {
@@ -141,14 +136,13 @@ public class TestTransformCorrelatedJoinToJoin
                                     p.values(b)));
                 })
                 .matches(
-                        join(
-                                JoinNode.Type.LEFT,
-                                ImmutableList.of(),
-                                Optional.of("b > a AND b < 3"),
-                                values("a"),
-                                filter(
-                                        TRUE_LITERAL,
-                                        values("b"))));
+                        join(Type.LEFT, builder -> builder
+                                .filter("b > a AND b < 3")
+                                .left(values("a"))
+                                .right(
+                                        filter(
+                                                TRUE_LITERAL,
+                                                values("b")))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformFilteringSemiJoinToInnerJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformFilteringSemiJoinToInnerJoin.java
@@ -24,7 +24,6 @@ import org.testng.annotations.Test;
 import java.util.Optional;
 
 import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregation;
-import static io.trino.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.singleGroupingSet;
@@ -58,17 +57,17 @@ public class TestTransformFilteringSemiJoinToInnerJoin
                 })
                 .matches(project(
                         ImmutableMap.of("a", PlanMatchPattern.expression("a"), "a_in_b", PlanMatchPattern.expression("true")),
-                        join(
-                                INNER,
-                                ImmutableList.of(equiJoinClause("a", "b")),
-                                Optional.of("a > 5"),
-                                values("a"),
-                                aggregation(
-                                        singleGroupingSet("b"),
-                                        ImmutableMap.of(),
-                                        Optional.empty(),
-                                        SINGLE,
-                                        values("b")))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("a", "b")
+                                .filter("a > 5")
+                                .left(values("a"))
+                                .right(
+                                        aggregation(
+                                                singleGroupingSet("b"),
+                                                ImmutableMap.of(),
+                                                Optional.empty(),
+                                                SINGLE,
+                                                values("b"))))));
     }
 
     @Test
@@ -93,17 +92,16 @@ public class TestTransformFilteringSemiJoinToInnerJoin
                 })
                 .matches(project(
                         ImmutableMap.of("a", PlanMatchPattern.expression("a"), "a_in_b", PlanMatchPattern.expression("true")),
-                        join(
-                                INNER,
-                                ImmutableList.of(equiJoinClause("a", "b")),
-                                Optional.empty(),
-                                values("a"),
-                                aggregation(
-                                        singleGroupingSet("b"),
-                                        ImmutableMap.of(),
-                                        Optional.empty(),
-                                        SINGLE,
-                                        values("b")))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("a", "b")
+                                .left(values("a"))
+                                .right(
+                                        aggregation(
+                                                singleGroupingSet("b"),
+                                                ImmutableMap.of(),
+                                                Optional.empty(),
+                                                SINGLE,
+                                                values("b"))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestUseNonPartitionedJoinLookupSource.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestUseNonPartitionedJoinLookupSource.java
@@ -65,11 +65,9 @@ public class TestUseNonPartitionedJoinLookupSource
                             repartitioningExchange(p, b, p.values(b)));
                 })
                 .matches(
-                        join(
-                                INNER,
-                                ImmutableList.of(),
-                                values("a"),
-                                exchange(LOCAL, GATHER, values("b"))));
+                        join(INNER, builder -> builder
+                                .left(values("a"))
+                                .right(exchange(LOCAL, GATHER, values("b")))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestAddExchangesPlans.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestAddExchangesPlans.java
@@ -52,7 +52,6 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.any;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyNot;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anySymbol;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
-import static io.trino.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.exchange;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
@@ -141,34 +140,40 @@ public class TestAddExchangesPlans
         assertDistributedPlan("SELECT * FROM (SELECT nationkey FROM nation UNION ALL select nationkey from nation) n join region r on n.nationkey = r.regionkey",
                 session,
                 anyTree(
-                        join(INNER, ImmutableList.of(equiJoinClause("nationkey", "regionkey")),
-                                anyTree(
-                                        exchange(REMOTE, REPARTITION,
-                                                anyTree(
-                                                        tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))),
-                                        exchange(REMOTE, REPARTITION,
-                                                anyTree(
-                                                        tableScan("nation")))),
-                                anyTree(
-                                        exchange(REMOTE, REPARTITION,
-                                                anyTree(
-                                                        tableScan("region", ImmutableMap.of("regionkey", "regionkey"))))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("nationkey", "regionkey")
+                                .left(
+                                        anyTree(
+                                                exchange(REMOTE, REPARTITION,
+                                                        anyTree(
+                                                                tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))),
+                                                exchange(REMOTE, REPARTITION,
+                                                        anyTree(
+                                                                tableScan("nation")))))
+                                .right(
+                                        anyTree(
+                                                exchange(REMOTE, REPARTITION,
+                                                        anyTree(
+                                                                tableScan("region", ImmutableMap.of("regionkey", "regionkey")))))))));
 
         assertDistributedPlan("SELECT * FROM (SELECT nationkey FROM nation UNION ALL select 1) n join region r on n.nationkey = r.regionkey",
                 session,
                 anyTree(
-                        join(INNER, ImmutableList.of(equiJoinClause("nationkey", "regionkey")),
-                                anyTree(
-                                        exchange(REMOTE, REPARTITION,
-                                                anyTree(
-                                                        tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))),
-                                        exchange(REMOTE, REPARTITION,
-                                                project(
-                                                        values(ImmutableList.of("expr"), ImmutableList.of(ImmutableList.of(new GenericLiteral("BIGINT", "1"))))))),
-                                anyTree(
-                                        exchange(REMOTE, REPARTITION,
-                                                anyTree(
-                                                        tableScan("region", ImmutableMap.of("regionkey", "regionkey"))))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("nationkey", "regionkey")
+                                .left(
+                                        anyTree(
+                                                exchange(REMOTE, REPARTITION,
+                                                        anyTree(
+                                                                tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))),
+                                                exchange(REMOTE, REPARTITION,
+                                                        project(
+                                                                values(ImmutableList.of("expr"), ImmutableList.of(ImmutableList.of(new GenericLiteral("BIGINT", "1"))))))))
+                                .right(
+                                        anyTree(
+                                                exchange(REMOTE, REPARTITION,
+                                                        anyTree(
+                                                                tableScan("region", ImmutableMap.of("regionkey", "regionkey")))))))));
     }
 
     @Test
@@ -178,28 +183,37 @@ public class TestAddExchangesPlans
                 "SELECT * FROM nation n join region r on n.nationkey = r.regionkey",
                 noJoinReordering(),
                 anyTree(
-                        join(INNER, ImmutableList.of(equiJoinClause("nationkey", "regionkey")), Optional.empty(), Optional.of(REPLICATED), Optional.of(false),
-                                anyNot(ExchangeNode.class,
-                                        node(
-                                                FilterNode.class,
-                                                tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))),
-                                anyTree(
-                                        exchange(REMOTE, REPLICATE,
-                                                anyTree(
-                                                        tableScan("region", ImmutableMap.of("regionkey", "regionkey"))))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("nationkey", "regionkey")
+                                .distributionType(REPLICATED)
+                                .spillable(false)
+                                .left(
+                                        anyNot(ExchangeNode.class,
+                                                node(
+                                                        FilterNode.class,
+                                                        tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))))
+                                .right(
+                                        anyTree(
+                                                exchange(REMOTE, REPLICATE,
+                                                        anyTree(
+                                                                tableScan("region", ImmutableMap.of("regionkey", "regionkey")))))))));
 
         assertDistributedPlan(
                 "SELECT * FROM nation n join region r on n.nationkey = r.regionkey",
                 spillEnabledWithJoinDistributionType(PARTITIONED),
                 anyTree(
-                        join(INNER, ImmutableList.of(equiJoinClause("nationkey", "regionkey")), Optional.empty(), Optional.of(DistributionType.PARTITIONED), Optional.empty(),
-                                exchange(REMOTE, REPARTITION,
-                                        anyTree(
-                                                tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))),
-                                exchange(LOCAL, GATHER,
+                        join(INNER, builder -> builder
+                                .equiCriteria("nationkey", "regionkey")
+                                .distributionType(DistributionType.PARTITIONED)
+                                .left(
                                         exchange(REMOTE, REPARTITION,
                                                 anyTree(
-                                                        tableScan("region", ImmutableMap.of("regionkey", "regionkey"))))))));
+                                                        tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))))
+                                .right(
+                                        exchange(LOCAL, GATHER,
+                                                exchange(REMOTE, REPARTITION,
+                                                        anyTree(
+                                                                tableScan("region", ImmutableMap.of("regionkey", "regionkey")))))))));
     }
 
     @Test
@@ -458,15 +472,18 @@ public class TestAddExchangesPlans
                 "SELECT * FROM nation n join region r on n.nationkey = r.regionkey",
                 noJoinReordering(),
                 anyTree(
-                        join(INNER, ImmutableList.of(equiJoinClause("nationkey", "regionkey")),
-                                anyNot(ExchangeNode.class,
-                                        node(
-                                                FilterNode.class,
-                                                tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))),
-                                exchange(LOCAL, GATHER,
-                                        exchange(REMOTE, REPLICATE,
-                                                anyTree(
-                                                        tableScan("region", ImmutableMap.of("regionkey", "regionkey"))))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("nationkey", "regionkey")
+                                .left(
+                                        anyNot(ExchangeNode.class,
+                                                node(
+                                                        FilterNode.class,
+                                                        tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))))
+                                .right(
+                                        exchange(LOCAL, GATHER,
+                                                exchange(REMOTE, REPLICATE,
+                                                        anyTree(
+                                                                tableScan("region", ImmutableMap.of("regionkey", "regionkey")))))))));
 
         // build side bigger than threshold, local partitioned exchanged expected
         assertDistributedPlan(
@@ -475,37 +492,45 @@ public class TestAddExchangesPlans
                         .setSystemProperty(JOIN_PARTITIONED_BUILD_MIN_ROW_COUNT, "1")
                         .build(),
                 anyTree(
-                        join(INNER, ImmutableList.of(equiJoinClause("nationkey", "regionkey")),
-                                anyNot(ExchangeNode.class,
-                                        node(
-                                                FilterNode.class,
-                                                tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))),
-                                exchange(LOCAL, REPARTITION,
-                                        exchange(REMOTE, REPLICATE,
-                                                anyTree(
-                                                        tableScan("region", ImmutableMap.of("regionkey", "regionkey"))))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("nationkey", "regionkey")
+                                .left(
+                                        anyNot(ExchangeNode.class,
+                                                node(
+                                                        FilterNode.class,
+                                                        tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))))
+                                .right(
+                                        exchange(LOCAL, REPARTITION,
+                                                exchange(REMOTE, REPLICATE,
+                                                        anyTree(
+                                                                tableScan("region", ImmutableMap.of("regionkey", "regionkey")))))))));
         // build side contains join, local partitioned exchanged expected
         assertDistributedPlan(
                 "SELECT * FROM nation n join (select r.regionkey from region r join region r2 on r.regionkey = r2.regionkey) j on n.nationkey = j.regionkey ",
                 noJoinReordering(),
                 anyTree(
-                        join(INNER, ImmutableList.of(equiJoinClause("nationkey", "regionkey2")),
-                                anyNot(ExchangeNode.class,
-                                        node(
-                                                FilterNode.class,
-                                                tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))),
-                                exchange(LOCAL, REPARTITION,
-                                        exchange(REMOTE, REPLICATE,
-                                                join(INNER, ImmutableList.of(equiJoinClause("regionkey2", "regionkey1")),
-                                                        anyNot(ExchangeNode.class,
-                                                                node(
-                                                                        FilterNode.class,
-                                                                        tableScan("region", ImmutableMap.of("regionkey2", "regionkey")))),
-                                                        exchange(LOCAL, GATHER,
-
-                                                                exchange(REMOTE, REPLICATE,
-                                                                        anyTree(
-                                                                                tableScan("region", ImmutableMap.of("regionkey1", "regionkey")))))))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("nationkey", "regionkey2")
+                                .left(
+                                        anyNot(ExchangeNode.class,
+                                                node(
+                                                        FilterNode.class,
+                                                        tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))))
+                                .right(
+                                        exchange(LOCAL, REPARTITION,
+                                                exchange(REMOTE, REPLICATE,
+                                                        join(INNER, rightJoinBuilder -> rightJoinBuilder
+                                                                .equiCriteria("regionkey2", "regionkey1")
+                                                                .left(
+                                                                        anyNot(ExchangeNode.class,
+                                                                                node(
+                                                                                        FilterNode.class,
+                                                                                        tableScan("region", ImmutableMap.of("regionkey2", "regionkey")))))
+                                                                .right(
+                                                                        exchange(LOCAL, GATHER,
+                                                                                exchange(REMOTE, REPLICATE,
+                                                                                        anyTree(
+                                                                                                tableScan("region", ImmutableMap.of("regionkey1", "regionkey")))))))))))));
 
         // build side smaller than threshold, but stats not available. local partitioned exchanged expected
         assertDistributedPlan(
@@ -514,15 +539,18 @@ public class TestAddExchangesPlans
                         .setSystemProperty(ENABLE_STATS_CALCULATOR, "false")
                         .build(),
                 anyTree(
-                        join(INNER, ImmutableList.of(equiJoinClause("nationkey", "regionkey")),
-                                anyNot(ExchangeNode.class,
-                                        node(
-                                                FilterNode.class,
-                                                tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))),
-                                exchange(LOCAL, REPARTITION,
-                                        exchange(REMOTE, REPLICATE,
-                                                anyTree(
-                                                        tableScan("region", ImmutableMap.of("regionkey", "regionkey"))))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("nationkey", "regionkey")
+                                .left(
+                                        anyNot(ExchangeNode.class,
+                                                node(
+                                                        FilterNode.class,
+                                                        tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))))
+                                .right(
+                                        exchange(LOCAL, REPARTITION,
+                                                exchange(REMOTE, REPLICATE,
+                                                        anyTree(
+                                                                tableScan("region", ImmutableMap.of("regionkey", "regionkey")))))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestEliminateCrossJoins.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestEliminateCrossJoins.java
@@ -13,17 +13,13 @@
  */
 package io.trino.sql.planner.optimizations;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.SystemSessionProperties;
 import io.trino.sql.planner.assertions.BasePlanTest;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
 import org.testng.annotations.Test;
 
-import java.util.Optional;
-
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
-import static io.trino.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
@@ -69,12 +65,15 @@ public class TestEliminateCrossJoins
     {
         assertPlan("SELECT * FROM part p, orders o, lineitem l WHERE p.partkey = l.partkey AND l.orderkey = o.orderkey",
                 anyTree(
-                        join(INNER, ImmutableList.of(equiJoinClause("L_ORDERKEY", "O_ORDERKEY")),
-                                anyTree(
-                                        join(INNER, ImmutableList.of(equiJoinClause("P_PARTKEY", "L_PARTKEY")),
-                                                anyTree(PART_TABLESCAN),
-                                                anyTree(LINEITEM_TABLESCAN))),
-                                anyTree(ORDERS_TABLESCAN))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("L_ORDERKEY", "O_ORDERKEY")
+                                .left(
+                                        anyTree(
+                                                join(INNER, leftJoinBuilder -> leftJoinBuilder
+                                                        .equiCriteria("P_PARTKEY", "L_PARTKEY")
+                                                        .left(anyTree(PART_TABLESCAN))
+                                                        .right(anyTree(LINEITEM_TABLESCAN)))))
+                                .right(anyTree(ORDERS_TABLESCAN)))));
     }
 
     @Test
@@ -84,14 +83,19 @@ public class TestEliminateCrossJoins
                         "FROM (orders o1 JOIN orders o2 ON o1.orderkey = o2.orderkey) " +
                         "JOIN (orders o3 JOIN orders o4 ON o3.orderkey = o4.orderkey) ON o1.orderkey = o3.orderkey",
                 anyTree(
-                        join(INNER, ImmutableList.of(equiJoinClause("O1_ORDERKEY", "O3_ORDERKEY")),
-                                join(INNER, ImmutableList.of(equiJoinClause("O1_ORDERKEY", "O2_ORDERKEY")),
-                                        anyTree(strictTableScan("orders", ImmutableMap.of("O1_ORDERKEY", "orderkey"))),
-                                        anyTree(strictTableScan("orders", ImmutableMap.of("O2_ORDERKEY", "orderkey", "O2_CUSTKEY", "custkey")))),
-                                anyTree(
-                                        join(INNER, ImmutableList.of(equiJoinClause("O3_ORDERKEY", "O4_ORDERKEY")),
-                                                anyTree(strictTableScan("orders", ImmutableMap.of("O3_ORDERKEY", "orderkey", "O3_ORDERSTATUS", "orderstatus"))),
-                                                anyTree(strictTableScan("orders", ImmutableMap.of("O4_ORDERKEY", "orderkey", "O4_totalprice", "totalprice"))))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("O1_ORDERKEY", "O3_ORDERKEY")
+                                .left(
+                                        join(INNER, leftJoinBuilder -> leftJoinBuilder
+                                                .equiCriteria("O1_ORDERKEY", "O2_ORDERKEY")
+                                                .left(anyTree(strictTableScan("orders", ImmutableMap.of("O1_ORDERKEY", "orderkey"))))
+                                                .right(anyTree(strictTableScan("orders", ImmutableMap.of("O2_ORDERKEY", "orderkey", "O2_CUSTKEY", "custkey"))))))
+                                .right(
+                                        anyTree(
+                                                join(INNER, rightJoinBuilder -> rightJoinBuilder
+                                                        .equiCriteria("O3_ORDERKEY", "O4_ORDERKEY")
+                                                        .left(anyTree(strictTableScan("orders", ImmutableMap.of("O3_ORDERKEY", "orderkey", "O3_ORDERSTATUS", "orderstatus"))))
+                                                        .right(anyTree(strictTableScan("orders", ImmutableMap.of("O4_ORDERKEY", "orderkey", "O4_totalprice", "totalprice"))))))))));
     }
 
     @Test
@@ -99,12 +103,15 @@ public class TestEliminateCrossJoins
     {
         assertPlan("SELECT o.orderkey FROM part p, orders o, lineitem l WHERE l.orderkey = o.orderkey",
                 anyTree(
-                        join(INNER, ImmutableList.of(equiJoinClause("O_ORDERKEY", "L_ORDERKEY")),
-                                anyTree(
-                                        join(INNER, ImmutableList.of(),
-                                                tableScan("part"),
-                                                anyTree(tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))))),
-                                anyTree(tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey"))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("O_ORDERKEY", "L_ORDERKEY")
+                                .left(
+                                        anyTree(
+                                                join(INNER, leftJoinBuilder -> leftJoinBuilder
+                                                        .left(tableScan("part"))
+                                                        .right(anyTree(tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey")))))))
+                                .right(
+                                        anyTree(tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey")))))));
     }
 
     @Test
@@ -115,20 +122,21 @@ public class TestEliminateCrossJoins
         assertPlan("SELECT o.orderkey FROM part p, orders o, lineitem l " +
                         "WHERE p.partkey = l.partkey AND l.orderkey = o.orderkey AND p.partkey <> o.orderkey AND p.name < l.comment",
                 anyTree(
-                        join(INNER, ImmutableList.of(equiJoinClause("L_ORDERKEY", "O_ORDERKEY")),
-                                anyTree(
-                                        join(
-                                                INNER,
-                                                ImmutableList.of(equiJoinClause("P_PARTKEY", "L_PARTKEY")),
-                                                Optional.of("P_NAME < expr"),
-                                                anyTree(PART_WITH_NAME_TABLESCAN),
-                                                anyTree(
-                                                        project(
-                                                                ImmutableMap.of("expr", expression("cast(L_COMMENT AS varchar(55))")),
-                                                                filter(
-                                                                        "L_PARTKEY <> L_ORDERKEY",
-                                                                        LINEITEM_WITH_COMMENT_TABLESCAN))))),
-                                anyTree(ORDERS_TABLESCAN))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("L_ORDERKEY", "O_ORDERKEY")
+                                .left(
+                                        anyTree(
+                                                join(INNER, leftJoinBuilder -> leftJoinBuilder
+                                                        .equiCriteria("P_PARTKEY", "L_PARTKEY")
+                                                        .filter("P_NAME < expr")
+                                                        .left(anyTree(PART_WITH_NAME_TABLESCAN))
+                                                        .right(
+                                                                anyTree(
+                                                                        project(
+                                                                                ImmutableMap.of("expr", expression("cast(L_COMMENT AS varchar(55))")),
+                                                                                filter("L_PARTKEY <> L_ORDERKEY",
+                                                                                        LINEITEM_WITH_COMMENT_TABLESCAN)))))))
+                                .right(anyTree(ORDERS_TABLESCAN)))));
     }
 
     @Test
@@ -136,11 +144,16 @@ public class TestEliminateCrossJoins
     {
         assertPlan("SELECT o.orderkey FROM part p, orders o, lineitem l " +
                         "WHERE p.partkey = l.partkey AND l.orderkey = o.orderkey AND l.returnflag = 'R' AND shippriority >= 10",
-                anyTree(join(INNER, ImmutableList.of(equiJoinClause("L_ORDERKEY", "O_ORDERKEY")),
-                        anyTree(
-                                join(INNER, ImmutableList.of(equiJoinClause("P_PARTKEY", "L_PARTKEY")),
-                                        anyTree(PART_TABLESCAN),
-                                        anyTree(filter("L_RETURNFLAG = 'R'", LINEITEM_WITH_RETURNFLAG_TABLESCAN)))),
-                        anyTree(filter("O_SHIPPRIORITY >= 10", ORDERS_WITH_SHIPPRIORITY_TABLESCAN)))));
+                anyTree(
+                        join(INNER, builder -> builder
+                                .equiCriteria("L_ORDERKEY", "O_ORDERKEY")
+                                .left(
+                                        anyTree(
+                                                join(INNER, leftJoinBuilder -> leftJoinBuilder
+                                                        .equiCriteria("P_PARTKEY", "L_PARTKEY")
+                                                        .left(anyTree(PART_TABLESCAN))
+                                                        .right(anyTree(filter("L_RETURNFLAG = 'R'", LINEITEM_WITH_RETURNFLAG_TABLESCAN))))))
+                                .right(
+                                        anyTree(filter("O_SHIPPRIORITY >= 10", ORDERS_WITH_SHIPPRIORITY_TABLESCAN))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestMergeWindows.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestMergeWindows.java
@@ -25,7 +25,6 @@ import io.trino.sql.planner.iterative.IterativeOptimizer;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.iterative.rule.GatherAndMergeWindows;
 import io.trino.sql.planner.iterative.rule.RemoveRedundantIdentityProjections;
-import io.trino.sql.planner.plan.JoinNode;
 import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.tree.FrameBound;
 import io.trino.sql.tree.WindowFrame;
@@ -48,6 +47,7 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.specification;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.window;
+import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
 
 public class TestMergeWindows
         extends BasePlanTest
@@ -469,19 +469,19 @@ public class TestMergeWindows
         assertUnitPlan(sql,
                 anyTree(
                         filter("SUM = AVG",
-                                join(JoinNode.Type.INNER, ImmutableList.of(),
-                                        any(
-                                                window(windowMatcherBuilder -> windowMatcherBuilder
-                                                                .specification(leftSpecification)
-                                                                .addFunction("SUM", functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS))),
-                                                        any(
-                                                                leftTableScan))),
-                                        any(
-                                                window(windowMatcherBuilder -> windowMatcherBuilder
-                                                                .specification(rightSpecification)
-                                                                .addFunction("AVG", functionCall("avg", COMMON_FRAME, ImmutableList.of(rQuantityAlias))),
-                                                        any(
-                                                                rightTableScan)))))));
+                                join(INNER, builder -> builder
+                                        .left(
+                                                any(
+                                                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                                                        .specification(leftSpecification)
+                                                                        .addFunction("SUM", functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS))),
+                                                                any(leftTableScan))))
+                                        .right(
+                                                any(
+                                                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                                                        .specification(rightSpecification)
+                                                                        .addFunction("AVG", functionCall("avg", COMMON_FRAME, ImmutableList.of(rQuantityAlias))),
+                                                                any(rightTableScan))))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
@@ -54,7 +54,6 @@ import static io.trino.sql.DynamicFilters.createDynamicFilterExpression;
 import static io.trino.sql.ExpressionUtils.combineConjuncts;
 import static io.trino.sql.ExpressionUtils.combineDisjuncts;
 import static io.trino.sql.planner.TypeAnalyzer.createTestingTypeAnalyzer;
-import static io.trino.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.output;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.semiJoin;
@@ -116,15 +115,15 @@ public class TestRemoveUnsupportedDynamicFilters
                 ImmutableMap.of(new DynamicFilterId("DF"), lineitemOrderKeySymbol));
         assertPlan(
                 removeUnsupportedDynamicFilters(root),
-                join(
-                        INNER,
-                        ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
-                        ImmutableMap.of(),
-                        PlanMatchPattern.filter(
-                                expression("ORDERS_OK > 0"),
-                                TRUE_LITERAL,
-                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
-                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))));
+                join(INNER, builder -> builder
+                        .equiCriteria("ORDERS_OK", "LINEITEM_OK")
+                        .left(
+                                PlanMatchPattern.filter(
+                                        expression("ORDERS_OK > 0"),
+                                        TRUE_LITERAL,
+                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))
+                        .right(
+                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))));
     }
 
     @Test
@@ -148,15 +147,16 @@ public class TestRemoveUnsupportedDynamicFilters
                 ImmutableMap.of(new DynamicFilterId("DF"), lineitemOrderKeySymbol));
         assertPlan(
                 removeUnsupportedDynamicFilters(root),
-                join(
-                        INNER,
-                        ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
-                        ImmutableMap.of("ORDERS_OK", "LINEITEM_OK"),
-                        PlanMatchPattern.filter(
-                                TRUE_LITERAL,
-                                createDynamicFilterExpression(TEST_SESSION, metadata, new DynamicFilterId("DF"), BIGINT, new SymbolReference("ORDERS_OK")),
-                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
-                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))));
+                join(INNER, builder -> builder
+                        .equiCriteria("ORDERS_OK", "LINEITEM_OK")
+                        .dynamicFilter("ORDERS_OK", "LINEITEM_OK")
+                        .left(
+                                PlanMatchPattern.filter(
+                                        TRUE_LITERAL,
+                                        createDynamicFilterExpression(TEST_SESSION, metadata, new DynamicFilterId("DF"), BIGINT, new SymbolReference("ORDERS_OK")),
+                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))
+                        .right(
+                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))));
     }
 
     @Test
@@ -184,14 +184,14 @@ public class TestRemoveUnsupportedDynamicFilters
         assertPlan(
                 removeUnsupportedDynamicFilters(root),
                 output(
-                        join(
-                                INNER,
-                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
-                                ImmutableMap.of(),
-                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")),
-                                filter(
-                                        expression("LINEITEM_OK > 0"),
-                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("ORDERS_OK", "LINEITEM_OK")
+                                .left(
+                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))
+                                .right(
+                                        filter(
+                                                expression("LINEITEM_OK > 0"),
+                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
     }
 
     @Test
@@ -219,14 +219,14 @@ public class TestRemoveUnsupportedDynamicFilters
         assertPlan(
                 removeUnsupportedDynamicFilters(root),
                 output(
-                        join(
-                                INNER,
-                                ImmutableList.of(equiJoinClause("LINEITEM_OK", "ORDERS_OK")),
-                                ImmutableMap.of(),
-                                filter(
-                                        expression("LINEITEM_OK > 0"),
-                                        values("LINEITEM_OK")),
-                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("LINEITEM_OK", "ORDERS_OK")
+                                .left(
+                                        filter(
+                                                expression("LINEITEM_OK > 0"),
+                                                values("LINEITEM_OK")))
+                                .right(
+                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))));
     }
 
     @Test
@@ -260,12 +260,12 @@ public class TestRemoveUnsupportedDynamicFilters
         assertPlan(
                 removeUnsupportedDynamicFilters(root),
                 output(
-                        join(
-                                INNER,
-                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
-                                ImmutableMap.of(),
-                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")),
-                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("ORDERS_OK", "LINEITEM_OK")
+                                .left(
+                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))
+                                .right(
+                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))));
     }
 
     @Test
@@ -297,17 +297,17 @@ public class TestRemoveUnsupportedDynamicFilters
         assertPlan(
                 removeUnsupportedDynamicFilters(root),
                 output(
-                        join(
-                                INNER,
-                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
-                                ImmutableMap.of(),
-                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")),
-                                filter(
-                                        combineDisjuncts(
-                                                metadata,
-                                                expression("LINEITEM_OK IS NULL"),
-                                                expression("LINEITEM_OK IS NOT NULL")),
-                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("ORDERS_OK", "LINEITEM_OK")
+                                .left(
+                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))
+                                .right(
+                                        filter(
+                                                combineDisjuncts(
+                                                        metadata,
+                                                        expression("LINEITEM_OK IS NULL"),
+                                                        expression("LINEITEM_OK IS NOT NULL")),
+                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
     }
 
     @Test
@@ -336,12 +336,12 @@ public class TestRemoveUnsupportedDynamicFilters
         assertPlan(
                 removeUnsupportedDynamicFilters(root),
                 output(
-                        join(
-                                INNER,
-                                ImmutableList.of(equiJoinClause("LINEITEM_DOUBLE_OK", "ORDERS_OK")),
-                                ImmutableMap.of(),
-                                tableScan("lineitem", ImmutableMap.of("LINEITEM_DOUBLE_OK", "orderkey")),
-                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("LINEITEM_DOUBLE_OK", "ORDERS_OK")
+                                .left(
+                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_DOUBLE_OK", "orderkey")))
+                                .right(
+                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestUnaliasSymbolReferences.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestUnaliasSymbolReferences.java
@@ -101,18 +101,18 @@ public class TestUnaliasSymbolReferences
                             Optional.empty(),
                             ImmutableMap.of(dynamicFilterId1, buildAlias1, dynamicFilterId2, buildAlias2));
                 },
-                join(
-                        INNER,
-                        ImmutableList.of(),
-                        ImmutableMap.of("probeColumn1", "column", "probeColumn2", "column"),
-                        filter(
-                                TRUE_LITERAL,
+                join(INNER, builder -> builder
+                        .dynamicFilter(ImmutableMap.of("probeColumn1", "column", "probeColumn2", "column"))
+                        .left(
                                 filter(
                                         TRUE_LITERAL,
-                                        tableScan(
-                                                probeTable,
-                                                ImmutableMap.of("probeColumn1", "suppkey", "probeColumn2", "nationkey")))),
-                        project(tableScan(buildTable, ImmutableMap.of("column", "nationkey")))));
+                                        filter(
+                                                TRUE_LITERAL,
+                                                tableScan(
+                                                        probeTable,
+                                                        ImmutableMap.of("probeColumn1", "suppkey", "probeColumn2", "nationkey")))))
+                        .right(
+                                project(tableScan(buildTable, ImmutableMap.of("column", "nationkey"))))));
     }
 
     private void assertOptimizedPlan(PlanOptimizer optimizer, PlanCreator planCreator, PlanMatchPattern pattern)

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJoin.java
@@ -253,10 +253,9 @@ public class TestJoin
                         aggregation(
                                 ImmutableMap.of("COUNT", functionCall("count", ImmutableList.of())),
                                 anyTree(
-                                        join(INNER, ImmutableList.of(),
-                                                anyTree(
-                                                        values("y")),
-                                                values())
+                                        join(INNER, builder -> builder
+                                                .left(anyTree(values("y")))
+                                                .right(values()))
                                                 .with(JoinNode.class, not(JoinNode::isMaySkipOutputDuplicates))))));
 
         assertions.assertQueryAndPlan(
@@ -267,10 +266,9 @@ public class TestJoin
                                 ImmutableMap.of(),
                                 FINAL,
                                 anyTree(
-                                        join(INNER, ImmutableList.of(),
-                                                anyTree(
-                                                        values("y")),
-                                                values())
+                                        join(INNER, builder -> builder
+                                                .left(anyTree(values("y")))
+                                                .right(values()))
                                                 .with(JoinNode.class, JoinNode::isMaySkipOutputDuplicates)))));
     }
 

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoinPlanning.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoinPlanning.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.geospatial;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.DynamicSliceOutput;
 import io.trino.Session;
@@ -30,7 +29,6 @@ import io.trino.spi.block.TestingBlockEncodingSerde;
 import io.trino.sql.planner.assertions.BasePlanTest;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.sql.planner.plan.ExchangeNode;
-import io.trino.sql.planner.plan.JoinNode;
 import io.trino.testing.LocalQueryRunner;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -49,7 +47,6 @@ import static io.trino.spi.predicate.Utils.nativeValueToBlock;
 import static io.trino.sql.planner.LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.any;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
-import static io.trino.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.exchange;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
@@ -59,11 +56,11 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.spatialJoin;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.spatialLeftJoin;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.unnest;
+import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.lang.Math.cos;
 import static java.lang.Math.toRadians;
 import static java.lang.String.format;
-import static java.util.Collections.emptyList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
@@ -360,10 +357,11 @@ public class TestSpatialJoinPlanning
                         "WHERE NOT ST_Contains(ST_GeometryFromText(wkt), ST_Point(lng, lat))",
                 anyTree(
                         filter("NOT ST_Contains(ST_GeometryFromText(cast(wkt as varchar)), ST_Point(lng, lat))",
-                                join(JoinNode.Type.INNER, emptyList(),
-                                        tableScan("points", ImmutableMap.of("lng", "lng", "lat", "lat", "name_a", "name")),
-                                        anyTree(
-                                                tableScan("polygons", ImmutableMap.of("wkt", "wkt", "name_b", "name")))))));
+                                join(INNER, builder -> builder
+                                        .left(tableScan("points", ImmutableMap.of("lng", "lng", "lat", "lat", "name_a", "name")))
+                                        .right(
+                                                anyTree(
+                                                        tableScan("polygons", ImmutableMap.of("wkt", "wkt", "name_b", "name"))))))));
     }
 
     @Test
@@ -377,13 +375,15 @@ public class TestSpatialJoinPlanning
                 anyTree(
                         filter(
                                 "NOT ST_Intersects(ST_GeometryFromText(cast(wkt_a as varchar)), ST_GeometryFromText(cast(wkt_b as varchar)))",
-                                join(JoinNode.Type.INNER, emptyList(),
-                                        project(
-                                                ImmutableMap.of("wkt_a", expression("(CASE WHEN (rand() >= 0E0) THEN 'POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))' END)"), "name_a", expression("'a'")),
-                                                singleRow()),
-                                        any(project(
-                                                ImmutableMap.of("wkt_b", expression("(CASE WHEN (rand() >= 0E0) THEN 'POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))' END)"), "name_b", expression("'a'")),
-                                                singleRow()))))));
+                                join(INNER, builder -> builder
+                                        .left(
+                                                project(
+                                                        ImmutableMap.of("wkt_a", expression("(CASE WHEN (rand() >= 0E0) THEN 'POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))' END)"), "name_a", expression("'a'")),
+                                                        singleRow()))
+                                        .right(
+                                                any(project(
+                                                        ImmutableMap.of("wkt_b", expression("(CASE WHEN (rand() >= 0E0) THEN 'POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))' END)"), "name_b", expression("'a'")),
+                                                        singleRow())))))));
     }
 
     @Test
@@ -393,12 +393,15 @@ public class TestSpatialJoinPlanning
                         "FROM points a, polygons b " +
                         "WHERE a.name = b.name AND ST_Contains(ST_GeometryFromText(wkt), ST_Point(lng, lat))",
                 anyTree(
-                        join(JoinNode.Type.INNER, ImmutableList.of(equiJoinClause("name_a", "name_b")),
-                                Optional.of("ST_Contains(ST_GeometryFromText(cast(wkt as varchar)), ST_Point(lng, lat))"),
-                                anyTree(
-                                        tableScan("points", ImmutableMap.of("lng", "lng", "lat", "lat", "name_a", "name"))),
-                                anyTree(
-                                        tableScan("polygons", ImmutableMap.of("wkt", "wkt", "name_b", "name"))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("name_a", "name_b")
+                                .filter("ST_Contains(ST_GeometryFromText(cast(wkt as varchar)), ST_Point(lng, lat))")
+                                .left(
+                                        anyTree(
+                                                tableScan("points", ImmutableMap.of("lng", "lng", "lat", "lat", "name_a", "name"))))
+                                .right(
+                                        anyTree(
+                                                tableScan("polygons", ImmutableMap.of("wkt", "wkt", "name_b", "name")))))));
     }
 
     @Test
@@ -408,12 +411,15 @@ public class TestSpatialJoinPlanning
                         "FROM polygons a, polygons b " +
                         "WHERE a.name = b.name AND ST_Intersects(ST_GeometryFromText(a.wkt), ST_GeometryFromText(b.wkt))",
                 anyTree(
-                        join(JoinNode.Type.INNER, ImmutableList.of(equiJoinClause("name_a", "name_b")),
-                                Optional.of("ST_Intersects(ST_GeometryFromText(cast(wkt_a as varchar)), ST_GeometryFromText(cast(wkt_b as varchar)))"),
-                                anyTree(
-                                        tableScan("polygons", ImmutableMap.of("wkt_a", "wkt", "name_a", "name"))),
-                                anyTree(
-                                        tableScan("polygons", ImmutableMap.of("wkt_b", "wkt", "name_b", "name"))))));
+                        join(INNER, builder -> builder
+                                .equiCriteria("name_a", "name_b")
+                                .filter("ST_Intersects(ST_GeometryFromText(cast(wkt_a as varchar)), ST_GeometryFromText(cast(wkt_b as varchar)))")
+                                .left(
+                                        anyTree(
+                                                tableScan("polygons", ImmutableMap.of("wkt_a", "wkt", "name_a", "name"))))
+                                .right(
+                                        anyTree(
+                                                tableScan("polygons", ImmutableMap.of("wkt_b", "wkt", "name_b", "name")))))));
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fixes [#5976](https://github.com/trinodb/trino/issues/5976). 

The Builder class was added to make assertions easier to create and remove the overload.


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Clean the test code.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
