### PR TITLE
Push DictionaryBlock through remote partitioned exchange

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
@@ -17,8 +17,13 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntArrays;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.instanceSize;
+import static io.trino.operator.output.PositionsAppenderUtil.calculateBlockResetSize;
+import static io.trino.operator.output.PositionsAppenderUtil.calculateNewArraySize;
+import static java.lang.Math.max;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -30,10 +35,12 @@ public class UnnestingPositionsAppender
     private static final int INSTANCE_SIZE = instanceSize(UnnestingPositionsAppender.class);
 
     private final PositionsAppender delegate;
+    private DictionaryBlockBuilder dictionaryBlockBuilder;
 
     public UnnestingPositionsAppender(PositionsAppender delegate)
     {
         this.delegate = requireNonNull(delegate, "delegate is null");
+        this.dictionaryBlockBuilder = new DictionaryBlockBuilder();
     }
 
     @Override
@@ -43,12 +50,14 @@ public class UnnestingPositionsAppender
             return;
         }
         if (source instanceof RunLengthEncodedBlock) {
+            dictionaryBlockBuilder.flushDictionary(delegate);
             delegate.appendRle(((RunLengthEncodedBlock) source).getValue(), positions.size());
         }
         else if (source instanceof DictionaryBlock) {
             appendDictionary(positions, (DictionaryBlock) source);
         }
         else {
+            dictionaryBlockBuilder.flushDictionary(delegate);
             delegate.append(positions, source);
         }
     }
@@ -59,12 +68,15 @@ public class UnnestingPositionsAppender
         if (rlePositionCount == 0) {
             return;
         }
+        dictionaryBlockBuilder.flushDictionary(delegate);
         delegate.appendRle(block, rlePositionCount);
     }
 
     @Override
     public void append(int position, Block source)
     {
+        dictionaryBlockBuilder.flushDictionary(delegate);
+
         if (source instanceof RunLengthEncodedBlock runLengthEncodedBlock) {
             delegate.append(0, runLengthEncodedBlock.getValue());
         }
@@ -79,13 +91,21 @@ public class UnnestingPositionsAppender
     @Override
     public Block build()
     {
-        return delegate.build();
+        Block result;
+        if (dictionaryBlockBuilder.isEmpty()) {
+            result = delegate.build();
+        }
+        else {
+            result = dictionaryBlockBuilder.build();
+        }
+        dictionaryBlockBuilder = dictionaryBlockBuilder.newBuilderLike();
+        return result;
     }
 
     @Override
     public long getRetainedSizeInBytes()
     {
-        return INSTANCE_SIZE + delegate.getRetainedSizeInBytes();
+        return INSTANCE_SIZE + delegate.getRetainedSizeInBytes() + dictionaryBlockBuilder.getRetainedSizeInBytes();
     }
 
     @Override
@@ -96,15 +116,114 @@ public class UnnestingPositionsAppender
 
     private void appendDictionary(IntArrayList positions, DictionaryBlock source)
     {
-        delegate.append(mapPositions(positions, source), source.getDictionary());
+        Block dictionary = source.getDictionary();
+        IntArrayList dictionaryPositions = getDictionaryPositions(positions, source);
+        if (dictionaryBlockBuilder.canAppend(dictionary)) {
+            dictionaryBlockBuilder.append(dictionaryPositions, dictionary);
+        }
+        else {
+            dictionaryBlockBuilder.flushDictionary(delegate);
+            delegate.append(dictionaryPositions, dictionary);
+        }
     }
 
-    private IntArrayList mapPositions(IntArrayList positions, DictionaryBlock block)
+    private IntArrayList getDictionaryPositions(IntArrayList positions, DictionaryBlock block)
     {
         int[] positionArray = new int[positions.size()];
         for (int i = 0; i < positions.size(); i++) {
             positionArray[i] = block.getId(positions.getInt(i));
         }
         return IntArrayList.wrap(positionArray);
+    }
+
+    private static class DictionaryBlockBuilder
+    {
+        private static final int INSTANCE_SIZE = instanceSize(DictionaryBlockBuilder.class);
+        private final int initialEntryCount;
+        private Block dictionary;
+        private int[] dictionaryIds;
+        private int positionCount;
+        private boolean closed;
+
+        public DictionaryBlockBuilder()
+        {
+            this(1024);
+        }
+
+        public DictionaryBlockBuilder(int initialEntryCount)
+        {
+            this.initialEntryCount = initialEntryCount;
+            this.dictionaryIds = new int[0];
+        }
+
+        public boolean isEmpty()
+        {
+            return positionCount == 0;
+        }
+
+        public Block build()
+        {
+            return DictionaryBlock.create(positionCount, dictionary, dictionaryIds);
+        }
+
+        public long getRetainedSizeInBytes()
+        {
+            return INSTANCE_SIZE
+                    + (long) dictionaryIds.length * Integer.BYTES
+                    + (dictionary != null ? dictionary.getRetainedSizeInBytes() : 0);
+        }
+
+        public boolean canAppend(Block dictionary)
+        {
+            return !closed && (dictionary == this.dictionary || this.dictionary == null);
+        }
+
+        public void append(IntArrayList mappedPositions, Block dictionary)
+        {
+            checkArgument(canAppend(dictionary));
+            this.dictionary = dictionary;
+            ensureCapacity(positionCount + mappedPositions.size());
+            System.arraycopy(mappedPositions.elements(), 0, dictionaryIds, positionCount, mappedPositions.size());
+            positionCount += mappedPositions.size();
+        }
+
+        public void flushDictionary(PositionsAppender delegate)
+        {
+            if (closed) {
+                return;
+            }
+            if (positionCount > 0) {
+                requireNonNull(dictionary, () -> "dictionary is null but we have pending dictionaryIds " + positionCount);
+                delegate.append(IntArrayList.wrap(dictionaryIds, positionCount), dictionary);
+            }
+
+            closed = true;
+            dictionaryIds = new int[0];
+            positionCount = 0;
+            dictionary = null;
+        }
+
+        public DictionaryBlockBuilder newBuilderLike()
+        {
+            return new DictionaryBlockBuilder(max(calculateBlockResetSize(positionCount), initialEntryCount));
+        }
+
+        private void ensureCapacity(int capacity)
+        {
+            if (dictionaryIds.length >= capacity) {
+                return;
+            }
+
+            int newSize;
+            if (dictionaryIds.length > 0) {
+                newSize = calculateNewArraySize(dictionaryIds.length);
+            }
+            else {
+                newSize = initialEntryCount;
+            }
+            newSize = Math.max(newSize, capacity);
+
+            dictionaryIds = IntArrays.ensureCapacity(dictionaryIds, newSize, positionCount);
+        }
     }
 }

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestDictionaryBlockEncoding.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestDictionaryBlockEncoding.java
@@ -18,7 +18,6 @@ import org.testng.annotations.Test;
 
 import static io.trino.spi.block.BlockTestUtils.assertBlockEquals;
 import static io.trino.spi.type.VarcharType.VARCHAR;
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 public class TestDictionaryBlockEncoding
@@ -40,13 +39,7 @@ public class TestDictionaryBlockEncoding
         DictionaryBlock dictionaryBlock = (DictionaryBlock) DictionaryBlock.create(ids.length, dictionary, ids);
 
         Block actualBlock = roundTripBlock(dictionaryBlock);
-        assertTrue(actualBlock instanceof DictionaryBlock);
-        DictionaryBlock actualDictionaryBlock = (DictionaryBlock) actualBlock;
-        assertBlockEquals(VARCHAR, actualDictionaryBlock.getDictionary(), dictionary);
-        for (int position = 0; position < actualDictionaryBlock.getPositionCount(); position++) {
-            assertEquals(actualDictionaryBlock.getId(position), ids[position]);
-        }
-        assertEquals(actualDictionaryBlock.getDictionarySourceId(), dictionaryBlock.getDictionarySourceId());
+        assertBlockEquals(VARCHAR, actualBlock, dictionaryBlock);
     }
 
     @Test
@@ -56,7 +49,6 @@ public class TestDictionaryBlockEncoding
         DictionaryBlock dictionaryBlock = (DictionaryBlock) DictionaryBlock.create(ids.length, dictionary, ids);
 
         Block actualBlock = roundTripBlock(dictionaryBlock);
-        assertTrue(actualBlock instanceof DictionaryBlock);
         assertBlockEquals(VARCHAR, actualBlock, dictionary.getPositions(ids, 0, 4));
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Dictionary-encoded blocks are currently flatened by the partitioned exchange operator. This prevents dictionary based optimizations from taking advantage of the encoded blocks (or results in additional overhead).
This PR adds support for dictionary encoded blocks through partitioned exchange for a case where the same dictionary (the same java object) is used by subsequent Blocks sent through `PartitionedOutputOperator`

Other than possible CPU optimizations, transmitting `DictionaryBlock`s over network reduces is more efficient than flat blocks.
As an example for query on tpch schema (sf10) encoded in orc files
```
explain analyze verbose select mktsegment from customer c, nation n where c.nationkey = n.nationkey;
```
**mktsegment** is dictionary encoded.

so when we look at the customer table scan we see
```
 Fragment 2 [SOURCE]                                                                                                                                                                                                     
     CPU: 308.06ms, Scheduled: 368.72ms, Blocked 0.00ns (Input: 0.00ns, Output: 0.00ns), Input: 1500000 rows (18.62MB); per task: avg.: 500000.00 std.dev.: 35568.30, Output: 1500000 rows (45.78MB)                     
     Output buffer active time: 385.00ms, buffer utilization distribution (%): {p01=0.00, p05=0.00, p10=0.00, p25=0.00, p50=0.00, p75=0.01, p90=2.97, p95=3.04, p99=3.10, max=6.15}                                      
     Output layout: [nationkey, mktsegment, $hashvalue_6]                                                                                                                                                                
     Output partitioning: HASH [nationkey][$hashvalue_6]                                                                                                                                                                 
     ScanFilterProject[table = hive:tpch:customer, dynamicFilters = {"nationkey" = #df_332}]                                                                                                                             
         Layout: [nationkey:bigint, mktsegment:varchar(10), $hashvalue_6:bigint]                                                                                                                                         
         Estimates: {rows: 1500000 (45.78MB), cpu: 32.90M, memory: 0B, network: 0B}/{rows: 1500000 (45.78MB), cpu: 32.90M, memory: 0B, network: 0B}/{rows: 1500000 (45.78MB), cpu: 45.78M, memory: 0B, network: 0B}      
         CPU: 309.00ms (59.54%), Scheduled: 368.00ms (60.83%), Blocked: 0.00ns (0.00%), Output: 1500000 rows (45.78MB)                                                                                                   
         connector metrics:                                                                                                                                                                                              
           'OrcReaderCompressionFormat_ZLIB' = LongCount{total=75868244}                                                                                                                                                 
           'Physical input read time' = {duration=5.19ms}                                                                                                                                                                
         metrics:                                                                                                                                                                                                        
           'Blocked time distribution (s)' = {count=3.00, p01=0.00, p05=0.00, p10=0.00, p25=0.00, p50=0.00, p75=0.00, p90=0.00, p95=0.00, p99=0.00, min=0.00, max=0.00}                                                  
           'CPU time distribution (s)' = {count=3.00, p01=0.06, p05=0.06, p10=0.06, p25=0.06, p50=0.06, p75=0.07, p90=0.07, p95=0.07, p99=0.07, min=0.06, max=0.07}                                                      
           'Input block types' = {}                                                                                                                                                                                      
           'Input rows distribution' = {count=3.00, p01=467180.00, p05=467180.00, p10=467180.00, p25=467180.00, p50=483398.00, p75=549422.00, p90=549422.00, p95=549422.00, p99=549422.00, min=467180.00, max=549422.00} 
           'Output block types' = {DictionaryBlock=LongCount{total=312}, LongArrayBlock=LongCount{total=922}, VariableWidthBlock=LongCount{total=149}}                                                                   
           'Projection CPU time' = {duration=612.80us}                                                                                                                                                                   
           'Scheduled time distribution (s)' = {count=3.00, p01=0.07, p05=0.07, p10=0.07, p25=0.07, p50=0.07, p75=0.07, p90=0.07, p95=0.07, p99=0.07, min=0.07, max=0.07}                                                
         Input avg.: 500000.00 rows, Input std.dev.: 7.11%                                                                                                                                                               
         $hashvalue_6 := combine_hash(bigint '0', COALESCE("$operator$hash_code"("nationkey"), 0))                                                                                                                       
         nationkey := nationkey:bigint:REGULAR                                                                                                                                                                           
         mktsegment := mktsegment:varchar(10):REGULAR                                                                                                                                                                    
         Input: 1500000 rows (18.62MB), Filtered: 0.00%                                                                                                                                                                  
         Dynamic filters:                                                                                                                                                                                                
             - df_332, [ SortedRangeSet[type=bigint, ranges=25, {[0], ..., [24]}] ], collection time=31.86ms    
```
and with this optimization
```
 Fragment 2 [SOURCE]                                                                                                                                                                                                     
     CPU: 294.82ms, Scheduled: 317.47ms, Blocked 0.00ns (Input: 0.00ns, Output: 0.00ns), Input: 1500000 rows (18.62MB); per task: avg.: 500000.00 std.dev.: 35568.30, Output: 1500000 rows (34.43MB)                     
     Output buffer active time: 342.36ms, buffer utilization distribution (%): {p01=0.00, p05=0.00, p10=0.00, p25=0.00, p50=0.00, p75=0.06, p90=3.40, p95=3.58, p99=3.94, max=7.09}                                      
     Output layout: [nationkey, mktsegment, $hashvalue_6]                                                                                                                                                                
     Output partitioning: HASH [nationkey][$hashvalue_6]                                                                                                                                                                 
     ScanFilterProject[table = hive:tpch:customer, dynamicFilters = {"nationkey" = #df_332}]                                                                                                                             
         Layout: [nationkey:bigint, mktsegment:varchar(10), $hashvalue_6:bigint]                                                                                                                                         
         Estimates: {rows: 1500000 (45.78MB), cpu: 32.90M, memory: 0B, network: 0B}/{rows: 1500000 (45.78MB), cpu: 32.90M, memory: 0B, network: 0B}/{rows: 1500000 (45.78MB), cpu: 45.78M, memory: 0B, network: 0B}      
         CPU: 294.00ms (59.51%), Scheduled: 317.00ms (59.36%), Blocked: 0.00ns (0.00%), Output: 1500000 rows (34.43MB)                                                                                                   
         connector metrics:                                                                                                                                                                                              
           'OrcReaderCompressionFormat_ZLIB' = LongCount{total=75868244}                                                                                                                                                 
           'Physical input read time' = {duration=15.62ms}                                                                                                                                                               
         metrics:                                                                                                                                                                                                        
           'Blocked time distribution (s)' = {count=3.00, p01=0.00, p05=0.00, p10=0.00, p25=0.00, p50=0.00, p75=0.00, p90=0.00, p95=0.00, p99=0.00, min=0.00, max=0.00}                                                  
           'CPU time distribution (s)' = {count=3.00, p01=0.06, p05=0.06, p10=0.06, p25=0.06, p50=0.06, p75=0.06, p90=0.06, p95=0.06, p99=0.06, min=0.06, max=0.06}                                                      
           'Input block types' = {}                                                                                                                                                                                      
           'Input rows distribution' = {count=3.00, p01=467180.00, p05=467180.00, p10=467180.00, p25=467180.00, p50=483398.00, p75=549422.00, p90=549422.00, p95=549422.00, p99=549422.00, min=467180.00, max=549422.00} 
           'Output block types' = {DictionaryBlock=LongCount{total=312}, LongArrayBlock=LongCount{total=922}, VariableWidthBlock=LongCount{total=149}}                                                                   
           'Projection CPU time' = {duration=498.71us}                                                                                                                                                                   
           'Scheduled time distribution (s)' = {count=3.00, p01=0.06, p05=0.06, p10=0.06, p25=0.06, p50=0.06, p75=0.07, p90=0.07, p95=0.07, p99=0.07, min=0.06, max=0.07}                                                
         Input avg.: 500000.00 rows, Input std.dev.: 7.11%                                                                                                                                                               
         $hashvalue_6 := combine_hash(bigint '0', COALESCE("$operator$hash_code"("nationkey"), 0))                                                                                                                       
         nationkey := nationkey:bigint:REGULAR                                                                                                                                                                           
         mktsegment := mktsegment:varchar(10):REGULAR                                                                                                                                                                    
         Input: 1500000 rows (18.62MB), Filtered: 0.00%                                                                                                                                                                  
         Dynamic filters:                                                                                                                                                                                                
             - df_332, [ SortedRangeSet[type=bigint, ranges=25, {[0], ..., [24]}] ], collection time=33.37ms 
```

so `Output: 1500000 rows (45.78MB) ` goes down to ` Output: 1500000 rows (34.43MB)`.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
Increase dictionary-encoded block usage in the engine.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
