### PR TITLE
Fix ignore exclusion if not working as expected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -682,6 +682,17 @@ jobs:
             - default
             - hdp3
             # TODO: config-apache-hive3
+          ignore exclusion if:
+            # Do not use this property outside of the matrix configuration.
+            #
+            # This is added to all matrix entries so they may be conditionally
+            # excluded by adding them to the excludes list with a GHA expression
+            # for this property.
+            # - If the expression evaluates to true, it will never match the a
+            #   actual value of the property, and will therefore not be excluded.
+            # - If the expression evaluates to false, it will match the actual
+            #   value of the property, and the exclusion will apply normally.
+            - false # intentionally a boolean instead of string like other matrix keys to make it easier to evaluate expressions
           suite:
             - suite-1
             - suite-2
@@ -718,17 +729,6 @@ jobs:
               ignore exclusion if: >-
                 ${{ needs.build-pt.outputs.have_databricks_secrets == 'true' }}
 
-          ignore exclusion if:
-            # Do not use this property outside of the matrix configuration.
-            #
-            # This is added to all matrix entries so they may be conditionally
-            # excluded by adding them to the excludes list with a GHA expression
-            # for this property.
-            # - If the expression evaluates to true, it will never match the a
-            #   actual value of the property, and will therefore not be excluded.
-            # - If the expression evaluates to false, it will match the actual
-            #   value of the property, and the exclusion will apply normally.
-            - false # intentionally a boolean instead of string like other matrix keys to make it easier to evaluate expressions
           include:
             # this suite is not meant to be run with different configs
             - config: default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -728,7 +728,7 @@ jobs:
             #   actual value of the property, and will therefore not be excluded.
             # - If the expression evaluates to false, it will match the actual
             #   value of the property, and the exclusion will apply normally.
-            - "false"
+            - false # intentionally a boolean instead of string like other matrix keys to make it easier to evaluate expressions
           include:
             # this suite is not meant to be run with different configs
             - config: default


### PR DESCRIPTION
Fix ignore exclusion if not working as expected
    
After c9deaf6e0e5f710e6fa4964caed5844be77b1253 change the ignore exclusion if
key no longer matches any value from the matrix because the exclude entries set
'ignore exclusion if' to a boolean false while the 'ignore exclusion if'
default was changed to a string "false".

This meant that any product tests which were executed conditionally based on
value of 'ignore exclusion if' were not executed at all - even on master. This
change fixes that.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.