### PR TITLE
Mitigate Writer skewness when writing partitioned data with preferred partitioning enabled

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/IndexedPriorityQueue.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/IndexedPriorityQueue.java
@@ -46,6 +46,9 @@ public final class IndexedPriorityQueue<E>
     {
         Entry<E> entry = index.get(element);
         if (entry != null) {
+            if (entry.getPriority() == priority) {
+                return false;
+            }
             queue.remove(entry);
             Entry<E> newEntry = new Entry<>(element, priority, entry.getGeneration());
             queue.add(newEntry);

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/ScaleWriterPartitioningExchanger.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/ScaleWriterPartitioningExchanger.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.operator.exchange;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import io.trino.operator.PartitionFunction;
+import io.trino.operator.exchange.PageReference.PageReleasedListener;
+import io.trino.spi.Page;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.longs.Long2IntMap;
+import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
+import it.unimi.dsi.fastutil.longs.Long2LongMap;
+import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static io.trino.operator.exchange.PageReference.PageReleasedListener.forLocalExchangeMemoryManager;
+import static io.trino.operator.exchange.UniformPartitionRebalancer.WriterPartitionId;
+import static io.trino.operator.exchange.UniformPartitionRebalancer.WriterPartitionId.serialize;
+import static java.util.Arrays.fill;
+import static java.util.Objects.requireNonNull;
+
+public class ScaleWriterPartitioningExchanger
+        implements LocalExchanger
+{
+    private final List<Consumer<PageReference>> buffers;
+    private final LocalExchangeMemoryManager memoryManager;
+    private final long maxBufferedBytes;
+    private final Function<Page, Page> partitionedPagePreparer;
+    private final PartitionFunction partitionFunction;
+    private final UniformPartitionRebalancer partitionRebalancer;
+    private final PageReleasedListener onPageReleased;
+
+    private final IntArrayList[] writerAssignments;
+    private final int[] partitionRowCounts;
+    private final int[] partitionWriterIds;
+    private final int[] partitionWriterIndexes;
+
+    private final IntArrayList usedPartitions = new IntArrayList();
+
+    // Use Long2IntMap instead of Map<WriterPartitionId, Integer> which helps to save memory in the worst case scenario.
+    // Here first 32 bit of long key contains writerId whereas last 32 bit contains partitionId.
+    private final Long2IntMap pageWriterPartitionRowCounts = new Long2IntOpenHashMap();
+
+    // Use Long2LongMap instead of Map<WriterPartitionId, Long> which helps to save memory in the worst case scenario.
+    // Here first 32 bit of long key contains writerId whereas last 32 bit contains partitionId.
+    @GuardedBy("this")
+    private final Long2LongMap writerPartitionRowCounts = new Long2LongOpenHashMap();
+
+    public ScaleWriterPartitioningExchanger(
+            List<Consumer<PageReference>> buffers,
+            LocalExchangeMemoryManager memoryManager,
+            long maxBufferedBytes,
+            Function<Page, Page> partitionedPagePreparer,
+            PartitionFunction partitionFunction,
+            int partitionCount,
+            UniformPartitionRebalancer partitionRebalancer)
+    {
+        this.buffers = requireNonNull(buffers, "buffers is null");
+        this.memoryManager = requireNonNull(memoryManager, "memoryManager is null");
+        this.maxBufferedBytes = maxBufferedBytes;
+        this.partitionedPagePreparer = requireNonNull(partitionedPagePreparer, "partitionedPagePreparer is null");
+        this.partitionFunction = requireNonNull(partitionFunction, "partitionFunction is null");
+        this.partitionRebalancer = requireNonNull(partitionRebalancer, "partitionRebalancer is null");
+        this.onPageReleased = forLocalExchangeMemoryManager(memoryManager);
+
+        // Initialize writerAssignments with the buffer size
+        writerAssignments = new IntArrayList[buffers.size()];
+        for (int i = 0; i < writerAssignments.length; i++) {
+            writerAssignments[i] = new IntArrayList();
+        }
+
+        partitionRowCounts = new int[partitionCount];
+        partitionWriterIndexes = new int[partitionCount];
+        partitionWriterIds = new int[partitionCount];
+
+        // Initialize partitionWriterIds with negative values since it indicates that writerIds should be fetched
+        // from the scaling state while page processing.
+        fill(partitionWriterIds, -1);
+    }
+
+    @Override
+    public void accept(Page page)
+    {
+        // Scale up writers when current buffer memory utilization is more than 50% of the maximum
+        if (memoryManager.getBufferedBytes() > maxBufferedBytes * 0.5) {
+            partitionRebalancer.rebalancePartitions();
+        }
+
+        Page partitionPage = partitionedPagePreparer.apply(page);
+
+        // Assign each row to a writer by looking at partitions scaling state using partitionRebalancer
+        for (int position = 0; position < partitionPage.getPositionCount(); position++) {
+            // Get row partition id (or bucket id) which limits to the partitionCount. If there are more physical partitions than
+            // this artificial partition limit, then it is possible that multiple physical partitions will get assigned the same
+            // bucket id. Thus, multiple partitions will be scaled together since we track partition physicalWrittenBytes
+            // using the artificial limit (partitionCount).
+            int partitionId = partitionFunction.getPartition(partitionPage, position);
+            partitionRowCounts[partitionId] += 1;
+
+            // Get writer id for this partition by looking at the scaling state
+            int writerId = partitionWriterIds[partitionId];
+            if (writerId == -1) {
+                writerId = getNextWriterId(partitionId);
+                partitionWriterIds[partitionId] = writerId;
+                usedPartitions.add(partitionId);
+            }
+            writerAssignments[writerId].add(position);
+        }
+
+        for (int partitionId : usedPartitions) {
+            int writerId = partitionWriterIds[partitionId];
+            pageWriterPartitionRowCounts.put(serialize(new WriterPartitionId(writerId, partitionId)), partitionRowCounts[partitionId]);
+
+            // Reset the value of partition row count and writer id for the next page processing cycle
+            partitionRowCounts[partitionId] = 0;
+            partitionWriterIds[partitionId] = -1;
+        }
+
+        // Update partitions row count state which will help with scaling partitions across writers
+        updatePartitionRowCounts(pageWriterPartitionRowCounts);
+
+        // Reset pageWriterPartitionRowCounts and usedPartitions for the next page processing cycle
+        pageWriterPartitionRowCounts.clear();
+        usedPartitions.clear();
+
+        // build a page for each writer
+        for (int bucket = 0; bucket < writerAssignments.length; bucket++) {
+            IntArrayList positionsList = writerAssignments[bucket];
+            int bucketSize = positionsList.size();
+            if (bucketSize == 0) {
+                continue;
+            }
+            // clear the assigned positions list size for the next iteration to start empty. This
+            // only resets the size() to 0 which controls the index where subsequent calls to add()
+            // will store new values, but does not modify the positions array
+            int[] positions = positionsList.elements();
+            positionsList.clear();
+
+            if (bucketSize == page.getPositionCount()) {
+                // whole input page will go to this partition, compact the input page avoid over-retaining memory and to
+                // match the behavior of sub-partitioned pages that copy positions out
+                page.compact();
+                sendPageToPartition(buffers.get(bucket), page);
+                return;
+            }
+
+            Page pageSplit = page.copyPositions(positions, 0, bucketSize);
+            sendPageToPartition(buffers.get(bucket), pageSplit);
+        }
+    }
+
+    @Override
+    public ListenableFuture<Void> waitForWriting()
+    {
+        return memoryManager.getNotFullFuture();
+    }
+
+    public synchronized Long2LongMap getAndResetPartitionRowCounts()
+    {
+        Long2LongMap result = new Long2LongOpenHashMap(writerPartitionRowCounts);
+        writerPartitionRowCounts.clear();
+        return result;
+    }
+
+    private synchronized void updatePartitionRowCounts(Long2IntMap pagePartitionRowCounts)
+    {
+        pagePartitionRowCounts.forEach((writerPartitionId, rowCount) ->
+                writerPartitionRowCounts.merge(writerPartitionId, rowCount, Long::sum));
+    }
+
+    private int getNextWriterId(int partitionId)
+    {
+        return partitionRebalancer.getWriterId(partitionId, partitionWriterIndexes[partitionId]++);
+    }
+
+    private void sendPageToPartition(Consumer<PageReference> buffer, Page pageSplit)
+    {
+        PageReference pageReference = new PageReference(pageSplit, 1, onPageReleased);
+        memoryManager.updateMemoryUsage(pageReference.getRetainedSizeInBytes());
+        buffer.accept(pageReference);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/UniformPartitionRebalancer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/UniformPartitionRebalancer.java
@@ -1,0 +1,432 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.operator.exchange;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import io.airlift.log.Logger;
+import io.airlift.units.DataSize;
+import io.trino.execution.resourcegroups.IndexedPriorityQueue;
+import it.unimi.dsi.fastutil.longs.Long2LongMap;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.function.Supplier;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.lang.Double.isNaN;
+import static java.lang.Math.floorMod;
+import static java.lang.Math.max;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Help in finding the skewness across writers when writing partitioned data using preferred partitioning.
+ * It then tries to uniformly distribute the biggest partitions from skewed writers to all the available writers.
+ * <p>
+ * Example:
+ * <p>
+ * Before: For three writers with skewed partitions
+ *      Writer 1 -> No partition assigned -> 0 bytes
+ *      Writer 2 -> No partition assigned -> 0 bytes
+ *      Writer 3 -> Partition 1 (100MB) + Partition 2 (100MB) + Partition 3 (100MB) ->  300 MB
+ * <p>
+ * After scaling:
+ *      Writer 1 -> Partition 1 (50MB) + Partition 3 (50MB) -> 100 MB
+ *      Writer 2 -> Partition 2 (50MB) -> 50 MB
+ *      Writer 3 -> Partition 1 (150MB) + Partition 2 (150MB) + Partition 3 (150MB) ->  450 MB
+ */
+@ThreadSafe
+public class UniformPartitionRebalancer
+{
+    private static final Logger log = Logger.get(UniformPartitionRebalancer.class);
+    // If the percentage difference between the two writers with maximum and minimum physical written bytes
+    // since last rebalance is above 0.7 (or 70%), then we consider them skewed.
+    private static final double SKEWNESS_THRESHOLD = 0.7;
+
+    private final List<Supplier<Long>> writerPhysicalWrittenBytesSuppliers;
+    // Use Long2LongMap instead of Map<WriterPartitionId, Integer> which helps to save memory in the worst case scenario.
+    // Here first 32 bit of Long key contains writerId whereas last 32 bit contains partitionId.
+    private final Supplier<Long2LongMap> partitionRowCountsSupplier;
+    private final long writerMinSize;
+    private final int numberOfWriters;
+    private final long rebalanceThresholdMinPhysicalWrittenBytes;
+
+    private final AtomicLongArray writerPhysicalWrittenBytesAtLastRebalance;
+
+    private final PartitionInfo[] partitionInfos;
+
+    public UniformPartitionRebalancer(
+            List<Supplier<Long>> writerPhysicalWrittenBytesSuppliers,
+            Supplier<Long2LongMap> partitionRowCountsSupplier,
+            int partitionCount,
+            int numberOfWriters,
+            long writerMinSize)
+    {
+        this.writerPhysicalWrittenBytesSuppliers = requireNonNull(writerPhysicalWrittenBytesSuppliers, "writerPhysicalWrittenBytesSuppliers is null");
+        this.partitionRowCountsSupplier = requireNonNull(partitionRowCountsSupplier, "partitionRowCountsSupplier is null");
+        this.writerMinSize = writerMinSize;
+        this.numberOfWriters = numberOfWriters;
+        this.rebalanceThresholdMinPhysicalWrittenBytes = max(DataSize.of(50, MEGABYTE).toBytes(), writerMinSize);
+
+        this.writerPhysicalWrittenBytesAtLastRebalance = new AtomicLongArray(numberOfWriters);
+
+        partitionInfos = new PartitionInfo[partitionCount];
+        for (int i = 0; i < partitionCount; i++) {
+            partitionInfos[i] = new PartitionInfo(i % numberOfWriters);
+        }
+    }
+
+    public int getWriterId(int partitionId, int index)
+    {
+        return partitionInfos[partitionId].getWriterId(index);
+    }
+
+    @VisibleForTesting
+    List<Integer> getWriterIds(int partitionId)
+    {
+        return partitionInfos[partitionId].getWriterIds();
+    }
+
+    public void rebalancePartitions()
+    {
+        List<Long> writerPhysicalWrittenBytes = writerPhysicalWrittenBytesSuppliers.stream()
+                .map(Supplier::get)
+                .collect(toImmutableList());
+
+        // Rebalance only when total bytes written since last rebalance is greater than rebalance threshold
+        if (getPhysicalWrittenBytesSinceLastRebalance(writerPhysicalWrittenBytes) > rebalanceThresholdMinPhysicalWrittenBytes) {
+            rebalancePartitions(writerPhysicalWrittenBytes);
+        }
+    }
+
+    private int getPhysicalWrittenBytesSinceLastRebalance(List<Long> writerPhysicalWrittenBytes)
+    {
+        int physicalWrittenBytesSinceLastRebalance = 0;
+        for (int writerId = 0; writerId < writerPhysicalWrittenBytes.size(); writerId++) {
+            physicalWrittenBytesSinceLastRebalance +=
+                    writerPhysicalWrittenBytes.get(writerId) - writerPhysicalWrittenBytesAtLastRebalance.get(writerId);
+        }
+
+        return physicalWrittenBytesSinceLastRebalance;
+    }
+
+    private synchronized void rebalancePartitions(List<Long> writerPhysicalWrittenBytes)
+    {
+        Long2LongMap partitionRowCounts = partitionRowCountsSupplier.get();
+        RebalanceContext context = new RebalanceContext(writerPhysicalWrittenBytes, partitionRowCounts);
+
+        IndexedPriorityQueue<WriterId> maxWriters = new IndexedPriorityQueue<>();
+        IndexedPriorityQueue<WriterId> minWriters = new IndexedPriorityQueue<>();
+        for (int writerId = 0; writerId < numberOfWriters; writerId++) {
+            WriterId writer = new WriterId(writerId);
+            maxWriters.addOrUpdate(writer, context.getWriterEstimatedWrittenBytes(writer));
+            minWriters.addOrUpdate(writer, Long.MAX_VALUE - context.getWriterEstimatedWrittenBytes(writer));
+        }
+
+        // Find skewed partitions and scale them across multiple writers
+        while (true) {
+            // Find the writer with maximum physical written bytes since last rebalance
+            WriterId maxWriter = maxWriters.poll();
+
+            if (maxWriter == null) {
+                break;
+            }
+
+            // Find the skewness against writer with max physical written bytes since last rebalance
+            List<WriterId> minSkewedWriters = findSkewedMinWriters(context, maxWriter, minWriters);
+            if (minSkewedWriters.isEmpty()) {
+                break;
+            }
+
+            for (WriterId minSkewedWriter : minSkewedWriters) {
+                // There's no need to add the maxWriter back to priority queues if no partition rebalancing happened
+                if (context.rebalancePartition(maxWriter, minSkewedWriter)) {
+                    maxWriters.addOrUpdate(maxWriter, context.getWriterEstimatedWrittenBytes(maxWriter));
+                    minWriters.addOrUpdate(maxWriter, Long.MAX_VALUE - context.getWriterEstimatedWrittenBytes(maxWriter));
+                    break;
+                }
+            }
+
+            // Add all the min skewed writers back to the minWriters queue with updated priorities
+            for (WriterId minSkewedWriter : minSkewedWriters) {
+                maxWriters.addOrUpdate(minSkewedWriter, context.getWriterEstimatedWrittenBytes(minSkewedWriter));
+                minWriters.addOrUpdate(minSkewedWriter, Long.MAX_VALUE - context.getWriterEstimatedWrittenBytes(minSkewedWriter));
+            }
+        }
+
+        resetStateForNextRebalance(context, writerPhysicalWrittenBytes, partitionRowCounts);
+    }
+
+    private List<WriterId> findSkewedMinWriters(RebalanceContext context, WriterId maxWriter, IndexedPriorityQueue<WriterId> minWriters)
+    {
+        ImmutableList.Builder<WriterId> minSkewedWriters = ImmutableList.builder();
+        long maxWriterWrittenBytes = context.getWriterEstimatedWrittenBytes(maxWriter);
+        while (true) {
+            // Find the writer with minimum written bytes since last rebalance
+            WriterId minWriter = minWriters.poll();
+            if (minWriter == null) {
+                break;
+            }
+
+            long minWriterWrittenBytes = context.getWriterEstimatedWrittenBytes(minWriter);
+
+            // find the skewness against writer with max written bytes since last rebalance
+            double skewness = ((double) (maxWriterWrittenBytes - minWriterWrittenBytes)) / maxWriterWrittenBytes;
+            if (skewness <= SKEWNESS_THRESHOLD || isNaN(skewness)) {
+                break;
+            }
+
+            minSkewedWriters.add(minWriter);
+        }
+        return minSkewedWriters.build();
+    }
+
+    private void resetStateForNextRebalance(RebalanceContext context, List<Long> writerPhysicalWrittenBytes, Long2LongMap partitionRowCounts)
+    {
+        partitionRowCounts.forEach((serializedKey, rowCount) -> {
+            WriterPartitionId writerPartitionId = WriterPartitionId.deserialize(serializedKey);
+            PartitionInfo partitionInfo = partitionInfos[writerPartitionId.partitionId];
+            if (context.isPartitionRebalanced(writerPartitionId.partitionId)) {
+                // Reset physical written bytes for rebalanced partitions
+                partitionInfo.resetPhysicalWrittenBytesAtLastRebalance();
+            }
+            else {
+                long writtenBytes = context.estimatePartitionWrittenBytesSinceLastRebalance(new WriterId(writerPartitionId.writerId), rowCount);
+                partitionInfo.addToPhysicalWrittenBytesAtLastRebalance(writtenBytes);
+            }
+        });
+
+        for (int i = 0; i < numberOfWriters; i++) {
+            writerPhysicalWrittenBytesAtLastRebalance.set(i, writerPhysicalWrittenBytes.get(i));
+        }
+    }
+
+    private class RebalanceContext
+    {
+        private final Set<Integer> rebalancedPartitions = new HashSet<>();
+        private final long[] writerPhysicalWrittenBytesSinceLastRebalance;
+        private final long[] writerRowCountSinceLastRebalance;
+        private final long[] writerEstimatedWrittenBytes;
+        private final List<IndexedPriorityQueue<PartitionIdWithRowCount>> writerMaxPartitions;
+
+        private RebalanceContext(List<Long> writerPhysicalWrittenBytes, Long2LongMap partitionRowCounts)
+        {
+            writerPhysicalWrittenBytesSinceLastRebalance = new long[numberOfWriters];
+            writerEstimatedWrittenBytes = new long[numberOfWriters];
+            for (int writerId = 0; writerId < writerPhysicalWrittenBytes.size(); writerId++) {
+                long physicalWrittenBytesSinceLastRebalance =
+                        writerPhysicalWrittenBytes.get(writerId) - writerPhysicalWrittenBytesAtLastRebalance.get(writerId);
+                writerPhysicalWrittenBytesSinceLastRebalance[writerId] = physicalWrittenBytesSinceLastRebalance;
+                writerEstimatedWrittenBytes[writerId] = physicalWrittenBytesSinceLastRebalance;
+            }
+
+            writerRowCountSinceLastRebalance = new long[numberOfWriters];
+            writerMaxPartitions = new ArrayList<>(numberOfWriters);
+            for (int writerId = 0; writerId < numberOfWriters; writerId++) {
+                writerMaxPartitions.add(new IndexedPriorityQueue<>());
+            }
+
+            partitionRowCounts.forEach((serializedKey, rowCount) -> {
+                WriterPartitionId writerPartitionId = WriterPartitionId.deserialize(serializedKey);
+                writerRowCountSinceLastRebalance[writerPartitionId.writerId] += rowCount;
+                writerMaxPartitions
+                        .get(writerPartitionId.writerId)
+                        .addOrUpdate(new PartitionIdWithRowCount(writerPartitionId.partitionId, rowCount), rowCount);
+            });
+        }
+
+        private boolean rebalancePartition(WriterId from, WriterId to)
+        {
+            IndexedPriorityQueue<PartitionIdWithRowCount> maxPartitions = writerMaxPartitions.get(from.id);
+
+            for (PartitionIdWithRowCount partitionToRebalance : maxPartitions) {
+                // Find the partition with maximum written bytes since last rebalance
+                PartitionInfo partitionInfo = partitionInfos[partitionToRebalance.id];
+
+                // If a partition is already rebalanced or min skewed writer is already writing to that partition, then skip
+                // this partition and move on to the other partition inside max writer. Also, we don't rebalance same partition
+                // twice because we want to make sure that every writer wrote writerMinSize for a given partition
+                if (!isPartitionRebalanced(partitionToRebalance.id) && !partitionInfo.containsWriter(to.id)) {
+                    // First remove the partition from the priority queue since there's no need go over it again. As in the next
+                    // section we will check whether it can be scaled or not.
+                    maxPartitions.remove(partitionToRebalance);
+
+                    long estimatedPartitionWrittenBytesSinceLastRebalance = estimatePartitionWrittenBytesSinceLastRebalance(from, partitionToRebalance.rowCount);
+                    long estimatedPartitionWrittenBytes =
+                            estimatedPartitionWrittenBytesSinceLastRebalance + partitionInfo.getPhysicalWrittenBytesAtLastRebalancePerWriter();
+
+                    // Scale the partition when estimated physicalWrittenBytes is greater than writerMinSize.
+                    if (partitionInfo.getWriterCount() <= numberOfWriters && estimatedPartitionWrittenBytes >= writerMinSize) {
+                        partitionInfo.addWriter(to.id);
+                        rebalancedPartitions.add(partitionToRebalance.id);
+                        updateWriterEstimatedWrittenBytes(from, to, estimatedPartitionWrittenBytesSinceLastRebalance, partitionInfo.getWriterCount());
+                        log.debug("Scaled partition (%s) to writer %s with writer count %s", partitionToRebalance.id, to.id, partitionInfo.getWriterCount());
+                        return true;
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        }
+
+        private void updateWriterEstimatedWrittenBytes(WriterId from, WriterId to, long estimatedPartitionWrittenBytesSinceLastRebalance, int newWriterCount)
+        {
+            // Since a partition is rebalanced from max to min skewed writer, decrease the priority of max
+            // writer as well as increase the priority of min writer.
+            int oldWriterCount = newWriterCount - 1;
+            writerEstimatedWrittenBytes[from.id] -= (estimatedPartitionWrittenBytesSinceLastRebalance * oldWriterCount) / newWriterCount;
+            writerEstimatedWrittenBytes[to.id] += (estimatedPartitionWrittenBytesSinceLastRebalance * oldWriterCount) / newWriterCount;
+        }
+
+        private long getWriterEstimatedWrittenBytes(WriterId writer)
+        {
+            return writerEstimatedWrittenBytes[writer.id];
+        }
+
+        private boolean isPartitionRebalanced(int partitionId)
+        {
+            return rebalancedPartitions.contains(partitionId);
+        }
+
+        private long estimatePartitionWrittenBytesSinceLastRebalance(WriterId writer, long partitionRowCount)
+        {
+            return (writerPhysicalWrittenBytesSinceLastRebalance[writer.id] * partitionRowCount) / writerRowCountSinceLastRebalance[writer.id];
+        }
+    }
+
+    @ThreadSafe
+    private static class PartitionInfo
+    {
+        private final List<Integer> writerAssignments;
+        // Partition estimated physical written bytes at the end of last rebalance cycle
+        private final AtomicLong physicalWrittenBytesAtLastRebalance = new AtomicLong(0);
+
+        private PartitionInfo(int initialWriterId)
+        {
+            this.writerAssignments = new CopyOnWriteArrayList<>(ImmutableList.of(initialWriterId));
+        }
+
+        private boolean containsWriter(int writerId)
+        {
+            return writerAssignments.contains(writerId);
+        }
+
+        private void addWriter(int writerId)
+        {
+            writerAssignments.add(writerId);
+        }
+
+        private int getWriterId(int index)
+        {
+            return writerAssignments.get(floorMod(index, getWriterCount()));
+        }
+
+        private List<Integer> getWriterIds()
+        {
+            return ImmutableList.copyOf(writerAssignments);
+        }
+
+        private int getWriterCount()
+        {
+            return writerAssignments.size();
+        }
+
+        private void resetPhysicalWrittenBytesAtLastRebalance()
+        {
+            physicalWrittenBytesAtLastRebalance.set(0);
+        }
+
+        private void addToPhysicalWrittenBytesAtLastRebalance(long writtenBytes)
+        {
+            physicalWrittenBytesAtLastRebalance.addAndGet(writtenBytes);
+        }
+
+        private long getPhysicalWrittenBytesAtLastRebalancePerWriter()
+        {
+            return physicalWrittenBytesAtLastRebalance.get() / writerAssignments.size();
+        }
+    }
+
+    public record WriterPartitionId(int writerId, int partitionId)
+    {
+        public static WriterPartitionId deserialize(long value)
+        {
+            int writerId = (int) (value >> 32);
+            int partitionId = (int) value;
+
+            return new WriterPartitionId(writerId, partitionId);
+        }
+
+        public static long serialize(WriterPartitionId writerPartitionId)
+        {
+            // Serialize to long to save memory where first 32 bit contains writerId whereas last 32 bit
+            // contains partitionId.
+            return ((long) writerPartitionId.writerId << 32 | writerPartitionId.partitionId & 0xFFFFFFFFL);
+        }
+
+        public WriterPartitionId(int writerId, int partitionId)
+        {
+            this.writerId = writerId;
+            this.partitionId = partitionId;
+        }
+    }
+
+    private record WriterId(int id)
+    {
+        private WriterId(int id)
+        {
+            this.id = id;
+        }
+    }
+
+    private record PartitionIdWithRowCount(int id, long rowCount)
+    {
+        private PartitionIdWithRowCount(int id, long rowCount)
+        {
+            this.id = id;
+            this.rowCount = rowCount;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            PartitionIdWithRowCount that = (PartitionIdWithRowCount) o;
+            return id == that.id;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hashCode(id);
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PartitioningHandle.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PartitioningHandle.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.sql.planner.SystemPartitioningHandle.SCALED_WRITER_HASH_DISTRIBUTION;
 import static java.util.Objects.requireNonNull;
 
 public class PartitioningHandle
@@ -31,6 +32,12 @@ public class PartitioningHandle
     private final Optional<ConnectorTransactionHandle> transactionHandle;
     private final ConnectorPartitioningHandle connectorHandle;
     private final boolean scaleWriters;
+
+    public static boolean isScaledWriterHashDistribution(PartitioningHandle partitioning)
+    {
+        return partitioning.isScaleWriters()
+                && (partitioning.equals(SCALED_WRITER_HASH_DISTRIBUTION) || partitioning.getCatalogHandle().isPresent());
+    }
 
     public PartitioningHandle(
             Optional<CatalogHandle> catalogHandle,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PartitioningScheme.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PartitioningScheme.java
@@ -114,6 +114,12 @@ public class PartitioningScheme
         return new PartitioningScheme(partitioning, outputLayout, hashColumn, replicateNullsAndAny, bucketToPartition);
     }
 
+    public PartitioningScheme withPartitioningHandle(PartitioningHandle partitioningHandle)
+    {
+        Partitioning newPartitioning = partitioning.withAlternativePartitioningHandle(partitioningHandle);
+        return new PartitioningScheme(newPartitioning, outputLayout, hashColumn, replicateNullsAndAny, bucketToPartition);
+    }
+
     public PartitioningScheme translateOutputLayout(List<Symbol> newOutputLayout)
     {
         requireNonNull(newOutputLayout, "newOutputLayout is null");

--- a/core/trino-main/src/main/java/io/trino/sql/planner/SystemPartitioningHandle.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SystemPartitioningHandle.java
@@ -51,6 +51,7 @@ public final class SystemPartitioningHandle
     public static final PartitioningHandle FIXED_ARBITRARY_DISTRIBUTION = createSystemPartitioning(SystemPartitioning.FIXED, SystemPartitionFunction.ROUND_ROBIN);
     public static final PartitioningHandle FIXED_BROADCAST_DISTRIBUTION = createSystemPartitioning(SystemPartitioning.FIXED, SystemPartitionFunction.BROADCAST);
     public static final PartitioningHandle SCALED_WRITER_ROUND_ROBIN_DISTRIBUTION = createScaledWriterSystemPartitioning(SystemPartitionFunction.ROUND_ROBIN);
+    public static final PartitioningHandle SCALED_WRITER_HASH_DISTRIBUTION = createScaledWriterSystemPartitioning(SystemPartitionFunction.HASH);
     public static final PartitioningHandle SOURCE_DISTRIBUTION = createSystemPartitioning(SystemPartitioning.SOURCE, SystemPartitionFunction.UNKNOWN);
     public static final PartitioningHandle ARBITRARY_DISTRIBUTION = createSystemPartitioning(SystemPartitioning.ARBITRARY, SystemPartitionFunction.UNKNOWN);
     public static final PartitioningHandle FIXED_PASSTHROUGH_DISTRIBUTION = createSystemPartitioning(SystemPartitioning.FIXED, SystemPartitionFunction.UNKNOWN);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -32,6 +32,7 @@ import io.trino.spi.function.OperatorType;
 import io.trino.spi.type.StandardTypes;
 import io.trino.sql.planner.FunctionCallBuilder;
 import io.trino.sql.planner.Partitioning.ArgumentBinding;
+import io.trino.sql.planner.PartitioningHandle;
 import io.trino.sql.planner.PartitioningScheme;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.Symbol;
@@ -86,6 +87,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.metadata.OperatorNameUtil.mangleOperatorName;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.SCALED_WRITER_HASH_DISTRIBUTION;
 import static io.trino.sql.planner.plan.ChildReplacer.replaceChildren;
 import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
 import static io.trino.sql.planner.plan.JoinNode.Type.LEFT;
@@ -507,8 +509,11 @@ public class HashGenerationOptimizer
             // Currently, precomputed hash values are only supported for system hash distributions without constants
             Optional<HashComputation> partitionSymbols = Optional.empty();
             PartitioningScheme partitioningScheme = node.getPartitioningScheme();
-            if (partitioningScheme.getPartitioning().getHandle().equals(FIXED_HASH_DISTRIBUTION) &&
-                    partitioningScheme.getPartitioning().getArguments().stream().allMatch(ArgumentBinding::isVariable)) {
+            PartitioningHandle partitioningHandle = partitioningScheme.getPartitioning().getHandle();
+
+            if ((partitioningHandle.equals(FIXED_HASH_DISTRIBUTION)
+                    || partitioningHandle.equals(SCALED_WRITER_HASH_DISTRIBUTION))
+                    && partitioningScheme.getPartitioning().getArguments().stream().allMatch(ArgumentBinding::isVariable)) {
                 // add precomputed hash for exchange
                 partitionSymbols = computeHash(partitioningScheme.getPartitioning().getArguments().stream()
                         .map(ArgumentBinding::getColumn)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/sanity/ValidateScaledWritersUsage.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/sanity/ValidateScaledWritersUsage.java
@@ -31,7 +31,8 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkState;
-import static io.trino.sql.planner.SystemPartitioningHandle.SCALED_WRITER_ROUND_ROBIN_DISTRIBUTION;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.sql.planner.PartitioningHandle.isScaledWriterHashDistribution;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -75,10 +76,20 @@ public class ValidateScaledWritersUsage
         public List<PartitioningHandle> visitTableWriter(TableWriterNode node, Void context)
         {
             List<PartitioningHandle> children = collectPartitioningHandles(node.getSources());
-            boolean anyScaledWriterDistribution = children.stream().anyMatch(partitioningHandle -> partitioningHandle == SCALED_WRITER_ROUND_ROBIN_DISTRIBUTION);
+            List<PartitioningHandle> scaleWriterPartitioningHandle = children.stream()
+                    .filter(PartitioningHandle::isScaleWriters)
+                    .collect(toImmutableList());
             TableWriterNode.WriterTarget target = node.getTarget();
-            checkState(!anyScaledWriterDistribution || target.supportsReportingWrittenBytes(plannerContext.getMetadata(), session),
-                    "The partitioning scheme is set to SCALED_WRITER_DISTRIBUTION but writer target %s does support for it", target);
+
+            scaleWriterPartitioningHandle.forEach(partitioningHandle -> {
+                checkState(target.supportsReportingWrittenBytes(plannerContext.getMetadata(), session),
+                        "The scaled writer partitioning scheme is set but writer target %s doesn't support reporting physical written bytes", target);
+
+                if (isScaledWriterHashDistribution(partitioningHandle)) {
+                    checkState(target.supportsMultipleWritersPerPartition(plannerContext.getMetadata(), session),
+                            "The scaled writer partitioning scheme is set for the partitioned write but writer target %s doesn't support multiple writers per partition", target);
+                }
+            });
             return children;
         }
 

--- a/core/trino-main/src/test/java/io/trino/operator/exchange/TestUniformPartitionRebalancer.java
+++ b/core/trino-main/src/test/java/io/trino/operator/exchange/TestUniformPartitionRebalancer.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.operator.exchange;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
+import it.unimi.dsi.fastutil.longs.Long2LongMap;
+import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.trino.operator.exchange.UniformPartitionRebalancer.WriterPartitionId;
+import static io.trino.operator.exchange.UniformPartitionRebalancer.WriterPartitionId.serialize;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestUniformPartitionRebalancer
+{
+    @Test
+    public void testRebalanceWithWriterSkewness()
+    {
+        AtomicLong physicalWrittenBytesForWriter0 = new AtomicLong(0);
+        AtomicLong physicalWrittenBytesForWriter1 = new AtomicLong(0);
+        List<Supplier<Long>> writerPhysicalWrittenBytes = ImmutableList.of(
+                physicalWrittenBytesForWriter0::get,
+                physicalWrittenBytesForWriter1::get);
+        AtomicReference<Long2LongMap> partitionRowCounts = new AtomicReference<>(new Long2LongOpenHashMap());
+
+        UniformPartitionRebalancer partitionRebalancer = new UniformPartitionRebalancer(
+                writerPhysicalWrittenBytes,
+                partitionRowCounts::get,
+                4,
+                2,
+                DataSize.of(4, MEGABYTE).toBytes());
+
+        partitionRowCounts.set(serializeToLong2LongMap(ImmutableMap.of(
+                new WriterPartitionId(0, 0), 2L,
+                new WriterPartitionId(1, 1), 20000L,
+                new WriterPartitionId(0, 2), 2L,
+                new WriterPartitionId(1, 3), 20000L)));
+
+        physicalWrittenBytesForWriter1.set(DataSize.of(200, MEGABYTE).toBytes());
+
+        partitionRebalancer.rebalancePartitions();
+
+        assertThat(getWriterIdsForPartitions(partitionRebalancer, 4))
+                .containsExactly(
+                        ImmutableList.of(0),
+                        ImmutableList.of(1),
+                        ImmutableList.of(0),
+                        ImmutableList.of(1, 0));
+
+        partitionRowCounts.set(serializeToLong2LongMap(ImmutableMap.of(
+                new WriterPartitionId(0, 3), 10000L,
+                new WriterPartitionId(1, 3), 10000L,
+                new WriterPartitionId(1, 1), 40000L)));
+
+        physicalWrittenBytesForWriter0.set(DataSize.of(50, MEGABYTE).toBytes());
+        physicalWrittenBytesForWriter1.set(DataSize.of(500, MEGABYTE).toBytes());
+
+        partitionRebalancer.rebalancePartitions();
+
+        assertThat(getWriterIdsForPartitions(partitionRebalancer, 4))
+                .containsExactly(
+                        ImmutableList.of(0),
+                        ImmutableList.of(1, 0),
+                        ImmutableList.of(0),
+                        ImmutableList.of(1, 0));
+
+        partitionRowCounts.set(serializeToLong2LongMap(ImmutableMap.of(
+                new WriterPartitionId(0, 1), 10000L,
+                new WriterPartitionId(1, 1), 10000L,
+                new WriterPartitionId(0, 3), 10000L,
+                new WriterPartitionId(1, 3), 20000L)));
+
+        physicalWrittenBytesForWriter0.set(DataSize.of(100, MEGABYTE).toBytes());
+        physicalWrittenBytesForWriter1.set(DataSize.of(100, MEGABYTE).toBytes());
+
+        partitionRebalancer.rebalancePartitions();
+
+        assertThat(getWriterIdsForPartitions(partitionRebalancer, 4))
+                .containsExactly(
+                        ImmutableList.of(0),
+                        ImmutableList.of(1, 0),
+                        ImmutableList.of(0),
+                        ImmutableList.of(1, 0));
+    }
+
+    @Test
+    public void testNoRebalanceWhenDataWrittenIsLessThanTheRebalanceLimit()
+    {
+        AtomicLong physicalWrittenBytesForWriter0 = new AtomicLong(0);
+        AtomicLong physicalWrittenBytesForWriter1 = new AtomicLong(0);
+        List<Supplier<Long>> writerPhysicalWrittenBytes = ImmutableList.of(
+                physicalWrittenBytesForWriter0::get,
+                physicalWrittenBytesForWriter1::get);
+        AtomicReference<Long2LongMap> partitionRowCounts = new AtomicReference<>(new Long2LongOpenHashMap());
+
+        UniformPartitionRebalancer partitionRebalancer = new UniformPartitionRebalancer(
+                writerPhysicalWrittenBytes,
+                partitionRowCounts::get,
+                4,
+                2,
+                DataSize.of(4, MEGABYTE).toBytes());
+
+        partitionRowCounts.set(serializeToLong2LongMap(ImmutableMap.of(
+                new WriterPartitionId(0, 0), 2L,
+                new WriterPartitionId(1, 1), 20000L,
+                new WriterPartitionId(0, 2), 2L,
+                new WriterPartitionId(1, 3), 20000L)));
+
+        physicalWrittenBytesForWriter1.set(DataSize.of(30, MEGABYTE).toBytes());
+
+        assertThat(getWriterIdsForPartitions(partitionRebalancer, 4))
+                .containsExactly(
+                        ImmutableList.of(0),
+                        ImmutableList.of(1),
+                        ImmutableList.of(0),
+                        ImmutableList.of(1));
+
+        partitionRebalancer.rebalancePartitions();
+
+        assertThat(getWriterIdsForPartitions(partitionRebalancer, 4))
+                .containsExactly(
+                        ImmutableList.of(0),
+                        ImmutableList.of(1),
+                        ImmutableList.of(0),
+                        ImmutableList.of(1));
+    }
+
+    @Test
+    public void testNoRebalanceWithoutWriterSkewness()
+    {
+        AtomicReference<Long> physicalWrittenBytesForWriter0 = new AtomicReference<>(0L);
+        AtomicReference<Long> physicalWrittenBytesForWriter1 = new AtomicReference<>(0L);
+        List<Supplier<Long>> writerPhysicalWrittenBytes = ImmutableList.of(
+                physicalWrittenBytesForWriter0::get,
+                physicalWrittenBytesForWriter1::get);
+        AtomicReference<Long2LongMap> partitionRowCounts = new AtomicReference<>(new Long2LongOpenHashMap());
+
+        UniformPartitionRebalancer partitionRebalancer = new UniformPartitionRebalancer(
+                writerPhysicalWrittenBytes,
+                partitionRowCounts::get,
+                4,
+                2,
+                DataSize.of(4, MEGABYTE).toBytes());
+
+        partitionRowCounts.set(serializeToLong2LongMap(ImmutableMap.of(
+                new WriterPartitionId(0, 0), 20000L,
+                new WriterPartitionId(1, 1), 20000L,
+                new WriterPartitionId(0, 2), 20000L,
+                new WriterPartitionId(1, 3), 20000L)));
+
+        physicalWrittenBytesForWriter0.set(DataSize.of(50, MEGABYTE).toBytes());
+        physicalWrittenBytesForWriter1.set(DataSize.of(100, MEGABYTE).toBytes());
+
+        partitionRebalancer.rebalancePartitions();
+
+        assertThat(getWriterIdsForPartitions(partitionRebalancer, 4))
+                .containsExactly(
+                        ImmutableList.of(0),
+                        ImmutableList.of(1),
+                        ImmutableList.of(0),
+                        ImmutableList.of(1));
+
+        partitionRebalancer.rebalancePartitions();
+
+        assertThat(getWriterIdsForPartitions(partitionRebalancer, 4))
+                .containsExactly(
+                        ImmutableList.of(0),
+                        ImmutableList.of(1),
+                        ImmutableList.of(0),
+                        ImmutableList.of(1));
+    }
+
+    @Test
+    public void testNoRebalanceWhenDataWrittenByThePartitionIsLessThanWriterMinSize()
+    {
+        AtomicReference<Long> physicalWrittenBytesForWriter0 = new AtomicReference<>(0L);
+        AtomicReference<Long> physicalWrittenBytesForWriter1 = new AtomicReference<>(0L);
+        List<Supplier<Long>> writerPhysicalWrittenBytes = ImmutableList.of(
+                physicalWrittenBytesForWriter0::get,
+                physicalWrittenBytesForWriter1::get);
+        AtomicReference<Long2LongMap> partitionRowCounts = new AtomicReference<>(new Long2LongOpenHashMap());
+
+        UniformPartitionRebalancer partitionRebalancer = new UniformPartitionRebalancer(
+                writerPhysicalWrittenBytes,
+                partitionRowCounts::get,
+                4,
+                2,
+                DataSize.of(500, MEGABYTE).toBytes());
+
+        partitionRowCounts.set(serializeToLong2LongMap(ImmutableMap.of(
+                new WriterPartitionId(0, 0), 2L,
+                new WriterPartitionId(1, 1), 20000L,
+                new WriterPartitionId(0, 2), 2L,
+                new WriterPartitionId(1, 3), 20000L)));
+
+        physicalWrittenBytesForWriter1.set(DataSize.of(200, MEGABYTE).toBytes());
+
+        partitionRebalancer.rebalancePartitions();
+
+        assertThat(getWriterIdsForPartitions(partitionRebalancer, 4))
+                .containsExactly(
+                        ImmutableList.of(0),
+                        ImmutableList.of(1),
+                        ImmutableList.of(0),
+                        ImmutableList.of(1));
+    }
+
+    @Test
+    public void testPartitionShouldNotScaledTwiceInTheSameRebalanceCall()
+    {
+        AtomicReference<Long> physicalWrittenBytesForWriter0 = new AtomicReference<>(0L);
+        AtomicReference<Long> physicalWrittenBytesForWriter1 = new AtomicReference<>(0L);
+        AtomicReference<Long> physicalWrittenBytesForWriter2 = new AtomicReference<>(0L);
+        List<Supplier<Long>> writerPhysicalWrittenBytes = ImmutableList.of(
+                physicalWrittenBytesForWriter0::get,
+                physicalWrittenBytesForWriter1::get,
+                physicalWrittenBytesForWriter2::get);
+        AtomicReference<Long2LongMap> partitionRowCounts = new AtomicReference<>(new Long2LongOpenHashMap());
+
+        UniformPartitionRebalancer partitionRebalancer = new UniformPartitionRebalancer(
+                writerPhysicalWrittenBytes,
+                partitionRowCounts::get,
+                6,
+                3,
+                DataSize.of(32, MEGABYTE).toBytes());
+
+        partitionRowCounts.set(serializeToLong2LongMap(ImmutableMap.of(
+                new WriterPartitionId(0, 0), 2L,
+                new WriterPartitionId(1, 1), 2L,
+                new WriterPartitionId(2, 2), 2L,
+                new WriterPartitionId(0, 3), 2L,
+                new WriterPartitionId(1, 4), 2L,
+                new WriterPartitionId(2, 5), 20000L)));
+
+        physicalWrittenBytesForWriter2.set(DataSize.of(200, MEGABYTE).toBytes());
+
+        partitionRebalancer.rebalancePartitions();
+
+        assertThat(getWriterIdsForPartitions(partitionRebalancer, 6))
+                .containsExactly(
+                        ImmutableList.of(0),
+                        ImmutableList.of(1),
+                        ImmutableList.of(2),
+                        ImmutableList.of(0),
+                        ImmutableList.of(1),
+                        ImmutableList.of(2, 0));
+
+        partitionRowCounts.set(serializeToLong2LongMap(ImmutableMap.of(
+                new WriterPartitionId(0, 5), 10000L,
+                new WriterPartitionId(2, 5), 10000L)));
+
+        physicalWrittenBytesForWriter0.set(DataSize.of(100, MEGABYTE).toBytes());
+        physicalWrittenBytesForWriter2.set(DataSize.of(300, MEGABYTE).toBytes());
+
+        partitionRebalancer.rebalancePartitions();
+
+        assertThat(getWriterIdsForPartitions(partitionRebalancer, 6))
+                .containsExactly(
+                        ImmutableList.of(0),
+                        ImmutableList.of(1),
+                        ImmutableList.of(2),
+                        ImmutableList.of(0),
+                        ImmutableList.of(1),
+                        ImmutableList.of(2, 0, 1));
+    }
+
+    private Long2LongMap serializeToLong2LongMap(Map<WriterPartitionId, Long> input)
+    {
+        return new Long2LongOpenHashMap(
+                input.entrySet().stream()
+                        .collect(toImmutableMap(
+                                entry -> serialize(entry.getKey()),
+                                Map.Entry::getValue)));
+    }
+
+    private List<List<Integer>> getWriterIdsForPartitions(UniformPartitionRebalancer partitionRebalancer, int partitionCount)
+    {
+        return IntStream.range(0, partitionCount)
+                .mapToObj(partitionRebalancer::getWriterIds)
+                .collect(toImmutableList());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestAddLocalExchangesForTaskScaleWriters.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestAddLocalExchangesForTaskScaleWriters.java
@@ -16,20 +16,32 @@ package io.trino.sql.planner.optimizations;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.trino.Session;
+import io.trino.connector.CatalogHandle;
 import io.trino.connector.MockConnectorFactory;
-import io.trino.plugin.tpch.TpchConnectorFactory;
+import io.trino.connector.MockConnectorTableHandle;
+import io.trino.connector.MockConnectorTransactionHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorPartitioningHandle;
+import io.trino.spi.connector.ConnectorTableLayout;
+import io.trino.sql.planner.PartitioningHandle;
 import io.trino.sql.planner.assertions.BasePlanTest;
 import io.trino.testing.LocalQueryRunner;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import java.util.Optional;
 
 import static io.trino.SystemSessionProperties.SCALE_WRITERS;
 import static io.trino.SystemSessionProperties.TASK_SCALE_WRITERS_ENABLED;
+import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.SCALED_WRITER_HASH_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.SCALED_WRITER_ROUND_ROBIN_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.exchange;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableWriter;
 import static io.trino.sql.planner.plan.ExchangeNode.Scope.LOCAL;
@@ -41,90 +53,278 @@ import static io.trino.testing.TestingSession.testSessionBuilder;
 public class TestAddLocalExchangesForTaskScaleWriters
         extends BasePlanTest
 {
+    private static final ConnectorPartitioningHandle CONNECTOR_PARTITIONING_HANDLE = new ConnectorPartitioningHandle() {};
+
     @Override
     protected LocalQueryRunner createLocalQueryRunner()
     {
-        Session session = testSessionBuilder()
-                .setCatalog("tpch")
-                .setSchema("tiny")
-                .build();
-        LocalQueryRunner queryRunner = LocalQueryRunner.create(session);
-        queryRunner.createCatalog("tpch", new TpchConnectorFactory(1), ImmutableMap.of());
-        queryRunner.createCatalog("mock_dont_report_written_bytes", createConnectorFactorySupportingReportingBytesWritten(false, "mock_dont_report_written_bytes"), ImmutableMap.of());
-        queryRunner.createCatalog("mock_report_written_bytes", createConnectorFactorySupportingReportingBytesWritten(true, "mock_report_written_bytes"), ImmutableMap.of());
+        LocalQueryRunner queryRunner = LocalQueryRunner.create(testSessionBuilder().build());
+        queryRunner.createCatalog(
+                "mock_dont_report_written_bytes",
+                createConnectorFactory("mock_dont_report_written_bytes", false, true),
+                ImmutableMap.of());
+        queryRunner.createCatalog(
+                "mock_report_written_bytes_without_multiple_writer_per_partition",
+                createConnectorFactory("mock_report_written_bytes", true, false),
+                ImmutableMap.of());
+        queryRunner.createCatalog(
+                "mock_report_written_bytes_with_multiple_writer_per_partition",
+                createConnectorFactory("mock_report_written_bytes_with_multiple_writer_per_partition", true, true),
+                ImmutableMap.of());
         return queryRunner;
     }
 
-    private MockConnectorFactory createConnectorFactorySupportingReportingBytesWritten(boolean supportsWrittenBytes, String name)
+    private MockConnectorFactory createConnectorFactory(
+            String catalogHandle,
+            boolean supportsWrittenBytes,
+            boolean supportsMultipleWritersPerPartition)
     {
         return MockConnectorFactory.builder()
                 .withSupportsReportingWrittenBytes(supportsWrittenBytes)
-                .withGetTableHandle(((session, schemaTableName) -> null))
-                .withName(name)
+                .withGetTableHandle(((session, tableName) -> {
+                    if (tableName.getTableName().equals("source_table")
+                            || tableName.getTableName().equals("system_partitioned_table")
+                            || tableName.getTableName().equals("connector_partitioned_table")
+                            || tableName.getTableName().equals("unpartitioned_table")) {
+                        return new MockConnectorTableHandle(tableName);
+                    }
+                    return null;
+                }))
+                .withGetColumns(schemaTableName -> ImmutableList.of(
+                        new ColumnMetadata("customer", INTEGER),
+                        new ColumnMetadata("year", INTEGER)))
+                .withGetInsertLayout((session, tableName) -> {
+                    if (tableName.getTableName().equals("system_partitioned_table")) {
+                        return Optional.of(new ConnectorTableLayout(ImmutableList.of("year")));
+                    }
+                    if (tableName.getTableName().equals("connector_partitioned_table")) {
+                        return Optional.of(new ConnectorTableLayout(
+                                CONNECTOR_PARTITIONING_HANDLE,
+                                ImmutableList.of("year"),
+                                supportsMultipleWritersPerPartition));
+                    }
+                    return Optional.empty();
+                })
+                .withName(catalogHandle)
                 .build();
     }
 
     @Test
-    public void testLocalScaledWriterDistributionWithSupportsReportingWrittenBytes()
+    public void testLocalScaledUnpartitionedWriterDistributionWithSupportsReportingWrittenBytes()
     {
         assertDistributedPlan(
-                "CREATE TABLE mock_report_written_bytes.mock.test AS SELECT nationkey FROM tpch.tiny.nation",
+                "INSERT INTO unpartitioned_table SELECT * FROM source_table",
                 testSessionBuilder()
+                        .setCatalog("mock_report_written_bytes_without_multiple_writer_per_partition")
+                        .setSchema("mock")
                         .setSystemProperty(TASK_SCALE_WRITERS_ENABLED, "true")
                         .setSystemProperty(SCALE_WRITERS, "false")
                         .build(),
                 anyTree(
                         tableWriter(
-                                ImmutableList.of("nationkey"),
-                                ImmutableList.of("nationkey"),
+                                ImmutableList.of("customer", "year"),
+                                ImmutableList.of("customer", "year"),
                                 exchange(LOCAL, REPARTITION, SCALED_WRITER_ROUND_ROBIN_DISTRIBUTION,
                                         exchange(REMOTE, REPARTITION, FIXED_ARBITRARY_DISTRIBUTION,
-                                                tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))))));
+                                                tableScan("source_table", ImmutableMap.of("customer", "customer", "year", "year")))))));
 
         assertDistributedPlan(
-                "CREATE TABLE mock_report_written_bytes.mock.test AS SELECT nationkey FROM tpch.tiny.nation",
+                "INSERT INTO unpartitioned_table SELECT * FROM source_table",
                 testSessionBuilder()
+                        .setCatalog("mock_report_written_bytes_without_multiple_writer_per_partition")
+                        .setSchema("mock")
                         .setSystemProperty(TASK_SCALE_WRITERS_ENABLED, "false")
                         .setSystemProperty(SCALE_WRITERS, "false")
                         .build(),
                 anyTree(
                         tableWriter(
-                                ImmutableList.of("nationkey"),
-                                ImmutableList.of("nationkey"),
+                                ImmutableList.of("customer", "year"),
+                                ImmutableList.of("customer", "year"),
                                 exchange(LOCAL, GATHER, SINGLE_DISTRIBUTION,
                                         exchange(REMOTE, REPARTITION, FIXED_ARBITRARY_DISTRIBUTION,
-                                                tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))))));
+                                                tableScan("source_table", ImmutableMap.of("customer", "customer", "year", "year")))))));
+    }
+
+    @Test(dataProvider = "taskScaleWritersOption")
+    public void testLocalScaledPartitionedWriterWithoutSupportForMultipleWritersPerPartition(boolean taskScaleWritersEnabled)
+    {
+        String catalogName = "mock_report_written_bytes_without_multiple_writer_per_partition";
+        PartitioningHandle partitioningHandle = new PartitioningHandle(
+                Optional.of(CatalogHandle.fromId(catalogName)),
+                Optional.of(MockConnectorTransactionHandle.INSTANCE),
+                CONNECTOR_PARTITIONING_HANDLE);
+
+        assertDistributedPlan(
+                "INSERT INTO connector_partitioned_table SELECT * FROM source_table",
+                testSessionBuilder()
+                        .setCatalog(catalogName)
+                        .setSchema("mock")
+                        .setSystemProperty(TASK_SCALE_WRITERS_ENABLED, String.valueOf(taskScaleWritersEnabled))
+                        .setSystemProperty(SCALE_WRITERS, "false")
+                        .build(),
+                anyTree(
+                        tableWriter(
+                                ImmutableList.of("customer", "year"),
+                                ImmutableList.of("customer", "year"),
+                                exchange(LOCAL, REPARTITION, partitioningHandle,
+                                        exchange(REMOTE, REPARTITION, partitioningHandle,
+                                                tableScan("source_table", ImmutableMap.of("customer", "customer", "year", "year")))))));
+    }
+
+    @Test(dataProvider = "taskScaleWritersOption")
+    public void testLocalScaledUnpartitionedWriterDistributionWithoutSupportsReportingWrittenBytes(boolean taskScaleWritersEnabled)
+    {
+        assertDistributedPlan(
+                "INSERT INTO unpartitioned_table SELECT * FROM source_table",
+                testSessionBuilder()
+                        .setCatalog("mock_dont_report_written_bytes")
+                        .setSchema("mock")
+                        .setSystemProperty(TASK_SCALE_WRITERS_ENABLED, String.valueOf(taskScaleWritersEnabled))
+                        .setSystemProperty(SCALE_WRITERS, "false")
+                        .build(),
+                anyTree(
+                        tableWriter(
+                                ImmutableList.of("customer", "year"),
+                                ImmutableList.of("customer", "year"),
+                                exchange(LOCAL, GATHER, SINGLE_DISTRIBUTION,
+                                        exchange(REMOTE, REPARTITION, FIXED_ARBITRARY_DISTRIBUTION,
+                                                tableScan("source_table", ImmutableMap.of("customer", "customer", "year", "year")))))));
+    }
+
+    @Test(dataProvider = "taskScaleWritersOption")
+    public void testLocalScaledPartitionedWriterWithoutSupportsForReportingWrittenBytes(boolean taskScaleWritersEnabled)
+    {
+        String catalogName = "mock_dont_report_written_bytes";
+        PartitioningHandle partitioningHandle = new PartitioningHandle(
+                Optional.of(CatalogHandle.fromId(catalogName)),
+                Optional.of(MockConnectorTransactionHandle.INSTANCE),
+                CONNECTOR_PARTITIONING_HANDLE);
+
+        assertDistributedPlan(
+                "INSERT INTO system_partitioned_table SELECT * FROM source_table",
+                testSessionBuilder()
+                        .setCatalog(catalogName)
+                        .setSchema("mock")
+                        .setSystemProperty(TASK_SCALE_WRITERS_ENABLED, String.valueOf(taskScaleWritersEnabled))
+                        .setSystemProperty(SCALE_WRITERS, "false")
+                        .build(),
+                anyTree(
+                        tableWriter(
+                                ImmutableList.of("customer", "year"),
+                                ImmutableList.of("customer", "year"),
+                                project(
+                                        exchange(LOCAL, REPARTITION, FIXED_HASH_DISTRIBUTION,
+                                                exchange(REMOTE, REPARTITION, FIXED_HASH_DISTRIBUTION,
+                                                        project(
+                                                                tableScan("source_table", ImmutableMap.of("customer", "customer", "year", "year")))))))));
+
+        assertDistributedPlan(
+                "INSERT INTO connector_partitioned_table SELECT * FROM source_table",
+                testSessionBuilder()
+                        .setCatalog(catalogName)
+                        .setSchema("mock")
+                        .setSystemProperty(TASK_SCALE_WRITERS_ENABLED, String.valueOf(taskScaleWritersEnabled))
+                        .setSystemProperty(SCALE_WRITERS, "false")
+                        .build(),
+                anyTree(
+                        tableWriter(
+                                ImmutableList.of("customer", "year"),
+                                ImmutableList.of("customer", "year"),
+                                exchange(LOCAL, REPARTITION, partitioningHandle,
+                                        exchange(REMOTE, REPARTITION, partitioningHandle,
+                                                tableScan("source_table", ImmutableMap.of("customer", "customer", "year", "year")))))));
+    }
+
+    @DataProvider
+    public Object[][] taskScaleWritersOption()
+    {
+        return new Object[][] {{true}, {false}};
     }
 
     @Test
-    public void testLocalScaledWriterDistributionWithoutSupportsReportingWrittenBytes()
+    public void testLocalScaledPartitionedWriterForSystemPartitioning()
     {
         assertDistributedPlan(
-                "CREATE TABLE mock_dont_report_written_bytes.mock.test AS SELECT nationkey FROM tpch.tiny.nation",
+                "INSERT INTO system_partitioned_table SELECT * FROM source_table",
                 testSessionBuilder()
+                        .setCatalog("mock_report_written_bytes_with_multiple_writer_per_partition")
+                        .setSchema("mock")
                         .setSystemProperty(TASK_SCALE_WRITERS_ENABLED, "true")
                         .setSystemProperty(SCALE_WRITERS, "false")
                         .build(),
                 anyTree(
                         tableWriter(
-                                ImmutableList.of("nationkey"),
-                                ImmutableList.of("nationkey"),
-                                exchange(LOCAL, GATHER, SINGLE_DISTRIBUTION,
-                                        exchange(REMOTE, REPARTITION, FIXED_ARBITRARY_DISTRIBUTION,
-                                                tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))))));
+                                ImmutableList.of("customer", "year"),
+                                ImmutableList.of("customer", "year"),
+                                project(
+                                        exchange(LOCAL, REPARTITION, SCALED_WRITER_HASH_DISTRIBUTION,
+                                                exchange(REMOTE, REPARTITION, FIXED_HASH_DISTRIBUTION,
+                                                        project(
+                                                                tableScan("source_table", ImmutableMap.of("customer", "customer", "year", "year")))))))));
 
         assertDistributedPlan(
-                "CREATE TABLE mock_dont_report_written_bytes.mock.test AS SELECT nationkey FROM tpch.tiny.nation",
+                "INSERT INTO system_partitioned_table SELECT * FROM source_table",
                 testSessionBuilder()
+                        .setCatalog("mock_report_written_bytes_with_multiple_writer_per_partition")
+                        .setSchema("mock")
                         .setSystemProperty(TASK_SCALE_WRITERS_ENABLED, "false")
                         .setSystemProperty(SCALE_WRITERS, "false")
                         .build(),
                 anyTree(
                         tableWriter(
-                                ImmutableList.of("nationkey"),
-                                ImmutableList.of("nationkey"),
-                                exchange(LOCAL, GATHER, SINGLE_DISTRIBUTION,
-                                        exchange(REMOTE, REPARTITION, FIXED_ARBITRARY_DISTRIBUTION,
-                                                tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))))));
+                                ImmutableList.of("customer", "year"),
+                                ImmutableList.of("customer", "year"),
+                                project(
+                                        exchange(LOCAL, REPARTITION, FIXED_HASH_DISTRIBUTION,
+                                                exchange(REMOTE, REPARTITION, FIXED_HASH_DISTRIBUTION,
+                                                        project(
+                                                                tableScan("source_table", ImmutableMap.of("customer", "customer", "year", "year")))))))));
+    }
+
+    @Test
+    public void testLocalScaledPartitionedWriterForConnectorPartitioning()
+    {
+        String catalogName = "mock_report_written_bytes_with_multiple_writer_per_partition";
+        PartitioningHandle partitioningHandle = new PartitioningHandle(
+                Optional.of(CatalogHandle.fromId(catalogName)),
+                Optional.of(MockConnectorTransactionHandle.INSTANCE),
+                CONNECTOR_PARTITIONING_HANDLE);
+        PartitioningHandle scaledPartitioningHandle = new PartitioningHandle(
+                Optional.of(CatalogHandle.fromId(catalogName)),
+                Optional.of(MockConnectorTransactionHandle.INSTANCE),
+                CONNECTOR_PARTITIONING_HANDLE,
+                true);
+
+        assertDistributedPlan(
+                "INSERT INTO connector_partitioned_table SELECT * FROM source_table",
+                testSessionBuilder()
+                        .setCatalog(catalogName)
+                        .setSchema("mock")
+                        .setSystemProperty(TASK_SCALE_WRITERS_ENABLED, "true")
+                        .setSystemProperty(SCALE_WRITERS, "false")
+                        .build(),
+                anyTree(
+                        tableWriter(
+                                ImmutableList.of("customer", "year"),
+                                ImmutableList.of("customer", "year"),
+                                exchange(LOCAL, REPARTITION, scaledPartitioningHandle,
+                                        exchange(REMOTE, REPARTITION, partitioningHandle,
+                                                tableScan("source_table", ImmutableMap.of("customer", "customer", "year", "year")))))));
+
+        assertDistributedPlan(
+                "INSERT INTO connector_partitioned_table SELECT * FROM source_table",
+                testSessionBuilder()
+                        .setCatalog(catalogName)
+                        .setSchema("mock")
+                        .setSystemProperty(TASK_SCALE_WRITERS_ENABLED, "false")
+                        .setSystemProperty(SCALE_WRITERS, "false")
+                        .build(),
+                anyTree(
+                        tableWriter(
+                                ImmutableList.of("customer", "year"),
+                                ImmutableList.of("customer", "year"),
+                                exchange(LOCAL, REPARTITION, partitioningHandle,
+                                        exchange(REMOTE, REPARTITION, partitioningHandle,
+                                                tableScan("source_table", ImmutableMap.of("customer", "customer", "year", "year")))))));
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Issue: https://github.com/trinodb/trino/issues/13379

## Problem

 - Improve the performance of partitioned writes specifically in case writers/partitions are skewed.
      - Known issue: https://github.com/trinodb/trino/issues/10791
      - Relevant slack thread: https://trinodb.slack.com/archives/CFLB9AMBN/p1642961339264200

- Right now, prefer-partitioning only works if you have statistics and the number of partitions is greater than preferred-write-partitioning-min-number-of-partitions (default to 50). However, we know that stats are not always guaranteed to be present in which case partitioned writes will go through from an inefficient route. But with scaling, we could enable prefer-partitioning for any number of partitions thus we don't have to rely on statistics.

## Benchmarks

Cluster with 6 worker nodes

### 1.) Single partition (260M rows)
- Without preferred partitioning: `1:31 mins`
- With preferred partitioning (before): `18:34 mins`
- With preferred partitioning (after): `2:55 mins`

### 2.) 8 partitions (600M rows)
- Without preferred partitioning: `2:11 mins`
- With preferred partitioning (before): `6:23 mins`
- With preferred partitioning (after): `1:48 mins`

### 3.) 2000+ partitions with almost no skewness (600M rows)
- Without preferred partitioning: `13:23 mins`
- With preferred partitioning (before): `11:32 mins`
- With preferred partitioning (after): `10:55 mins`

### 4.) 2000+ partitions with 6 skewed partitions (2.74B rows)
- Without preferred partitioning: `22:18 mins` (400GB peak memory)
- With preferred partitioning (before): `55:26 mins` (76.1GB peak memory)
- With preferred partitioning (after): `20:33 mins` (79.5GB peak memory)

In experiments 3 and 4, the finishing time is also substantial and included in the measurements (almost +9 mins)


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
