### PR TITLE
Ensure concurrency/write parallelism for product tests

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard-multinode/multinode-master-config.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard-multinode/multinode-master-config.properties
@@ -10,3 +10,5 @@ discovery.uri=http://presto-master:8080
 
 # Use task.writer-count > 1, as this allows to expose writer-concurrency related bugs.
 task.writer-count=2
+task.concurrency=2
+task.partitioned-writer-count=2

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard-multinode/multinode-worker-config.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard-multinode/multinode-worker-config.properties
@@ -10,3 +10,5 @@ discovery.uri=http://presto-master:8080
 
 # Use task.writer-count > 1, as this allows to expose writer-concurrency related bugs.
 task.writer-count=2
+task.concurrency=2
+task.partitioned-writer-count=2

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard/config.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard/config.properties
@@ -11,3 +11,5 @@ discovery.uri=http://presto-master:8080
 
 # Use task.writer-count > 1, as this allows to expose writer-concurrency related bugs.
 task.writer-count=2
+task.concurrency=2
+task.partitioned-writer-count=2


### PR DESCRIPTION
## Description
Some product tests (e.g. TestHiveMerge) rely on write parallelism to expose certain bugs. Some
settings have defaults based on the number of CPUs on the machine, and so certain tests that fail
on the continuous build may pass when run in a different environment with a single CPU. 

## Non-technical explanation
This change ensures that CB test failures are reproducible locally.

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: