### PR TITLE
fix(sec): upgrade com.amazonaws:aws-java-sdk-s3 to 1.12.261

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dep.antlr.version>4.11.1</dep.antlr.version>
         <dep.airlift.version>219</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
-        <dep.aws-sdk.version>1.12.172</dep.aws-sdk.version>
+        <dep.aws-sdk.version>1.12.261</dep.aws-sdk.version>
         <dep.okhttp.version>3.14.9</dep.okhttp.version>
         <dep.joda.version>2.12.0</dep.joda.version>
         <dep.jsonwebtoken.version>0.11.2</dep.jsonwebtoken.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.amazonaws:aws-java-sdk-s3 1.12.172
- [CVE-2022-31159](https://www.oscs1024.com/hd/CVE-2022-31159)


### What did I do？
Upgrade com.amazonaws:aws-java-sdk-s3 from 1.12.172 to 1.12.261 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS