### PR TITLE
Convert types to sealed classes where possible

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/type/DecimalType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/DecimalType.java
@@ -23,9 +23,10 @@ import static io.trino.spi.type.Decimals.MAX_SHORT_PRECISION;
 import static io.trino.spi.type.TypeSignatureParameter.numericParameter;
 import static java.lang.String.format;
 
-public abstract class DecimalType
+public abstract sealed class DecimalType
         extends AbstractType
         implements FixedWidthType
+        permits LongDecimalType, ShortDecimalType
 {
     public static final int DEFAULT_SCALE = 0;
     public static final int DEFAULT_PRECISION = MAX_PRECISION;

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimeWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimeWithTimeZoneType.java
@@ -36,7 +36,7 @@ import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclarati
 import static java.lang.String.format;
 import static java.lang.invoke.MethodHandles.lookup;
 
-class LongTimeWithTimeZoneType
+final class LongTimeWithTimeZoneType
         extends TimeWithTimeZoneType
 {
     private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(LongTimeWithTimeZoneType.class, lookup(), LongTimeWithTimeZone.class);

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampWithTimeZoneType.java
@@ -42,7 +42,7 @@ import static java.lang.invoke.MethodHandles.lookup;
  * in the first long and the fractional increment in the remaining integer, as a number of picoseconds
  * additional to the epoch millisecond.
  */
-class LongTimestampWithTimeZoneType
+final class LongTimestampWithTimeZoneType
         extends TimestampWithTimeZoneType
 {
     private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(LongTimestampWithTimeZoneType.class, lookup(), LongTimestampWithTimeZone.class);

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimeWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimeWithTimeZoneType.java
@@ -40,7 +40,7 @@ import static java.lang.invoke.MethodHandles.lookup;
 /**
  * Encodes time with time zone up to p = 9.
  */
-class ShortTimeWithTimeZoneType
+final class ShortTimeWithTimeZoneType
         extends TimeWithTimeZoneType
 {
     private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(ShortTimeWithTimeZoneType.class, lookup(), long.class);

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampWithTimeZoneType.java
@@ -40,7 +40,7 @@ import static java.lang.invoke.MethodHandles.lookup;
  * <p>
  * The value is encoded as milliseconds from the 1970-01-01 00:00:00 epoch.
  */
-class ShortTimestampWithTimeZoneType
+final class ShortTimestampWithTimeZoneType
         extends TimestampWithTimeZoneType
 {
     private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(ShortTimestampWithTimeZoneType.class, lookup(), long.class);

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TimeWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TimeWithTimeZoneType.java
@@ -18,9 +18,10 @@ import io.trino.spi.TrinoException;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static java.lang.String.format;
 
-public abstract class TimeWithTimeZoneType
+public abstract sealed class TimeWithTimeZoneType
         extends AbstractType
         implements FixedWidthType
+        permits LongTimeWithTimeZoneType, ShortTimeWithTimeZoneType
 {
     public static final int MAX_PRECISION = 12;
     public static final int MAX_SHORT_PRECISION = 9;

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TimestampWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TimestampWithTimeZoneType.java
@@ -22,9 +22,10 @@ import static java.lang.String.format;
  * @see ShortTimestampWithTimeZoneType
  * @see LongTimestampWithTimeZoneType
  */
-public abstract class TimestampWithTimeZoneType
+public abstract sealed class TimestampWithTimeZoneType
         extends AbstractType
         implements FixedWidthType
+        permits LongTimestampWithTimeZoneType, ShortTimestampWithTimeZoneType
 {
     public static final int MAX_PRECISION = 12;
 


### PR DESCRIPTION
Convert DecimalType, TimeWithTimeZoneType, and TimestampWithTimeZoneType to sealed classes

## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
