### PR TITLE
Support Change Data Feed for delta lake UPDATE queries

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeCDFPageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeCDFPageSink.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.json.JsonCodec;
+import io.airlift.slice.Slice;
+import io.trino.hdfs.HdfsEnvironment;
+import io.trino.spi.Page;
+import io.trino.spi.PageIndexerFactory;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static io.trino.plugin.deltalake.DeltaLakeColumnType.REGULAR;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public class DeltaLakeCDFPageSink
+        extends DeltaLakePageSink
+{
+    public static final String CHANGE_TYPE_COLUMN_NAME = "_change_type";
+
+    private final JsonCodec<DeltaLakeUpdateResult> updateResultJsonCodec;
+
+    private final String tableLocation;
+
+    private final ImmutableList.Builder<DataFileInfo> dataFileInfos = ImmutableList.builder();
+
+    public DeltaLakeCDFPageSink(
+            List<DeltaLakeColumnHandle> inputColumns,
+            List<String> originalPartitionColumns,
+            PageIndexerFactory pageIndexerFactory,
+            HdfsEnvironment hdfsEnvironment,
+            int maxOpenWriters,
+            JsonCodec<DataFileInfo> dataFileInfoCodec,
+            JsonCodec<DeltaLakeUpdateResult> updateResultJsonCodec,
+            String outputPath,
+            String tableLocation,
+            ConnectorSession session,
+            DeltaLakeWriterStats stats,
+            TypeManager typeManager,
+            String trinoVersion)
+    {
+        super(
+                inputColumns,
+                originalPartitionColumns,
+                pageIndexerFactory,
+                hdfsEnvironment,
+                maxOpenWriters,
+                dataFileInfoCodec,
+                outputPath,
+                session,
+                stats,
+                typeManager,
+                trinoVersion);
+
+        this.updateResultJsonCodec = requireNonNull(updateResultJsonCodec, "updateResultJsonCodec is null");
+
+        this.tableLocation = tableLocation;
+    }
+
+    private static Page extractColumns(Page page, int[] columns)
+    {
+        Block[] blocks = new Block[columns.length];
+        for (int i = 0; i < columns.length; i++) {
+            int dataColumn = columns[i];
+            blocks[i] = page.getBlock(dataColumn);
+        }
+        return new Page(page.getPositionCount(), blocks);
+    }
+
+    @Override
+    protected void processSynthesizedColumn(DeltaLakeColumnHandle column) {}
+
+    @Override
+    protected void addSpecialColumns(
+            List<DeltaLakeColumnHandle> inputColumns,
+            ImmutableList.Builder<DeltaLakeColumnHandle> dataColumnHandles,
+            ImmutableList.Builder<Integer> dataColumnsInputIndex,
+            ImmutableList.Builder<String> dataColumnNames,
+            ImmutableList.Builder<Type> dataColumnTypes)
+    {
+        dataColumnHandles.add(new DeltaLakeColumnHandle(
+                "_change_type",
+                VARCHAR,
+                OptionalInt.empty(),
+                "_change_type",
+                VARCHAR,
+                REGULAR));
+        dataColumnsInputIndex.add(inputColumns.size());
+        dataColumnNames.add(CHANGE_TYPE_COLUMN_NAME);
+        dataColumnTypes.add(VARCHAR);
+    }
+
+    @Override
+    protected String getRootTableLocation()
+    {
+        return tableLocation;
+    }
+
+    @Override
+    protected String getPartitionPrefixPath()
+    {
+        return "_data_change/";
+    }
+
+    @Override
+    protected Collection<Slice> buildResult()
+    {
+        List<DataFileInfo> dataFilesInfo = dataFileInfos.build();
+        return dataFilesInfo.stream()
+                .map(dataFileInfo -> new DeltaLakeUpdateResult("", Optional.of(dataFileInfo), true))
+                .map(deltaLakeUpdateResult -> wrappedBuffer(updateResultJsonCodec.toJsonBytes(deltaLakeUpdateResult)))
+                .collect(toImmutableList());
+    }
+
+    @Override
+    protected void collectDataFileInfo(DataFileInfo dataFileInfo)
+    {
+        dataFileInfos.add(dataFileInfo);
+    }
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeUpdateResult.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeUpdateResult.java
@@ -24,14 +24,17 @@ public class DeltaLakeUpdateResult
 {
     private final String oldFile;
     private final Optional<DataFileInfo> newFile;
+    private final boolean isCDFData;
 
     @JsonCreator
     public DeltaLakeUpdateResult(
             @JsonProperty("oldFile") String oldFile,
-            @JsonProperty("newFile") Optional<DataFileInfo> newFile)
+            @JsonProperty("newFile") Optional<DataFileInfo> newFile,
+            @JsonProperty("isCDFData") boolean isCDFData)
     {
         this.oldFile = requireNonNull(oldFile, "oldFile is null");
         this.newFile = requireNonNull(newFile, "newFile is null");
+        this.isCDFData = isCDFData;
     }
 
     @JsonProperty
@@ -44,5 +47,11 @@ public class DeltaLakeUpdateResult
     public Optional<DataFileInfo> getNewFile()
     {
         return newFile;
+    }
+
+    @JsonProperty("isCDFData")
+    public boolean isCDFData()
+    {
+        return isCDFData;
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/CDFFileEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/CDFFileEntry.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.transactionlog;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+import static java.lang.String.format;
+
+public class CDFFileEntry
+{
+    private final String path;
+    private final Map<String, String> partitionValues;
+    private final long size;
+    private final boolean dataChange;
+
+    @JsonCreator
+    public CDFFileEntry(
+            @JsonProperty("path") String path,
+            @JsonProperty("partitionValues") Map<String, String> partitionValues,
+            @JsonProperty("size") long size)
+    {
+        this.path = path;
+        this.partitionValues = partitionValues;
+        this.size = size;
+        this.dataChange = false;
+    }
+
+    @JsonProperty
+    public String getPath()
+    {
+        return path;
+    }
+
+    @JsonProperty
+    public Map<String, String> getPartitionValues()
+    {
+        return partitionValues;
+    }
+
+    @JsonProperty
+    public long getSize()
+    {
+        return size;
+    }
+
+    @JsonProperty("dataChange")
+    public boolean isDataChange()
+    {
+        return dataChange;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("CDFFileEntry{path=%s, partitionValues=%s, size=%d, dataChange=%b}",
+                path, partitionValues, size, dataChange);
+    }
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeTransactionLogEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeTransactionLogEntry.java
@@ -28,6 +28,7 @@ public class DeltaLakeTransactionLogEntry
     private final MetadataEntry metaData;
     private final ProtocolEntry protocol;
     private final CommitInfoEntry commitInfo;
+    private final CDFFileEntry cdfFileEntry;
 
     private DeltaLakeTransactionLogEntry(
             TransactionEntry txn,
@@ -35,7 +36,8 @@ public class DeltaLakeTransactionLogEntry
             RemoveFileEntry remove,
             MetadataEntry metaData,
             ProtocolEntry protocol,
-            CommitInfoEntry commitInfo)
+            CommitInfoEntry commitInfo,
+            CDFFileEntry cdfFileEntry)
     {
         this.txn = txn;
         this.add = add;
@@ -43,6 +45,7 @@ public class DeltaLakeTransactionLogEntry
         this.metaData = metaData;
         this.protocol = protocol;
         this.commitInfo = commitInfo;
+        this.cdfFileEntry = cdfFileEntry;
     }
 
     @JsonCreator
@@ -52,45 +55,52 @@ public class DeltaLakeTransactionLogEntry
             @JsonProperty("remove") RemoveFileEntry remove,
             @JsonProperty("metaData") MetadataEntry metaData,
             @JsonProperty("protocol") ProtocolEntry protocol,
-            @JsonProperty("commitInfo") CommitInfoEntry commitInfo)
+            @JsonProperty("commitInfo") CommitInfoEntry commitInfo,
+            @JsonProperty("cdfFileEntry") CDFFileEntry cdfFileEntry)
     {
-        return new DeltaLakeTransactionLogEntry(txn, add, remove, metaData, protocol, commitInfo);
+        return new DeltaLakeTransactionLogEntry(txn, add, remove, metaData, protocol, commitInfo, cdfFileEntry);
     }
 
     public static DeltaLakeTransactionLogEntry transactionEntry(TransactionEntry transaction)
     {
         requireNonNull(transaction, "transaction is null");
-        return new DeltaLakeTransactionLogEntry(transaction, null, null, null, null, null);
+        return new DeltaLakeTransactionLogEntry(transaction, null, null, null, null, null, null);
     }
 
     public static DeltaLakeTransactionLogEntry commitInfoEntry(CommitInfoEntry commitInfo)
     {
         requireNonNull(commitInfo, "commitInfo is null");
-        return new DeltaLakeTransactionLogEntry(null, null, null, null, null, commitInfo);
+        return new DeltaLakeTransactionLogEntry(null, null, null, null, null, commitInfo, null);
     }
 
     public static DeltaLakeTransactionLogEntry protocolEntry(ProtocolEntry protocolEntry)
     {
         requireNonNull(protocolEntry, "protocolEntry is null");
-        return new DeltaLakeTransactionLogEntry(null, null, null, null, protocolEntry, null);
+        return new DeltaLakeTransactionLogEntry(null, null, null, null, protocolEntry, null, null);
     }
 
     public static DeltaLakeTransactionLogEntry metadataEntry(MetadataEntry metadataEntry)
     {
         requireNonNull(metadataEntry, "metadataEntry is null");
-        return new DeltaLakeTransactionLogEntry(null, null, null, metadataEntry, null, null);
+        return new DeltaLakeTransactionLogEntry(null, null, null, metadataEntry, null, null, null);
     }
 
     public static DeltaLakeTransactionLogEntry addFileEntry(AddFileEntry addFileEntry)
     {
         requireNonNull(addFileEntry, "addFileEntry is null");
-        return new DeltaLakeTransactionLogEntry(null, addFileEntry, null, null, null, null);
+        return new DeltaLakeTransactionLogEntry(null, addFileEntry, null, null, null, null, null);
     }
 
     public static DeltaLakeTransactionLogEntry removeFileEntry(RemoveFileEntry removeFileEntry)
     {
         requireNonNull(removeFileEntry, "removeFileEntry is null");
-        return new DeltaLakeTransactionLogEntry(null, null, removeFileEntry, null, null, null);
+        return new DeltaLakeTransactionLogEntry(null, null, removeFileEntry, null, null, null, null);
+    }
+
+    public static DeltaLakeTransactionLogEntry cdfFileEntry(CDFFileEntry cdfFileEntry)
+    {
+        requireNonNull(cdfFileEntry, "cdfFileEntry is null");
+        return new DeltaLakeTransactionLogEntry(null, null, null, null, null, null, cdfFileEntry);
     }
 
     @Nullable
@@ -135,9 +145,16 @@ public class DeltaLakeTransactionLogEntry
         return commitInfo;
     }
 
+    @Nullable
+    @JsonProperty
+    public CDFFileEntry getCDC()
+    {
+        return cdfFileEntry;
+    }
+
     @Override
     public String toString()
     {
-        return String.format("DeltaLakeTransactionLogEntry{%s, %s, %s, %s, %s, %s}", txn, add, remove, metaData, protocol, commitInfo);
+        return String.format("DeltaLakeTransactionLogEntry{%s, %s, %s, %s, %s, %s, %s}", txn, add, remove, metaData, protocol, commitInfo, cdfFileEntry);
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/TransactionLogWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/TransactionLogWriter.java
@@ -16,6 +16,7 @@ package io.trino.plugin.deltalake.transactionlog.writer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.airlift.json.ObjectMapperProvider;
 import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
+import io.trino.plugin.deltalake.transactionlog.CDFFileEntry;
 import io.trino.plugin.deltalake.transactionlog.CommitInfoEntry;
 import io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
@@ -78,6 +79,11 @@ public class TransactionLogWriter
     public void appendRemoveFileEntry(RemoveFileEntry removeFileEntry)
     {
         entries.add(DeltaLakeTransactionLogEntry.removeFileEntry(removeFileEntry));
+    }
+
+    public void appendCDFFileEntry(CDFFileEntry cdfFileEntry)
+    {
+        entries.add(DeltaLakeTransactionLogEntry.cdfFileEntry(cdfFileEntry));
     }
 
     public boolean isUnsafe()

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksChangeDataFeedCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksChangeDataFeedCompatibility.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.deltalake;
+
+import org.testng.annotations.Test;
+
+import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertThat;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_DATABRICKS;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_EXCLUDE_73;
+import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.hive.util.TemporaryHiveTable.randomTableSuffix;
+import static io.trino.tests.product.utils.QueryExecutors.onDelta;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+
+public class TestDeltaLakeDatabricksChangeDataFeedCompatibility
+        extends BaseTestDeltaLakeS3Storage
+{
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
+    public void testUpdateTableWithCDF()
+    {
+        String tableName = "test_updates_to_table_with_cdf_" + randomTableSuffix();
+        try {
+            onDelta().executeQuery("CREATE TABLE default." + tableName + " (col1 STRING, updated_column INT) " +
+                    "USING DELTA " +
+                    "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
+                    "TBLPROPERTIES (delta.enableChangeDataFeed = true)");
+
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES('testValue1', 1)");
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES('testValue2', 2)");
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES('testValue3', 3)");
+            onTrino().executeQuery("UPDATE delta.default." + tableName + " SET updated_column = 5 WHERE col1 = 'testValue3'");
+
+            assertThat(onDelta().executeQuery("SELECT col1, updated_column, _change_type, _commit_version FROM table_changes('default." + tableName + "', 0)"))
+                    .containsOnly(
+                            row("testValue1", 1, "insert", 1L),
+                            row("testValue2", 2, "insert", 2L),
+                            row("testValue3", 3, "insert", 3L),
+                            row("testValue3", 3, "update_preimage", 4L),
+                            row("testValue3", 5, "update_postimage", 4L));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE IF EXISTS default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
+    public void testUpdatePartitionedTableWithCDF()
+    {
+        String tableName = "test_updates_to_partitioned_table_with_cdf_" + randomTableSuffix();
+        try {
+            onDelta().executeQuery("CREATE TABLE default." + tableName + " (updated_column STRING, partitioning_column_1 INT, partitioning_column_2 STRING) " +
+                    "USING DELTA " +
+                    "PARTITIONED BY (partitioning_column_1, partitioning_column_2) " +
+                    "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
+                    "TBLPROPERTIES (delta.enableChangeDataFeed = true)");
+
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES('testValue1', 1, 'partition1')");
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES('testValue2', 2, 'partition2')");
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES('testValue3', 3, 'partition3')");
+            onTrino().executeQuery("UPDATE delta.default." + tableName + " SET updated_column = 'testValue5' WHERE partitioning_column_1 = 3");
+
+            assertThat(onDelta().executeQuery(
+                    "SELECT updated_column, partitioning_column_1, partitioning_column_2, _change_type, _commit_version " +
+                            "FROM table_changes('default." + tableName + "', 0)"))
+                    .containsOnly(
+                            row("testValue1", 1, "partition1", "insert", 1L),
+                            row("testValue2", 2, "partition2", "insert", 2L),
+                            row("testValue3", 3, "partition3", "insert", 3L),
+                            row("testValue3", 3, "partition3", "update_preimage", 4L),
+                            row("testValue5", 3, "partition3", "update_postimage", 4L));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE IF EXISTS default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
+    public void testUpdateTableWithManyRowsInsertedInTheSameRequestAndCDFEnabled()
+    {
+        String tableName = "test_updates_to_table_with_cdf_" + randomTableSuffix();
+        try {
+            onDelta().executeQuery("CREATE TABLE default." + tableName + " (col1 STRING, updated_column INT) " +
+                    "USING DELTA " +
+                    "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
+                    "TBLPROPERTIES (delta.enableChangeDataFeed = true)");
+
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES('testValue1', 1), ('testValue2', 2), ('testValue3', 3)");
+            onTrino().executeQuery("UPDATE delta.default." + tableName + " SET updated_column = 5 WHERE col1 = 'testValue3'");
+
+            assertThat(onDelta().executeQuery("SELECT col1, updated_column, _change_type, _commit_version FROM table_changes('default." + tableName + "', 0)"))
+                    .containsOnly(
+                            row("testValue1", 1, "insert", 1L),
+                            row("testValue2", 2, "insert", 1L),
+                            row("testValue3", 3, "insert", 1L),
+                            row("testValue3", 3, "update_preimage", 2L),
+                            row("testValue3", 5, "update_postimage", 2L));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE IF EXISTS default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
+    public void testUpdatePartitionedTableWithManyRowsInsertedInTheSameRequestAndCDFEnabled()
+    {
+        String tableName = "test_updates_to_partitioned_table_with_cdf_" + randomTableSuffix();
+        try {
+            onDelta().executeQuery("CREATE TABLE default." + tableName + " (updated_column STRING, partitioning_column_1 INT, partitioning_column_2 STRING) " +
+                    "USING DELTA " +
+                    "PARTITIONED BY (partitioning_column_1, partitioning_column_2) " +
+                    "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
+                    "TBLPROPERTIES (delta.enableChangeDataFeed = true)");
+
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES('testValue1', 1, 'partition1'), ('testValue2', 2, 'partition2'), ('testValue3', 3, 'partition3')");
+            onTrino().executeQuery("UPDATE delta.default." + tableName + " SET updated_column = 'testValue5' WHERE partitioning_column_1 = 3");
+
+            assertThat(onDelta().executeQuery(
+                    "SELECT updated_column, partitioning_column_1, partitioning_column_2, _change_type, _commit_version " +
+                            "FROM table_changes('default." + tableName + "', 0)"))
+                    .containsOnly(
+                            row("testValue1", 1, "partition1", "insert", 1L),
+                            row("testValue2", 2, "partition2", "insert", 1L),
+                            row("testValue3", 3, "partition3", "insert", 1L),
+                            row("testValue3", 3, "partition3", "update_preimage", 2L),
+                            row("testValue5", 3, "partition3", "update_postimage", 2L));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE IF EXISTS default." + tableName);
+        }
+    }
+}

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksInsertCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksInsertCompatibility.java
@@ -527,8 +527,6 @@ public class TestDeltaLakeDatabricksInsertCompatibility
                     "TBLPROPERTIES (delta.enableChangeDataFeed = true)");
 
             onTrino().executeQuery("INSERT INTO delta.default." + tableName + " VALUES (1, 2)");
-            assertQueryFailure(() -> onTrino().executeQuery("UPDATE delta.default." + tableName + " SET a = 3 WHERE b = 3"))
-                    .hasMessageContaining("Writing to tables with Change Data Feed enabled is not supported");
             assertQueryFailure(() -> onTrino().executeQuery("DELETE FROM delta.default." + tableName + " WHERE a = 3"))
                     .hasMessageContaining("Writing to tables with Change Data Feed enabled is not supported");
             assertQueryFailure(() -> onTrino().executeQuery("MERGE INTO delta.default." + tableName + " t USING delta.default." + tableName + " s " +


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
The goal of this change is to support CDF for delta lake for UPDATE queries.
The idea is that each update will store additional data in _data_change folder in table folder with state of data before update and after. 


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
It is a step towards supporting delta lake CDF.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# delta
* Add support for CFD for UPDATE queries ({issue}`issuenumber`)
```
