### PR TITLE
Document MySQL and PostgreSQL support for fault tolerant execution

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
@@ -43,8 +43,13 @@ depending on the desired :ref:`retry policy <fte-retry-policy>`.
   * Fault-tolerant execution of :ref:`read operations <sql-read-operations>` is
     supported by all connectors.
   * Fault tolerant execution of :ref:`write operations <sql-write-operations>`
-    is only supported by the :doc:`/connector/delta-lake`,
-    :doc:`/connector/hive`, and :doc:`/connector/iceberg`.
+    is supported by the following connectors:
+
+    * :doc:`/connector/delta-lake`
+    * :doc:`/connector/hive`
+    * :doc:`/connector/iceberg`
+    * :doc:`/connector/mysql`
+    * :doc:`/connector/postgresql`
 
 The following configuration properties control the behavior of fault-tolerant
 execution on a Trino cluster:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Document that MySQL and PostgreSQL catalogs now support fault-tolerant execution of write operations. Follow-up documentation for https://github.com/trinodb/trino/pull/14445

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Expand support of fault-tolerant execution in the documentation

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
