### PR TITLE
Enable Trino to read Hive struct fields using name based coercion

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveApplyProjectionUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveApplyProjectionUtil.java
@@ -74,7 +74,7 @@ public final class HiveApplyProjectionUtil
             }
             if (expression instanceof FieldDereference) {
                 FieldDereference dereference = (FieldDereference) expression;
-                ordinals.add(dereference.getField());
+                ordinals.add(dereference.getField()); // index within the target
                 expression = dereference.getTarget();
             }
             else {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCoercionRecordCursor.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCoercionRecordCursor.java
@@ -496,6 +496,7 @@ public class HiveCoercionRecordCursor
         private final BridgingRecordCursor bridgingRecordCursor;
         private final PageBuilder pageBuilder;
 
+        // todo: change
         public StructCoercer(TypeManager typeManager, HiveType fromHiveType, HiveType toHiveType, BridgingRecordCursor bridgingRecordCursor)
         {
             requireNonNull(typeManager, "typeManager is null");

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveColumnProjectionInfo.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveColumnProjectionInfo.java
@@ -32,7 +32,12 @@ public class HiveColumnProjectionInfo
 {
     private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(HiveColumnProjectionInfo.class).instanceSize());
 
+    // indices chain in the schema/table order
     private final List<Integer> dereferenceIndices;
+
+    // indices chain in the partition order
+    private final List<Integer> dereferenceDataAccessIndices;
+
     private final List<String> dereferenceNames;
     private final HiveType hiveType;
     private final Type type;
@@ -41,12 +46,15 @@ public class HiveColumnProjectionInfo
     @JsonCreator
     public HiveColumnProjectionInfo(
             @JsonProperty("dereferenceIndices") List<Integer> dereferenceIndices,
+            @JsonProperty("dereferenceDataAccessIndices") List<Integer> dereferenceDataAccessIndices,
             @JsonProperty("dereferenceNames") List<String> dereferenceNames,
             @JsonProperty("hiveType") HiveType hiveType,
             @JsonProperty("type") Type type)
     {
         this.dereferenceIndices = requireNonNull(dereferenceIndices, "dereferenceIndices is null");
+        this.dereferenceDataAccessIndices = requireNonNull(dereferenceDataAccessIndices, "dereferenceDataAccessIndices is null");
         this.dereferenceNames = requireNonNull(dereferenceNames, "dereferenceNames is null");
+
         checkArgument(dereferenceIndices.size() > 0, "dereferenceIndices should not be empty");
         checkArgument(dereferenceIndices.size() == dereferenceNames.size(), "dereferenceIndices and dereferenceNames should have the same sizes");
 
@@ -66,6 +74,13 @@ public class HiveColumnProjectionInfo
     {
         return dereferenceIndices;
     }
+
+    @JsonProperty
+    public List<Integer> getDereferenceDataAccessIndices()
+    {
+        return dereferenceDataAccessIndices;
+    }
+
 
     @JsonProperty
     public List<String> getDereferenceNames()
@@ -103,6 +118,7 @@ public class HiveColumnProjectionInfo
 
         HiveColumnProjectionInfo other = (HiveColumnProjectionInfo) obj;
         return Objects.equals(this.dereferenceIndices, other.dereferenceIndices) &&
+                Objects.equals(this.dereferenceDataAccessIndices, other.dereferenceDataAccessIndices) &&
                 Objects.equals(this.dereferenceNames, other.dereferenceNames) &&
                 Objects.equals(this.hiveType, other.hiveType) &&
                 Objects.equals(this.type, other.type);
@@ -119,6 +135,7 @@ public class HiveColumnProjectionInfo
     {
         return INSTANCE_SIZE
                 + estimatedSizeOf(dereferenceIndices, SizeOf::sizeOf)
+                + estimatedSizeOf(dereferenceDataAccessIndices, SizeOf::sizeOf)
                 + estimatedSizeOf(dereferenceNames, SizeOf::estimatedSizeOf)
                 + hiveType.getRetainedSizeInBytes()
                 // type is not accounted for as the instances are cached (by TypeRegistry) and shared

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -2972,6 +2972,7 @@ public class HiveMetadata
                                 .orElse(ImmutableList.of()))
                         .addAll(indices)
                         .build(),
+                ImmutableList.of(),
                 // Merge names
                 ImmutableList.<String>builder()
                         .addAll(column.getHiveColumnProjectionInfo()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -2932,6 +2932,7 @@ public class HiveMetadata
             else {
                 // Create a new column handle
                 HiveColumnHandle oldColumnHandle = (HiveColumnHandle) assignments.get(projectedColumn.getVariable().getName());
+                // todo: change here, since need to change projection for dereference.
                 projectedColumnHandle = createProjectedColumnHandle(oldColumnHandle, projectedColumn.getDereferenceIndices());
                 projectedColumnName = ((HiveColumnHandle) projectedColumnHandle).getName();
             }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
@@ -147,6 +147,11 @@ public class HivePageSource
                 List<Integer> dereferenceIndices = column.getHiveColumnProjectionInfo()
                         .map(HiveColumnProjectionInfo::getDereferenceIndices)
                         .orElse(ImmutableList.of());
+                // todo: use dereferenceIndices:
+                // 1. columnMapping.getHiveColumnHandle().getBaseColumn().getHiveType()
+                // 2. index via dereferenceIndices: get c1(int)
+                // 3. use c1 and look up in columnMapping.getBaseTypeCoercionFrom() via name
+                // 4. depends on get / not get: get toType.
                 HiveType fromType = columnMapping.getBaseTypeCoercionFrom().get().getHiveTypeForDereferences(dereferenceIndices).get();
                 HiveType toType = columnMapping.getHiveColumnHandle().getHiveType();
                 coercers.add(createCoercer(typeManager, fromType, toType));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
@@ -158,6 +158,7 @@ public class HivePageSource
                             .orElse(ImmutableList.of());
                     fromType = columnMapping.getBaseTypeCoercionFrom().get().getHiveTypeForDereferences(dereferenceIndices).get();
                 }
+
                 HiveType toType = columnMapping.getHiveColumnHandle().getHiveType();
                 coercers.add(createCoercer(typeManager, fromType, toType, columnMapping.isNestedStructNameBasedMapping()));
             }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
@@ -627,12 +627,15 @@ public class HivePageSourceProvider
 
         private static boolean projectionValidForType(HiveType baseType, Optional<HiveColumnProjectionInfo> projection, boolean nestedStructNameBasedMapping)
         {
-            List<Integer> dereferences = nestedStructNameBasedMapping ?
-                    projection.map(HiveColumnProjectionInfo::getDereferenceDataAccessIndices).orElse(ImmutableList.of()) :
-                    projection.map(HiveColumnProjectionInfo::getDereferenceIndices).orElse(ImmutableList.of());
-
-            Optional<HiveType> targetType = baseType.getHiveTypeForDereferences(dereferences);
-            return targetType.isPresent();
+            if (nestedStructNameBasedMapping) {
+                List<String> dereferences = projection.map(HiveColumnProjectionInfo::getDereferenceNames).orElse(ImmutableList.of());
+                Optional<HiveType> targetType = baseType.getHiveTypeForDereferencesNameBased(dereferences);
+                return targetType.isPresent();
+            } else {
+                List<Integer> dereferences = projection.map(HiveColumnProjectionInfo::getDereferenceIndices).orElse(ImmutableList.of());
+                Optional<HiveType> targetType = baseType.getHiveTypeForDereferences(dereferences);
+                return targetType.isPresent();
+            }
         }
 
         public static List<ColumnMapping> extractRegularAndInterimColumnMappings(List<ColumnMapping> columnMappings)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
@@ -464,7 +464,7 @@ public class HiveSplitManager
             }
         }
 
-        return new TableToPartitionMapping(Optional.of(tableToPartitionColumns.buildOrThrow()), columnCoercions.buildOrThrow());
+        return new TableToPartitionMapping(Optional.of(tableToPartitionColumns.buildOrThrow()), columnCoercions.buildOrThrow(), true);
     }
 
     private TrinoException tablePartitionColumnMismatchException(SchemaTableName tableName, String partName, String tableColumnName, HiveType tableType, String partitionColumnName, HiveType partitionType)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
@@ -411,7 +411,7 @@ public class HiveSplitManager
             HiveType tableType = tableColumns.get(i).getType();
             HiveType partitionType = partitionColumns.get(i).getType();
             if (!tableType.equals(partitionType)) {
-                if (!canCoerce(typeManager, partitionType, tableType)) {
+                if (!canCoerce(typeManager, partitionType, tableType, false)) {
                     throw tablePartitionColumnMismatchException(tableName, partName, tableColumns.get(i).getName(), tableType, partitionColumns.get(i).getName(), partitionType);
                 }
                 columnCoercions.put(i, partitionType.getHiveTypeName());
@@ -457,7 +457,7 @@ public class HiveSplitManager
             Column partitionColumn = partitionColumns.get(partitionColumnIndex);
             HiveType partitionType = partitionColumn.getType();
             if (!tableType.equals(partitionType)) {
-                if (!canCoerce(typeManager, partitionType, tableType)) {
+                if (!canCoerce(typeManager, partitionType, tableType, true)) {
                     throw tablePartitionColumnMismatchException(tableName, partName, tableColumn.getName(), tableType, partitionColumn.getName(), partitionType);
                 }
                 columnCoercions.put(partitionColumnIndex, partitionType.getHiveTypeName());

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
@@ -411,7 +411,7 @@ public class HiveSplitManager
             HiveType tableType = tableColumns.get(i).getType();
             HiveType partitionType = partitionColumns.get(i).getType();
             if (!tableType.equals(partitionType)) {
-                if (!canCoerce(typeManager, partitionType, tableType, false)) {
+                if (!canCoerce(typeManager, partitionType, tableType, true)) {
                     throw tablePartitionColumnMismatchException(tableName, partName, tableColumns.get(i).getName(), tableType, partitionColumns.get(i).getName(), partitionType);
                 }
                 columnCoercions.put(i, partitionType.getHiveTypeName());

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveType.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveType.java
@@ -215,13 +215,32 @@ public final class HiveType
         return new HiveType(toTypeInfo(type));
     }
 
-    public Optional<HiveType> getHiveTypeForDereferences(List<Integer> dereferences)
+    public Optional<HiveType> getHiveTypeForDereferences(List<? extends Integer> dereferences)
     {
         TypeInfo typeInfo = getTypeInfo();
         for (int fieldIndex : dereferences) {
             checkArgument(typeInfo instanceof StructTypeInfo, "typeInfo should be struct type", typeInfo);
             StructTypeInfo structTypeInfo = (StructTypeInfo) typeInfo;
+           // TODO: USE name based mapping here
             try {
+                typeInfo = structTypeInfo.getAllStructFieldTypeInfos().get(fieldIndex);
+            }
+            catch (RuntimeException e) {
+                return Optional.empty();
+            }
+        }
+        return Optional.of(toHiveType(typeInfo));
+    }
+
+    public Optional<HiveType> getHiveTypeForDereferencesNameBased(List<String> dereferences)
+    {
+        TypeInfo typeInfo = getTypeInfo();
+        for (String fieldName : dereferences) {
+            checkArgument(typeInfo instanceof StructTypeInfo, "typeInfo should be struct type", typeInfo);
+            StructTypeInfo structTypeInfo = (StructTypeInfo) typeInfo;
+            // TODO: USE name based mapping here
+            try {
+                int fieldIndex = structTypeInfo.getAllStructFieldNames().indexOf(fieldName);
                 typeInfo = structTypeInfo.getAllStructFieldTypeInfos().get(fieldIndex);
             }
             catch (RuntimeException e) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ReaderColumns.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ReaderColumns.java
@@ -37,6 +37,7 @@ public class ReaderColumns
 
     public ReaderColumns(List<? extends ColumnHandle> readerColumns, List<Integer> readerBlockIndices)
     {
+        // todo: change here?
         this.readerColumns = ImmutableList.copyOf(requireNonNull(readerColumns, "readerColumns is null"));
 
         readerBlockIndices.forEach(value -> checkArgument(value >= 0 && value < readerColumns.size(), "block index out of bounds"));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ReaderColumns.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ReaderColumns.java
@@ -32,7 +32,7 @@ public class ReaderColumns
 {
     // columns to be read by the reader (ordered)
     private final List<ColumnHandle> readerColumns;
-    // indices for mapping expected column handles to the reader's column handles
+    // indices for mapping expected column handles to the reader's column handles(as above)
     private final List<Integer> readerBlockIndices;
 
     public ReaderColumns(List<? extends ColumnHandle> readerColumns, List<Integer> readerBlockIndices)
@@ -52,9 +52,14 @@ public class ReaderColumns
         checkArgument(index >= 0 && index < readerBlockIndices.size(), "index is not valid");
         int readerIndex = readerBlockIndices.get(index);
         return readerColumns.get(readerIndex);
+
+//        checkArgument(index >= 0 && index < readerBlockIndices.size(), "index is not valid");
+//        int readerIndex = readerBlockIndices.get(index);
+//        return readerColumns.get(getPositionForColumnAt(index));
     }
 
     /**
+     * todo: what is channel? seems like index in readerColumns when creating the map
      * For a channel expected by wrapper page source, returns the channel index in the underlying page source or record cursor.
      */
     public int getPositionForColumnAt(int index)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ReaderProjectionsAdapter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ReaderProjectionsAdapter.java
@@ -52,6 +52,7 @@ public class ReaderProjectionsAdapter
         ImmutableList.Builder<ChannelMapping> mappingBuilder = ImmutableList.builder();
 
         for (int i = 0; i < expectedColumns.size(); i++) {
+            // underlying datasource
             ColumnHandle projectedColumnHandle = readColumns.getForColumnAt(i);
             // todo: change here
             int inputChannel = readColumns.getPositionForColumnAt(i);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ReaderProjectionsAdapter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ReaderProjectionsAdapter.java
@@ -53,6 +53,7 @@ public class ReaderProjectionsAdapter
 
         for (int i = 0; i < expectedColumns.size(); i++) {
             ColumnHandle projectedColumnHandle = readColumns.getForColumnAt(i);
+            // todo: change here
             int inputChannel = readColumns.getPositionForColumnAt(i);
             List<Integer> dereferences = projectionGetter.get(expectedColumns.get(i), projectedColumnHandle);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TableToPartitionMapping.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TableToPartitionMapping.java
@@ -32,12 +32,12 @@ public class TableToPartitionMapping
 {
     public static TableToPartitionMapping empty()
     {
-        return new TableToPartitionMapping(Optional.empty(), ImmutableMap.of());
+        return new TableToPartitionMapping(Optional.empty(), ImmutableMap.of(), false);
     }
 
     public static TableToPartitionMapping mapColumnsByIndex(Map<Integer, HiveTypeName> columnCoercions)
     {
-        return new TableToPartitionMapping(Optional.empty(), columnCoercions);
+        return new TableToPartitionMapping(Optional.empty(), columnCoercions, false);
     }
 
     // Overhead of ImmutableMap is not accounted because of its complexity.
@@ -48,10 +48,13 @@ public class TableToPartitionMapping
     private final Optional<Map<Integer, Integer>> tableToPartitionColumns;
     private final Map<Integer, HiveTypeName> partitionColumnCoercions;
 
+    private final boolean nestedStructNameBasedMapping;
+
     @JsonCreator
     public TableToPartitionMapping(
             @JsonProperty("tableToPartitionColumns") Optional<Map<Integer, Integer>> tableToPartitionColumns,
-            @JsonProperty("partitionColumnCoercions") Map<Integer, HiveTypeName> partitionColumnCoercions)
+            @JsonProperty("partitionColumnCoercions") Map<Integer, HiveTypeName> partitionColumnCoercions,
+            @JsonProperty("nestedStructNameBasedMapping") boolean nestedStructNameBasedMapping)
     {
         if (tableToPartitionColumns.map(TableToPartitionMapping::isIdentityMapping).orElse(true)) {
             this.tableToPartitionColumns = Optional.empty();
@@ -60,6 +63,7 @@ public class TableToPartitionMapping
             this.tableToPartitionColumns = tableToPartitionColumns.map(ImmutableMap::copyOf);
         }
         this.partitionColumnCoercions = ImmutableMap.copyOf(requireNonNull(partitionColumnCoercions, "partitionColumnCoercions is null"));
+        this.nestedStructNameBasedMapping = nestedStructNameBasedMapping;
     }
 
     @VisibleForTesting
@@ -77,6 +81,11 @@ public class TableToPartitionMapping
     public Map<Integer, HiveTypeName> getPartitionColumnCoercions()
     {
         return partitionColumnCoercions;
+    }
+
+    @JsonProperty
+    public boolean getNestedStructNameBasedMapping(){
+        return nestedStructNameBasedMapping;
     }
 
     @JsonProperty
@@ -117,6 +126,7 @@ public class TableToPartitionMapping
         return toStringHelper(this)
                 .add("columnCoercions", partitionColumnCoercions)
                 .add("tableToPartitionColumns", tableToPartitionColumns)
+                .add("nestedStructNameBasedMapping", nestedStructNameBasedMapping)
                 .toString();
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TableToPartitionMapping.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TableToPartitionMapping.java
@@ -32,12 +32,12 @@ public class TableToPartitionMapping
 {
     public static TableToPartitionMapping empty()
     {
-        return new TableToPartitionMapping(Optional.empty(), ImmutableMap.of(), false);
+        return new TableToPartitionMapping(Optional.empty(), ImmutableMap.of(), true);
     }
 
     public static TableToPartitionMapping mapColumnsByIndex(Map<Integer, HiveTypeName> columnCoercions)
     {
-        return new TableToPartitionMapping(Optional.empty(), columnCoercions, false);
+        return new TableToPartitionMapping(Optional.empty(), columnCoercions, true);
     }
 
     // Overhead of ImmutableMap is not accounted because of its complexity.
@@ -84,7 +84,7 @@ public class TableToPartitionMapping
     }
 
     @JsonProperty
-    public boolean getNestedStructNameBasedMapping(){
+    public boolean isNestedStructNameBasedMapping(){
         return nestedStructNameBasedMapping;
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
@@ -182,7 +182,7 @@ public class OrcPageSourceFactory
         }
 
         List<HiveColumnHandle> readerColumnHandles = columns;
-
+        // list of physical read data columns
         Optional<ReaderColumns> readerColumns = projectBaseColumns(columns);
         if (readerColumns.isPresent()) {
             readerColumnHandles = readerColumns.get().get().stream()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -291,6 +291,7 @@ public class ParquetPageSourceFactory
         }
     }
 
+
     public static Optional<MessageType> getParquetMessageType(List<HiveColumnHandle> columns, boolean useColumnNames, MessageType fileSchema)
     {
         Optional<MessageType> message = projectSufficientColumns(columns)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 import static io.trino.plugin.hive.HiveType.HIVE_BYTE;
@@ -35,7 +34,6 @@ import static io.trino.plugin.hive.HiveType.HIVE_INT;
 import static io.trino.plugin.hive.HiveType.HIVE_LONG;
 import static io.trino.plugin.hive.HiveType.HIVE_SHORT;
 import static io.trino.plugin.hive.util.HiveUtil.extractStructFieldTypes;
-import static java.lang.Math.min;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileFormats.java
@@ -516,6 +516,7 @@ public abstract class AbstractTestHiveFileFormats
                         baseHiveType.getType(TESTING_TYPE_MANAGER),
                         Optional.of(new HiveColumnProjectionInfo(
                                 testColumn.getDereferenceIndices(),
+                                testColumn.getDereferenceIndices(),
                                 testColumn.getDereferenceNames(),
                                 partialHiveType,
                                 partialHiveType.getType(TESTING_TYPE_MANAGER))),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveColumnHandle.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveColumnHandle.java
@@ -68,6 +68,7 @@ public class TestHiveColumnHandle
 
         HiveColumnProjectionInfo columnProjectionInfo = new HiveColumnProjectionInfo(
                 ImmutableList.of(1),
+                ImmutableList.of(1),
                 ImmutableList.of("b"),
                 HiveType.HIVE_LONG,
                 BIGINT);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveReaderProjectionsUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveReaderProjectionsUtil.java
@@ -70,6 +70,7 @@ public class TestHiveReaderProjectionsUtil
 
         HiveType baseHiveType = column.getHiveType();
         List<String> names = baseHiveType.getHiveDereferenceNames(indices);
+        // todo: test
         HiveType hiveType = baseHiveType.getHiveTypeForDereferences(indices).get();
 
         HiveColumnProjectionInfo columnProjection = new HiveColumnProjectionInfo(indices, names, hiveType, hiveType.getType(TESTING_TYPE_MANAGER));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveReaderProjectionsUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveReaderProjectionsUtil.java
@@ -73,7 +73,7 @@ public class TestHiveReaderProjectionsUtil
         // todo: test
         HiveType hiveType = baseHiveType.getHiveTypeForDereferences(indices).get();
 
-        HiveColumnProjectionInfo columnProjection = new HiveColumnProjectionInfo(indices, names, hiveType, hiveType.getType(TESTING_TYPE_MANAGER));
+        HiveColumnProjectionInfo columnProjection = new HiveColumnProjectionInfo(indices,indices, names, hiveType, hiveType.getType(TESTING_TYPE_MANAGER));
 
         return new HiveColumnHandle(
                 column.getBaseColumnName(),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
@@ -159,6 +159,7 @@ public class TestConnectorPushdownRulesWithHive
                 baseType,
                 Optional.of(new HiveColumnProjectionInfo(
                         ImmutableList.of(0),
+                        ImmutableList.of(0),
                         ImmutableList.of("a"),
                         toHiveType(BIGINT),
                         BIGINT)),
@@ -314,6 +315,7 @@ public class TestConnectorPushdownRulesWithHive
                 toHiveType(ROW_TYPE),
                 ROW_TYPE,
                 Optional.of(new HiveColumnProjectionInfo(
+                        ImmutableList.of(0),
                         ImmutableList.of(0),
                         ImmutableList.of("a"),
                         toHiveType(BIGINT),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetPageSourceFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetPageSourceFactory.java
@@ -53,7 +53,8 @@ public class TestParquetPageSourceFactory
                 Optional.of(
                     new HiveColumnProjectionInfo(
                         ImmutableList.of(1, 1),
-                        ImmutableList.of("optional_level2", "required_level3"),
+                            ImmutableList.of(1, 1),
+                            ImmutableList.of("optional_level2", "required_level3"),
                         toHiveType(IntegerType.INTEGER),
                         IntegerType.INTEGER)),
                 REGULAR,

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeMinioDataLake.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeMinioDataLake.java
@@ -15,6 +15,7 @@ package io.trino.tests.product.launcher.env.environment;
 
 import io.trino.tests.product.launcher.docker.DockerFiles;
 import io.trino.tests.product.launcher.env.Environment;
+import io.trino.tests.product.launcher.env.EnvironmentConfig;
 import io.trino.tests.product.launcher.env.EnvironmentProvider;
 import io.trino.tests.product.launcher.env.common.Hadoop;
 import io.trino.tests.product.launcher.env.common.Minio;
@@ -23,7 +24,10 @@ import io.trino.tests.product.launcher.env.common.TestsEnvironment;
 
 import javax.inject.Inject;
 
+import static io.trino.tests.product.launcher.env.EnvironmentContainers.HADOOP;
+import static io.trino.tests.product.launcher.env.common.Hadoop.CONTAINER_HADOOP_INIT_D;
 import static io.trino.tests.product.launcher.env.common.Standard.CONTAINER_TRINO_ETC;
+import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
 
 /**
@@ -34,17 +38,31 @@ public class EnvMultinodeMinioDataLake
         extends EnvironmentProvider
 {
     private final DockerFiles.ResourceProvider configDir;
+    private final String hadoopImagesVersion;
+    private final DockerFiles dockerFiles;
+
 
     @Inject
-    public EnvMultinodeMinioDataLake(StandardMultinode standardMultinode, Hadoop hadoop, Minio minio, DockerFiles dockerFiles)
+    public EnvMultinodeMinioDataLake(StandardMultinode standardMultinode, DockerFiles dockerFiles, Hadoop hadoop, Minio minio, EnvironmentConfig environmentConfig)
     {
         super(standardMultinode, hadoop, minio);
         this.configDir = dockerFiles.getDockerFilesHostDirectory("conf/environment/multinode-minio-data-lake");
+        this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
+        this.hadoopImagesVersion = environmentConfig.getHadoopImagesVersion();
     }
 
     @Override
     public void extendEnvironment(Environment.Builder builder)
     {
+        String dockerImageName = "ghcr.io/trinodb/testing/hdp3.1-hive:" + hadoopImagesVersion;
+
+        builder.configureContainer(HADOOP, dockerContainer -> {
+            dockerContainer.setDockerImageName(dockerImageName);
+            dockerContainer.withCopyFileToContainer(
+                    forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-hdp3/apply-hdp3-config.sh")),
+                    CONTAINER_HADOOP_INIT_D + "apply-hdp3-config.sh");
+        });
+
         builder.addConnector("hive", forHostPath(configDir.getPath("hive.properties")));
         builder.addConnector(
                 "delta-lake",

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercion.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercion.java
@@ -110,7 +110,7 @@ public class TestHiveCoercion
         return HiveTableDefinition.builder(tableName)
                 .setCreateTableDDLTemplate("" +
                         "CREATE TABLE %NAME%(" +
-                        // all nested primitive/varchar coercions and adding/removing tailing nested fields are covered across row_to_row, list_to_list, and map_to_map
+                        // all nested primitive/varchar coercions and adding/removing nested fields are covered across row_to_row, list_to_list, and map_to_map
                         "    row_to_row                 STRUCT<keep: STRING, ti2si: TINYINT, si2int: SMALLINT, int2bi: INT, bi2vc: BIGINT, lower2uppercase: BIGINT>, " +
                         "    list_to_list               ARRAY<STRUCT<ti2int: TINYINT, si2bi: SMALLINT, bi2vc: BIGINT, remove: STRING>>, " +
                         "    map_to_map                 MAP<TINYINT, STRUCT<ti2bi: TINYINT, int2bi: INT, float2double: " + floatType + ">>, " +

--- a/testing/trino-server-dev/etc/catalog/hive.properties
+++ b/testing/trino-server-dev/etc/catalog/hive.properties
@@ -1,23 +1,13 @@
 connector.name=hive
 
-
 # Configuration appropriate for Hive as started by product test environment, e.g.
-#  testing/bin/ptl env up --environment multinode-minio-data-lake --without-trino
+#   trino-product-tests-launcher/bin/run-launcher env up --environment singlenode --without-trino
 # On Mac, this additionally requires that you add "<your external IP> hadoop-master" to /etc/hosts
 hive.metastore.uri=thrift://localhost:9083
-
-
-# MinIO uses 9000 by default, but this change conflicts with Hadoop
-hive.s3.endpoint=http://localhost:9080
-hive.s3.path-style-access=true
-hive.s3.ssl.enabled=false
-hive.s3.aws-access-key=minio-access-key
-hive.s3.aws-secret-key=minio-secret-key
-
+hive.hdfs.socks-proxy=localhost:1180
 
 # Fail-fast in development
 hive.metastore.thrift.client.max-retry-time=1s
-
 
 # Be permissive in development
 hive.allow-add-column=true
@@ -27,5 +17,3 @@ hive.allow-rename-table=true
 hive.allow-comment-table=true
 hive.allow-comment-column=true
 hive.allow-rename-column=true
-
-hive.orc.use-column-names=true

--- a/testing/trino-server-dev/etc/catalog/hive.properties
+++ b/testing/trino-server-dev/etc/catalog/hive.properties
@@ -27,3 +27,5 @@ hive.allow-rename-table=true
 hive.allow-comment-table=true
 hive.allow-comment-column=true
 hive.allow-rename-column=true
+
+hive.orc.use-column-names=true

--- a/testing/trino-server-dev/etc/catalog/hive.properties
+++ b/testing/trino-server-dev/etc/catalog/hive.properties
@@ -1,20 +1,23 @@
-#
-# WARNING
-# ^^^^^^^
-# This configuration file is for development only and should NOT be used
-# in production. For example configuration, see the Trino documentation.
-#
-
 connector.name=hive
 
+
 # Configuration appropriate for Hive as started by product test environment, e.g.
-#   trino-product-tests-launcher/bin/run-launcher env up --environment singlenode --without-trino
+#  testing/bin/ptl env up --environment multinode-minio-data-lake --without-trino
 # On Mac, this additionally requires that you add "<your external IP> hadoop-master" to /etc/hosts
 hive.metastore.uri=thrift://localhost:9083
-hive.hdfs.socks-proxy=localhost:1180
+
+
+# MinIO uses 9000 by default, but this change conflicts with Hadoop
+hive.s3.endpoint=http://localhost:9080
+hive.s3.path-style-access=true
+hive.s3.ssl.enabled=false
+hive.s3.aws-access-key=minio-access-key
+hive.s3.aws-secret-key=minio-secret-key
+
 
 # Fail-fast in development
 hive.metastore.thrift.client.max-retry-time=1s
+
 
 # Be permissive in development
 hive.allow-add-column=true

--- a/testing/trino-server-dev/etc/config.properties
+++ b/testing/trino-server-dev/etc/config.properties
@@ -10,9 +10,9 @@ node.id=ffffffff-ffff-ffff-ffff-ffffffffffff
 node.environment=test
 node.internal-address=localhost
 experimental.concurrent-startup=true
-http-server.http.port=8080
+http-server.http.port=8081
 
-discovery.uri=http://localhost:8080
+discovery.uri=http://localhost:8081
 
 exchange.http-client.max-connections=1000
 exchange.http-client.max-connections-per-server=1000


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Enable Trino to read Hive struct fields using name based coercion.

This will allow the Trino reading struct fields containing different partition schemas that are:
1. Added fields in the middle 
2. Removed fields from the front 
3. ordered   

This change only affect formats using HivePageSourceFactory(Orc, Parquet and ..). Formats using HiveRecordCursorProvider such as textfile and Avro are not affected. 

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Enable Trino to read Hive struct fields using name based coercion

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Enable Trino to read Hive struct fields using name based coercion
```
