### PR TITLE
Filter out fully acknowledged split assignments

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecution.java
@@ -244,6 +244,9 @@ public class SqlTaskExecution
                                 .filter(scheduledSplit -> scheduledSplit.getSequenceId() > currentMaxAcknowledgedSplit)
                                 .collect(toImmutableSet()),
                         assignment.isNoMoreSplits()))
+                // drop assignments containing no unacknowledged splits
+                // the noMoreSplits signal acknowledgement is not tracked but it is okay to deliver it more than once
+                .filter(assignment -> !assignment.getSplits().isEmpty() || assignment.isNoMoreSplits())
                 .collect(toList());
 
         // update task with new assignments

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecution.java
@@ -57,13 +57,13 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.concat;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.SystemSessionProperties.getInitialSplitsPerNode;
@@ -238,12 +238,12 @@ public class SqlTaskExecution
         // first remove any split that was already acknowledged
         long currentMaxAcknowledgedSplit = this.maxAcknowledgedSplit;
         splitAssignments = splitAssignments.stream()
-                .map(source -> new SplitAssignment(
-                        source.getPlanNodeId(),
-                        source.getSplits().stream()
+                .map(assignment -> new SplitAssignment(
+                        assignment.getPlanNodeId(),
+                        assignment.getSplits().stream()
                                 .filter(scheduledSplit -> scheduledSplit.getSequenceId() > currentMaxAcknowledgedSplit)
-                                .collect(Collectors.toSet()),
-                        source.isNoMoreSplits()))
+                                .collect(toImmutableSet()),
+                        assignment.isNoMoreSplits()))
                 .collect(toList());
 
         // update task with new assignments


### PR DESCRIPTION
Here is a sequence of interaction that leads to a failure at the
 `!this.noMoreSplits.get() || noMoreSplits` check in
DriverSplitRunnerFactory#enqueueSplits:

- The coordinator sends a TaskUpdateRequest[1] containing some splits and a noMoreSplits
set to false
- A TaskUpdateRequest[1] times out on coordinator and coordinator
re-sends it as TaskUpdateRequest[1']
- The TaskUpdateRequest[1'] succeeds and the coordinator sends a TaskUpdateRequest[2]
with noMoreSplits set to true.
- The TaskUpdateRequest[2] succeeds
- The original TaskUpdateRequest[1] arrives to the worker node. The
splits in this requests are getting filtered out by the logic in the updateSplitAssignments
- DriverSplitRunnerFactory#enqueueSplits is called with an empty list of
splits, so the first (really important check) "!this.noMoreSplits.get() || splits.isEmpty()"
passes, but the second check (not so important) "!this.noMoreSplits.get() || noMoreSplits" fails
what leads to a task failure

To avoid a failure of the check mentioned we filter out fully
acknowledged SplitAssignment's (ones that contain no unacknowledged
splits)

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

- Fix rare query failures with `com.google.common.base.VerifyException: cannot unset noMoreSplits`

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Core engine
* Fix rare query failures with `com.google.common.base.VerifyException: cannot unset noMoreSplits`
```
