### PR TITLE
Support more types in batched parquet reader

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
@@ -14,6 +14,7 @@
 package io.trino.parquet;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.spi.TrinoException;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.MapType;
@@ -33,6 +34,7 @@ import org.apache.parquet.schema.MessageType;
 
 import javax.annotation.Nullable;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -42,6 +44,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.lang.String.format;
 import static org.apache.parquet.io.ColumnIOUtil.columnDefinitionLevel;
 import static org.apache.parquet.io.ColumnIOUtil.columnRepetitionLevel;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
@@ -283,6 +287,21 @@ public final class ParquetTypeUtils
         }
         value = value >> ((8 - length) * 8);
         return value;
+    }
+
+    public static void checkBytesFitInShortDecimal(byte[] bytes, int endOffset, Type trinoType, int typeLength)
+    {
+        // Equivalent to expectedValue = bytes[endOffset] < 0 ? -1 : 0
+        byte expectedValue = (byte) (bytes[endOffset] >> 7);
+        for (int i = 0; i < endOffset; i++) {
+            if (bytes[i] != expectedValue) {
+                throw new TrinoException(NOT_SUPPORTED, format(
+                        "Could not read fixed_len_byte_array(%d) value %s into %s",
+                        typeLength,
+                        new BigDecimal(new BigInteger(bytes), ((DecimalType) trinoType).getScale()),
+                        trinoType));
+            }
+        }
     }
 
     public static byte[] paddingBigInteger(BigInteger bigInteger, int numBytes)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
@@ -34,7 +34,6 @@ import org.apache.parquet.schema.MessageType;
 
 import javax.annotation.Nullable;
 
-import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -289,17 +288,17 @@ public final class ParquetTypeUtils
         return value;
     }
 
-    public static void checkBytesFitInShortDecimal(byte[] bytes, int endOffset, Type trinoType, int typeLength)
+    public static void checkBytesFitInShortDecimal(byte[] bytes, int endOffset, Type trinoType, ColumnDescriptor descriptor)
     {
         // Equivalent to expectedValue = bytes[endOffset] < 0 ? -1 : 0
         byte expectedValue = (byte) (bytes[endOffset] >> 7);
         for (int i = 0; i < endOffset; i++) {
             if (bytes[i] != expectedValue) {
                 throw new TrinoException(NOT_SUPPORTED, format(
-                        "Could not read fixed_len_byte_array(%d) value %s into %s",
-                        typeLength,
-                        new BigDecimal(new BigInteger(bytes), ((DecimalType) trinoType).getScale()),
-                        trinoType));
+                        "Could not read unscaled value %s into %s from column %s",
+                        new BigInteger(bytes),
+                        trinoType,
+                        descriptor));
             }
         }
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
@@ -288,11 +288,12 @@ public final class ParquetTypeUtils
         return value;
     }
 
-    public static void checkBytesFitInShortDecimal(byte[] bytes, int endOffset, Type trinoType, ColumnDescriptor descriptor)
+    public static void checkBytesFitInShortDecimal(byte[] bytes, int offset, int length, Type trinoType, ColumnDescriptor descriptor)
     {
+        int endOffset = offset + length;
         // Equivalent to expectedValue = bytes[endOffset] < 0 ? -1 : 0
         byte expectedValue = (byte) (bytes[endOffset] >> 7);
-        for (int i = 0; i < endOffset; i++) {
+        for (int i = offset; i < endOffset; i++) {
             if (bytes[i] != expectedValue) {
                 throw new TrinoException(NOT_SUPPORTED, format(
                         "Could not read unscaled value %s into %s from column %s",

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
@@ -102,6 +102,12 @@ public final class ColumnReaderFactory
                 }
                 throw unsupportedException(type, field);
             }
+            if (type instanceof AbstractLongType && primitiveType == INT32) {
+                if (isIntegerAnnotation(annotation)) {
+                    return new FlatColumnReader<>(field, ValueDecoders::getIntToLongDecoder, LONG_ADAPTER);
+                }
+                throw unsupportedException(type, field);
+            }
             if (type instanceof AbstractLongType && primitiveType == INT64) {
                 if (BIGINT.equals(type) && annotation instanceof TimestampLogicalTypeAnnotation) {
                     return new FlatColumnReader<>(field, ValueDecoders::getLongDecoder, LONG_ADAPTER);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
@@ -54,6 +54,7 @@ import static org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit.MICROS;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit.MILLIS;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit.NANOS;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
@@ -109,7 +110,8 @@ public final class ColumnReaderFactory
             if (DOUBLE.equals(type) && primitiveType == PrimitiveTypeName.DOUBLE) {
                 return new FlatColumnReader<>(field, ValueDecoders::getDoubleDecoder, LONG_ADAPTER);
             }
-            if (type instanceof DecimalType decimalType && decimalType.isShort() && (primitiveType == INT32 || primitiveType == INT64)) {
+            if (type instanceof DecimalType decimalType && decimalType.isShort()
+                    && (primitiveType == INT32 || primitiveType == INT64 || primitiveType == FIXED_LEN_BYTE_ARRAY)) {
                 if (annotation instanceof DecimalLogicalTypeAnnotation decimalAnnotation && !isDecimalRescaled(decimalAnnotation, decimalType)) {
                     return new FlatColumnReader<>(field, ValueDecoders::getShortDecimalDecoder, LONG_ADAPTER);
                 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
@@ -22,6 +22,7 @@ import io.trino.spi.type.AbstractLongType;
 import io.trino.spi.type.AbstractVariableWidthType;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.TimeType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
@@ -108,6 +109,12 @@ public final class ColumnReaderFactory
                 }
                 throw unsupportedException(type, field);
             }
+            if (type instanceof TimeType && primitiveType == INT64) {
+                if (annotation instanceof TimeLogicalTypeAnnotation timeAnnotation && timeAnnotation.getUnit() == MICROS) {
+                    return new FlatColumnReader<>(field, ValueDecoders::getTimeMicrosDecoder, LONG_ADAPTER);
+                }
+                throw unsupportedException(type, field);
+            }
             if (type instanceof AbstractLongType && primitiveType == INT64) {
                 if (BIGINT.equals(type) && annotation instanceof TimestampLogicalTypeAnnotation) {
                     return new FlatColumnReader<>(field, ValueDecoders::getLongDecoder, LONG_ADAPTER);
@@ -115,6 +122,7 @@ public final class ColumnReaderFactory
                 if (isIntegerAnnotation(annotation)) {
                     return new FlatColumnReader<>(field, ValueDecoders::getLongDecoder, LONG_ADAPTER);
                 }
+                throw unsupportedException(type, field);
             }
             if (REAL.equals(type) && primitiveType == FLOAT) {
                 return new FlatColumnReader<>(field, ValueDecoders::getRealDecoder, INT_ADAPTER);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import static io.trino.parquet.ParquetTypeUtils.createDecimalType;
 import static io.trino.parquet.reader.flat.BooleanColumnAdapter.BOOLEAN_ADAPTER;
 import static io.trino.parquet.reader.flat.ByteColumnAdapter.BYTE_ADAPTER;
+import static io.trino.parquet.reader.flat.Int128ColumnAdapter.INT128_ADAPTER;
 import static io.trino.parquet.reader.flat.IntColumnAdapter.INT_ADAPTER;
 import static io.trino.parquet.reader.flat.LongColumnAdapter.LONG_ADAPTER;
 import static io.trino.parquet.reader.flat.ShortColumnAdapter.SHORT_ADAPTER;
@@ -54,6 +55,7 @@ import static org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit.MICROS;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit.MILLIS;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit.NANOS;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
@@ -114,6 +116,12 @@ public final class ColumnReaderFactory
                     && (primitiveType == INT32 || primitiveType == INT64 || primitiveType == FIXED_LEN_BYTE_ARRAY)) {
                 if (annotation instanceof DecimalLogicalTypeAnnotation decimalAnnotation && !isDecimalRescaled(decimalAnnotation, decimalType)) {
                     return new FlatColumnReader<>(field, ValueDecoders::getShortDecimalDecoder, LONG_ADAPTER);
+                }
+            }
+            if (type instanceof DecimalType decimalType && !decimalType.isShort()
+                    && (primitiveType == BINARY || primitiveType == FIXED_LEN_BYTE_ARRAY)) {
+                if (annotation instanceof DecimalLogicalTypeAnnotation decimalAnnotation && !isDecimalRescaled(decimalAnnotation, decimalType)) {
+                    return new FlatColumnReader<>(field, ValueDecoders::getLongDecimalDecoder, INT128_ADAPTER);
                 }
             }
         }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ShortDecimalColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ShortDecimalColumnReader.java
@@ -42,13 +42,12 @@ public class ShortDecimalColumnReader
         extends PrimitiveColumnReader
 {
     private final DecimalType parquetDecimalType;
-    private final int typeLength;
 
     ShortDecimalColumnReader(PrimitiveField field, DecimalType parquetDecimalType)
     {
         super(field);
         this.parquetDecimalType = requireNonNull(parquetDecimalType, "parquetDecimalType is null");
-        typeLength = field.getDescriptor().getPrimitiveType().getTypeLength();
+        int typeLength = field.getDescriptor().getPrimitiveType().getTypeLength();
         checkArgument(typeLength <= 16, "Type length %s should be <= 16 for short decimal column %s", typeLength, field.getDescriptor());
     }
 
@@ -70,12 +69,12 @@ public class ShortDecimalColumnReader
         }
         else {
             byte[] bytes = valuesReader.readBytes().getBytes();
-            if (typeLength <= Long.BYTES) {
+            if (bytes.length <= Long.BYTES) {
                 value = getShortDecimalValue(bytes);
             }
             else {
                 int startOffset = bytes.length - Long.BYTES;
-                checkBytesFitInShortDecimal(bytes, startOffset, trinoType, typeLength);
+                checkBytesFitInShortDecimal(bytes, startOffset, trinoType, field.getDescriptor());
                 value = getShortDecimalValue(bytes, startOffset, Long.BYTES);
             }
         }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ShortDecimalColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ShortDecimalColumnReader.java
@@ -74,7 +74,7 @@ public class ShortDecimalColumnReader
             }
             else {
                 int startOffset = bytes.length - Long.BYTES;
-                checkBytesFitInShortDecimal(bytes, startOffset, trinoType, field.getDescriptor());
+                checkBytesFitInShortDecimal(bytes, 0, startOffset, trinoType, field.getDescriptor());
                 value = getShortDecimalValue(bytes, startOffset, Long.BYTES);
             }
         }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ApacheParquetValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ApacheParquetValueDecoders.java
@@ -13,9 +13,16 @@
  */
 package io.trino.parquet.reader.decoders;
 
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import io.trino.parquet.reader.SimpleSliceInputStream;
+import io.trino.parquet.reader.flat.BinaryBuffer;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.Chars;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Int128;
+import io.trino.spi.type.VarcharType;
+import io.trino.spi.type.Varchars;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.values.ValuesReader;
@@ -30,6 +37,7 @@ import static io.trino.parquet.ParquetReaderUtils.toByteExact;
 import static io.trino.parquet.ParquetReaderUtils.toShortExact;
 import static io.trino.parquet.ParquetTypeUtils.checkBytesFitInShortDecimal;
 import static io.trino.parquet.ParquetTypeUtils.getShortDecimalValue;
+import static io.trino.spi.type.Varchars.truncateToLength;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -367,6 +375,112 @@ public class ApacheParquetValueDecoders
                 Int128 value = Int128.fromBigEndian(delegate.readBytes().getBytes());
                 values[currentOutputOffset] = value.getHigh();
                 values[currentOutputOffset + 1] = value.getLow();
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            delegate.skip(n);
+        }
+    }
+
+    public static final class BoundedVarcharApacheParquetValueDecoder
+            implements ValueDecoder<BinaryBuffer>
+    {
+        private final ValuesReader delegate;
+        private final int boundedLength;
+
+        public BoundedVarcharApacheParquetValueDecoder(ValuesReader delegate, VarcharType varcharType)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+            checkArgument(
+                    !varcharType.isUnbounded(),
+                    "Trino type %s is not a bounded varchar",
+                    varcharType);
+            this.boundedLength = varcharType.getBoundedLength();
+        }
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            initialize(input, delegate);
+        }
+
+        @Override
+        public void read(BinaryBuffer values, int offsetsIndex, int length)
+        {
+            for (int i = 0; i < length; i++) {
+                byte[] value = delegate.readBytes().getBytes();
+                Slice slice = Varchars.truncateToLength(Slices.wrappedBuffer(value), boundedLength);
+                values.add(slice, i + offsetsIndex);
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            delegate.skip(n);
+        }
+    }
+
+    public static final class CharApacheParquetValueDecoder
+            implements ValueDecoder<BinaryBuffer>
+    {
+        private final ValuesReader delegate;
+        private final int maxLength;
+
+        public CharApacheParquetValueDecoder(ValuesReader delegate, CharType charType)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+            this.maxLength = charType.getLength();
+        }
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            initialize(input, delegate);
+        }
+
+        @Override
+        public void read(BinaryBuffer values, int offsetsIndex, int length)
+        {
+            for (int i = 0; i < length; i++) {
+                byte[] value = delegate.readBytes().getBytes();
+                Slice slice = Chars.trimTrailingSpaces(truncateToLength(Slices.wrappedBuffer(value), maxLength));
+                values.add(slice, i + offsetsIndex);
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            delegate.skip(n);
+        }
+    }
+
+    public static final class BinaryApacheParquetValueDecoder
+            implements ValueDecoder<BinaryBuffer>
+    {
+        private final ValuesReader delegate;
+
+        public BinaryApacheParquetValueDecoder(ValuesReader delegate)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            initialize(input, delegate);
+        }
+
+        @Override
+        public void read(BinaryBuffer values, int offsetsIndex, int length)
+        {
+            for (int i = 0; i < length; i++) {
+                byte[] value = delegate.readBytes().getBytes();
+                values.add(value, i + offsetsIndex);
             }
         }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/DelegateDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/DelegateDecoders.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.trino.parquet.reader.SimpleSliceInputStream;
+
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+
+public class DelegateDecoders
+{
+    private DelegateDecoders() {}
+
+    public static ValueDecoder<long[]> timeMicrosDecoder(ValueDecoder<long[]> delegate)
+    {
+        return new ValueDecoder<>()
+        {
+            @Override
+            public void init(SimpleSliceInputStream input)
+            {
+                delegate.init(input);
+            }
+
+            @Override
+            public void read(long[] values, int offset, int length)
+            {
+                delegate.read(values, offset, length);
+                for (int i = offset; i < offset + length; i++) {
+                    values[i] = values[i] * PICOSECONDS_PER_MICROSECOND;
+                }
+            }
+
+            @Override
+            public void skip(int n)
+            {
+                delegate.skip(n);
+            }
+        };
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
@@ -32,6 +32,7 @@ import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.FloatA
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.IntApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.IntToLongApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.LongApacheParquetValueDecoder;
+import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.LongDecimalApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortDecimalApacheParquetValueDecoder;
 import static java.util.Objects.requireNonNull;
@@ -70,6 +71,15 @@ public final class ValueDecoders
             case INT64 -> getLongDecoder(encoding, field, dictionary);
             case INT32 -> getIntToLongDecoder(encoding, field, dictionary);
             case FIXED_LEN_BYTE_ARRAY -> getFixedWidthShortDecimalDecoder(encoding, field, dictionary, (DecimalType) field.getType());
+            default -> throw wrongEncoding(encoding, field);
+        };
+    }
+
+    public static ValueDecoder<long[]> getLongDecimalDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    {
+        return switch (field.getDescriptor().getPrimitiveType().getPrimitiveTypeName()) {
+            case FIXED_LEN_BYTE_ARRAY -> getFixedWidthLongDecimalDecoder(encoding, field, dictionary);
+            case BINARY -> getBinaryLongDecimalDecoder(encoding, field, dictionary);
             default -> throw wrongEncoding(encoding, field);
         };
     }
@@ -135,6 +145,24 @@ public final class ValueDecoders
                     getApacheParquetReader(encoding, field, dictionary),
                     decimalType,
                     field.getDescriptor());
+            default -> throw wrongEncoding(encoding, field);
+        };
+    }
+
+    private static ValueDecoder<long[]> getFixedWidthLongDecimalDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    {
+        return switch (encoding) {
+            case PLAIN, DELTA_BYTE_ARRAY, PLAIN_DICTIONARY, RLE_DICTIONARY ->
+                    new LongDecimalApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
+            default -> throw wrongEncoding(encoding, field);
+        };
+    }
+
+    private static ValueDecoder<long[]> getBinaryLongDecimalDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    {
+        return switch (encoding) {
+            case PLAIN, DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY, PLAIN_DICTIONARY, RLE_DICTIONARY ->
+                    new LongDecimalApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
             default -> throw wrongEncoding(encoding, field);
         };
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
@@ -102,7 +102,7 @@ public final class ValueDecoders
 
     public static ValueDecoder<long[]> getIntToLongDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
     {
-        // We need to produce LongArrayBlock from the decoded integers for INT32 backed decimals
+        // We need to produce LongArrayBlock from the decoded integers for INT32 backed decimals and bigints
         return switch (encoding) {
             case PLAIN, DELTA_BINARY_PACKED, RLE, BIT_PACKED, PLAIN_DICTIONARY, RLE_DICTIONARY ->
                     new IntToLongApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
@@ -42,6 +42,7 @@ import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.LongAp
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.LongDecimalApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortDecimalApacheParquetValueDecoder;
+import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.UuidApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.DelegateDecoders.timeMicrosDecoder;
 import static java.util.Objects.requireNonNull;
 
@@ -93,6 +94,15 @@ public final class ValueDecoders
         return switch (field.getDescriptor().getPrimitiveType().getPrimitiveTypeName()) {
             case FIXED_LEN_BYTE_ARRAY -> getFixedWidthLongDecimalDecoder(encoding, field, dictionary);
             case BINARY -> getBinaryLongDecimalDecoder(encoding, field, dictionary);
+            default -> throw wrongEncoding(encoding, field);
+        };
+    }
+
+    public static ValueDecoder<long[]> getUuidDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    {
+        return switch (encoding) {
+            case PLAIN, DELTA_BYTE_ARRAY, PLAIN_DICTIONARY, RLE_DICTIONARY ->
+                    new UuidApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
             default -> throw wrongEncoding(encoding, field);
         };
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
@@ -42,6 +42,7 @@ import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.LongAp
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.LongDecimalApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortDecimalApacheParquetValueDecoder;
+import static io.trino.parquet.reader.decoders.DelegateDecoders.timeMicrosDecoder;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -69,6 +70,11 @@ public final class ValueDecoders
             case PLAIN, PLAIN_DICTIONARY, RLE_DICTIONARY -> new FloatApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
             default -> throw wrongEncoding(encoding, field);
         };
+    }
+
+    public static ValueDecoder<long[]> getTimeMicrosDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    {
+        return timeMicrosDecoder(getLongDecoder(encoding, field, dictionary));
     }
 
     public static ValueDecoder<long[]> getShortDecimalDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/BinaryBuffer.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/BinaryBuffer.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A structure holding lazily populated binary data and offsets array.
+ * <p>
+ * The data is stored as a list of Slices that are joined together when needed.
+ * This approach performs better if the slices are as big as possible. That is
+ * why the cases when the size of the resulting array is known beforehand it is
+ * more performant to add a single big byte array to this object rather than
+ * add slices one by one.
+ * The offset array is compatible with VariableWidthBlock.offsets field, i.e., the
+ * first value is always 0 and the last (number of positions + 1) is equal to
+ * the last offset + lest position length.
+ * <p>
+ */
+public class BinaryBuffer
+{
+    private final List<Slice> chunks;
+    private final int[] offsets;
+
+    public BinaryBuffer(int valueCount)
+    {
+        this(new int[valueCount + 1], new ArrayList<>());
+    }
+
+    private BinaryBuffer(int[] offsets, List<Slice> chunks)
+    {
+        this.offsets = requireNonNull(offsets, "offsets is null");
+        this.chunks = requireNonNull(chunks, "chunks is null");
+    }
+
+    /**
+     * Returns a shallow copy of this buffer with empty offsets array.
+     * The first offset is set to the value of the last one in the original buffer.
+     * It can be used to add data to the original object while offsets land in temporary array
+     */
+    public BinaryBuffer withTemporaryOffsets(int offset, int offsetCount)
+    {
+        int[] tmpOffsets = new int[offsetCount + 1];
+        tmpOffsets[0] = offsets[offset];
+        return new BinaryBuffer(tmpOffsets, chunks);
+    }
+
+    public void add(byte[] source, int offset)
+    {
+        add(Slices.wrappedBuffer(source), offset);
+    }
+
+    public void add(Slice slice, int offset)
+    {
+        chunks.add(slice);
+        offsets[offset + 1] = offsets[offset] + slice.length();
+    }
+
+    public Slice asSlice()
+    {
+        if (chunks.size() == 1) {
+            return chunks.get(0);
+        }
+        int totalLength = 0;
+        for (Slice chunk : chunks) {
+            totalLength += chunk.length();
+        }
+        Slice slice = Slices.allocate(totalLength);
+        int offset = 0;
+        for (Slice chunk : chunks) {
+            slice.setBytes(offset, chunk);
+            offset += chunk.length();
+        }
+        chunks.clear();
+        chunks.add(slice);
+        return slice;
+    }
+
+    public int[] getOffsets()
+    {
+        return offsets;
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/BinaryColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/BinaryColumnAdapter.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.block.VariableWidthBlock;
+
+import java.util.Optional;
+
+import static io.trino.parquet.ParquetReaderUtils.castToByteNegate;
+
+public class BinaryColumnAdapter
+        implements ColumnAdapter<BinaryBuffer>
+{
+    public static final BinaryColumnAdapter BINARY_ADAPTER = new BinaryColumnAdapter();
+
+    @Override
+    public BinaryBuffer createBuffer(int batchSize)
+    {
+        return new BinaryBuffer(batchSize);
+    }
+
+    @Override
+    public BinaryBuffer createTemporaryBuffer(int currentOffset, int size, BinaryBuffer buffer)
+    {
+        return buffer.withTemporaryOffsets(currentOffset, size);
+    }
+
+    @Override
+    public void copyValue(BinaryBuffer source, int sourceIndex, BinaryBuffer destination, int destinationIndex)
+    {
+        // ignore as unpackNullValues is overridden
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Block createNullableBlock(int batchSize, boolean[] nulls, BinaryBuffer values)
+    {
+        return new VariableWidthBlock(batchSize, values.asSlice(), values.getOffsets(), Optional.of(nulls));
+    }
+
+    @Override
+    public Block createNonNullBlock(int batchSize, BinaryBuffer values)
+    {
+        return new VariableWidthBlock(batchSize, values.asSlice(), values.getOffsets(), Optional.empty());
+    }
+
+    @Override
+    public void unpackNullValues(BinaryBuffer sourceBuffer, BinaryBuffer destinationBuffer, boolean[] isNull, int destOffset, int nonNullCount, int totalValuesCount)
+    {
+        int endOffset = destOffset + totalValuesCount;
+        int srcOffset = 0;
+        int[] destination = destinationBuffer.getOffsets();
+        int[] source = sourceBuffer.getOffsets();
+
+        while (srcOffset < nonNullCount) {
+            destination[destOffset] = source[srcOffset];
+            srcOffset += castToByteNegate(isNull[destOffset]);
+            destOffset++;
+        }
+        // The last+1 offset is always a sentinel value equal to last offset + last position length.
+        // In case of null values at the end, the last offset value needs to be repeated for every null position
+        while (destOffset <= endOffset) {
+            destination[destOffset++] = source[nonNullCount];
+        }
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ColumnAdapter.java
@@ -22,7 +22,7 @@ public interface ColumnAdapter<BufferType>
     /**
      * Temporary buffer used for null unpacking
      */
-    default BufferType createTemporaryBuffer(int size)
+    default BufferType createTemporaryBuffer(int currentOffset, int size, BufferType buffer)
     {
         return createBuffer(size);
     }
@@ -35,7 +35,7 @@ public interface ColumnAdapter<BufferType>
 
     Block createNonNullBlock(int size, BufferType values);
 
-    default void unpackNullValues(BufferType source, BufferType destination, boolean[] isNull, int destOffset, int nonNullCount)
+    default void unpackNullValues(BufferType source, BufferType destination, boolean[] isNull, int destOffset, int nonNullCount, int totalValuesCount)
     {
         int srcOffset = 0;
         while (srcOffset < nonNullCount) {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/Int128ColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/Int128ColumnAdapter.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.block.Int128ArrayBlock;
+
+import java.util.Optional;
+
+public class Int128ColumnAdapter
+        implements ColumnAdapter<long[]>
+{
+    public static final Int128ColumnAdapter INT128_ADAPTER = new Int128ColumnAdapter();
+
+    @Override
+    public long[] createBuffer(int size)
+    {
+        return new long[size * 2];
+    }
+
+    @Override
+    public Block createNonNullBlock(int size, long[] values)
+    {
+        return new Int128ArrayBlock(size, Optional.empty(), values);
+    }
+
+    @Override
+    public Block createNullableBlock(int size, boolean[] nulls, long[] values)
+    {
+        return new Int128ArrayBlock(size, Optional.of(nulls), values);
+    }
+
+    @Override
+    public void copyValue(long[] source, int sourceIndex, long[] destination, int destinationIndex)
+    {
+        destination[destinationIndex * 2] = source[sourceIndex * 2];
+        destination[(destinationIndex * 2) + 1] = source[(sourceIndex * 2) + 1];
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/AbstractColumnReaderBenchmark.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/AbstractColumnReaderBenchmark.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.parquet.DataPage;
+import io.trino.parquet.DataPageV1;
+import io.trino.parquet.PrimitiveField;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.WarmupMode;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.parquet.ParquetEncoding.RLE;
+import static io.trino.parquet.ParquetTypeUtils.getParquetEncoding;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.parquet.hadoop.metadata.CompressionCodecName.UNCOMPRESSED;
+import static org.joda.time.DateTimeZone.UTC;
+
+@State(Scope.Thread)
+@OutputTimeUnit(SECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = MILLISECONDS)
+@Warmup(iterations = 5, time = 500, timeUnit = MILLISECONDS)
+@Fork(2)
+public abstract class AbstractColumnReaderBenchmark<VALUES>
+{
+    // Parquet pages are usually about 1MB
+    private static final int MIN_PAGE_SIZE = 1_000_000;
+    private static final int OUTPUT_BUFFER_SIZE = MIN_PAGE_SIZE * 2; // Needs to be more than MIN_PAGE_SIZE
+    private static final int MAX_VALUES = 1_000_000;
+
+    private static final int DATA_GENERATION_BATCH_SIZE = 16384;
+    private static final int READ_BATCH_SIZE = 4096;
+
+    private final List<DataPage> dataPages = new ArrayList<>();
+    private int dataPositions;
+
+    protected PrimitiveField field;
+
+    protected abstract PrimitiveField createPrimitiveField();
+
+    protected abstract ValuesWriter createValuesWriter(int bufferSize);
+
+    protected abstract VALUES generateDataBatch(int size);
+
+    protected abstract void writeValue(ValuesWriter writer, VALUES batch, int index);
+
+    @Setup
+    public void setup()
+            throws IOException
+    {
+        this.field = createPrimitiveField();
+
+        ValuesWriter writer = createValuesWriter(OUTPUT_BUFFER_SIZE);
+        int batchIndex = 0;
+        VALUES batch = generateDataBatch(DATA_GENERATION_BATCH_SIZE);
+        while (writer.getBufferedSize() < MIN_PAGE_SIZE && dataPositions < MAX_VALUES) {
+            if (batchIndex == DATA_GENERATION_BATCH_SIZE) {
+                dataPages.add(createDataPage(writer, batchIndex));
+                batch = generateDataBatch(DATA_GENERATION_BATCH_SIZE);
+                batchIndex = 0;
+            }
+            writeValue(writer, batch, batchIndex++);
+            dataPositions++;
+        }
+
+        if (batchIndex > 0) {
+            dataPages.add(createDataPage(writer, batchIndex));
+        }
+    }
+
+    @Benchmark
+    public int read()
+            throws IOException
+    {
+        ColumnReader columnReader = ColumnReaderFactory.create(field, UTC, true);
+        columnReader.setPageReader(new PageReader(UNCOMPRESSED, new LinkedList<>(dataPages), null, dataPositions, false), Optional.empty());
+        int rowsRead = 0;
+        while (rowsRead < dataPositions) {
+            int remaining = dataPositions - rowsRead;
+            columnReader.prepareNextRead(Math.min(READ_BATCH_SIZE, remaining));
+            rowsRead += columnReader.readPrimitive().getBlock().getPositionCount();
+        }
+        return rowsRead;
+    }
+
+    private DataPage createDataPage(ValuesWriter writer, int valuesCount)
+    {
+        Slice data;
+        try {
+            data = Slices.wrappedBuffer(writer.getBytes().toByteArray());
+            writer.reset();
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return new DataPageV1(
+                data,
+                valuesCount,
+                data.length(),
+                OptionalLong.empty(),
+                RLE,
+                RLE,
+                getParquetEncoding(writer.getEncoding()));
+    }
+
+    protected static void run(Class<?> clazz)
+            throws RunnerException
+    {
+        benchmark(clazz, WarmupMode.BULK)
+                .withOptions(optionsBuilder -> optionsBuilder.jvmArgsAppend("-Xmx4g", "-Xms4g"))
+                .run();
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkBinaryColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkBinaryColumnReader.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.trino.parquet.PrimitiveField;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.deltastrings.DeltaByteArrayWriter;
+import org.apache.parquet.column.values.plain.PlainValuesWriter;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.util.Objects;
+import java.util.Random;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static java.lang.Math.max;
+import static java.util.Objects.requireNonNull;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+
+public class BenchmarkBinaryColumnReader
+        extends AbstractColumnReaderBenchmark<byte[][]>
+{
+    @Param
+    public Encoding encoding;
+    @Param
+    public FieldType type;
+    @Param
+    public PositionLength positionLength;
+
+    @Override
+    protected PrimitiveField createPrimitiveField()
+    {
+        PrimitiveType parquetType = Types.optional(BINARY)
+                .named("name");
+        return new PrimitiveField(
+                type.getType(positionLength.getRange()),
+                true,
+                new ColumnDescriptor(new String[] {"test"}, parquetType, 0, 0),
+                0);
+    }
+
+    @Override
+    protected ValuesWriter createValuesWriter(int bufferSize)
+    {
+        return encoding.getWriter(bufferSize);
+    }
+
+    @Override
+    protected byte[][] generateDataBatch(int size)
+    {
+        return type.generateData(size, positionLength.getRange());
+    }
+
+    @Override
+    protected void writeValue(ValuesWriter writer, byte[][] batch, int index)
+    {
+        writer.writeBytes(Binary.fromConstantByteArray(batch[index]));
+    }
+
+    public enum Encoding
+    {
+        PLAIN {
+            @Override
+            ValuesWriter getWriter(int bufferSize)
+            {
+                return new PlainValuesWriter(bufferSize, bufferSize, HeapByteBufferAllocator.getInstance());
+            }
+        },
+        DELTA_BYTE_ARRAY {
+            @Override
+            ValuesWriter getWriter(int bufferSize)
+            {
+                return new DeltaByteArrayWriter(bufferSize, bufferSize, HeapByteBufferAllocator.getInstance());
+            }
+        };
+
+        abstract ValuesWriter getWriter(int bufferSize);
+    }
+
+    public enum FieldType
+    {
+        UNBOUNDED(range -> VARBINARY, BenchmarkBinaryColumnReader::randomData),
+        VARCHAR_ASCII_BOUND_EXACT(range -> VarcharType.createVarcharType(max(1, range.to)), BenchmarkBinaryColumnReader::randomAsciiData),
+        CHAR_ASCII_BOUND_HALF(range -> CharType.createCharType(max(1, range.to / 2)), BenchmarkBinaryColumnReader::randomAsciiData),
+        CHAR_BOUND_HALF_PADDING_SOMETIMES(range -> CharType.createCharType(max(1, range.to / 2)), (length, range) -> randomAsciiDataWithPadding(length, range, .01)),
+        /**/;
+
+        private final Function<Range, Type> type;
+        private final BiFunction<Integer, Range, byte[][]> dataGenerator;
+
+        public Type getType(Range length)
+        {
+            return type.apply(length);
+        }
+
+        public byte[][] generateData(int size, Range positionLength)
+        {
+            return dataGenerator.apply(size, positionLength);
+        }
+
+        FieldType(Function<Range, Type> type, BiFunction<Integer, Range, byte[][]> dataGenerator)
+        {
+            this.type = requireNonNull(type, "type is null");
+            this.dataGenerator = requireNonNull(dataGenerator, "dataGenerator is null");
+        }
+    }
+
+    public enum PositionLength
+    {
+        VARIABLE_0_100(0, 100),
+        VARIABLE_0_1000(0, 1000),
+        FIXED_10(10, 10),
+        FIXED_100(100, 100),
+        /**/;
+
+        private final Range range;
+
+        public Range getRange()
+        {
+            return range;
+        }
+
+        PositionLength(int from, int to)
+        {
+            this.range = new Range(from, to);
+        }
+    }
+
+    record Range(int from, int to) {}
+
+    private static byte[][] randomData(int size, Range positionLength)
+    {
+        Random random = new Random(Objects.hash(size, positionLength.from(), positionLength.to()));
+        byte[][] data = new byte[size][];
+        for (int i = 0; i < size; i++) {
+            int length = random.nextInt(positionLength.to() - positionLength.from() + 1) + positionLength.from();
+            byte[] value = new byte[length];
+            random.nextBytes(value);
+            data[i] = value;
+        }
+
+        return data;
+    }
+
+    private static byte[][] randomAsciiData(int size, Range positionLength)
+    {
+        Random random = new Random(Objects.hash(size, positionLength.from(), positionLength.to()));
+        byte[][] data = new byte[size][];
+        for (int i = 0; i < size; i++) {
+            int length = random.nextInt(positionLength.to() - positionLength.from() + 1) + positionLength.from();
+            byte[] value = new byte[length];
+            for (int j = 0; j < length; j++) {
+                value[j] = (byte) random.nextInt(128);
+            }
+            data[i] = value;
+        }
+
+        return data;
+    }
+
+    private static byte[][] randomAsciiDataWithPadding(int size, Range positionLength, double paddingChance)
+    {
+        Random random = new Random(Objects.hash(size, positionLength.from(), positionLength.to()));
+        byte[][] data = new byte[size][];
+        for (int i = 0; i < size; i++) {
+            int length = random.nextInt(positionLength.to() - positionLength.from() + 1) + positionLength.from();
+            boolean padding = random.nextDouble() < paddingChance;
+            byte[] value = new byte[length + (padding ? 1 : 0)];
+            for (int j = 0; j < length; j++) {
+                value[j] = (byte) random.nextInt(128);
+            }
+            if (padding) {
+                value[length] = ' ';
+            }
+            data[i] = value;
+        }
+
+        return data;
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        run(BenchmarkBinaryColumnReader.class);
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkLongDecimalColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkLongDecimalColumnReader.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.parquet.PrimitiveField;
+import io.trino.spi.type.DecimalType;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.plain.FixedLenByteArrayPlainValuesWriter;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+
+import java.util.Random;
+
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.trino.parquet.reader.TestData.randomBigInteger;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+
+public class BenchmarkLongDecimalColumnReader
+        extends AbstractColumnReaderBenchmark<long[]>
+{
+    private static final int LENGTH = 2 * SIZE_OF_LONG;
+
+    private final Random random = new Random(1);
+
+    @Override
+    protected PrimitiveField createPrimitiveField()
+    {
+        PrimitiveType parquetType = Types.optional(FIXED_LEN_BYTE_ARRAY)
+                .length(LENGTH)
+                .as(LogicalTypeAnnotation.decimalType(0, 38))
+                .named("name");
+        return new PrimitiveField(
+                DecimalType.createDecimalType(38),
+                true,
+                new ColumnDescriptor(new String[] {"test"}, parquetType, 0, 0),
+                0);
+    }
+
+    @Override
+    protected ValuesWriter createValuesWriter(int bufferSize)
+    {
+        return new FixedLenByteArrayPlainValuesWriter(LENGTH, bufferSize, bufferSize, HeapByteBufferAllocator.getInstance());
+    }
+
+    @Override
+    protected void writeValue(ValuesWriter writer, long[] batch, int index)
+    {
+        Slice slice = Slices.wrappedLongArray(batch, index * 2, 2);
+        writer.writeBytes(Binary.fromConstantByteArray(slice.getBytes()));
+    }
+
+    @Override
+    protected long[] generateDataBatch(int size)
+    {
+        long[] batch = new long[size * 2];
+        for (int i = 0; i < size; i++) {
+            Slice slice = randomBigInteger(random);
+            batch[i * 2] = slice.getLong(0);
+            batch[(i * 2) + 1] = slice.getLong(SIZE_OF_LONG);
+        }
+        return batch;
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        run(BenchmarkLongDecimalColumnReader.class);
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkShortDecimalColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkShortDecimalColumnReader.java
@@ -74,18 +74,12 @@ public class BenchmarkShortDecimalColumnReader
 
     private final List<DataPage> dataPages = new ArrayList<>();
 
+    private PrimitiveField field;
+
     @Param({
             "1", "2", "3", "4", "5", "6", "7", "8",
     })
-    private int byteArrayLength;
-    private PrimitiveField field;
-
-    public BenchmarkShortDecimalColumnReader() {}
-
-    public BenchmarkShortDecimalColumnReader(int byteArrayLength)
-    {
-        this.byteArrayLength = byteArrayLength;
-    }
+    public int byteArrayLength;
 
     @Setup
     public void setup()
@@ -99,7 +93,7 @@ public class BenchmarkShortDecimalColumnReader
         this.field = new PrimitiveField(
                 DecimalType.createDecimalType(precision),
                 true,
-                new ColumnDescriptor(new String[] {}, parquetType, 0, 0),
+                new ColumnDescriptor(new String[] {"test"}, parquetType, 0, 0),
                 0);
 
         ValuesWriter writer = createValuesWriter(OUTPUT_BUFFER_SIZE);

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkShortDecimalColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkShortDecimalColumnReader.java
@@ -13,10 +13,6 @@
  */
 package io.trino.parquet.reader;
 
-import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
-import io.trino.parquet.DataPage;
-import io.trino.parquet.DataPageV1;
 import io.trino.parquet.PrimitiveField;
 import io.trino.spi.type.DecimalType;
 import org.apache.parquet.bytes.HeapByteBufferAllocator;
@@ -27,35 +23,20 @@ import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
-import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.runner.options.WarmupMode;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-import java.util.OptionalLong;
-
-import static io.trino.jmh.Benchmarks.benchmark;
-import static io.trino.parquet.ParquetEncoding.PLAIN;
-import static io.trino.parquet.ParquetEncoding.RLE;
 import static io.trino.parquet.reader.TestData.longToBytes;
 import static io.trino.parquet.reader.TestData.unscaledRandomShortDecimalSupplier;
 import static java.lang.Math.toIntExact;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.parquet.hadoop.metadata.CompressionCodecName.UNCOMPRESSED;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
-import static org.joda.time.DateTimeZone.UTC;
 
 @State(Scope.Thread)
 @OutputTimeUnit(SECONDS)
@@ -63,107 +44,46 @@ import static org.joda.time.DateTimeZone.UTC;
 @Warmup(iterations = 5, time = 500, timeUnit = MILLISECONDS)
 @Fork(2)
 public class BenchmarkShortDecimalColumnReader
+        extends AbstractColumnReaderBenchmark<long[]>
 {
-    // Parquet pages are usually about 1MB
-    private static final int MIN_PAGE_SIZE = 1_000_000;
-    private static final int OUTPUT_BUFFER_SIZE = MIN_PAGE_SIZE * 2; // Needs to be more than MIN_PAGE_SIZE
-    private static final int MAX_VALUES = 5_000_000;
-
-    private static final int DATA_GENERATION_BATCH_SIZE = 16384;
-    private static final int READ_BATCH_SIZE = 4096;
-
-    private final List<DataPage> dataPages = new ArrayList<>();
-
-    private PrimitiveField field;
-
     @Param({
             "1", "2", "3", "4", "5", "6", "7", "8",
     })
     public int byteArrayLength;
 
-    @Setup
-    public void setup()
-            throws IOException
+    @Override
+    protected PrimitiveField createPrimitiveField()
     {
         int precision = maxPrecision(byteArrayLength);
         PrimitiveType parquetType = Types.optional(FIXED_LEN_BYTE_ARRAY)
                 .length(byteArrayLength)
                 .as(LogicalTypeAnnotation.decimalType(0, precision))
                 .named("name");
-        this.field = new PrimitiveField(
+        return new PrimitiveField(
                 DecimalType.createDecimalType(precision),
                 true,
                 new ColumnDescriptor(new String[] {"test"}, parquetType, 0, 0),
                 0);
-
-        ValuesWriter writer = createValuesWriter(OUTPUT_BUFFER_SIZE);
-        int positions = 0;
-        int batchIndex = 0;
-        long[] batch = generateDataBatch(DATA_GENERATION_BATCH_SIZE, precision);
-        while (writer.getBufferedSize() < MIN_PAGE_SIZE && positions < MAX_VALUES) {
-            if (batchIndex == DATA_GENERATION_BATCH_SIZE) {
-                dataPages.add(createDataPage(writer, batchIndex));
-                batch = generateDataBatch(DATA_GENERATION_BATCH_SIZE, precision);
-                batchIndex = 0;
-            }
-            writeValue(writer, batch, batchIndex++);
-            positions++;
-        }
-
-        if (batchIndex > 0) {
-            dataPages.add(createDataPage(writer, batchIndex));
-        }
     }
 
-    @Benchmark
-    public int read()
-            throws IOException
-    {
-        ColumnReader columnReader = ColumnReaderFactory.create(field, UTC, true);
-        columnReader.setPageReader(new PageReader(UNCOMPRESSED, new LinkedList<>(dataPages), null, MAX_VALUES, false), Optional.empty());
-        int rowsRead = 0;
-        while (rowsRead < MAX_VALUES) {
-            int remaining = MAX_VALUES - rowsRead;
-            columnReader.prepareNextRead(Math.min(READ_BATCH_SIZE, remaining));
-            rowsRead += columnReader.readPrimitive().getBlock().getPositionCount();
-        }
-        return rowsRead;
-    }
-
-    private DataPage createDataPage(ValuesWriter writer, int valuesCount)
-    {
-        Slice data;
-        try {
-            data = Slices.wrappedBuffer(writer.getBytes().toByteArray());
-            writer.reset();
-        }
-        catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return new DataPageV1(
-                data,
-                valuesCount,
-                byteArrayLength * valuesCount,
-                OptionalLong.empty(),
-                RLE,
-                RLE,
-                PLAIN);
-    }
-
-    private ValuesWriter createValuesWriter(int bufferSize)
+    @Override
+    protected ValuesWriter createValuesWriter(int bufferSize)
     {
         return new FixedLenByteArrayPlainValuesWriter(byteArrayLength, bufferSize, bufferSize, HeapByteBufferAllocator.getInstance());
     }
 
-    private void writeValue(ValuesWriter writer, long[] batch, int index)
+    @Override
+    protected long[] generateDataBatch(int size)
+    {
+        int precision = ((DecimalType) field.getType()).getPrecision();
+        return unscaledRandomShortDecimalSupplier(byteArrayLength * Byte.SIZE, precision).apply(size);
+    }
+
+    @Override
+    protected void writeValue(ValuesWriter writer, long[] batch, int index)
     {
         Binary binary = Binary.fromConstantByteArray(longToBytes(batch[index], byteArrayLength));
         writer.writeBytes(binary);
-    }
-
-    private long[] generateDataBatch(int size, int precision)
-    {
-        return unscaledRandomShortDecimalSupplier(byteArrayLength * Byte.SIZE, precision).apply(size);
     }
 
     private static int maxPrecision(int numBytes)
@@ -179,8 +99,6 @@ public class BenchmarkShortDecimalColumnReader
     public static void main(String[] args)
             throws Exception
     {
-        benchmark(BenchmarkShortDecimalColumnReader.class, WarmupMode.BULK)
-                .withOptions(optionsBuilder -> optionsBuilder.jvmArgsAppend("-Xmx4g", "-Xms4g"))
-                .run();
+        run(BenchmarkShortDecimalColumnReader.class);
     }
 }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestBinaryColumnBenchmark.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestBinaryColumnBenchmark.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.trino.parquet.reader.BenchmarkBinaryColumnReader.Encoding;
+import io.trino.parquet.reader.BenchmarkBinaryColumnReader.FieldType;
+import io.trino.parquet.reader.BenchmarkBinaryColumnReader.PositionLength;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+public class TestBinaryColumnBenchmark
+{
+    @Test
+    public void testBinaryColumnBenchmark()
+            throws IOException
+    {
+        for (Encoding encoding : Encoding.values()) {
+            for (FieldType type : FieldType.values()) {
+                for (PositionLength length : PositionLength.values()) {
+                    BenchmarkBinaryColumnReader benchmark = new BenchmarkBinaryColumnReader();
+                    benchmark.encoding = encoding;
+                    benchmark.type = type;
+                    benchmark.positionLength = length;
+                    benchmark.setup();
+                    benchmark.read();
+                }
+            }
+        }
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestData.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestData.java
@@ -13,16 +13,22 @@
  */
 package io.trino.parquet.reader;
 
+import com.google.common.primitives.Bytes;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import io.trino.spi.type.Decimals;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.function.IntFunction;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.trino.parquet.ParquetTypeUtils.paddingBigInteger;
 
 public final class TestData
 {
@@ -100,6 +106,14 @@ public final class TestData
         int[] result = new int[size];
         mixedList.getElements(0, result, 0, size);
         return result;
+    }
+
+    public static Slice randomBigInteger(Random r)
+    {
+        BigInteger bigInteger = new BigInteger(126, r);
+        byte[] result = paddingBigInteger(bigInteger, 2 * SIZE_OF_LONG);
+        Bytes.reverse(result);
+        return Slices.wrappedBuffer(result);
     }
 
     public static int randomInt(Random r, int bitWidth)

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestShortDecimalColumnReaderBenchmark.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestShortDecimalColumnReaderBenchmark.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+public class TestShortDecimalColumnReaderBenchmark
+{
+    @Test
+    public void testShortDecimalColumnReaderBenchmark()
+            throws IOException
+    {
+        for (int typeLength = 1; typeLength <= 8; typeLength++) {
+            BenchmarkShortDecimalColumnReader benchmark = new BenchmarkShortDecimalColumnReader();
+            benchmark.byteArrayLength = typeLength;
+            benchmark.setup();
+            benchmark.read();
+        }
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/TestBinaryBuffer.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/TestBinaryBuffer.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertSame;
+
+public class TestBinaryBuffer
+{
+    @Test
+    public void testAsSlice()
+    {
+        BinaryBuffer buffer = new BinaryBuffer(2);
+        Slice a = Slices.wrappedBuffer((byte) 0);
+        Slice b = Slices.wrappedBuffer((byte) 1);
+
+        buffer.add(a, 0);
+        Slice result = buffer.asSlice();
+        assertSame(a, result);
+
+        buffer.add(b, 1);
+
+        result = buffer.asSlice();
+        Slice secondInvocation = buffer.asSlice();
+
+        assertSame(secondInvocation, result);
+        assertThat(result.getBytes()).isEqualTo(new byte[] {0, 1});
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
@@ -24,6 +24,8 @@ import io.airlift.units.DataSize;
 import io.trino.plugin.hive.HiveTimestampPrecision;
 import io.trino.spi.TrinoException;
 import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.Chars;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.SqlDate;
 import io.trino.spi.type.SqlDecimal;
@@ -73,6 +75,7 @@ import static io.trino.plugin.hive.parquet.ParquetTester.TEST_COLUMN;
 import static io.trino.plugin.hive.parquet.ParquetTester.insertNullEvery;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.CharType.createCharType;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.Decimals.MAX_PRECISION;
@@ -91,6 +94,7 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.testing.DataProviders.toDataProvider;
 import static io.trino.testing.DateTimeTestingUtils.sqlTimestampOf;
 import static io.trino.testing.StructuralTestUtil.mapType;
@@ -1731,35 +1735,55 @@ public abstract class AbstractTestParquetReader
     public void testStringUnicode()
             throws Exception
     {
-        tester.testRoundTrip(javaStringObjectInspector, limit(cycle(ImmutableList.of("apple", "apple pie", "apple\uD835\uDC03", "apple\uFFFD")), 30_000), createUnboundedVarcharType());
+        Iterable<String> writeValues = limit(cycle(ImmutableList.of("apple", "apple pie", "apple\uD835\uDC03", "apple\uFFFD")), 30_000);
+        tester.testRoundTrip(javaStringObjectInspector, writeValues, createUnboundedVarcharType());
+        tester.testRoundTrip(javaStringObjectInspector, writeValues, createVarcharType(25));
+        CharType charType = createCharType(25);
+        tester.testRoundTrip(javaStringObjectInspector, writeValues, value -> Chars.padSpaces(value, charType), charType);
     }
 
     @Test
     public void testStringDirectSequence()
             throws Exception
     {
-        tester.testRoundTrip(javaStringObjectInspector, transform(intsBetween(0, 30_000), Object::toString), createUnboundedVarcharType());
+        Iterable<String> writeValues = transform(intsBetween(0, 30_000), Object::toString);
+        tester.testRoundTrip(javaStringObjectInspector, writeValues, createUnboundedVarcharType());
+        tester.testRoundTrip(javaStringObjectInspector, writeValues, createVarcharType(5));
+        CharType charType = createCharType(5);
+        tester.testRoundTrip(javaStringObjectInspector, writeValues, value -> Chars.padSpaces(value, charType), charType);
     }
 
     @Test
     public void testStringDictionarySequence()
             throws Exception
     {
-        tester.testRoundTrip(javaStringObjectInspector, limit(cycle(transform(ImmutableList.of(1, 3, 5, 7, 11, 13, 17), Object::toString)), 30_000), createUnboundedVarcharType());
+        Iterable<String> writeValues = limit(cycle(transform(ImmutableList.of(1, 3, 5, 7, 11, 13, 17), Object::toString)), 30_000);
+        tester.testRoundTrip(javaStringObjectInspector, writeValues, createUnboundedVarcharType());
+        tester.testRoundTrip(javaStringObjectInspector, writeValues, createVarcharType(3));
+        CharType charType = createCharType(3);
+        tester.testRoundTrip(javaStringObjectInspector, writeValues, value -> Chars.padSpaces(value, charType), charType);
     }
 
     @Test
     public void testStringStrideDictionary()
             throws Exception
     {
-        tester.testRoundTrip(javaStringObjectInspector, concat(ImmutableList.of("a"), Collections.nCopies(9999, "123"), ImmutableList.of("b"), Collections.nCopies(9999, "123")), createUnboundedVarcharType());
+        Iterable<String> writeValues = concat(ImmutableList.of("a"), Collections.nCopies(9999, "123"), ImmutableList.of("b"), Collections.nCopies(9999, "123"));
+        tester.testRoundTrip(javaStringObjectInspector, writeValues, createUnboundedVarcharType());
+        tester.testRoundTrip(javaStringObjectInspector, writeValues, createVarcharType(3));
+        CharType charType = createCharType(3);
+        tester.testRoundTrip(javaStringObjectInspector, writeValues, value -> Chars.padSpaces(value, charType), charType);
     }
 
     @Test
     public void testEmptyStringSequence()
             throws Exception
     {
-        tester.testRoundTrip(javaStringObjectInspector, limit(cycle(""), 30_000), createUnboundedVarcharType());
+        Iterable<String> writeValues = limit(cycle(""), 30_000);
+        tester.testRoundTrip(javaStringObjectInspector, writeValues, createUnboundedVarcharType());
+        tester.testRoundTrip(javaStringObjectInspector, writeValues, createVarcharType(3));
+        CharType charType = createCharType(3);
+        tester.testRoundTrip(javaStringObjectInspector, writeValues, value -> Chars.padSpaces(value, charType), charType);
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
@@ -1107,6 +1107,12 @@ public abstract class AbstractTestParquetReader
             tester.testRoundTrip(javaLongObjectInspector, ImmutableList.of(1L), ImmutableList.of(1L), BIGINT, Optional.of(parquetSchema));
         }).hasMessage("Unsupported Trino column type (bigint) for Parquet column ([test] optional int64 test (DECIMAL(10,1)))")
                 .isInstanceOf(TrinoException.class);
+
+        assertThatThrownBy(() -> {
+            MessageType parquetSchema = parseMessageType(format("message hive_decimal { optional INT32 test (DECIMAL(%d, %d)); }", 8, 1));
+            tester.testRoundTrip(javaIntObjectInspector, ImmutableList.of(1), ImmutableList.of(1), BIGINT, Optional.of(parquetSchema));
+        }).hasMessage("Unsupported Trino column type (bigint) for Parquet column ([test] optional int32 test (DECIMAL(8,1)))")
+                .isInstanceOf(TrinoException.class);
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetDecimalScaling.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetDecimalScaling.java
@@ -356,7 +356,11 @@ public class TestParquetDecimalScaling
 
         if (overflows(new BigDecimal(writeValue).unscaledValue(), schemaPrecision)) {
             @Language("SQL") String query = format("SELECT * FROM tpch.%s", tableName);
-            @Language("RegExp") String expectedMessage = format("Could not read fixed_len_byte_array\\(%d\\) value %s into decimal\\(%d,%d\\)", byteArrayLength, writeValue, schemaPrecision, schemaScale);
+            @Language("RegExp") String expectedMessage = format(
+                    "Could not read unscaled value %s into decimal\\(%d,%d\\) from column .*",
+                    new BigDecimal(writeValue).unscaledValue(),
+                    schemaPrecision,
+                    schemaScale);
 
             assertQueryFails(optimizedParquetReaderEnabled(false), query, expectedMessage);
             assertQueryFails(optimizedParquetReaderEnabled(true), query, expectedMessage);


### PR DESCRIPTION
## Description

Support UUID, time, decimals, varchar, char in batched parquet reader

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Improve performance of reading parquet files for column of type UUID, time, decimal, varchar and char.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Iceberg, Delta, Hudi
* Improve performance of reading parquet files for column of type UUID, time, decimal, varchar and char. ({issue}`14667`)
```
