### PR TITLE
Improve startup time for tests using HiveMinioDataLake

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeAwsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeAwsConnectorSmokeTest.java
@@ -27,7 +27,10 @@ public abstract class BaseDeltaLakeAwsConnectorSmokeTest
     @Override
     protected HiveMinioDataLake createHiveMinioDataLake()
     {
-        hiveMinioDataLake = new HiveMinioDataLake(bucketName);
+        hiveMinioDataLake = HiveMinioDataLake.builder()
+                .withBucketName(bucketName)
+                .withHdfsAndHiveRuntimeEnabled() // required for runOnHive
+                .build();
         hiveMinioDataLake.start();
         return hiveMinioDataLake;
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSharedHiveMetastoreWithViews.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSharedHiveMetastoreWithViews.java
@@ -42,7 +42,10 @@ public class TestDeltaLakeSharedHiveMetastoreWithViews
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        this.hiveMinioDataLake = closeAfterClass(new HiveMinioDataLake(bucketName));
+        this.hiveMinioDataLake = closeAfterClass(HiveMinioDataLake.builder()
+                .withBucketName(bucketName)
+                .withHdfsAndHiveRuntimeEnabled() // required for runOnHive
+                .build());
         this.hiveMinioDataLake.start();
 
         DistributedQueryRunner queryRunner = DeltaLakeQueryRunner.createS3DeltaLakeQueryRunner(

--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -403,6 +403,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.minio</groupId>
             <artifactId>minio</artifactId>
             <scope>test</scope>

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
@@ -78,7 +78,11 @@ public abstract class BaseTestHiveOnDataLake
     {
         this.bucketName = "test-hive-insert-overwrite-" + randomTableSuffix();
         this.hiveMinioDataLake = closeAfterClass(
-                new HiveMinioDataLake(bucketName, hiveHadoopImage));
+                HiveMinioDataLake.builder()
+                        .withBucketName(bucketName)
+                        .withHiveHadoopImage(hiveHadoopImage)
+                        .withHdfsAndHiveRuntimeEnabled() // required for runOnHive
+                        .build());
         this.hiveMinioDataLake.start();
         this.metastoreClient = new BridgingHiveMetastore(
                 testingThriftHiveMetastoreBuilder()

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiCopyOnWriteMinioConnectorTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiCopyOnWriteMinioConnectorTest.java
@@ -30,7 +30,11 @@ public class TestHudiCopyOnWriteMinioConnectorTest
             throws Exception
     {
         String bucketName = "test-hudi-connector-" + randomTableSuffix();
-        hiveMinioDataLake = closeAfterClass(new HiveMinioDataLake(bucketName, HIVE3_IMAGE));
+        hiveMinioDataLake = closeAfterClass(HiveMinioDataLake.builder()
+                .withBucketName(bucketName)
+                .withHiveHadoopImage(HIVE3_IMAGE)
+                .withHdfsAndHiveRuntimeEnabled() // TODO why is this needed? Are we still using HDFS despite desire to use MinIO
+                .build());
         hiveMinioDataLake.start();
         hiveMinioDataLake.getMinioClient().ensureBucketExists(bucketName);
 

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiMergeOnReadMinioConnectorTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiMergeOnReadMinioConnectorTest.java
@@ -30,7 +30,11 @@ public class TestHudiMergeOnReadMinioConnectorTest
             throws Exception
     {
         String bucketName = "test-hudi-connector-" + randomTableSuffix();
-        hiveMinioDataLake = closeAfterClass(new HiveMinioDataLake(bucketName, HIVE3_IMAGE));
+        hiveMinioDataLake = closeAfterClass(HiveMinioDataLake.builder()
+                .withBucketName(bucketName)
+                .withHiveHadoopImage(HIVE3_IMAGE)
+                .withHdfsAndHiveRuntimeEnabled() // TODO why is this needed? Are we still using HDFS despite desire to use MinIO
+                .build());
         hiveMinioDataLake.start();
         hiveMinioDataLake.getMinioClient().ensureBucketExists(bucketName);
 

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/BaseTestContainer.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/BaseTestContainer.java
@@ -53,7 +53,7 @@ public abstract class BaseTestContainer
     private final Optional<Network> network;
     private final int startupRetryLimit;
 
-    private GenericContainer<?> container;
+    protected GenericContainer<?> container;
 
     protected BaseTestContainer(
             String image,


### PR DESCRIPTION
`HiveMinioDataLake` uses `HiveHadoop` only to have the metastore service. Tests using MinIO don't want to use the HDFS and don't need to wait for it.

The startup time is especially severe on Apple M1 chips. The change brings down container startup time from ~43s to ~13s.
