### PR TITLE
Add Europe/Kyiv

### DIFF
--- a/core/trino-spi/src/main/resources/io/trino/spi/type/zone-index.properties
+++ b/core/trino-spi/src/main/resources/io/trino/spi/type/zone-index.properties
@@ -2238,3 +2238,4 @@
 2229 Asia/Qostanay
 2230 America/Nuuk
 2231 Pacific/Kanton
+2232 Europe/Kyiv

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestTimeZoneKey.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestTimeZoneKey.java
@@ -220,7 +220,7 @@ public class TestTimeZoneKey
             hasher.putString(timeZoneKey.getId(), StandardCharsets.UTF_8);
         }
         // Zone file should not (normally) be changed, so let's make this more difficult
-        assertEquals(hasher.hash().asLong(), -2665680993684804317L, "zone-index.properties file contents changed!");
+        assertEquals(hasher.hash().asLong(), 3150949494363069024L, "zone-index.properties file contents changed!");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.aws-sdk.version>1.12.172</dep.aws-sdk.version>
         <dep.okhttp.version>3.14.9</dep.okhttp.version>
-        <dep.joda.version>2.10.13</dep.joda.version>
+        <dep.joda.version>2.12.0</dep.joda.version>
         <dep.jsonwebtoken.version>0.11.2</dep.jsonwebtoken.version>
         <dep.oracle.version>19.3.0.0</dep.oracle.version>
         <dep.drift.version>1.14</dep.drift.version>


### PR DESCRIPTION
Recent JVM versions includes `Europe/Kyiv` time zone.

Fixes https://github.com/trinodb/trino/issues/14682
