### PR TITLE
Add dataset cache to BigQuery connector

### DIFF
--- a/docs/src/main/sphinx/connector/bigquery.rst
+++ b/docs/src/main/sphinx/connector/bigquery.rst
@@ -133,6 +133,8 @@ Property                                              Description               
                                                       ``BIGNUMERIC`` and ``TIMESTAMP`` types are unsupported.        ``false``
 ``bigquery.views-cache-ttl``                          Duration for which the materialization of a view will be       ``15m``
                                                       cached and reused. Set to ``0ms`` to disable the cache.
+``bigquery.metadata.cache-ttl``                       Duration for which metadata retrieved from BigQuery            ``0ms``
+                                                      is cached and reused. Set to ``0ms`` to disable the cache.
 ``bigquery.max-read-rows-retries``                    The number of retries in case of retryable server issues       ``3``
 ``bigquery.credentials-key``                          The base64 encoded credentials key                             None. See the `requirements <#requirements>`_ section.
 ``bigquery.credentials-file``                         The path to the JSON credentials file                          None. See the `requirements <#requirements>`_ section.

--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -381,6 +381,7 @@
                             <excludes>
                                 <!-- If you are adding entry here also add an entry to cloud-tests or cloud-tests-case-insensitive-mapping profile below -->
                                 <exclude>**/TestBigQueryConnectorTest.java</exclude>
+                                <exclude>**/TestBigQueryMetadataCaching.java</exclude>
                                 <exclude>**/TestBigQueryTypeMapping.java</exclude>
                                 <exclude>**/TestBigQueryMetadata.java</exclude>
                                 <exclude>**/TestBigQueryInstanceCleaner.java</exclude>
@@ -415,6 +416,7 @@
                         <configuration>
                             <includes>
                                 <include>**/TestBigQueryConnectorTest.java</include>
+                                <include>**/TestBigQueryMetadataCaching.java</include>
                                 <include>**/TestBigQueryTypeMapping.java</include>
                                 <include>**/TestBigQueryMetadata.java</include>
                                 <include>**/TestBigQueryInstanceCleaner.java</include>

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 @DefunctConfig("bigquery.case-insensitive-name-matching.cache-ttl")
@@ -51,6 +52,7 @@ public class BigQueryConfig
     private boolean caseInsensitiveNameMatching;
     private Duration viewsCacheTtl = new Duration(15, MINUTES);
     private Duration serviceCacheTtl = new Duration(3, MINUTES);
+    private Duration metadataCacheTtl = new Duration(0, MILLISECONDS);
     private boolean queryResultsCacheEnabled;
 
     private int rpcInitialChannelCount = 1;
@@ -219,6 +221,21 @@ public class BigQueryConfig
     public BigQueryConfig setServiceCacheTtl(Duration serviceCacheTtl)
     {
         this.serviceCacheTtl = serviceCacheTtl;
+        return this;
+    }
+
+    @NotNull
+    @MinDuration("0ms")
+    public Duration getMetadataCacheTtl()
+    {
+        return metadataCacheTtl;
+    }
+
+    @Config("bigquery.metadata.cache-ttl")
+    @ConfigDescription("Duration for which BigQuery client metadata is cached after listing")
+    public BigQueryConfig setMetadataCacheTtl(Duration metadataCacheTtl)
+    {
+        this.metadataCacheTtl = metadataCacheTtl;
         return this;
     }
 

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
@@ -24,6 +24,7 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDe
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -44,6 +45,7 @@ public class TestBigQueryConfig
                 .setCaseInsensitiveNameMatching(false)
                 .setViewsCacheTtl(new Duration(15, MINUTES))
                 .setServiceCacheTtl(new Duration(3, MINUTES))
+                .setMetadataCacheTtl(new Duration(0, MILLISECONDS))
                 .setViewsEnabled(false)
                 .setQueryResultsCacheEnabled(false)
                 .setRpcInitialChannelCount(1)
@@ -69,6 +71,7 @@ public class TestBigQueryConfig
                 .put("bigquery.case-insensitive-name-matching", "true")
                 .put("bigquery.views-cache-ttl", "1m")
                 .put("bigquery.service-cache-ttl", "10d")
+                .put("bigquery.metadata.cache-ttl", "5d")
                 .put("bigquery.query-results-cache.enabled", "true")
                 .put("bigquery.channel-pool.initial-size", "11")
                 .put("bigquery.channel-pool.min-size", "12")
@@ -90,6 +93,7 @@ public class TestBigQueryConfig
                 .setCaseInsensitiveNameMatching(true)
                 .setViewsCacheTtl(new Duration(1, MINUTES))
                 .setServiceCacheTtl(new Duration(10, DAYS))
+                .setMetadataCacheTtl(new Duration(5, DAYS))
                 .setQueryResultsCacheEnabled(true)
                 .setRpcInitialChannelCount(11)
                 .setRpcMinChannelCount(12)

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryMetadataCaching.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryMetadataCaching.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.Test;
+
+import static io.trino.plugin.bigquery.BigQueryQueryRunner.BigQuerySqlExecutor;
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static org.testng.Assert.assertEquals;
+
+public class TestBigQueryMetadataCaching
+        extends AbstractTestQueryFramework
+{
+    protected BigQuerySqlExecutor bigQuerySqlExecutor;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        this.bigQuerySqlExecutor = new BigQuerySqlExecutor();
+        return BigQueryQueryRunner.createQueryRunner(
+                ImmutableMap.of(),
+                ImmutableMap.of("bigquery.metadata.cache-ttl", "5m"));
+    }
+
+    @Test
+    public void testMetadataCaching()
+    {
+        String schema = "test_metadata_caching_" + randomTableSuffix();
+        try {
+            getQueryRunner().execute("CREATE SCHEMA " + schema);
+            assertEquals(getQueryRunner().execute("SHOW SCHEMAS IN bigquery LIKE '" + schema + "'").getOnlyValue(), schema);
+
+            String schemaTableName = schema + ".test_metadata_caching";
+            getQueryRunner().execute("CREATE TABLE " + schemaTableName + " AS SELECT * FROM tpch.tiny.region");
+            assertEquals(getQueryRunner().execute("SELECT * FROM " + schemaTableName).getRowCount(), 5);
+
+            bigQuerySqlExecutor.execute("DROP SCHEMA " + schema + " CASCADE");
+            assertEquals(getQueryRunner().execute("SHOW SCHEMAS IN bigquery LIKE '" + schema + "'").getOnlyValue(), schema);
+
+            assertQueryFails("SELECT * FROM " + schemaTableName, ".*Schema '.+' does not exist.*");
+        }
+        finally {
+            bigQuerySqlExecutor.execute("DROP SCHEMA IF EXISTS " + schema + " CASCADE");
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

When `caseInsensitiveNameMatching=true`, the `BigQueryClient` makes a call to `listDatasets` for each call on `toRemoteDataset`. This is problematic when running queries like `SHOW SCHEMAS` since `listDatasets` is called once to get the initial list, then once again for each schema. This is expensive if the BigQuery project has a large number of datasets.

This commit adds a cache to listing datasets to drastically reduce the query time for `SHOW SCHEMAS`.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

This commit improves the runtime of `SHOW SCHEMAS` when BigQuery has a large number of datasets.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# BigQuery Connector
* Improve the runtime of `SHOW SCHEMAS` by adding a dataset metadata cache. Set `bigquery.dataset-cache-ttl` in your catalog configuration to a duration, default is `1m`.
```