### PR TITLE
Remove PTF mention from table function ordering fragment

### DIFF
--- a/docs/src/main/sphinx/connector/bigquery.rst
+++ b/docs/src/main/sphinx/connector/bigquery.rst
@@ -355,8 +355,6 @@ running a query natively may be faster.
 
 .. include:: query-passthrough-warning.fragment
 
-.. include:: polymorphic-table-function-ordering.fragment
-
 For example, query the ``example`` catalog and group and concatenate all
 employee IDs by manager ID::
 
@@ -373,6 +371,8 @@ employee IDs by manager ID::
             manager_id'
         )
       );
+
+.. include:: query-table-function-ordering.fragment
 
 FAQ
 ---

--- a/docs/src/main/sphinx/connector/cassandra.rst
+++ b/docs/src/main/sphinx/connector/cassandra.rst
@@ -414,7 +414,7 @@ processed by Cassandra. This can be useful for accessing native features which a
 not available in Trino or for improving query performance in situations where
 running a query natively may be faster.
 
-.. include:: polymorphic-table-function-ordering.fragment
+.. include:: query-table-function-ordering.fragment
 
 As a simple example, to select an entire table::
 

--- a/docs/src/main/sphinx/connector/druid.rst
+++ b/docs/src/main/sphinx/connector/druid.rst
@@ -136,8 +136,6 @@ running a query natively may be faster.
 
 .. include:: query-passthrough-warning.fragment
 
-.. include:: polymorphic-table-function-ordering.fragment
-
 As an example, query the ``example`` catalog and use ``STRING_TO_MV`` and
 ``MV_LENGTH`` from `Druid SQL's multi-value string functions
 <https://druid.apache.org/docs/latest/querying/sql-multivalue-string-functions.html>`_
@@ -156,3 +154,4 @@ to split and then count the number of comma-separated values in a column::
         )
       );
 
+.. include:: query-table-function-ordering.fragment

--- a/docs/src/main/sphinx/connector/elasticsearch.rst
+++ b/docs/src/main/sphinx/connector/elasticsearch.rst
@@ -442,8 +442,6 @@ natively may be faster.
 
 .. include:: query-passthrough-warning.fragment
 
-.. include:: polymorphic-table-function-ordering.fragment
-
 The ``raw_query`` function requires three parameters:
 
 * ``schema``: The schema in the catalog that the query is to be executed on.
@@ -473,3 +471,5 @@ is ``ALGERIA``::
           }'
         )
       );
+
+.. include:: query-table-function-ordering.fragment

--- a/docs/src/main/sphinx/connector/mariadb.rst
+++ b/docs/src/main/sphinx/connector/mariadb.rst
@@ -302,8 +302,6 @@ running a query natively may be faster.
 
 .. include:: query-passthrough-warning.fragment
 
-.. include:: polymorphic-table-function-ordering.fragment
-
 As an example, query the ``example`` catalog and select the age of employees by
 using ``TIMESTAMPDIFF`` and ``CURDATE``::
 
@@ -322,6 +320,8 @@ using ``TIMESTAMPDIFF`` and ``CURDATE``::
             tiny.employees'
         )
       );
+
+.. include:: query-table-function-ordering.fragment
 
 Performance
 -----------

--- a/docs/src/main/sphinx/connector/mysql.rst
+++ b/docs/src/main/sphinx/connector/mysql.rst
@@ -345,8 +345,6 @@ running a query natively may be faster.
 
 .. include:: query-passthrough-warning.fragment
 
-.. include:: polymorphic-table-function-ordering.fragment
-
 For example, query the ``example`` catalog and group and concatenate all
 employee IDs by manager ID::
 
@@ -363,6 +361,8 @@ employee IDs by manager ID::
             manager_id'
         )
       );
+
+.. include:: query-table-function-ordering.fragment
 
 Performance
 -----------

--- a/docs/src/main/sphinx/connector/oracle.rst
+++ b/docs/src/main/sphinx/connector/oracle.rst
@@ -430,8 +430,6 @@ running a query natively may be faster.
 
 .. include:: query-passthrough-warning.fragment
 
-.. include:: polymorphic-table-function-ordering.fragment
-
 As a simple example, query the ``example`` catalog and select an entire table::
 
     SELECT
@@ -477,6 +475,8 @@ As a practical example, you can use the
             country'
         )
       );
+
+.. include:: query-table-function-ordering.fragment
 
 Performance
 -----------

--- a/docs/src/main/sphinx/connector/polymorphic-table-function-ordering.fragment
+++ b/docs/src/main/sphinx/connector/polymorphic-table-function-ordering.fragment
@@ -1,5 +1,0 @@
-.. note::
-
-    Polymorphic table functions may not preserve the order of the query result.
-    If the table function contains a query with an ``ORDER BY`` clause, the
-    function result may not be ordered as expected.

--- a/docs/src/main/sphinx/connector/postgresql.rst
+++ b/docs/src/main/sphinx/connector/postgresql.rst
@@ -354,8 +354,6 @@ where running a query natively may be faster.
 
 .. include:: query-passthrough-warning.fragment
 
-.. include:: polymorphic-table-function-ordering.fragment
-
 As a simple example, query the ``example`` catalog and select an entire table::
 
     SELECT
@@ -402,6 +400,7 @@ when using window functions::
         )
       );
 
+.. include:: query-table-function-ordering.fragment
 
 Performance
 -----------

--- a/docs/src/main/sphinx/connector/query-table-function-ordering.fragment
+++ b/docs/src/main/sphinx/connector/query-table-function-ordering.fragment
@@ -1,0 +1,5 @@
+.. note::
+
+    The query engine does not preserve the order of the results of this
+    function. If the passed query contains an ``ORDER BY`` clause, the
+    function result may not be ordered as expected.

--- a/docs/src/main/sphinx/connector/redshift.rst
+++ b/docs/src/main/sphinx/connector/redshift.rst
@@ -169,8 +169,6 @@ where running a query natively may be faster.
 
 .. include:: query-passthrough-warning.fragment
 
-.. include:: polymorphic-table-function-ordering.fragment
-
 For example, query the ``example`` catalog and select the top 10 nations by
 population::
 
@@ -188,3 +186,4 @@ population::
         )
       );
 
+.. include:: query-table-function-ordering.fragment

--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -358,8 +358,6 @@ where running a query natively may be faster.
 
 .. include:: query-passthrough-warning.fragment
 
-.. include:: polymorphic-table-function-ordering.fragment
-
 For example, query the ``example`` catalog and select the top 10 percent of
 nations by population::
 
@@ -421,6 +419,8 @@ append the parameter value to the procedure statement::
           query => 'EXECUTE example_schema.employee_sp 0'
         )
       );
+
+.. include:: query-table-function-ordering.fragment
 
 Performance
 -----------


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Follow up to discussion https://github.com/trinodb/trino/pull/14505#discussion_r1006963928

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Modify the documentation fragment describing row ordering not being preserved by some table functions to not focus on polymorphic table functions specifically

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
