### PR TITLE
Increase max writer version to 4 for delta lake

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -266,7 +266,7 @@ public class DeltaLakeMetadata
     // The required writer version used by tables created by Trino
     private static final int WRITER_VERSION = 2;
     // The highest writer version Trino supports writing to
-    private static final int MAX_WRITER_VERSION = 3;
+    private static final int MAX_WRITER_VERSION = 4;
     // This constant should be used only for a new table
     private static final ProtocolEntry DEFAULT_PROTOCOL = new ProtocolEntry(READER_VERSION, WRITER_VERSION);
     // Matches the dummy column Databricks stores in the metastore

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeAlterTableCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeAlterTableCompatibility.java
@@ -69,14 +69,14 @@ public class TestDeltaLakeAlterTableCompatibility
         onDelta().executeQuery(format("" +
                         "CREATE TABLE default.%s (col int) " +
                         "USING DELTA LOCATION 's3://%s/%s'" +
-                        "TBLPROPERTIES ('delta.minWriterVersion'='4')",
+                        "TBLPROPERTIES ('delta.minWriterVersion'='5')",
                 tableName,
                 bucketName,
                 tableDirectory));
 
         try {
             assertQueryFailure(() -> onTrino().executeQuery("ALTER TABLE delta.default." + tableName + " ADD COLUMN new_col int"))
-                    .hasMessageMatching(".* Table .* requires Delta Lake writer version 4 which is not supported");
+                    .hasMessageMatching(".* Table .* requires Delta Lake writer version 5 which is not supported");
         }
         finally {
             onDelta().executeQuery("DROP TABLE default." + tableName);
@@ -180,14 +180,14 @@ public class TestDeltaLakeAlterTableCompatibility
         onDelta().executeQuery(format("" +
                         "CREATE TABLE default.%s (col int) " +
                         "USING DELTA LOCATION 's3://%s/%s'" +
-                        "TBLPROPERTIES ('delta.minWriterVersion'='4')",
+                        "TBLPROPERTIES ('delta.minWriterVersion'='5')",
                 tableName,
                 bucketName,
                 tableDirectory));
 
         try {
             assertQueryFailure(() -> onTrino().executeQuery("COMMENT ON TABLE delta.default." + tableName + " IS 'test comment'"))
-                    .hasMessageMatching(".* Table .* requires Delta Lake writer version 4 which is not supported");
+                    .hasMessageMatching(".* Table .* requires Delta Lake writer version 5 which is not supported");
         }
         finally {
             onTrino().executeQuery("DROP TABLE delta.default." + tableName);
@@ -224,14 +224,14 @@ public class TestDeltaLakeAlterTableCompatibility
         onDelta().executeQuery(format("" +
                         "CREATE TABLE default.%s (col int) " +
                         "USING DELTA LOCATION 's3://%s/%s'" +
-                        "TBLPROPERTIES ('delta.minWriterVersion'='4')",
+                        "TBLPROPERTIES ('delta.minWriterVersion'='5')",
                 tableName,
                 bucketName,
                 tableDirectory));
 
         try {
             assertQueryFailure(() -> onTrino().executeQuery("COMMENT ON COLUMN delta.default." + tableName + ".col IS 'test column comment'"))
-                    .hasMessageMatching(".* Table .* requires Delta Lake writer version 4 which is not supported");
+                    .hasMessageMatching(".* Table .* requires Delta Lake writer version 5 which is not supported");
         }
         finally {
             onTrino().executeQuery("DROP TABLE delta.default." + tableName);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksInsertCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksInsertCompatibility.java
@@ -562,6 +562,8 @@ public class TestDeltaLakeDatabricksInsertCompatibility
                     .hasMessageContaining("Writing to tables with Change Data Feed enabled is not supported");
             assertThat(onTrino().executeQuery("SELECT * FROM delta.default." + tableName))
                     .containsOnly(row(1, 2));
+            assertThat(onDelta().executeQuery("SELECT a, b, _change_type, _commit_version FROM table_changes('default." + tableName + "', 0)"))
+                    .containsOnly(row(1, 2, "insert", 1L));
         }
         finally {
             onDelta().executeQuery("DROP TABLE IF EXISTS default." + tableName);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
As we have checks that blocks writing to tables with specific features like CDF and generated columns we can safely update accepted writer version to 4.
I also refactored a little TestDeltaLakeDatabricksInsertCompatibility class


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Add support for writing to tables using [version 4 of the writer](https://docs.delta.io/latest/versioning.html#features-by-protocol-version). 
  This does not yet include support for change data feeds and generated columns. ({issue}`14573 `)
```
