### PR TITLE
Expose test containers' hostnames on custom networks

### DIFF
--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/BaseTestContainer.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/BaseTestContainer.java
@@ -87,7 +87,7 @@ public abstract class BaseTestContainer
                 .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
                 .waitingFor(Wait.forListeningPort())
                 .withStartupTimeout(Duration.ofMinutes(5));
-        network.ifPresent(container::withNetwork);
+        network.ifPresent(net -> container.withNetwork(net).withNetworkAliases(hostName));
     }
 
     protected void withRunCommand(List<String> runCommand)


### PR DESCRIPTION
## Description
On some Docker environment, tests that rely on communication between Docker containers using a custom
network (e.g. those using `HiveMinioDataLake`) fail. This change ensures that, in this situation, containers
are always configured to expose their hostname as a DNS alias over Docker custom networks.

## Non-technical explanation
Ensure that tests using multiple Docker containers are reproducible on non-continuous-build environments

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: