### PR TITLE
Fix IDE warnings in trino caches

### DIFF
--- a/lib/trino-collect/src/main/java/io/trino/collect/cache/ElementTypesAreNonnullByDefault.java
+++ b/lib/trino-collect/src/main/java/io/trino/collect/cache/ElementTypesAreNonnullByDefault.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.collect.cache;
+
+import javax.annotation.Nonnull;
+import javax.annotation.meta.TypeQualifierDefault;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+/**
+ * Copy of package-private {@code com.google.common.cache.ElementTypesAreNonnullByDefault}.
+ * Exists to suppress IDE warnings when extending Guava Cache classes.
+ */
+@Retention(SOURCE)
+@Target(TYPE)
+@TypeQualifierDefault({FIELD, METHOD, PARAMETER})
+@Nonnull
+@interface ElementTypesAreNonnullByDefault {}

--- a/lib/trino-collect/src/main/java/io/trino/collect/cache/EmptyCache.java
+++ b/lib/trino-collect/src/main/java/io/trino/collect/cache/EmptyCache.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 
 import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
 
 import java.util.Collection;
 import java.util.Map;
@@ -30,6 +31,7 @@ import java.util.concurrent.ExecutionException;
 
 import static java.util.Objects.requireNonNull;
 
+@ElementTypesAreNonnullByDefault
 class EmptyCache<K, V>
         extends AbstractLoadingCache<K, V>
 {
@@ -162,12 +164,14 @@ class EmptyCache<K, V>
             }
 
             @Override
+            @Nullable
             public V get(Object key)
             {
                 return null;
             }
 
             @Override
+            @Nullable
             public V put(K key, V value)
             {
                 // Cache, even if configured to evict everything immediately, should allow writes.
@@ -175,6 +179,7 @@ class EmptyCache<K, V>
             }
 
             @Override
+            @Nullable
             public V remove(Object key)
             {
                 return null;

--- a/lib/trino-collect/src/main/java/io/trino/collect/cache/EvictableCache.java
+++ b/lib/trino-collect/src/main/java/io/trino/collect/cache/EvictableCache.java
@@ -27,6 +27,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import org.gaul.modernizer_maven_annotations.SuppressModernizer;
 
 import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -54,6 +55,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @see EvictableCacheBuilder
  */
+@ElementTypesAreNonnullByDefault
 class EvictableCache<K, V>
         extends AbstractLoadingCache<K, V>
         implements LoadingCache<K, V>
@@ -345,6 +347,7 @@ class EvictableCache<K, V>
             }
 
             @Override
+            @Nullable
             public V get(Object key)
             {
                 return getIfPresent(key);
@@ -357,6 +360,7 @@ class EvictableCache<K, V>
             }
 
             @Override
+            @Nullable
             public V remove(Object key)
             {
                 Token<K> token = tokens.remove(key);

--- a/lib/trino-collect/src/main/java/io/trino/collect/cache/EvictableCacheBuilder.java
+++ b/lib/trino-collect/src/main/java/io/trino/collect/cache/EvictableCacheBuilder.java
@@ -19,6 +19,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.cache.Weigher;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.CheckReturnValue;
 import io.trino.collect.cache.EvictableCache.Token;
 import org.gaul.modernizer_maven_annotations.SuppressModernizer;
@@ -60,17 +61,20 @@ public final class EvictableCacheBuilder<K, V>
     /**
      * Pass-through for {@link CacheBuilder#ticker(Ticker)}.
      */
+    @CanIgnoreReturnValue
     public EvictableCacheBuilder<K, V> ticker(Ticker ticker)
     {
         this.ticker = Optional.of(ticker);
         return this;
     }
 
+    @CanIgnoreReturnValue
     public EvictableCacheBuilder<K, V> expireAfterWrite(long duration, TimeUnit unit)
     {
         return expireAfterWrite(toDuration(duration, unit));
     }
 
+    @CanIgnoreReturnValue
     public EvictableCacheBuilder<K, V> expireAfterWrite(Duration duration)
     {
         checkState(!this.expireAfterWrite.isPresent(), "expireAfterWrite already set");
@@ -78,11 +82,13 @@ public final class EvictableCacheBuilder<K, V>
         return this;
     }
 
+    @CanIgnoreReturnValue
     public EvictableCacheBuilder<K, V> refreshAfterWrite(long duration, TimeUnit unit)
     {
         return refreshAfterWrite(toDuration(duration, unit));
     }
 
+    @CanIgnoreReturnValue
     public EvictableCacheBuilder<K, V> refreshAfterWrite(Duration duration)
     {
         checkState(!this.refreshAfterWrite.isPresent(), "refreshAfterWrite already set");
@@ -90,6 +96,7 @@ public final class EvictableCacheBuilder<K, V>
         return this;
     }
 
+    @CanIgnoreReturnValue
     public EvictableCacheBuilder<K, V> maximumSize(long maximumSize)
     {
         checkState(!this.maximumSize.isPresent(), "maximumSize already set");
@@ -98,6 +105,7 @@ public final class EvictableCacheBuilder<K, V>
         return this;
     }
 
+    @CanIgnoreReturnValue
     public EvictableCacheBuilder<K, V> maximumWeight(long maximumWeight)
     {
         checkState(!this.maximumWeight.isPresent(), "maximumWeight already set");
@@ -115,6 +123,7 @@ public final class EvictableCacheBuilder<K, V>
         return cast;
     }
 
+    @CanIgnoreReturnValue
     public EvictableCacheBuilder<K, V> recordStats()
     {
         recordStats = true;
@@ -124,6 +133,7 @@ public final class EvictableCacheBuilder<K, V>
     /**
      * Choose a behavior for case when caching is disabled that may allow data and failure sharing between concurrent callers.
      */
+    @CanIgnoreReturnValue
     public EvictableCacheBuilder<K, V> shareResultsAndFailuresEvenIfDisabled()
     {
         checkState(!disabledCacheImplementation.isPresent(), "disabledCacheImplementation already set");
@@ -135,6 +145,7 @@ public final class EvictableCacheBuilder<K, V>
      * Choose a behavior for case when caching is disabled that prevents data and failure sharing between concurrent callers.
      * Note: disabled cache won't report any statistics.
      */
+    @CanIgnoreReturnValue
     public EvictableCacheBuilder<K, V> shareNothingWhenDisabled()
     {
         checkState(!disabledCacheImplementation.isPresent(), "disabledCacheImplementation already set");
@@ -214,6 +225,7 @@ public final class EvictableCacheBuilder<K, V>
         });
     }
 
+    @ElementTypesAreNonnullByDefault
     private static final class TokenWeigher<K, V>
             implements Weigher<Token<K>, V>
     {

--- a/lib/trino-collect/src/main/java/io/trino/collect/cache/NonEvictableCache.java
+++ b/lib/trino-collect/src/main/java/io/trino/collect/cache/NonEvictableCache.java
@@ -18,6 +18,7 @@ import com.google.common.cache.Cache;
 /**
  * A {@link com.google.common.cache.Cache} that does not support eviction.
  */
+@ElementTypesAreNonnullByDefault
 public interface NonEvictableCache<K, V>
         extends Cache<K, V>
 {

--- a/lib/trino-collect/src/main/java/io/trino/collect/cache/NonKeyEvictableCache.java
+++ b/lib/trino-collect/src/main/java/io/trino/collect/cache/NonKeyEvictableCache.java
@@ -18,6 +18,7 @@ import com.google.common.cache.Cache;
 /**
  * A {@link com.google.common.cache.Cache} that does not support key-based eviction.
  */
+@ElementTypesAreNonnullByDefault
 public interface NonKeyEvictableCache<K, V>
         extends Cache<K, V>
 {

--- a/lib/trino-collect/src/main/java/io/trino/collect/cache/NonKeyEvictableCacheImpl.java
+++ b/lib/trino-collect/src/main/java/io/trino/collect/cache/NonKeyEvictableCacheImpl.java
@@ -19,6 +19,7 @@ import com.google.common.cache.ForwardingCache;
 import static java.util.Objects.requireNonNull;
 
 // package-private. The interface provides deprecation and javadoc to help at call sites
+@ElementTypesAreNonnullByDefault
 class NonKeyEvictableCacheImpl<K, V>
         extends ForwardingCache<K, V>
         implements NonKeyEvictableCache<K, V>

--- a/lib/trino-collect/src/main/java/io/trino/collect/cache/NonKeyEvictableLoadingCache.java
+++ b/lib/trino-collect/src/main/java/io/trino/collect/cache/NonKeyEvictableLoadingCache.java
@@ -18,6 +18,7 @@ import com.google.common.cache.LoadingCache;
 /**
  * A {@link com.google.common.cache.LoadingCache} that does not support key-based eviction.
  */
+@ElementTypesAreNonnullByDefault
 public interface NonKeyEvictableLoadingCache<K, V>
         extends LoadingCache<K, V>
 {

--- a/lib/trino-collect/src/main/java/io/trino/collect/cache/NonKeyEvictableLoadingCacheImpl.java
+++ b/lib/trino-collect/src/main/java/io/trino/collect/cache/NonKeyEvictableLoadingCacheImpl.java
@@ -19,6 +19,7 @@ import com.google.common.cache.LoadingCache;
 import static java.util.Objects.requireNonNull;
 
 // package-private. The interface provides deprecation and javadoc to help at call sites
+@ElementTypesAreNonnullByDefault
 class NonKeyEvictableLoadingCacheImpl<K, V>
         extends ForwardingLoadingCache<K, V>
         implements NonKeyEvictableLoadingCache<K, V>


### PR DESCRIPTION
Guava cache classes use `@ElementTypesAreNonnullByDefault` annotation and some IDEs complain about it when subclasses do not do that.

Fixing these warnings has no value in itself, as they are ignorable, but helps notice potentially useful warnings, should there be any.
