### PR TITLE
Reduce memory usage for closed ORC and Parquet writers

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/DictionaryCompressionOptimizer.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/DictionaryCompressionOptimizer.java
@@ -14,12 +14,12 @@
 package io.trino.orc;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Longs;
 import io.airlift.units.DataSize;
 import io.airlift.units.DataSize.Unit;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.OptionalInt;
 import java.util.Set;
 
@@ -27,7 +27,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Collectors.toCollection;
 
 public class DictionaryCompressionOptimizer
 {
@@ -58,9 +58,9 @@ public class DictionaryCompressionOptimizer
             int dictionaryMemoryMaxBytes)
     {
         requireNonNull(writers, "writers is null");
-        this.allWriters = ImmutableSet.copyOf(writers.stream()
+        this.allWriters = writers.stream()
                 .map(DictionaryColumnManager::new)
-                .collect(toSet()));
+                .collect(toCollection(LinkedHashSet::new));
 
         checkArgument(stripeMinBytes >= 0, "stripeMinBytes is negative");
         this.stripeMinBytes = stripeMinBytes;
@@ -100,6 +100,13 @@ public class DictionaryCompressionOptimizer
         directConversionCandidates.addAll(allWriters);
         dictionaryMemoryBytes = 0;
         allWriters.forEach(DictionaryColumnManager::reset);
+    }
+
+    public void clear()
+    {
+        directConversionCandidates.clear();
+        dictionaryMemoryBytes = 0;
+        allWriters.clear();
     }
 
     public void finalOptimize(int bufferedBytes)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -216,6 +216,7 @@ public class ParquetWriter
             flush();
             writeFooter();
         }
+        columnWriters.clear();
         bufferedBytes = 0;
     }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
@@ -53,6 +53,7 @@ import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.joda.time.DateTimeZone;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -104,7 +105,7 @@ final class ParquetWriters
         private final ParquetProperties parquetProperties;
         private final CompressionCodecName compressionCodecName;
         private final Optional<DateTimeZone> parquetTimeZone;
-        private final ImmutableList.Builder<ColumnWriter> builder = ImmutableList.builder();
+        private final List<ColumnWriter> builder = new ArrayList<>();
 
         WriteBuilder(
                 MessageType messageType,
@@ -122,7 +123,7 @@ final class ParquetWriters
 
         List<ColumnWriter> build()
         {
-            return builder.build();
+            return builder;
         }
 
         @Override


### PR DESCRIPTION
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake connector
* Reduce memory overhead for long running write queries. ({issue}`14824`)

# Hive connector
* Reduce memory overhead for long running write queries. ({issue}`14824`)

# Iceberg connector
* Reduce memory overhead for long running write queries. ({issue}`14824`)
```
