### PR TITLE
Fix error message when creating table in non-existing schema

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -932,6 +932,20 @@ public class ThriftHiveMetastore
         catch (NoSuchObjectException e) {
             throw new SchemaNotFoundException(table.getDbName());
         }
+        catch (InvalidObjectException e) {
+            boolean databaseMissing;
+            try {
+                databaseMissing = getDatabase(table.getDbName()).isEmpty();
+            }
+            catch (Exception databaseCheckException) {
+                e.addSuppressed(databaseCheckException);
+                databaseMissing = false; // we don't know, assume it exists for the purpose of error reporting
+            }
+            if (databaseMissing) {
+                throw new SchemaNotFoundException(table.getDbName());
+            }
+            throw new TrinoException(HIVE_METASTORE_ERROR, e);
+        }
         catch (TException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
         }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestCreateTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestCreateTable.java
@@ -18,8 +18,10 @@ import io.trino.tempto.Requires;
 import io.trino.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements.ImmutableNationTable;
 import org.testng.annotations.Test;
 
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tests.product.TestGroups.CREATE_TABLE;
+import static io.trino.tests.product.hive.util.TemporaryHiveTable.randomTableSuffix;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 
@@ -43,5 +45,34 @@ public class TestCreateTable
         onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
         onTrino().executeQuery(format("CREATE TABLE %s(nationkey, name) AS SELECT n_nationkey, n_name FROM nation WHERE 0 is NULL", tableName));
         assertThat(onTrino().executeQuery(format("SELECT nationkey, name FROM %s", tableName))).hasRowsCount(0);
+    }
+
+    /**
+     * {@code BaseConnectorTest.testCreateTableSchemaNotFound()} copy run against Thrift metastore.
+     */
+    @Test(groups = CREATE_TABLE)
+    public void shouldNotCreateTableInNonExistentSchema()
+    {
+        String schemaName = "test_schema_" + randomTableSuffix();
+        String table = schemaName + ".test_create_no_schema_" + randomTableSuffix();
+        assertQueryFailure(() -> onTrino().executeQuery("CREATE TABLE " + table + " (a bigint)"))
+                .hasMessageMatching("\\QQuery failed (#\\E\\S+\\Q): Schema " + schemaName + " not found");
+
+        // Validate that table, nor schema, was not created
+        assertQueryFailure(() -> onTrino().executeQuery("TABLE " + table))
+                .hasMessageMatching("\\QQuery failed (#\\E\\S+\\Q): line 1:1: Schema '" + schemaName + "' does not exist");
+    }
+
+    @Test(groups = CREATE_TABLE)
+    public void shouldNotCreateExternalTableInNonExistentSchema()
+    {
+        String schemaName = "test_schema_" + randomTableSuffix();
+        String table = schemaName + ".test_create_no_schema_" + randomTableSuffix();
+        assertQueryFailure(() -> onTrino().executeQuery("CREATE TABLE " + table + " (a bigint) WITH (external_location = '/tmp')"))
+                .hasMessageMatching("\\QQuery failed (#\\E\\S+\\Q): Schema " + schemaName + " not found");
+
+        // Validate that table, nor schema, was not created
+        assertQueryFailure(() -> onTrino().executeQuery("TABLE " + table))
+                .hasMessageMatching("\\QQuery failed (#\\E\\S+\\Q): line 1:1: Schema '" + schemaName + "' does not exist");
     }
 }


### PR DESCRIPTION
Before the change, when using Hive with Thrift HMS, an error message would contain schema name, but not the words "Schema not found" (or the like).

Fixes https://github.com/trinodb/trino/issues/14741