### PR TITLE
Limit number of files for a single ExchangeStorageReader

### DIFF
--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeConfig.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeConfig.java
@@ -42,6 +42,7 @@ public class FileSystemExchangeConfig
     private int exchangeSinkBuffersPerPartition = 2;
     private DataSize exchangeSinkMaxFileSize = DataSize.of(1, GIGABYTE);
     private int exchangeSourceConcurrentReaders = 4;
+    private int exchangeSourceMaxFilesPerReader = 25;
     private int maxOutputPartitionCount = 50;
     private int exchangeFileListingParallelism = 50;
     private DataSize exchangeSourceHandleTargetDataSize = DataSize.of(256, MEGABYTE);
@@ -148,6 +149,19 @@ public class FileSystemExchangeConfig
     public FileSystemExchangeConfig setExchangeSourceConcurrentReaders(int exchangeSourceConcurrentReaders)
     {
         this.exchangeSourceConcurrentReaders = exchangeSourceConcurrentReaders;
+        return this;
+    }
+
+    @Min(1)
+    public int getExchangeSourceMaxFilesPerReader()
+    {
+        return exchangeSourceMaxFilesPerReader;
+    }
+
+    @Config("exchange.source-max-files-per-reader")
+    public FileSystemExchangeConfig setExchangeSourceMaxFilesPerReader(int exchangeSourceMaxFilesPerReader)
+    {
+        this.exchangeSourceMaxFilesPerReader = exchangeSourceMaxFilesPerReader;
         return this;
     }
 

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeManager.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeManager.java
@@ -57,6 +57,7 @@ public class FileSystemExchangeManager
     private final int exchangeSinkBuffersPerPartition;
     private final long exchangeSinkMaxFileSizeInBytes;
     private final int exchangeSourceConcurrentReaders;
+    private final int exchangeSourceMaxFilesPerReader;
     private final int maxOutputPartitionCount;
     private final int exchangeFileListingParallelism;
     private final long exchangeSourceHandleTargetDataSizeInBytes;
@@ -77,6 +78,7 @@ public class FileSystemExchangeManager
         this.exchangeSinkBuffersPerPartition = fileSystemExchangeConfig.getExchangeSinkBuffersPerPartition();
         this.exchangeSinkMaxFileSizeInBytes = fileSystemExchangeConfig.getExchangeSinkMaxFileSize().toBytes();
         this.exchangeSourceConcurrentReaders = fileSystemExchangeConfig.getExchangeSourceConcurrentReaders();
+        this.exchangeSourceMaxFilesPerReader = fileSystemExchangeConfig.getExchangeSourceMaxFilesPerReader();
         this.maxOutputPartitionCount = fileSystemExchangeConfig.getMaxOutputPartitionCount();
         this.exchangeFileListingParallelism = fileSystemExchangeConfig.getExchangeFileListingParallelism();
         this.exchangeSourceHandleTargetDataSizeInBytes = fileSystemExchangeConfig.getExchangeSourceHandleTargetDataSize().toBytes();
@@ -140,6 +142,7 @@ public class FileSystemExchangeManager
                 exchangeStorage,
                 stats,
                 maxPageStorageSizeInBytes,
-                exchangeSourceConcurrentReaders);
+                exchangeSourceConcurrentReaders,
+                exchangeSourceMaxFilesPerReader);
     }
 }

--- a/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/TestFileSystemExchangeConfig.java
+++ b/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/TestFileSystemExchangeConfig.java
@@ -38,6 +38,7 @@ public class TestFileSystemExchangeConfig
                 .setExchangeSinkBuffersPerPartition(2)
                 .setExchangeSinkMaxFileSize(DataSize.of(1, GIGABYTE))
                 .setExchangeSourceConcurrentReaders(4)
+                .setExchangeSourceMaxFilesPerReader(25)
                 .setMaxOutputPartitionCount(50)
                 .setExchangeFileListingParallelism(50)
                 .setExchangeSourceHandleTargetDataSize(DataSize.of(256, MEGABYTE)));
@@ -54,6 +55,7 @@ public class TestFileSystemExchangeConfig
                 .put("exchange.sink-buffers-per-partition", "3")
                 .put("exchange.sink-max-file-size", "2GB")
                 .put("exchange.source-concurrent-readers", "10")
+                .put("exchange.source-max-files-per-reader", "111")
                 .put("exchange.max-output-partition-count", "53")
                 .put("exchange.file-listing-parallelism", "20")
                 .put("exchange.source-handle-target-data-size", "1GB")
@@ -67,6 +69,7 @@ public class TestFileSystemExchangeConfig
                 .setExchangeSinkBuffersPerPartition(3)
                 .setExchangeSinkMaxFileSize(DataSize.of(2, GIGABYTE))
                 .setExchangeSourceConcurrentReaders(10)
+                .setExchangeSourceMaxFilesPerReader(111)
                 .setMaxOutputPartitionCount(53)
                 .setExchangeFileListingParallelism(20)
                 .setExchangeSourceHandleTargetDataSize(DataSize.of(1, GIGABYTE));

--- a/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/TestFileSystemExchangeSource.java
+++ b/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/TestFileSystemExchangeSource.java
@@ -29,7 +29,8 @@ public class TestFileSystemExchangeSource
                 new LocalFileSystemExchangeStorage(),
                 new FileSystemExchangeStats(),
                 1024,
-                2)) {
+                2,
+                1)) {
             CompletableFuture<Void> first = source.isBlocked();
             CompletableFuture<Void> second = source.isBlocked();
             assertThat(first)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

ExchangeStorageReader implementations try to load all files concurrently if possible. If the number of files is large (e.g.: a lot of small files) the underlying implementation may not be able to handle that many concurrent fetch requests.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Fix occasional "Maximum pending connection acquisitions exceeded" failures in fault tolerant execution.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# Fault tolerant execution
* Fix occasional "Maximum pending connection acquisitions exceeded" failures in fault tolerant execution.
```
