### PR TITLE
Report physical input data size in EXPLAIN ANALYZE

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/HashCollisionPlanNodeStats.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/HashCollisionPlanNodeStats.java
@@ -49,6 +49,7 @@ public class HashCollisionPlanNodeStats
                 planNodeBlockedTime,
                 planNodeInputPositions,
                 planNodeInputDataSize,
+                DataSize.ofBytes(0L),
                 planNodeOutputPositions,
                 planNodeOutputDataSize,
                 planNodeSpilledDataSize,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStats.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStats.java
@@ -41,6 +41,7 @@ public class PlanNodeStats
     private final Duration planNodeBlockedTime;
     private final long planNodeInputPositions;
     private final DataSize planNodeInputDataSize;
+    private final DataSize planNodePhysicalInputDataSize;
     private final long planNodeOutputPositions;
     private final DataSize planNodeOutputDataSize;
     private final DataSize planNodeSpilledDataSize;
@@ -54,6 +55,7 @@ public class PlanNodeStats
             Duration planNodeBlockedTime,
             long planNodeInputPositions,
             DataSize planNodeInputDataSize,
+            DataSize planNodePhysicalInputDataSize,
             long planNodeOutputPositions,
             DataSize planNodeOutputDataSize,
             DataSize planNodeSpilledDataSize,
@@ -65,6 +67,7 @@ public class PlanNodeStats
         this.planNodeCpuTime = requireNonNull(planNodeCpuTime, "planNodeCpuTime is null");
         this.planNodeBlockedTime = requireNonNull(planNodeBlockedTime, "planNodeBlockedTime is null");
         this.planNodeInputPositions = planNodeInputPositions;
+        this.planNodePhysicalInputDataSize = planNodePhysicalInputDataSize;
         this.planNodeInputDataSize = planNodeInputDataSize;
         this.planNodeOutputPositions = planNodeOutputPositions;
         this.planNodeOutputDataSize = planNodeOutputDataSize;
@@ -113,6 +116,11 @@ public class PlanNodeStats
     public DataSize getPlanNodeInputDataSize()
     {
         return planNodeInputDataSize;
+    }
+
+    public DataSize getPlanNodePhysicalInputDataSize()
+    {
+        return planNodePhysicalInputDataSize;
     }
 
     public long getPlanNodeOutputPositions()
@@ -172,6 +180,7 @@ public class PlanNodeStats
                 new Duration(planNodeCpuTime.toMillis() + other.getPlanNodeCpuTime().toMillis(), MILLISECONDS),
                 new Duration(planNodeBlockedTime.toMillis() + other.getPlanNodeBlockedTime().toMillis(), MILLISECONDS),
                 planNodeInputPositions, planNodeInputDataSize,
+                succinctBytes(this.planNodePhysicalInputDataSize.toBytes() + other.planNodePhysicalInputDataSize.toBytes()),
                 planNodeOutputPositions, planNodeOutputDataSize,
                 succinctBytes(this.planNodeSpilledDataSize.toBytes() + other.planNodeSpilledDataSize.toBytes()),
                 operatorStats);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStatsSummarizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStatsSummarizer.java
@@ -78,6 +78,7 @@ public final class PlanNodeStatsSummarizer
         Map<PlanNodeId, Long> planNodeSpilledDataSize = new HashMap<>();
         Map<PlanNodeId, Long> planNodeScheduledMillis = new HashMap<>();
         Map<PlanNodeId, Long> planNodeCpuMillis = new HashMap<>();
+        Map<PlanNodeId, Long> planNodePhysicalInputDataSize = new HashMap<>();
         Map<PlanNodeId, Long> planNodeBlockedMillis = new HashMap<>();
 
         Map<PlanNodeId, Map<String, BasicOperatorStats>> basicOperatorStats = new HashMap<>();
@@ -107,7 +108,7 @@ public final class PlanNodeStatsSummarizer
 
                 planNodeBlockedMillis.merge(planNodeId, operatorStats.getBlockedWall().toMillis(), Long::sum);
                 planNodeSpilledDataSize.merge(planNodeId, operatorStats.getSpilledDataSize().toBytes(), Long::sum);
-
+                planNodePhysicalInputDataSize.merge(planNodeId, operatorStats.getPhysicalInputDataSize().toBytes(), Long::sum);
                 // A plan node like LocalExchange consists of LocalExchangeSource which links to another pipeline containing LocalExchangeSink
                 if (operatorStats.getPlanNodeId().equals(inputPlanNode) && !pipelineStats.isInputPipeline()) {
                     continue;
@@ -230,6 +231,7 @@ public final class PlanNodeStatsSummarizer
                         new Duration(planNodeBlockedMillis.get(planNodeId), MILLISECONDS),
                         planNodeInputPositions.get(planNodeId),
                         succinctBytes(planNodeInputBytes.get(planNodeId)),
+                        succinctBytes(planNodePhysicalInputDataSize.getOrDefault(planNodeId, 0L)),
                         outputPositions,
                         succinctBytes(planNodeOutputBytes.getOrDefault(planNodeId, 0L)),
                         succinctBytes(planNodeSpilledDataSize.get(planNodeId)),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/WindowPlanNodeStats.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/WindowPlanNodeStats.java
@@ -44,6 +44,7 @@ public class WindowPlanNodeStats
                 planNodeBlockedTime,
                 planNodeInputPositions,
                 planNodeInputDataSize,
+                DataSize.ofBytes(0L),
                 planNodeOutputPositions,
                 planNodeOutputDataSize,
                 planNodeSpilledDataSize,

--- a/docs/src/main/sphinx/sql/explain-analyze.rst
+++ b/docs/src/main/sphinx/sql/explain-analyze.rst
@@ -42,38 +42,50 @@ relevant plan nodes). Such statistics are useful when one wants to detect data a
                                               Query Plan
     -----------------------------------------------------------------------------------------------
     Fragment 1 [HASH]
-        Cost: CPU 88.57ms, Input: 4000 rows (148.44kB), Output: 1000 rows (28.32kB)
-        Output layout: [count, clerk]
+        CPU: 22.58ms, Scheduled: 96.72ms, Blocked 46.21s (Input: 23.06s, Output: 0.00ns), Input: 1000 rows (37.11kB); per task: avg.: 1000.00 std.dev.: 0.00, Output: 1000 rows (28.32kB)
+        Output layout: [clerk, count]
         Output partitioning: SINGLE []
-        - Project[] => [count:bigint, clerk:varchar(15)]
-                Cost: 26.24%, Input: 1000 rows (37.11kB), Output: 1000 rows (28.32kB), Filtered: 0.00%
-                Input avg.: 62.50 lines, Input std.dev.: 14.77%
-            - Aggregate(FINAL)[clerk][$hashvalue] => [clerk:varchar(15), $hashvalue:bigint, count:bigint]
-                    Cost: 16.83%, Output: 1000 rows (37.11kB)
-                    Input avg.: 250.00 lines, Input std.dev.: 14.77%
-                    count := "count"("count_8")
-                - LocalExchange[HASH][$hashvalue] ("clerk") => clerk:varchar(15), count_8:bigint, $hashvalue:bigint
-                        Cost: 47.28%, Output: 4000 rows (148.44kB)
-                        Input avg.: 4000.00 lines, Input std.dev.: 0.00%
-                    - RemoteSource[2] => [clerk:varchar(15), count_8:bigint, $hashvalue_9:bigint]
-                            Cost: 9.65%, Output: 4000 rows (148.44kB)
-                            Input avg.: 4000.00 lines, Input std.dev.: 0.00%
+        Project[]
+        │   Layout: [clerk:varchar(15), count:bigint]
+        │   Estimates: {rows: ? (?), cpu: ?, memory: 0B, network: 0B}
+        │   CPU: 8.00ms (3.51%), Scheduled: 63.00ms (15.11%), Blocked: 0.00ns (0.00%), Output: 1000 rows (28.32kB)
+        │   Input avg.: 15.63 rows, Input std.dev.: 24.36%
+        └─ Aggregate[type = FINAL, keys = [clerk], hash = [$hashvalue]]
+           │   Layout: [clerk:varchar(15), $hashvalue:bigint, count:bigint]
+           │   Estimates: {rows: ? (?), cpu: ?, memory: ?, network: 0B}
+           │   CPU: 8.00ms (3.51%), Scheduled: 22.00ms (5.28%), Blocked: 0.00ns (0.00%), Output: 1000 rows (37.11kB)
+           │   Input avg.: 15.63 rows, Input std.dev.: 24.36%
+           │   Collisions avg.: 0.00 (0.00% est.), Collisions std.dev.: ?%
+           │   count := count("count_0")
+           └─ LocalExchange[partitioning = HASH, hashColumn = [$hashvalue], arguments = ["clerk"]]
+              │   Layout: [clerk:varchar(15), count_0:bigint, $hashvalue:bigint]
+              │   Estimates: {rows: ? (?), cpu: ?, memory: 0B, network: 0B}
+              │   CPU: 2.00ms (0.88%), Scheduled: 4.00ms (0.96%), Blocked: 23.15s (50.10%), Output: 1000 rows (37.11kB)
+              │   Input avg.: 15.63 rows, Input std.dev.: 793.73%
+              └─ RemoteSource[sourceFragmentIds = [2]]
+                     Layout: [clerk:varchar(15), count_0:bigint, $hashvalue_1:bigint]
+                     CPU: 0.00ns (0.00%), Scheduled: 0.00ns (0.00%), Blocked: 23.06s (49.90%), Output: 1000 rows (37.11kB)
+                     Input avg.: 15.63 rows, Input std.dev.: 793.73%
 
-    Fragment 2 [tpch:orders:1500000]
-        Cost: CPU 14.00s, Input: 818058 rows (22.62MB), Output: 4000 rows (148.44kB)
-        Output layout: [clerk, count_8, $hashvalue_10]
-        Output partitioning: HASH [clerk][$hashvalue_10]
-        - Aggregate(PARTIAL)[clerk][$hashvalue_10] => [clerk:varchar(15), $hashvalue_10:bigint, count_8:bigint]
-                Cost: 4.47%, Output: 4000 rows (148.44kB)
-                Input avg.: 204514.50 lines, Input std.dev.: 0.05%
-                Collisions avg.: 5701.28 (17569.93% est.), Collisions std.dev.: 1.12%
-                count_8 := "count"(*)
-            - ScanFilterProject[table = tpch:tpch:orders:sf1.0, originalConstraint = ("orderdate" > "$literal$date"(BIGINT '9131')), filterPredicate = ("orderdate" > "$literal$date"(BIGINT '9131'))] => [cler
-                    Cost: 95.53%, Input: 1500000 rows (0B), Output: 818058 rows (22.62MB), Filtered: 45.46%
-                    Input avg.: 375000.00 lines, Input std.dev.: 0.00%
-                    $hashvalue_10 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("clerk"), 0))
-                    orderdate := tpch:orderdate
-                    clerk := tpch:clerk
+    Fragment 2 [SOURCE]
+        CPU: 210.60ms, Scheduled: 327.92ms, Blocked 0.00ns (Input: 0.00ns, Output: 0.00ns), Input: 1500000 rows (18.17MB); per task: avg.: 1500000.00 std.dev.: 0.00, Output: 1000 rows (37.11kB)
+        Output layout: [clerk, count_0, $hashvalue_2]
+        Output partitioning: HASH [clerk][$hashvalue_2]
+        Aggregate[type = PARTIAL, keys = [clerk], hash = [$hashvalue_2]]
+        │   Layout: [clerk:varchar(15), $hashvalue_2:bigint, count_0:bigint]
+        │   CPU: 30.00ms (13.16%), Scheduled: 30.00ms (7.19%), Blocked: 0.00ns (0.00%), Output: 1000 rows (37.11kB)
+        │   Input avg.: 818058.00 rows, Input std.dev.: 0.00%
+        │   Collisions avg.: 8247.00 (25415.23% est.), Collisions std.dev.: 0.00%
+        │   count_0 := count(*)
+        └─ ScanFilterProject[table = hive:sf1:orders, filterPredicate = ("orderdate" > DATE '1995-01-01')]
+               Layout: [clerk:varchar(15), $hashvalue_2:bigint]
+               Estimates: {rows: 1500000 (41.48MB), cpu: 35.76M, memory: 0B, network: 0B}/{rows: 816424 (22.58MB), cpu: 35.76M, memory: 0B, network: 0B}/{rows: 816424 (22.58MB), cpu: 22.58M, memory: 0B, network: 0B}
+               CPU: 180.00ms (78.95%), Scheduled: 298.00ms (71.46%), Blocked: 0.00ns (0.00%), Output: 818058 rows (12.98MB)
+               Input avg.: 1500000.00 rows, Input std.dev.: 0.00%
+               $hashvalue_2 := combine_hash(bigint '0', COALESCE("$operator$hash_code"("clerk"), 0))
+               clerk := clerk:varchar(15):REGULAR
+               orderdate := orderdate:date:REGULAR
+               Input: 1500000 rows (18.17MB), Filtered: 45.46%, Physical Input: 4.51MB
 
 When the ``VERBOSE`` option is used, some operators may report additional information.
 For example, the window function operator will output the following::
@@ -86,16 +98,21 @@ For example, the window function operator will output the following::
                                               Query Plan
     -----------------------------------------------------------------------------------------------
       ...
-             - Window[] => [clerk:varchar(15), count:bigint]
-                     Cost: {rows: ?, bytes: ?}
-                     CPU fraction: 75.93%, Output: 8130 rows (230.24kB)
-                     Input avg.: 8130.00 lines, Input std.dev.: 0.00%
-                     Active Drivers: [ 1 / 1 ]
-                     Index size: std.dev.: 0.00 bytes , 0.00 rows
-                     Index count per driver: std.dev.: 0.00
-                     Rows per driver: std.dev.: 0.00
-                     Size of partition: std.dev.: 0.00
-                     count := count("clerk")
+             ─ Window[]
+               │   Layout: [clerk:varchar(15), count:bigint]
+               │   CPU: 157.00ms (53.40%), Scheduled: 158.00ms (37.71%), Blocked: 0.00ns (0.00%), Output: 818058 rows (22.62MB)
+               │   metrics:
+               │     'Blocked time distribution (s)' = {count=1.00, p01=0.00, p05=0.00, p10=0.00, p25=0.00, p50=0.00, p75=0.00, p90=0.00, p95=0.00, p99=0.00, min=0.00, max=0.00}
+               │     'CPU time distribution (s)' = {count=1.00, p01=0.16, p05=0.16, p10=0.16, p25=0.16, p50=0.16, p75=0.16, p90=0.16, p95=0.16, p99=0.16, min=0.16, max=0.16}
+               │     'Input rows distribution' = {count=1.00, p01=818058.00, p05=818058.00, p10=818058.00, p25=818058.00, p50=818058.00, p75=818058.00, p90=818058.00, p95=818058.00, p99=818058.00, min=818058.00, max=818058.00}
+               │     'Scheduled time distribution (s)' = {count=1.00, p01=0.16, p05=0.16, p10=0.16, p25=0.16, p50=0.16, p75=0.16, p90=0.16, p95=0.16, p99=0.16, min=0.16, max=0.16}
+               │   Input avg.: 818058.00 rows, Input std.dev.: 0.00%
+               │   Active Drivers: [ 1 / 1 ]
+               │   Index size: std.dev.: 0.00 bytes, 0.00 rows
+               │   Index count per driver: std.dev.: 0.00
+               │   Rows per driver: std.dev.: 0.00
+               │   Size of partition: std.dev.: 0.00
+               │   count := count("clerk") RANGE UNBOUNDED_PRECEDING CURRENT_ROW
      ...
 
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -8312,6 +8312,14 @@ public abstract class BaseHiveConnectorTest
     }
 
     @Test
+    public void testExplainAnalyzePhysicalInputSize()
+    {
+        assertExplainAnalyze(
+                "EXPLAIN ANALYZE SELECT * FROM nation a",
+                "Physical Input: .*B");
+    }
+
+    @Test
     public void testExplainAnalyzePhysicalReadWallTime()
     {
         assertExplainAnalyze(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Additional information about physical data size used by connector to EXPLAIN ANALYZE in connector metrics section.

Example output.
```
     └─ TableScan[table = iceberg:part.ztest$data@1581575691215353074]
            Layout: [id:bigint, small:varchar, medium:varchar, big:varchar]
            Estimates: {rows: 483 (125.00kB), cpu: 125.00k, memory: 0B, network: 0B}
            CPU: 1.32s (62.71%), Scheduled: 3.59s (76.56%), Blocked: 0.00ns (0.00%), Output: 87 rows (1.36GB)
            Input avg.: 0.97 rows, Input std.dev.: 18.57%
            small := 2:small:varchar
            big := 4:big:varchar
            id := 1:id:bigint
            medium := 3:medium:varchar
            Physical Input: 932.06kB
```

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Additional information about physical data size used by connector to EXPLAIN ANALYZE.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```
# General
* Add the amount of data read from an external source during table scan to EXPLAIN ANALYZE. ({issue}`14907`)
```