### PR TITLE
Replace invalid Lookup.resolveGroup usage with resolve

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DetermineJoinDistributionType.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DetermineJoinDistributionType.java
@@ -27,7 +27,6 @@ import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.sql.planner.OptimizerConfig.JoinDistributionType;
 import io.trino.sql.planner.TypeProvider;
-import io.trino.sql.planner.iterative.GroupReference;
 import io.trino.sql.planner.iterative.Lookup;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.optimizations.PlanNodeSearcher;
@@ -145,12 +144,7 @@ public class DetermineJoinDistributionType
     static double getFirstKnownOutputSizeInBytes(PlanNode node, Lookup lookup, StatsProvider statsProvider, TypeProvider typeProvider)
     {
         return Stream.of(node)
-                .flatMap(planNode -> {
-                    if (planNode instanceof GroupReference) {
-                        return lookup.resolveGroup(node);
-                    }
-                    return Stream.of(planNode);
-                })
+                .map(lookup::resolve)
                 .mapToDouble(resolvedNode -> {
                     double outputSizeInBytes = statsProvider.getStats(resolvedNode).getOutputSizeInBytes(
                             resolvedNode.getOutputSymbols(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneDistinctAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneDistinctAggregation.java
@@ -26,8 +26,8 @@ import io.trino.sql.planner.plan.PlanVisitor;
 import io.trino.sql.planner.plan.UnionNode;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.sql.planner.plan.ChildReplacer.replaceChildren;
 import static io.trino.sql.planner.plan.Patterns.aggregation;
 
@@ -52,7 +52,7 @@ public class PruneDistinctAggregation
         List<PlanNode> newSources = node.getSources().stream()
                 .map(lookup::resolve)
                 .map(source -> source.accept(rewriter, true))
-                .collect(Collectors.toList());
+                .collect(toImmutableList());
 
         if (rewriter.isRewritten()) {
             return Result.ofPlanNode(replaceChildren(node, newSources));
@@ -86,7 +86,8 @@ public class PruneDistinctAggregation
         {
             List<PlanNode> newSources = node.getSources().stream()
                     .map(lookup::resolve)
-                    .map(source -> source.accept(this, context)).collect(Collectors.toList());
+                    .map(source -> source.accept(this, context))
+                    .collect(toImmutableList());
 
             return replaceChildren(node, newSources);
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneDistinctAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneDistinctAggregation.java
@@ -28,7 +28,6 @@ import io.trino.sql.planner.plan.UnionNode;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.sql.planner.plan.ChildReplacer.replaceChildren;
 import static io.trino.sql.planner.plan.Patterns.aggregation;
 
@@ -128,8 +127,7 @@ public class PruneDistinctAggregation
         {
             boolean distinct = isDistinctOperator(node);
 
-            PlanNode rewrittenNode = getOnlyElement(lookup.resolveGroup(node.getSource())
-                    .map(source -> source.accept(this, distinct)).collect(Collectors.toList()));
+            PlanNode rewrittenNode = lookup.resolve(node.getSource()).accept(this, distinct);
 
             if (context && distinct) {
                 this.rewritten = true;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneDistinctAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneDistinctAggregation.java
@@ -51,7 +51,7 @@ public class PruneDistinctAggregation
         DistinctAggregationRewriter rewriter = new DistinctAggregationRewriter(lookup);
 
         List<PlanNode> newSources = node.getSources().stream()
-                .flatMap(lookup::resolveGroup)
+                .map(lookup::resolve)
                 .map(source -> source.accept(rewriter, true))
                 .collect(Collectors.toList());
 
@@ -86,7 +86,7 @@ public class PruneDistinctAggregation
         private PlanNode rewriteChildren(PlanNode node, Boolean context)
         {
             List<PlanNode> newSources = node.getSources().stream()
-                    .flatMap(lookup::resolveGroup)
+                    .map(lookup::resolve)
                     .map(source -> source.accept(this, context)).collect(Collectors.toList());
 
             return replaceChildren(node, newSources);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SetOperationMerge.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SetOperationMerge.java
@@ -56,7 +56,7 @@ class SetOperationMerge
     {
         Lookup lookup = context.getLookup();
         List<PlanNode> sources = node.getSources().stream()
-                .flatMap(lookup::resolveGroup)
+                .map(lookup::resolve)
                 .collect(Collectors.toList());
 
         PlanNode child = sources.get(0);
@@ -101,7 +101,7 @@ class SetOperationMerge
 
         Lookup lookup = context.getLookup();
         List<PlanNode> sources = node.getSources().stream()
-                .flatMap(lookup::resolveGroup)
+                .map(lookup::resolve)
                 .collect(Collectors.toList());
 
         ImmutableListMultimap.Builder<Symbol, Symbol> newMappingsBuilder = ImmutableListMultimap.builder();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SetOperationMerge.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SetOperationMerge.java
@@ -29,9 +29,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 
 class SetOperationMerge
 {
@@ -57,7 +57,7 @@ class SetOperationMerge
         Lookup lookup = context.getLookup();
         List<PlanNode> sources = node.getSources().stream()
                 .map(lookup::resolve)
-                .collect(Collectors.toList());
+                .collect(toImmutableList());
 
         PlanNode child = sources.get(0);
 
@@ -102,7 +102,7 @@ class SetOperationMerge
         Lookup lookup = context.getLookup();
         List<PlanNode> sources = node.getSources().stream()
                 .map(lookup::resolve)
-                .collect(Collectors.toList());
+                .collect(toImmutableList());
 
         ImmutableListMultimap.Builder<Symbol, Symbol> newMappingsBuilder = ImmutableListMultimap.builder();
         boolean resultIsDistinct = false;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Since `Lookup.resolveGroup` returns sub-plan
alternatives, the results cannot be joined
inside a single plan node.


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
