### PR TITLE
Reduce writers retained memory utilization

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -48,6 +48,7 @@ import org.roaringbitmap.longlong.ImmutableLongBitmapDataProvider;
 import org.roaringbitmap.longlong.LongBitmapDataProvider;
 import org.roaringbitmap.longlong.Roaring64Bitmap;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -55,7 +56,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.IntStream;
 
@@ -210,10 +210,7 @@ public class DeltaLakeMergeSink
         CompressionCodecName compressionCodecName = getCompressionCodec(session).getParquetCompressionCodec();
 
         try {
-            Callable<Void> rollbackAction = () -> {
-                fileSystem.delete(path, false);
-                return null;
-            };
+            Closeable rollbackAction = () -> fileSystem.delete(path, false);
 
             List<Type> parquetTypes = dataColumns.stream()
                     .map(column -> {

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -170,7 +170,7 @@ public class DeltaLakeMergeSink
         return completedFuture(fragments);
     }
 
-     // In spite of the name "Delta" Lake, we must rewrite the entire file to delete rows.
+    // In spite of the name "Delta" Lake, we must rewrite the entire file to delete rows.
     private List<Slice> rewriteFile(Path sourcePath, FileDeletion deletion)
     {
         try {

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.joda.time.DateTimeZone;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -57,7 +58,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 
 import static com.google.common.base.Verify.verify;
@@ -469,10 +469,7 @@ public class DeltaLakePageSink
 
         try {
             FileSystem fileSystem = hdfsEnvironment.getFileSystem(session.getIdentity(), path, conf);
-            Callable<Void> rollbackAction = () -> {
-                fileSystem.delete(path, false);
-                return null;
-            };
+            Closeable rollbackAction = () -> fileSystem.delete(path, false);
 
             List<Type> parquetTypes = dataColumnTypes.stream()
                     .map(type -> {

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
@@ -405,6 +405,7 @@ public class DeltaLakePageSink
                         dataColumnHandles);
 
                 writers.set(writerIndex, writer);
+                memoryUsage += writer.getMemoryUsage();
             }
             catch (IOException e) {
                 throw new TrinoException(DELTA_LAKE_BAD_WRITE, "Unable to create writer for location: " + outputPath, e);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
@@ -35,6 +35,7 @@ import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Collection;
@@ -139,9 +140,9 @@ public class DeltaLakeWriter
     }
 
     @Override
-    public void commit()
+    public Closeable commit()
     {
-        fileWriter.commit();
+        return fileWriter.commit();
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/FileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/FileWriter.java
@@ -15,6 +15,7 @@ package io.trino.plugin.hive;
 
 import io.trino.spi.Page;
 
+import java.io.Closeable;
 import java.util.Optional;
 
 public interface FileWriter
@@ -25,7 +26,10 @@ public interface FileWriter
 
     void appendRows(Page dataPage);
 
-    void commit();
+    /**
+     * Commits written data. Returns rollback {@link Closeable} which can be used to cleanup on failure.
+     */
+    Closeable commit();
 
     void rollback();
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSink.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSink.java
@@ -405,6 +405,7 @@ public class HivePageSink
             writer = writerFactory.createWriter(partitionColumns, position, bucketNumber);
 
             writers.set(writerIndex, writer);
+            memoryUsage += writer.getMemoryUsage();
         }
         verify(writers.size() == pagePartitioner.getMaxIndex() + 1);
         verify(!writers.contains(null));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSink.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSink.java
@@ -14,14 +14,13 @@
 package io.trino.plugin.hive;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
+import com.google.common.collect.Streams;
 import com.google.common.primitives.Ints;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import io.airlift.concurrent.MoreFutures;
 import io.airlift.json.JsonCodec;
-import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
 import io.trino.hdfs.HdfsEnvironment;
 import io.trino.plugin.hive.util.HiveBucketing.BucketingVersion;
@@ -38,11 +37,13 @@ import io.trino.spi.type.Type;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.Callable;
@@ -51,6 +52,7 @@ import java.util.concurrent.Executors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_TOO_MANY_OPEN_PARTITIONS;
@@ -63,8 +65,6 @@ import static java.util.stream.Collectors.toList;
 public class HivePageSink
         implements ConnectorPageSink, ConnectorMergeSink
 {
-    private static final Logger log = Logger.get(HivePageSink.class);
-
     private static final int MAX_PAGE_POSITIONS = 4096;
 
     private final HiveWriterFactory writerFactory;
@@ -89,7 +89,7 @@ public class HivePageSink
     private final ConnectorSession session;
 
     private final long targetMaxFileSize;
-    private final List<HiveWriter> closedWriters = new ArrayList<>();
+    private final List<Closeable> closedWriterRollbackActions = new ArrayList<>();
     private final List<Slice> partitionUpdates = new ArrayList<>();
     private final List<Callable<Object>> verificationTasks = new ArrayList<>();
 
@@ -218,17 +218,12 @@ public class HivePageSink
 
     private ListenableFuture<Collection<Slice>> doInsertSinkFinish()
     {
-        for (HiveWriter writer : writers) {
-            closeWriter(writer);
+        for (int writerIndex = 0; writerIndex < writers.size(); writerIndex++) {
+            closeWriter(writerIndex);
         }
-        List<Slice> result = ImmutableList.copyOf(partitionUpdates);
+        writers.clear();
 
-        writtenBytes = closedWriters.stream()
-                .mapToLong(HiveWriter::getWrittenBytes)
-                .sum();
-        validationCpuNanos = closedWriters.stream()
-                .mapToLong(HiveWriter::getValidationCpuNanos)
-                .sum();
+        List<Slice> result = ImmutableList.copyOf(partitionUpdates);
 
         if (verificationTasks.isEmpty()) {
             return Futures.immediateFuture(result);
@@ -256,13 +251,17 @@ public class HivePageSink
 
     private void doAbort()
     {
+        List<Closeable> rollbackActions = Streams.concat(
+                        writers.stream()
+                                // writers can contain nulls if an exception is thrown when doAppend expends the writer list
+                                .filter(Objects::nonNull)
+                                .map(writer -> writer::rollback),
+                        closedWriterRollbackActions.stream())
+                .collect(toImmutableList());
         RuntimeException rollbackException = null;
-        for (HiveWriter writer : Iterables.concat(writers, closedWriters)) {
+        for (Closeable rollbackAction : rollbackActions) {
             try {
-                // writers can contain nulls if an exception is thrown when doAppend expends the writer list
-                if (writer != null) {
-                    writer.rollback();
-                }
+                rollbackAction.close();
             }
             catch (Throwable t) {
                 if (rollbackException == null) {
@@ -351,15 +350,20 @@ public class HivePageSink
         }
     }
 
-    private void closeWriter(HiveWriter writer)
+    private void closeWriter(int writerIndex)
     {
+        HiveWriter writer = writers.get(writerIndex);
+
         long currentWritten = writer.getWrittenBytes();
         long currentMemory = writer.getMemoryUsage();
-        writer.commit();
-        writtenBytes += (writer.getWrittenBytes() - currentWritten);
-        memoryUsage += (writer.getMemoryUsage() - currentMemory);
 
-        closedWriters.add(writer);
+        closedWriterRollbackActions.add(writer.commit());
+
+        writtenBytes += (writer.getWrittenBytes() - currentWritten);
+        memoryUsage -= currentMemory;
+        validationCpuNanos += writer.getValidationCpuNanos();
+
+        writers.set(writerIndex, null);
 
         PartitionUpdate partitionUpdate = writer.getPartitionUpdate();
         partitionUpdates.add(wrappedBuffer(partitionUpdateCodec.toJsonBytes(partitionUpdate)));
@@ -394,7 +398,7 @@ public class HivePageSink
                     continue;
                 }
                 // close current writer
-                closeWriter(writer);
+                closeWriter(writerIndex);
             }
 
             OptionalInt bucketNumber = OptionalInt.empty();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveStorageFormat.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveStorageFormat.java
@@ -61,12 +61,12 @@ public enum HiveStorageFormat
             OrcSerde.class.getName(),
             OrcInputFormat.class.getName(),
             OrcOutputFormat.class.getName(),
-            DataSize.of(256, Unit.MEGABYTE)),
+            DataSize.of(64, Unit.MEGABYTE)),
     PARQUET(
             ParquetHiveSerDe.class.getName(),
             MapredParquetInputFormat.class.getName(),
             MapredParquetOutputFormat.class.getName(),
-            DataSize.of(128, Unit.MEGABYTE)),
+            DataSize.of(64, Unit.MEGABYTE)),
     AVRO(
             AvroSerDe.class.getName(),
             AvroContainerInputFormat.class.getName(),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriter.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.trino.plugin.hive.PartitionUpdate.UpdateMode;
 import io.trino.spi.Page;
 
+import java.io.Closeable;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -86,10 +87,11 @@ public class HiveWriter
         inputSizeInBytes += dataPage.getSizeInBytes();
     }
 
-    public void commit()
+    public Closeable commit()
     {
-        fileWriter.commit();
+        Closeable rollbackAction = fileWriter.commit();
         onCommit.accept(this);
+        return rollbackAction;
     }
 
     long getValidationCpuNanos()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/MergeFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/MergeFileWriter.java
@@ -107,7 +107,7 @@ public class MergeFileWriter
                 .filter(column -> !column.isPartitionKey() && !column.isHidden())
                 .map(column -> insertPage.getBlock(column.getBaseHiveColumnIndex()))
                 .collect(toImmutableList());
-        Block mergedColumnsBlock = RowBlock.fromFieldBlocks(positionCount, Optional.empty(), dataColumns.toArray(new Block[]{}));
+        Block mergedColumnsBlock = RowBlock.fromFieldBlocks(positionCount, Optional.empty(), dataColumns.toArray(new Block[] {}));
         Block currentTransactionBlock = RunLengthEncodedBlock.create(BIGINT, writeId, positionCount);
         Block[] blockArray = {
                 RunLengthEncodedBlock.create(INSERT_OPERATION_BLOCK, positionCount),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriter.java
@@ -131,7 +131,7 @@ public class RcFileFileWriter
     }
 
     @Override
-    public void commit()
+    public Closeable commit()
     {
         try {
             rcFileWriter.close();
@@ -158,6 +158,8 @@ public class RcFileFileWriter
                 throw new TrinoException(HIVE_WRITE_VALIDATION_FAILED, e);
             }
         }
+
+        return rollbackAction;
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriter.java
@@ -163,13 +163,8 @@ public class RcFileFileWriter
     @Override
     public void rollback()
     {
-        try {
-            try {
-                rcFileWriter.close();
-            }
-            finally {
-                rollbackAction.close();
-            }
+        try (rollbackAction) {
+            rcFileWriter.close();
         }
         catch (Exception e) {
             throw new TrinoException(HIVE_WRITER_CLOSE_ERROR, "Error rolling back write to Hive", e);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriterFactory.java
@@ -36,13 +36,13 @@ import org.joda.time.DateTimeZone;
 
 import javax.inject.Inject;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Properties;
-import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_OPEN_ERROR;
@@ -152,10 +152,7 @@ public class RcFileFileWriterFactory
                 });
             }
 
-            Callable<Void> rollbackAction = () -> {
-                fileSystem.delete(path, false);
-                return null;
-            };
+            Closeable rollbackAction = () -> fileSystem.delete(path, false);
 
             return Optional.of(new RcFileFileWriter(
                     outputStream,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RecordFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RecordFileWriter.java
@@ -193,7 +193,7 @@ public class RecordFileWriter
     }
 
     @Override
-    public void commit()
+    public Closeable commit()
     {
         try {
             recordWriter.close(false);
@@ -202,6 +202,8 @@ public class RecordFileWriter
         catch (IOException e) {
             throw new TrinoException(HIVE_WRITER_CLOSE_ERROR, "Error committing write to Hive", e);
         }
+
+        return createRollbackAction(path, conf);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriter.java
@@ -240,13 +240,8 @@ public class OrcFileWriter
     @Override
     public void rollback()
     {
-        try {
-            try {
-                orcWriter.close();
-            }
-            finally {
-                rollbackAction.close();
-            }
+        try (rollbackAction) {
+            orcWriter.close();
         }
         catch (Exception e) {
             throw new TrinoException(HIVE_WRITER_CLOSE_ERROR, "Error rolling back write to Hive", e);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriter.java
@@ -180,7 +180,7 @@ public class OrcFileWriter
     }
 
     @Override
-    public void commit()
+    public Closeable commit()
     {
         try {
             if (transaction.isAcidTransactionRunning() && useAcidSchema) {
@@ -211,6 +211,8 @@ public class OrcFileWriter
                 throw new TrinoException(HIVE_WRITE_VALIDATION_FAILED, e);
             }
         }
+
+        return rollbackAction;
     }
 
     private void updateUserMetadata()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriterFactory.java
@@ -46,12 +46,12 @@ import org.weakref.jmx.Managed;
 
 import javax.inject.Inject;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Properties;
-import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
 import static io.trino.orc.metadata.OrcType.createRootOrcType;
@@ -183,10 +183,7 @@ public class OrcFileWriterFactory
                 });
             }
 
-            Callable<Void> rollbackAction = () -> {
-                fileSystem.deleteFile(stringPath);
-                return null;
-            };
+            Closeable rollbackAction = () -> fileSystem.deleteFile(stringPath);
 
             if (transaction.isInsert() && useAcidSchema) {
                 // Only add the ACID columns if the request is for insert-type operations - - for delete operations,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
@@ -138,7 +138,7 @@ public class ParquetFileWriter
     }
 
     @Override
-    public void commit()
+    public Closeable commit()
     {
         try {
             parquetWriter.close();
@@ -165,6 +165,8 @@ public class ParquetFileWriter
                 throw new TrinoException(HIVE_WRITE_VALIDATION_FAILED, e);
             }
         }
+
+        return rollbackAction;
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
@@ -170,13 +170,8 @@ public class ParquetFileWriter
     @Override
     public void rollback()
     {
-        try {
-            try {
-                parquetWriter.close();
-            }
-            finally {
-                rollbackAction.close();
-            }
+        try (rollbackAction) {
+            parquetWriter.close();
         }
         catch (Exception e) {
             throw new TrinoException(HIVE_WRITER_CLOSE_ERROR, "Error rolling back write parquet to Hive", e);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
@@ -44,12 +44,12 @@ import org.weakref.jmx.Managed;
 
 import javax.inject.Inject;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Properties;
-import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
 import static io.trino.parquet.writer.ParquetSchemaConverter.HIVE_PARQUET_USE_INT96_TIMESTAMP_ENCODING;
@@ -128,10 +128,7 @@ public class ParquetFileWriterFactory
         try {
             FileSystem fileSystem = hdfsEnvironment.getFileSystem(session.getIdentity(), path, conf);
 
-            Callable<Void> rollbackAction = () -> {
-                fileSystem.delete(path, false);
-                return null;
-            };
+            Closeable rollbackAction = () -> fileSystem.delete(path, false);
 
             ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(
                     fileColumnTypes,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroFileWriter.java
@@ -97,7 +97,7 @@ public class IcebergAvroFileWriter
     }
 
     @Override
-    public void commit()
+    public Closeable commit()
     {
         try {
             avroWriter.close();
@@ -113,6 +113,8 @@ public class IcebergAvroFileWriter
             }
             throw new TrinoException(ICEBERG_WRITER_CLOSE_ERROR, "Error closing Avro file", e);
         }
+
+        return rollbackAction;
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroFileWriter.java
@@ -118,13 +118,8 @@ public class IcebergAvroFileWriter
     @Override
     public void rollback()
     {
-        try {
-            try {
-                avroWriter.close();
-            }
-            finally {
-                rollbackAction.close();
-            }
+        try (rollbackAction) {
+            avroWriter.close();
         }
         catch (Exception e) {
             throw new TrinoException(ICEBERG_WRITER_CLOSE_ERROR, "Error rolling back write to Avro file", e);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
@@ -41,12 +41,12 @@ import org.weakref.jmx.Managed;
 
 import javax.inject.Inject;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
@@ -172,10 +172,7 @@ public class IcebergFileWriterFactory
         try {
             OutputStream outputStream = fileSystem.newOutputFile(outputPath).create();
 
-            Callable<Void> rollbackAction = () -> {
-                fileSystem.deleteFile(outputPath);
-                return null;
-            };
+            Closeable rollbackAction = () -> fileSystem.deleteFile(outputPath);
 
             ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
                     .setMaxPageSize(getParquetWriterPageSize(session))
@@ -215,10 +212,7 @@ public class IcebergFileWriterFactory
         try {
             OrcDataSink orcDataSink = new OutputStreamOrcDataSink(fileSystem.newOutputFile(outputPath).create());
 
-            Callable<Void> rollbackAction = () -> {
-                fileSystem.deleteFile(outputPath);
-                return null;
-            };
+            Closeable rollbackAction = () -> fileSystem.deleteFile(outputPath);
 
             List<Types.NestedField> columnFields = icebergSchema.columns();
             List<String> fileColumnNames = columnFields.stream()
@@ -297,10 +291,7 @@ public class IcebergFileWriterFactory
             Schema icebergSchema,
             ConnectorSession session)
     {
-        Callable<Void> rollbackAction = () -> {
-            fileIo.deleteFile(outputPath);
-            return null;
-        };
+        Closeable rollbackAction = () -> fileIo.deleteFile(outputPath);
 
         List<Type> columnTypes = icebergSchema.columns().stream()
                 .map(column -> toTrinoType(column.type(), typeManager))

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergOrcFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergOrcFileWriter.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.BinaryUtil;
 import org.apache.iceberg.util.UnicodeUtil;
 
+import java.io.Closeable;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -54,7 +55,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Verify.verify;
@@ -77,7 +77,7 @@ public class IcebergOrcFileWriter
             MetricsConfig metricsConfig,
             Schema icebergSchema,
             OrcDataSink orcDataSink,
-            Callable<Void> rollbackAction,
+            Closeable rollbackAction,
             List<String> columnNames,
             List<Type> fileColumnTypes,
             ColumnMetadata<OrcType> fileColumnOrcTypes,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
@@ -289,6 +289,7 @@ public class IcebergPageSink
             writer = createWriter(partitionData);
 
             writers.set(writerIndex, writer);
+            memoryUsage += writer.getWriter().getMemoryUsage();
         }
         verify(writers.size() == pagePartitioner.getMaxIndex() + 1);
         verify(!writers.contains(null));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetFileWriter.java
@@ -23,11 +23,11 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.schema.MessageType;
 
+import java.io.Closeable;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.Callable;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.parquet.ParquetUtil.fileMetrics;
@@ -43,7 +43,7 @@ public class IcebergParquetFileWriter
     public IcebergParquetFileWriter(
             MetricsConfig metricsConfig,
             OutputStream outputStream,
-            Callable<Void> rollbackAction,
+            Closeable rollbackAction,
             List<Type> fileColumnTypes,
             List<String> fileColumnNames,
             MessageType messageType,


### PR DESCRIPTION
Whenever writer is closed, it's instance was
retained so that rollback could be performed
in case of an error. However, this was retaining
excessive amount of memory which was not needed
anymore.

This commit introduces RollbackAction that can
be retained after driver is closed which should
significantly reduce memory usage during long
inserts.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
