### PR TITLE
Optimize BETWEEN predicate in SortedPositionLinks

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestSortExpressionExtractor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestSortExpressionExtractor.java
@@ -82,7 +82,9 @@ public class TestSortExpressionExtractor
 
         assertGetSortExpression("p1 BETWEEN p2 AND b1", "b1", "p1 <= b1");
 
-        assertGetSortExpression("b1 BETWEEN p1 AND p2", "b1", "b1 >= p1");
+        assertGetSortExpression("b1 BETWEEN p1 AND p2", "b1", "b1 >= p1", "b1 <= p2");
+
+        assertGetSortExpression("p1 BETWEEN b1 AND b2 AND b2 < p2 + 1", "b2", "p1 <= b2", "b2 < p2 + 1");
 
         assertGetSortExpression("b1 > p1 AND p1 BETWEEN b1 AND b2", "b1", "b1 > p1", "p1 >= b1");
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
`visitBetweenPredicate ` in `SortExpressionVisitor` can only handle one side of BETWEEN (GREATER_THAN_OR_EQUAL or LESS_THAN_OR_EQUAL), this pr optimize it and let it handle both sides of BETWEEN as conjunct expressions
Fixes #12096 

## Documentation
(x) Sufficient documentation is included in this PR.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes
(x) Release notes are required, please propose a release note for me.

```markdown
# Performance
* Optimize BETWEEN predicate in SortedPositionLinks, let it handle both sides of BETWEEN as conjunct expressions. ({issue}`12096`)
```
