### PR TITLE
Fix propagation of noMoreSplits flag to running tasks

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/ArbitraryDistributionSplitAssigner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/ArbitraryDistributionSplitAssigner.java
@@ -143,6 +143,13 @@ class ArbitraryDistributionSplitAssigner
                             replicatedSplits.get(replicatedSourceId),
                             true));
                 }
+                for (PlanNodeId partitionedSourceId : partitionedSources) {
+                    assignment.updatePartition(new PartitionUpdate(
+                            0,
+                            partitionedSourceId,
+                            ImmutableList.of(),
+                            true));
+                }
                 assignment.sealPartition(0);
             }
             else {
@@ -232,6 +239,14 @@ class ArbitraryDistributionSplitAssigner
                             replicatedSplits.get(replicatedSourceId),
                             true));
                 }
+                for (PlanNodeId partitionedSourceId : partitionedSources) {
+                    assignment.updatePartition(new PartitionUpdate(
+                            0,
+                            partitionedSourceId,
+                            ImmutableList.of(),
+                            true));
+                }
+
                 assignment.sealPartition(0);
             }
             else {

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenTaskSource.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenTaskSource.java
@@ -273,7 +273,9 @@ class EventDrivenTaskSource
 
     private void fail(Throwable failure)
     {
-        callback.failed(failure);
+        synchronized (assignerLock) {
+            callback.failed(failure);
+        }
         close();
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestArbitraryDistributionSplitAssigner.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestArbitraryDistributionSplitAssigner.java
@@ -47,6 +47,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Collections.shuffle;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -73,6 +74,7 @@ public class TestArbitraryDistributionSplitAssigner
         SplitAssigner splitAssigner = createSplitAssigner(ImmutableSet.of(PARTITIONED_1), ImmutableSet.of(), 100, false);
         TestingTaskSourceCallback callback = new TestingTaskSourceCallback();
         splitAssigner.assign(PARTITIONED_1, ImmutableListMultimap.of(), true).update(callback);
+        assertTrue(callback.isNoMoreSplits(0, PARTITIONED_1));
         splitAssigner.finish().update(callback);
         List<TaskDescriptor> taskDescriptors = callback.getTaskDescriptors();
         assertThat(taskDescriptors).hasSize(1);
@@ -82,6 +84,7 @@ public class TestArbitraryDistributionSplitAssigner
         splitAssigner = createSplitAssigner(ImmutableSet.of(), ImmutableSet.of(REPLICATED_1), 100, false);
         callback = new TestingTaskSourceCallback();
         splitAssigner.assign(REPLICATED_1, ImmutableListMultimap.of(), true).update(callback);
+        assertTrue(callback.isNoMoreSplits(0, REPLICATED_1));
         splitAssigner.finish().update(callback);
         taskDescriptors = callback.getTaskDescriptors();
         assertThat(taskDescriptors).hasSize(1);
@@ -91,7 +94,11 @@ public class TestArbitraryDistributionSplitAssigner
         splitAssigner = createSplitAssigner(ImmutableSet.of(PARTITIONED_1), ImmutableSet.of(REPLICATED_1), 100, true);
         callback = new TestingTaskSourceCallback();
         splitAssigner.assign(REPLICATED_1, ImmutableListMultimap.of(), true).update(callback);
+        assertFalse(callback.isNoMoreSplits(0, PARTITIONED_1));
+        assertFalse(callback.isNoMoreSplits(0, REPLICATED_1));
         splitAssigner.assign(PARTITIONED_1, ImmutableListMultimap.of(), true).update(callback);
+        assertTrue(callback.isNoMoreSplits(0, PARTITIONED_1));
+        assertTrue(callback.isNoMoreSplits(0, REPLICATED_1));
         splitAssigner.finish().update(callback);
         taskDescriptors = callback.getTaskDescriptors();
         assertThat(taskDescriptors).hasSize(1);
@@ -100,7 +107,11 @@ public class TestArbitraryDistributionSplitAssigner
         splitAssigner = createSplitAssigner(ImmutableSet.of(PARTITIONED_1), ImmutableSet.of(REPLICATED_1), 100, true);
         callback = new TestingTaskSourceCallback();
         splitAssigner.assign(PARTITIONED_1, ImmutableListMultimap.of(), true).update(callback);
+        assertFalse(callback.isNoMoreSplits(0, PARTITIONED_1));
+        assertFalse(callback.isNoMoreSplits(0, REPLICATED_1));
         splitAssigner.assign(REPLICATED_1, ImmutableListMultimap.of(), true).update(callback);
+        assertTrue(callback.isNoMoreSplits(0, PARTITIONED_1));
+        assertTrue(callback.isNoMoreSplits(0, REPLICATED_1));
         splitAssigner.finish().update(callback);
         taskDescriptors = callback.getTaskDescriptors();
         assertThat(taskDescriptors).hasSize(1);
@@ -111,7 +122,16 @@ public class TestArbitraryDistributionSplitAssigner
         splitAssigner.assign(REPLICATED_1, ImmutableListMultimap.of(), true).update(callback);
         splitAssigner.assign(PARTITIONED_1, ImmutableListMultimap.of(), true).update(callback);
         splitAssigner.assign(PARTITIONED_2, ImmutableListMultimap.of(), true).update(callback);
+        assertFalse(callback.isNoMoreSplits(0, PARTITIONED_1));
+        assertFalse(callback.isNoMoreSplits(0, REPLICATED_1));
+        assertFalse(callback.isNoMoreSplits(0, PARTITIONED_2));
+        assertFalse(callback.isNoMoreSplits(0, REPLICATED_2));
         splitAssigner.assign(REPLICATED_2, ImmutableListMultimap.of(), true).update(callback);
+        assertTrue(callback.isNoMoreSplits(0, PARTITIONED_1));
+        assertTrue(callback.isNoMoreSplits(0, REPLICATED_1));
+        assertTrue(callback.isNoMoreSplits(0, PARTITIONED_2));
+        assertTrue(callback.isNoMoreSplits(0, REPLICATED_2));
+
         splitAssigner.finish().update(callback);
         taskDescriptors = callback.getTaskDescriptors();
         assertThat(taskDescriptors).hasSize(1);


### PR DESCRIPTION
Without the fix, the update with noMoreSplits=true was not called
on an open partition in the case when source fragments did not generate any splits.
As a result of that, if tasks consuming this partition were scheduled
before the partition was sealed they never learned that there will not be any more
splits for the partition, and never finished. As a result, the query hung.

The common case was that query was completed successfully as usually tasks
only started after the partition was already sealed which implied
noMoreSplits=true, even if not set explicitly.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Engine
* Fix a rare condition when some queries where one of the stages did not produce any data could hang indefinitely when running in fault-tolerant mode (with `retry-mode` set to `TASK`). ({issue}`14794`)
```
