### PR TITLE
Add `register_table` procedure support for delta table

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.rst
+++ b/docs/src/main/sphinx/connector/delta-lake.rst
@@ -155,6 +155,9 @@ values. Typical usage does not require you to configure them.
     * - ``delta.unique-table-location``
       - Use randomized, unique table locations.
       - ``true``
+    * - ``delta.register-table-procedure.enabled``
+      - Enable to allow users to call the ``register_table`` procedure
+      - ``false``
 
 The following table describes performance tuning catalog properties for the
 connector.
@@ -526,6 +529,13 @@ ignored. The table schema is read from the transaction log, instead. If the
 schema is changed by an external system, Trino automatically uses the new
 schema.
 
+.. warning::
+
+   Using ``CREATE TABLE`` with an existing table content is deprecated, instead use the
+   ``system.register_table`` procedure. The ``CREATE TABLE ... WITH (location=...)``
+   syntax can be temporarily re-enabled using the ``delta.legacy-create-table-with-existing-location.enabled``
+   config property or ``legacy_create_table_with_existing_location_enabled`` session property.
+
 If the specified location does not already contain a Delta table, the connector
 automatically writes the initial transaction log entries and registers the table
 in the metastore. As a result, any Databricks engine can write to the table::
@@ -559,6 +569,21 @@ The following example uses all three table properties::
     checkpoint_interval = 5
   )
   AS SELECT name, comment, regionkey FROM tpch.tiny.nation;
+
+.. _delta-lake-register-table:
+
+Register table
+^^^^^^^^^^^^^^
+
+The connector can register table into the metastore with existing transaction logs and data files.
+
+The ``system.register_table`` procedure allows the caller to register an existing delta lake
+table in the metastore, using its existing transaction logs and data files::
+
+    CALL delta.system.register_table(schema_name => 'testdb', table_name => 'customer_orders', table_location => 's3://my-bucket/a/path')
+
+To prevent unauthorized users from accessing data, this procedure is disabled by default.
+The procedure is enabled only when ``delta.register-table-procedure.enabled`` is set to ``true``.
 
 .. _delta-lake-write-support:
 

--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -421,6 +421,7 @@
                                 <exclude>**/TestDeltaLakeSharedGlueMetastoreWithTableRedirections.java</exclude>
                                 <exclude>**/TestDeltaLakeTableWithCustomLocationUsingGlueMetastore.java</exclude>
                                 <exclude>**/TestDeltaLakeRenameToWithGlueMetastore.java</exclude>
+                                <exclude>**/TestDeltaLakeRegisterTableProcedureWithGlue.java</exclude>
                                 <exclude>**/TestDeltaLakeGcsConnectorSmokeTest.java</exclude>
                             </excludes>
                         </configuration>
@@ -471,6 +472,7 @@
                                 <include>**/TestDeltaLakeSharedGlueMetastoreWithTableRedirections.java</include>
                                 <include>**/TestDeltaLakeTableWithCustomLocationUsingGlueMetastore.java</include>
                                 <include>**/TestDeltaLakeRenameToWithGlueMetastore.java</include>
+                                <include>**/TestDeltaLakeRegisterTableProcedureWithGlue.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
@@ -74,6 +74,8 @@ public class DeltaLakeConfig
     private String parquetTimeZone = TimeZone.getDefault().getID();
     private DataSize targetMaxFileSize = DataSize.of(1, GIGABYTE);
     private boolean uniqueTableLocation = true;
+    private boolean legacyCreateTableWithExistingLocationEnabled;
+    private boolean registerTableProcedureEnabled;
 
     public Duration getMetadataCacheTtl()
     {
@@ -429,6 +431,34 @@ public class DeltaLakeConfig
     public DeltaLakeConfig setUniqueTableLocation(boolean uniqueTableLocation)
     {
         this.uniqueTableLocation = uniqueTableLocation;
+        return this;
+    }
+
+    @Deprecated
+    public boolean isLegacyCreateTableWithExistingLocationEnabled()
+    {
+        return legacyCreateTableWithExistingLocationEnabled;
+    }
+
+    @Deprecated
+    @Config("delta.legacy-create-table-with-existing-location.enabled")
+    @ConfigDescription("Enable using the CREATE TABLE statement to register an existing table")
+    public DeltaLakeConfig setLegacyCreateTableWithExistingLocationEnabled(boolean legacyCreateTableWithExistingLocationEnabled)
+    {
+        this.legacyCreateTableWithExistingLocationEnabled = legacyCreateTableWithExistingLocationEnabled;
+        return this;
+    }
+
+    public boolean isRegisterTableProcedureEnabled()
+    {
+        return registerTableProcedureEnabled;
+    }
+
+    @Config("delta.register-table-procedure.enabled")
+    @ConfigDescription("Allow users to call the register_table procedure")
+    public DeltaLakeConfig setRegisterTableProcedureEnabled(boolean registerTableProcedureEnabled)
+    {
+        this.registerTableProcedureEnabled = registerTableProcedureEnabled;
         return this;
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeModule.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeModule.java
@@ -26,6 +26,7 @@ import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.plugin.deltalake.metastore.DeltaLakeMetastore;
 import io.trino.plugin.deltalake.procedure.DropExtendedStatsProcedure;
 import io.trino.plugin.deltalake.procedure.OptimizeTableProcedure;
+import io.trino.plugin.deltalake.procedure.RegisterTableProcedure;
 import io.trino.plugin.deltalake.procedure.VacuumProcedure;
 import io.trino.plugin.deltalake.statistics.CachingExtendedStatisticsAccess;
 import io.trino.plugin.deltalake.statistics.CachingExtendedStatisticsAccess.ForCachingExtendedStatisticsAccess;
@@ -144,6 +145,7 @@ public class DeltaLakeModule
         Multibinder<Procedure> procedures = newSetBinder(binder, Procedure.class);
         procedures.addBinding().toProvider(DropExtendedStatsProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(VacuumProcedure.class).in(Scopes.SINGLETON);
+        procedures.addBinding().toProvider(RegisterTableProcedure.class).in(Scopes.SINGLETON);
 
         Multibinder<TableProcedureMetadata> tableProcedures = newSetBinder(binder, TableProcedureMetadata.class);
         tableProcedures.addBinding().toProvider(OptimizeTableProcedure.class).in(Scopes.SINGLETON);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
@@ -57,6 +57,7 @@ public final class DeltaLakeSessionProperties
     private static final String DYNAMIC_FILTERING_WAIT_TIMEOUT = "dynamic_filtering_wait_timeout";
     private static final String TABLE_STATISTICS_ENABLED = "statistics_enabled";
     public static final String EXTENDED_STATISTICS_ENABLED = "extended_statistics_enabled";
+    public static final String LEGACY_CREATE_TABLE_WITH_EXISTING_LOCATION_ENABLED = "legacy_create_table_with_existing_location_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -146,6 +147,11 @@ public final class DeltaLakeSessionProperties
                         "Use extended statistics collected by ANALYZE",
                         deltaLakeConfig.isExtendedStatisticsEnabled(),
                         false),
+                booleanProperty(
+                        LEGACY_CREATE_TABLE_WITH_EXISTING_LOCATION_ENABLED,
+                        "Enable using the CREATE TABLE statement to register an existing table",
+                        deltaLakeConfig.isLegacyCreateTableWithExistingLocationEnabled(),
+                        false),
                 enumProperty(
                         COMPRESSION_CODEC,
                         "Compression codec to use when writing new data files",
@@ -228,6 +234,12 @@ public final class DeltaLakeSessionProperties
     public static boolean isExtendedStatisticsEnabled(ConnectorSession session)
     {
         return session.getProperty(EXTENDED_STATISTICS_ENABLED, Boolean.class);
+    }
+
+    @Deprecated
+    public static boolean isLegacyCreateTableWithExistingLocationEnabled(ConnectorSession session)
+    {
+        return session.getProperty(LEGACY_CREATE_TABLE_WITH_EXISTING_LOCATION_ENABLED, Boolean.class);
     }
 
     public static HiveCompressionCodec getCompressionCodec(ConnectorSession session)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/RegisterTableProcedure.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/RegisterTableProcedure.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.procedure;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.plugin.deltalake.DeltaLakeConfig;
+import io.trino.plugin.deltalake.DeltaLakeMetadataFactory;
+import io.trino.plugin.deltalake.metastore.DeltaLakeMetastore;
+import io.trino.plugin.hive.metastore.PrincipalPrivileges;
+import io.trino.plugin.hive.metastore.Table;
+import io.trino.spi.TrinoException;
+import io.trino.spi.classloader.ThreadContextClassLoader;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.SchemaNotFoundException;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.procedure.Procedure;
+import org.apache.hadoop.fs.Path;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static io.trino.plugin.base.util.Procedures.checkProcedureArgument;
+import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_FILESYSTEM_ERROR;
+import static io.trino.plugin.deltalake.DeltaLakeMetadata.buildTable;
+import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.getTransactionLogDir;
+import static io.trino.plugin.hive.metastore.MetastoreUtil.buildInitialPrivilegeSet;
+import static io.trino.spi.StandardErrorCode.GENERIC_USER_ERROR;
+import static io.trino.spi.StandardErrorCode.PERMISSION_DENIED;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.String.format;
+import static java.lang.invoke.MethodHandles.lookup;
+import static java.util.Objects.requireNonNull;
+
+public class RegisterTableProcedure
+        implements Provider<Procedure>
+{
+    private static final MethodHandle REGISTER_TABLE;
+
+    private static final String PROCEDURE_NAME = "register_table";
+    private static final String SYSTEM_SCHEMA = "system";
+
+    private static final String SCHEMA_NAME = "SCHEMA_NAME";
+    private static final String TABLE_NAME = "TABLE_NAME";
+    private static final String TABLE_LOCATION = "TABLE_LOCATION";
+
+    static {
+        try {
+            REGISTER_TABLE = lookup().unreflect(RegisterTableProcedure.class.getMethod("registerTable", ConnectorSession.class, String.class, String.class, String.class));
+        }
+        catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private final DeltaLakeMetadataFactory metadataFactory;
+    private final TrinoFileSystemFactory fileSystemFactory;
+    private final boolean registerTableProcedureEnabled;
+
+    @Inject
+    public RegisterTableProcedure(DeltaLakeMetadataFactory metadataFactory, TrinoFileSystemFactory fileSystemFactory, DeltaLakeConfig deltaLakeConfig)
+    {
+        this.metadataFactory = requireNonNull(metadataFactory, "metadataFactory is null");
+        this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
+        this.registerTableProcedureEnabled = deltaLakeConfig.isRegisterTableProcedureEnabled();
+    }
+
+    @Override
+    public Procedure get()
+    {
+        return new Procedure(
+                SYSTEM_SCHEMA,
+                PROCEDURE_NAME,
+                ImmutableList.of(
+                        new Procedure.Argument(SCHEMA_NAME, VARCHAR),
+                        new Procedure.Argument(TABLE_NAME, VARCHAR),
+                        new Procedure.Argument(TABLE_LOCATION, VARCHAR)),
+                REGISTER_TABLE.bindTo(this));
+    }
+
+    public void registerTable(
+            ConnectorSession clientSession,
+            String schemaName,
+            String tableName,
+            String tableLocation)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            doRegisterTable(
+                    clientSession,
+                    schemaName,
+                    tableName,
+                    tableLocation);
+        }
+    }
+
+    private void doRegisterTable(
+            ConnectorSession session,
+            String schemaName,
+            String tableName,
+            String tableLocation)
+    {
+        if (!registerTableProcedureEnabled) {
+            throw new TrinoException(PERMISSION_DENIED, "register_table procedure is disabled");
+        }
+        checkProcedureArgument(!isNullOrEmpty(schemaName), "schema_name cannot be null or empty");
+        checkProcedureArgument(!isNullOrEmpty(tableName), "table_name cannot be null or empty");
+        checkProcedureArgument(!isNullOrEmpty(tableLocation), "table_location cannot be null or empty");
+
+        SchemaTableName schemaTableName = new SchemaTableName(schemaName, tableName);
+        DeltaLakeMetastore metastore = metadataFactory.create(session.getIdentity()).getMetastore();
+
+        if (metastore.getDatabase(schemaName).isEmpty()) {
+            throw new SchemaNotFoundException(schemaTableName.getSchemaName());
+        }
+
+        TrinoFileSystem fileSystem = fileSystemFactory.create(session);
+        try {
+            Path transactionLogDir = getTransactionLogDir(new Path(tableLocation));
+            if (!fileSystem.listFiles(transactionLogDir.toString()).hasNext()) {
+                throw new TrinoException(GENERIC_USER_ERROR, format("No transaction log found in location %s", transactionLogDir));
+            }
+        }
+        catch (IOException e) {
+            throw new TrinoException(DELTA_LAKE_FILESYSTEM_ERROR, format("Failed checking table location %s", tableLocation), e);
+        }
+
+        Table table = buildTable(session, schemaTableName, tableLocation, new Path(tableLocation), true);
+
+        PrincipalPrivileges principalPrivileges = buildInitialPrivilegeSet(table.getOwner().orElseThrow());
+        metastore.createTable(
+                session,
+                table,
+                principalPrivileges);
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeAwsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeAwsConnectorSmokeTest.java
@@ -33,10 +33,12 @@ public abstract class BaseDeltaLakeAwsConnectorSmokeTest
     }
 
     @Override
-    protected void createTableFromResources(String table, String resourcePath, QueryRunner queryRunner)
+    protected void registerTableFromResources(String table, String resourcePath, QueryRunner queryRunner)
     {
         hiveMinioDataLake.copyResources(resourcePath, table);
-        queryRunner.execute(format("CREATE TABLE %s (dummy int) WITH (location = '%s')",
+        queryRunner.execute(format(
+                "CALL system.register_table('%s', '%s', '%s')",
+                SCHEMA,
                 table,
                 getLocationForTable(bucketName, table)));
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -26,6 +26,8 @@ import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
 import io.trino.plugin.hive.TestingHivePlugin;
 import io.trino.plugin.hive.containers.HiveHadoop;
 import io.trino.plugin.hive.containers.HiveMinioDataLake;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.hive.metastore.thrift.BridgingHiveMetastore;
 import io.trino.spi.QueryId;
 import io.trino.sql.planner.OptimizerConfig.JoinDistributionType;
 import io.trino.testing.BaseConnectorSmokeTest;
@@ -46,7 +48,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.MoreCollectors.onlyElement;
@@ -55,6 +60,7 @@ import static io.trino.SystemSessionProperties.ENABLE_DYNAMIC_FILTERING;
 import static io.trino.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.TRANSACTION_LOG_DIRECTORY;
+import static io.trino.plugin.hive.TestingThriftHiveMetastoreBuilder.testingThriftHiveMetastoreBuilder;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.DELETE_TABLE;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.INSERT_TABLE;
 import static io.trino.testing.TestingAccessControlManager.privilege;
@@ -111,6 +117,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     protected final String bucketName = "test-delta-lake-integration-smoke-test-" + randomNameSuffix();
 
     protected HiveMinioDataLake hiveMinioDataLake;
+    private HiveMetastore metastore;
 
     protected abstract HiveMinioDataLake createHiveMinioDataLake()
             throws Exception;
@@ -118,7 +125,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     protected abstract QueryRunner createDeltaLakeQueryRunner(Map<String, String> connectorProperties)
             throws Exception;
 
-    protected abstract void createTableFromResources(String table, String resourcePath, QueryRunner queryRunner);
+    protected abstract void registerTableFromResources(String table, String resourcePath, QueryRunner queryRunner);
 
     protected abstract String getLocationForTable(String bucketName, String tableName);
 
@@ -131,12 +138,17 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
             throws Exception
     {
         this.hiveMinioDataLake = closeAfterClass(createHiveMinioDataLake());
+        this.metastore = new BridgingHiveMetastore(
+                testingThriftHiveMetastoreBuilder()
+                        .metastoreClient(hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint())
+                        .build());
 
         QueryRunner queryRunner = createDeltaLakeQueryRunner(
                 ImmutableMap.<String, String>builder()
                         .put("delta.metadata.cache-ttl", TEST_METADATA_CACHE_TTL_SECONDS + "s")
                         .put("delta.metadata.live-files.cache-ttl", TEST_METADATA_CACHE_TTL_SECONDS + "s")
                         .put("hive.metastore-cache-ttl", TEST_METADATA_CACHE_TTL_SECONDS + "s")
+                        .put("delta.register-table-procedure.enabled", "true")
                         .buildOrThrow());
 
         queryRunner.execute(format("CREATE SCHEMA %s WITH (location = '%s')", SCHEMA, getLocationForTable(bucketName, SCHEMA)));
@@ -164,7 +176,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
          */
         NON_TPCH_TABLES.forEach(table -> {
             String resourcePath = "databricks/" + table;
-            createTableFromResources(table, resourcePath, queryRunner);
+            registerTableFromResources(table, resourcePath, queryRunner);
         });
 
         return queryRunner;
@@ -397,7 +409,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
 
     private void testDropTable(String tableName, String resourcePath)
     {
-        createTableFromResources(tableName, resourcePath, getQueryRunner());
+        registerTableFromResources(tableName, resourcePath, getQueryRunner());
         assertTrue(getQueryRunner().tableExists(getSession(), tableName));
         assertUpdate("DROP TABLE " + tableName);
         assertFalse(getQueryRunner().tableExists(getSession(), tableName));
@@ -408,11 +420,11 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     public void testDropAndRecreateTable()
     {
         String tableName = "testDropAndRecreate_" + randomNameSuffix();
-        assertUpdate(format("CREATE TABLE %s (dummy int) WITH (location = '%s')", tableName, getLocationForTable(bucketName, "nation")));
+        assertUpdate(format("CALL system.register_table('%s', '%s', '%s')", SCHEMA, tableName, getLocationForTable(bucketName, "nation")));
         assertQuery("SELECT * FROM " + tableName, "SELECT * FROM nation");
 
         assertUpdate("DROP TABLE " + tableName);
-        assertUpdate(format("CREATE TABLE %s (dummy int) WITH (location = '%s')", tableName, getLocationForTable(bucketName, "customer")));
+        assertUpdate(format("CALL system.register_table('%s', '%s', '%s')", SCHEMA, tableName, getLocationForTable(bucketName, "customer")));
         assertQuery("SELECT * FROM " + tableName, "SELECT * FROM customer");
         assertUpdate("DROP TABLE " + tableName);
     }
@@ -420,7 +432,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testDropColumnNotSupported()
     {
-        createTableFromResources("testdropcolumn", "io/trino/plugin/deltalake/testing/resources/databricks/nation", getQueryRunner());
+        registerTableFromResources("testdropcolumn", "io/trino/plugin/deltalake/testing/resources/databricks/nation", getQueryRunner());
         assertQueryFails("ALTER TABLE testdropcolumn DROP COLUMN comment", ".*This connector does not support dropping columns.*");
     }
 
@@ -1313,7 +1325,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
                                 "   partitioned_by = ARRAY[%s]\n" +
                                 ")",
                         getSession().getCatalog().orElseThrow(),
-                        getSession().getSchema().orElseThrow(),
+                        SCHEMA,
                         tableName,
                         newLocation,
                         secondPartitioned ? "'a_number'" : ""));
@@ -1397,7 +1409,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     public void testStatsSplitPruningBasedOnSepCreatedCheckpointOnTopOfCheckpointWithJustStructStats()
     {
         String tableName = "test_sep_checkpoint_stats_pruning_struct_stats_" + randomNameSuffix();
-        createTableFromResources(tableName, "databricks/pruning/parquet_struct_statistics", getQueryRunner());
+        registerTableFromResources(tableName, "databricks/pruning/parquet_struct_statistics", getQueryRunner());
         String transactionLogDirectory = format("%s/_delta_log", tableName);
 
         // there should should be one checkpoint already (created by DB)
@@ -1664,7 +1676,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
         Set<?> activeFiles = computeActual("SELECT \"$path\" FROM " + tableName).getOnlyColumnAsSet();
         String location = (String) computeScalar(format("SELECT DISTINCT regexp_replace(\"$path\", '/[^/]*$', '') FROM %s", tableName));
         assertUpdate("DROP TABLE " + tableName);
-        assertUpdate(format("CREATE TABLE %s(ignore integer) WITH (location = '%s')", tableName, location));
+        assertUpdate(format("CALL system.register_table('%s', '%s', '%s')", SCHEMA, tableName, location));
         // sanity check
         assertThat(computeActual("SELECT \"$path\" FROM " + tableName).getOnlyColumnAsSet()).as("active files after table recreated")
                 .isEqualTo(activeFiles);
@@ -1751,6 +1763,37 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
         assertThat(getAllDataFilesFromTableDirectory(tableName)).isEqualTo(union(initialFiles, updatedFiles));
     }
 
+    /**
+     * @see BaseDeltaLakeRegisterTableProcedureTest for more detailed tests
+     */
+    @Test
+    public void testRegisterTable()
+    {
+        String tableName = "test_register_table_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (a INT, b VARCHAR, c BOOLEAN)");
+        assertUpdate("INSERT INTO " + tableName + " VALUES(1, 'INDIA', true)", 1);
+
+        String tableLocation = getTableLocation(tableName);
+        String showCreateTableOld = (String) computeScalar("SHOW CREATE TABLE " + tableName);
+
+        // Drop table from metastore and use the table content to register a table
+        metastore.dropTable(SCHEMA, tableName, false);
+        assertUpdate("CALL system.flush_metadata_cache(schema_name => CURRENT_SCHEMA, table_name => '" + tableName + "')");
+        // Verify that dropTableFromMetastore actually works
+        assertQueryFails("SELECT * FROM " + tableName, ".* Table '.*' does not exist");
+
+        assertUpdate("CALL system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "')");
+        assertQuery("SELECT * FROM " + tableName, "VALUES (1, 'INDIA', true)");
+
+        assertUpdate("INSERT INTO " + tableName + " VALUES(2, 'POLAND', false)", 1);
+        String showCreateTableNew = (String) computeScalar("SHOW CREATE TABLE " + tableName);
+
+        assertThat(showCreateTableOld).isEqualTo(showCreateTableNew);
+        assertQuery("SELECT * FROM " + tableName, "VALUES (1, 'INDIA', true), (2, 'POLAND', false)");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
     private Set<String> getActiveFiles(String tableName)
     {
         return getActiveFiles(tableName, getQueryRunner().getDefaultSession());
@@ -1776,5 +1819,35 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, JoinDistributionType.BROADCAST.name())
                 .setSystemProperty(ENABLE_DYNAMIC_FILTERING, Boolean.toString(dynamicFilteringEnabled))
                 .build();
+    }
+
+    private String getTableLocation(String tableName)
+    {
+        Pattern locationPattern = Pattern.compile(".*location = '(.*?)'.*", Pattern.DOTALL);
+        Matcher m = locationPattern.matcher((String) computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue());
+        if (m.find()) {
+            String location = m.group(1);
+            verify(!m.find(), "Unexpected second match");
+            return location;
+        }
+        throw new IllegalStateException("Location not found in SHOW CREATE TABLE result");
+    }
+
+    private String getTableComment(String tableName)
+    {
+        return (String) computeScalar(format(
+                "SELECT comment FROM system.metadata.table_comments WHERE catalog_name = '%s' AND schema_name = '%s' AND table_name = '%s'",
+                getSession().getCatalog().orElseThrow(),
+                SCHEMA,
+                tableName));
+    }
+
+    private String getColumnComment(String tableName, String columnName)
+    {
+        return (String) computeScalar(format(
+                "SELECT comment FROM information_schema.columns WHERE table_schema = '%s' AND table_name = '%s' AND column_name = '%s'",
+                SCHEMA,
+                tableName,
+                columnName));
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
@@ -80,15 +80,16 @@ public abstract class BaseDeltaLakeMinioConnectorTest
         QueryRunner queryRunner = DeltaLakeQueryRunner.createS3DeltaLakeQueryRunner(
                 DELTA_CATALOG,
                 SCHEMA,
-                ImmutableMap.of("delta.enable-non-concurrent-writes", "true"),
+                ImmutableMap.of(
+                        "delta.enable-non-concurrent-writes", "true",
+                        "delta.register-table-procedure.enabled", "true"),
                 hiveMinioDataLake.getMinioAddress(),
                 hiveMinioDataLake.getHiveHadoop());
         queryRunner.execute("CREATE SCHEMA " + SCHEMA + " WITH (location = 's3://" + bucketName + "/" + SCHEMA + "')");
         TpchTable.getTables().forEach(table -> {
             String tableName = table.getTableName();
             hiveMinioDataLake.copyResources(resourcePath + tableName, SCHEMA + "/" + tableName);
-            queryRunner.execute(format("CREATE TABLE %1$s.%2$s.%3$s (dummy int) WITH (location = 's3://%4$s/%2$s/%3$s')",
-                    DELTA_CATALOG,
+            queryRunner.execute(format("CALL system.register_table('%1$s', '%2$s', 's3://%3$s/%1$s/%2$s')",
                     SCHEMA,
                     tableName,
                     bucketName));

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeRegisterTableProcedureTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeRegisterTableProcedureTest.java
@@ -1,0 +1,310 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Verify.verify;
+import static com.google.common.io.MoreFiles.deleteDirectoryContents;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.trino.plugin.deltalake.DeltaLakeConnectorFactory.CONNECTOR_NAME;
+import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.getTransactionLogDir;
+import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.getTransactionLogJsonEntryPath;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertFalse;
+
+public abstract class BaseDeltaLakeRegisterTableProcedureTest
+        extends AbstractTestQueryFramework
+{
+    protected static final String CATALOG_NAME = "delta_lake";
+    protected static final String SCHEMA = "test_delta_lake_register_table_" + randomNameSuffix();
+
+    private String dataDirectory;
+    private HiveMetastore metastore;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog(CATALOG_NAME)
+                .setSchema(SCHEMA)
+                .build();
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
+
+        this.dataDirectory = queryRunner.getCoordinator().getBaseDataDir().resolve("delta_lake_data").toString();
+        this.metastore = createTestMetastore(dataDirectory);
+
+        queryRunner.installPlugin(new TestingDeltaLakePlugin());
+
+        Map<String, String> connectorProperties = ImmutableMap.<String, String>builder()
+                .putAll(getConnectorProperties(dataDirectory))
+                .put("delta.unique-table-location", "true")
+                .put("delta.register-table-procedure.enabled", "true")
+                .buildOrThrow();
+
+        queryRunner.createCatalog(CATALOG_NAME, CONNECTOR_NAME, connectorProperties);
+        queryRunner.execute("CREATE SCHEMA " + SCHEMA);
+
+        return queryRunner;
+    }
+
+    protected abstract Map<String, String> getConnectorProperties(String dataDirectory);
+
+    protected abstract HiveMetastore createTestMetastore(String dataDirectory);
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws IOException
+    {
+        if (metastore != null) {
+            metastore.dropDatabase(SCHEMA, false);
+            deleteRecursively(Path.of(dataDirectory), ALLOW_INSECURE);
+        }
+    }
+
+    @Test
+    public void testRegisterTable()
+    {
+        String tableName = "test_register_table_" + randomNameSuffix();
+
+        assertQuerySucceeds("CREATE TABLE " + tableName + " AS SELECT 1 as a, 'INDIA' as b, true as c");
+        assertQuery("SELECT * FROM " + tableName, "VALUES (1, 'INDIA', true)");
+
+        String tableLocation = getTableLocation(tableName);
+        String showCreateTableOld = (String) computeScalar("SHOW CREATE TABLE " + tableName);
+
+        // Drop table from metastore and use the table content to register a table
+        metastore.dropTable(SCHEMA, tableName, false);
+        // Verify that dropTableFromMetastore actually works
+        assertFalse(getQueryRunner().tableExists(getSession(), tableName));
+
+        assertQuerySucceeds(format("CALL system.register_table('%s', '%s', '%s')", SCHEMA, tableName, tableLocation));
+        String showCreateTableNew = (String) computeScalar("SHOW CREATE TABLE " + tableName);
+
+        assertThat(showCreateTableOld).isEqualTo(showCreateTableNew);
+        assertQuery("SELECT * FROM " + tableName, "VALUES (1, 'INDIA', true)");
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testRegisterTableWithComments()
+    {
+        String tableName = "test_register_table_with_comments_" + randomNameSuffix();
+
+        assertQuerySucceeds("CREATE TABLE " + tableName + " (a, b, c) COMMENT 'my-table-comment' AS VALUES (1, 'INDIA', true)");
+        assertQuery("SELECT * FROM " + tableName, "VALUES (1, 'INDIA', true)");
+
+        String tableLocation = getTableLocation(tableName);
+        // Drop table from metastore and use the table content to register a table
+        metastore.dropTable(SCHEMA, tableName, false);
+
+        assertQuerySucceeds("CALL system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "')");
+        assertThat(getTableComment(tableName)).isEqualTo("my-table-comment");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testRegisterTableWithDifferentTableName()
+    {
+        String tableName = "test_register_table_with_different_table_name_old_" + randomNameSuffix();
+
+        assertQuerySucceeds("CREATE TABLE " + tableName + " AS SELECT 1 as a, 'INDIA' as b, true as c");
+        assertQuery("SELECT * FROM " + tableName, "VALUES (1, 'INDIA', true)");
+
+        String showCreateTableOld = (String) computeScalar("SHOW CREATE TABLE " + tableName);
+        String tableLocation = getTableLocation(tableName);
+        // Drop table from metastore and use the table content to register a table
+        metastore.dropTable(SCHEMA, tableName, false);
+
+        String tableNameNew = "test_register_table_with_different_table_name_new_" + randomNameSuffix();
+        assertQuerySucceeds(format("CALL %s.system.register_table('%s', '%s', '%s')", CATALOG_NAME, SCHEMA, tableNameNew, tableLocation));
+        String showCreateTableNew = (String) computeScalar("SHOW CREATE TABLE " + tableNameNew);
+
+        assertThat(showCreateTableOld).isEqualTo(showCreateTableNew.replaceFirst(tableNameNew, tableName));
+        assertQuery("SELECT * FROM " + tableNameNew, "VALUES (1, 'INDIA', true)");
+
+        assertUpdate(format("DROP TABLE %s", tableNameNew));
+    }
+
+    @Test
+    public void testRegisterEmptyTable()
+    {
+        String tableName = "test_register_table_with_no_data_" + randomNameSuffix();
+
+        assertQuerySucceeds("CREATE TABLE " + tableName + "(a INT, b VARCHAR, c BOOLEAN)");
+
+        String tableLocation = getTableLocation(tableName);
+        metastore.dropTable(SCHEMA, tableName, false);
+
+        assertQuerySucceeds(format("CALL system.register_table('%s', '%s', '%s')", SCHEMA, tableName, tableLocation));
+
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
+    @Test
+    public void testRegisterTableWithInvalidDeltaTable()
+            throws Exception
+    {
+        String tableName = "test_register_table_with_no_transaction_log_" + randomNameSuffix();
+
+        assertQuerySucceeds("CREATE TABLE " + tableName + " AS SELECT 1 as a, 'INDIA' as b, true as c");
+        assertQuery("SELECT * FROM " + tableName, "VALUES (1, 'INDIA', true)");
+
+        String tableLocation = getTableLocation(tableName);
+        String tableNameNew = "test_register_table_with_no_transaction_log_new_" + randomNameSuffix();
+
+        // Delete files under transaction log directory and put an invalid log file to verify register_table call fails
+        String transactionLogDir = getTransactionLogDir(new org.apache.hadoop.fs.Path(tableLocation)).toString();
+        deleteDirectoryContents(Path.of(transactionLogDir), ALLOW_INSECURE);
+        new File(getTransactionLogJsonEntryPath(new org.apache.hadoop.fs.Path(transactionLogDir), 0).toString()).createNewFile();
+
+        assertQueryFails(format("CALL system.register_table('%s', '%s', '%s')", SCHEMA, tableNameNew, tableLocation),
+                ".*Failed to access table location: (.*)");
+
+        deleteRecursively(Path.of(tableLocation), ALLOW_INSECURE);
+        metastore.dropTable(SCHEMA, tableName, false);
+    }
+
+    @Test
+    public void testRegisterTableWithNoTransactionLog()
+            throws Exception
+    {
+        String tableName = "test_register_table_with_no_transaction_log_" + randomNameSuffix();
+
+        assertQuerySucceeds("CREATE TABLE " + tableName + " AS SELECT 1 as a, 'INDIA' as b, true as c");
+        assertQuery("SELECT * FROM " + tableName, "VALUES (1, 'INDIA', true)");
+
+        String tableLocation = getTableLocation(tableName);
+        String tableNameNew = "test_register_table_with_no_transaction_log_new_" + randomNameSuffix();
+
+        // Delete files under transaction log directory to verify register_table call fails
+        deleteDirectoryContents(Path.of(getTransactionLogDir(new org.apache.hadoop.fs.Path(tableLocation)).toString()), ALLOW_INSECURE);
+
+        assertQueryFails(format("CALL system.register_table('%s', '%s', '%s')", SCHEMA, tableNameNew, tableLocation),
+                ".*No transaction log found in location (.*)");
+
+        deleteRecursively(Path.of(tableLocation), ALLOW_INSECURE);
+        metastore.dropTable(SCHEMA, tableName, false);
+    }
+
+    @Test
+    public void testRegisterTableWithNonExistingTableLocation()
+    {
+        String tableName = "test_register_table_with_non_existing_table_location_" + randomNameSuffix();
+        String tableLocation = "/test/delta-lake/hive/warehouse/orders_5-581fad8517934af6be1857a903559d44";
+        assertQueryFails(format("CALL system.register_table('%s', '%s', '%s')", SCHEMA, tableName, tableLocation),
+                ".*No transaction log found in location (.*).*");
+    }
+
+    @Test
+    public void testRegisterTableWithNonExistingSchema()
+    {
+        String tableLocation = "/test/delta-lake/hive/warehouse/orders_5-581fad8517934af6be1857a903559d44";
+        assertQueryFails(format("CALL system.register_table('%s', '%s', '%s')", SCHEMA + "_new", "delta_table_1", tableLocation),
+                "Schema (.*) not found");
+    }
+
+    @Test
+    public void testRegisterTableWithExistingTable()
+    {
+        String tableName = "test_register_table_with_existing_table_" + randomNameSuffix();
+
+        assertQuerySucceeds("CREATE TABLE " + tableName + " AS SELECT 1 as a, 'INDIA' as b, true as c");
+        assertQuery("SELECT * FROM " + tableName, "VALUES (1, 'INDIA', true)");
+
+        String tableLocation = getTableLocation(tableName);
+
+        assertQueryFails(format("CALL system.register_table('%s', '%s', '%s')", SCHEMA, tableName, tableLocation),
+                ".*Table already exists: '(.*)'.*");
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testRegisterTableWithInvalidUriScheme()
+    {
+        String tableName = "test_register_table_with_invalid_uri_scheme_" + randomNameSuffix();
+        String tableLocation = "invalid://hadoop-master:9000/test/delta-lake/hive/orders_5-581fad8517934af6be1857a903559d44";
+        assertQueryFails(format("CALL system.register_table('%s', '%s', '%s')", SCHEMA, tableName, tableLocation),
+                ".*Failed checking table location (.*)");
+    }
+
+    @Test
+    public void testRegisterTableWithInvalidParameter()
+    {
+        String tableName = "test_register_table_with_invalid_parameter_" + randomNameSuffix();
+        String tableLocation = "/test/delta-lake/hive/table1/";
+
+        assertQueryFails(format("CALL system.register_table('%s', '%s')", SCHEMA, tableName),
+                ".*'TABLE_LOCATION' is missing.*");
+        assertQueryFails(format("CALL system.register_table('%s')", SCHEMA),
+                ".*'TABLE_NAME' is missing.*");
+        assertQueryFails("CALL system.register_table()",
+                ".*'SCHEMA_NAME' is missing.*");
+
+        assertQueryFails(format("CALL system.register_table(NULL, '%s', '%s')", tableName, tableLocation),
+                ".*schema_name cannot be null or empty.*");
+        assertQueryFails(format("CALL system.register_table('%s', NULL, '%s')", SCHEMA, tableLocation),
+                ".*table_name cannot be null or empty.*");
+        assertQueryFails(format("CALL system.register_table('%s', '%s', NULL)", SCHEMA, tableName),
+                ".*table_location cannot be null or empty.*");
+
+        assertQueryFails(format("CALL system.register_table('', '%s', '%s')", tableName, tableLocation),
+                ".*schema_name cannot be null or empty.*");
+        assertQueryFails(format("CALL system.register_table('%s', '', '%s')", SCHEMA, tableLocation),
+                ".*table_name cannot be null or empty.*");
+        assertQueryFails(format("CALL system.register_table('%s', '%s', '')", SCHEMA, tableName),
+                ".*table_location cannot be null or empty.*");
+    }
+
+    protected String getTableLocation(String tableName)
+    {
+        Pattern locationPattern = Pattern.compile(".*location = '(.*?)'.*", Pattern.DOTALL);
+        Matcher m = locationPattern.matcher((String) computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue());
+        if (m.find()) {
+            String location = m.group(1);
+            verify(!m.find(), "Unexpected second match");
+            return location;
+        }
+        throw new IllegalStateException("Location not found in SHOW CREATE TABLE result");
+    }
+
+    private String getTableComment(String tableName)
+    {
+        return (String) computeScalar(format(
+                "SELECT comment FROM system.metadata.table_comments WHERE catalog_name = '%s' AND schema_name = '%s' AND table_name = '%s'",
+                CATALOG_NAME,
+                SCHEMA,
+                tableName));
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsConnectorSmokeTest.java
@@ -114,7 +114,7 @@ public class TestDeltaLakeAdlsConnectorSmokeTest
     }
 
     @Override
-    protected void createTableFromResources(String table, String resourcePath, QueryRunner queryRunner)
+    protected void registerTableFromResources(String table, String resourcePath, QueryRunner queryRunner)
     {
         String targetDirectory = bucketName + "/" + table;
 
@@ -134,7 +134,7 @@ public class TestDeltaLakeAdlsConnectorSmokeTest
             throw new UncheckedIOException(e);
         }
 
-        queryRunner.execute(format("CREATE TABLE %s (dummy int) WITH (location = '%s')", table, getLocationForTable(bucketName, table)));
+        queryRunner.execute(format("CALL system.register_table('%s', '%s', '%s')", SCHEMA, table, getLocationForTable(bucketName, table)));
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsStorage.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsStorage.java
@@ -85,7 +85,12 @@ public class TestDeltaLakeAdlsStorage
                         "/etc/hadoop/conf/core-site.xml", hadoopCoreSiteXmlTempFile.toString()))
                 .build());
         hiveHadoop.start();
-        return createAbfsDeltaLakeQueryRunner(DELTA_CATALOG, SCHEMA_NAME, ImmutableMap.of(), ImmutableMap.of(), hiveHadoop);
+        return createAbfsDeltaLakeQueryRunner(
+                DELTA_CATALOG,
+                SCHEMA_NAME,
+                ImmutableMap.of(),
+                ImmutableMap.of("delta.register-table-procedure.enabled", "true"),
+                hiveHadoop);
     }
 
     private Path createHadoopCoreSiteXmlTempFileWithAbfsSettings()
@@ -109,12 +114,7 @@ public class TestDeltaLakeAdlsStorage
         hiveHadoop.executeInContainerFailOnError("hadoop", "fs", "-mkdir", "-p", adlsDirectory);
         TABLES.forEach(table -> {
             hiveHadoop.executeInContainerFailOnError("hadoop", "fs", "-copyFromLocal", "-f", "/tmp/tpch-tiny/" + table, adlsDirectory);
-            getQueryRunner().execute(format("CREATE TABLE %s.%s.%s (dummy int) WITH (location = '%s/%s')",
-                    DELTA_CATALOG,
-                    SCHEMA_NAME,
-                    table,
-                    adlsDirectory,
-                    table));
+            getQueryRunner().execute(format("CALL system.register_table('%s', '%s', '%s/%s')", SCHEMA_NAME, table, adlsDirectory, table));
         });
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
@@ -64,7 +64,9 @@ public class TestDeltaLakeConfig
                 .setParquetTimeZone(TimeZone.getDefault().getID())
                 .setPerTransactionMetastoreCacheMaximumSize(1000)
                 .setTargetMaxFileSize(DataSize.of(1, GIGABYTE))
-                .setUniqueTableLocation(true));
+                .setUniqueTableLocation(true)
+                .setLegacyCreateTableWithExistingLocationEnabled(false)
+                .setRegisterTableProcedureEnabled(false));
     }
 
     @Test
@@ -97,6 +99,8 @@ public class TestDeltaLakeConfig
                 .put("delta.parquet.time-zone", nonDefaultTimeZone().getID())
                 .put("delta.target-max-file-size", "2 GB")
                 .put("delta.unique-table-location", "false")
+                .put("delta.legacy-create-table-with-existing-location.enabled", "true")
+                .put("delta.register-table-procedure.enabled", "true")
                 .buildOrThrow();
 
         DeltaLakeConfig expected = new DeltaLakeConfig()
@@ -125,7 +129,9 @@ public class TestDeltaLakeConfig
                 .setParquetTimeZone(nonDefaultTimeZone().getID())
                 .setPerTransactionMetastoreCacheMaximumSize(500)
                 .setTargetMaxFileSize(DataSize.of(2, GIGABYTE))
-                .setUniqueTableLocation(false);
+                .setUniqueTableLocation(false)
+                .setLegacyCreateTableWithExistingLocationEnabled(true)
+                .setRegisterTableProcedureEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorSmokeTest.java
@@ -174,7 +174,9 @@ public class TestDeltaLakeConnectorSmokeTest
     {
         String tableName = "test_schema_evolution_on_table_with_column_invariant_" + randomNameSuffix();
         hiveMinioDataLake.copyResources("databricks/invariants", tableName);
-        getQueryRunner().execute(format("CREATE TABLE %s (ignored int) WITH (location = '%s')",
+        getQueryRunner().execute(format(
+                "CALL system.register_table('%s', '%s', '%s')",
+                SCHEMA,
                 tableName,
                 getLocationForTable(bucketName, tableName)));
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeDelete.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeDelete.java
@@ -49,7 +49,9 @@ public class TestDeltaLakeDelete
         QueryRunner queryRunner = DeltaLakeQueryRunner.createS3DeltaLakeQueryRunner(
                 DELTA_CATALOG,
                 SCHEMA,
-                ImmutableMap.of("delta.enable-non-concurrent-writes", "true"),
+                ImmutableMap.of(
+                        "delta.enable-non-concurrent-writes", "true",
+                        "delta.register-table-procedure.enabled", "true"),
                 hiveMinioDataLake.getMinioAddress(),
                 hiveMinioDataLake.getHiveHadoop());
 
@@ -101,9 +103,7 @@ public class TestDeltaLakeDelete
     private void testDeleteMultiFile(String tableName, String resourcePath)
     {
         hiveMinioDataLake.copyResources(resourcePath + "/lineitem", tableName);
-        getQueryRunner().execute(format("CREATE TABLE %s (dummy int) WITH (location = '%s')",
-                tableName,
-                getLocationForTable(tableName)));
+        getQueryRunner().execute(format("CALL system.register_table('%s', '%s', '%s')", SCHEMA, tableName, getLocationForTable(tableName)));
 
         assertQuery("SELECT count(*) FROM " + tableName, "SELECT count(*) FROM lineitem");
         assertUpdate("DELETE FROM " + tableName + " WHERE partkey % 2 = 0", "SELECT count(*) FROM lineitem WHERE partkey % 2 = 0");
@@ -198,9 +198,7 @@ public class TestDeltaLakeDelete
     {
         hiveMinioDataLake.copyResources(resourcePath + "/customer", tableName);
         Set<String> originalFiles = ImmutableSet.copyOf(hiveMinioDataLake.listFiles(tableName));
-        getQueryRunner().execute(format("CREATE TABLE %s (dummy int) WITH (location = '%s')",
-                tableName,
-                getLocationForTable(tableName)));
+        getQueryRunner().execute(format("CALL system.register_table('%s', '%s', '%s')", SCHEMA, tableName, getLocationForTable(tableName)));
         assertQuery("SELECT * FROM " + tableName, "SELECT * FROM customer");
         assertUpdate("DELETE FROM " + tableName, "SELECT count(*) FROM customer");
         assertQuery("SELECT count(*) FROM " + tableName, "VALUES 0");

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeDynamicFiltering.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeDynamicFiltering.java
@@ -79,14 +79,14 @@ public class TestDeltaLakeDynamicFiltering
         QueryRunner queryRunner = DeltaLakeQueryRunner.createS3DeltaLakeQueryRunner(
                 DELTA_CATALOG,
                 "default",
-                ImmutableMap.of(),
+                ImmutableMap.of("delta.register-table-procedure.enabled", "true"),
                 hiveMinioDataLake.getMinioAddress(),
                 hiveMinioDataLake.getHiveHadoop());
 
         ImmutableList.of(LINE_ITEM, ORDERS).forEach(table -> {
             String tableName = table.getTableName();
             hiveMinioDataLake.copyResources("io/trino/plugin/deltalake/testing/resources/databricks/" + tableName, tableName);
-            queryRunner.execute(format("CREATE TABLE %s.%s.%s (dummy int) WITH (location = 's3://%s/%3$s')",
+            queryRunner.execute(format("CALL %1$s.system.register_table('%2$s', '%3$s', 's3://%4$s/%3$s')",
                     DELTA_CATALOG,
                     "default",
                     tableName,

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeGcsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeGcsConnectorSmokeTest.java
@@ -154,7 +154,7 @@ public class TestDeltaLakeGcsConnectorSmokeTest
     }
 
     @Override
-    protected void createTableFromResources(String table, String resourcePath, QueryRunner queryRunner)
+    protected void registerTableFromResources(String table, String resourcePath, QueryRunner queryRunner)
     {
         String targetDirectory = bucketName + "/" + table;
 
@@ -176,7 +176,7 @@ public class TestDeltaLakeGcsConnectorSmokeTest
             throw new UncheckedIOException(e);
         }
 
-        queryRunner.execute(format("CREATE TABLE %s (dummy int) WITH (location = '%s')", table, getLocationForTable(bucketName, table)));
+        queryRunner.execute(format("CALL system.register_table('%s', '%s', '%s')", SCHEMA, table, getLocationForTable(bucketName, table)));
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeLegacyCreateTableWithExistingLocation.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeLegacyCreateTableWithExistingLocation.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.createDeltaLakeQueryRunner;
+import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestDeltaLakeLegacyCreateTableWithExistingLocation
+        extends AbstractTestQueryFramework
+{
+    private static final String CATALOG_NAME = "delta_lake";
+
+    private File dataDirectory;
+    private HiveMetastore metastore;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        this.dataDirectory = Files.createTempDirectory("test_delta_lake").toFile();
+        this.metastore = createTestingFileHiveMetastore(dataDirectory);
+
+        return createDeltaLakeQueryRunner(
+                CATALOG_NAME,
+                ImmutableMap.of(),
+                ImmutableMap.of(
+                        "delta.unique-table-location", "true",
+                        "hive.metastore", "file",
+                        "hive.metastore.catalog.dir", dataDirectory.getPath()));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws IOException
+    {
+        if (dataDirectory != null) {
+            deleteRecursively(dataDirectory.toPath(), ALLOW_INSECURE);
+        }
+    }
+
+    @Test
+    public void testLegacyCreateTable()
+    {
+        String tableName = "test_legacy_create_table_" + randomNameSuffix();
+
+        assertQuerySucceeds("CREATE TABLE " + tableName + " AS SELECT 1 as a, 'INDIA' as b, true as c");
+        assertQuery("SELECT * FROM " + tableName, "VALUES (1, 'INDIA', true)");
+
+        String tableLocation = (String) computeScalar("SELECT DISTINCT regexp_replace(\"$path\", '/[^/]*$', '') FROM " + tableName);
+        metastore.dropTable("tpch", tableName, false);
+
+        assertQueryFails(format("CREATE TABLE %s.%s.%s (dummy int) with (location = '%s')", CATALOG_NAME, "tpch", tableName, tableLocation),
+                ".*Using CREATE TABLE with an existing table content is deprecated.*");
+
+        Session sessionWithLegacyCreateTableEnabled = Session
+                .builder(getSession())
+                .setCatalogSessionProperty(CATALOG_NAME, "legacy_create_table_with_existing_location_enabled", "true")
+                .build();
+        assertQuerySucceeds(sessionWithLegacyCreateTableEnabled, format("CREATE TABLE %s.%s.%s (dummy int) with (location = '%s')", CATALOG_NAME, "tpch", tableName, tableLocation));
+
+        assertQuery("SELECT * FROM " + tableName, "VALUES (1, 'INDIA', true)");
+
+        assertUpdate("DROP TABLE " + tableName);
+        assertThat(metastore.getTable("tpch", tableName)).as("Table should be dropped from metastore").isEmpty();
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePartitioning.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePartitioning.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.deltalake;
 
+import com.google.common.collect.ImmutableMap;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
 import org.testng.annotations.BeforeClass;
@@ -30,14 +31,14 @@ public class TestDeltaLakePartitioning
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createDeltaLakeQueryRunner(DELTA_CATALOG);
+        return createDeltaLakeQueryRunner(DELTA_CATALOG, ImmutableMap.of(), ImmutableMap.of("delta.register-table-procedure.enabled", "true"));
     }
 
     @BeforeClass
     public void registerTables()
     {
         String dataPath = getClass().getClassLoader().getResource("deltalake/partitions").toExternalForm();
-        getQueryRunner().execute(format("CREATE TABLE partitions (t_string VARCHAR) WITH (location = '%s')", dataPath));
+        getQueryRunner().execute(format("CALL system.register_table('%s', 'partitions', '%s')", getSession().getSchema().orElseThrow(), dataPath));
     }
 
     @Test

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePerTransactionMetastoreCache.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePerTransactionMetastoreCache.java
@@ -145,6 +145,7 @@ public class TestDeltaLakePerTransactionMetastoreCache
         deltaLakeProperties.put("hive.s3.path-style-access", "true");
         deltaLakeProperties.put("hive.metastore", "test"); // use test value so we do not get clash with default bindings)
         deltaLakeProperties.put("hive.metastore-timeout", "1m"); // read timed out sometimes happens with the default timeout
+        deltaLakeProperties.put("delta.register-table-procedure.enabled", "true");
         if (!enablePerTransactionHiveMetastoreCaching) {
             // almost disable the cache; 0 is not allowed as config property value
             deltaLakeProperties.put("delta.per-transaction-metastore-cache-maximum-size", "1");
@@ -157,7 +158,7 @@ public class TestDeltaLakePerTransactionMetastoreCache
             tpchTables.forEach(table -> {
                 String tableName = table.getTableName();
                 hiveMinioDataLake.copyResources("io/trino/plugin/deltalake/testing/resources/databricks/" + tableName, tableName);
-                queryRunner.execute(format("CREATE TABLE %s.%s.%s (dummy int) WITH (location = 's3://%s/%3$s')",
+                queryRunner.execute(format("CALL %1$s.system.register_table('%2$s', '%3$s', 's3://%4$s/%3$s')",
                         DELTA_CATALOG,
                         "default",
                         tableName,

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeReadTimestamps.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeReadTimestamps.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.deltalake;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.Session;
 import io.trino.testing.AbstractTestQueryFramework;
@@ -93,14 +94,14 @@ public class TestDeltaLakeReadTimestamps
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createDeltaLakeQueryRunner(DELTA_CATALOG);
+        return createDeltaLakeQueryRunner(DELTA_CATALOG, ImmutableMap.of(), ImmutableMap.of("delta.register-table-procedure.enabled", "true"));
     }
 
     @BeforeClass
     public void registerTables()
     {
         String dataPath = getClass().getClassLoader().getResource("databricks/read_timestamps").toExternalForm();
-        getQueryRunner().execute(format("CREATE TABLE read_timestamps (col_0 VARCHAR, col_1 TIMESTAMP(3) WITH TIME ZONE) WITH (location = '%s')", dataPath));
+        getQueryRunner().execute(format("CALL system.register_table('%s', 'read_timestamps', '%s')", getSession().getSchema().orElseThrow(), dataPath));
     }
 
     @Test

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeRegisterTableProcedureWithFileMetastore.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeRegisterTableProcedureWithFileMetastore.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+
+import java.io.File;
+import java.util.Map;
+
+import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
+
+public class TestDeltaLakeRegisterTableProcedureWithFileMetastore
+        extends BaseDeltaLakeRegisterTableProcedureTest
+{
+    @Override
+    protected Map<String, String> getConnectorProperties(String dataDirectory)
+    {
+        return ImmutableMap.of(
+                "hive.metastore", "file",
+                "hive.metastore.catalog.dir", dataDirectory);
+    }
+
+    @Override
+    protected HiveMetastore createTestMetastore(String dataDirectory)
+    {
+        return createTestingFileHiveMetastore(new File(dataDirectory));
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableStatistics.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.deltalake;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
@@ -30,17 +31,15 @@ public class TestDeltaLakeTableStatistics
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createDeltaLakeQueryRunner(DELTA_CATALOG);
+        return createDeltaLakeQueryRunner(DELTA_CATALOG, ImmutableMap.of(), ImmutableMap.of("delta.register-table-procedure.enabled", "true"));
     }
 
     @BeforeClass
     public void registerTables()
     {
         String dataPath = Resources.getResource("databricks/person").toExternalForm();
-        // register the table for which we have data on disk; note that the schema is actually defined
-        // in the transaction log and is different from what we specify here
         getQueryRunner().execute(
-                format("CREATE TABLE person (name VARCHAR(256), age INTEGER) WITH (location = '%s')", dataPath));
+                format("CALL system.register_table('%s', 'person', '%s')", getSession().getSchema().orElseThrow(), dataPath));
     }
 
     @Test

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestPredicatePushdown.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestPredicatePushdown.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.deltalake;
 
 import com.google.common.collect.ContiguousSet;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import io.trino.plugin.hive.containers.HiveMinioDataLake;
 import io.trino.spi.QueryId;
@@ -26,7 +27,6 @@ import org.testng.annotations.Test;
 import org.testng.asserts.SoftAssert;
 
 import java.nio.file.Path;
-import java.util.Map;
 import java.util.OptionalLong;
 import java.util.Set;
 
@@ -47,8 +47,7 @@ public class TestPredicatePushdown
      * This single-file Parquet table has known row groups. See the test
      * resource {@code pushdown/custkey_15rowgroups/README.md} for details.
      */
-    private final TableResource testTable =
-            new TableResource("custkey_15rowgroups", "custkey bigint, mktsegment varchar, phone varchar");
+    private final TableResource testTable = new TableResource("custkey_15rowgroups");
 
     private HiveMinioDataLake hiveMinioDataLake;
 
@@ -61,7 +60,9 @@ public class TestPredicatePushdown
         return createS3DeltaLakeQueryRunner(
                 DELTA_CATALOG,
                 TEST_SCHEMA,
-                Map.of("delta.enable-non-concurrent-writes", "true"),
+                ImmutableMap.of(
+                        "delta.enable-non-concurrent-writes", "true",
+                        "delta.register-table-procedure.enabled", "true"),
                 hiveMinioDataLake.getMinioAddress(),
                 hiveMinioDataLake.getHiveHadoop());
     }
@@ -69,7 +70,7 @@ public class TestPredicatePushdown
     @Test
     public void testSelectPushdown()
     {
-        String table = testTable.create("select_pushdown");
+        String table = testTable.register("select_pushdown");
 
         assertPushdown(
                 format("SELECT custkey FROM %s WHERE custkey > 1495", table),
@@ -88,7 +89,7 @@ public class TestPredicatePushdown
     {
         String table;
 
-        table = testTable.create("delete_pushdown");
+        table = testTable.register("delete_pushdown");
         // Only 5 row groups have data above 1300, so pushdown to Parquet
         // should ensure only 500 rows are read.
         assertPushdownUpdate(
@@ -100,7 +101,7 @@ public class TestPredicatePushdown
                 execute(format("SELECT custkey FROM %s", table)).getOnlyColumnAsSet(),
                 ContiguousSet.closed(1L, 1300L));
 
-        table = testTable.create("delete_pushdown_disjoint");
+        table = testTable.register("delete_pushdown_disjoint");
         // 11 groups have data outside of (500, 1100]
         assertPushdownUpdate(
                 format("DELETE FROM %s WHERE custkey <= 500 OR custkey > 1100", table),
@@ -116,7 +117,7 @@ public class TestPredicatePushdown
     {
         String table;
 
-        table = testTable.create("update_pushdown_simple");
+        table = testTable.register("update_pushdown_simple");
         // 7 row groups include 500 in their range
         assertPushdownUpdate(
                 format("UPDATE %s SET phone = 'phone number' WHERE custkey = 500", table),
@@ -124,7 +125,7 @@ public class TestPredicatePushdown
                 700);
         assertQuery(format("SELECT phone FROM %s WHERE custkey = 500", table), "VALUES 'phone number'");
 
-        table = testTable.create("update_pushdown_range");
+        table = testTable.register("update_pushdown_range");
         // 9 groups have data on (1000, 1200]
         assertPushdownUpdate(
                 format("UPDATE %s SET mktsegment = phone WHERE 1000 < custkey AND custkey <= 1200", table),
@@ -211,27 +212,24 @@ public class TestPredicatePushdown
     private class TableResource
     {
         private final String resourcePath;
-        private final String tableDefinition;
 
-        private TableResource(String resourcePath, String tableDefinition)
+        private TableResource(String resourcePath)
         {
             this.resourcePath = resourcePath;
-            this.tableDefinition = tableDefinition;
         }
 
         /**
-         * Create a table using the described resource and the given name prefix.
-         * @return The name of the created table.
+         * Register a table in the metastore using the described resource and the given name prefix.
+         * @return The name of the registered table.
          */
-        String create(String namePrefix)
+        String register(String namePrefix)
         {
             String name = format("%s_%s", namePrefix, randomNameSuffix());
             hiveMinioDataLake.copyResources(RESOURCE_PATH.resolve(resourcePath).toString(), name);
             getQueryRunner().execute(format(
-                    "CREATE TABLE %2$s (%3$s) WITH (location = 's3://%1$s/%2$s')",
+                    "CALL system.register_table(CURRENT_SCHEMA, '%2$s', 's3://%1$s/%2$s')",
                     BUCKET_NAME,
-                    name,
-                    tableDefinition));
+                    name));
             return name;
         }
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestSplitPruning.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestSplitPruning.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.deltalake;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import io.trino.execution.QueryStats;
 import io.trino.operator.OperatorStats;
@@ -57,7 +58,7 @@ public class TestSplitPruning
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createDeltaLakeQueryRunner(DELTA_CATALOG);
+        return createDeltaLakeQueryRunner(DELTA_CATALOG, ImmutableMap.of(), ImmutableMap.of("delta.register-table-procedure.enabled", "true"));
     }
 
     @BeforeClass
@@ -66,7 +67,7 @@ public class TestSplitPruning
         for (String table : TABLES) {
             String dataPath = Resources.getResource("databricks/pruning/" + table).toExternalForm();
             getQueryRunner().execute(
-                    format("CREATE TABLE %s (part_key double, name varchar, val double) WITH (location = '%s')", table, dataPath));
+                    format("CALL system.register_table('%s', '%s', '%s')", getSession().getSchema().orElseThrow(), table, dataPath));
         }
     }
 
@@ -274,7 +275,7 @@ public class TestSplitPruning
         // log entry with invalid stats (low > high)
         String dataPath = Resources.getResource("databricks/pruning/invalid_log").toExternalForm();
         getQueryRunner().execute(
-                format("CREATE TABLE person (part_key double, name VARCHAR, val double) WITH (location = '%s')", dataPath));
+                format("CALL system.register_table('%s', 'person', '%s')", getSession().getSchema().orElseThrow(), dataPath));
         assertQueryFails("SELECT name FROM person WHERE income < 1000", "Failed to generate splits for tpch.person");
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeRegisterTableProcedureWithGlue.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeRegisterTableProcedureWithGlue.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.metastore.glue;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.deltalake.BaseDeltaLakeRegisterTableProcedureTest;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.hive.metastore.glue.DefaultGlueColumnStatisticsProviderFactory;
+import io.trino.plugin.hive.metastore.glue.GlueHiveMetastore;
+import io.trino.plugin.hive.metastore.glue.GlueHiveMetastoreConfig;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
+
+public class TestDeltaLakeRegisterTableProcedureWithGlue
+        extends BaseDeltaLakeRegisterTableProcedureTest
+{
+    @Override
+    protected Map<String, String> getConnectorProperties(String dataDirectory)
+    {
+        return ImmutableMap.of(
+                "hive.metastore", "glue",
+                "hive.metastore.glue.default-warehouse-dir", dataDirectory);
+    }
+
+    @Override
+    protected HiveMetastore createTestMetastore(String dataDirectory)
+    {
+        return new GlueHiveMetastore(
+                HDFS_ENVIRONMENT,
+                new GlueHiveMetastoreConfig(),
+                DefaultAWSCredentialsProviderChain.getInstance(),
+                directExecutor(),
+                new DefaultGlueColumnStatisticsProviderFactory(directExecutor(), directExecutor()),
+                Optional.empty(),
+                table -> true);
+    }
+}

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-minio-data-lake/delta.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-minio-data-lake/delta.properties
@@ -5,3 +5,4 @@ hive.s3.aws-secret-key=minio-secret-key
 hive.s3.endpoint=http://minio:9080/
 hive.s3.path-style-access=true
 hive.s3.ssl.enabled=false
+delta.register-table-procedure.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-delta-lake-kerberized-hdfs/delta.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-delta-lake-kerberized-hdfs/delta.properties
@@ -10,3 +10,4 @@ hive.hdfs.authentication.type=KERBEROS
 hive.hdfs.impersonation.enabled=false
 hive.hdfs.presto.principal=hdfs/hadoop-master@LABS.TERADATA.COM
 hive.hdfs.presto.keytab=/etc/hadoop/conf/hdfs.keytab
+delta.register-table-procedure.enabled=true

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/BaseTestDeltaLakeHdfsReads.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/BaseTestDeltaLakeHdfsReads.java
@@ -69,11 +69,7 @@ public abstract class BaseTestDeltaLakeHdfsReads
     @Test(groups = {DELTA_LAKE_HDFS, PROFILE_SPECIFIC_TESTS})
     public void testReads()
     {
-        onTrino().executeQuery("CREATE TABLE IF NOT EXISTS delta.default.region (" +
-                "  regionkey bigint, " +
-                "  name varchar, " +
-                "  comment varchar) " +
-                "WITH (location = 'hdfs://hadoop-master:9000/tmp/region')");
+        onTrino().executeQuery("CALL delta.system.register_table('default', 'region', 'hdfs://hadoop-master:9000/tmp/region')");
 
         assertThat(onTrino().executeQuery("SELECT count(*) FROM delta.default.region")).containsOnly(row(5L));
         onTrino().executeQuery("DROP TABLE delta.default.region");

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/BaseTestDeltaLakeMinioReads.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/BaseTestDeltaLakeMinioReads.java
@@ -72,14 +72,7 @@ public abstract class BaseTestDeltaLakeMinioReads
     @Test(groups = {DELTA_LAKE_MINIO, PROFILE_SPECIFIC_TESTS})
     public void testReadRegionTable()
     {
-        onTrino().executeQuery(format(
-                "CREATE TABLE IF NOT EXISTS delta.default.\"%1$s\" (" +
-                        "  regionkey bigint, " +
-                        "  name varchar, " +
-                        "  comment varchar) " +
-                        "WITH (location = 's3://%2$s/%1$s')",
-                tableName,
-                BUCKET_NAME));
+        onTrino().executeQuery(format("CALL delta.system.register_table('default', '%1$s', 's3://%2$s/%1$s')", tableName, BUCKET_NAME));
 
         assertThat(onTrino().executeQuery(
                 format("SELECT count(*) FROM delta.default.\"%s\"", tableName)))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fixes https://github.com/trinodb/trino/issues/13568

1. Procedure call -> `delta.system.register_table(shcema_name => 'testdb', table_name => 'table1', table_location => 's3://my-bukcet/a/path/')`
2. By default `CREATE TABLE` `with(location='***')` will not allow to register table using existing location.
3. Enable via `delta.create-table-with-existing-location.enabled` config property or `create_table_with_existing_location_enabled` session property to allow user to register table using `CREATE TABLE` statement (This support will be removed permanently after some release)
4. By default `register_table` procedure is disabled. Enable it via `delta.allow-register-table-procedure` config property

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
NA


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(X) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
