### PR TITLE
Add additional tests for outer join push downs

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
@@ -29,6 +29,7 @@ import io.trino.sql.planner.Plan;
 import io.trino.sql.planner.assertions.PlanAssert;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.sql.planner.optimizations.PlanNodeSearcher;
+import io.trino.sql.planner.plan.JoinNode;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.testing.LocalQueryRunner;
@@ -527,6 +528,21 @@ public class QueryAssertions
         }
 
         /**
+         * Verifies join query is not fully pushed down by containing JOIN node.
+         */
+        public QueryAssert joinIsNotFullyPushedDown()
+        {
+            return verifyPlan(plan -> {
+                if (PlanNodeSearcher.searchFrom(plan.getRoot())
+                        .whereIsInstanceOfAny(JoinNode.class)
+                        .findFirst()
+                        .isEmpty()) {
+                    throw new IllegalStateException("Join node should be present in explain plan, when pushdown is not applied");
+                }
+            });
+        }
+
+        /**
          * Verifies query has the expected plan and that results are the same as when pushdown is fully disabled.
          */
         @CanIgnoreReturnValue
@@ -548,6 +564,21 @@ public class QueryAssertions
                                 plan,
                                 expectedPlan);
                         additionalPlanVerification.accept(plan);
+                    });
+
+            if (!skipResultsCorrectnessCheckForPushdown) {
+                // Compare the results with pushdown disabled, so that explicit matches() call is not needed
+                hasCorrectResultsRegardlessOfPushdown();
+            }
+            return this;
+        }
+
+        private QueryAssert verifyPlan(Consumer<Plan> planVerification)
+        {
+            transaction(runner.getTransactionManager(), runner.getAccessControl())
+                    .execute(session, session -> {
+                        Plan plan = runner.createPlan(session, query, WarningCollector.NOOP);
+                        planVerification.accept(plan);
                     });
 
             if (!skipResultsCorrectnessCheckForPushdown) {

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/JoinOperator.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/JoinOperator.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+public enum JoinOperator
+{
+    JOIN("JOIN"),
+    LEFT_JOIN("LEFT JOIN"),
+    RIGHT_JOIN("RIGHT JOIN"),
+    FULL_JOIN("FULL JOIN"),
+    /**/;
+
+    private final String value;
+
+    JoinOperator(String value)
+    {
+        this.value = value;
+    }
+
+    public String getValue()
+    {
+        return value;
+    }
+
+    @Override
+    public String toString()
+    {
+        return value;
+    }
+}

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -970,6 +970,10 @@ public class PostgreSqlClient
             Map<JdbcColumnHandle, String> leftAssignments,
             JoinStatistics statistics)
     {
+        if (joinType == JoinType.FULL_OUTER) {
+            // FULL JOIN is only supported with merge-joinable or hash-joinable join conditions
+            return Optional.empty();
+        }
         return implementJoinCostAware(
                 session,
                 joinType,

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -61,6 +61,7 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.exchange;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_AGGREGATION_PUSHDOWN;
+import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_JOIN_PUSHDOWN_WITH_FULL_JOIN;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_LIMIT_PUSHDOWN;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_EQUALITY;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_TOPN_PUSHDOWN;
@@ -117,7 +118,10 @@ public class TestPostgreSqlConnectorTest
                 return true;
 
             case SUPPORTS_JOIN_PUSHDOWN:
+            case SUPPORTS_JOIN_PUSHDOWN_WITH_VARCHAR_EQUALITY:
                 return true;
+            case SUPPORTS_JOIN_PUSHDOWN_WITH_FULL_JOIN:
+                return false;
 
             case SUPPORTS_CREATE_TABLE_WITH_TABLE_COMMENT:
             case SUPPORTS_CREATE_TABLE_WITH_COLUMN_COMMENT:
@@ -593,7 +597,7 @@ public class TestPostgreSqlConnectorTest
             assertConditionallyPushedDown(
                     session,
                     "SELECT r.name, n.name FROM nation n FULL JOIN region r ON n.nationkey = r.regionkey",
-                    true,
+                    hasBehavior(SUPPORTS_JOIN_PUSHDOWN_WITH_FULL_JOIN),
                     joinOverTableScans);
 
             // Join over a (double) predicate


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In [Implement Join pushdown for JDBC connectors](https://github.com/trinodb/trino/pull/6874) we implemented join pushdown for JDBC connectors.

As part of that a test BaseJdbcConnectorTest#testJoinPushdown was added which verifies that LEFT, RIGHT and FULL joins get pushed down with all possible operators (=, !=, <, <=, >, >=, IS DISTINCT FROM, IS NOT DISTINCT FROM).

This PR is initial attempt to add more test cases for outer join pushdowns



<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
