### PR TITLE
Update jinja2 version to fix CVE-2020-28493

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ beautifulsoup4==4.9.1
 certifi==2019.11.28
 css-html-js-minify==2.5.5
 idna==2.9
-Jinja2==2.11.1
+Jinja2==2.11.3
 lxml==4.5.2
 markdown-it-py==0.5.6
 myst-parser==0.12.10


### PR DESCRIPTION
This minor version update will fix CVE-2020-28493

Fixes: https://github.com/trinodb/trino/issues/8803