### PR TITLE
Rewrite casts in between predicate

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
@@ -40,8 +40,10 @@ import io.trino.sql.ir.ComparisonOperator;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.ExpressionTreeRewriter;
+import io.trino.sql.ir.IrExpressions.Between;
 import io.trino.sql.ir.IrExpressions.Comparison;
 import io.trino.sql.ir.IsNull;
+import io.trino.sql.ir.Let;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.ir.optimizer.IrExpressionOptimizer;
 import io.trino.sql.planner.SymbolAllocator;
@@ -80,8 +82,10 @@ import static io.trino.sql.ir.ComparisonOperator.IDENTICAL;
 import static io.trino.sql.ir.ComparisonOperator.LESS_THAN;
 import static io.trino.sql.ir.ComparisonOperator.LESS_THAN_OR_EQUAL;
 import static io.trino.sql.ir.ComparisonOperator.NOT_EQUAL;
+import static io.trino.sql.ir.IrExpressions.between;
 import static io.trino.sql.ir.IrExpressions.bindIfNecessary;
 import static io.trino.sql.ir.IrExpressions.comparison;
+import static io.trino.sql.ir.IrExpressions.matchBetween;
 import static io.trino.sql.ir.IrExpressions.matchComparison;
 import static io.trino.sql.ir.IrExpressions.not;
 import static io.trino.sql.ir.IrUtils.and;
@@ -122,6 +126,24 @@ import static java.util.Objects.requireNonNull;
  *
  * <pre>
  * CAST(x AS bigint) > bigint '10000000'
+ * </pre>
+ * <p>
+ * The same unwrapping applies to a BETWEEN range, rewriting
+ *
+ * <pre>
+ * CAST(s AS T) BETWEEN t1 AND t2
+ * </pre>
+ * <p>
+ * into an inclusive range on s. For example, given ts::timestamp(6),
+ *
+ * <pre>
+ * CAST(ts AS date) BETWEEN date '2020-01-01' AND date '2020-01-02'
+ * </pre>
+ * <p>
+ * turns into
+ *
+ * <pre>
+ * ts BETWEEN timestamp '2020-01-01 00:00:00.000000' AND timestamp '2020-01-02 23:59:59.999999'
  * </pre>
  */
 public class UnwrapCastInComparison
@@ -180,6 +202,126 @@ public class UnwrapCastInComparison
                 return unwrapCast(comparison.operator().flip(), comparison.right(), comparison.left());
             }
             return unwrapCast(comparison.operator(), comparison.left(), comparison.right());
+        }
+
+        @Override
+        public Expression rewriteLet(Let node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+        {
+            Let expression = treeRewriter.defaultRewrite(node, null);
+            // A BETWEEN over a non-trivial value binds it in a Let; unwrap a cast in that bound value here.
+            return unwrapCastInBetween(expression).orElse(expression);
+        }
+
+        private Optional<Expression> unwrapCastInBetween(Expression expression)
+        {
+            if (!(matchBetween(expression) instanceof Between range) || !(range.value() instanceof Cast cast)) {
+                return Optional.empty();
+            }
+
+            Expression source = cast.expression();
+            Type sourceType = source.type();
+            // Unwrap each half of the BETWEEN independently, as the lower and upper comparison against the cast.
+            Expression low = unwrapCast(GREATER_THAN_OR_EQUAL, cast, range.min());
+            Expression high = unwrapCast(LESS_THAN_OR_EQUAL, cast, range.max());
+
+            // unwrapCast collapses a bound to a constant truth value when the literal falls outside the source
+            // type range: a never-satisfied bound empties the range, an always-satisfied bound drops out.
+            if (isNeverSatisfied(low, source) || isNeverSatisfied(high, source)) {
+                return Optional.of(falseIfNotNull(source));
+            }
+            boolean lowAlwaysHolds = trueIfNotNull(source).equals(low);
+            boolean highAlwaysHolds = trueIfNotNull(source).equals(high);
+            if (lowAlwaysHolds && highAlwaysHolds) {
+                return Optional.of(trueIfNotNull(source));
+            }
+            if (lowAlwaysHolds) {
+                return Optional.of(high);
+            }
+            if (highAlwaysHolds) {
+                return Optional.of(low);
+            }
+
+            // Each surviving bound must be a comparison of the source against a constant; otherwise leave the
+            // BETWEEN untouched.
+            Optional<ComparisonBound> lowBound = comparisonBound(low, source);
+            Optional<ComparisonBound> highBound = comparisonBound(high, source);
+            if (lowBound.isEmpty() || highBound.isEmpty()) {
+                return Optional.empty();
+            }
+
+            // Rebuild an inclusive BETWEEN when the two comparisons form a lower/upper pair whose strict ends have
+            // an inclusive neighbor; otherwise keep them as a conjunction.
+            Optional<Object> inclusiveLow = inclusiveLowBound(sourceType, lowBound.get());
+            Optional<Object> inclusiveHigh = inclusiveHighBound(sourceType, highBound.get());
+            if (inclusiveLow.isEmpty() || inclusiveHigh.isEmpty()) {
+                // The conjunction references the cast source in both halves; bind a non-trivial source once so it is
+                // evaluated a single time, and recompute each half against the bound operand.
+                return Optional.of(bindSourceIfNecessary(source, operand -> {
+                    Cast boundCast = new Cast(operand, cast.type(), cast.kind());
+                    return and(
+                            unwrapCast(GREATER_THAN_OR_EQUAL, boundCast, range.min()),
+                            unwrapCast(LESS_THAN_OR_EQUAL, boundCast, range.max()));
+                }));
+            }
+            if (compare(sourceType, inclusiveLow.get(), inclusiveHigh.get()) > 0) {
+                return Optional.of(falseIfNotNull(source));
+            }
+            return Optional.of(between(plannerContext.getMetadata(), symbolAllocator, source, new Constant(sourceType, inclusiveLow.get()), new Constant(sourceType, inclusiveHigh.get())));
+        }
+
+        private static boolean isNeverSatisfied(Expression bound, Expression source)
+        {
+            return FALSE.equals(bound) || falseIfNotNull(source).equals(bound);
+        }
+
+        // A comparison of the source against a non-null constant, with the source normalized to the left operand.
+        private record ComparisonBound(ComparisonOperator operator, Object value) {}
+
+        private static Optional<ComparisonBound> comparisonBound(Expression bound, Expression source)
+        {
+            if (!(matchComparison(bound) instanceof Comparison comparison)) {
+                return Optional.empty();
+            }
+            ComparisonOperator operator;
+            Expression other;
+            if (source.equals(comparison.left())) {
+                operator = comparison.operator();
+                other = comparison.right();
+            }
+            else if (source.equals(comparison.right())) {
+                // comparison() canonicalizes operand order, so an unwrapped `source >= x` surfaces as `x <= source`.
+                operator = comparison.operator().flip();
+                other = comparison.left();
+            }
+            else {
+                return Optional.empty();
+            }
+            if (other instanceof Constant(Type _, Object value) && value != null) {
+                return Optional.of(new ComparisonBound(operator, value));
+            }
+            return Optional.empty();
+        }
+
+        // The inclusive lower bound value, tightening a strict `>` to its next value; empty when the operator is not
+        // a lower bound or the next value does not exist.
+        private static Optional<Object> inclusiveLowBound(Type sourceType, ComparisonBound bound)
+        {
+            return switch (bound.operator()) {
+                case GREATER_THAN_OR_EQUAL -> Optional.of(bound.value());
+                case GREATER_THAN -> sourceType.getNextValue(bound.value());
+                default -> Optional.empty();
+            };
+        }
+
+        // The inclusive upper bound value, tightening a strict `<` to its previous value; empty when the operator is
+        // not an upper bound or the previous value does not exist.
+        private static Optional<Object> inclusiveHighBound(Type sourceType, ComparisonBound bound)
+        {
+            return switch (bound.operator()) {
+                case LESS_THAN_OR_EQUAL -> Optional.of(bound.value());
+                case LESS_THAN -> sourceType.getPreviousValue(bound.value());
+                default -> Optional.empty();
+            };
         }
 
         private Expression unwrapCast(ComparisonOperator operator, Expression originalLeft, Expression originalRight)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapCastInComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapCastInComparison.java
@@ -853,6 +853,62 @@ public class TestUnwrapCastInComparison
         testUnwrap("timestamp(3)", "DATE '1981-06-22' = date(a)", new Logical(AND, ImmutableList.of(comparison(GREATER_THAN_OR_EQUAL, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1981-06-22 00:00:00.000"))), comparison(LESS_THAN, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1981-06-23 00:00:00.000"))))));
     }
 
+    @Test
+    public void testBetween()
+    {
+        // widening cast: bounds unwrap onto the source type
+        testUnwrap("smallint", "a BETWEEN DOUBLE '1' AND DOUBLE '2'", new Logical(AND, ImmutableList.of(comparison(GREATER_THAN_OR_EQUAL, new Reference(SMALLINT, "a"), new Constant(SMALLINT, 1L)), comparison(LESS_THAN_OR_EQUAL, new Reference(SMALLINT, "a"), new Constant(SMALLINT, 2L)))));
+        testUnwrap("bigint", "a BETWEEN DOUBLE '1' AND DOUBLE '2'", new Logical(AND, ImmutableList.of(comparison(GREATER_THAN_OR_EQUAL, new Reference(BIGINT, "a"), new Constant(BIGINT, 1L)), comparison(LESS_THAN_OR_EQUAL, new Reference(BIGINT, "a"), new Constant(BIGINT, 2L)))));
+
+        // fractional bounds tighten to their inclusive integer neighbors via getNextValue/getPreviousValue
+        testUnwrap("smallint", "a BETWEEN DOUBLE '1.1' AND DOUBLE '2.9'", new Logical(AND, ImmutableList.of(comparison(GREATER_THAN_OR_EQUAL, new Reference(SMALLINT, "a"), new Constant(SMALLINT, 2L)), comparison(LESS_THAN_OR_EQUAL, new Reference(SMALLINT, "a"), new Constant(SMALLINT, 2L)))));
+        // fractional bounds with no integer between them tighten to an empty range: false for a non-null source
+        testUnwrap("smallint", "a BETWEEN DOUBLE '1.4' AND DOUBLE '1.6'", new Logical(AND, ImmutableList.of(new IsNull(new Reference(SMALLINT, "a")), new Constant(BOOLEAN, null))));
+
+        // CAST(timestamp AS date) range unwrapped to a raw timestamp range, inclusive on both ends
+        testUnwrap("timestamp(3)", "CAST(a AS DATE) BETWEEN DATE '1981-06-22' AND DATE '1981-07-23'", new Logical(AND, ImmutableList.of(comparison(GREATER_THAN_OR_EQUAL, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1981-06-22 00:00:00.000"))), comparison(LESS_THAN_OR_EQUAL, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1981-07-23 23:59:59.999"))))));
+        testUnwrap("timestamp(6)", "CAST(a AS DATE) BETWEEN DATE '1981-06-22' AND DATE '1981-07-23'", new Logical(AND, ImmutableList.of(comparison(GREATER_THAN_OR_EQUAL, new Reference(createTimestampType(6), "a"), new Constant(createTimestampType(6), DateTimes.parseTimestamp(6, "1981-06-22 00:00:00.000000"))), comparison(LESS_THAN_OR_EQUAL, new Reference(createTimestampType(6), "a"), new Constant(createTimestampType(6), DateTimes.parseTimestamp(6, "1981-07-23 23:59:59.999999"))))));
+
+        // low bound below the source type range always holds and drops out, leaving the upper comparison
+        testUnwrap("smallint", "a BETWEEN DOUBLE '-40000' AND DOUBLE '2'", comparison(LESS_THAN_OR_EQUAL, new Reference(SMALLINT, "a"), new Constant(SMALLINT, 2L)));
+        // high bound above the source type range always holds and drops out, leaving the lower comparison
+        testUnwrap("smallint", "a BETWEEN DOUBLE '1' AND DOUBLE '40000'", comparison(GREATER_THAN_OR_EQUAL, new Reference(SMALLINT, "a"), new Constant(SMALLINT, 1L)));
+        // both bounds outside the source type range: always true for a non-null source
+        testUnwrap("smallint", "a BETWEEN DOUBLE '-40000' AND DOUBLE '40000'", new Logical(OR, ImmutableList.of(not(new IsNull(new Reference(SMALLINT, "a"))), new Constant(BOOLEAN, null))));
+        // low bound above the source type range is never satisfied: false for a non-null source
+        testUnwrap("smallint", "a BETWEEN DOUBLE '40000' AND DOUBLE '50000'", new Logical(AND, ImmutableList.of(new IsNull(new Reference(SMALLINT, "a")), new Constant(BOOLEAN, null))));
+        // empty range (low above high): false for a non-null source
+        testUnwrap("bigint", "a BETWEEN DOUBLE '5' AND DOUBLE '2'", new Logical(AND, ImmutableList.of(new IsNull(new Reference(BIGINT, "a")), new Constant(BOOLEAN, null))));
+    }
+
+    @Test
+    public void testBetweenDouble()
+    {
+        // CAST(real AS double) bounds cannot tighten to an inclusive pair (a real source has no adjacent value),
+        // so the two comparisons stay a conjunction: a non-trivial source is bound once via Let, a column stays inline.
+        Expression nonTrivial = new Cast(new Call(RANDOM, ImmutableList.of()), REAL);
+        Expression unwrappedNonTrivial = unwrapBetweenDouble(nonTrivial);
+        List<Let> bindings = letsBinding(unwrappedNonTrivial, nonTrivial);
+        assertThat(bindings).hasSize(1);
+        assertThat(occurrences(bindings.getFirst().body(), nonTrivial)).isEqualTo(0);
+        assertThat(occurrences(unwrappedNonTrivial, nonTrivial)).isEqualTo(1);
+
+        Reference trivial = new Reference(REAL, "a");
+        Expression unwrappedTrivial = unwrapBetweenDouble(trivial);
+        assertThat(unwrappedTrivial).isNotInstanceOf(Let.class);
+        assertThat(occurrences(unwrappedTrivial, trivial)).isGreaterThanOrEqualTo(2);
+    }
+
+    private static Expression unwrapBetweenDouble(Expression source)
+    {
+        SymbolAllocator symbolAllocator = new SymbolAllocator();
+        return unwrapCasts(
+                TEST_SESSION,
+                FUNCTIONS.getPlannerContext(),
+                symbolAllocator,
+                IrExpressions.between(FUNCTIONS.getMetadata(), symbolAllocator, new Cast(source, DOUBLE), new Constant(DOUBLE, 1.1), new Constant(DOUBLE, 2.2)));
+    }
+
     private void testRemoveFilter(String inputType, String inputPredicate)
     {
         assertPlan(format("SELECT * FROM (VALUES CAST(NULL AS %s)) t(a) WHERE %s AND rand() = 42", inputType, inputPredicate),

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestUnwrapCastInComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestUnwrapCastInComparison.java
@@ -75,6 +75,14 @@ public class TestUnwrapCastInComparison
                     validate(operator, fromType, from, "DOUBLE", to);
                 }
             }
+
+            for (Number to : asList(null, Byte.MIN_VALUE - 1, Byte.MIN_VALUE, 0, 1, Byte.MAX_VALUE, Byte.MAX_VALUE + 1)) {
+                validateBetween(fromType, from, "SMALLINT", to, to);
+                validateBetween(fromType, from, "INTEGER", to, to);
+                validateBetween(fromType, from, "BIGINT", to, to);
+                validateBetween(fromType, from, "REAL", to, to);
+                validateBetween(fromType, from, "DOUBLE", to, to);
+            }
         }
     }
 
@@ -100,6 +108,13 @@ public class TestUnwrapCastInComparison
                     validate(operator, fromType, from, "DOUBLE", to);
                 }
             }
+
+            for (Number to : asList(null, Short.MIN_VALUE - 1, Short.MIN_VALUE, 0, 1, Short.MAX_VALUE, Short.MAX_VALUE + 1)) {
+                validateBetween(fromType, from, "INTEGER", to, to);
+                validateBetween(fromType, from, "BIGINT", to, to);
+                validateBetween(fromType, from, "REAL", to, to);
+                validateBetween(fromType, from, "DOUBLE", to, to);
+            }
         }
     }
 
@@ -121,6 +136,16 @@ public class TestUnwrapCastInComparison
                     validate(operator, fromType, from, "REAL", to);
                 }
             }
+
+            for (Number to : asList(null, Integer.MIN_VALUE - 1L, Integer.MIN_VALUE, 0, 1, Integer.MAX_VALUE, Integer.MAX_VALUE + 1L)) {
+                validateBetween(fromType, from, "BIGINT", to, to);
+            }
+            for (Number to : asList(null, Integer.MIN_VALUE - 1L, Integer.MIN_VALUE, 0, 0.1, 0.9, 1, Integer.MAX_VALUE, Integer.MAX_VALUE + 1L)) {
+                validateBetween(fromType, from, "DOUBLE", to, to);
+            }
+            for (Number to : asList(null, Integer.MIN_VALUE - 1L, Integer.MIN_VALUE, -1L << 23 + 1, 0, 0.1, 0.9, 1, 1L << 23 - 1, Integer.MAX_VALUE, Integer.MAX_VALUE + 1L)) {
+                validateBetween(fromType, from, "REAL", to, to);
+            }
         }
     }
 
@@ -138,6 +163,13 @@ public class TestUnwrapCastInComparison
                     validate(operator, fromType, from, "REAL", to);
                 }
             }
+
+            for (Number to : asList(null, Long.MIN_VALUE, Long.MIN_VALUE + 1, -1L << 53 + 1, 0, 0.1, 0.9, 1, 1L << 53 - 1, Long.MAX_VALUE - 1, Long.MAX_VALUE)) {
+                validateBetween(fromType, from, "DOUBLE", to, to);
+            }
+            for (Number to : asList(null, Long.MIN_VALUE, Long.MIN_VALUE + 1, -1L << 23 + 1, 0, 0.1, 0.9, 1, 1L << 23 - 1, Long.MAX_VALUE - 1, Long.MAX_VALUE)) {
+                validateBetween(fromType, from, "REAL", to, to);
+            }
         }
     }
 
@@ -153,6 +185,9 @@ public class TestUnwrapCastInComparison
                     validate(operator, fromType, from, toType, to);
                 }
             }
+            for (String to : toLiteral(toType, asList(null, Double.NEGATIVE_INFINITY, Math.nextDown((double) -Float.MIN_VALUE), (double) -Float.MIN_VALUE, 0, 0.1, 0.9, 1, (double) Float.MAX_VALUE, Math.nextUp((double) Float.MAX_VALUE), Double.POSITIVE_INFINITY, Double.NaN))) {
+                validateBetween(fromType, from, toType, to, to);
+            }
         }
     }
 
@@ -167,6 +202,9 @@ public class TestUnwrapCastInComparison
                     validate(operator, "DECIMAL(15, 0)", from, "DOUBLE", Double.valueOf(to));
                 }
             }
+            for (String to : values) {
+                validateBetween("DECIMAL(15, 0)", from, "DOUBLE", Double.valueOf(to), Double.valueOf(to));
+            }
         }
 
         // decimal(16) -> double
@@ -176,6 +214,9 @@ public class TestUnwrapCastInComparison
                 for (String to : values) {
                     validate(operator, "DECIMAL(16, 0)", from, "DOUBLE", Double.valueOf(to));
                 }
+            }
+            for (String to : values) {
+                validateBetween("DECIMAL(16, 0)", from, "DOUBLE", Double.valueOf(to), Double.valueOf(to));
             }
         }
 
@@ -187,6 +228,9 @@ public class TestUnwrapCastInComparison
                     validate(operator, "DECIMAL(7, 0)", from, "REAL", Double.valueOf(to));
                 }
             }
+            for (String to : values) {
+                validateBetween("DECIMAL(7, 0)", from, "REAL", Double.valueOf(to), Double.valueOf(to));
+            }
         }
 
         // decimal(8) -> real
@@ -196,6 +240,9 @@ public class TestUnwrapCastInComparison
                 for (String to : values) {
                     validate(operator, "DECIMAL(8, 0)", from, "REAL", Double.valueOf(to));
                 }
+            }
+            for (String to : values) {
+                validateBetween("DECIMAL(8, 0)", from, "REAL", Double.valueOf(to), Double.valueOf(to));
             }
         }
     }
@@ -209,6 +256,9 @@ public class TestUnwrapCastInComparison
                     validate(operator, "VARCHAR(1)", from, "VARCHAR(2)", to);
                 }
             }
+            for (String to : asList(null, "''", "'a'", "'aa'", "'b'", "'bb'")) {
+                validateBetween("VARCHAR(1)", from, "VARCHAR(2)", to, to);
+            }
         }
 
         // type with no range
@@ -216,6 +266,9 @@ public class TestUnwrapCastInComparison
             for (String to : asList("'" + "a".repeat(200) + "'", "'" + "b".repeat(200) + "'")) {
                 validate(operator, "VARCHAR(200)", "'" + "a".repeat(200) + "'", "VARCHAR(300)", to);
             }
+        }
+        for (String to : asList("'" + "a".repeat(200) + "'", "'" + "b".repeat(200) + "'")) {
+            validateBetween("VARCHAR(200)", "'" + "a".repeat(200) + "'", "VARCHAR(300)", to, to);
         }
     }
 
@@ -326,6 +379,15 @@ public class TestUnwrapCastInComparison
             validate(session, operator, "timestamp(12)", "TIMESTAMP '2020-07-03 01:23:45.123456789123'", "timestamp(12) with time zone", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'");
             validate(session, operator, "timestamp(12)", "TIMESTAMP '2020-07-03 01:23:45.123456789123'", "timestamp(12) with time zone", "TIMESTAMP '2020-07-03 01:23:45 UTC'");
         }
+
+        validateBetween(session, "timestamp(3)", "TIMESTAMP '2020-07-03 01:23:45.123'", "timestamp(3) with time zone", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'");
+        validateBetween(session, "timestamp(3)", "TIMESTAMP '2020-07-03 01:23:45.123'", "timestamp(3) with time zone", "TIMESTAMP '2020-07-03 01:23:45 UTC'", "TIMESTAMP '2020-07-03 01:23:45 UTC'");
+        validateBetween(session, "timestamp(6)", "TIMESTAMP '2020-07-03 01:23:45.123456'", "timestamp(6) with time zone", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'");
+        validateBetween(session, "timestamp(6)", "TIMESTAMP '2020-07-03 01:23:45.123456'", "timestamp(6) with time zone", "TIMESTAMP '2020-07-03 01:23:45 UTC'", "TIMESTAMP '2020-07-03 01:23:45 UTC'");
+        validateBetween(session, "timestamp(9)", "TIMESTAMP '2020-07-03 01:23:45.123456789'", "timestamp(9) with time zone", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'");
+        validateBetween(session, "timestamp(9)", "TIMESTAMP '2020-07-03 01:23:45.123456789'", "timestamp(9) with time zone", "TIMESTAMP '2020-07-03 01:23:45 UTC'", "TIMESTAMP '2020-07-03 01:23:45 UTC'");
+        validateBetween(session, "timestamp(12)", "TIMESTAMP '2020-07-03 01:23:45.123456789123'", "timestamp(12) with time zone", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'");
+        validateBetween(session, "timestamp(12)", "TIMESTAMP '2020-07-03 01:23:45.123456789123'", "timestamp(12) with time zone", "TIMESTAMP '2020-07-03 01:23:45 UTC'", "TIMESTAMP '2020-07-03 01:23:45 UTC'");
 
         // DST forward change (2017-09-24 03:00 -> 2017-09-24 04:00)
         List<LocalTime> fromLocalTimes = asList(
@@ -447,6 +509,32 @@ public class TestUnwrapCastInComparison
                         "FROM (VALUES CAST(ROW(%s) AS ROW(%s))) t(v)",
                 toType, operator, toValue, toType,
                 fromValue, toType, operator, toValue, toType,
+                fromValue, fromType);
+
+        boolean result = (boolean) assertions.execute(session, query)
+                .getMaterializedRows()
+                .get(0)
+                .getField(0);
+
+        assertThat(result)
+                .as("Query evaluated to false: " + query)
+                .isTrue();
+    }
+
+    private void validateBetween(String fromType, Object fromValue, String toType, Object minValue, Object maxValue)
+    {
+        validateBetween(assertions.getDefaultSession(), fromType, fromValue, toType, minValue, maxValue);
+    }
+
+    private void validateBetween(Session session, String fromType, Object fromValue, String toType, Object minValue, Object maxValue)
+    {
+        String query = format(
+                "SELECT (CAST(v AS %s) BETWEEN CAST(%s AS %s) AND CAST(%s AS %s)) " +
+                        "IS NOT DISTINCT FROM " +
+                        "(CAST(%s AS %s) BETWEEN CAST(%s AS %s) AND CAST(%s AS %s)) " +
+                        "FROM (VALUES CAST(%s AS %s)) t(v)",
+                toType, minValue, toType, maxValue, toType,
+                fromValue, toType, minValue, toType, maxValue, toType,
                 fromValue, fromType);
 
         boolean result = (boolean) assertions.execute(session, query)

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestUnwrapCastInComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestUnwrapCastInComparison.java
@@ -75,6 +75,17 @@ public class TestUnwrapCastInComparison
                     validate(operator, fromType, from, "DOUBLE", to);
                 }
             }
+
+            for (Number to : asList(null, Byte.MIN_VALUE - 1, Byte.MIN_VALUE, 0, 1, Byte.MAX_VALUE, Byte.MAX_VALUE + 1)) {
+                validateBetween(fromType, from, "SMALLINT", to, to);
+                validateBetween(fromType, from, "INTEGER", to, to);
+                validateBetween(fromType, from, "BIGINT", to, to);
+                validateBetween(fromType, from, "REAL", to, to);
+                validateBetween(fromType, from, "DOUBLE", to, to);
+            }
+            for (String toType : asList("SMALLINT", "INTEGER", "BIGINT", "REAL", "DOUBLE")) {
+                validateBetweenBounds(fromType, from, toType);
+            }
         }
     }
 
@@ -100,6 +111,16 @@ public class TestUnwrapCastInComparison
                     validate(operator, fromType, from, "DOUBLE", to);
                 }
             }
+
+            for (Number to : asList(null, Short.MIN_VALUE - 1, Short.MIN_VALUE, 0, 1, Short.MAX_VALUE, Short.MAX_VALUE + 1)) {
+                validateBetween(fromType, from, "INTEGER", to, to);
+                validateBetween(fromType, from, "BIGINT", to, to);
+                validateBetween(fromType, from, "REAL", to, to);
+                validateBetween(fromType, from, "DOUBLE", to, to);
+            }
+            for (String toType : asList("INTEGER", "BIGINT", "REAL", "DOUBLE")) {
+                validateBetweenBounds(fromType, from, toType);
+            }
         }
     }
 
@@ -121,6 +142,19 @@ public class TestUnwrapCastInComparison
                     validate(operator, fromType, from, "REAL", to);
                 }
             }
+
+            for (Number to : asList(null, Integer.MIN_VALUE - 1L, Integer.MIN_VALUE, 0, 1, Integer.MAX_VALUE, Integer.MAX_VALUE + 1L)) {
+                validateBetween(fromType, from, "BIGINT", to, to);
+            }
+            for (Number to : asList(null, Integer.MIN_VALUE - 1L, Integer.MIN_VALUE, 0, 0.1, 0.9, 1, Integer.MAX_VALUE, Integer.MAX_VALUE + 1L)) {
+                validateBetween(fromType, from, "DOUBLE", to, to);
+            }
+            for (Number to : asList(null, Integer.MIN_VALUE - 1L, Integer.MIN_VALUE, -1L << 23 + 1, 0, 0.1, 0.9, 1, 1L << 23 - 1, Integer.MAX_VALUE, Integer.MAX_VALUE + 1L)) {
+                validateBetween(fromType, from, "REAL", to, to);
+            }
+            for (String toType : asList("BIGINT", "DOUBLE", "REAL")) {
+                validateBetweenBounds(fromType, from, toType);
+            }
         }
     }
 
@@ -138,6 +172,16 @@ public class TestUnwrapCastInComparison
                     validate(operator, fromType, from, "REAL", to);
                 }
             }
+
+            for (Number to : asList(null, Long.MIN_VALUE, Long.MIN_VALUE + 1, -1L << 53 + 1, 0, 0.1, 0.9, 1, 1L << 53 - 1, Long.MAX_VALUE - 1, Long.MAX_VALUE)) {
+                validateBetween(fromType, from, "DOUBLE", to, to);
+            }
+            for (Number to : asList(null, Long.MIN_VALUE, Long.MIN_VALUE + 1, -1L << 23 + 1, 0, 0.1, 0.9, 1, 1L << 23 - 1, Long.MAX_VALUE - 1, Long.MAX_VALUE)) {
+                validateBetween(fromType, from, "REAL", to, to);
+            }
+            for (String toType : asList("DOUBLE", "REAL")) {
+                validateBetweenBounds(fromType, from, toType);
+            }
         }
     }
 
@@ -153,6 +197,10 @@ public class TestUnwrapCastInComparison
                     validate(operator, fromType, from, toType, to);
                 }
             }
+            for (String to : toLiteral(toType, asList(null, Double.NEGATIVE_INFINITY, Math.nextDown((double) -Float.MIN_VALUE), (double) -Float.MIN_VALUE, 0, 0.1, 0.9, 1, (double) Float.MAX_VALUE, Math.nextUp((double) Float.MAX_VALUE), Double.POSITIVE_INFINITY, Double.NaN))) {
+                validateBetween(fromType, from, toType, to, to);
+            }
+            validateBetweenBounds(fromType, from, toType);
         }
     }
 
@@ -167,6 +215,10 @@ public class TestUnwrapCastInComparison
                     validate(operator, "DECIMAL(15, 0)", from, "DOUBLE", Double.valueOf(to));
                 }
             }
+            for (String to : values) {
+                validateBetween("DECIMAL(15, 0)", from, "DOUBLE", Double.valueOf(to), Double.valueOf(to));
+            }
+            validateBetweenBounds("DECIMAL(15, 0)", from, "DOUBLE");
         }
 
         // decimal(16) -> double
@@ -177,6 +229,10 @@ public class TestUnwrapCastInComparison
                     validate(operator, "DECIMAL(16, 0)", from, "DOUBLE", Double.valueOf(to));
                 }
             }
+            for (String to : values) {
+                validateBetween("DECIMAL(16, 0)", from, "DOUBLE", Double.valueOf(to), Double.valueOf(to));
+            }
+            validateBetweenBounds("DECIMAL(16, 0)", from, "DOUBLE");
         }
 
         // decimal(7) -> real
@@ -187,6 +243,10 @@ public class TestUnwrapCastInComparison
                     validate(operator, "DECIMAL(7, 0)", from, "REAL", Double.valueOf(to));
                 }
             }
+            for (String to : values) {
+                validateBetween("DECIMAL(7, 0)", from, "REAL", Double.valueOf(to), Double.valueOf(to));
+            }
+            validateBetweenBounds("DECIMAL(7, 0)", from, "REAL");
         }
 
         // decimal(8) -> real
@@ -197,6 +257,10 @@ public class TestUnwrapCastInComparison
                     validate(operator, "DECIMAL(8, 0)", from, "REAL", Double.valueOf(to));
                 }
             }
+            for (String to : values) {
+                validateBetween("DECIMAL(8, 0)", from, "REAL", Double.valueOf(to), Double.valueOf(to));
+            }
+            validateBetweenBounds("DECIMAL(8, 0)", from, "REAL");
         }
     }
 
@@ -209,6 +273,9 @@ public class TestUnwrapCastInComparison
                     validate(operator, "VARCHAR(1)", from, "VARCHAR(2)", to);
                 }
             }
+            for (String to : asList(null, "''", "'a'", "'aa'", "'b'", "'bb'")) {
+                validateBetween("VARCHAR(1)", from, "VARCHAR(2)", to, to);
+            }
         }
 
         // type with no range
@@ -216,6 +283,9 @@ public class TestUnwrapCastInComparison
             for (String to : asList("'" + "a".repeat(200) + "'", "'" + "b".repeat(200) + "'")) {
                 validate(operator, "VARCHAR(200)", "'" + "a".repeat(200) + "'", "VARCHAR(300)", to);
             }
+        }
+        for (String to : asList("'" + "a".repeat(200) + "'", "'" + "b".repeat(200) + "'")) {
+            validateBetween("VARCHAR(200)", "'" + "a".repeat(200) + "'", "VARCHAR(300)", to, to);
         }
     }
 
@@ -326,6 +396,15 @@ public class TestUnwrapCastInComparison
             validate(session, operator, "timestamp(12)", "TIMESTAMP '2020-07-03 01:23:45.123456789123'", "timestamp(12) with time zone", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'");
             validate(session, operator, "timestamp(12)", "TIMESTAMP '2020-07-03 01:23:45.123456789123'", "timestamp(12) with time zone", "TIMESTAMP '2020-07-03 01:23:45 UTC'");
         }
+
+        validateBetween(session, "timestamp(3)", "TIMESTAMP '2020-07-03 01:23:45.123'", "timestamp(3) with time zone", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'");
+        validateBetween(session, "timestamp(3)", "TIMESTAMP '2020-07-03 01:23:45.123'", "timestamp(3) with time zone", "TIMESTAMP '2020-07-03 01:23:45 UTC'", "TIMESTAMP '2020-07-03 01:23:45 UTC'");
+        validateBetween(session, "timestamp(6)", "TIMESTAMP '2020-07-03 01:23:45.123456'", "timestamp(6) with time zone", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'");
+        validateBetween(session, "timestamp(6)", "TIMESTAMP '2020-07-03 01:23:45.123456'", "timestamp(6) with time zone", "TIMESTAMP '2020-07-03 01:23:45 UTC'", "TIMESTAMP '2020-07-03 01:23:45 UTC'");
+        validateBetween(session, "timestamp(9)", "TIMESTAMP '2020-07-03 01:23:45.123456789'", "timestamp(9) with time zone", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'");
+        validateBetween(session, "timestamp(9)", "TIMESTAMP '2020-07-03 01:23:45.123456789'", "timestamp(9) with time zone", "TIMESTAMP '2020-07-03 01:23:45 UTC'", "TIMESTAMP '2020-07-03 01:23:45 UTC'");
+        validateBetween(session, "timestamp(12)", "TIMESTAMP '2020-07-03 01:23:45.123456789123'", "timestamp(12) with time zone", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'");
+        validateBetween(session, "timestamp(12)", "TIMESTAMP '2020-07-03 01:23:45.123456789123'", "timestamp(12) with time zone", "TIMESTAMP '2020-07-03 01:23:45 UTC'", "TIMESTAMP '2020-07-03 01:23:45 UTC'");
 
         // DST forward change (2017-09-24 03:00 -> 2017-09-24 04:00)
         List<LocalTime> fromLocalTimes = asList(
@@ -465,6 +544,51 @@ public class TestUnwrapCastInComparison
         assertThat(result)
                 .as("Query evaluated to false: " + query)
                 .isTrue();
+    }
+
+    private void validateBetween(String fromType, Object fromValue, String toType, Object minValue, Object maxValue)
+    {
+        validateBetween(assertions.getDefaultSession(), fromType, fromValue, toType, minValue, maxValue);
+    }
+
+    private void validateBetween(Session session, String fromType, Object fromValue, String toType, Object minValue, Object maxValue)
+    {
+        String query = format(
+                "SELECT (CAST(v AS %s) BETWEEN CAST(%s AS %s) AND CAST(%s AS %s)) " +
+                        "IS NOT DISTINCT FROM " +
+                        "(CAST(%s AS %s) BETWEEN CAST(%s AS %s) AND CAST(%s AS %s)) " +
+                        "FROM (VALUES CAST(%s AS %s)) t(v)",
+                toType,
+                minValue,
+                toType,
+                maxValue,
+                toType,
+                fromValue,
+                toType,
+                minValue,
+                toType,
+                maxValue,
+                toType,
+                fromValue,
+                fromType);
+
+        boolean result = (boolean) assertions.execute(session, query)
+                .getMaterializedRows()
+                .get(0)
+                .getField(0);
+
+        assertThat(result)
+                .as("Query evaluated to false: " + query)
+                .isTrue();
+    }
+
+    private void validateBetweenBounds(String fromType, Object fromValue, String toType)
+    {
+        // distinct, reversed, and single-null endpoints exercise independent endpoint rewriting and BETWEEN three-valued logic
+        validateBetween(fromType, fromValue, toType, 0, 1);
+        validateBetween(fromType, fromValue, toType, 1, 0);
+        validateBetween(fromType, fromValue, toType, null, 1);
+        validateBetween(fromType, fromValue, toType, 0, null);
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -2071,14 +2071,26 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE CAST(d AS date) >= DATE '2015-05-15'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE CAST(d AS DATE) BETWEEN DATE '2015-05-15' AND DATE '2015-06-15'"))
+                .isFullyPushedDown();
 
         assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE d >= TIMESTAMP '2015-05-15 12:00:00'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE d BETWEEN TIMESTAMP '2015-05-15 12:00:00' AND TIMESTAMP '2015-06-15 11:59:59.999999'"))
+                .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE d >= TIMESTAMP '2015-05-15 12:00:00.000001'"))
+                .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE d BETWEEN TIMESTAMP '2015-05-15 12:00:00.000001' AND TIMESTAMP '2015-06-15 11:59:59.999999'"))
+                .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE d BETWEEN TIMESTAMP '2015-05-15 12:00:00' AND TIMESTAMP '2015-06-15 12:00:00.00000'"))
                 .isNotFullyPushedDown(FilterNode.class);
 
         // date()
         assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE date(d) = DATE '2015-05-15'"))
+                .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE date(d) BETWEEN DATE '2015-05-15' AND DATE '2015-06-15'"))
+                .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE date(d) BETWEEN TIMESTAMP '2015-05-15 12:00:00' AND TIMESTAMP '2015-06-15 12:00:00.00000'"))
                 .isFullyPushedDown();
 
         // year()
@@ -2177,6 +2189,8 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_hour_transform_timestamptz WHERE CAST(d AS date) >= DATE '2015-05-15'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_hour_transform_timestamptz WHERE CAST(d AS date) BETWEEN DATE '2015-05-15' AND DATE '2015-06-15'"))
+                .isFullyPushedDown();
 
         assertThat(query("SELECT * FROM test_hour_transform_timestamptz WHERE d >= TIMESTAMP '2015-05-15 12:00:00 UTC'"))
                 .isFullyPushedDown();
@@ -2185,6 +2199,8 @@ public abstract class BaseIcebergConnectorTest
 
         // date()
         assertThat(query("SELECT * FROM test_hour_transform_timestamptz WHERE date(d) = DATE '2015-05-15'"))
+                .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_hour_transform_timestamptz WHERE date(d) BETWEEN DATE '2015-05-15' AND DATE '2015-06-15'"))
                 .isFullyPushedDown();
 
         // year()
@@ -2357,6 +2373,8 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_day_transform_date WHERE CAST(d AS date) >= DATE '2015-01-13'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_day_transform_date WHERE d BETWEEN DATE '2015-01-13' AND DATE '2015-01-14'"))
+                .isFullyPushedDown();
 
         // d comparison with TIMESTAMP can be unwrapped
         assertThat(query("SELECT * FROM test_day_transform_date WHERE d >= TIMESTAMP '2015-01-13 00:00:00'"))
@@ -2470,14 +2488,22 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE CAST(d AS date) >= DATE '2015-05-15'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE d BETWEEN DATE '2015-05-15' AND DATE '2015-05-16'"))
+                .isNotFullyPushedDown(FilterNode.class);
 
         assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE d >= TIMESTAMP '2015-05-15 00:00:00'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE d BETWEEN TIMESTAMP '2015-05-15 00:00:00' AND TIMESTAMP '2015-05-16 23:59:59.999999'"))
+                .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE d >= TIMESTAMP '2015-05-15 00:00:00.000001'"))
+                .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE d BETWEEN TIMESTAMP '2015-05-15 00:00:00' AND TIMESTAMP '2015-05-16 00:00:00'"))
                 .isNotFullyPushedDown(FilterNode.class);
 
         // date()
         assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE date(d) = DATE '2015-05-15'"))
+                .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE date(d) BETWEEN DATE '2015-05-15' AND DATE '2015-06-15'"))
                 .isFullyPushedDown();
 
         // year()
@@ -2693,12 +2719,16 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_month_transform_date WHERE CAST(d AS date) >= DATE '2020-06-02'"))
                 .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_month_transform_date WHERE d BETWEEN DATE '2020-06-01' AND DATE '2020-07-31'"))
+                .isFullyPushedDown();
 
         // d comparison with TIMESTAMP can be unwrapped
         assertThat(query("SELECT * FROM test_month_transform_date WHERE d >= TIMESTAMP '2015-06-01 00:00:00'"))
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_month_transform_date WHERE d >= TIMESTAMP '2015-05-01 00:00:00.000001'"))
                 .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_month_transform_date WHERE d BETWEEN TIMESTAMP '2015-05-01 00:00:00' AND TIMESTAMP '2015-06-30 00:00:00'"))
+                .isFullyPushedDown();
 
         // year()
         assertThat(query("SELECT * FROM test_month_transform_date WHERE year(d) = 2015"))
@@ -2823,6 +2853,11 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_month_transform_timestamp WHERE d >= TIMESTAMP '2015-05-01 00:00:00.000001'"))
                 .isNotFullyPushedDown(FilterNode.class);
+
+        assertThat(query("SELECT * FROM test_month_transform_timestamp WHERE d BETWEEN DATE '2015-05-01' AND DATE '2015-06-01'"))
+                .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_month_transform_timestamp WHERE d BETWEEN DATE '2015-05-01' AND TIMESTAMP '2015-05-31 23:59:59.999999'"))
+                .isFullyPushedDown();
 
         // year()
         assertThat(query("SELECT * FROM test_month_transform_timestamp WHERE year(d) = 2015"))
@@ -3028,6 +3063,10 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_year_transform_date WHERE CAST(d AS date) >= DATE '2015-01-02'"))
                 .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_year_transform_date WHERE d BETWEEN DATE '2015-01-01' AND DATE '2016-01-01'"))
+                .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_year_transform_date WHERE d BETWEEN DATE '2015-01-01' AND TIMESTAMP '2015-12-31 23:59:59.999999'"))
+                .isFullyPushedDown();
 
         // d comparison with TIMESTAMP can be unwrapped
         assertThat(query("SELECT * FROM test_year_transform_date WHERE d >= TIMESTAMP '2015-01-01 00:00:00'"))
@@ -3148,6 +3187,8 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_year_transform_timestamp WHERE CAST(d AS date) >= DATE '2015-01-02'"))
                 .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_year_transform_timestamp WHERE CAST(d AS date) BETWEEN DATE '2015-01-01' AND DATE '2016-12-31'"))
+                .isFullyPushedDown();
 
         assertThat(query("SELECT * FROM test_year_transform_timestamp WHERE d >= TIMESTAMP '2015-01-01 00:00:00'"))
                 .isFullyPushedDown();
@@ -3243,6 +3284,10 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE d >= with_timezone(DATE '2015-01-02', 'UTC')"))
                 .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE d BETWEEN DATE '2015-01-01' AND DATE '2016-01-01'"))
+                .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE d BETWEEN with_timezone(DATE '2015-01-01', 'UTC') AND with_timezone(TIMESTAMP '2016-12-31 23:59:59.999999', 'UTC')"))
+                .isFullyPushedDown();
 
         assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE CAST(d AS date) >= DATE '2015-01-01'"))
                 .isFullyPushedDown();
@@ -3252,6 +3297,8 @@ public abstract class BaseIcebergConnectorTest
                 // Engine can eliminate the table scan after connector accepts the filter pushdown
                 .hasPlan(node(OutputNode.class, node(ValuesNode.class)))
                 .returnsEmptyResult();
+        assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE CAST(d AS date) BETWEEN DATE '2015-01-01' AND DATE '2016-12-31'"))
+                .isFullyPushedDown();
 
         assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE d >= TIMESTAMP '2015-01-01 00:00:00 UTC'"))
                 .isFullyPushedDown();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -2221,14 +2221,26 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE CAST(d AS date) >= DATE '2015-05-15'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE CAST(d AS DATE) BETWEEN DATE '2015-05-15' AND DATE '2015-06-15'"))
+                .isFullyPushedDown();
 
         assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE d >= TIMESTAMP '2015-05-15 12:00:00'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE d BETWEEN TIMESTAMP '2015-05-15 12:00:00' AND TIMESTAMP '2015-06-15 11:59:59.999999'"))
+                .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE d >= TIMESTAMP '2015-05-15 12:00:00.000001'"))
+                .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE d BETWEEN TIMESTAMP '2015-05-15 12:00:00.000001' AND TIMESTAMP '2015-06-15 11:59:59.999999'"))
+                .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE d BETWEEN TIMESTAMP '2015-05-15 12:00:00' AND TIMESTAMP '2015-06-15 12:00:00.00000'"))
                 .isNotFullyPushedDown(FilterNode.class);
 
         // date()
         assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE date(d) = DATE '2015-05-15'"))
+                .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE date(d) BETWEEN DATE '2015-05-15' AND DATE '2015-06-15'"))
+                .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE date(d) BETWEEN TIMESTAMP '2015-05-15 12:00:00' AND TIMESTAMP '2015-06-15 12:00:00.00000'"))
                 .isFullyPushedDown();
 
         // year()
@@ -2327,6 +2339,8 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_hour_transform_timestamptz WHERE CAST(d AS date) >= DATE '2015-05-15'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_hour_transform_timestamptz WHERE CAST(d AS date) BETWEEN DATE '2015-05-15' AND DATE '2015-06-15'"))
+                .isFullyPushedDown();
 
         assertThat(query("SELECT * FROM test_hour_transform_timestamptz WHERE d >= TIMESTAMP '2015-05-15 12:00:00 UTC'"))
                 .isFullyPushedDown();
@@ -2335,6 +2349,8 @@ public abstract class BaseIcebergConnectorTest
 
         // date()
         assertThat(query("SELECT * FROM test_hour_transform_timestamptz WHERE date(d) = DATE '2015-05-15'"))
+                .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_hour_transform_timestamptz WHERE date(d) BETWEEN DATE '2015-05-15' AND DATE '2015-06-15'"))
                 .isFullyPushedDown();
 
         // year()
@@ -2507,6 +2523,8 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_day_transform_date WHERE CAST(d AS date) >= DATE '2015-01-13'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_day_transform_date WHERE d BETWEEN DATE '2015-01-13' AND DATE '2015-01-14'"))
+                .isFullyPushedDown();
 
         // d comparison with TIMESTAMP can be unwrapped
         assertThat(query("SELECT * FROM test_day_transform_date WHERE d >= TIMESTAMP '2015-01-13 00:00:00'"))
@@ -2620,14 +2638,22 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE CAST(d AS date) >= DATE '2015-05-15'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE d BETWEEN DATE '2015-05-15' AND DATE '2015-05-16'"))
+                .isNotFullyPushedDown(FilterNode.class);
 
         assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE d >= TIMESTAMP '2015-05-15 00:00:00'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE d BETWEEN TIMESTAMP '2015-05-15 00:00:00' AND TIMESTAMP '2015-05-16 23:59:59.999999'"))
+                .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE d >= TIMESTAMP '2015-05-15 00:00:00.000001'"))
+                .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE d BETWEEN TIMESTAMP '2015-05-15 00:00:00' AND TIMESTAMP '2015-05-16 00:00:00'"))
                 .isNotFullyPushedDown(FilterNode.class);
 
         // date()
         assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE date(d) = DATE '2015-05-15'"))
+                .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE date(d) BETWEEN DATE '2015-05-15' AND DATE '2015-06-15'"))
                 .isFullyPushedDown();
 
         // year()
@@ -2843,12 +2869,16 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_month_transform_date WHERE CAST(d AS date) >= DATE '2020-06-02'"))
                 .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_month_transform_date WHERE d BETWEEN DATE '2020-06-01' AND DATE '2020-07-31'"))
+                .isFullyPushedDown();
 
         // d comparison with TIMESTAMP can be unwrapped
         assertThat(query("SELECT * FROM test_month_transform_date WHERE d >= TIMESTAMP '2015-06-01 00:00:00'"))
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_month_transform_date WHERE d >= TIMESTAMP '2015-05-01 00:00:00.000001'"))
                 .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_month_transform_date WHERE d BETWEEN TIMESTAMP '2015-05-01 00:00:00' AND TIMESTAMP '2015-06-30 00:00:00'"))
+                .isFullyPushedDown();
 
         // year()
         assertThat(query("SELECT * FROM test_month_transform_date WHERE year(d) = 2015"))
@@ -2973,6 +3003,11 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_month_transform_timestamp WHERE d >= TIMESTAMP '2015-05-01 00:00:00.000001'"))
                 .isNotFullyPushedDown(FilterNode.class);
+
+        assertThat(query("SELECT * FROM test_month_transform_timestamp WHERE d BETWEEN DATE '2015-05-01' AND DATE '2015-06-01'"))
+                .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_month_transform_timestamp WHERE d BETWEEN DATE '2015-05-01' AND TIMESTAMP '2015-05-31 23:59:59.999999'"))
+                .isFullyPushedDown();
 
         // year()
         assertThat(query("SELECT * FROM test_month_transform_timestamp WHERE year(d) = 2015"))
@@ -3178,6 +3213,10 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_year_transform_date WHERE CAST(d AS date) >= DATE '2015-01-02'"))
                 .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_year_transform_date WHERE d BETWEEN DATE '2015-01-01' AND DATE '2016-01-01'"))
+                .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_year_transform_date WHERE d BETWEEN DATE '2015-01-01' AND TIMESTAMP '2015-12-31 23:59:59.999999'"))
+                .isFullyPushedDown();
 
         // d comparison with TIMESTAMP can be unwrapped
         assertThat(query("SELECT * FROM test_year_transform_date WHERE d >= TIMESTAMP '2015-01-01 00:00:00'"))
@@ -3298,6 +3337,8 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_year_transform_timestamp WHERE CAST(d AS date) >= DATE '2015-01-02'"))
                 .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_year_transform_timestamp WHERE CAST(d AS date) BETWEEN DATE '2015-01-01' AND DATE '2016-12-31'"))
+                .isFullyPushedDown();
 
         assertThat(query("SELECT * FROM test_year_transform_timestamp WHERE d >= TIMESTAMP '2015-01-01 00:00:00'"))
                 .isFullyPushedDown();
@@ -3393,6 +3434,10 @@ public abstract class BaseIcebergConnectorTest
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE d >= with_timezone(DATE '2015-01-02', 'UTC')"))
                 .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE d BETWEEN DATE '2015-01-01' AND DATE '2016-01-01'"))
+                .isNotFullyPushedDown(FilterNode.class);
+        assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE d BETWEEN with_timezone(DATE '2015-01-01', 'UTC') AND with_timezone(TIMESTAMP '2016-12-31 23:59:59.999999', 'UTC')"))
+                .isFullyPushedDown();
 
         assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE CAST(d AS date) >= DATE '2015-01-01'"))
                 .isFullyPushedDown();
@@ -3402,6 +3447,8 @@ public abstract class BaseIcebergConnectorTest
                 // Engine can eliminate the table scan after connector accepts the filter pushdown
                 .hasPlan(node(OutputNode.class, node(ValuesNode.class)))
                 .returnsEmptyResult();
+        assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE CAST(d AS date) BETWEEN DATE '2015-01-01' AND DATE '2016-12-31'"))
+                .isFullyPushedDown();
 
         assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE d >= TIMESTAMP '2015-01-01 00:00:00 UTC'"))
                 .isFullyPushedDown();


### PR DESCRIPTION
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Rewrite a cast that appears as the value of a `BETWEEN` predicate into a range over the underlying expression, so the predicate can be pushed into the scan. For example, given `t::timestamp(6)`:

    CAST(t AS date) BETWEEN DATE '2022-01-01' AND DATE '2022-01-02'

is rewritten as

    t BETWEEN TIMESTAMP '2022-01-01 00:00:00.000000' AND TIMESTAMP '2022-01-02 23:59:59.999999'

Each half of the `BETWEEN` is unwrapped independently. A strict bound produced by the unwrapping (for example `t < TIMESTAMP '...start of next day...'`) is tightened to its inclusive neighbor using `Type.getPreviousValue`/`getNextValue`, and the two bounds are recombined into an inclusive range. Bounds that fall outside the source type range collapse to a constant truth value: an always-true bound drops out, and an empty or unsatisfiable range becomes `false` for a non-null source.

When a bound cannot be tightened to an inclusive neighbor (a source type such as `real` has no adjacent value), the two comparisons are kept as a conjunction that references the source in both halves. A non-trivial source is bound once via a `Let` so it is evaluated a single time; a column reference stays inline so the bare comparisons remain available for pruning.

A range predicate over the raw column can be turned into a `TupleDomain`, which connectors with min/max metadata (such as Iceberg manifest and data file statistics) use for partition and file pruning. That range representation is not available while the predicate is left as a cast.

## Additional context and related issues

Alternative to #14452, built on the work in #12797 and #14390. The `Between` IR node has since been removed, so the rewrite runs over the `Let` form that `BETWEEN` desugars into (`UnwrapCastInComparison.Visitor#rewriteLet` and `unwrapCastInBetween`); the original author's boundary logic and test cases are preserved.

Rebased on #30286, which fixes the same class of source duplication for plain timestamp-to-date comparisons by binding a non-trivial source once via `Let` instead of duplicating it. This PR reuses that `bindSourceIfNecessary` helper for the `BETWEEN` conjunction fallback described above.

Correctness is covered by `io.trino.sql.planner.TestUnwrapCastInComparison#testBetween`, `#testBetweenDouble`, and `io.trino.sql.query.TestUnwrapCastInComparison`.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Improve performance of queries with `BETWEEN` predicates that compare a cast expression against a range of literals, such as `CAST(ts AS date) BETWEEN DATE '2020-01-01' AND DATE '2020-01-02'`. ({issue}`14648`)
```
