### PR TITLE
Respect `java.io.tempdir` system property

### DIFF
--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestingDruidServer.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestingDruidServer.java
@@ -41,7 +41,6 @@ import java.util.Map;
 
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static java.lang.String.format;
-import static java.util.UUID.randomUUID;
 import static org.testcontainers.utility.MountableFile.forClasspathResource;
 import static org.testcontainers.utility.MountableFile.forHostPath;
 
@@ -72,11 +71,7 @@ public class TestingDruidServer
     public TestingDruidServer(String dockerImageName)
     {
         try {
-            // Cannot use Files.createTempDirectory() because on Mac by default it uses
-            // /var/folders/ which is not visible to Docker for Mac
-            hostWorkingDirectory = Files.createDirectory(
-                    Paths.get("/tmp/docker-tests-files-" + randomUUID().toString()))
-                    .toAbsolutePath().toString();
+            hostWorkingDirectory = Files.createTempDirectory("docker-tests-files-").toAbsolutePath().toString();
             File f = new File(hostWorkingDirectory);
             // Enable read/write/exec access for the services running in containers
             f.setWritable(true, false);

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/docker/DockerFiles.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/docker/DockerFiles.java
@@ -26,7 +26,6 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermissions;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -35,7 +34,6 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static java.nio.file.Files.copy;
-import static java.util.UUID.randomUUID;
 
 public final class DockerFiles
         implements AutoCloseable
@@ -127,8 +125,7 @@ public final class DockerFiles
     {
         Path temporaryDirectoryForDocker;
         try {
-            // Cannot use Files.createTempDirectory() because on Mac by default it uses /var/folders/ which is not visible to Docker for Mac
-            temporaryDirectoryForDocker = Files.createDirectory(Paths.get("/tmp/docker-files-" + randomUUID().toString()));
+            temporaryDirectoryForDocker = Files.createTempDirectory("docker-files-");
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvTwoKerberosHives.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvTwoKerberosHives.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
@@ -43,7 +42,6 @@ import static io.trino.tests.product.launcher.env.common.Hadoop.CONTAINER_HADOOP
 import static io.trino.tests.product.launcher.env.common.Hadoop.createHadoopContainer;
 import static io.trino.tests.product.launcher.env.common.Standard.CONTAINER_TRINO_ETC;
 import static java.util.Objects.requireNonNull;
-import static java.util.UUID.randomUUID;
 import static org.testcontainers.containers.BindMode.READ_WRITE;
 import static org.testcontainers.utility.MountableFile.forHostPath;
 
@@ -116,8 +114,7 @@ public final class EnvTwoKerberosHives
     private Path createKeytabsHostDirectory()
     {
         try {
-            // Cannot use Files.createTempDirectory() because on Mac by default it uses /var/folders/ which is not visible to Docker for Mac
-            Path temporaryDirectory = Files.createDirectory(Paths.get("/tmp/keytabs-" + randomUUID().toString()));
+            Path temporaryDirectory = Files.createTempDirectory("keytabs-");
             closer.register(() -> deleteRecursively(temporaryDirectory, ALLOW_INSECURE));
             return temporaryDirectory;
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Since Docker Desktop `2.3.0.2` `/var/folders` directory is shared by default so existing workaround is no longer needed. https://docs.docker.com/desktop/previous-versions/2.x-mac/#docker-desktop-community-2302

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Clean up of an old workaround for Docker Desktop limitation on macOS.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
