### PR TITLE
[WIP] Kudu: Asynchronous send keepalives for KuduScanner 

### DIFF
--- a/plugin/trino-kudu/pom.xml
+++ b/plugin/trino-kudu/pom.xml
@@ -30,6 +30,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>configuration</artifactId>
         </dependency>
 

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientSession.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientSession.java
@@ -85,11 +85,13 @@ public class KuduClientSession
     public static final String DEFAULT_SCHEMA = "default";
     private final KuduClientWrapper client;
     private final SchemaEmulation schemaEmulation;
+    private final KuduScannerConfig scannerConfig;
 
-    public KuduClientSession(KuduClientWrapper client, SchemaEmulation schemaEmulation)
+    public KuduClientSession(KuduClientWrapper client, SchemaEmulation schemaEmulation, KuduScannerConfig scannerConfig)
     {
         this.client = client;
         this.schemaEmulation = schemaEmulation;
+        this.scannerConfig = scannerConfig;
     }
 
     public List<String> listSchemaNames()
@@ -157,6 +159,9 @@ public class KuduClientSession
         KuduScanToken.KuduScanTokenBuilder builder = client.newScanTokenBuilder(table);
         // TODO: remove when kudu client bug is fixed: https://gerrit.cloudera.org/#/c/18166/
         builder.includeTabletMetadata(false);
+        builder.scanRequestTimeout(scannerConfig.getScanRequestTimeout().toMillis());
+        builder.batchSizeBytes((int) scannerConfig.getBatchSize().toBytes());
+        builder.keepAlivePeriodMs(scannerConfig.getKeepaliveInterval().toMillis());
 
         TupleDomain<ColumnHandle> constraint = tableHandle.getConstraint()
                 .intersect(dynamicFilter.getCurrentPredicate().simplify(100));

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientSession.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientSession.java
@@ -229,7 +229,9 @@ public class KuduClientSession
     public KuduScanner createScanner(KuduSplit kuduSplit)
     {
         try {
-            return client.deserializeIntoScanner(kuduSplit.getSerializedScanToken());
+            KuduScanner scanner = client.deserializeIntoScanner(kuduSplit.getSerializedScanToken());
+            KuduScannerAliveKeeper.add(scanner, scannerConfig.getKeepaliveInterval());
+            return scanner;
         }
         catch (IOException e) {
             throw new RuntimeException(e);

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduScannerAliveKeeper.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduScannerAliveKeeper.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kudu;
+
+import io.airlift.log.Logger;
+import io.airlift.units.Duration;
+import org.apache.kudu.client.KuduException;
+import org.apache.kudu.client.KuduScanner;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static io.airlift.concurrent.Threads.threadsNamed;
+
+public class KuduScannerAliveKeeper
+{
+    private static final Logger logger = Logger.get(KuduScannerAliveKeeper.class);
+    private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(2, threadsNamed("kudu-scanner-keepalive-%s"));
+
+    public static void add(KuduScanner scanner, Duration keepaliveInterval)
+    {
+        final long keepaliveIntervalMillis = keepaliveInterval.toMillis();
+        scheduler.scheduleAtFixedRate(() -> {
+            if (scanner.isClosed()) {
+                // this exception will terminate the schedule
+                throw new RuntimeException("no need to keepalive any longer");
+            }
+            try {
+                scanner.keepAlive();
+            }
+            catch (KuduException e) {
+                // a KuduException thrown by keepAlive should not be taken as indication that the scan has failed
+                logger.warn("fail to send keepalive", e);
+            }
+        }, keepaliveIntervalMillis, keepaliveIntervalMillis, TimeUnit.MILLISECONDS);
+    }
+}

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduScannerConfig.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduScannerConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kudu;
+
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.trino.plugin.kudu.KuduClientConfig.DEFAULT_OPERATION_TIMEOUT;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class KuduScannerConfig
+{
+    private DataSize batchSize = DataSize.of(1, MEGABYTE);
+    private Duration keepaliveInterval = new Duration(15, SECONDS);
+    private Duration scanRequestTimeout = DEFAULT_OPERATION_TIMEOUT;
+
+    public KuduScannerConfig() {}
+
+    public DataSize getBatchSize()
+    {
+        return batchSize;
+    }
+
+    public KuduScannerConfig withBatchSize(DataSize batchSize)
+    {
+        this.batchSize = batchSize;
+        return this;
+    }
+
+    public Duration getKeepaliveInterval()
+    {
+        return keepaliveInterval;
+    }
+
+    public KuduScannerConfig withKeepaliveInterval(Duration keepaliveInterval)
+    {
+        this.keepaliveInterval = keepaliveInterval;
+        return this;
+    }
+
+    public Duration getScanRequestTimeout()
+    {
+        return scanRequestTimeout;
+    }
+
+    public KuduScannerConfig withScanRequestTimeout(Duration scanRequestTimeout)
+    {
+        this.scanRequestTimeout = scanRequestTimeout;
+        return this;
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Kudu keepalives are sent synchronous during scan iteration. When Trino or Kudu is under load, keepalive interval may exceed Kudu's time limit for scanner survival, resulting in the scanner being cleared, and the query will fail. Send keepalives in another thread asynchronously with a fixed rate before it being closed will solve this problem.

This PR fixes #11136 .

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Fix a bug that queries on Kudu may fail under load.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix a bug that keepalives may not be sent in time for Kudu scanners. ({issue}`11136`)
```
