### PR TITLE
Allow reversed order in AutoCloseableCloser

### DIFF
--- a/core/trino-main/src/main/java/io/trino/util/AutoCloseableCloser.java
+++ b/core/trino-main/src/main/java/io/trino/util/AutoCloseableCloser.java
@@ -26,12 +26,21 @@ public final class AutoCloseableCloser
         implements AutoCloseable
 {
     private final Deque<AutoCloseable> stack = new ArrayDeque<>(4);
+    private final boolean reverseOrder;
 
-    private AutoCloseableCloser() {}
+    private AutoCloseableCloser(boolean reverseOrder)
+    {
+        this.reverseOrder = reverseOrder;
+    }
 
     public static AutoCloseableCloser create()
     {
-        return new AutoCloseableCloser();
+        return new AutoCloseableCloser(false);
+    }
+
+    public static AutoCloseableCloser create(boolean reverseOrder)
+    {
+        return new AutoCloseableCloser(reverseOrder);
     }
 
     public <C extends AutoCloseable> C register(C closeable)
@@ -47,7 +56,13 @@ public final class AutoCloseableCloser
     {
         Throwable rootCause = null;
         while (!stack.isEmpty()) {
-            AutoCloseable closeable = stack.removeFirst();
+            AutoCloseable closeable;
+            if (!reverseOrder) {
+                closeable = stack.removeFirst();
+            }
+            else {
+                closeable = stack.removeLast();
+            }
             try {
                 closeable.close();
             }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/containers/HiveMinioDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/containers/HiveMinioDataLake.java
@@ -45,7 +45,7 @@ public class HiveMinioDataLake
     private final Minio minio;
     private final HiveHadoop hiveHadoop;
 
-    private final AutoCloseableCloser closer = AutoCloseableCloser.create();
+    private final AutoCloseableCloser closer = AutoCloseableCloser.create(true);
 
     private State state = State.INITIAL;
     private MinioClient minioClient;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Allow reverse order of closing in AutoCloseableCloser. Example usage in `HiveMinioDataLake` to allow closing Minio client before Minio server. This should fix flaky `TestS3WrongRegionPicked::testS3WrongRegionSelection` test.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Fix flaky test TestS3WrongRegionPicked

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
