### PR TITLE
Enable predicate pushdown in MongoDB temporal types

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoColumnHandle.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoColumnHandle.java
@@ -23,7 +23,6 @@ import org.bson.Document;
 import java.util.Objects;
 import java.util.Optional;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class MongoColumnHandle
@@ -114,11 +113,6 @@ public class MongoColumnHandle
     @Override
     public String toString()
     {
-        return toStringHelper(this)
-                .add("name", name)
-                .add("type", type)
-                .add("hidden", hidden)
-                .add("comment", comment)
-                .toString();
+        return name + ":" + type;
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -409,7 +409,7 @@ public class MongoSession
         Document filter = buildFilter(tableHandle);
         FindIterable<Document> iterable = collection.find(filter).projection(output);
         tableHandle.getLimit().ifPresent(iterable::limit);
-        log.debug("Find documents: collection: %s, filter: %s, projection: %s", tableHandle.getSchemaTableName(), filter.toJson(), output);
+        log.debug("Find documents: collection: %s, filter: %s, projection: %s", tableHandle.getSchemaTableName(), filter, output);
 
         if (cursorBatchSize != 0) {
             iterable.batchSize(cursorBatchSize);

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTableHandle.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTableHandle.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class MongoTableHandle
@@ -102,6 +103,11 @@ public class MongoTableHandle
     @Override
     public String toString()
     {
-        return schemaTableName.toString();
+        return toStringHelper(this)
+                .add("schemaTableName", schemaTableName)
+                .add("filter", filter)
+                .add("limit", limit)
+                .add("constraint", constraint)
+                .toString();
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
@@ -24,9 +24,13 @@ import java.util.Set;
 
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.StandardTypes.JSON;
+import static io.trino.spi.type.TimeType.TIME_MILLIS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.TinyintType.TINYINT;
 
 public final class TypeUtils
@@ -36,7 +40,11 @@ public final class TypeUtils
             TINYINT,
             SMALLINT,
             INTEGER,
-            BIGINT);
+            BIGINT,
+            DATE,
+            TIME_MILLIS,
+            TIMESTAMP_MILLIS,
+            TIMESTAMP_TZ_MILLIS);
 
     private TypeUtils() {}
 

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
@@ -259,6 +259,10 @@ public abstract class BaseMongoConnectorTest
                 {"bigint '4'"},
                 {"'test'"},
                 {"objectid('6216f0c6c432d45190f25e7c')"},
+                {"date '1970-01-01'"},
+                {"time '00:00:00.000'"},
+                {"timestamp '1970-01-01 00:00:00.000'"},
+                {"timestamp '1970-01-01 00:00:00.000 UTC'"},
         };
     }
 

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
@@ -239,6 +239,29 @@ public abstract class BaseMongoConnectorTest
         assertFalse(getQueryRunner().tableExists(getSession(), "test_insert_types_table"));
     }
 
+    @Test(dataProvider = "predicatePushdownProvider")
+    public void testPredicatePushdown(String value)
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_predicate_pushdown", "AS SELECT %s col".formatted(value))) {
+            assertThat(query("SELECT * FROM " + table.getName() + " WHERE col = " + value + ""))
+                    .isFullyPushedDown();
+        }
+    }
+
+    @DataProvider
+    public Object[][] predicatePushdownProvider()
+    {
+        return new Object[][] {
+                {"true"},
+                {"tinyint '1'"},
+                {"smallint '2'"},
+                {"integer '3'"},
+                {"bigint '4'"},
+                {"'test'"},
+                {"objectid('6216f0c6c432d45190f25e7c')"},
+        };
+    }
+
     @Test
     public void testJson()
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Follow-up of #14413. Changes in TypeUtils were missing.


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# MongoDB
* Support predicate pushdown on `date`, `time(3)`, `timestamp(3)` and
  `timestamp(3) with time zone` columns. ({issue}`14795`)
```
