### PR TITLE
Clarify ConnectorMetadata listing when schema name not found

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -250,6 +250,7 @@ public interface ConnectorMetadata
 
     /**
      * List table, view and materialized view names, possibly filtered by schema. An empty list is returned if none match.
+     * An empty list is returned also when schema name does not refer to an existing schema.
      */
     default List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
     {
@@ -770,6 +771,10 @@ public interface ConnectorMetadata
         throw new TrinoException(NOT_SUPPORTED, "This connector does not support dropping views");
     }
 
+    /**
+     * List view names, possibly filtered by schema. An empty list is returned if none match.
+     * An empty list is returned also when schema name does not refer to an existing schema.
+     */
     default List<SchemaTableName> listViews(ConnectorSession session, Optional<String> schemaName)
     {
         return emptyList();
@@ -1388,7 +1393,8 @@ public interface ConnectorMetadata
     }
 
     /**
-     * Get the names that match the specified table prefix (never null).
+     * List materialized view names, possibly filtered by schema. An empty list is returned if none match.
+     * An empty list is returned also when schema name does not refer to an existing schema.
      */
     default List<SchemaTableName> listMaterializedViews(ConnectorSession session, Optional<String> schemaName)
     {


### PR DESCRIPTION
It's important to require that `listTables`, `listViews` and `listMaterializedViews` do not fail when asked to list relations from a schema that does not exist. This is because schema existence cannot be ensured in a concurrent environment, i.e. a schema could have just been deleted concurrently. Lack of such assumptions for these methods would make predicate pushdown for tables like `system.jdbc.tables` impossible to do properly.
