### PR TITLE
Fix real/double round returning rescaled Long.MAX_VALUE

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator.scalar;
 
+import com.google.common.math.DoubleMath;
 import com.google.common.math.LongMath;
 import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Shorts;
@@ -830,11 +831,13 @@ public final class MathFunctions
         }
 
         double factor = Math.pow(10, decimals);
-        if (num < 0) {
-            return -(Math.round(-num * factor) / factor);
+        int sign = (num < 0) ? -1 : 1;
+        double rescaled = sign * num * factor;
+        long rescaledRound = Math.round(rescaled);
+        if (rescaledRound != Long.MAX_VALUE) {
+            return sign * (rescaledRound / factor);
         }
-
-        return Math.round(num * factor) / factor;
+        return sign * DoubleMath.roundToBigInteger(rescaled, RoundingMode.HALF_UP).doubleValue() / factor;
     }
 
     @Description("Round to given number of decimal places")
@@ -848,11 +851,19 @@ public final class MathFunctions
         }
 
         double factor = Math.pow(10, decimals);
-        if (numInFloat < 0) {
-            return floatToRawIntBits((float) -(Math.round(-numInFloat * factor) / factor));
+        int sign = (numInFloat < 0) ? -1 : 1;
+        double result;
+        double rescaled = sign * numInFloat * factor;
+        long rescaledRound = Math.round(rescaled);
+        if (rescaledRound != Long.MAX_VALUE) {
+            result = sign * (rescaledRound / factor);
         }
-
-        return floatToRawIntBits((float) (Math.round(numInFloat * factor) / factor));
+        else {
+            result = sign * (DoubleMath.roundToBigInteger(rescaled, RoundingMode.HALF_UP).doubleValue() / factor);
+        }
+        @SuppressWarnings("NumericCastThatLosesPrecision")
+        float resultAsFloat = (float) result;
+        return floatToRawIntBits(resultAsFloat);
     }
 
     @ScalarFunction("round")

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
@@ -816,9 +816,9 @@ public final class MathFunctions
     @Description("Round to given number of decimal places")
     @ScalarFunction("round")
     @SqlType(StandardTypes.REAL)
-    public static long roundFloat(@SqlType(StandardTypes.REAL) long num)
+    public static long roundReal(@SqlType(StandardTypes.REAL) long num)
     {
-        return roundFloat(num, 0);
+        return roundReal(num, 0);
     }
 
     @Description("Round to given number of decimal places")
@@ -843,7 +843,7 @@ public final class MathFunctions
     @Description("Round to given number of decimal places")
     @ScalarFunction("round")
     @SqlType(StandardTypes.REAL)
-    public static long roundFloat(@SqlType(StandardTypes.REAL) long num, @SqlType(StandardTypes.INTEGER) long decimals)
+    public static long roundReal(@SqlType(StandardTypes.REAL) long num, @SqlType(StandardTypes.INTEGER) long decimals)
     {
         float numInFloat = intBitsToFloat((int) num);
         if (Float.isNaN(numInFloat) || Float.isInfinite(numInFloat)) {

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathFunctions.java
@@ -1650,6 +1650,14 @@ public class TestMathFunctions
         assertThat(assertions.function("round", "-0.3E0"))
                 .isEqualTo(-0.0);
 
+        // 923 * 10^16 exceeds Long.MAX_VALUE
+        assertThat(assertions.function("round", "923e0", "16"))
+                .isEqualTo(923.0);
+
+        // 3000 * 10^16 exceeds Long.MAX_VALUE. Note that value has limited precision even before round is invoked
+        assertThat(assertions.function("round", "DOUBLE '3000.1234567890123456789'", "16"))
+                .isEqualTo(3000.1234567890124);
+
         assertThat(assertions.function("round", "TINYINT '3'", "TINYINT '1'"))
                 .isEqualTo((byte) 3);
 
@@ -1685,6 +1693,14 @@ public class TestMathFunctions
 
         assertThat(assertions.function("round", "REAL '-3.99'", "0"))
                 .isEqualTo(-4.0f);
+
+        // 923 * 10^16 exceeds Long.MAX_VALUE
+        assertThat(assertions.function("round", "REAL '923'", "16"))
+                .isEqualTo(923f);
+
+        // 3000 * 10^16 exceeds Long.MAX_VALUE. Note that value has limited precision even before round is invoked
+        assertThat(assertions.function("round", "REAL '3000.1234567890123456789'", "16"))
+                .isEqualTo(3000.1235f);
 
         assertThat(assertions.function("round", "3", "1"))
                 .isEqualTo(3);


### PR DESCRIPTION
Before the change, the real and double `round` function would return a bogus value when `long Math.round(double)` invoked on the rescaled value returns `Long.MAX_VALUE`.


Fixes https://github.com/trinodb/trino/issues/14613