### PR TITLE
Fix merge(qdigest) function

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/MergeQuantileDigestFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/MergeQuantileDigestFunction.java
@@ -43,9 +43,9 @@ public final class MergeQuantileDigestFunction
     @InputFunction
     @TypeParameter("V")
     public static void input(
-            @TypeParameter("V") Type type,
+            @TypeParameter("qdigest(V)") Type type,
             @AggregationState QuantileDigestState state,
-            @BlockPosition @SqlType("V") Block value,
+            @BlockPosition @SqlType("qdigest(V)") Block value,
             @BlockIndex int index)
     {
         merge(state, new QuantileDigest(type.getSlice(value, index)));
@@ -80,7 +80,7 @@ public final class MergeQuantileDigestFunction
 
     @OutputFunction("qdigest(V)")
     public static void output(
-            @TypeParameter("V") Type type,
+            @TypeParameter("qdigest(V)") Type type,
             @AggregationState QuantileDigestState state,
             BlockBuilder out)
     {

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -2097,6 +2097,29 @@ public abstract class AbstractTestEngineOnlyQueries
     }
 
     @Test
+    public void testMergeQuantileDigest()
+    {
+        assertThat(query("""
+                WITH
+                    a(field_a, field_b) AS (
+                        VALUES (DOUBLE '10.3', 'group1'), (DOUBLE '11.3', 'group2')),
+                    b AS (
+                        SELECT CAST(qdigest_agg(field_a) AS varbinary) AS qdigest_binary
+                        FROM a GROUP BY field_b)
+                SELECT CAST(merge(CAST(qdigest_binary AS qdigest(double))) AS varbinary)
+                FROM b"""))
+                .matches("""
+                    VALUES X'
+                        00 7b 14 ae 47 e1 7a 84 3f 00 00 00 00 00 00 00
+                        00 00 00 00 00 00 00 00 00 9a 99 99 99 99 99 24
+                        40 9a 99 99 99 99 99 26 40 03 00 00 00 00 00 00
+                        00 00 00 00 f0 3f 9a 99 99 99 99 99 24 c0 00 00
+                        00 00 00 00 00 f0 3f 9a 99 99 99 99 99 26 c0 c7
+                        00 00 00 00 00 00 00 00 9a 99 99 99 99 99 24 c0'
+                    """);
+    }
+
+    @Test
     public void testValues()
     {
         assertQuery("VALUES 1, 2, 3, 4");


### PR DESCRIPTION
Fixes mismatched annotations added in
ff24f6afabe2e882eb8f3c78fa72667c67226c90 (https://github.com/trinodb/trino/pull/11477), i.e. in v 383.
