### PR TITLE
Introduce constants to BaseJdbcConfig

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -140,7 +140,7 @@ public abstract class BaseJdbcClient
     {
         try (Connection connection = connectionFactory.openConnection(session)) {
             return listSchemas(connection).stream()
-                    .map(remoteSchemaName -> identifierMapping.fromRemoteSchemaName(remoteSchemaName))
+                    .map(identifierMapping::fromRemoteSchemaName)
                     .collect(toImmutableSet());
         }
         catch (SQLException e) {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcConfig.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcConfig.java
@@ -34,6 +34,9 @@ import static javax.validation.constraints.Pattern.Flag.CASE_INSENSITIVE;
 
 public class BaseJdbcConfig
 {
+    public static final String METADATA_CACHE_TTL = "metadata.cache-ttl";
+    public static final String METADATA_CACHE_MAXIMUM_SIZE = "metadata.cache-maximum-size";
+
     private String connectionUrl;
     private Set<String> jdbcTypesMappedToVarchar = ImmutableSet.of();
     public static final Duration CACHING_DISABLED = new Duration(0, MILLISECONDS);
@@ -76,7 +79,7 @@ public class BaseJdbcConfig
         return metadataCacheTtl;
     }
 
-    @Config("metadata.cache-ttl")
+    @Config(METADATA_CACHE_TTL)
     @ConfigDescription("Determines how long meta information will be cached")
     public BaseJdbcConfig setMetadataCacheTtl(Duration metadataCacheTtl)
     {
@@ -103,7 +106,7 @@ public class BaseJdbcConfig
         return cacheMaximumSize;
     }
 
-    @Config("metadata.cache-maximum-size")
+    @Config(METADATA_CACHE_MAXIMUM_SIZE)
     @ConfigDescription("Maximum number of objects stored in the metadata cache")
     public BaseJdbcConfig setCacheMaximumSize(long cacheMaximumSize)
     {
@@ -116,7 +119,7 @@ public class BaseJdbcConfig
     {
         if (metadataCacheTtl.equals(CACHING_DISABLED) && cacheMaximumSize != BaseJdbcConfig.DEFAULT_METADATA_CACHE_SIZE) {
             throw new IllegalArgumentException(
-                    format("metadata.cache-ttl must be set to a non-zero value when metadata.cache-maximum-size is set"));
+                    format("%s must be set to a non-zero value when %s is set", METADATA_CACHE_TTL, METADATA_CACHE_MAXIMUM_SIZE));
         }
     }
 }


### PR DESCRIPTION
## Description

The configuration `metadata.cache-ttl` and `metadata.cache-maximum-size`
are used in the exception message of `BaseJdbcConfig#validate`, so it is
better to use constants to avoid the problem that the configuration is
not synchronized with the exception message.

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
