### PR TITLE
Fault tolerant execution for SqlServer connector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,6 +481,7 @@ jobs:
             - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-iceberg }
             - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-postgresql }
             - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-mysql }
+            - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-sqlserver }
             - { modules: testing/trino-tests }
           EOF
           ./.github/bin/build-matrix-from-impacted.py -v -i gib-impacted.log -m .github/test-matrix.yaml -o matrix.json

--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
@@ -50,6 +50,7 @@ depending on the desired :ref:`retry policy <fte-retry-policy>`.
     * :doc:`/connector/iceberg`
     * :doc:`/connector/mysql`
     * :doc:`/connector/postgresql`
+    * :doc:`/connector/sqlserver`
 
 The following configuration properties control the behavior of fault-tolerant
 execution on a Trino cluster:

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -208,7 +208,7 @@ public class SqlServerClient
             QueryBuilder queryBuilder,
             IdentifierMapping identifierMapping)
     {
-        super(config, "\"", connectionFactory, queryBuilder, identifierMapping);
+        super(config, "\"", connectionFactory, queryBuilder, identifierMapping, true);
 
         this.statisticsEnabled = statisticsConfig.isEnabled();
 

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
@@ -24,6 +24,7 @@ import io.trino.tpch.TpchTable;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
@@ -47,8 +48,22 @@ public final class SqlServerQueryRunner
             Iterable<TpchTable<?>> tables)
             throws Exception
     {
+        return createSqlServerQueryRunner(testingSqlServer, extraProperties, Map.of(), connectorProperties, tables, runner -> {});
+    }
+
+    public static QueryRunner createSqlServerQueryRunner(
+            TestingSqlServer testingSqlServer,
+            Map<String, String> extraProperties,
+            Map<String, String> coordinatorProperties,
+            Map<String, String> connectorProperties,
+            Iterable<TpchTable<?>> tables,
+            Consumer<QueryRunner> moreSetup)
+            throws Exception
+    {
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(createSession(testingSqlServer.getUsername()))
                 .setExtraProperties(extraProperties)
+                .setCoordinatorProperties(coordinatorProperties)
+                .setAdditionalSetup(moreSetup)
                 .build();
         try {
             queryRunner.installPlugin(new TpchPlugin());

--- a/pom.xml
+++ b/pom.xml
@@ -606,6 +606,13 @@
 
             <dependency>
                 <groupId>io.trino</groupId>
+                <artifactId>trino-sqlserver</artifactId>
+                <type>test-jar</type>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
                 <artifactId>trino-testing</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/testing/trino-faulttolerant-tests/pom.xml
+++ b/testing/trino-faulttolerant-tests/pom.xml
@@ -306,6 +306,19 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-sqlserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-sqlserver</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-testing</artifactId>
             <scope>test</scope>
         </dependency>
@@ -392,6 +405,12 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
+            <artifactId>mssqlserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
             <artifactId>mysql</artifactId>
             <scope>test</scope>
         </dependency>
@@ -452,6 +471,7 @@
                                 <exclude>**/io/trino/faulttolerant/iceberg/Test*.java</exclude>
                                 <exclude>**/io/trino/faulttolerant/mysql/Test*.java</exclude>
                                 <exclude>**/io/trino/faulttolerant/postgresql/Test*.java</exclude>
+                                <exclude>**/io/trino/faulttolerant/sqlserver/Test*.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -564,6 +584,24 @@
                             <threadCount>4</threadCount>
                             <includes>
                                 <include>**/io/trino/faulttolerant/mysql/Test*.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>test-fault-tolerant-sqlserver</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <threadCount>4</threadCount>
+                            <includes>
+                                <include>**/io/trino/faulttolerant/sqlserver/Test*.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/sqlserver/BaseSqlServerFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/sqlserver/BaseSqlServerFailureRecoveryTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.faulttolerant.sqlserver;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.faulttolerant.jdbc.BaseJdbcFailureRecoveryTest;
+import io.trino.operator.RetryPolicy;
+import io.trino.plugin.exchange.filesystem.FileSystemExchangePlugin;
+import io.trino.plugin.sqlserver.TestingSqlServer;
+import io.trino.testing.QueryRunner;
+import io.trino.tpch.TpchTable;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.trino.plugin.sqlserver.SqlServerQueryRunner.createSqlServerQueryRunner;
+
+public abstract class BaseSqlServerFailureRecoveryTest
+        extends BaseJdbcFailureRecoveryTest
+{
+    public BaseSqlServerFailureRecoveryTest(RetryPolicy retryPolicy)
+    {
+        super(retryPolicy);
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner(
+            List<TpchTable<?>> requiredTpchTables,
+            Map<String, String> configProperties,
+            Map<String, String> coordinatorProperties)
+            throws Exception
+    {
+        return createSqlServerQueryRunner(
+                closeAfterClass(new TestingSqlServer()),
+                configProperties,
+                coordinatorProperties,
+                Map.of(),
+                requiredTpchTables,
+                runner -> {
+                    runner.installPlugin(new FileSystemExchangePlugin());
+                    runner.loadExchangeManager("filesystem", ImmutableMap.<String, String>builder()
+                            .put("exchange.base-directories", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager")
+                            .buildOrThrow());
+                });
+    }
+}

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/sqlserver/TestSqlServerQueryFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/sqlserver/TestSqlServerQueryFailureRecoveryTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.faulttolerant.sqlserver;
+
+import io.trino.operator.RetryPolicy;
+
+public class TestSqlServerQueryFailureRecoveryTest
+        extends BaseSqlServerFailureRecoveryTest
+{
+    public TestSqlServerQueryFailureRecoveryTest()
+    {
+        super(RetryPolicy.QUERY);
+    }
+}

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/sqlserver/TestSqlServerTaskFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/sqlserver/TestSqlServerTaskFailureRecoveryTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.faulttolerant.sqlserver;
+
+import io.trino.operator.RetryPolicy;
+
+public class TestSqlServerTaskFailureRecoveryTest
+        extends BaseSqlServerFailureRecoveryTest
+{
+    public TestSqlServerTaskFailureRecoveryTest()
+    {
+        super(RetryPolicy.TASK);
+    }
+}


### PR DESCRIPTION
## Description

This pr enables fault tolerant execution for the SqlServer connector. It builds on the work done in my [previous](https://github.com/trinodb/trino/pull/14445) PR, which is why these changes are so minimal. The main change is passing `true` to the SqlServerClient's `super` constructor's `supportsRetries` parameter.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

This enables FTE for SqlServer and adds fault tolerance tests for the same.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:
Enables fault tolerant execution on SqlServer connector.

```markdown
# Section
* Allow writes to SqlServer connector when fault tolerant execution is enabled (`retry-policy` is set to `TASK` or `QUERY`). (https://github.com/starburstdata/stargate/issues/3877)
```