### PR TITLE
Only allow Hive ACID tables for Thrift metastore

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
@@ -305,8 +305,14 @@ public class HiveMetastoreClosure
         return delegate.listTablePrivileges(databaseName, tableName, tableOwner, principal);
     }
 
+    public void checkSupportsTransactions()
+    {
+        delegate.checkSupportsTransactions();
+    }
+
     public long openTransaction(AcidTransactionOwner transactionOwner)
     {
+        checkSupportsTransactions();
         return delegate.openTransaction(transactionOwner);
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/ForwardingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/ForwardingHiveMetastore.java
@@ -346,6 +346,12 @@ public abstract class ForwardingHiveMetastore
     }
 
     @Override
+    public void checkSupportsTransactions()
+    {
+        delegate.checkSupportsTransactions();
+    }
+
+    @Override
     public long openTransaction(AcidTransactionOwner transactionOwner)
     {
         return delegate.openTransaction(transactionOwner);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
@@ -21,6 +21,7 @@ import io.trino.plugin.hive.PartitionStatistics;
 import io.trino.plugin.hive.acid.AcidOperation;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege;
+import io.trino.spi.TrinoException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.security.RoleGrant;
@@ -33,6 +34,8 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.Function;
+
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 
 public interface HiveMetastore
 {
@@ -140,6 +143,11 @@ public interface HiveMetastore
      * @param principal when empty, all table privileges are returned
      */
     Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, Optional<String> tableOwner, Optional<HivePrincipal> principal);
+
+    default void checkSupportsTransactions()
+    {
+        throw new TrinoException(NOT_SUPPORTED, getClass().getSimpleName() + " does not support ACID tables");
+    }
 
     default long openTransaction(AcidTransactionOwner transactionOwner)
     {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -1369,6 +1369,11 @@ public class SemiTransactionalHiveMetastore
         }
     }
 
+    public void checkSupportsHiveAcidTransactions()
+    {
+        delegate.checkSupportsTransactions();
+    }
+
     public void beginQuery(ConnectorSession session)
     {
         String queryId = session.getQueryId();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -918,6 +918,12 @@ public class CachingHiveMetastore
     }
 
     @Override
+    public void checkSupportsTransactions()
+    {
+        delegate.checkSupportsTransactions();
+    }
+
+    @Override
     public long openTransaction(AcidTransactionOwner transactionOwner)
     {
         return delegate.openTransaction(transactionOwner);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -1126,6 +1126,12 @@ public class GlueHiveMetastore
         return ImmutableSet.of();
     }
 
+    @Override
+    public void checkSupportsTransactions()
+    {
+        throw new TrinoException(NOT_SUPPORTED, "Glue does not support ACID tables");
+    }
+
     static class StatsRecordingAsyncHandler<Request extends AmazonWebServiceRequest, Result>
             implements AsyncHandler<Request, Result>
     {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -453,6 +453,12 @@ public class BridgingHiveMetastore
     }
 
     @Override
+    public void checkSupportsTransactions()
+    {
+        delegate.checkSupportsTransactions();
+    }
+
+    @Override
     public long openTransaction(AcidTransactionOwner transactionOwner)
     {
         return delegate.openTransaction(transactionOwner);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -1446,6 +1446,9 @@ public class ThriftHiveMetastore
     }
 
     @Override
+    public void checkSupportsTransactions() {}
+
+    @Override
     public long openTransaction(AcidTransactionOwner transactionOwner)
     {
         requireNonNull(transactionOwner, "transactionOwner is null");

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastore.java
@@ -43,6 +43,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_INVALID_METADATA;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 
 public interface ThriftMetastore
 {
@@ -127,6 +128,11 @@ public interface ThriftMetastore
         }
 
         return Optional.of(table.getSd().getCols());
+    }
+
+    default void checkSupportsTransactions()
+    {
+        throw new TrinoException(NOT_SUPPORTED, getClass().getSimpleName() + " does not support ACID tables");
     }
 
     default long openTransaction(AcidTransactionOwner transactionOwner)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -4120,8 +4120,7 @@ public abstract class BaseHiveConnectorTest
                         "   orc_bloom_filter_columns = ARRAY['c1','c 2'],\n" +
                         "   orc_bloom_filter_fpp = 7E-1,\n" +
                         "   partitioned_by = ARRAY['c5'],\n" +
-                        "   sorted_by = ARRAY['c1','c 2 DESC'],\n" +
-                        "   transactional = true\n" +
+                        "   sorted_by = ARRAY['c1','c 2 DESC']\n" +
                         ")",
                 getSession().getCatalog().get(),
                 getSession().getSchema().get(),
@@ -8335,6 +8334,13 @@ public abstract class BaseHiveConnectorTest
                 "EXPLAIN ANALYZE VERBOSE SELECT * FROM (SELECT nationkey, count(*) cnt FROM nation GROUP BY 1) where cnt > 0",
                 "'Filter CPU time' = \\{duration=.*}",
                 "'Projection CPU time' = \\{duration=.*}");
+    }
+
+    @Test
+    public void testCreateAcidTableUnsupported()
+    {
+        assertQueryFails("CREATE TABLE acid_unsupported (x int) WITH (transactional = true)", "FileHiveMetastore does not support ACID tables");
+        assertQueryFails("CREATE TABLE acid_unsupported WITH (transactional = true) AS SELECT 123 x", "FileHiveMetastore does not support ACID tables");
     }
 
     private static final Set<HiveStorageFormat> NAMED_COLUMN_ONLY_FORMATS = ImmutableSet.of(HiveStorageFormat.AVRO, HiveStorageFormat.JSON);


### PR DESCRIPTION
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Hive connector
* Only allow creating ACID tables with the Thrift metastore. Improve error message when
  attempting to modifying existing ACID tables with a non-Thrift metastore. ({issue}`14673`)
```
