### PR TITLE
Map sqlserver uniqueidentifier to trino UUID

### DIFF
--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -221,6 +221,9 @@ The connector maps SQL server types to the corresponding Trino types following t
   * - ``DATETIMEOFFSET[(n)]``
     - ``TIMESTAMP(n) WITH TIME ZONE``
     - ``0 <= n <= 7``
+  * - ``UNIQUEIDENTIFIER``
+    - ``UUID``
+    -
 
 Trino type to SQL Server type mapping
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -276,6 +279,9 @@ The connector maps Trino types to the corresponding SQL Server types following t
   * - ``TIMESTAMP(n)``
     - ``DATETIME2(n)``
     - ``0 <= n <= 7``
+  * - ``UUID``
+    - ``UNIQUEIDENTIFIER``
+    -
 
 Complete list of `SQL Server data types
 <https://msdn.microsoft.com/en-us/library/ms187752.aspx>`_.

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/sqlserver/SqlServerDataTypesTableDefinition.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/sqlserver/SqlServerDataTypesTableDefinition.java
@@ -57,7 +57,8 @@ public final class SqlServerDataTypesTableDefinition
                     "dt3 datetime2, " +
                     "sdt smalldatetime, " +
                     "pf30 float(30), " +
-                    "pf22 float(22))";
+                    "pf22 float(22), " +
+                    "ui uniqueidentifier)";
 
     private static final String INSERT_DDL =
             "CREATE TABLE %NAME% (bi bigint, si smallint, i int, f float,c char(4), vc varchar(6), pf30 float(30), d date) ";
@@ -83,7 +84,8 @@ public final class SqlServerDataTypesTableDefinition
                         Timestamp.valueOf("1970-01-01 00:00:00"),
                         Timestamp.valueOf("1960-01-01 00:00:00"),
                         Double.MIN_VALUE,
-                        -3.40E+38f),
+                        -3.40E+38f,
+                        "754c6fb2-d6f7-8c49-f991-80b155cefead"),
                 ImmutableList.of(
                         Long.MAX_VALUE,
                         Short.MAX_VALUE,
@@ -103,8 +105,9 @@ public final class SqlServerDataTypesTableDefinition
                         Timestamp.valueOf("9999-12-31 23:59:59.999"),
                         Timestamp.valueOf("2079-06-05 23:59:59"),
                         12345678912.3456756,
-                        12345678.6557f),
-                nCopies(19, null))
+                        12345678.6557f,
+                        "e04949ec-8c67-409e-1983-e7ace2e55a8c"),
+                nCopies(20, null))
                 .iterator();
 
         SQLSERVER_ALL_TYPES = RelationalTableDefinition.builder(ALL_TYPES_TABLE_NAME)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/sqlserver/TestSelect.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/sqlserver/TestSelect.java
@@ -45,6 +45,7 @@ import static java.sql.JDBCType.CHAR;
 import static java.sql.JDBCType.DATE;
 import static java.sql.JDBCType.DOUBLE;
 import static java.sql.JDBCType.INTEGER;
+import static java.sql.JDBCType.JAVA_OBJECT;
 import static java.sql.JDBCType.REAL;
 import static java.sql.JDBCType.SMALLINT;
 import static java.sql.JDBCType.TIMESTAMP;
@@ -147,7 +148,8 @@ public class TestSelect
                         TIMESTAMP,
                         TIMESTAMP,
                         DOUBLE,
-                        REAL)
+                        REAL,
+                        JAVA_OBJECT)
                 .containsOnly(
                         row(
                                 Long.MIN_VALUE,
@@ -168,7 +170,8 @@ public class TestSelect
                                 Timestamp.valueOf("1970-01-01 00:00:00.000"),
                                 Timestamp.valueOf("1960-01-01 00:00:00"),
                                 Double.MIN_VALUE,
-                                -3.40E+38f),
+                                -3.40E+38f,
+                                "754c6fb2-d6f7-8c49-f991-80b155cefead"),
                         row(
                                 Long.MAX_VALUE,
                                 Short.MAX_VALUE,
@@ -188,8 +191,9 @@ public class TestSelect
                                 Timestamp.valueOf("9999-12-31 23:59:59.999"),
                                 Timestamp.valueOf("2079-06-06 00:00:00"),
                                 12345678912.3456756,
-                                12345678.6557f),
-                        row(nCopies(19, null).toArray()));
+                                12345678.6557f,
+                                "e04949ec-8c67-409e-1983-e7ace2e55a8c"),
+                        row(nCopies(20, null).toArray()));
     }
 
     @Test(groups = {SQL_SERVER, PROFILE_SPECIFIC_TESTS})


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR should close #14456 .
* Add logic to map sqlserver `uniqueidentifier` to trino `uuid`
  * The JDBC type for `uniqueidentifier` is `CHAR` hence, transform the object to string for reading and writing `UUID`.
* Add a type mapping unit test case
* Update `sqlserver.rst`

I've tested with my local set up by verifying the data type with `DESC` and `SELECT` `INSERT` statements. I am looking into adding product test cases for this, but I want to send the PR out to get comments on the implementation.


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:
