### PR TITLE
Fix EventDrivenTaskSource record split time

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenTaskSource.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenTaskSource.java
@@ -464,7 +464,7 @@ class EventDrivenTaskSource
                 return;
             }
             verify(splitLoadingFuture == null || splitLoadingFuture.isDone(), "splitLoadingFuture is still running");
-            long start = System.currentTimeMillis();
+            long start = System.nanoTime();
             splitLoadingFuture = splitSource.getNextBatch(splitBatchSize);
             Futures.addCallback(splitLoadingFuture, new FutureCallback<>()
             {
@@ -472,7 +472,7 @@ class EventDrivenTaskSource
                 public void onSuccess(SplitBatch result)
                 {
                     try {
-                        getSplitTimeRecorder.accept(System.currentTimeMillis() - start);
+                        getSplitTimeRecorder.accept(start);
                         ListMultimap<Integer, Split> splits = result.getSplits().stream()
                                 .collect(toImmutableListMultimap(splitToPartition::applyAsInt, Function.identity()));
                         callback.update(splits, result.isLastBatch());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

`getSplitTimeRecorder` expects start time of operation, and it needs to be defined in nanoseconds. 


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Scheduler statistics for splitting can present invalid information because use of inconsistent time units. 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: