### PR TITLE
Fix elastic connector can't filter 'not equal' ('<>' or '!=' ) correctly

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -757,7 +757,8 @@ public final class DomainTranslator
                     case GREATER_THAN_OR_EQUAL -> Optional.of(Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.greaterThanOrEqual(type, value)), complement), false));
                     case LESS_THAN -> Optional.of(Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.lessThan(type, value)), complement), false));
                     case LESS_THAN_OR_EQUAL -> Optional.of(Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.lessThanOrEqual(type, value)), complement), false));
-                    case NOT_EQUAL ->
+                    case NOT_EQUAL -> value instanceof Slice && ((Slice) value).length() == 0 ?
+                            Optional.of(Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.greaterThan(type, value)), complement), false)) :
                             Optional.of(Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.lessThan(type, value), Range.greaterThan(type, value)), complement), false));
                     case IS_DISTINCT_FROM ->
                         // Need to potential complement the whole domain for IS_DISTINCT_FROM since it is null-aware

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchQueryBuilder.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchQueryBuilder.java
@@ -159,7 +159,7 @@ public final class ElasticsearchQueryBuilder
             return Float.intBitsToFloat(toIntExact(((Long) value)));
         }
         if (type.equals(VARCHAR)) {
-            return ((Slice) value).toStringUtf8();
+            return ((Slice) value).length() == 0 ? 0 : ((Slice) value).toStringUtf8();
         }
         if (type.equals(TIMESTAMP_MILLIS)) {
             return Instant.ofEpochMilli(floorDiv((Long) value, MICROSECONDS_PER_MILLISECOND))

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -1468,6 +1468,32 @@ public abstract class BaseElasticsearchConnectorTest
                 .put("ipv6_column", "2001:db8:0:0:1:0:0:1")
                 .buildOrThrow());
 
+        // filter push down 'not equal' ('<>' or '!=' ) correctly
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE keyword_column <> ''", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE keyword_column = ''", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE keyword_column = '0'", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE text_column != ''", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE byte_column <> 0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE byte_column <> 1", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE short_column <> 0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE short_column <> 2", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE integer_column <> 0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE integer_column <> 3", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE long_column <> 0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE long_column <> 4", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE float_column <> 0.0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE float_column <> 1.0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE double_column <> 0.0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE double_column <> 1.0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE binary_column <> x''", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE binary_column <> x'CAFE'", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE timestamp_column <> TIMESTAMP '2019-10-01 00:00:11'", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE timestamp_column <> TIMESTAMP '2019-10-01 00:00:00'", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE ipv4_column <> IPADDRESS '1.1.1.1'", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE ipv4_column <> IPADDRESS '1.2.3.4'", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE ipv6_column <> IPADDRESS '2001:2001::1:0:0:9'", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE ipv6_column <> IPADDRESS '2001:db8::1:0:0:1'", "VALUES 0");
+
         // _score column
         assertQuery("SELECT count(*) FROM \"filter_pushdown: cool\" WHERE _score > 0", "VALUES 1");
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fix #14533

When Slice is empty, translate the NOT_EQUAL to Range.greaterThan(type, value). Because in Elastic, we could use RangeQueryBuilder to filter the empty column as following:
```
range.gt(0)
```
And for other connector, we could use range.gt('')


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`14533`)
```
