### PR TITLE
WIP: Add staging plugin for automated central release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>130</version>
+        <version>131-SNAPSHOT</version>
     </parent>
 
     <groupId>io.trino</groupId>
@@ -45,6 +45,7 @@
         <air.modernizer.java-version>8</air.modernizer.java-version>
 
         <air.release.preparation-goals>clean verify -DskipTests</air.release.preparation-goals>
+        <air.staging.profile-id>3275892c20a21</air.staging.profile-id>
 
         <dep.accumulo.version>1.7.4</dep.accumulo.version>
         <dep.accumulo-hadoop.version>2.7.7-1</dep.accumulo-hadoop.version>


### PR DESCRIPTION
## Description

Relies on https://github.com/airlift/airbase/pull/333

Add a Maven plugin to allow command-line based closing and releasing of the staging repository from the release process. 

This is for a test to be done with @martint and still needs details we will look up in the OSSRH UI together. 

We might have to fine-tune and test this quite a bit.. before and after merge. 

Also https://github.com/sonatype/nexus-maven-plugins/tree/main/staging/maven-plugin and https://central.sonatype.org/publish/publish-maven/

On the command line we should be able to run the following command after the deployment to the staging repo from the release process is done:

```
mvn nexus-staging:close
mvn nexus-staging:release
```

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Tool for simplified release process. 


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
