### PR TITLE
Don't send Sphinx build script output to dev/null

### DIFF
--- a/docs/build
+++ b/docs/build
@@ -9,4 +9,4 @@ test -t 1 && OPTS='-it' || OPTS=''
 SPHINX_IMAGE=${SPHINX_IMAGE:-ghcr.io/trinodb/build/sphinx:3}
 
 docker run --rm $OPTS -e TRINO_VERSION -u $(id -u):$(id -g) -v "$PWD":/docs $SPHINX_IMAGE \
-  sphinx-build -q -j auto -b html -W -d target/doctrees src/main/sphinx target/html > /dev/null
+  sphinx-build -q -j auto -b html -W -d target/doctrees src/main/sphinx target/html


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

#13688 added a `> dev/null` to the Sphinx build script, which swallows up the output of trying to build docs. This is pretty counterproductive for anyone working on docs, because if there are any errors or issues when building, you can't see the output of the script to inform you what/where the error is. It looks like one of the other flags added made it much less verbose, anyway, so un-dev-nulling would be extraordinarily helpful.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Make docs easier to work on.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
