### PR TITLE
Remove unnecessary pattern matching in testShowCreateTable

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -311,8 +311,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Override
     public void testShowCreateTable()
     {
-        assertThat(computeActual("SHOW CREATE TABLE person").getOnlyValue())
-                .isInstanceOf(String.class)
+        assertThat(computeScalar("SHOW CREATE TABLE person"))
                 .isEqualTo(format(
                         "CREATE TABLE delta_lake.%s.person (\n" +
                                 "   name varchar,\n" +
@@ -377,7 +376,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     {
         String viewName = "dummy_view";
         hiveMinioDataLake.getHiveHadoop().runOnHive(format("CREATE VIEW %1$s.%2$s AS SELECT * FROM %1$s.customer", SCHEMA, viewName));
-        assertEquals(computeActual(format("SHOW TABLES LIKE '%s'", viewName)).getOnlyValue(), viewName);
+        assertEquals(computeScalar(format("SHOW TABLES LIKE '%s'", viewName)), viewName);
         assertThatThrownBy(() -> computeActual("DESCRIBE " + viewName)).hasMessageContaining(format("%s.%s is not a Delta Lake table", SCHEMA, viewName));
         hiveMinioDataLake.getHiveHadoop().runOnHive("DROP VIEW " + viewName);
     }
@@ -387,7 +386,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     {
         String tableName = "hive_table";
         hiveMinioDataLake.getHiveHadoop().runOnHive(format("CREATE TABLE %s.%s (id BIGINT)", SCHEMA, tableName));
-        assertEquals(computeActual(format("SHOW TABLES LIKE '%s'", tableName)).getOnlyValue(), tableName);
+        assertEquals(computeScalar(format("SHOW TABLES LIKE '%s'", tableName)), tableName);
         assertThatThrownBy(() -> computeActual("DESCRIBE " + tableName)).hasMessageContaining(tableName + " is not a Delta Lake table");
         hiveMinioDataLake.getHiveHadoop().runOnHive(format("DROP TABLE %s.%s", SCHEMA, tableName));
     }
@@ -445,8 +444,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
                 format("CREATE TABLE " + tableName + " WITH (location = '%s', partitioned_by = ARRAY['regionkey']) AS SELECT name, regionkey, comment from nation",
                         getLocationForTable(bucketName, tableName)),
                 25);
-        assertThat(computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue())
-                .isInstanceOf(String.class)
+        assertThat(computeScalar("SHOW CREATE TABLE " + tableName))
                 .isEqualTo(format(
                         "CREATE TABLE %s.%s.%s (\n" +
                                 "   name varchar,\n" +
@@ -1718,7 +1716,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     private void invalidateMetadataCache(String tableName)
     {
         Set<?> activeFiles = computeActual("SELECT \"$path\" FROM " + tableName).getOnlyColumnAsSet();
-        String location = (String) computeActual(format("SELECT DISTINCT regexp_replace(\"$path\", '/[^/]*$', '') FROM %s", tableName)).getOnlyValue();
+        String location = (String) computeScalar(format("SELECT DISTINCT regexp_replace(\"$path\", '/[^/]*$', '') FROM %s", tableName));
         assertUpdate("DROP TABLE " + tableName);
         assertUpdate(format("CREATE TABLE %s(ignore integer) WITH (location = '%s')", tableName, location));
         // sanity check

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
@@ -246,7 +246,7 @@ public abstract class BaseDeltaLakeMinioConnectorTest
     public void testShowCreateTable()
     {
         assertThat((String) computeActual("SHOW CREATE TABLE orders").getOnlyValue())
-                .matches("CREATE TABLE \\w+\\.\\w+\\.orders \\Q(\n" +
+                .matches("\\QCREATE TABLE " + DELTA_CATALOG + "." + SCHEMA + ".orders (\n" +
                         "   orderkey bigint,\n" +
                         "   custkey bigint,\n" +
                         "   orderstatus varchar,\n" +

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
@@ -245,7 +245,7 @@ public abstract class BaseDeltaLakeMinioConnectorTest
     @Override
     public void testShowCreateTable()
     {
-        assertThat((String) computeActual("SHOW CREATE TABLE orders").getOnlyValue())
+        assertThat((String) computeScalar("SHOW CREATE TABLE orders"))
                 .matches("\\QCREATE TABLE " + DELTA_CATALOG + "." + SCHEMA + ".orders (\n" +
                         "   orderkey bigint,\n" +
                         "   custkey bigint,\n" +

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/BaseHudiConnectorTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/BaseHudiConnectorTest.java
@@ -62,8 +62,9 @@ public abstract class BaseHudiConnectorTest
     @Override
     public void testShowCreateTable()
     {
+        String schema = getSession().getSchema().orElseThrow();
         assertThat((String) computeActual("SHOW CREATE TABLE orders").getOnlyValue())
-                .matches("CREATE TABLE \\w+\\.\\w+\\.orders \\Q(\n" +
+                .matches("\\QCREATE TABLE hudi." + schema + ".orders (\n" +
                         "   orderkey bigint,\n" +
                         "   custkey bigint,\n" +
                         "   orderstatus varchar(1),\n" +

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/BaseHudiConnectorTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/BaseHudiConnectorTest.java
@@ -63,7 +63,7 @@ public abstract class BaseHudiConnectorTest
     public void testShowCreateTable()
     {
         String schema = getSession().getSchema().orElseThrow();
-        assertThat((String) computeActual("SHOW CREATE TABLE orders").getOnlyValue())
+        assertThat((String) computeScalar("SHOW CREATE TABLE orders"))
                 .matches("\\QCREATE TABLE hudi." + schema + ".orders (\n" +
                         "   orderkey bigint,\n" +
                         "   custkey bigint,\n" +

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
@@ -214,7 +214,7 @@ public class TestKuduConnectorTest
     @Override
     public void testShowCreateTable()
     {
-        assertThat((String) computeActual("SHOW CREATE TABLE orders").getOnlyValue())
+        assertThat(computeScalar("SHOW CREATE TABLE orders"))
                 .isEqualTo("CREATE TABLE kudu.default.orders (\n" +
                         "   orderkey bigint COMMENT '' WITH ( nullable = true ),\n" +
                         "   custkey bigint COMMENT '' WITH ( nullable = true ),\n" +
@@ -243,8 +243,7 @@ public class TestKuduConnectorTest
                 " number_of_replicas = 1\n" +
                 ")");
 
-        MaterializedResult result = computeActual("SHOW CREATE TABLE test_show_create_table");
-        String sqlStatement = (String) result.getOnlyValue();
+        String sqlStatement = (String) computeScalar("SHOW CREATE TABLE test_show_create_table");
         String tableProperties = sqlStatement.split("\\)\\s*WITH\\s*\\(")[1];
         assertTableProperty(tableProperties, "number_of_replicas", "1");
         assertTableProperty(tableProperties, "partition_by_hash_columns", Pattern.quote("ARRAY['id']"));

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
@@ -215,7 +215,7 @@ public class TestKuduConnectorTest
     public void testShowCreateTable()
     {
         assertThat((String) computeActual("SHOW CREATE TABLE orders").getOnlyValue())
-                .matches("CREATE TABLE kudu\\.\\w+\\.orders \\Q(\n" +
+                .isEqualTo("CREATE TABLE kudu.default.orders (\n" +
                         "   orderkey bigint COMMENT '' WITH ( nullable = true ),\n" +
                         "   custkey bigint COMMENT '' WITH ( nullable = true ),\n" +
                         "   orderstatus varchar COMMENT '' WITH ( nullable = true ),\n" +

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -1688,19 +1688,23 @@ public abstract class BaseConnectorTest
     @Test
     public void testShowCreateTable()
     {
+        String catalog = getSession().getCatalog().orElseThrow();
+        String schema = getSession().getSchema().orElseThrow();
         assertThat((String) computeActual("SHOW CREATE TABLE orders").getOnlyValue())
                 // If the connector reports additional column properties, the expected value needs to be adjusted in the test subclass
-                .matches("CREATE TABLE \\w+\\.\\w+\\.orders \\Q(\n" +
-                        "   orderkey bigint,\n" +
-                        "   custkey bigint,\n" +
-                        "   orderstatus varchar(1),\n" +
-                        "   totalprice double,\n" +
-                        "   orderdate date,\n" +
-                        "   orderpriority varchar(15),\n" +
-                        "   clerk varchar(15),\n" +
-                        "   shippriority integer,\n" +
-                        "   comment varchar(79)\n" +
-                        ")");
+                .isEqualTo(format("""
+                                CREATE TABLE %s.%s.orders (
+                                   orderkey bigint,
+                                   custkey bigint,
+                                   orderstatus varchar(1),
+                                   totalprice double,
+                                   orderdate date,
+                                   orderpriority varchar(15),
+                                   clerk varchar(15),
+                                   shippriority integer,
+                                   comment varchar(79)
+                                )""",
+                        catalog, schema));
     }
 
     @Test


### PR DESCRIPTION
This somewhat improves test coverage, since now we also validate the catalog and schema are correctly reported back.
