### PR TITLE
Improve CI cache usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,13 @@ jobs:
           platforms: arm64,ppc64le
       - name: Test Docker Image
         run: core/docker/build.sh
+      - name: Clean local Maven repo
+        # Avoid creating a cache entry except when pushing to the default branch
+        if: steps.cache.outputs.cache-hit != 'true' || !(github.event_name == 'push' && github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch)
+        run: rm -rf ~/.m2/repository
       - name: Remove Trino from local Maven repo to avoid caching it
         # Avoid caching artifacts built in this job, cache should only include dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache.outputs.cache-hit != 'true' && github.event_name == 'push' && github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch
         run: rm -rf ~/.m2/repository/io/trino/trino-*
 
   check-commits:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ env:
   # This value should be greater than the time taken for the longest image pull.
   TESTCONTAINERS_PULL_PAUSE_TIMEOUT: 600
   TEST_REPORT_RETENTION_DAYS: 5
+  # used by actions/cache to retry the download after this time: https://github.com/actions/cache/blob/main/workarounds.md#cache-segment-restore-timeout
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
 
 # Cancel previous PR builds.
 concurrency:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

I noticed we're still creating too many cache entries so it gets cleared too often, so we should not create them on forks, because such entries cannot be reused except for that fork and branch.

Ref: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache

I also noticed downloading the cache sometimes gets stuck, like here: https://github.com/trinodb/trino/actions/runs/3384101557/jobs/5620679970. There's a new setting in the cache action documented here: https://github.com/actions/cache/blob/main/workarounds.md#cache-segment-restore-timeout and it should be available because `actions/setup-java` is using `actions/cache` 3.0.4 (the JS lib, not the GH action): https://github.com/actions/setup-java/blob/main/package.json

Ref: https://github.com/actions/toolkit/blob/main/packages/cache/RELEASES.md#304

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

n/a

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
