### PR TITLE
Upgrade minimum required and latest Cassandra version to 3.0 and 4.1 respectively

### DIFF
--- a/docs/src/main/sphinx/connector/cassandra.rst
+++ b/docs/src/main/sphinx/connector/cassandra.rst
@@ -14,7 +14,7 @@ Requirements
 
 To connect to Cassandra, you need:
 
-* Cassandra version 2.2 or higher.
+* Cassandra version 3.0 or higher.
 * Network access from the Trino coordinator and workers to Cassandra.
   Port 9042 is the default port.
 

--- a/plugin/trino-cassandra/pom.xml
+++ b/plugin/trino-cassandra/pom.xml
@@ -15,6 +15,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.native-protocol.version>1.5.1</dep.native-protocol.version>
+        <air.test.parallel>instances</air.test.parallel>
     </properties>
 
     <dependencies>

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraServer.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraServer.java
@@ -69,13 +69,13 @@ public class CassandraServer
     public CassandraServer()
             throws Exception
     {
-        this("cassandra:2.2");
+        this("cassandra:3.0", "cu-cassandra.yaml");
     }
 
-    public CassandraServer(String imageName)
+    public CassandraServer(String imageName, String configFileName)
             throws Exception
     {
-        this(imageName, ImmutableMap.of(), "/etc/cassandra/cassandra.yaml", "cu-cassandra.yaml");
+        this(imageName, ImmutableMap.of(), "/etc/cassandra/cassandra.yaml", configFileName);
     }
 
     public CassandraServer(String imageName, Map<String, String> environmentVariables, String configPath, String configFileName)

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
@@ -550,15 +550,6 @@ public class TestCassandraConnectorTest
         execute("DROP TABLE test_create_table");
     }
 
-    @Override
-    public void testCreateTableWithLongColumnName()
-    {
-        // TODO: Find the maximum column name length in Cassandra and enable this test.
-        assertThatThrownBy(super::testCreateTableWithLongColumnName)
-                .hasMessageMatching(".* Mutation of .* bytes is too large.*");
-        throw new SkipException("TODO");
-    }
-
     @Test
     public void testCreateTableAs()
     {
@@ -1324,6 +1315,18 @@ public class TestCassandraConnectorTest
     {
         assertThatThrownBy(super::testRowLevelDelete)
                 .hasStackTraceContaining("Delete without primary key or partition key is not supported");
+    }
+
+    @Override
+    protected OptionalInt maxColumnNameLength()
+    {
+        return OptionalInt.of(65535);
+    }
+
+    @Override
+    protected void verifyColumnNameLengthFailurePermissible(Throwable e)
+    {
+        assertThat(e).hasMessageContaining("Attempted serializing to buffer exceeded maximum of 65535 bytes:");
     }
 
     @Override

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraLatestConnectorSmokeTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraLatestConnectorSmokeTest.java
@@ -28,7 +28,7 @@ public class TestCassandraLatestConnectorSmokeTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        CassandraServer server = closeAfterClass(new CassandraServer("cassandra:3.11.10"));
+        CassandraServer server = closeAfterClass(new CassandraServer("cassandra:3.11.10", "cu-cassandra.yaml"));
         CassandraSession session = server.getSession();
         createTestTables(session, KEYSPACE, Timestamp.from(TIMESTAMP_VALUE.toInstant()));
         return createCassandraQueryRunner(server, ImmutableMap.of(), ImmutableMap.of(), REQUIRED_TPCH_TABLES);

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraLatestConnectorSmokeTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraLatestConnectorSmokeTest.java
@@ -28,7 +28,7 @@ public class TestCassandraLatestConnectorSmokeTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        CassandraServer server = closeAfterClass(new CassandraServer("cassandra:3.11.10", "cu-cassandra.yaml"));
+        CassandraServer server = closeAfterClass(new CassandraServer("cassandra:4.1", "cu-cassandra-latest.yaml"));
         CassandraSession session = server.getSession();
         createTestTables(session, KEYSPACE, Timestamp.from(TIMESTAMP_VALUE.toInstant()));
         return createCassandraQueryRunner(server, ImmutableMap.of(), ImmutableMap.of(), REQUIRED_TPCH_TABLES);

--- a/plugin/trino-cassandra/src/test/resources/cu-cassandra-latest.yaml
+++ b/plugin/trino-cassandra/src/test/resources/cu-cassandra-latest.yaml
@@ -1,0 +1,29 @@
+cluster_name: 'Test Cluster'
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+
+data_file_directories:
+    - /var/lib/cassandra/data
+saved_caches_directory: /var/lib/cassandra/saved_caches
+
+commitlog_directory: /var/lib/cassandra/commitlog
+commitlog_sync: periodic
+commitlog_sync_period: 10000ms
+commitlog_segment_size: 1MiB
+commitlog_total_space: 1MiB
+
+seed_provider:
+    - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+      parameters:
+          - seeds: "127.0.0.1:7000"
+
+concurrent_reads: 2
+concurrent_writes: 2
+concurrent_counter_writes: 2
+concurrent_materialized_view_writes: 2
+
+listen_address: 127.0.0.1
+native_transport_port: 9142
+rpc_address: localhost
+broadcast_rpc_address: localhost
+
+endpoint_snitch: SimpleSnitch


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fixes https://github.com/trinodb/trino/issues/14404

I am increasing the cassandra version for the test environment from 2.2 to 3.0. Minimum supported version is 3.0, see [here](https://cassandra.apache.org/_/download.html) and increasing the latest cassandra version to 4.1.

Both versions use different sets of properties, so added a separate file for the 4.1 version.
 
<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
NA


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# Cassandra
* Upgrade minimum required Cassandra version to 3.0. ({issue}`14562`)
* Upgrade latest Cassandra version to 4.1. ({issue}`14562`)
```
