### PR TITLE
Append a slash to DeltaLake splits' path only when necessary

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
@@ -291,7 +291,11 @@ public class DeltaLakeSplitManager
     private static String buildSplitPath(String tableLocation, AddFileEntry addAction)
     {
         // paths are relative to the table location and URL encoded
-        return tableLocation + '/' + URLDecoder.decode(addAction.getPath(), UTF_8);
+        String path = URLDecoder.decode(addAction.getPath(), UTF_8);
+        if (tableLocation.endsWith("/")) {
+            return tableLocation + path;
+        }
+        return tableLocation + "/" + path;
     }
 
     private DeltaLakeMetastore getMetastore(ConnectorSession session, ConnectorTransactionHandle transactionHandle)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
@@ -561,6 +561,24 @@ public abstract class BaseDeltaLakeMinioConnectorTest
     }
 
     @Test
+    public void testTableLocationTrailingSlash()
+    {
+        String tableWithSlash = "table_with_slash";
+        String tableWithoutSlash = "table_without_slash";
+
+        assertUpdate(format("CREATE TABLE %s (customer VARCHAR) WITH (location = 's3://%s/%s/')", tableWithSlash, bucketName, tableWithSlash));
+        assertUpdate(format("INSERT INTO %s (customer) VALUES ('Aaron'), ('Bill')", tableWithSlash), 2);
+        assertQuery("SELECT * FROM " + tableWithSlash, "VALUES ('Aaron'), ('Bill')");
+
+        assertUpdate(format("CREATE TABLE %s (customer VARCHAR) WITH (location = 's3://%s/%s')", tableWithoutSlash, bucketName, tableWithoutSlash));
+        assertUpdate(format("INSERT INTO %s (customer) VALUES ('Carol'), ('Dave')", tableWithoutSlash), 2);
+        assertQuery("SELECT * FROM " + tableWithoutSlash, "VALUES ('Carol'), ('Dave')");
+
+        assertUpdate("DROP TABLE " + tableWithSlash);
+        assertUpdate("DROP TABLE " + tableWithoutSlash);
+    }
+
+    @Test
     public void testMergeSimpleSelectPartitioned()
     {
         String targetTable = "merge_simple_target_" + randomTableSuffix();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Before this change, a slash was always appended to `tableLocation`, even when not necessary. 
`create table as` with `location='<s3_path>/'` didn't fail, but the next `SELECT` failed on `The specified key does not exist`.
This doesn't happen on Iceberg, so I assume this is not intentional.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

