### PR TITLE
Decrease number of old JDBC drivers tested

### DIFF
--- a/testing/trino-test-jdbc-compatibility-old-driver/bin/run_tests.sh
+++ b/testing/trino-test-jdbc-compatibility-old-driver/bin/run_tests.sh
@@ -12,7 +12,7 @@ current_version=$(${maven} help:evaluate -Dexpression=project.version -q -Dforce
 previous_released_version=$((${current_version%-SNAPSHOT}-1))
 first_tested_version=352
 # test n-th version only
-version_step=3
+version_step=5
 
 echo "Current version: ${current_version}"
 


### PR DESCRIPTION
Decrease the number of JDBC versions tested as we started getting timeout on CI often recently.

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
