### PR TITLE
Make parquet.fail-on-corrupted-statistics defunct

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetReaderConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetReaderConfig.java
@@ -15,12 +15,17 @@ package io.trino.plugin.hive.parquet;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.DataSize;
 import io.trino.parquet.ParquetReaderOptions;
 
 import javax.validation.constraints.NotNull;
 
+@DefunctConfig({
+        "hive.parquet.fail-on-corrupted-statistics",
+        "parquet.fail-on-corrupted-statistics",
+})
 public class ParquetReaderConfig
 {
     private ParquetReaderOptions options = new ParquetReaderOptions();
@@ -38,16 +43,6 @@ public class ParquetReaderConfig
     {
         options = options.withIgnoreStatistics(ignoreStatistics);
         return this;
-    }
-
-    /**
-     * @deprecated Use {@link #setIgnoreStatistics} instead.
-     */
-    @Deprecated
-    @LegacyConfig(value = {"hive.parquet.fail-on-corrupted-statistics", "parquet.fail-on-corrupted-statistics"}, replacedBy = "parquet.ignore-statistics")
-    public ParquetReaderConfig setFailOnCorruptedStatistics(boolean failOnCorruptedStatistics)
-    {
-        return setIgnoreStatistics(!failOnCorruptedStatistics);
     }
 
     @NotNull


### PR DESCRIPTION
## Description

Remove deprecated configuration properties `hive.parquet.fail-on-corrupted-statistics` and `parquet.fail-on-corrupted-statistics`

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Remove deprecated configuration properties `hive.parquet.fail-on-corrupted-statistics` and `parquet.fail-on-corrupted-statistics`

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Remove deprecated configuration properties `hive.parquet.fail-on-corrupted-statistics` and `parquet.fail-on-corrupted-statistics`. The property `parquet.ignore-statistics` can be used to allow querying Parquet files with corrupted or incorrect statistics ({issue}`14777`)
```
