### PR TITLE
Avoid trying to create directory twice

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -819,9 +819,6 @@ public class DeltaLakeMetadata
         }
         Path targetPath = new Path(location);
         ensurePathExists(session, targetPath);
-
-        HdfsContext hdfsContext = new HdfsContext(session);
-        createDirectory(hdfsContext, hdfsEnvironment, targetPath);
         checkPathContainsNoFiles(session, targetPath);
 
         setRollback(() -> deleteRecursivelyIfExists(new HdfsContext(session), hdfsEnvironment, targetPath));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description


Avoid trying to create directory twice when creating a table.

This problem has been observed in `TestDeltaLakeGcsConnectorSmokeTest` when initially creating the test tables:

```
2022-10-14T07:08:36.287-0500	INFO	Query-20221014_120835_00002_z4h39-420	com.google.cloud.hadoop.repackaged.gcs.com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl	Ignoring exception of type GoogleJsonResponseException; verified object already exists with desired state.
```

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
