### PR TITLE
Fix milestone worfklow

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -27,18 +27,24 @@ jobs:
             // Get pull request number from commit sha
             // 'listPullRequestsAssociatedWithCommit()' lists the merged pull request
             // https://docs.github.com/en/rest/reference/repos#list-pull-requests-associated-with-a-commit
-            const pr_response = await github.repos.listPullRequestsAssociatedWithCommit({ owner: context.repo.owner, repo:context.repo.repo, commit_sha: context.sha })
+            const pr_response = await github.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: context.sha
+            })
             if (pr_response.data.length === 0) {
-              console.log('Pull request not found')
-              return
+                console.log('Pull request not found')
+                return
             }
             if (pr_response.data.length > 1) {
-              console.log(pr_response.data)
-              throw 'Expect 1 pull request but found: ' + pr_response.data.length
+                console.log(pr_response.data)
+                throw 'Expect 1 pull request but found: ' + pr_response.data.length
             }
 
             // Get milestone
-            const { MILESTONE_NUMBER } = process.env
+            const {
+                MILESTONE_NUMBER
+            } = process.env
 
             // Find milestone
             const response = await github.issues.listMilestones(context.repo)
@@ -46,9 +52,18 @@ jobs:
 
             // Create new milestone if it doesn't exist
             if (!milestone) {
-              const create_response = await github.issues.createMilestone({ owner: context.repo.owner, repo:context.repo.repo, title: MILESTONE_NUMBER })
-              milestone = create_response.data
+                const create_response = await github.issues.createMilestone({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    title: MILESTONE_NUMBER
+                })
+                milestone = create_response.data
             }
 
             // Set milestone to PR
-            await github.issues.update({ owner: context.repo.owner, repo: context.repo.repo, milestone: milestone.number, issue_number: pr_response.data[0].number })
+            await github.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                milestone: milestone.number,
+                issue_number: pr_response.data[0].number
+            })

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -27,7 +27,8 @@ jobs:
             // Get pull request number from commit sha
             // 'listPullRequestsAssociatedWithCommit()' lists the merged pull request
             // https://docs.github.com/en/rest/reference/repos#list-pull-requests-associated-with-a-commit
-            const pr_response = await github.repos.listPullRequestsAssociatedWithCommit({
+            // and https://octokit.github.io/rest.js/v19#repos-list-pull-requests-associated-with-commit
+            const pr_response = await github.rest.repos.listPullRequestsAssociatedWithCommit({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 commit_sha: context.sha
@@ -47,12 +48,12 @@ jobs:
             } = process.env
 
             // Find milestone
-            const response = await github.issues.listMilestones(context.repo)
+            const response = await github.rest.issues.listMilestones(context.repo)
             let milestone = response.data.find(milestoneResponse => milestoneResponse.title === MILESTONE_NUMBER)
 
             // Create new milestone if it doesn't exist
             if (!milestone) {
-                const create_response = await github.issues.createMilestone({
+                const create_response = await github.rest.issues.createMilestone({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     title: MILESTONE_NUMBER
@@ -61,7 +62,7 @@ jobs:
             }
 
             // Set milestone to PR
-            await github.issues.update({
+            await github.rest.issues.update({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 milestone: milestone.number,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

#14712 upgraded `actions/github-script` from v4 to v6 which includes a breaking change, where most API calls in `github` now require a `rest` prefix: https://github.com/actions/github-script#breaking-changes-in-v5

This PR fixes this.

Since the lines in that script got pretty long, I first formatted it with js-beautifier.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

n/a

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: