### PR TITLE
Repackage Iceberg runtime exceptions into TrinoException during add/d…

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -160,6 +160,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -1477,9 +1478,14 @@ public class IcebergMetadata
             throw new TrinoException(NOT_SUPPORTED, "This connector does not support adding not null columns");
         }
         Table icebergTable = catalog.loadTable(session, ((IcebergTableHandle) tableHandle).getSchemaTableName());
-        icebergTable.updateSchema()
-                .addColumn(column.getName(), toIcebergType(column.getType()), column.getComment())
-                .commit();
+        try {
+            icebergTable.updateSchema()
+                    .addColumn(column.getName(), toIcebergType(column.getType()), column.getComment())
+                    .commit();
+        }
+        catch (RuntimeException e) {
+            throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to add column: " + firstNonNull(e.getMessage(), e), e);
+        }
     }
 
     @Override
@@ -1487,9 +1493,14 @@ public class IcebergMetadata
     {
         IcebergColumnHandle handle = (IcebergColumnHandle) column;
         Table icebergTable = catalog.loadTable(session, ((IcebergTableHandle) tableHandle).getSchemaTableName());
-        icebergTable.updateSchema()
-                .deleteColumn(handle.getName())
-                .commit();
+        try {
+            icebergTable.updateSchema()
+                    .deleteColumn(handle.getName())
+                    .commit();
+        }
+        catch (RuntimeException e) {
+            throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to drop column: " + firstNonNull(e.getMessage(), e), e);
+        }
     }
 
     @Override
@@ -1497,9 +1508,14 @@ public class IcebergMetadata
     {
         IcebergColumnHandle columnHandle = (IcebergColumnHandle) source;
         Table icebergTable = catalog.loadTable(session, ((IcebergTableHandle) tableHandle).getSchemaTableName());
-        icebergTable.updateSchema()
-                .renameColumn(columnHandle.getName(), target)
-                .commit();
+        try {
+            icebergTable.updateSchema()
+                    .renameColumn(columnHandle.getName(), target)
+                    .commit();
+        }
+        catch (RuntimeException e) {
+            throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to rename column: " + firstNonNull(e.getMessage(), e), e);
+        }
     }
 
     private List<ColumnMetadata> getColumnMetadatas(Schema schema)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -204,7 +204,7 @@ public abstract class BaseIcebergConnectorTest
     {
         if (columnName.equals("a.dot")) {
             assertThatThrownBy(() -> super.testAddAndDropColumnName(columnName))
-                    .hasMessageContaining("Cannot add column with ambiguous name");
+                    .hasMessage("Failed to add column: Cannot add column with ambiguous name: a.dot, use addColumn(parent, name, type)");
             return;
         }
         super.testAddAndDropColumnName(columnName);
@@ -231,6 +231,8 @@ public abstract class BaseIcebergConnectorTest
     protected void verifyConcurrentAddColumnFailurePermissible(Exception e)
     {
         assertThat(e)
+                .hasMessageStartingWith("Failed to add column: Failed to replace table due to concurrent updates")
+                .getRootCause()
                 .hasMessageContaining("Cannot update Iceberg table: supplied previous location does not match current location");
     }
 
@@ -4428,12 +4430,12 @@ public abstract class BaseIcebergConnectorTest
 
         assertUpdate("CREATE TABLE ambiguous (\"a.cow\" BIGINT, b ROW(cow BIGINT))");
         assertThatThrownBy(() -> assertUpdate("ALTER TABLE ambiguous RENAME COLUMN b TO a"))
-                .hasMessage("Invalid schema: multiple fields for name a.cow: 1 and 3");
+                .hasMessage("Failed to rename column: Invalid schema: multiple fields for name a.cow: 1 and 3");
         assertUpdate("DROP TABLE ambiguous");
 
         assertUpdate("CREATE TABLE ambiguous (a ROW(cow BIGINT))");
         assertThatThrownBy(() -> assertUpdate("ALTER TABLE ambiguous ADD COLUMN \"a.cow\" BIGINT"))
-                .hasMessage("Cannot add column with ambiguous name: a.cow, use addColumn(parent, name, type)");
+                .hasMessage("Failed to add column: Cannot add column with ambiguous name: a.cow, use addColumn(parent, name, type)");
         assertUpdate("DROP TABLE ambiguous");
     }
 


### PR DESCRIPTION
While working on https://github.com/trinodb/trino/pull/13294 we noticed that during adding/dropping/renaming a column a direct `CommitFailedException` can be thrown from these methods. However, such exceptions should most likely be wrapped in a `TrinoException`