### PR TITLE
Use batch deletes in IcebergMetadata

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1900,11 +1900,10 @@ public class IcebergMetadata
         if (!fullyDeletedFiles.isEmpty()) {
             try {
                 TrinoFileSystem fileSystem = fileSystemFactory.create(session);
-                for (List<CommitTaskData> commitTasksToCleanUp : fullyDeletedFiles.values()) {
-                    for (CommitTaskData commitTaskData : commitTasksToCleanUp) {
-                        fileSystem.deleteFile(commitTaskData.getPath());
-                    }
-                }
+                fileSystem.deleteFiles(fullyDeletedFiles.values().stream()
+                        .flatMap(Collection::stream)
+                        .map(CommitTaskData::getPath)
+                        .collect(toImmutableSet()));
             }
             catch (IOException e) {
                 log.warn(e, "Failed to clean up uncommitted position delete files");


### PR DESCRIPTION
## Description

@homar recently added an API to the FileSystem API to delete a batch of files, if the underlying filesystem supports it. Leverage that API in places where many files are deleted at once.

## Non-technical explanation

Leverage delete APIs in a more efficient way, if available.

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: