### PR TITLE
Report HashBuilderOperator stat for join build-side in EXPLAIN ANALYZE

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStatsSummarizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStatsSummarizer.java
@@ -106,6 +106,7 @@ public final class PlanNodeStatsSummarizer
                 planNodeCpuMillis.merge(planNodeId, cpuMillis, Long::sum);
 
                 planNodeBlockedMillis.merge(planNodeId, operatorStats.getBlockedWall().toMillis(), Long::sum);
+                planNodeSpilledDataSize.merge(planNodeId, operatorStats.getSpilledDataSize().toBytes(), Long::sum);
 
                 // A plan node like LocalExchange consists of LocalExchangeSource which links to another pipeline containing LocalExchangeSink
                 if (operatorStats.getPlanNodeId().equals(inputPlanNode) && !pipelineStats.isInputPipeline()) {
@@ -128,7 +129,6 @@ public final class PlanNodeStatsSummarizer
 
                 planNodeInputPositions.merge(planNodeId, operatorStats.getInputPositions(), Long::sum);
                 planNodeInputBytes.merge(planNodeId, operatorStats.getInputDataSize().toBytes(), Long::sum);
-                planNodeSpilledDataSize.merge(planNodeId, operatorStats.getSpilledDataSize().toBytes(), Long::sum);
                 processedNodes.add(planNodeId);
             }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStatsSummarizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStatsSummarizer.java
@@ -112,6 +112,11 @@ public final class PlanNodeStatsSummarizer
                 if (operatorStats.getPlanNodeId().equals(inputPlanNode) && !pipelineStats.isInputPipeline()) {
                     continue;
                 }
+                // Skip DynamicFilterSourceOperator as input operator as for join build side HashBuilderOperator metrics
+                // should be reported
+                if (operatorStats.getOperatorType().equals("DynamicFilterSourceOperator")) {
+                    continue;
+                }
                 if (processedNodes.contains(planNodeId)) {
                     continue;
                 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStatsSummarizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStatsSummarizer.java
@@ -107,7 +107,7 @@ public final class PlanNodeStatsSummarizer
 
                 planNodeBlockedMillis.merge(planNodeId, operatorStats.getBlockedWall().toMillis(), Long::sum);
 
-                // A pipeline like hash build before join might link to another "internal" pipelines which provide actual input for this plan node
+                // A plan node like LocalExchange consists of LocalExchangeSource which links to another pipeline containing LocalExchangeSink
                 if (operatorStats.getPlanNodeId().equals(inputPlanNode) && !pipelineStats.isInputPipeline()) {
                     continue;
                 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TextRenderer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TextRenderer.java
@@ -247,13 +247,6 @@ public class TextRenderer
                     "HashBuilderOperator", "Right (build) ");
         }
 
-        if (operators.contains("LookupJoinOperator") && operators.contains("DynamicFilterSourceOperator")) {
-            // join plan node
-            return ImmutableMap.of(
-                    "LookupJoinOperator", "Left (probe) ",
-                    "DynamicFilterSourceOperator", "Right (build) ");
-        }
-
         return ImmutableMap.of();
     }
 


### PR DESCRIPTION
    DynamicFilterSourceOperator takes only fraction of processing therefore
    it doesn't make sense to report it's metrics (e.g. wall time/cpu time distribution)
    in EXPLAIN ANALYZE