### PR TITLE
Split the Delta Lake product test suite per Databricks runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -683,7 +683,9 @@ jobs:
             # suite-4 does not exist
             - suite-5
             - suite-azure
-            - suite-delta-lake-databricks
+            - suite-delta-lake-databricks73
+            - suite-delta-lake-databricks91
+            - suite-delta-lake-databricks104
             - suite-gcs
           exclude:
             - config: default
@@ -708,9 +710,19 @@ jobs:
               ignore exclusion if: >-
                 ${{ secrets.GCP_CREDENTIALS_KEY != '' }}
 
-            - suite: suite-delta-lake-databricks
+            - suite: suite-delta-lake-databricks73
               config: hdp3
-            - suite: suite-delta-lake-databricks
+            - suite: suite-delta-lake-databricks73
+              ignore exclusion if: >-
+                ${{ secrets.DATABRICKS_TOKEN != '' }}
+            - suite: suite-delta-lake-databricks91
+              config: hdp3
+            - suite: suite-delta-lake-databricks91
+              ignore exclusion if: >-
+                ${{ secrets.DATABRICKS_TOKEN != '' }}
+            - suite: suite-delta-lake-databricks104
+              config: hdp3
+            - suite: suite-delta-lake-databricks104
               ignore exclusion if: >-
                 ${{ secrets.DATABRICKS_TOKEN != '' }}
 

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/SuiteDeltaLakeDatabricks.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/SuiteDeltaLakeDatabricks.java
@@ -11,27 +11,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.tests.product.launcher.suite.suites;
+package io.trino.tests.product.launcher.suite;
 
-import com.google.common.collect.ImmutableList;
-import io.trino.tests.product.launcher.env.EnvironmentConfig;
-import io.trino.tests.product.launcher.env.environment.EnvSinglenodeDeltaLakeDatabricks104;
-import io.trino.tests.product.launcher.env.environment.EnvSinglenodeDeltaLakeDatabricks73;
-import io.trino.tests.product.launcher.env.environment.EnvSinglenodeDeltaLakeDatabricks91;
-import io.trino.tests.product.launcher.suite.Suite;
-import io.trino.tests.product.launcher.suite.SuiteTestRun;
-
-import java.util.List;
-
-import static io.trino.tests.product.launcher.suite.SuiteTestRun.testOnEnvironment;
-
-public class SuiteDeltaLakeDatabricks
+public abstract class SuiteDeltaLakeDatabricks
         extends Suite
 {
-    @Override
-    public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
+    protected String[] getExcludedTests()
     {
-        String[] excludedTests = {
+        return new String[] {
                 // AWS Glue does not support table comments
                 "io.trino.tests.product.deltalake.TestHiveAndDeltaLakeRedirect.testDeltaToHiveCommentTable",
                 "io.trino.tests.product.deltalake.TestHiveAndDeltaLakeRedirect.testHiveToDeltaCommentTable",
@@ -46,22 +33,5 @@ public class SuiteDeltaLakeDatabricks
                 // TODO https://github.com/trinodb/trino/issues/13017
                 "io.trino.tests.product.deltalake.TestDeltaLakeDropTableCompatibility.testCreateManagedTableInDeltaDropTableInTrino"
         };
-        return ImmutableList.of(
-                testOnEnvironment(EnvSinglenodeDeltaLakeDatabricks73.class)
-                        .withGroups("configured_features", "delta-lake-databricks")
-                        .withExcludedGroups("delta-lake-exclude-73")
-                        .withExcludedTests(excludedTests)
-                        .build(),
-
-                testOnEnvironment(EnvSinglenodeDeltaLakeDatabricks91.class)
-                        .withGroups("configured_features", "delta-lake-databricks")
-                        .withExcludedGroups("delta-lake-exclude-91")
-                        .withExcludedTests(excludedTests)
-                        .build(),
-
-                testOnEnvironment(EnvSinglenodeDeltaLakeDatabricks104.class)
-                        .withGroups("configured_features", "delta-lake-databricks")
-                        .withExcludedTests(excludedTests)
-                        .build());
     }
 }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeDatabricks104.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeDatabricks104.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.launcher.suite.suites;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.tests.product.launcher.env.EnvironmentConfig;
+import io.trino.tests.product.launcher.env.environment.EnvSinglenodeDeltaLakeDatabricks104;
+import io.trino.tests.product.launcher.suite.SuiteDeltaLakeDatabricks;
+import io.trino.tests.product.launcher.suite.SuiteTestRun;
+
+import java.util.List;
+
+import static io.trino.tests.product.launcher.suite.SuiteTestRun.testOnEnvironment;
+
+public class SuiteDeltaLakeDatabricks104
+        extends SuiteDeltaLakeDatabricks
+{
+    @Override
+    public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
+    {
+        return ImmutableList.of(
+                testOnEnvironment(EnvSinglenodeDeltaLakeDatabricks104.class)
+                        .withGroups("configured_features", "delta-lake-databricks")
+                        .withExcludedTests(getExcludedTests())
+                        .build());
+    }
+}

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeDatabricks73.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeDatabricks73.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.launcher.suite.suites;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.tests.product.launcher.env.EnvironmentConfig;
+import io.trino.tests.product.launcher.env.environment.EnvSinglenodeDeltaLakeDatabricks73;
+import io.trino.tests.product.launcher.suite.SuiteDeltaLakeDatabricks;
+import io.trino.tests.product.launcher.suite.SuiteTestRun;
+
+import java.util.List;
+
+import static io.trino.tests.product.launcher.suite.SuiteTestRun.testOnEnvironment;
+
+public class SuiteDeltaLakeDatabricks73
+        extends SuiteDeltaLakeDatabricks
+{
+    @Override
+    public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
+    {
+        return ImmutableList.of(
+                testOnEnvironment(EnvSinglenodeDeltaLakeDatabricks73.class)
+                        .withGroups("configured_features", "delta-lake-databricks")
+                        .withExcludedGroups("delta-lake-exclude-73")
+                        .withExcludedTests(getExcludedTests())
+                        .build());
+    }
+}

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeDatabricks91.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeDatabricks91.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.launcher.suite.suites;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.tests.product.launcher.env.EnvironmentConfig;
+import io.trino.tests.product.launcher.env.environment.EnvSinglenodeDeltaLakeDatabricks91;
+import io.trino.tests.product.launcher.suite.SuiteDeltaLakeDatabricks;
+import io.trino.tests.product.launcher.suite.SuiteTestRun;
+
+import java.util.List;
+
+import static io.trino.tests.product.launcher.suite.SuiteTestRun.testOnEnvironment;
+
+public class SuiteDeltaLakeDatabricks91
+        extends SuiteDeltaLakeDatabricks
+{
+    @Override
+    public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
+    {
+        return ImmutableList.of(
+                testOnEnvironment(EnvSinglenodeDeltaLakeDatabricks91.class)
+                        .withGroups("configured_features", "delta-lake-databricks")
+                        .withExcludedGroups("delta-lake-exclude-91")
+                        .withExcludedTests(getExcludedTests())
+                        .build());
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Instead of running all the product tests on a suite doing the tests for  Delta Lake on top of Databricks for all custer versions, use one suite for each Databricks cluster runtime to reduce the product test runtime.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
