### PR TITLE
Fix incorrect result due to different column order in equality delete filter in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/EqualityDeleteFilter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/EqualityDeleteFilter.java
@@ -19,14 +19,11 @@ import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.type.Type;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
-import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.StructLikeSet;
 import org.apache.iceberg.util.StructProjection;
 
 import java.util.List;
-import java.util.Set;
 
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.plugin.iceberg.IcebergUtil.schemaFromHandles;
 import static java.util.Objects.requireNonNull;
 
@@ -60,15 +57,11 @@ public final class EqualityDeleteFilter
 
     public static DeleteFilter readEqualityDeletes(ConnectorPageSource pageSource, List<IcebergColumnHandle> columns, Schema tableSchema)
     {
-        Set<Integer> ids = columns.stream()
-                .map(IcebergColumnHandle::getId)
-                .collect(toImmutableSet());
-
         Type[] types = columns.stream()
                 .map(IcebergColumnHandle::getType)
                 .toArray(Type[]::new);
 
-        Schema deleteSchema = TypeUtil.select(tableSchema, ids);
+        Schema deleteSchema = schemaFromHandles(columns);
         StructLikeSet deleteSet = StructLikeSet.create(deleteSchema.asStruct());
 
         while (!pageSource.isFinished()) {


### PR DESCRIPTION
## Description

Fixes #14693

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Fix incorrect result when column orders in equality delete filter is different from the table definition. ({issue}`14693`)
```
