### PR TITLE
Update to Hadoop 3.3.4

### DIFF
--- a/lib/trino-hive-formats/pom.xml
+++ b/lib/trino-hive-formats/pom.xml
@@ -80,6 +80,12 @@
             <artifactId>jol-core</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- for hadoop compression -->
         <dependency>
             <groupId>io.trino.hadoop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -732,7 +732,7 @@
             <dependency>
                 <groupId>io.trino.hadoop</groupId>
                 <artifactId>hadoop-apache</artifactId>
-                <version>3.2.0-18</version>
+                <version>3.3.4-1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Update to Hadoop 3.3.4.
Depends on https://github.com/trinodb/trino-hadoop-apache/pull/44


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
Update to Hadoop 3.3.4.
`org.xerial.snappy:snappy-java` is required for some tests. (Caused by [HADOOP-17125](https://issues.apache.org/jira/browse/HADOOP-17125))



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( x ) Release notes are required, with the following suggested text:

```markdown
# Section
* Update Hadoop library to 3.3.4
```

TODO:

- [x] Verify is `snappy-java` dependency needed for `trino-orc`

---
ORC Reader doesn't need `snappy-java`:
https://github.com/trinodb/trino/blob/833819e09c361d8fde156e6e76296a90579381e5/lib/trino-orc/src/main/java/io/trino/orc/OrcOutputBuffer.java#L19
https://github.com/trinodb/trino/blob/cea58426e0a8f4cfe330bc805f88d12ab2d3fc4e/lib/trino-orc/src/main/java/io/trino/orc/OrcSnappyDecompressor.java