### PR TITLE
Do not create temporary staging path for CREATE TABLE statement

### DIFF
--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHiveAlluxioMetastore.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHiveAlluxioMetastore.java
@@ -386,4 +386,10 @@ public class TestHiveAlluxioMetastore
     {
         // Alluxio metastore does not support insert/update/delete operations
     }
+
+    @Override
+    public void testCreateEmptyTableShouldNotCreateStagingDirectory()
+    {
+        // Alluxio metastore does not support create operations
+    }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -946,8 +946,7 @@ public class HiveMetadata
                 targetPath = Optional.empty();
             }
             else {
-                LocationHandle locationHandle = locationService.forNewTable(metastore, session, schemaName, tableName, Optional.empty());
-                targetPath = Optional.of(locationService.getQueryWriteInfo(locationHandle).getTargetPath());
+                targetPath = Optional.of(locationService.forNewTable(metastore, session, schemaName, tableName));
             }
         }
 
@@ -1536,7 +1535,7 @@ public class HiveMetadata
                 .collect(toImmutableList());
         checkPartitionTypesSupported(partitionColumns);
 
-        LocationHandle locationHandle = locationService.forNewTable(metastore, session, schemaName, tableName, externalLocation);
+        LocationHandle locationHandle = locationService.forNewTableAsSelect(metastore, session, schemaName, tableName, externalLocation);
 
         AcidTransaction transaction = isTransactional ? forCreateTable() : NO_ACID_TRANSACTION;
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/LocationService.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/LocationService.java
@@ -25,7 +25,9 @@ import static java.util.Objects.requireNonNull;
 
 public interface LocationService
 {
-    LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName, Optional<Path> externalLocation);
+    Path forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName);
+
+    LocationHandle forNewTableAsSelect(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName, Optional<Path> externalLocation);
 
     LocationHandle forExistingTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, Table table);
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
I am continuing the work in #5802 . 
The issue is that both `CREATE TABLE` and `CREATE TABLE AS ...` use `forNewTable` to generate a `LocationHandle`. In subsequent operations the directory created for `CREATE TABLE` is never renamed as the target directory because there was no data written to it.
The solution is to not create any temporary staging directory for `CREATE TABLE` operations. As suggested by the previous discussion I decided to create a new API `forNewTableAsSelect` in `LocationService`, and modify the original `forNewTable` to not create any temporary staging directory as it should.


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
Currently during `CREATE TABLE` operation, Trino creates a unnecessary directory that is not used and cleaned up afterwards. This patch will fix this issue.


(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
