### PR TITLE
Revert "Expose stage buffer utilization distribution to event listener"

### DIFF
--- a/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
+++ b/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
@@ -220,7 +220,6 @@ public class QueryMonitor
                         true,
                         ImmutableList.of(),
                         ImmutableList.of(),
-                        ImmutableList.of(),
                         Optional.empty()),
                 createQueryContext(
                         queryInfo.getSession(),
@@ -325,7 +324,6 @@ public class QueryMonitor
                 queryStats.getCompletedDrivers(),
                 queryInfo.isFinalQueryInfo(),
                 getCpuDistributions(queryInfo),
-                getStageOutputBufferUtilizationDistributions(queryInfo),
                 operatorSummaries.build(),
                 serializedPlanNodeStatsAndCosts);
     }
@@ -703,29 +701,6 @@ public class QueryMonitor
                 (long) snapshot.getMax(),
                 (long) snapshot.getTotal(),
                 snapshot.getTotal() / snapshot.getCount());
-    }
-
-    private static List<Optional<io.trino.spi.metrics.Distribution<?>>> getStageOutputBufferUtilizationDistributions(QueryInfo queryInfo)
-    {
-        if (queryInfo.getOutputStage().isEmpty()) {
-            return ImmutableList.of();
-        }
-
-        ImmutableList.Builder<Optional<io.trino.spi.metrics.Distribution<?>>> builder = ImmutableList.builder();
-        populateStageOutputBufferUtilizationDistribution(queryInfo.getOutputStage().get(), builder);
-
-        return builder.build();
-    }
-
-    private static void populateStageOutputBufferUtilizationDistribution(StageInfo stageInfo, ImmutableList.Builder<Optional<io.trino.spi.metrics.Distribution<?>>> distributions)
-    {
-        Optional<io.trino.spi.metrics.Distribution<?>> distribution = stageInfo.getStageStats().getOutputBufferUtilization()
-                // cast to ?
-                .map(dist -> dist);
-        distributions.add(distribution);
-        for (StageInfo subStage : stageInfo.getSubStages()) {
-            populateStageOutputBufferUtilizationDistribution(subStage, distributions);
-        }
     }
 
     private static class FragmentNode

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -264,13 +264,6 @@
                                     <oldVisibility>public</oldVisibility>
                                     <newVisibility>private</newVisibility>
                                 </item>
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.method.numberOfParametersChanged</code>
-                                    <old>method void io.trino.spi.eventlistener.QueryStatistics::&lt;init&gt;(java.time.Duration, java.time.Duration, java.time.Duration, java.time.Duration, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, long, long, long, long, long, long, long, long, long, long, long, long, long, long, long, double, double, java.util.List&lt;io.trino.spi.eventlistener.StageGcStatistics&gt;, int, boolean, java.util.List&lt;io.trino.spi.eventlistener.StageCpuDistribution&gt;, java.util.List&lt;java.lang.String&gt;, java.util.Optional&lt;java.lang.String&gt;)</old>
-                                    <new>method void io.trino.spi.eventlistener.QueryStatistics::&lt;init&gt;(java.time.Duration, java.time.Duration, java.time.Duration, java.time.Duration, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, long, long, long, long, long, long, long, long, long, long, long, long, long, long, long, double, double, java.util.List&lt;io.trino.spi.eventlistener.StageGcStatistics&gt;, int, boolean, java.util.List&lt;io.trino.spi.eventlistener.StageCpuDistribution&gt;, java.util.List&lt;java.util.Optional&lt;io.trino.spi.metrics.Distribution&lt;?&gt;&gt;&gt;, java.util.List&lt;java.lang.String&gt;, java.util.Optional&lt;java.lang.String&gt;)
-                                    </new>
-                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryStatistics.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryStatistics.java
@@ -15,7 +15,6 @@ package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.trino.spi.metrics.Distribution;
 
 import java.time.Duration;
 import java.util.List;
@@ -68,7 +67,6 @@ public class QueryStatistics
     private final boolean complete;
 
     private final List<StageCpuDistribution> cpuTimeDistribution;
-    private final List<Optional<Distribution<?>>> stageOutputBufferUtilizationDistribution;
 
     /**
      * Operator summaries serialized to JSON. Serialization format and structure
@@ -118,7 +116,6 @@ public class QueryStatistics
             int completedSplits,
             boolean complete,
             List<StageCpuDistribution> cpuTimeDistribution,
-            List<Optional<Distribution<?>>> stageOutputBufferUtilizationDistribution,
             List<String> operatorSummaries,
             Optional<String> planNodeStatsAndCosts)
     {
@@ -157,7 +154,6 @@ public class QueryStatistics
         this.completedSplits = completedSplits;
         this.complete = complete;
         this.cpuTimeDistribution = requireNonNull(cpuTimeDistribution, "cpuTimeDistribution is null");
-        this.stageOutputBufferUtilizationDistribution = requireNonNull(stageOutputBufferUtilizationDistribution, "stageOutputBufferUtilizationDistribution is null");
         this.operatorSummaries = requireNonNull(operatorSummaries, "operatorSummaries is null");
         this.planNodeStatsAndCosts = requireNonNull(planNodeStatsAndCosts, "planNodeStatsAndCosts is null");
     }
@@ -370,12 +366,6 @@ public class QueryStatistics
     public List<StageCpuDistribution> getCpuTimeDistribution()
     {
         return cpuTimeDistribution;
-    }
-
-    @JsonProperty
-    public List<Optional<Distribution<?>>> getStageOutputBufferUtilizationDistribution()
-    {
-        return stageOutputBufferUtilizationDistribution;
     }
 
     @JsonProperty

--- a/plugin/trino-http-event-listener/pom.xml
+++ b/plugin/trino-http-event-listener/pom.xml
@@ -112,12 +112,6 @@
 
         <dependency>
             <groupId>io.trino</groupId>
-            <artifactId>trino-plugin-toolkit</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino</groupId>
             <artifactId>trino-testing-services</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpEventListener.java
+++ b/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpEventListener.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonCodec;
 import io.trino.operator.RetryPolicy;
-import io.trino.plugin.base.metrics.TDigestHistogram;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.eventlistener.QueryCompletedEvent;
 import io.trino.spi.eventlistener.QueryContext;
@@ -180,7 +179,6 @@ public class TestHttpEventListener
                 0,
                 true,
                 Collections.emptyList(),
-                List.of(Optional.of(TDigestHistogram.fromValue(42))),
                 Collections.emptyList(),
                 Optional.empty());
 

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerWithSplits.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerWithSplits.java
@@ -183,8 +183,6 @@ public class TestEventListenerWithSplits
         assertTrue(statistics.getWallTime().getSeconds() >= 0);
         assertTrue(statistics.getCpuTimeDistribution().size() > 0);
         assertTrue(statistics.getOperatorSummaries().size() > 0);
-        assertTrue(statistics.getStageOutputBufferUtilizationDistribution().size() > 0);
-        assertTrue(statistics.getStageOutputBufferUtilizationDistribution().stream().allMatch(Optional::isPresent));
     }
 
     @Test


### PR DESCRIPTION
This reverts commit a102324c6c9238bb340274c5a52b6bd2cfaab5e1.

Implementations of Count, Timing and Distribution are not in the SPI, and therefore they are not visible to the json serializer. As a result, they cannot be embedded in event listener objects. Doing so causes errors when attempting to log query events.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix query completion events being dropped silently. ({issue}`...`)
```
