### PR TITLE
Update Iceberg from 0.14.1 to 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dep.confluent.version>5.5.2</dep.confluent.version>
         <dep.casandra.version>4.14.0</dep.casandra.version>
         <dep.minio.version>7.1.4</dep.minio.version>
-        <dep.iceberg.version>0.14.1</dep.iceberg.version>
+        <dep.iceberg.version>1.0.0</dep.iceberg.version>
         <dep.spotbugs-annotations.version>4.7.2</dep.spotbugs-annotations.version>
 
         <dep.docker.images.version>65</dep.docker.images.version>


### PR DESCRIPTION
## Description

This updates the `trino-iceberg` connector to the latest Iceberg version 1.0.0. This release is based on the 0.14.1 release and includes changes to remove deprecated APIs with some bug fixes. Release notes can be found [here](https://iceberg.apache.org/releases/#100-release).

