### PR TITLE
Fix broken `TestSharedGlueMetastore.getExpectedHiveCreateSchema`

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestSharedGlueMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestSharedGlueMetastore.java
@@ -143,7 +143,6 @@ public class TestSharedGlueMetastore
     protected String getExpectedHiveCreateSchema(String catalogName)
     {
         String expectedHiveCreateSchema = "CREATE SCHEMA %s.%s\n" +
-                "AUTHORIZATION ROLE public\n" +
                 "WITH (\n" +
                 "   location = '%s'\n" +
                 ")";


### PR DESCRIPTION
## Description

Relates to https://github.com/trinodb/trino/pull/14285#issuecomment-1306186338

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
