### PR TITLE
Improve Varbinary Hex Functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/VarbinaryFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/VarbinaryFunctions.java
@@ -30,6 +30,7 @@ import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
 
 import java.util.Base64;
+import java.util.HexFormat;
 import java.util.zip.CRC32;
 
 import static io.airlift.slice.Slices.EMPTY_SLICE;
@@ -39,6 +40,11 @@ import static io.trino.util.Failures.checkCondition;
 
 public final class VarbinaryFunctions
 {
+    private static final byte[] UPPERCASE_HEX_DIGITS = {
+            '0', '1', '2', '3', '4', '5', '6', '7',
+            '8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
+    };
+
     private VarbinaryFunctions() {}
 
     @Description("Length of the given binary")
@@ -189,14 +195,23 @@ public final class VarbinaryFunctions
     @SqlType(StandardTypes.VARCHAR)
     public static Slice toHex(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
-        String encoded;
+        byte[] result = new byte[slice.length() * 2];
         if (slice.hasByteArray()) {
-            encoded = BaseEncoding.base16().encode(slice.byteArray(), slice.byteArrayOffset(), slice.length());
+            byte[] source = slice.byteArray();
+            for (int sourceIndex = slice.byteArrayOffset(), resultIndex = 0; resultIndex < result.length; sourceIndex++, resultIndex += 2) {
+                int value = source[sourceIndex] & 0xFF;
+                result[resultIndex] = UPPERCASE_HEX_DIGITS[(value & 0xF0) >>> 4];
+                result[resultIndex + 1] = UPPERCASE_HEX_DIGITS[(value & 0x0F)];
+            }
         }
         else {
-            encoded = BaseEncoding.base16().encode(slice.getBytes());
+            for (int sourceIndex = 0, resultIndex = 0; resultIndex < result.length; sourceIndex++, resultIndex += 2) {
+                int value = slice.getByte(sourceIndex) & 0xFF;
+                result[resultIndex] = UPPERCASE_HEX_DIGITS[(value & 0xF0) >>> 4];
+                result[resultIndex + 1] = UPPERCASE_HEX_DIGITS[(value & 0x0F)];
+            }
         }
-        return Slices.utf8Slice(encoded);
+        return Slices.wrappedBuffer(result);
     }
 
     @Description("Decode hex encoded binary data")
@@ -205,15 +220,33 @@ public final class VarbinaryFunctions
     @SqlType(StandardTypes.VARBINARY)
     public static Slice fromHexVarchar(@SqlType("varchar(x)") Slice slice)
     {
-        if (slice.length() % 2 != 0) {
+        int resultLength = slice.length() / 2;
+        if (resultLength * 2 != slice.length()) {
             throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "invalid input length " + slice.length());
         }
 
-        byte[] result = new byte[slice.length() / 2];
-        for (int i = 0; i < slice.length(); i += 2) {
-            result[i / 2] = (byte) ((hexDigitCharToInt(slice.getByte(i)) << 4) | hexDigitCharToInt(slice.getByte(i + 1)));
+        try {
+            byte[] result = new byte[resultLength];
+            if (slice.hasByteArray()) {
+                byte[] source = slice.byteArray();
+                for (int sourceIndex = slice.byteArrayOffset(), resultIndex = 0; resultIndex < result.length; resultIndex++, sourceIndex += 2) {
+                    int high = HexFormat.fromHexDigit(source[sourceIndex]);
+                    int low = HexFormat.fromHexDigit(source[sourceIndex + 1]);
+                    result[resultIndex] = (byte) ((high << 4) | low);
+                }
+            }
+            else {
+                for (int sourceIndex = 0, resultIndex = 0; resultIndex < result.length; resultIndex++, sourceIndex += 2) {
+                    int high = HexFormat.fromHexDigit(slice.getByte(sourceIndex));
+                    int low = HexFormat.fromHexDigit(slice.getByte(sourceIndex + 1));
+                    result[resultIndex] = (byte) ((high << 4) | low);
+                }
+            }
+            return Slices.wrappedBuffer(result);
         }
-        return Slices.wrappedBuffer(result);
+        catch (NumberFormatException e) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, e.getMessage());
+        }
     }
 
     @Description("Encode value as a 64-bit 2's complement big endian varbinary")
@@ -338,20 +371,6 @@ public final class VarbinaryFunctions
     public static Slice murmur3(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
         return Murmur3Hash128.hash(slice, 0, slice.length());
-    }
-
-    private static int hexDigitCharToInt(byte b)
-    {
-        if (b >= '0' && b <= '9') {
-            return b - '0';
-        }
-        if (b >= 'a' && b <= 'f') {
-            return b - 'a' + 10;
-        }
-        if (b >= 'A' && b <= 'F') {
-            return b - 'A' + 10;
-        }
-        throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "invalid hex character: " + (char) b);
     }
 
     @Description("Compute xxhash64 hash")

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/VarbinaryFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/VarbinaryFunctions.java
@@ -417,7 +417,12 @@ public final class VarbinaryFunctions
     public static long crc32(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
         CRC32 crc32 = new CRC32();
-        crc32.update(slice.toByteBuffer());
+        if (slice.hasByteArray()) {
+            crc32.update(slice.byteArray(), slice.byteArrayOffset(), slice.length());
+        }
+        else {
+            crc32.update(slice.toByteBuffer());
+        }
         return crc32.getValue();
     }
 

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -90,6 +90,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
             <scope>test</scope>
@@ -128,6 +140,23 @@
         </resources>
 
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <!-- allow both JUnit and TestNG -->
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit-platform</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
             <plugin>
                 <groupId>org.revapi</groupId>
                 <artifactId>revapi-maven-plugin</artifactId>

--- a/core/trino-spi/src/main/java/io/trino/spi/type/SqlVarbinary.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/SqlVarbinary.java
@@ -16,15 +16,18 @@ package io.trino.spi.type;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.util.Arrays;
+import java.util.HexFormat;
 
-import static java.lang.String.format;
+import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public final class SqlVarbinary
         implements Comparable<SqlVarbinary>
 {
-    private static final String BYTE_SEPARATOR = " ";
+    private static final HexFormat HEX_FORMAT = HexFormat.of().withDelimiter(" ");
     private static final String WORD_SEPARATOR = "   ";
+    private static final int OUTPUT_CHARS_PER_FULL_WORD = (8 * 2) + 7; // two output hex chars per byte, 7 padding chars between them
 
     private final byte[] bytes;
 
@@ -36,15 +39,7 @@ public final class SqlVarbinary
     @Override
     public int compareTo(SqlVarbinary obj)
     {
-        for (int i = 0; i < Math.min(bytes.length, obj.bytes.length); i++) {
-            if (bytes[i] < obj.bytes[i]) {
-                return -1;
-            }
-            if (bytes[i] > obj.bytes[i]) {
-                return 1;
-            }
-        }
-        return bytes.length - obj.bytes.length;
+        return Arrays.compare(bytes, obj.bytes);
     }
 
     @JsonValue
@@ -75,22 +70,65 @@ public final class SqlVarbinary
     @Override
     public String toString()
     {
-        StringBuilder builder = new StringBuilder();
+        if (bytes.length == 0) {
+            return "";
+        }
+        int fullLineCount = bytes.length / 32;
+        int lastLineBytes = bytes.length % 32;
 
-        for (int i = 0; i < bytes.length; ++i) {
+        // 4 full words with 3 word separators and one line break per full line of output
+        long totalSize = fullLineCount * ((4 * OUTPUT_CHARS_PER_FULL_WORD) + (3 * WORD_SEPARATOR.length()) + 1);
+        if (lastLineBytes == 0) {
+            totalSize--; // no final line separator
+        }
+        else {
+            int lastLineWords = lastLineBytes / 8;
+            totalSize += (lastLineWords * (OUTPUT_CHARS_PER_FULL_WORD + WORD_SEPARATOR.length()));
+            // whole words and separators on last line
+            if (lastLineWords * 8 == lastLineBytes) {
+                totalSize -= WORD_SEPARATOR.length(); // last line ends on a word boundary, no separator
+            }
+            else {
+                // Trailing partial word on the last line
+                int lastWordBytes = lastLineBytes % 8;
+                // 2 hex chars per byte in the last word, plus 1 byte separator between each hex pair
+                totalSize += (2L * lastWordBytes) + (lastWordBytes - 1);
+            }
+        }
+
+        StringBuilder builder = new StringBuilder(toIntExact(totalSize));
+
+        int index = 0;
+        for (int i = 0; i < fullLineCount; i++) {
             if (i != 0) {
-                if (i % 32 == 0) {
-                    builder.append("\n");
-                }
-                else if (i % 8 == 0) {
+                builder.append("\n");
+            }
+            HEX_FORMAT.formatHex(builder, bytes, index, index + 8);
+            builder.append(WORD_SEPARATOR);
+            index += 8;
+            HEX_FORMAT.formatHex(builder, bytes, index, index + 8);
+            builder.append(WORD_SEPARATOR);
+            index += 8;
+            HEX_FORMAT.formatHex(builder, bytes, index, index + 8);
+            builder.append(WORD_SEPARATOR);
+            index += 8;
+            HEX_FORMAT.formatHex(builder, bytes, index, index + 8);
+            index += 8;
+        }
+        if (lastLineBytes > 0) {
+            if (fullLineCount > 0) {
+                builder.append("\n");
+            }
+            boolean firstWord = true;
+            while (index < bytes.length) {
+                if (!firstWord) {
                     builder.append(WORD_SEPARATOR);
                 }
-                else {
-                    builder.append(BYTE_SEPARATOR);
-                }
+                firstWord = false;
+                int length = min(8, bytes.length - index);
+                HEX_FORMAT.formatHex(builder, bytes, index, index + length);
+                index += length;
             }
-
-            builder.append(format("%02x", bytes[i] & 0xff));
         }
         return builder.toString();
     }

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestSqlVarbinary.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestSqlVarbinary.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.type;
+
+import org.testng.annotations.Test;
+
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+
+public class TestSqlVarbinary
+{
+    @Test
+    public void testToString()
+    {
+        for (int lines = 0; lines < 5; lines++) {
+            for (int lastLineBytes = 0; lastLineBytes < 32; lastLineBytes++) {
+                byte[] bytes = createBytes(lines, lastLineBytes);
+                String expected = simpleToString(bytes);
+                assertEquals(new SqlVarbinary(bytes).toString(), expected);
+            }
+        }
+    }
+
+    private static String simpleToString(byte[] bytes)
+    {
+        StringBuilder builder = new StringBuilder();
+
+        for (int i = 0; i < bytes.length; ++i) {
+            if (i != 0) {
+                if (i % 32 == 0) {
+                    builder.append("\n");
+                }
+                else if (i % 8 == 0) {
+                    builder.append("   ");
+                }
+                else {
+                    builder.append(" ");
+                }
+            }
+
+            builder.append(format("%02x", bytes[i] & 0xff));
+        }
+        return builder.toString();
+    }
+
+    private static byte[] createBytes(int lines, int lastLineLength)
+    {
+        byte[] bytes = new byte[(lines * 32) + lastLineLength];
+        for (int i = 0; i < bytes.length; i++) {
+            bytes[i] = (byte) i;
+        }
+        return bytes;
+    }
+}

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestSqlVarbinary.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestSqlVarbinary.java
@@ -13,10 +13,10 @@
  */
 package io.trino.spi.type;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import static java.lang.String.format;
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestSqlVarbinary
 {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR contains three minor improvements, in separate commits:
- Improves performance of `VarbinaryFunctions.{toHex,fromHexVarchar}` implementations by avoiding intermediate `String` materializations and operating over the primitive byte arrays where possible.
- Improves `VarbinaryFunctions.crc32` to use the primitive byte array when possible instead of creating a new `ByteBuffer` to compute the crc32 value
- Improves `SqlVarbinary#toString` by precomputing the exact output size required for the `StringBuilder` and using `java.util.HexFormat` instead of calling `String.format` as part of the per-byte inner loop.


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

No non-technical explanation is necessary, this are not user visible changes.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

