### PR TITLE
Fix HiveMinioDataLake leak when start fails

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/containers/HiveMinioDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/containers/HiveMinioDataLake.java
@@ -81,7 +81,7 @@ public class HiveMinioDataLake
         this.hiveHadoop = closer.register(hiveHadoopBuilder.build());
     }
 
-    public HiveMinioDataLake start()
+    public void start()
     {
         checkState(state == State.INITIAL, "Already started: %s", state);
         state = State.STARTING;
@@ -90,8 +90,6 @@ public class HiveMinioDataLake
         minioClient = closer.register(minio.createMinioClient());
         minio.createBucket(bucketName);
         state = State.STARTED;
-
-        return this;
     }
 
     public void stop()

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestS3WrongRegionPicked.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestS3WrongRegionPicked.java
@@ -30,16 +30,18 @@ public class TestS3WrongRegionPicked
         // Bucket names are global so a unique one needs to be used.
         String bucketName = "test-bucket" + randomTableSuffix();
 
-        try (HiveMinioDataLake dataLake = new HiveMinioDataLake(bucketName).start();
-                QueryRunner queryRunner = S3HiveQueryRunner.builder(dataLake)
-                        .setHiveProperties(ImmutableMap.of("hive.s3.region", "eu-central-1")) // Different than the default one
-                        .build()) {
-            String tableName = "s3_region_test_" + randomTableSuffix();
-            queryRunner.execute("CREATE TABLE default." + tableName + " (a int) WITH (external_location = 's3://" + bucketName + "/" + tableName + "')");
-            assertThatThrownBy(() -> queryRunner.execute("SELECT * FROM default." + tableName))
-                    .getRootCause()
-                    .hasMessageContaining("Status Code: 400")
-                    .hasMessageContaining("Error Code: AuthorizationHeaderMalformed"); // That is how Minio reacts to bad region
+        try (HiveMinioDataLake dataLake = new HiveMinioDataLake(bucketName)) {
+            dataLake.start();
+            try (QueryRunner queryRunner = S3HiveQueryRunner.builder(dataLake)
+                    .setHiveProperties(ImmutableMap.of("hive.s3.region", "eu-central-1")) // Different than the default one
+                    .build()) {
+                String tableName = "s3_region_test_" + randomTableSuffix();
+                queryRunner.execute("CREATE TABLE default." + tableName + " (a int) WITH (external_location = 's3://" + bucketName + "/" + tableName + "')");
+                assertThatThrownBy(() -> queryRunner.execute("SELECT * FROM default." + tableName))
+                        .getRootCause()
+                        .hasMessageContaining("Status Code: 400")
+                        .hasMessageContaining("Error Code: AuthorizationHeaderMalformed"); // That is how Minio reacts to bad region
+            }
         }
     }
 }


### PR DESCRIPTION
`HiveMinioDataLake.start` starts more than one container. If second
fails to start, first will be left running. That's why the class has
separate `start` method. The caller needs to hold on to an instance
before invoking the `start` method, and ensure `close()` is called
regardless of `start` success.