### PR TITLE
Fix compile issue

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogSkipArchive.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogSkipArchive.java
@@ -23,7 +23,7 @@ import com.amazonaws.services.glue.model.TableInput;
 import com.amazonaws.services.glue.model.TableVersion;
 import com.amazonaws.services.glue.model.UpdateTableRequest;
 import com.google.common.collect.ImmutableMap;
-import io.trino.plugin.hive.metastore.glue.GlueMetastoreApiStats;
+import io.trino.plugin.hive.aws.AwsApiCallStats;
 import io.trino.plugin.iceberg.IcebergQueryRunner;
 import io.trino.plugin.iceberg.SchemaInitializer;
 import io.trino.testing.AbstractTestQueryFramework;
@@ -131,7 +131,7 @@ public class TestIcebergGlueCatalogSkipArchive
                 new GetTableVersionsRequest().withDatabaseName(databaseName).withTableName(tableName),
                 GetTableVersionsRequest::setNextToken,
                 GetTableVersionsResult::getNextToken,
-                new GlueMetastoreApiStats())
+                new AwsApiCallStats())
                 .map(GetTableVersionsResult::getTableVersions)
                 .flatMap(Collection::stream)
                 .collect(toImmutableList());


### PR DESCRIPTION
Adapt newly merged code to match the fact that
`GlueMetastoreApiStats` class has been renamed in the meantime to a more general name `AwsApiCallStats`.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
