### PR TITLE
fix(sec): upgrade mysql:mysql-connector-java to 8.0.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1456,7 +1456,7 @@
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>8.0.22</version>
+                <version>8.0.28</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Description

Upgrade MySQL JDBC driver to 8.0.28 for [CVE-2022-21363](https://github.com/advisories/GHSA-g76j-4cxx-23h9)

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`14533`)
```

