### PR TITLE
Add InstanceSize with support for Java records

### DIFF
--- a/.mvn/modernizer/violations.xml
+++ b/.mvn/modernizer/violations.xml
@@ -271,4 +271,10 @@
         <version>1.8</version>
         <comment>Use io.trino.server.security.jwt.JwtsUtil or equivalent</comment>
     </violation>
+
+    <violation>
+        <name>org/openjdk/jol/info/ClassLayout.instanceSize:()J</name>
+        <version>1.8</version>
+        <comment>Use io.airlift.slice.SizeOf.instanceSize</comment>
+    </violation>
 </modernizer>

--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -338,11 +338,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.openjdk.jol</groupId>
-            <artifactId>jol-core</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
         </dependency>

--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaSplit.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaSplit.java
@@ -18,19 +18,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class InformationSchemaSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(InformationSchemaSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(InformationSchemaSplit.class);
 
     private final List<HostAddress> addresses;
 

--- a/core/trino-main/src/main/java/io/trino/connector/system/SystemColumnHandle.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SystemColumnHandle.java
@@ -18,19 +18,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorTableMetadata;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Map;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class SystemColumnHandle
         implements ColumnHandle
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SystemColumnHandle.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SystemColumnHandle.class);
 
     private final String columnName;
 

--- a/core/trino-main/src/main/java/io/trino/connector/system/SystemSplit.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SystemSplit.java
@@ -20,20 +20,19 @@ import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.predicate.TupleDomain;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class SystemSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SystemSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SystemSplit.class);
 
     private final List<HostAddress> addresses;
     private final TupleDomain<ColumnHandle> constraint;

--- a/core/trino-main/src/main/java/io/trino/exchange/DirectExchangeInput.java
+++ b/core/trino-main/src/main/java/io/trino/exchange/DirectExchangeInput.java
@@ -16,17 +16,16 @@ package io.trino.exchange;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.execution.TaskId;
-import org.openjdk.jol.info.ClassLayout;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class DirectExchangeInput
         implements ExchangeInput
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DirectExchangeInput.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DirectExchangeInput.class);
 
     private final TaskId taskId;
     private final String location;

--- a/core/trino-main/src/main/java/io/trino/exchange/SpoolingExchangeInput.java
+++ b/core/trino-main/src/main/java/io/trino/exchange/SpoolingExchangeInput.java
@@ -18,21 +18,20 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.exchange.ExchangeSourceHandle;
 import io.trino.spi.exchange.ExchangeSourceOutputSelector;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class SpoolingExchangeInput
         implements ExchangeInput
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SpoolingExchangeInput.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SpoolingExchangeInput.class);
 
     private final List<ExchangeSourceHandle> exchangeSourceHandles;
     private final Optional<ExchangeSourceOutputSelector> outputSelector;

--- a/core/trino-main/src/main/java/io/trino/execution/TaskId.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TaskId.java
@@ -16,21 +16,20 @@ package io.trino.execution;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.trino.spi.QueryId;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.QueryId.parseDottedId;
 import static java.lang.Integer.parseInt;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class TaskId
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TaskId.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(TaskId.class);
 
     @JsonCreator
     public static TaskId valueOf(String taskId)

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/PageDeserializer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/PageDeserializer.java
@@ -23,7 +23,6 @@ import io.airlift.slice.Slices;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.BlockEncodingSerde;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
@@ -37,6 +36,7 @@ import java.security.GeneralSecurityException;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.SizeOf.sizeOfByteArray;
 import static io.trino.execution.buffer.PagesSerdeUtil.ESTIMATED_AES_CIPHER_RETAINED_SIZE;
@@ -54,7 +54,7 @@ import static javax.crypto.Cipher.DECRYPT_MODE;
 
 public class PageDeserializer
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(PageDeserializer.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(PageDeserializer.class);
 
     private final BlockEncodingSerde blockEncodingSerde;
     private final SerializedPageInput input;
@@ -90,10 +90,10 @@ public class PageDeserializer
     private static class SerializedPageInput
             extends SliceInput
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SerializedPageInput.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(SerializedPageInput.class);
         // TODO: implement getRetainedSizeInBytes in Lz4Decompressor
-        private static final int DECOMPRESSOR_RETAINED_SIZE = toIntExact(ClassLayout.parseClass(Lz4Decompressor.class).instanceSize());
-        private static final int ENCRYPTION_KEY_RETAINED_SIZE = toIntExact(ClassLayout.parseClass(SecretKeySpec.class).instanceSize() + sizeOfByteArray(256 / 8));
+        private static final int DECOMPRESSOR_RETAINED_SIZE = instanceSize(Lz4Decompressor.class);
+        private static final int ENCRYPTION_KEY_RETAINED_SIZE = toIntExact(instanceSize(SecretKeySpec.class) + sizeOfByteArray(256 / 8));
 
         private final Optional<Lz4Decompressor> decompressor;
         private final Optional<SecretKey> encryptionKey;
@@ -460,7 +460,7 @@ public class PageDeserializer
 
     private static class ReadBuffer
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ReadBuffer.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(ReadBuffer.class);
 
         private final Slice slice;
         private int position;

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/PageSerializer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/PageSerializer.java
@@ -23,7 +23,6 @@ import io.airlift.slice.Slices;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.BlockEncodingSerde;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
@@ -36,6 +35,7 @@ import java.security.GeneralSecurityException;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.SizeOf.sizeOfByteArray;
 import static io.airlift.slice.SizeOf.sizeOfIntArray;
@@ -58,7 +58,7 @@ import static javax.crypto.Cipher.ENCRYPT_MODE;
 
 public class PageSerializer
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(PageSerializer.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(PageSerializer.class);
 
     private final BlockEncodingSerde blockEncodingSerde;
     private final SerializedPageOutput output;
@@ -93,10 +93,10 @@ public class PageSerializer
     private static class SerializedPageOutput
             extends SliceOutput
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SerializedPageOutput.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(SerializedPageOutput.class);
         // TODO: implement getRetainedSizeInBytes in Lz4Compressor
-        private static final int COMPRESSOR_RETAINED_SIZE = toIntExact(ClassLayout.parseClass(Lz4Compressor.class).instanceSize() + sizeOfIntArray(Lz4RawCompressor.MAX_TABLE_SIZE));
-        private static final int ENCRYPTION_KEY_RETAINED_SIZE = toIntExact(ClassLayout.parseClass(SecretKeySpec.class).instanceSize() + sizeOfByteArray(256 / 8));
+        private static final int COMPRESSOR_RETAINED_SIZE = toIntExact(instanceSize(Lz4Compressor.class) + sizeOfIntArray(Lz4RawCompressor.MAX_TABLE_SIZE));
+        private static final int ENCRYPTION_KEY_RETAINED_SIZE = toIntExact(instanceSize(SecretKeySpec.class) + sizeOfByteArray(256 / 8));
 
         private static final double MINIMUM_COMPRESSION_RATIO = 0.8;
 
@@ -531,7 +531,7 @@ public class PageSerializer
 
     private static class WriteBuffer
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(WriteBuffer.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(WriteBuffer.class);
 
         private Slice slice;
         private int position;

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeRequirements.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeRequirements.java
@@ -16,7 +16,6 @@ package io.trino.execution.scheduler;
 import com.google.common.collect.ImmutableSet;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.CatalogHandle;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -24,13 +23,13 @@ import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class NodeRequirements
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(NodeRequirements.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(NodeRequirements.class);
 
     private final Optional<CatalogHandle> catalogHandle;
     private final Set<HostAddress> addresses;

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/TaskDescriptor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/TaskDescriptor.java
@@ -17,19 +17,18 @@ import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ListMultimap;
 import io.trino.metadata.Split;
 import io.trino.sql.planner.plan.PlanNodeId;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.collect.Multimaps.asMap;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class TaskDescriptor
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TaskDescriptor.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(TaskDescriptor.class);
 
     private final int partitionId;
     private final ListMultimap<PlanNodeId, Split> splits;

--- a/core/trino-main/src/main/java/io/trino/metadata/Split.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Split.java
@@ -19,17 +19,16 @@ import io.trino.spi.HostAddress;
 import io.trino.spi.SplitWeight;
 import io.trino.spi.connector.CatalogHandle;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public final class Split
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(Split.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(Split.class);
 
     private final CatalogHandle catalogHandle;
     private final ConnectorSplit connectorSplit;

--- a/core/trino-main/src/main/java/io/trino/operator/BigintGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/BigintGroupByHash.java
@@ -26,7 +26,6 @@ import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.AbstractLongType;
 import io.trino.spi.type.BigintType;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.List;
@@ -35,6 +34,7 @@ import java.util.Optional;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -48,7 +48,7 @@ import static java.util.Objects.requireNonNull;
 public class BigintGroupByHash
         implements GroupByHash
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(BigintGroupByHash.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(BigintGroupByHash.class);
     private static final int BATCH_SIZE = 1024;
 
     private static final float FILL_RATIO = 0.75f;

--- a/core/trino-main/src/main/java/io/trino/operator/GroupByIdBlock.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupByIdBlock.java
@@ -16,22 +16,21 @@ package io.trino.operator;
 import io.airlift.slice.Slice;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.type.BigintType.BIGINT;
-import static java.lang.Math.toIntExact;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
 public class GroupByIdBlock
         implements Block
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(GroupByIdBlock.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(GroupByIdBlock.class);
 
     private final long groupCount;
     private final Block block;

--- a/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankAccumulator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankAccumulator.java
@@ -17,7 +17,6 @@ import com.google.common.annotations.VisibleForTesting;
 import io.trino.array.LongBigArray;
 import io.trino.util.HeapTraversal;
 import io.trino.util.LongBigArrayFIFOQueue;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -26,6 +25,7 @@ import java.util.function.LongConsumer;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.Math.abs;
 import static java.lang.Math.max;
 import static java.util.Objects.requireNonNull;
@@ -57,7 +57,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class GroupedTopNRankAccumulator
 {
-    private static final long INSTANCE_SIZE = ClassLayout.parseClass(GroupedTopNRankAccumulator.class).instanceSize();
+    private static final long INSTANCE_SIZE = instanceSize(GroupedTopNRankAccumulator.class);
     private static final long UNKNOWN_INDEX = -1;
     private static final long NULL_GROUP_ID = -1;
 
@@ -579,7 +579,7 @@ public class GroupedTopNRankAccumulator
      */
     private static class GroupIdToHeapBuffer
     {
-        private static final long INSTANCE_SIZE = ClassLayout.parseClass(GroupIdToHeapBuffer.class).instanceSize();
+        private static final long INSTANCE_SIZE = instanceSize(GroupIdToHeapBuffer.class);
         private static final int METRICS_POSITIONS_PER_ENTRY = 2;
         private static final int METRICS_HEAP_SIZE_OFFSET = 1;
 
@@ -677,7 +677,7 @@ public class GroupedTopNRankAccumulator
      */
     private static class HeapNodeBuffer
     {
-        private static final long INSTANCE_SIZE = ClassLayout.parseClass(HeapNodeBuffer.class).instanceSize();
+        private static final long INSTANCE_SIZE = instanceSize(HeapNodeBuffer.class);
         private static final int POSITIONS_PER_ENTRY = 4;
         private static final int PEER_GROUP_COUNT_OFFSET = 1;
         private static final int LEFT_CHILD_HEAP_INDEX_OFFSET = 2;
@@ -792,7 +792,7 @@ public class GroupedTopNRankAccumulator
      */
     private static class PeerGroupBuffer
     {
-        private static final long INSTANCE_SIZE = ClassLayout.parseClass(PeerGroupBuffer.class).instanceSize();
+        private static final long INSTANCE_SIZE = instanceSize(PeerGroupBuffer.class);
         private static final int POSITIONS_PER_ENTRY = 2;
         private static final int NEXT_PEER_INDEX_OFFSET = 1;
 

--- a/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankBuilder.java
@@ -20,13 +20,13 @@ import io.trino.operator.RowReferencePageManager.LoadCursor;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Iterator;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static java.util.Objects.requireNonNull;
 
@@ -37,7 +37,7 @@ import static java.util.Objects.requireNonNull;
 public class GroupedTopNRankBuilder
         implements GroupedTopNBuilder
 {
-    private static final long INSTANCE_SIZE = ClassLayout.parseClass(GroupedTopNRankBuilder.class).instanceSize();
+    private static final long INSTANCE_SIZE = instanceSize(GroupedTopNRankBuilder.class);
 
     private final List<Type> sourceTypes;
     private final boolean produceRanking;

--- a/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRowNumberAccumulator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRowNumberAccumulator.java
@@ -17,7 +17,6 @@ import com.google.common.annotations.VisibleForTesting;
 import io.trino.array.LongBigArray;
 import io.trino.util.HeapTraversal;
 import io.trino.util.LongBigArrayFIFOQueue;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -26,6 +25,7 @@ import java.util.function.LongConsumer;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.Math.abs;
 import static java.lang.Math.max;
 import static java.util.Objects.requireNonNull;
@@ -48,7 +48,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class GroupedTopNRowNumberAccumulator
 {
-    private static final long INSTANCE_SIZE = ClassLayout.parseClass(GroupedTopNRowNumberAccumulator.class).instanceSize();
+    private static final long INSTANCE_SIZE = instanceSize(GroupedTopNRowNumberAccumulator.class);
     private static final long UNKNOWN_INDEX = -1;
 
     private final GroupIdToHeapBuffer groupIdToHeapBuffer = new GroupIdToHeapBuffer();
@@ -387,7 +387,7 @@ public class GroupedTopNRowNumberAccumulator
      */
     private static class GroupIdToHeapBuffer
     {
-        private static final long INSTANCE_SIZE = ClassLayout.parseClass(GroupIdToHeapBuffer.class).instanceSize();
+        private static final long INSTANCE_SIZE = instanceSize(GroupIdToHeapBuffer.class);
 
         /*
          *  Memory layout:
@@ -464,7 +464,7 @@ public class GroupedTopNRowNumberAccumulator
      */
     private static class HeapNodeBuffer
     {
-        private static final long INSTANCE_SIZE = ClassLayout.parseClass(HeapNodeBuffer.class).instanceSize();
+        private static final long INSTANCE_SIZE = instanceSize(HeapNodeBuffer.class);
         private static final int POSITIONS_PER_ENTRY = 3;
         private static final int LEFT_CHILD_HEAP_INDEX_OFFSET = 1;
         private static final int RIGHT_CHILD_HEAP_INDEX_OFFSET = 2;

--- a/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRowNumberBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRowNumberBuilder.java
@@ -21,13 +21,13 @@ import io.trino.operator.RowReferencePageManager.LoadCursor;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Iterator;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static java.util.Objects.requireNonNull;
 
@@ -37,7 +37,7 @@ import static java.util.Objects.requireNonNull;
 public class GroupedTopNRowNumberBuilder
         implements GroupedTopNBuilder
 {
-    private static final long INSTANCE_SIZE = ClassLayout.parseClass(GroupedTopNRowNumberBuilder.class).instanceSize();
+    private static final long INSTANCE_SIZE = instanceSize(GroupedTopNRowNumberBuilder.class);
 
     private final List<Type> sourceTypes;
     private final boolean produceRowNumber;

--- a/core/trino-main/src/main/java/io/trino/operator/IdRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/operator/IdRegistry.java
@@ -16,9 +16,10 @@ package io.trino.operator;
 import io.airlift.slice.SizeOf;
 import it.unimi.dsi.fastutil.ints.IntArrayFIFOQueue;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.function.IntFunction;
+
+import static io.airlift.slice.SizeOf.instanceSize;
 
 /**
  * Object registration system that allows looking up objects via stable IDs.
@@ -27,7 +28,7 @@ import java.util.function.IntFunction;
  */
 public class IdRegistry<T>
 {
-    private static final long INSTANCE_SIZE = ClassLayout.parseClass(IdRegistry.class).instanceSize();
+    private static final long INSTANCE_SIZE = instanceSize(IdRegistry.class);
 
     private final ObjectList<T> objects = new ObjectList<>();
     private final IntFIFOQueue emptySlots = new IntFIFOQueue();
@@ -73,7 +74,7 @@ public class IdRegistry<T>
     private static class IntFIFOQueue
             extends IntArrayFIFOQueue
     {
-        private static final long INSTANCE_SIZE = ClassLayout.parseClass(IntFIFOQueue.class).instanceSize();
+        private static final long INSTANCE_SIZE = instanceSize(IntFIFOQueue.class);
 
         public long sizeOf()
         {
@@ -84,7 +85,7 @@ public class IdRegistry<T>
     private static class ObjectList<T>
             extends ObjectArrayList<T>
     {
-        private static final long INSTANCE_SIZE = ClassLayout.parseClass(ObjectList.class).instanceSize();
+        private static final long INSTANCE_SIZE = instanceSize(ObjectList.class);
 
         public long sizeOf()
         {

--- a/core/trino-main/src/main/java/io/trino/operator/MultiChannelGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MultiChannelGroupByHash.java
@@ -27,7 +27,6 @@ import io.trino.spi.type.Type;
 import io.trino.sql.gen.JoinCompiler;
 import io.trino.type.BlockTypeOperators;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -39,6 +38,7 @@ import java.util.OptionalInt;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.SyntheticAddress.encodeSyntheticAddress;
 import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
@@ -55,7 +55,7 @@ import static java.util.Objects.requireNonNull;
 public class MultiChannelGroupByHash
         implements GroupByHash
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(MultiChannelGroupByHash.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(MultiChannelGroupByHash.class);
     private static final float FILL_RATIO = 0.75f;
     private static final int BATCH_SIZE = 1024;
     // Max (page value count / cumulative dictionary size) to trigger the low cardinality case
@@ -528,7 +528,7 @@ public class MultiChannelGroupByHash
 
     private static final class DictionaryLookBack
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DictionaryLookBack.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(DictionaryLookBack.class);
         private final Block dictionary;
         private final int[] processed;
 

--- a/core/trino-main/src/main/java/io/trino/operator/NoChannelGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/NoChannelGroupByHash.java
@@ -18,17 +18,16 @@ import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.type.BigintType.BIGINT;
-import static java.lang.Math.toIntExact;
 
 public class NoChannelGroupByHash
         implements GroupByHash
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(NoChannelGroupByHash.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(NoChannelGroupByHash.class);
 
     private int groupCount;
 

--- a/core/trino-main/src/main/java/io/trino/operator/PagesIndex.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesIndex.java
@@ -42,7 +42,6 @@ import it.unimi.dsi.fastutil.Swapper;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.inject.Inject;
 
@@ -58,6 +57,7 @@ import java.util.stream.Stream;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.HashArraySizeSupplier.defaultHashArraySizeSupplier;
 import static io.trino.operator.SyntheticAddress.decodePosition;
@@ -65,7 +65,6 @@ import static io.trino.operator.SyntheticAddress.decodeSliceIndex;
 import static io.trino.operator.SyntheticAddress.encodeSyntheticAddress;
 import static io.trino.operator.join.JoinUtils.getSingleBigintJoinChannel;
 import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -80,7 +79,7 @@ import static java.util.Objects.requireNonNull;
 public class PagesIndex
         implements Swapper
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(PagesIndex.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(PagesIndex.class);
     private static final Logger log = Logger.get(PagesIndex.class);
 
     private final OrderingCompiler orderingCompiler;

--- a/core/trino-main/src/main/java/io/trino/operator/PagesRTreeIndex.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesRTreeIndex.java
@@ -30,7 +30,6 @@ import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.index.strtree.STRtree;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Map;
@@ -38,6 +37,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 
 import static com.google.common.base.Verify.verifyNotNull;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.geospatial.serde.GeometrySerde.deserialize;
 import static io.trino.operator.SyntheticAddress.decodePosition;
 import static io.trino.operator.SyntheticAddress.decodeSliceIndex;
@@ -64,7 +64,7 @@ public class PagesRTreeIndex
 
     public static final class GeometryWithPosition
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(GeometryWithPosition.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(GeometryWithPosition.class);
 
         private final OGCGeometry ogcGeometry;
         private final int partition;

--- a/core/trino-main/src/main/java/io/trino/operator/PagesSpatialIndexSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesSpatialIndexSupplier.java
@@ -33,7 +33,6 @@ import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.index.strtree.AbstractNode;
 import org.locationtech.jts.index.strtree.ItemBoundable;
 import org.locationtech.jts.index.strtree.STRtree;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Map;
@@ -41,6 +40,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Verify.verifyNotNull;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.geospatial.serde.GeometrySerde.deserialize;
 import static io.trino.operator.PagesSpatialIndex.EMPTY_INDEX;
 import static io.trino.operator.SyntheticAddress.decodePosition;
@@ -52,10 +52,10 @@ import static java.lang.Math.toIntExact;
 public class PagesSpatialIndexSupplier
         implements Supplier<PagesSpatialIndex>
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(PagesSpatialIndexSupplier.class).instanceSize());
-    private static final int ENVELOPE_INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(Envelope.class).instanceSize());
-    private static final int STRTREE_INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(STRtree.class).instanceSize());
-    private static final int ABSTRACT_NODE_INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(AbstractNode.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(PagesSpatialIndexSupplier.class);
+    private static final int ENVELOPE_INSTANCE_SIZE = instanceSize(Envelope.class);
+    private static final int STRTREE_INSTANCE_SIZE = instanceSize(STRtree.class);
+    private static final int ABSTRACT_NODE_INSTANCE_SIZE = instanceSize(AbstractNode.class);
 
     private final Session session;
     private final LongArrayList addresses;

--- a/core/trino-main/src/main/java/io/trino/operator/RowReferencePageManager.java
+++ b/core/trino-main/src/main/java/io/trino/operator/RowReferencePageManager.java
@@ -20,7 +20,6 @@ import io.trino.spi.Page;
 import io.trino.util.LongBigArrayFIFOQueue;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -29,6 +28,7 @@ import java.util.Arrays;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 /**
  * Page buffering manager that enables access to individual rows via stable row IDs. This allows computation to be
@@ -37,8 +37,8 @@ import static com.google.common.base.Verify.verify;
  */
 public class RowReferencePageManager
 {
-    private static final long INSTANCE_SIZE = ClassLayout.parseClass(RowReferencePageManager.class).instanceSize();
-    private static final long PAGE_ACCOUNTING_INSTANCE_SIZE = ClassLayout.parseClass(PageAccounting.class).instanceSize();
+    private static final long INSTANCE_SIZE = instanceSize(RowReferencePageManager.class);
+    private static final long PAGE_ACCOUNTING_INSTANCE_SIZE = instanceSize(PageAccounting.class);
     private static final int RESERVED_ROW_ID_FOR_CURSOR = -1;
 
     private final IdRegistry<PageAccounting> pages = new IdRegistry<>();
@@ -361,7 +361,7 @@ public class RowReferencePageManager
     private static class RowIdBuffer
     {
         public static final long UNKNOWN_ID = -1;
-        private static final long INSTANCE_SIZE = ClassLayout.parseClass(RowIdBuffer.class).instanceSize();
+        private static final long INSTANCE_SIZE = instanceSize(RowIdBuffer.class);
 
         /*
          *  Memory layout:
@@ -432,7 +432,7 @@ public class RowReferencePageManager
     private static class IntHashSet
             extends IntOpenHashSet
     {
-        private static final long INSTANCE_SIZE = ClassLayout.parseClass(IntHashSet.class).instanceSize();
+        private static final long INSTANCE_SIZE = instanceSize(IntHashSet.class);
 
         public long sizeOf()
         {

--- a/core/trino-main/src/main/java/io/trino/operator/SimplePagesHashStrategy.java
+++ b/core/trino-main/src/main/java/io/trino/operator/SimplePagesHashStrategy.java
@@ -24,7 +24,6 @@ import io.trino.type.BlockTypeOperators.BlockPositionEqual;
 import io.trino.type.BlockTypeOperators.BlockPositionHashCode;
 import io.trino.type.BlockTypeOperators.BlockPositionIsDistinctFrom;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Optional;
@@ -32,15 +31,15 @@ import java.util.OptionalInt;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.type.BigintType.BIGINT;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class SimplePagesHashStrategy
         implements PagesHashStrategy
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SimplePagesHashStrategy.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SimplePagesHashStrategy.class);
     private final List<Type> types;
     private final List<Optional<BlockPositionComparison>> comparisonOperators;
     private final List<Integer> outputChannels;

--- a/core/trino-main/src/main/java/io/trino/operator/TopNPeerGroupLookup.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TopNPeerGroupLookup.java
@@ -14,13 +14,12 @@
 package io.trino.operator;
 
 import io.trino.array.LongBigArray;
-import org.openjdk.jol.info.ClassLayout;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static it.unimi.dsi.fastutil.HashCommon.bigArraySize;
 import static it.unimi.dsi.fastutil.HashCommon.maxFill;
 import static it.unimi.dsi.fastutil.HashCommon.mix;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -30,7 +29,7 @@ import static java.util.Objects.requireNonNull;
 // Copyright (C) 2002-2019 Sebastiano Vigna
 public class TopNPeerGroupLookup
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TopNPeerGroupLookup.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(TopNPeerGroupLookup.class);
 
     /**
      * The buffer containing key and value data.
@@ -333,7 +332,7 @@ public class TopNPeerGroupLookup
 
     private static class Buffer
     {
-        private static final long INSTANCE_SIZE = ClassLayout.parseClass(Buffer.class).instanceSize();
+        private static final long INSTANCE_SIZE = instanceSize(Buffer.class);
 
         private static final int POSITIONS_PER_ENTRY = 4;
         private static final int ROW_ID_OFFSET = 1;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AbstractGroupCollectionAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AbstractGroupCollectionAggregationState.java
@@ -20,13 +20,12 @@ import io.trino.spi.PageBuilder;
 import io.trino.spi.block.Block;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongList;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.common.base.Verify.verify;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 /**
  * Instances of this state use a single PageBuilder for all groups.
@@ -34,7 +33,7 @@ import static java.lang.Math.toIntExact;
 public abstract class AbstractGroupCollectionAggregationState<T>
         extends AbstractGroupedAccumulatorState
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(AbstractGroupCollectionAggregationState.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(AbstractGroupCollectionAggregationState.class);
     private static final int MAX_NUM_BLOCKS = 30000;
     private static final short NULL = -1;
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/ApproximateMostFrequentHistogram.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/ApproximateMostFrequentHistogram.java
@@ -21,12 +21,12 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceInput;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
@@ -40,10 +40,10 @@ import static java.util.Objects.requireNonNull;
 public class ApproximateMostFrequentHistogram<K>
 {
     private static final byte FORMAT_TAG = 0;
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ApproximateMostFrequentHistogram.class).instanceSize());
-    private static final int STREAM_SUMMARY_SIZE = toIntExact(ClassLayout.parseClass(StreamSummary.class).instanceSize());
-    private static final int LIST_NODE2_SIZE = toIntExact(ClassLayout.parseClass(ListNode2.class).instanceSize());
-    private static final int COUNTER_SIZE = toIntExact(ClassLayout.parseClass(Counter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ApproximateMostFrequentHistogram.class);
+    private static final int STREAM_SUMMARY_SIZE = instanceSize(StreamSummary.class);
+    private static final int LIST_NODE2_SIZE = instanceSize(ListNode2.class);
+    private static final int COUNTER_SIZE = instanceSize(Counter.class);
 
     private final StreamSummary<K> streamSummary;
     private final int maxBuckets;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/KeyValuePairs.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/KeyValuePairs.java
@@ -19,21 +19,20 @@ import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
 import io.trino.type.BlockTypeOperators.BlockPositionEqual;
 import io.trino.type.BlockTypeOperators.BlockPositionHashCode;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
 import static io.trino.type.TypeUtils.expectedValueSize;
 import static it.unimi.dsi.fastutil.HashCommon.arraySize;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class KeyValuePairs
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(KeyValuePairs.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(KeyValuePairs.class);
     private static final int EXPECTED_ENTRIES = 10;
     private static final int EXPECTED_ENTRY_SIZE = 16;
     private static final float FILL_RATIO = 0.75f;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/NumericHistogram.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/NumericHistogram.java
@@ -20,7 +20,6 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.Slices;
 import it.unimi.dsi.fastutil.Arrays;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -29,13 +28,13 @@ import java.util.PriorityQueue;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class NumericHistogram
 {
     private static final byte FORMAT_TAG = 0;
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(NumericHistogram.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(NumericHistogram.class);
 
     private final int maxBuckets;
     private final double[] values;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/TypedSet.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/TypedSet.java
@@ -23,14 +23,13 @@ import io.trino.type.BlockTypeOperators.BlockPositionEqual;
 import io.trino.type.BlockTypeOperators.BlockPositionHashCode;
 import io.trino.type.BlockTypeOperators.BlockPositionIsDistinctFrom;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import org.openjdk.jol.info.ClassLayout;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.spi.StandardErrorCode.EXCEEDED_FUNCTION_MEMORY_LIMIT;
 import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
 import static it.unimi.dsi.fastutil.HashCommon.arraySize;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -45,8 +44,8 @@ public class TypedSet
     @VisibleForTesting
     public static final DataSize MAX_FUNCTION_MEMORY = DataSize.of(4, MEGABYTE);
 
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TypedSet.class).instanceSize());
-    private static final int INT_ARRAY_LIST_INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(IntArrayList.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(TypedSet.class);
+    private static final int INT_ARRAY_LIST_INSTANCE_SIZE = instanceSize(IntArrayList.class);
     private static final float FILL_RATIO = 0.75f;
 
     private final Type elementType;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/arrayagg/SingleArrayAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/arrayagg/SingleArrayAggregationState.java
@@ -17,17 +17,16 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.function.AccumulatorState;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.operator.aggregation.BlockBuilderCopier.copyBlockBuilder;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class SingleArrayAggregationState
         implements ArrayAggregationState
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleArrayAggregationState.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SingleArrayAggregationState.class);
     private BlockBuilder blockBuilder;
     private final Type type;
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/histogram/GroupedHistogramState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/histogram/GroupedHistogramState.java
@@ -19,9 +19,8 @@ import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
 import io.trino.type.BlockTypeOperators.BlockPositionEqual;
 import io.trino.type.BlockTypeOperators.BlockPositionHashCode;
-import org.openjdk.jol.info.ClassLayout;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -31,7 +30,7 @@ public class GroupedHistogramState
         extends AbstractGroupedAccumulatorState
         implements HistogramState
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(GroupedHistogramState.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(GroupedHistogramState.class);
     private final Type type;
     private final BlockPositionEqual equalOperator;
     private final BlockPositionHashCode hashCodeOperator;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/histogram/GroupedTypedHistogram.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/histogram/GroupedTypedHistogram.java
@@ -21,10 +21,10 @@ import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
 import io.trino.type.BlockTypeOperators.BlockPositionEqual;
 import io.trino.type.BlockTypeOperators.BlockPositionHashCode;
-import org.openjdk.jol.info.ClassLayout;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.operator.aggregation.histogram.HashUtil.calculateMaxFill;
 import static io.trino.operator.aggregation.histogram.HashUtil.nextBucketId;
 import static io.trino.operator.aggregation.histogram.HashUtil.nextProbeLinear;
@@ -32,7 +32,6 @@ import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static it.unimi.dsi.fastutil.HashCommon.arraySize;
 import static it.unimi.dsi.fastutil.HashCommon.murmurHash3;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -58,7 +57,7 @@ public class GroupedTypedHistogram
 {
     private static final float MAX_FILL_RATIO = 0.5f;
 
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(GroupedTypedHistogram.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(GroupedTypedHistogram.class);
     private static final int EMPTY_BUCKET = -1;
     private static final int NULL = -1;
     private final int bucketId;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/histogram/SingleHistogramState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/histogram/SingleHistogramState.java
@@ -18,15 +18,14 @@ import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
 import io.trino.type.BlockTypeOperators.BlockPositionEqual;
 import io.trino.type.BlockTypeOperators.BlockPositionHashCode;
-import org.openjdk.jol.info.ClassLayout;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class SingleHistogramState
         implements HistogramState
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleHistogramState.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SingleHistogramState.class);
 
     private final Type keyType;
     private final BlockPositionEqual equalOperator;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/histogram/SingleTypedHistogram.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/histogram/SingleTypedHistogram.java
@@ -21,20 +21,19 @@ import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
 import io.trino.type.BlockTypeOperators.BlockPositionEqual;
 import io.trino.type.BlockTypeOperators.BlockPositionHashCode;
-import org.openjdk.jol.info.ClassLayout;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static it.unimi.dsi.fastutil.HashCommon.arraySize;
 import static it.unimi.dsi.fastutil.HashCommon.murmurHash3;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class SingleTypedHistogram
         implements TypedHistogram
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleTypedHistogram.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SingleTypedHistogram.class);
     private static final float FILL_RATIO = 0.75f;
 
     private final int expectedSize;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/histogram/ValueStore.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/histogram/ValueStore.java
@@ -21,15 +21,14 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
 import io.trino.type.BlockTypeOperators.BlockPositionEqual;
-import org.openjdk.jol.info.ClassLayout;
 
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.operator.aggregation.histogram.HashUtil.calculateMaxFill;
 import static io.trino.operator.aggregation.histogram.HashUtil.computeBucketCount;
 import static io.trino.operator.aggregation.histogram.HashUtil.nextBucketId;
 import static io.trino.operator.aggregation.histogram.HashUtil.nextProbeLinear;
 import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -42,7 +41,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class ValueStore
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(GroupedTypedHistogram.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(GroupedTypedHistogram.class);
     private static final float MAX_FILL_RATIO = 0.5f;
     private static final int EMPTY_BUCKET = -1;
     private final Type type;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/SingleListaggAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/SingleListaggAggregationState.java
@@ -16,16 +16,15 @@ package io.trino.operator.aggregation.listagg;
 import io.airlift.slice.Slice;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
-import org.openjdk.jol.info.ClassLayout;
 
 import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.type.VarcharType.VARCHAR;
-import static java.lang.Math.toIntExact;
 
 public class SingleListaggAggregationState
         implements ListaggAggregationState
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleListaggAggregationState.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SingleListaggAggregationState.class);
     private BlockBuilder blockBuilder;
     private Slice separator;
     private boolean overflowError;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxbyn/MinMaxByNStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxbyn/MinMaxByNStateFactory.java
@@ -18,13 +18,12 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.function.AccumulatorState;
 import io.trino.spi.function.GroupedAccumulatorState;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.function.Function;
 import java.util.function.LongFunction;
 
 import static com.google.common.base.Preconditions.checkState;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 public final class MinMaxByNStateFactory
 {
@@ -38,7 +37,7 @@ public final class MinMaxByNStateFactory
             extends AbstractMinMaxByNState
             implements GroupedAccumulatorState
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(GroupedMinMaxByNState.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(GroupedMinMaxByNState.class);
 
         private final LongFunction<TypedKeyValueHeap> heapFactory;
         private final Function<Block, TypedKeyValueHeap> deserializer;
@@ -166,7 +165,7 @@ public final class MinMaxByNStateFactory
     public abstract static class SingleMinMaxByNState
             extends AbstractMinMaxByNState
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleMinMaxByNState.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(SingleMinMaxByNState.class);
 
         private final LongFunction<TypedKeyValueHeap> heapFactory;
         private final Function<Block, TypedKeyValueHeap> deserializer;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxbyn/TypedKeyValueHeap.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxbyn/TypedKeyValueHeap.java
@@ -20,11 +20,11 @@ import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.lang.invoke.MethodHandle;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static java.lang.Math.toIntExact;
@@ -32,7 +32,7 @@ import static java.util.Objects.requireNonNull;
 
 public class TypedKeyValueHeap
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TypedKeyValueHeap.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(TypedKeyValueHeap.class);
 
     private static final int COMPACT_THRESHOLD_BYTES = 32768;
     private static final int COMPACT_THRESHOLD_RATIO = 3; // when 2/3 of elements in keyBlockBuilder is unreferenced, do compact

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxn/MinMaxNStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxn/MinMaxNStateFactory.java
@@ -18,13 +18,12 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.function.AccumulatorState;
 import io.trino.spi.function.GroupedAccumulatorState;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.function.Function;
 import java.util.function.LongFunction;
 
 import static com.google.common.base.Preconditions.checkState;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public final class MinMaxNStateFactory
@@ -41,7 +40,7 @@ public final class MinMaxNStateFactory
             extends AbstractMinMaxNState
             implements GroupedAccumulatorState
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(GroupedMinMaxNState.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(GroupedMinMaxNState.class);
 
         private final LongFunction<TypedHeap> heapFactory;
         private final Function<Block, TypedHeap> deserializer;
@@ -167,7 +166,7 @@ public final class MinMaxNStateFactory
     public abstract static class SingleMinMaxNState
             extends AbstractMinMaxNState
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleMinMaxNState.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(SingleMinMaxNState.class);
 
         private final LongFunction<TypedHeap> heapFactory;
         private final Function<Block, TypedHeap> deserializer;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxn/TypedHeap.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxn/TypedHeap.java
@@ -19,11 +19,11 @@ import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.Type;
 import it.unimi.dsi.fastutil.ints.IntArrays;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.lang.invoke.MethodHandle;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static java.lang.Math.toIntExact;
@@ -31,7 +31,7 @@ import static java.util.Objects.requireNonNull;
 
 public class TypedHeap
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TypedHeap.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(TypedHeap.class);
 
     private static final int COMPACT_THRESHOLD_BYTES = 32768;
     private static final int COMPACT_THRESHOLD_RATIO = 3; // when 2/3 of elements in heapBlockBuilder is unreferenced, do compact

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/multimapagg/SingleMultimapAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/multimapagg/SingleMultimapAggregationState.java
@@ -17,17 +17,16 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.function.AccumulatorState;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.operator.aggregation.BlockBuilderCopier.copyBlockBuilder;
 import static io.trino.type.TypeUtils.expectedValueSize;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class SingleMultimapAggregationState
         implements MultimapAggregationState
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleMultimapAggregationState.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SingleMultimapAggregationState.class);
     private static final int EXPECTED_ENTRIES = 10;
     private static final int EXPECTED_ENTRY_SIZE = 16;
     private final Type keyType;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/HyperLogLogStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/HyperLogLogStateFactory.java
@@ -16,9 +16,8 @@ package io.trino.operator.aggregation.state;
 import io.airlift.stats.cardinality.HyperLogLog;
 import io.trino.array.ObjectBigArray;
 import io.trino.spi.function.AccumulatorStateFactory;
-import org.openjdk.jol.info.ClassLayout;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class HyperLogLogStateFactory
@@ -40,7 +39,7 @@ public class HyperLogLogStateFactory
             extends AbstractGroupedAccumulatorState
             implements HyperLogLogState
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(GroupedHyperLogLogState.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(GroupedHyperLogLogState.class);
         private final ObjectBigArray<HyperLogLog> hlls = new ObjectBigArray<>();
         private long size;
 
@@ -79,7 +78,7 @@ public class HyperLogLogStateFactory
     public static class SingleHyperLogLogState
             implements HyperLogLogState
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleHyperLogLogState.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(SingleHyperLogLogState.class);
         private HyperLogLog hll;
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/KeyValuePairsStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/KeyValuePairsStateFactory.java
@@ -19,9 +19,8 @@ import io.trino.spi.function.AccumulatorState;
 import io.trino.spi.function.AccumulatorStateFactory;
 import io.trino.spi.function.TypeParameter;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class KeyValuePairsStateFactory
@@ -52,7 +51,7 @@ public class KeyValuePairsStateFactory
             extends AbstractGroupedAccumulatorState
             implements KeyValuePairsState
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(GroupedState.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(GroupedState.class);
         private final Type keyType;
         private final Type valueType;
         private final ObjectBigArray<KeyValuePairs> pairs = new ObjectBigArray<>();
@@ -118,7 +117,7 @@ public class KeyValuePairsStateFactory
     public static class SingleState
             implements KeyValuePairsState
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleState.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(SingleState.class);
         private final Type keyType;
         private final Type valueType;
         private KeyValuePairs pair;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowAndLongStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowAndLongStateFactory.java
@@ -16,9 +16,8 @@ package io.trino.operator.aggregation.state;
 import io.trino.array.LongBigArray;
 import io.trino.spi.function.AccumulatorState;
 import io.trino.spi.function.AccumulatorStateFactory;
-import org.openjdk.jol.info.ClassLayout;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 public class LongDecimalWithOverflowAndLongStateFactory
         implements AccumulatorStateFactory<LongDecimalWithOverflowAndLongState>
@@ -39,7 +38,7 @@ public class LongDecimalWithOverflowAndLongStateFactory
             extends LongDecimalWithOverflowStateFactory.GroupedLongDecimalWithOverflowState
             implements LongDecimalWithOverflowAndLongState
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(GroupedLongDecimalWithOverflowAndLongState.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(GroupedLongDecimalWithOverflowAndLongState.class);
         private final LongBigArray longs = new LongBigArray();
 
         @Override
@@ -78,7 +77,7 @@ public class LongDecimalWithOverflowAndLongStateFactory
             extends LongDecimalWithOverflowStateFactory.SingleLongDecimalWithOverflowState
             implements LongDecimalWithOverflowAndLongState
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleLongDecimalWithOverflowAndLongState.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(SingleLongDecimalWithOverflowAndLongState.class);
 
         protected long longValue;
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowStateFactory.java
@@ -17,12 +17,11 @@ import io.trino.array.BooleanBigArray;
 import io.trino.array.LongBigArray;
 import io.trino.spi.function.AccumulatorState;
 import io.trino.spi.function.AccumulatorStateFactory;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.lang.System.arraycopy;
 
 public class LongDecimalWithOverflowStateFactory
@@ -44,7 +43,7 @@ public class LongDecimalWithOverflowStateFactory
             extends AbstractGroupedAccumulatorState
             implements LongDecimalWithOverflowState
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(GroupedLongDecimalWithOverflowState.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(GroupedLongDecimalWithOverflowState.class);
         protected final BooleanBigArray isNotNull = new BooleanBigArray();
         /**
          * Stores 128-bit decimals as pairs of longs
@@ -134,7 +133,7 @@ public class LongDecimalWithOverflowStateFactory
     public static class SingleLongDecimalWithOverflowState
             implements LongDecimalWithOverflowState
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleLongDecimalWithOverflowState.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(SingleLongDecimalWithOverflowState.class);
         protected static final int SIZE = (int) sizeOf(new long[2]);
 
         protected final long[] unscaledDecimal = new long[2];

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/QuantileDigestAndPercentileStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/QuantileDigestAndPercentileStateFactory.java
@@ -17,9 +17,8 @@ import io.airlift.stats.QuantileDigest;
 import io.trino.array.DoubleBigArray;
 import io.trino.array.ObjectBigArray;
 import io.trino.spi.function.AccumulatorStateFactory;
-import org.openjdk.jol.info.ClassLayout;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class QuantileDigestAndPercentileStateFactory
@@ -41,7 +40,7 @@ public class QuantileDigestAndPercentileStateFactory
             extends AbstractGroupedAccumulatorState
             implements QuantileDigestAndPercentileState
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(GroupedQuantileDigestAndPercentileState.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(GroupedQuantileDigestAndPercentileState.class);
         private final ObjectBigArray<QuantileDigest> digests = new ObjectBigArray<>();
         private final DoubleBigArray percentiles = new DoubleBigArray();
         private long size;
@@ -94,7 +93,7 @@ public class QuantileDigestAndPercentileStateFactory
     public static class SingleQuantileDigestAndPercentileState
             implements QuantileDigestAndPercentileState
     {
-        public static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleQuantileDigestAndPercentileState.class).instanceSize());
+        public static final int INSTANCE_SIZE = instanceSize(SingleQuantileDigestAndPercentileState.class);
         private QuantileDigest digest;
         private double percentile;
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/QuantileDigestStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/QuantileDigestStateFactory.java
@@ -16,9 +16,8 @@ package io.trino.operator.aggregation.state;
 import io.airlift.stats.QuantileDigest;
 import io.trino.array.ObjectBigArray;
 import io.trino.spi.function.AccumulatorStateFactory;
-import org.openjdk.jol.info.ClassLayout;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class QuantileDigestStateFactory
@@ -40,7 +39,7 @@ public class QuantileDigestStateFactory
             extends AbstractGroupedAccumulatorState
             implements QuantileDigestState
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(GroupedQuantileDigestState.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(GroupedQuantileDigestState.class);
         private final ObjectBigArray<QuantileDigest> qdigests = new ObjectBigArray<>();
         private long size;
 
@@ -79,7 +78,7 @@ public class QuantileDigestStateFactory
     public static class SingleQuantileDigestState
             implements QuantileDigestState
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleQuantileDigestState.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(SingleQuantileDigestState.class);
         private QuantileDigest qdigest;
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/StateCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/StateCompiler.java
@@ -28,6 +28,7 @@ import io.airlift.bytecode.Scope;
 import io.airlift.bytecode.Variable;
 import io.airlift.bytecode.control.IfStatement;
 import io.airlift.bytecode.expression.BytecodeExpression;
+import io.airlift.slice.SizeOf;
 import io.airlift.slice.Slice;
 import io.trino.array.BlockBigArray;
 import io.trino.array.BooleanBigArray;
@@ -50,7 +51,6 @@ import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.sql.gen.CallSiteBinder;
 import io.trino.sql.gen.SqlTypeBytecodeExpression;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
@@ -832,8 +832,7 @@ public final class StateCompiler
         FieldDefinition instanceSize = definition.declareField(a(PRIVATE, STATIC, FINAL), "INSTANCE_SIZE", long.class);
         definition.getClassInitializer()
                 .getBody()
-                .comment("INSTANCE_SIZE = ClassLayout.parseClass(%s.class).instanceSize()", definition.getName())
-                .append(setStatic(instanceSize, invokeStatic(ClassLayout.class, "parseClass", ClassLayout.class, constantClass(definition.getType())).invoke("instanceSize", long.class)));
+                .append(setStatic(instanceSize, invokeStatic(SizeOf.class, "instanceSize", int.class, constantClass(definition.getType())).cast(long.class)));
         return instanceSize;
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/TDigestAndPercentileArrayStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/TDigestAndPercentileArrayStateFactory.java
@@ -17,11 +17,10 @@ import io.airlift.slice.SizeOf;
 import io.airlift.stats.TDigest;
 import io.trino.array.ObjectBigArray;
 import io.trino.spi.function.AccumulatorStateFactory;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class TDigestAndPercentileArrayStateFactory
@@ -43,7 +42,7 @@ public class TDigestAndPercentileArrayStateFactory
             extends AbstractGroupedAccumulatorState
             implements TDigestAndPercentileArrayState
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(GroupedTDigestAndPercentileArrayState.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(GroupedTDigestAndPercentileArrayState.class);
         private final ObjectBigArray<TDigest> digests = new ObjectBigArray<>();
         private final ObjectBigArray<List<Double>> percentilesArray = new ObjectBigArray<>();
         private long size;
@@ -95,7 +94,7 @@ public class TDigestAndPercentileArrayStateFactory
     public static class SingleTDigestAndPercentileArrayState
             implements TDigestAndPercentileArrayState
     {
-        public static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleTDigestAndPercentileArrayState.class).instanceSize());
+        public static final int INSTANCE_SIZE = instanceSize(SingleTDigestAndPercentileArrayState.class);
         private TDigest digest;
         private List<Double> percentiles;
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/TDigestAndPercentileStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/TDigestAndPercentileStateFactory.java
@@ -17,9 +17,8 @@ import io.airlift.stats.TDigest;
 import io.trino.array.DoubleBigArray;
 import io.trino.array.ObjectBigArray;
 import io.trino.spi.function.AccumulatorStateFactory;
-import org.openjdk.jol.info.ClassLayout;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class TDigestAndPercentileStateFactory
@@ -41,7 +40,7 @@ public class TDigestAndPercentileStateFactory
             extends AbstractGroupedAccumulatorState
             implements TDigestAndPercentileState
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(GroupedTDigestAndPercentileState.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(GroupedTDigestAndPercentileState.class);
         private final ObjectBigArray<TDigest> digests = new ObjectBigArray<>();
         private final DoubleBigArray percentiles = new DoubleBigArray();
         private long size;
@@ -94,7 +93,7 @@ public class TDigestAndPercentileStateFactory
     public static class SingleTDigestAndPercentileState
             implements TDigestAndPercentileState
     {
-        public static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleTDigestAndPercentileState.class).instanceSize());
+        public static final int INSTANCE_SIZE = instanceSize(SingleTDigestAndPercentileState.class);
         private TDigest digest;
         private double percentile;
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/TDigestStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/TDigestStateFactory.java
@@ -16,9 +16,8 @@ package io.trino.operator.aggregation.state;
 import io.airlift.stats.TDigest;
 import io.trino.array.ObjectBigArray;
 import io.trino.spi.function.AccumulatorStateFactory;
-import org.openjdk.jol.info.ClassLayout;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class TDigestStateFactory
@@ -40,7 +39,7 @@ public class TDigestStateFactory
             extends AbstractGroupedAccumulatorState
             implements TDigestState
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(GroupedTDigestState.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(GroupedTDigestState.class);
         private final ObjectBigArray<TDigest> digests = new ObjectBigArray<>();
         private long size;
 
@@ -79,7 +78,7 @@ public class TDigestStateFactory
     public static class SingleTDigestState
             implements TDigestState
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleTDigestState.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(SingleTDigestState.class);
         private TDigest digest;
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/operator/join/ArrayPositionLinks.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/ArrayPositionLinks.java
@@ -16,20 +16,19 @@ package io.trino.operator.join;
 import io.airlift.slice.Slices;
 import io.airlift.slice.XxHash64;
 import io.trino.spi.Page;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.List;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.SizeOf.sizeOfIntArray;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public final class ArrayPositionLinks
         implements PositionLinks
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ArrayPositionLinks.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ArrayPositionLinks.class);
 
     public static class FactoryBuilder
             implements PositionLinks.FactoryBuilder

--- a/core/trino-main/src/main/java/io/trino/operator/join/BigintPagesHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/BigintPagesHash.java
@@ -22,12 +22,12 @@ import io.trino.spi.PageBuilder;
 import io.trino.spi.block.Block;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.SizeOf.sizeOfIntArray;
 import static io.airlift.slice.SizeOf.sizeOfLongArray;
@@ -46,7 +46,7 @@ import static java.util.Objects.requireNonNull;
 public final class BigintPagesHash
         implements PagesHash
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(BigintPagesHash.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(BigintPagesHash.class);
     private static final DataSize CACHE_SIZE = DataSize.of(128, KILOBYTE);
 
     private final LongArrayList addresses;

--- a/core/trino-main/src/main/java/io/trino/operator/join/DefaultPagesHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/DefaultPagesHash.java
@@ -21,11 +21,11 @@ import io.trino.spi.PageBuilder;
 import io.trino.spi.block.Block;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.List;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.SizeOf.sizeOfByteArray;
 import static io.airlift.slice.SizeOf.sizeOfIntArray;
@@ -44,7 +44,7 @@ import static java.util.Objects.requireNonNull;
 public final class DefaultPagesHash
         implements PagesHash
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DefaultPagesHash.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DefaultPagesHash.class);
     private static final DataSize CACHE_SIZE = DataSize.of(128, KILOBYTE);
     private final LongArrayList addresses;
     private final PagesHashStrategy pagesHashStrategy;

--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinHash.java
@@ -15,13 +15,13 @@ package io.trino.operator.join;
 
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
@@ -29,7 +29,7 @@ import static java.util.Objects.requireNonNull;
 public final class JoinHash
         implements LookupSource
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(JoinHash.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(JoinHash.class);
     private final PagesHash pagesHash;
 
     // we unwrap Optional<JoinFilterFunction> to actual verifier or null in constructor for performance reasons

--- a/core/trino-main/src/main/java/io/trino/operator/join/SortedPositionLinks.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/SortedPositionLinks.java
@@ -22,18 +22,17 @@ import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntArrays;
 import it.unimi.dsi.fastutil.ints.IntComparator;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Iterator;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.SizeOf.sizeOfIntArray;
 import static io.airlift.slice.SizeOf.sizeOfObjectArray;
 import static io.trino.operator.SyntheticAddress.decodePosition;
 import static io.trino.operator.SyntheticAddress.decodeSliceIndex;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -45,7 +44,7 @@ import static java.util.Objects.requireNonNull;
 public final class SortedPositionLinks
         implements PositionLinks
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SortedPositionLinks.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SortedPositionLinks.class);
 
     public static class FactoryBuilder
             implements PositionLinks.FactoryBuilder

--- a/core/trino-main/src/main/java/io/trino/operator/output/BytePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/BytePositionsAppender.java
@@ -17,21 +17,20 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.ByteArrayBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.Optional;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateBlockResetSize;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateNewArraySize;
 import static java.lang.Math.max;
-import static java.lang.Math.toIntExact;
 
 public class BytePositionsAppender
         implements PositionsAppender
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(BytePositionsAppender.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(BytePositionsAppender.class);
     private static final Block NULL_VALUE_BLOCK = new ByteArrayBlock(1, Optional.of(new boolean[] {true}), new byte[1]);
 
     private boolean initialized;

--- a/core/trino-main/src/main/java/io/trino/operator/output/Int128PositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/Int128PositionsAppender.java
@@ -17,22 +17,21 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.Int128ArrayBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.Optional;
 
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateBlockResetSize;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateNewArraySize;
 import static java.lang.Math.max;
-import static java.lang.Math.toIntExact;
 
 public class Int128PositionsAppender
         implements PositionsAppender
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(Int128PositionsAppender.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(Int128PositionsAppender.class);
     private static final Block NULL_VALUE_BLOCK = new Int128ArrayBlock(1, Optional.of(new boolean[] {true}), new long[2]);
 
     private boolean initialized;

--- a/core/trino-main/src/main/java/io/trino/operator/output/Int96PositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/Int96PositionsAppender.java
@@ -17,22 +17,21 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.Int96ArrayBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.Optional;
 
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateBlockResetSize;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateNewArraySize;
 import static java.lang.Math.max;
-import static java.lang.Math.toIntExact;
 
 public class Int96PositionsAppender
         implements PositionsAppender
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(Int96PositionsAppender.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(Int96PositionsAppender.class);
     private static final Block NULL_VALUE_BLOCK = new Int96ArrayBlock(1, Optional.of(new boolean[] {true}), new long[1], new int[1]);
 
     private boolean initialized;

--- a/core/trino-main/src/main/java/io/trino/operator/output/IntPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/IntPositionsAppender.java
@@ -17,21 +17,20 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.IntArrayBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.Optional;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateBlockResetSize;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateNewArraySize;
 import static java.lang.Math.max;
-import static java.lang.Math.toIntExact;
 
 public class IntPositionsAppender
         implements PositionsAppender
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(IntPositionsAppender.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(IntPositionsAppender.class);
     private static final Block NULL_VALUE_BLOCK = new IntArrayBlock(1, Optional.of(new boolean[] {true}), new int[1]);
 
     private boolean initialized;

--- a/core/trino-main/src/main/java/io/trino/operator/output/LongPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/LongPositionsAppender.java
@@ -17,21 +17,20 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.LongArrayBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.Optional;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateBlockResetSize;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateNewArraySize;
 import static java.lang.Math.max;
-import static java.lang.Math.toIntExact;
 
 public class LongPositionsAppender
         implements PositionsAppender
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(LongPositionsAppender.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(LongPositionsAppender.class);
     private static final Block NULL_VALUE_BLOCK = new LongArrayBlock(1, Optional.of(new boolean[] {true}), new long[1]);
 
     private boolean initialized;

--- a/core/trino-main/src/main/java/io/trino/operator/output/RleAwarePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/RleAwarePositionsAppender.java
@@ -17,12 +17,11 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.type.BlockTypeOperators.BlockPositionIsDistinctFrom;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -32,7 +31,7 @@ import static java.util.Objects.requireNonNull;
 public class RleAwarePositionsAppender
         implements PositionsAppender
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(RleAwarePositionsAppender.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(RleAwarePositionsAppender.class);
     private static final int NO_RLE = -1;
 
     private final BlockPositionIsDistinctFrom isDistinctFromOperator;

--- a/core/trino-main/src/main/java/io/trino/operator/output/RowPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/RowPositionsAppender.java
@@ -18,23 +18,22 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.RowType;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateBlockResetSize;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateNewArraySize;
 import static io.trino.spi.block.RowBlock.fromFieldBlocks;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class RowPositionsAppender
         implements PositionsAppender
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(RowPositionsAppender.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(RowPositionsAppender.class);
     private final PositionsAppender[] fieldAppenders;
     private int initialEntryCount;
     private boolean initialized;

--- a/core/trino-main/src/main/java/io/trino/operator/output/ShortPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/ShortPositionsAppender.java
@@ -17,21 +17,20 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.block.ShortArrayBlock;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.Optional;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateBlockResetSize;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateNewArraySize;
 import static java.lang.Math.max;
-import static java.lang.Math.toIntExact;
 
 public class ShortPositionsAppender
         implements PositionsAppender
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ShortPositionsAppender.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ShortPositionsAppender.class);
     private static final Block NULL_VALUE_BLOCK = new ShortArrayBlock(1, Optional.of(new boolean[] {true}), new short[1]);
 
     private boolean initialized;

--- a/core/trino-main/src/main/java/io/trino/operator/output/SlicePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/SlicePositionsAppender.java
@@ -20,13 +20,13 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.block.VariableWidthBlock;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.Optional;
 
 import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.trino.operator.output.PositionsAppenderUtil.MAX_ARRAY_SIZE;
@@ -40,7 +40,7 @@ public class SlicePositionsAppender
         implements PositionsAppender
 {
     private static final int EXPECTED_BYTES_PER_ENTRY = 32;
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SlicePositionsAppender.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SlicePositionsAppender.class);
     private static final Block NULL_VALUE_BLOCK = new VariableWidthBlock(1, EMPTY_SLICE, new int[] {0, 0}, Optional.of(new boolean[] {true}));
 
     private boolean initialized;

--- a/core/trino-main/src/main/java/io/trino/operator/output/TypedPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/TypedPositionsAppender.java
@@ -17,15 +17,14 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import org.openjdk.jol.info.ClassLayout;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 class TypedPositionsAppender
         implements PositionsAppender
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TypedPositionsAppender.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(TypedPositionsAppender.class);
 
     private final Type type;
     private BlockBuilder blockBuilder;

--- a/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
@@ -17,9 +17,8 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import org.openjdk.jol.info.ClassLayout;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -28,7 +27,7 @@ import static java.util.Objects.requireNonNull;
 public class UnnestingPositionsAppender
         implements PositionsAppender
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(UnnestingPositionsAppender.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(UnnestingPositionsAppender.class);
 
     private final PositionsAppender delegate;
 

--- a/core/trino-main/src/main/java/io/trino/operator/unnest/ArrayOfRowsUnnester.java
+++ b/core/trino-main/src/main/java/io/trino/operator/unnest/ArrayOfRowsUnnester.java
@@ -16,19 +16,18 @@ package io.trino.operator.unnest;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.ColumnarArray;
 import io.trino.spi.block.ColumnarRow;
-import org.openjdk.jol.info.ClassLayout;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.unnest.UnnestOperator.ensureCapacity;
 import static io.trino.spi.block.ColumnarArray.toColumnarArray;
 import static io.trino.spi.block.ColumnarRow.toColumnarRow;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class ArrayOfRowsUnnester
         implements Unnester
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ArrayOfRowsUnnester.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ArrayOfRowsUnnester.class);
 
     private final int fieldCount;
     private final UnnestBlockBuilder[] blockBuilders;

--- a/core/trino-main/src/main/java/io/trino/operator/unnest/ArrayUnnester.java
+++ b/core/trino-main/src/main/java/io/trino/operator/unnest/ArrayUnnester.java
@@ -15,18 +15,17 @@ package io.trino.operator.unnest;
 
 import io.trino.spi.block.Block;
 import io.trino.spi.block.ColumnarArray;
-import org.openjdk.jol.info.ClassLayout;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.unnest.UnnestOperator.ensureCapacity;
 import static io.trino.spi.block.ColumnarArray.toColumnarArray;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class ArrayUnnester
         implements Unnester
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ArrayUnnester.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ArrayUnnester.class);
 
     private final UnnestBlockBuilder blockBuilder = new UnnestBlockBuilder();
     private int[] arrayLengths = new int[0];

--- a/core/trino-main/src/main/java/io/trino/operator/unnest/MapUnnester.java
+++ b/core/trino-main/src/main/java/io/trino/operator/unnest/MapUnnester.java
@@ -15,18 +15,17 @@ package io.trino.operator.unnest;
 
 import io.trino.spi.block.Block;
 import io.trino.spi.block.ColumnarMap;
-import org.openjdk.jol.info.ClassLayout;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.unnest.UnnestOperator.ensureCapacity;
 import static io.trino.spi.block.ColumnarMap.toColumnarMap;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class MapUnnester
         implements Unnester
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(MapUnnester.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(MapUnnester.class);
 
     private final UnnestBlockBuilder keyBlockBuilder;
     private final UnnestBlockBuilder valueBlockBuilder;

--- a/core/trino-main/src/main/java/io/trino/operator/unnest/UnnestOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/unnest/UnnestOperator.java
@@ -27,7 +27,6 @@ import io.trino.spi.type.MapType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.sql.planner.plan.PlanNodeId;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Optional;
@@ -35,9 +34,9 @@ import java.util.Optional;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class UnnestOperator
@@ -91,7 +90,7 @@ public class UnnestOperator
         }
     }
 
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(UnnestOperator.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(UnnestOperator.class);
     private static final int MAX_ROWS_PER_BLOCK = 1000;
 
     private final OperatorContext operatorContext;

--- a/core/trino-main/src/main/java/io/trino/operator/window/matcher/Captures.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/matcher/Captures.java
@@ -13,16 +13,14 @@
  */
 package io.trino.operator.window.matcher;
 
-import org.openjdk.jol.info.ClassLayout;
-
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 // TODO: optimize by
 //   - reference counting and copy on write
 //   - reuse allocated arrays
 class Captures
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(Captures.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(Captures.class);
 
     private final IntMultimap captures;
     private final IntMultimap labels;

--- a/core/trino-main/src/main/java/io/trino/operator/window/matcher/IntList.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/matcher/IntList.java
@@ -14,15 +14,14 @@
 package io.trino.operator.window.matcher;
 
 import io.airlift.slice.SizeOf;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 public class IntList
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(IntList.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(IntList.class);
 
     private int[] values;
     private int next;

--- a/core/trino-main/src/main/java/io/trino/operator/window/matcher/IntMultimap.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/matcher/IntMultimap.java
@@ -14,13 +14,14 @@
 package io.trino.operator.window.matcher;
 
 import io.airlift.slice.SizeOf;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 
+import static io.airlift.slice.SizeOf.instanceSize;
+
 class IntMultimap
 {
-    private static final long INSTANCE_SIZE = ClassLayout.parseClass(IntMultimap.class).instanceSize();
+    private static final long INSTANCE_SIZE = instanceSize(IntMultimap.class);
 
     private IntList[] values;
     private final int capacity;

--- a/core/trino-main/src/main/java/io/trino/operator/window/matcher/IntStack.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/matcher/IntStack.java
@@ -14,15 +14,14 @@
 package io.trino.operator.window.matcher;
 
 import io.airlift.slice.SizeOf;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 class IntStack
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(IntStack.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(IntStack.class);
 
     private int[] values;
     private int next;

--- a/core/trino-main/src/main/java/io/trino/operator/window/matcher/MatchAggregations.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/matcher/MatchAggregations.java
@@ -17,16 +17,16 @@ import io.airlift.slice.SizeOf;
 import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.operator.window.pattern.MatchAggregation;
 import io.trino.operator.window.pattern.MatchAggregation.MatchAggregationInstantiator;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 class MatchAggregations
 {
-    private static final long INSTANCE_SIZE = ClassLayout.parseClass(MatchAggregations.class).instanceSize();
+    private static final long INSTANCE_SIZE = instanceSize(MatchAggregations.class);
 
     private MatchAggregation[][] values;
     private final List<MatchAggregationInstantiator> aggregationInstantiators;

--- a/core/trino-main/src/main/java/io/trino/operator/window/matcher/Matcher.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/matcher/Matcher.java
@@ -19,12 +19,11 @@ import io.trino.operator.window.pattern.LabelEvaluator;
 import io.trino.operator.window.pattern.MatchAggregation.MatchAggregationInstantiator;
 import io.trino.operator.window.pattern.PhysicalValueAccessor;
 import io.trino.sql.planner.LocalExecutionPlanner.MatchAggregationLabelDependency;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.operator.window.matcher.MatchResult.NO_MATCH;
-import static java.lang.Math.toIntExact;
 
 public class Matcher
 {
@@ -34,7 +33,7 @@ public class Matcher
 
     private static class Runtime
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(Runtime.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(java.lang.Runtime.class);
 
         // a helper structure for identifying equivalent threads
         // program pointer (instruction) --> list of threads that have reached this instruction

--- a/core/trino-main/src/main/java/io/trino/split/EmptySplit.java
+++ b/core/trino-main/src/main/java/io/trino/split/EmptySplit.java
@@ -19,17 +19,16 @@ import com.google.common.collect.ImmutableList;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.CatalogHandle;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class EmptySplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(EmptySplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(EmptySplit.class);
 
     private final CatalogHandle catalogHandle;
 

--- a/core/trino-main/src/main/java/io/trino/split/RemoteSplit.java
+++ b/core/trino-main/src/main/java/io/trino/split/RemoteSplit.java
@@ -19,18 +19,17 @@ import com.google.common.collect.ImmutableList;
 import io.trino.exchange.ExchangeInput;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class RemoteSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(RemoteSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(RemoteSplit.class);
 
     private final ExchangeInput exchangeInput;
 

--- a/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
@@ -54,7 +54,6 @@ import io.trino.sql.gen.JoinFilterFunctionCompiler.JoinFilterFunctionFactory;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.assertj.core.util.VisibleForTesting;
-import org.openjdk.jol.info.ClassLayout;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
@@ -209,8 +208,7 @@ public class JoinCompiler
         FieldDefinition instanceSize = definition.declareField(a(PRIVATE, STATIC, FINAL), "INSTANCE_SIZE", long.class);
         definition.getClassInitializer()
                 .getBody()
-                .comment("INSTANCE_SIZE = ClassLayout.parseClass(%s.class).instanceSize()", definition.getName())
-                .append(setStatic(instanceSize, invokeStatic(ClassLayout.class, "parseClass", ClassLayout.class, constantClass(definition.getType())).invoke("instanceSize", long.class)));
+                .append(setStatic(instanceSize, invokeStatic(SizeOf.class, "instanceSize", int.class, constantClass(definition.getType())).cast(long.class)));
         return instanceSize;
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/DynamicFilterId.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/DynamicFilterId.java
@@ -15,18 +15,17 @@ package io.trino.sql.planner.plan;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.concurrent.Immutable;
 
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
 public class DynamicFilterId
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DynamicFilterId.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DynamicFilterId.class);
 
     private final String id;
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/PlanNodeId.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/PlanNodeId.java
@@ -15,18 +15,17 @@ package io.trino.sql.planner.plan;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.concurrent.Immutable;
 
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
 public class PlanNodeId
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(PlanNodeId.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(PlanNodeId.class);
 
     private final String id;
 

--- a/core/trino-main/src/main/java/io/trino/testing/TestingSplit.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingSplit.java
@@ -18,17 +18,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 public class TestingSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TestingSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(TestingSplit.class);
 
     private static final HostAddress localHost = HostAddress.fromString("127.0.0.1");
 

--- a/core/trino-main/src/main/java/io/trino/type/setdigest/SetDigest.java
+++ b/core/trino-main/src/main/java/io/trino/type/setdigest/SetDigest.java
@@ -29,7 +29,6 @@ import it.unimi.dsi.fastutil.longs.Long2ShortSortedMap;
 import it.unimi.dsi.fastutil.longs.LongBidirectionalIterator;
 import it.unimi.dsi.fastutil.longs.LongRBTreeSet;
 import it.unimi.dsi.fastutil.longs.LongSortedSet;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -41,7 +40,7 @@ import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -54,8 +53,8 @@ public class SetDigest
     public static final int NUMBER_OF_BUCKETS = 2048;
     public static final int DEFAULT_MAX_HASHES = 8192;
     private static final int SIZE_OF_ENTRY = SIZE_OF_LONG + SIZE_OF_SHORT;
-    private static final int SIZE_OF_SETDIGEST = toIntExact(ClassLayout.parseClass(SetDigest.class).instanceSize());
-    private static final int SIZE_OF_RBTREEMAP = toIntExact(ClassLayout.parseClass(Long2ShortRBTreeMap.class).instanceSize());
+    private static final int SIZE_OF_SETDIGEST = instanceSize(SetDigest.class);
+    private static final int SIZE_OF_RBTREEMAP = instanceSize(Long2ShortRBTreeMap.class);
 
     private final HyperLogLog hll;
     private final Long2ShortSortedMap minhash;

--- a/core/trino-main/src/main/java/io/trino/type/setdigest/SetDigestStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/type/setdigest/SetDigestStateFactory.java
@@ -17,15 +17,14 @@ package io.trino.type.setdigest;
 import io.trino.array.ObjectBigArray;
 import io.trino.spi.function.AccumulatorStateFactory;
 import io.trino.spi.function.GroupedAccumulatorState;
-import org.openjdk.jol.info.ClassLayout;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 public class SetDigestStateFactory
         implements AccumulatorStateFactory<SetDigestState>
 {
-    private static final int SIZE_OF_SINGLE = toIntExact(ClassLayout.parseClass(SingleSetDigestState.class).instanceSize());
-    private static final int SIZE_OF_GROUPED = toIntExact(ClassLayout.parseClass(GroupedSetDigestState.class).instanceSize());
+    private static final int SIZE_OF_SINGLE = instanceSize(SingleSetDigestState.class);
+    private static final int SIZE_OF_GROUPED = instanceSize(GroupedSetDigestState.class);
 
     @Override
     public SetDigestState createSingleState()

--- a/core/trino-main/src/main/java/io/trino/util/HeapTraversal.java
+++ b/core/trino-main/src/main/java/io/trino/util/HeapTraversal.java
@@ -13,10 +13,9 @@
  */
 package io.trino.util;
 
-import org.openjdk.jol.info.ClassLayout;
-
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 /**
  * If heap nodes are numbered top down, and left to right as follows:
@@ -48,7 +47,7 @@ public class HeapTraversal
         RIGHT
     }
 
-    private static final long INSTANCE_SIZE = ClassLayout.parseClass(HeapTraversal.class).instanceSize();
+    private static final long INSTANCE_SIZE = instanceSize(HeapTraversal.class);
     private static final long TOP_BIT_MASK = 1L << (Long.SIZE - 1);
 
     private long shifted;

--- a/core/trino-main/src/main/java/io/trino/util/Long2LongOpenBigHashMap.java
+++ b/core/trino-main/src/main/java/io/trino/util/Long2LongOpenBigHashMap.java
@@ -26,12 +26,12 @@ import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import it.unimi.dsi.fastutil.objects.AbstractObjectSet;
 import it.unimi.dsi.fastutil.objects.ObjectIterator;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static it.unimi.dsi.fastutil.HashCommon.bigArraySize;
 import static it.unimi.dsi.fastutil.HashCommon.maxFill;
 import static java.lang.Math.toIntExact;
@@ -44,7 +44,7 @@ public class Long2LongOpenBigHashMap
         extends AbstractLong2LongMap
         implements Hash
 {
-    private static final long INSTANCE_SIZE = ClassLayout.parseClass(Long2LongOpenBigHashMap.class).instanceSize();
+    private static final long INSTANCE_SIZE = instanceSize(Long2LongOpenBigHashMap.class);
     private static final boolean ASSERTS = false;
     /**
      * The array of keys.

--- a/core/trino-main/src/main/java/io/trino/util/LongBigArrayFIFOQueue.java
+++ b/core/trino-main/src/main/java/io/trino/util/LongBigArrayFIFOQueue.java
@@ -18,10 +18,10 @@ import io.trino.array.LongBigArray;
 import it.unimi.dsi.fastutil.PriorityQueue;
 import it.unimi.dsi.fastutil.longs.LongComparator;
 import it.unimi.dsi.fastutil.longs.LongPriorityQueue;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.NoSuchElementException;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.Math.toIntExact;
 
 /**
@@ -42,7 +42,7 @@ import static java.lang.Math.toIntExact;
 public class LongBigArrayFIFOQueue
         implements LongPriorityQueue
 {
-    private static final long INSTANCE_SIZE = ClassLayout.parseClass(LongBigArrayFIFOQueue.class).instanceSize();
+    private static final long INSTANCE_SIZE = instanceSize(LongBigArrayFIFOQueue.class);
     /**
      * The standard initial capacity of a queue.
      */

--- a/core/trino-main/src/main/java/io/trino/util/LongLong2LongOpenCustomBigHashMap.java
+++ b/core/trino-main/src/main/java/io/trino/util/LongLong2LongOpenCustomBigHashMap.java
@@ -17,13 +17,12 @@ import io.trino.array.BigArrays;
 import io.trino.array.LongBigArray;
 import it.unimi.dsi.fastutil.Hash;
 import it.unimi.dsi.fastutil.HashCommon;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.function.LongBinaryOperator;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static it.unimi.dsi.fastutil.HashCommon.bigArraySize;
 import static it.unimi.dsi.fastutil.HashCommon.maxFill;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 // Note: this code was forked from fastutil (http://fastutil.di.unimi.it/) Long2LongOpenCustomHashMap
@@ -32,7 +31,7 @@ import static java.util.Objects.requireNonNull;
 public class LongLong2LongOpenCustomBigHashMap
         implements Hash
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(LongLong2LongOpenCustomBigHashMap.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(LongLong2LongOpenCustomBigHashMap.class);
 
     public interface HashStrategy
     {

--- a/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
@@ -27,7 +27,6 @@ import io.trino.spi.block.DictionaryId;
 import io.trino.spi.block.MapHashTables;
 import io.trino.spi.block.SingleRowBlockWriter;
 import io.trino.spi.block.TestingBlockEncodingSerde;
-import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodHandle;
@@ -41,6 +40,7 @@ import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
@@ -89,7 +89,7 @@ public abstract class AbstractTestBlock
 
     private void assertRetainedSize(Block block)
     {
-        long retainedSize = ClassLayout.parseClass(block.getClass()).instanceSize();
+        long retainedSize = instanceSize(block.getClass());
         Field[] fields = block.getClass().getDeclaredFields();
         try {
             for (Field field : fields) {
@@ -146,7 +146,7 @@ public abstract class AbstractTestBlock
                     retainedSize += sizeOf((short[]) field.get(block));
                 }
                 else if (type == DictionaryId.class) {
-                    retainedSize += ClassLayout.parseClass(DictionaryId.class).instanceSize();
+                    retainedSize += instanceSize(DictionaryId.class);
                 }
                 else if (type == MapHashTables.class) {
                     retainedSize += ((MapHashTables) field.get(block)).getRetainedSizeInBytes();

--- a/core/trino-main/src/test/java/io/trino/connector/TestingTableFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/connector/TestingTableFunctions.java
@@ -45,7 +45,6 @@ import io.trino.spi.ptf.TableFunctionProcessorState;
 import io.trino.spi.ptf.TableFunctionProcessorState.Processed;
 import io.trino.spi.ptf.TableFunctionSplitProcessor;
 import io.trino.spi.type.RowType;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Map;
@@ -55,6 +54,7 @@ import java.util.stream.IntStream;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.connector.TestingTableFunctions.ConstantFunction.ConstantFunctionSplit.DEFAULT_SPLIT_SIZE;
 import static io.trino.spi.ptf.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
@@ -1241,7 +1241,7 @@ public class TestingTableFunctions
         public static final class ConstantFunctionSplit
                 implements ConnectorSplit
         {
-            private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ConstantFunctionSplit.class).instanceSize());
+            private static final int INSTANCE_SIZE = instanceSize(ConstantFunctionSplit.class);
             public static final int DEFAULT_SPLIT_SIZE = 5500;
 
             private final long count;

--- a/core/trino-main/src/test/java/io/trino/execution/BenchmarkNodeScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BenchmarkNodeScheduler.java
@@ -53,7 +53,6 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -70,9 +69,9 @@ import java.util.concurrent.TimeUnit;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.SystemSessionProperties.MAX_UNACKNOWLEDGED_SPLITS_PER_TASK;
 import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
-import static java.lang.Math.toIntExact;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 
@@ -249,7 +248,7 @@ public class BenchmarkNodeScheduler
     private static class TestSplitRemote
             implements ConnectorSplit
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TestSplitRemote.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(TestSplitRemote.class);
 
         private final List<HostAddress> hosts;
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestNodeScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestNodeScheduler.java
@@ -47,7 +47,6 @@ import io.trino.spi.connector.ConnectorSplit;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.testing.TestingSession;
 import io.trino.util.FinalizerService;
-import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -76,11 +75,11 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.testing.Assertions.assertLessThanOrEqual;
 import static io.trino.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -876,7 +875,7 @@ public class TestNodeScheduler
     private static class TestSplitLocal
             implements ConnectorSplit
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TestSplitLocal.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(TestSplitLocal.class);
 
         private final HostAddress address;
         private final SplitWeight splitWeight;
@@ -969,7 +968,7 @@ public class TestNodeScheduler
     private static class TestSplitRemote
             implements ConnectorSplit
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TestSplitRemote.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(TestSplitRemote.class);
 
         private final List<HostAddress> hosts;
         private final SplitWeight splitWeight;

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
@@ -52,7 +52,6 @@ import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spiller.SpillSpaceTracker;
 import io.trino.sql.planner.LocalExecutionPlanner.LocalExecutionPlan;
 import io.trino.sql.planner.plan.PlanNodeId;
-import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -66,6 +65,7 @@ import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.concurrent.Threads.threadsNamed;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.SessionTestUtils.TEST_SESSION;
@@ -79,7 +79,6 @@ import static io.trino.execution.buffer.PagesSerdeUtil.getSerializedPagePosition
 import static io.trino.execution.buffer.PipelinedOutputBuffers.BufferType.PARTITIONED;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.HOURS;
@@ -493,7 +492,7 @@ public class TestSqlTaskExecution
     public static class TestingSplit
             implements ConnectorSplit
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TestingSplit.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(TestingSplit.class);
 
         private final int begin;
         private final int end;

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestingConnectorSplit.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestingConnectorSplit.java
@@ -18,7 +18,6 @@ import io.trino.metadata.Split;
 import io.trino.spi.HostAddress;
 import io.trino.spi.SplitWeight;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Objects;
@@ -27,13 +26,14 @@ import java.util.OptionalInt;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.util.Objects.requireNonNull;
 
 class TestingConnectorSplit
         implements ConnectorSplit
 {
-    private static final long INSTANCE_SIZE = ClassLayout.parseClass(TestingConnectorSplit.class).instanceSize();
+    private static final long INSTANCE_SIZE = instanceSize(TestingConnectorSplit.class);
 
     private final int id;
     private final OptionalInt bucket;

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestingExchangeSourceHandle.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestingExchangeSourceHandle.java
@@ -14,16 +14,16 @@
 package io.trino.execution.scheduler;
 
 import io.trino.spi.exchange.ExchangeSourceHandle;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 public class TestingExchangeSourceHandle
         implements ExchangeSourceHandle
 {
-    private static final long INSTANCE_SIZE = ClassLayout.parseClass(TestingExchangeSourceHandle.class).instanceSize();
+    private static final long INSTANCE_SIZE = instanceSize(TestingExchangeSourceHandle.class);
 
     private final int id;
     private final int partitionId;

--- a/core/trino-main/src/test/java/io/trino/operator/CyclingGroupByHash.java
+++ b/core/trino-main/src/test/java/io/trino/operator/CyclingGroupByHash.java
@@ -18,12 +18,11 @@ import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.type.BigintType.BIGINT;
-import static java.lang.Math.toIntExact;
 
 /**
  * GroupByHash that provides a round robin group ID assignment.
@@ -31,7 +30,7 @@ import static java.lang.Math.toIntExact;
 public class CyclingGroupByHash
         implements GroupByHash
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(CyclingGroupByHash.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(CyclingGroupByHash.class);
 
     private final int totalGroupCount;
     private int maxGroupId;

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/state/TestStateCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/state/TestStateCompiler.java
@@ -34,13 +34,13 @@ import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.util.Reflection;
-import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Field;
 import java.util.Map;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedDoubleArray;
 import static io.trino.block.BlockAssertions.createLongsBlock;
@@ -239,7 +239,7 @@ public class TestStateCompiler
 
     private static long getComplexStateRetainedSize(TestComplexState state)
     {
-        long retainedSize = ClassLayout.parseClass(state.getClass()).instanceSize();
+        long retainedSize = instanceSize(state.getClass());
         // reflection is necessary because TestComplexState implementation is generated
         Field[] fields = state.getClass().getDeclaredFields();
         try {

--- a/core/trino-main/src/test/java/io/trino/operator/project/TestPageProcessor.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/TestPageProcessor.java
@@ -33,7 +33,6 @@ import io.trino.spi.type.Type;
 import io.trino.sql.gen.ExpressionProfiler;
 import io.trino.sql.gen.PageFunctionCompiler;
 import io.trino.sql.relational.CallExpression;
-import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -47,6 +46,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.block.BlockAssertions.createLongSequenceBlock;
 import static io.trino.block.BlockAssertions.createSlicesBlock;
 import static io.trino.block.BlockAssertions.createStringsBlock;
@@ -371,7 +371,7 @@ public class TestPageProcessor
 
         // verify we do not count block sizes twice
         // comparing with the input page, the output page also contains an extra instance size for previouslyComputedResults
-        assertEquals(memoryContext.getBytes() - ClassLayout.parseClass(VariableWidthBlock.class).instanceSize(), inputPage.getRetainedSizeInBytes());
+        assertEquals(memoryContext.getBytes() - instanceSize(VariableWidthBlock.class), inputPage.getRetainedSizeInBytes());
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestJoinCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestJoinCompiler.java
@@ -30,7 +30,6 @@ import io.trino.type.BlockTypeOperators.BlockPositionHashCode;
 import io.trino.type.BlockTypeOperators.BlockPositionIsDistinctFrom;
 import io.trino.type.TypeTestUtils;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
-import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -38,6 +37,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.block.BlockAssertions.assertBlockEquals;
 import static io.trino.operator.PageAssertions.assertPageEquals;
@@ -45,7 +45,6 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.VarcharType.VARCHAR;
-import static java.lang.Math.toIntExact;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -211,7 +210,7 @@ public class TestJoinCompiler
         // verify channel count
         assertEquals(hashStrategy.getChannelCount(), outputChannels.size());
         // verify size
-        int instanceSize = toIntExact(ClassLayout.parseClass(hashStrategy.getClass()).instanceSize());
+        int instanceSize = instanceSize(hashStrategy.getClass());
         long sizeInBytes = instanceSize +
                 (channels.size() > 0 ? sizeOf(channels.get(0).elements()) * channels.size() : 0) +
                 channels.stream()

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -247,6 +247,12 @@
                                 <!-- Backwards incompatible changes since the previous release -->
                                 <!-- Any exclusions below can be deleted after each release -->
                                 <item>
+                                    <code>java.method.exception.checkedRemoved</code>
+                                    <old>method void io.airlift.slice.SliceOutput::write(byte[]) throws java.io.IOException</old>
+                                    <new>method void io.airlift.slice.SliceOutput::write(byte[])</new>
+                                    <exception>java.io.IOException</exception>
+                                </item>
+                                <item>
                                     <ignore>true</ignore>
                                     <code>java.field.visibilityReduced</code>
                                     <old>field io.trino.spi.connector.InMemoryRecordSet.InMemoryRecordCursor&lt;T extends java.util.Iterator&lt;? extends java.util.List&lt;?&gt;&gt;&gt;.records</old>

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -35,9 +35,11 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- used by slice and must be listed for plugin dependency enforcer -->
         <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <!-- for testing -->

--- a/core/trino-spi/src/main/java/io/trino/spi/HostAddress.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/HostAddress.java
@@ -15,7 +15,6 @@ package io.trino.spi;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.net.InetAddress;
 import java.net.URI;
@@ -27,7 +26,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
@@ -64,7 +63,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class HostAddress
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(HostAddress.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(HostAddress.class);
 
     /**
      * Magic value indicating the absence of a port number.

--- a/core/trino-spi/src/main/java/io/trino/spi/Page.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/Page.java
@@ -16,7 +16,6 @@ package io.trino.spi;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.DictionaryId;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,14 +23,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOfObjectArray;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public final class Page
 {
-    public static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(Page.class).instanceSize());
+    public static final int INSTANCE_SIZE = instanceSize(Page.class);
     private static final Block[] EMPTY_BLOCKS = new Block[0];
 
     public static long getInstanceSizeInBytes(int blockCount)

--- a/core/trino-spi/src/main/java/io/trino/spi/SplitWeight.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/SplitWeight.java
@@ -15,19 +15,18 @@ package io.trino.spi;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.function.Function;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.Math.addExact;
 import static java.lang.Math.multiplyExact;
-import static java.lang.Math.toIntExact;
 
 public final class SplitWeight
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SplitWeight.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SplitWeight.class);
 
     private static final long UNIT_VALUE = 100;
     private static final int UNIT_SCALE = 2; // Decimal scale such that (10 ^ UNIT_SCALE) == UNIT_VALUE

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
@@ -13,24 +13,22 @@
  */
 package io.trino.spi.block;
 
-import org.openjdk.jol.info.ClassLayout;
-
 import javax.annotation.Nullable;
 
 import java.util.Optional;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.copyIsNullAndAppendNull;
 import static io.trino.spi.block.BlockUtil.copyOffsetsAndAppendNull;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class ArrayBlock
         extends AbstractArrayBlock
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ArrayBlock.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ArrayBlock.class);
 
     private final int arrayOffset;
     private final int positionCount;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockBuilder.java
@@ -14,26 +14,25 @@
 package io.trino.spi.block;
 
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.ArrayBlock.createArrayBlockInternal;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static java.lang.Math.max;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class ArrayBlockBuilder
         extends AbstractArrayBlock
         implements BlockBuilder
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ArrayBlockBuilder.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ArrayBlockBuilder.class);
 
     private int positionCount;
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/BlockBuilderStatus.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/BlockBuilderStatus.java
@@ -13,14 +13,12 @@
  */
 package io.trino.spi.block;
 
-import org.openjdk.jol.info.ClassLayout;
-
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class BlockBuilderStatus
 {
-    public static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(BlockBuilderStatus.class).instanceSize()) + PageBuilderStatus.INSTANCE_SIZE;
+    public static final int INSTANCE_SIZE = instanceSize(BlockBuilderStatus.class) + PageBuilderStatus.INSTANCE_SIZE;
 
     private final PageBuilderStatus pageBuilderStatus;
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlock.java
@@ -15,7 +15,6 @@ package io.trino.spi.block;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -23,6 +22,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
@@ -30,12 +30,11 @@ import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.BlockUtil.copyIsNullAndAppendNull;
 import static io.trino.spi.block.BlockUtil.ensureCapacity;
-import static java.lang.Math.toIntExact;
 
 public class ByteArrayBlock
         implements Block
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ByteArrayBlock.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ByteArrayBlock.class);
     public static final int SIZE_IN_BYTES_PER_POSITION = Byte.BYTES + Byte.BYTES;
 
     private final int arrayOffset;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlockBuilder.java
@@ -15,7 +15,6 @@ package io.trino.spi.block;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -23,17 +22,17 @@ import java.util.Arrays;
 import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static java.lang.Math.max;
-import static java.lang.Math.toIntExact;
 
 public class ByteArrayBlockBuilder
         implements BlockBuilder
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ByteArrayBlockBuilder.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ByteArrayBlockBuilder.class);
     private static final Block NULL_VALUE_BLOCK = new ByteArrayBlock(0, 1, new boolean[] {true}, new byte[1]);
 
     @Nullable

--- a/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
@@ -15,7 +15,6 @@ package io.trino.spi.block;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -23,6 +22,7 @@ import java.util.List;
 import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkValidPosition;
@@ -30,14 +30,13 @@ import static io.trino.spi.block.BlockUtil.checkValidPositions;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.DictionaryId.randomDictionaryId;
 import static java.lang.Math.min;
-import static java.lang.Math.toIntExact;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
 public class DictionaryBlock
         implements Block
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DictionaryBlock.class).instanceSize() + ClassLayout.parseClass(DictionaryId.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DictionaryBlock.class) + instanceSize(DictionaryId.class);
     private static final int NULL_NOT_FOUND = -1;
 
     private final int positionCount;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
@@ -15,7 +15,6 @@ package io.trino.spi.block;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -23,6 +22,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
@@ -30,12 +30,11 @@ import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.BlockUtil.copyIsNullAndAppendNull;
 import static io.trino.spi.block.BlockUtil.ensureCapacity;
-import static java.lang.Math.toIntExact;
 
 public class Int128ArrayBlock
         implements Block
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(Int128ArrayBlock.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(Int128ArrayBlock.class);
     public static final int INT128_BYTES = Long.BYTES + Long.BYTES;
     public static final int SIZE_IN_BYTES_PER_POSITION = INT128_BYTES + Byte.BYTES;
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlockBuilder.java
@@ -15,7 +15,6 @@ package io.trino.spi.block;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -24,6 +23,7 @@ import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
@@ -31,12 +31,11 @@ import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.Int128ArrayBlock.INT128_BYTES;
 import static java.lang.Math.max;
-import static java.lang.Math.toIntExact;
 
 public class Int128ArrayBlockBuilder
         implements BlockBuilder
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(Int128ArrayBlockBuilder.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(Int128ArrayBlockBuilder.class);
     private static final Block NULL_VALUE_BLOCK = new Int128ArrayBlock(0, 1, new boolean[] {true}, new long[2]);
 
     @Nullable

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int96ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int96ArrayBlock.java
@@ -15,7 +15,6 @@ package io.trino.spi.block;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -23,6 +22,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
@@ -30,12 +30,11 @@ import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.BlockUtil.copyIsNullAndAppendNull;
 import static io.trino.spi.block.BlockUtil.ensureCapacity;
-import static java.lang.Math.toIntExact;
 
 public class Int96ArrayBlock
         implements Block
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(Int96ArrayBlock.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(Int96ArrayBlock.class);
     public static final int INT96_BYTES = Long.BYTES + Integer.BYTES;
     public static final int SIZE_IN_BYTES_PER_POSITION = INT96_BYTES + Byte.BYTES;
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int96ArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int96ArrayBlockBuilder.java
@@ -15,7 +15,6 @@ package io.trino.spi.block;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -24,6 +23,7 @@ import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
@@ -31,12 +31,11 @@ import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.Int96ArrayBlock.INT96_BYTES;
 import static java.lang.Math.max;
-import static java.lang.Math.toIntExact;
 
 public class Int96ArrayBlockBuilder
         implements BlockBuilder
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(Int96ArrayBlockBuilder.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(Int96ArrayBlockBuilder.class);
     private static final Block NULL_VALUE_BLOCK = new Int96ArrayBlock(0, 1, new boolean[] {true}, new long[1], new int[1]);
 
     @Nullable

--- a/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
@@ -15,7 +15,6 @@ package io.trino.spi.block;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -23,6 +22,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
@@ -30,12 +30,11 @@ import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.BlockUtil.copyIsNullAndAppendNull;
 import static io.trino.spi.block.BlockUtil.ensureCapacity;
-import static java.lang.Math.toIntExact;
 
 public class IntArrayBlock
         implements Block
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(IntArrayBlock.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(IntArrayBlock.class);
     public static final int SIZE_IN_BYTES_PER_POSITION = Integer.BYTES + Byte.BYTES;
 
     private final int arrayOffset;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlockBuilder.java
@@ -15,7 +15,6 @@ package io.trino.spi.block;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -23,17 +22,17 @@ import java.util.Arrays;
 import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static java.lang.Math.max;
-import static java.lang.Math.toIntExact;
 
 public class IntArrayBlockBuilder
         implements BlockBuilder
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(IntArrayBlockBuilder.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(IntArrayBlockBuilder.class);
     private static final Block NULL_VALUE_BLOCK = new IntArrayBlock(0, 1, new boolean[] {true}, new int[1]);
 
     @Nullable

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LazyBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LazyBlock.java
@@ -14,7 +14,6 @@
 package io.trino.spi.block;
 
 import io.airlift.slice.Slice;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -25,9 +24,9 @@ import java.util.OptionalInt;
 import java.util.function.Consumer;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
@@ -36,7 +35,7 @@ import static java.util.Objects.requireNonNull;
 public class LazyBlock
         implements Block
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(LazyBlock.class).instanceSize() + ClassLayout.parseClass(LazyData.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(LazyBlock.class) + instanceSize(LazyData.class);
 
     private final int positionCount;
     private final LazyData lazyData;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
@@ -15,7 +15,6 @@ package io.trino.spi.block;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -23,6 +22,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
@@ -35,7 +35,7 @@ import static java.lang.Math.toIntExact;
 public class LongArrayBlock
         implements Block
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(LongArrayBlock.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(LongArrayBlock.class);
     public static final int SIZE_IN_BYTES_PER_POSITION = Long.BYTES + Byte.BYTES;
 
     private final int arrayOffset;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlockBuilder.java
@@ -15,7 +15,6 @@ package io.trino.spi.block;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -23,6 +22,7 @@ import java.util.Arrays;
 import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
@@ -33,7 +33,7 @@ import static java.lang.Math.toIntExact;
 public class LongArrayBlockBuilder
         implements BlockBuilder
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(LongArrayBlockBuilder.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(LongArrayBlockBuilder.class);
     private static final Block NULL_VALUE_BLOCK = new LongArrayBlock(0, 1, new boolean[] {true}, new long[1]);
 
     @Nullable

--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
@@ -15,25 +15,24 @@
 package io.trino.spi.block;
 
 import io.trino.spi.type.MapType;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
 import java.util.Optional;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.copyIsNullAndAppendNull;
 import static io.trino.spi.block.BlockUtil.copyOffsetsAndAppendNull;
 import static io.trino.spi.block.MapHashTables.HASH_MULTIPLIER;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class MapBlock
         extends AbstractMapBlock
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(MapBlock.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(MapBlock.class);
 
     private final int startOffset;
     private final int positionCount;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapBlockBuilder.java
@@ -15,7 +15,6 @@
 package io.trino.spi.block;
 
 import io.trino.spi.type.MapType;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -23,11 +22,11 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.calculateNewArraySize;
 import static io.trino.spi.block.MapBlock.createMapBlockInternal;
 import static io.trino.spi.block.MapHashTables.HASH_MULTIPLIER;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -35,7 +34,7 @@ public class MapBlockBuilder
         extends AbstractMapBlock
         implements BlockBuilder
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(MapBlockBuilder.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(MapBlockBuilder.class);
 
     @Nullable
     private final BlockBuilderStatus blockBuilderStatus;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapHashTables.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapHashTables.java
@@ -15,7 +15,6 @@ package io.trino.spi.block;
 
 import io.trino.spi.TrinoException;
 import io.trino.spi.type.MapType;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
@@ -24,15 +23,15 @@ import javax.annotation.concurrent.ThreadSafe;
 import java.util.Arrays;
 import java.util.Optional;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 
 @ThreadSafe
 public final class MapHashTables
 {
-    public static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(MapHashTables.class).instanceSize());
+    public static final int INSTANCE_SIZE = instanceSize(MapHashTables.class);
 
     // inverse of hash fill ratio, must be integer
     static final int HASH_MULTIPLIER = 2;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/PageBuilderStatus.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/PageBuilderStatus.java
@@ -13,13 +13,11 @@
  */
 package io.trino.spi.block;
 
-import org.openjdk.jol.info.ClassLayout;
-
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 public class PageBuilderStatus
 {
-    public static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(PageBuilderStatus.class).instanceSize());
+    public static final int INSTANCE_SIZE = instanceSize(PageBuilderStatus.class);
 
     public static final int DEFAULT_MAX_PAGE_SIZE_IN_BYTES = 1024 * 1024;
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
@@ -13,25 +13,23 @@
  */
 package io.trino.spi.block;
 
-import org.openjdk.jol.info.ClassLayout;
-
 import javax.annotation.Nullable;
 
 import java.util.Optional;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.copyIsNullAndAppendNull;
 import static io.trino.spi.block.BlockUtil.copyOffsetsAndAppendNull;
 import static io.trino.spi.block.BlockUtil.ensureBlocksAreLoaded;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class RowBlock
         extends AbstractRowBlock
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(RowBlock.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(RowBlock.class);
 
     private final int startOffset;
     private final int positionCount;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockBuilder.java
@@ -15,7 +15,6 @@
 package io.trino.spi.block;
 
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -23,11 +22,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.RowBlock.createRowBlockInternal;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -35,7 +34,7 @@ public class RowBlockBuilder
         extends AbstractRowBlock
         implements BlockBuilder
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(RowBlockBuilder.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(RowBlockBuilder.class);
 
     @Nullable
     private final BlockBuilderStatus blockBuilderStatus;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
@@ -16,7 +16,6 @@ package io.trino.spi.block;
 import io.airlift.slice.Slice;
 import io.trino.spi.predicate.Utils;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -24,11 +23,11 @@ import java.util.List;
 import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
 import static io.trino.spi.block.BlockUtil.checkValidPosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
@@ -36,7 +35,7 @@ import static java.util.Objects.requireNonNull;
 public class RunLengthEncodedBlock
         implements Block
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(RunLengthEncodedBlock.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(RunLengthEncodedBlock.class);
 
     public static Block create(Type type, Object value, int positionCount)
     {

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
@@ -15,7 +15,6 @@ package io.trino.spi.block;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -23,6 +22,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
@@ -30,12 +30,11 @@ import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.BlockUtil.copyIsNullAndAppendNull;
 import static io.trino.spi.block.BlockUtil.ensureCapacity;
-import static java.lang.Math.toIntExact;
 
 public class ShortArrayBlock
         implements Block
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ShortArrayBlock.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ShortArrayBlock.class);
     public static final int SIZE_IN_BYTES_PER_POSITION = Short.BYTES + Byte.BYTES;
 
     private final int arrayOffset;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlockBuilder.java
@@ -15,7 +15,6 @@ package io.trino.spi.block;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -23,17 +22,17 @@ import java.util.Arrays;
 import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static java.lang.Math.max;
-import static java.lang.Math.toIntExact;
 
 public class ShortArrayBlockBuilder
         implements BlockBuilder
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ShortArrayBlockBuilder.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ShortArrayBlockBuilder.class);
     private static final Block NULL_VALUE_BLOCK = new ShortArrayBlock(0, 1, new boolean[] {true}, new short[1]);
 
     @Nullable

--- a/core/trino-spi/src/main/java/io/trino/spi/block/SingleArrayBlockWriter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/SingleArrayBlockWriter.java
@@ -14,19 +14,18 @@
 package io.trino.spi.block;
 
 import io.airlift.slice.Slice;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.String.format;
 
 public class SingleArrayBlockWriter
         extends AbstractSingleArrayBlock
         implements BlockBuilder
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleArrayBlockWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SingleArrayBlockWriter.class);
 
     private final BlockBuilder blockBuilder;
     private final long initialBlockBuilderSize;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/SingleMapBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/SingleMapBlock.java
@@ -16,25 +16,24 @@ package io.trino.spi.block;
 
 import io.trino.spi.TrinoException;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.lang.invoke.MethodHandle;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOfIntArray;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.block.MapHashTables.HASH_MULTIPLIER;
 import static io.trino.spi.block.MapHashTables.computePosition;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 
 public class SingleMapBlock
         extends AbstractSingleMapBlock
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleMapBlock.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SingleMapBlock.class);
 
     private final int offset;
     private final int positionCount;    // The number of keys in this single map * 2

--- a/core/trino-spi/src/main/java/io/trino/spi/block/SingleMapBlockWriter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/SingleMapBlockWriter.java
@@ -14,19 +14,18 @@
 package io.trino.spi.block;
 
 import io.airlift.slice.Slice;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.String.format;
 
 public class SingleMapBlockWriter
         extends AbstractSingleMapBlock
         implements BlockBuilder
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleMapBlockWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SingleMapBlockWriter.class);
 
     private final int offset;
     private final BlockBuilder keyBlockBuilder;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/SingleRowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/SingleRowBlock.java
@@ -14,19 +14,17 @@
 
 package io.trino.spi.block;
 
-import org.openjdk.jol.info.ClassLayout;
-
 import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.block.BlockUtil.ensureBlocksAreLoaded;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 
 public class SingleRowBlock
         extends AbstractSingleRowBlock
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleRowBlock.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SingleRowBlock.class);
 
     private final Block[] fieldBlocks;
     private final int rowIndex;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/SingleRowBlockWriter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/SingleRowBlockWriter.java
@@ -14,19 +14,18 @@
 package io.trino.spi.block;
 
 import io.airlift.slice.Slice;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.String.format;
 
 public class SingleRowBlockWriter
         extends AbstractSingleRowBlock
         implements BlockBuilder
 {
-    public static final int INSTANCE_SIZE = toIntExact(toIntExact(ClassLayout.parseClass(SingleRowBlockWriter.class).instanceSize()));
+    public static final int INSTANCE_SIZE = instanceSize(SingleRowBlockWriter.class);
 
     private final BlockBuilder[] fieldBlockBuilders;
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlock.java
@@ -16,7 +16,6 @@ package io.trino.spi.block;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -24,6 +23,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
@@ -34,12 +34,11 @@ import static io.trino.spi.block.BlockUtil.compactOffsets;
 import static io.trino.spi.block.BlockUtil.compactSlice;
 import static io.trino.spi.block.BlockUtil.copyIsNullAndAppendNull;
 import static io.trino.spi.block.BlockUtil.copyOffsetsAndAppendNull;
-import static java.lang.Math.toIntExact;
 
 public class VariableWidthBlock
         extends AbstractVariableWidthBlock
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(VariableWidthBlock.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(VariableWidthBlock.class);
 
     private final int arrayOffset;
     private final int positionCount;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlockBuilder.java
@@ -17,7 +17,6 @@ import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -29,6 +28,7 @@ import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.trino.spi.block.BlockUtil.MAX_ARRAY_SIZE;
@@ -41,13 +41,12 @@ import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.BlockUtil.compactOffsets;
 import static io.trino.spi.block.BlockUtil.compactSlice;
 import static java.lang.Math.min;
-import static java.lang.Math.toIntExact;
 
 public class VariableWidthBlockBuilder
         extends AbstractVariableWidthBlock
         implements BlockBuilder
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(VariableWidthBlockBuilder.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(VariableWidthBlockBuilder.class);
     private static final Block NULL_VALUE_BLOCK = new VariableWidthBlock(0, 1, EMPTY_SLICE, new int[] {0, 0}, new boolean[] {true});
 
     private final BlockBuilderStatus blockBuilderStatus;

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/CatalogHandle.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/CatalogHandle.java
@@ -16,22 +16,21 @@ package io.trino.spi.connector;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.trino.spi.Experimental;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.connector.CatalogHandle.CatalogHandleType.INFORMATION_SCHEMA;
 import static io.trino.spi.connector.CatalogHandle.CatalogHandleType.NORMAL;
 import static io.trino.spi.connector.CatalogHandle.CatalogHandleType.SYSTEM;
-import static java.lang.Math.toIntExact;
 import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 
 @Experimental(eta = "2023-02-01")
 public final class CatalogHandle
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(CatalogHandle.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(CatalogHandle.class);
 
     private final String catalogName;
     private final CatalogHandleType type;
@@ -177,7 +176,7 @@ public final class CatalogHandle
     public static final class CatalogVersion
             implements Comparable<CatalogVersion>
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(CatalogVersion.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(CatalogVersion.class);
 
         private final String version;
 

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/SchemaTableName.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/SchemaTableName.java
@@ -15,18 +15,17 @@ package io.trino.spi.connector;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.connector.SchemaUtil.checkNotEmpty;
-import static java.lang.Math.toIntExact;
 import static java.util.Locale.ENGLISH;
 
 public final class SchemaTableName
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SchemaTableName.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SchemaTableName.class);
 
     private final String schemaName;
     private final String tableName;

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeId.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeId.java
@@ -16,19 +16,19 @@ package io.trino.spi.exchange;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.trino.spi.Experimental;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 import java.util.regex.Pattern;
 
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 
 @Experimental(eta = "2023-01-01")
 public class ExchangeId
 {
-    private static final long INSTANCE_SIZE = ClassLayout.parseClass(ExchangeId.class).instanceSize();
+    private static final long INSTANCE_SIZE = instanceSize(ExchangeId.class);
 
     private static final Pattern ID_PATTERN = Pattern.compile("[a-zA-Z0-9_-]+");
 

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeSourceOutputSelector.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeSourceOutputSelector.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.airlift.slice.SizeOf;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -26,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.exchange.ExchangeSourceOutputSelector.Selection.EXCLUDED;
 import static io.trino.spi.exchange.ExchangeSourceOutputSelector.Selection.INCLUDED;
 import static io.trino.spi.exchange.ExchangeSourceOutputSelector.Selection.UNKNOWN;
@@ -37,7 +37,7 @@ import static java.util.stream.Collectors.toUnmodifiableMap;
 
 public class ExchangeSourceOutputSelector
 {
-    private static final long INSTANCE_SIZE = ClassLayout.parseClass(ExchangeSourceOutputSelector.class).instanceSize();
+    private static final long INSTANCE_SIZE = instanceSize(ExchangeSourceOutputSelector.class);
 
     private final int version;
     private final Map<ExchangeId, Slice> values;

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/AllOrNoneValueSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/AllOrNoneValueSet.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Collection;
 import java.util.List;
@@ -26,7 +25,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -36,7 +35,7 @@ import static java.util.Objects.requireNonNull;
 public class AllOrNoneValueSet
         implements ValueSet
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(AllOrNoneValueSet.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(AllOrNoneValueSet.class);
 
     private final Type type;
     private final boolean all;

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/Domain.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/Domain.java
@@ -17,14 +17,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -43,7 +42,7 @@ import static java.util.Objects.requireNonNull;
  */
 public final class Domain
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(Domain.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(Domain.class);
 
     public static final int DEFAULT_COMPACTION_THRESHOLD = 32;
 

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/EquatableValueSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/EquatableValueSet.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.block.Block;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.lang.invoke.MethodHandle;
 import java.util.Collection;
@@ -36,13 +35,13 @@ import java.util.stream.Collector;
 import java.util.stream.Stream;
 
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.predicate.Utils.TUPLE_DOMAIN_TYPE_OPERATORS;
 import static io.trino.spi.predicate.Utils.handleThrowable;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Objects.requireNonNull;
@@ -58,7 +57,7 @@ import static java.util.stream.Collectors.toUnmodifiableList;
 public class EquatableValueSet
         implements ValueSet
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(EquatableValueSet.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(EquatableValueSet.class);
 
     private final Type type;
     private final boolean inclusive;
@@ -434,7 +433,7 @@ public class EquatableValueSet
 
     public static class ValueEntry
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ValueEntry.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(ValueEntry.class);
 
         private final Type type;
         private final Block block;

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
@@ -21,7 +21,6 @@ import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
@@ -38,6 +37,7 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
@@ -51,7 +51,6 @@ import static io.trino.spi.type.TypeUtils.readNativeValue;
 import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static java.lang.Boolean.TRUE;
 import static java.lang.Math.min;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
@@ -67,7 +66,7 @@ import static java.util.stream.Collectors.joining;
 public final class SortedRangeSet
         implements ValueSet
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SortedRangeSet.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SortedRangeSet.class);
 
     private final Type type;
     private final MethodHandle equalOperator;

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,8 +39,8 @@ import java.util.function.ToLongFunction;
 import java.util.stream.Collector;
 
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableList;
@@ -55,7 +54,7 @@ import static java.util.stream.Collectors.toUnmodifiableList;
  */
 public final class TupleDomain<T>
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TupleDomain.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(TupleDomain.class);
 
     private static final TupleDomain<?> NONE = new TupleDomain<>(Optional.empty());
     private static final TupleDomain<?> ALL = new TupleDomain<>(Optional.of(emptyMap()));

--- a/core/trino-spi/src/main/java/io/trino/spi/type/Int128.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/Int128.java
@@ -13,14 +13,12 @@
  */
 package io.trino.spi.type;
 
-import org.openjdk.jol.info.ClassLayout;
-
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.math.BigInteger;
 import java.nio.ByteOrder;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 public class Int128
         implements Comparable<Int128>
@@ -28,7 +26,7 @@ public class Int128
     private static final VarHandle BIG_ENDIAN_LONG_VIEW = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.BIG_ENDIAN);
 
     public static final int SIZE = 2 * Long.BYTES;
-    public static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(Int128.class).instanceSize());
+    public static final int INSTANCE_SIZE = instanceSize(Int128.class);
 
     public static final Int128 MAX_VALUE = Int128.valueOf(0x7FFF_FFFF_FFFF_FFFFL, 0xFFFF_FFFF_FFFF_FFFFL);
     public static final Int128 MIN_VALUE = Int128.valueOf(0x8000_0000_0000_0000L, 0x0000_0000_0000_0000L);

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimeWithTimeZone.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimeWithTimeZone.java
@@ -13,17 +13,15 @@
  */
 package io.trino.spi.type;
 
-import org.openjdk.jol.info.ClassLayout;
-
 import java.util.Objects;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.type.TimeWithTimeZoneTypes.normalize;
-import static java.lang.Math.toIntExact;
 
 public final class LongTimeWithTimeZone
         implements Comparable<LongTimeWithTimeZone>
 {
-    public static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(LongTimeWithTimeZone.class).instanceSize());
+    public static final int INSTANCE_SIZE = instanceSize(LongTimeWithTimeZone.class);
 
     private final long picoseconds;
     private final int offsetMinutes;

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestamp.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestamp.java
@@ -13,17 +13,15 @@
  */
 package io.trino.spi.type;
 
-import org.openjdk.jol.info.ClassLayout;
-
 import java.util.Objects;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.type.Timestamps.formatTimestamp;
-import static java.lang.Math.toIntExact;
 
 public final class LongTimestamp
         implements Comparable<LongTimestamp>
 {
-    public static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(LongTimestamp.class).instanceSize());
+    public static final int INSTANCE_SIZE = instanceSize(LongTimestamp.class);
 
     private static final int PICOSECONDS_PER_MICROSECOND = 1_000_000;
 

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampWithTimeZone.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampWithTimeZone.java
@@ -13,18 +13,16 @@
  */
 package io.trino.spi.type;
 
-import org.openjdk.jol.info.ClassLayout;
-
 import java.util.Objects;
 import java.util.StringJoiner;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
-import static java.lang.Math.toIntExact;
 
 public final class LongTimestampWithTimeZone
         implements Comparable<LongTimestampWithTimeZone>
 {
-    public static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(LongTimestampWithTimeZone.class).instanceSize());
+    public static final int INSTANCE_SIZE = instanceSize(LongTimestampWithTimeZone.class);
 
     private final long epochMillis;
     private final int picosOfMilli; // number of picoseconds of the millisecond corresponding to epochMillis

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestArrayBlockBuilder.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestArrayBlockBuilder.java
@@ -13,10 +13,11 @@
  */
 package io.trino.spi.block;
 
-import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static java.lang.Long.BYTES;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -60,7 +61,7 @@ public class TestArrayBlockBuilder
             BIGINT.writeLong(arrayElementBuilder, i);
             arrayBlockBuilder.closeEntry();
         }
-        assertTrue(arrayBlockBuilder.getRetainedSizeInBytes() >= (expectedEntries * Long.BYTES + ClassLayout.parseClass(LongArrayBlockBuilder.class).instanceSize() + initialRetainedSize));
+        assertTrue(arrayBlockBuilder.getRetainedSizeInBytes() >= (expectedEntries * BYTES + instanceSize(LongArrayBlockBuilder.class) + initialRetainedSize));
     }
 
     @Test

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestVariableWidthBlockBuilder.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestVariableWidthBlockBuilder.java
@@ -19,18 +19,17 @@ import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
 
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.Math.ceil;
-import static java.lang.Math.toIntExact;
-import static org.openjdk.jol.info.ClassLayout.parseClass;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 public class TestVariableWidthBlockBuilder
 {
-    private static final int BLOCK_BUILDER_INSTANCE_SIZE = toIntExact(parseClass(VariableWidthBlockBuilder.class).instanceSize());
-    private static final int SLICE_INSTANCE_SIZE = toIntExact(parseClass(DynamicSliceOutput.class).instanceSize() + parseClass(Slice.class).instanceSize());
+    private static final int BLOCK_BUILDER_INSTANCE_SIZE = instanceSize(VariableWidthBlockBuilder.class);
+    private static final int SLICE_INSTANCE_SIZE = instanceSize(DynamicSliceOutput.class) + instanceSize(Slice.class);
     private static final int VARCHAR_VALUE_SIZE = 7;
     private static final int VARCHAR_ENTRY_SIZE = SIZE_OF_INT + VARCHAR_VALUE_SIZE;
     private static final int EXPECTED_ENTRY_COUNT = 3;

--- a/lib/trino-array/pom.xml
+++ b/lib/trino-array/pom.xml
@@ -32,11 +32,6 @@
             <artifactId>fastutil</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.openjdk.jol</groupId>
-            <artifactId>jol-core</artifactId>
-        </dependency>
-
         <!-- for testing -->
         <dependency>
             <groupId>io.trino</groupId>

--- a/lib/trino-array/src/main/java/io/trino/array/BlockBigArray.java
+++ b/lib/trino-array/src/main/java/io/trino/array/BlockBigArray.java
@@ -14,13 +14,12 @@
 package io.trino.array;
 
 import io.trino.spi.block.Block;
-import org.openjdk.jol.info.ClassLayout;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 public final class BlockBigArray
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(BlockBigArray.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(BlockBigArray.class);
     private final ObjectBigArray<Block> array;
     private final ReferenceCountMap trackedObjects = new ReferenceCountMap();
     private long sizeOfBlocks;

--- a/lib/trino-array/src/main/java/io/trino/array/BooleanBigArray.java
+++ b/lib/trino-array/src/main/java/io/trino/array/BooleanBigArray.java
@@ -14,22 +14,21 @@
 package io.trino.array;
 
 import io.airlift.slice.SizeOf;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOfBooleanArray;
 import static io.trino.array.BigArrays.INITIAL_SEGMENTS;
 import static io.trino.array.BigArrays.SEGMENT_SIZE;
 import static io.trino.array.BigArrays.offset;
 import static io.trino.array.BigArrays.segment;
-import static java.lang.Math.toIntExact;
 
 // Note: this code was forked from fastutil (http://fastutil.di.unimi.it/)
 // Copyright (C) 2010-2013 Sebastiano Vigna
 public final class BooleanBigArray
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(BooleanBigArray.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(BooleanBigArray.class);
     private static final long SIZE_OF_SEGMENT = sizeOfBooleanArray(SEGMENT_SIZE);
 
     private final boolean initialValue;

--- a/lib/trino-array/src/main/java/io/trino/array/ByteBigArray.java
+++ b/lib/trino-array/src/main/java/io/trino/array/ByteBigArray.java
@@ -14,22 +14,21 @@
 package io.trino.array;
 
 import io.airlift.slice.SizeOf;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOfByteArray;
 import static io.trino.array.BigArrays.INITIAL_SEGMENTS;
 import static io.trino.array.BigArrays.SEGMENT_SIZE;
 import static io.trino.array.BigArrays.offset;
 import static io.trino.array.BigArrays.segment;
-import static java.lang.Math.toIntExact;
 
 // Note: this code was forked from fastutil (http://fastutil.di.unimi.it/)
 // Copyright (C) 2010-2013 Sebastiano Vigna
 public final class ByteBigArray
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ByteBigArray.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ByteBigArray.class);
     private static final long SIZE_OF_SEGMENT = sizeOfByteArray(SEGMENT_SIZE);
 
     private final byte initialValue;

--- a/lib/trino-array/src/main/java/io/trino/array/DoubleBigArray.java
+++ b/lib/trino-array/src/main/java/io/trino/array/DoubleBigArray.java
@@ -14,22 +14,21 @@
 package io.trino.array;
 
 import io.airlift.slice.SizeOf;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOfDoubleArray;
 import static io.trino.array.BigArrays.INITIAL_SEGMENTS;
 import static io.trino.array.BigArrays.SEGMENT_SIZE;
 import static io.trino.array.BigArrays.offset;
 import static io.trino.array.BigArrays.segment;
-import static java.lang.Math.toIntExact;
 
 // Note: this code was forked from fastutil (http://fastutil.di.unimi.it/)
 // Copyright (C) 2010-2013 Sebastiano Vigna
 public final class DoubleBigArray
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DoubleBigArray.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DoubleBigArray.class);
     private static final long SIZE_OF_SEGMENT = sizeOfDoubleArray(SEGMENT_SIZE);
 
     private final double initialValue;

--- a/lib/trino-array/src/main/java/io/trino/array/IntBigArray.java
+++ b/lib/trino-array/src/main/java/io/trino/array/IntBigArray.java
@@ -14,22 +14,21 @@
 package io.trino.array;
 
 import io.airlift.slice.SizeOf;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOfIntArray;
 import static io.trino.array.BigArrays.INITIAL_SEGMENTS;
 import static io.trino.array.BigArrays.SEGMENT_SIZE;
 import static io.trino.array.BigArrays.offset;
 import static io.trino.array.BigArrays.segment;
-import static java.lang.Math.toIntExact;
 
 // Note: this code was forked from fastutil (http://fastutil.di.unimi.it/)
 // Copyright (C) 2010-2013 Sebastiano Vigna
 public final class IntBigArray
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(IntBigArray.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(IntBigArray.class);
     private static final long SIZE_OF_SEGMENT = sizeOfIntArray(SEGMENT_SIZE);
 
     private final int initialValue;

--- a/lib/trino-array/src/main/java/io/trino/array/LongBigArray.java
+++ b/lib/trino-array/src/main/java/io/trino/array/LongBigArray.java
@@ -14,22 +14,21 @@
 package io.trino.array;
 
 import io.airlift.slice.SizeOf;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOfLongArray;
 import static io.trino.array.BigArrays.INITIAL_SEGMENTS;
 import static io.trino.array.BigArrays.SEGMENT_SIZE;
 import static io.trino.array.BigArrays.offset;
 import static io.trino.array.BigArrays.segment;
-import static java.lang.Math.toIntExact;
 
 // Note: this code was forked from fastutil (http://fastutil.di.unimi.it/)
 // Copyright (C) 2010-2013 Sebastiano Vigna
 public final class LongBigArray
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(LongBigArray.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(LongBigArray.class);
     private static final long SIZE_OF_SEGMENT = sizeOfLongArray(SEGMENT_SIZE);
 
     private final long initialValue;

--- a/lib/trino-array/src/main/java/io/trino/array/ObjectBigArray.java
+++ b/lib/trino-array/src/main/java/io/trino/array/ObjectBigArray.java
@@ -14,22 +14,21 @@
 package io.trino.array;
 
 import io.airlift.slice.SizeOf;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOfObjectArray;
 import static io.trino.array.BigArrays.INITIAL_SEGMENTS;
 import static io.trino.array.BigArrays.SEGMENT_SIZE;
 import static io.trino.array.BigArrays.offset;
 import static io.trino.array.BigArrays.segment;
-import static java.lang.Math.toIntExact;
 
 // Note: this code was forked from fastutil (http://fastutil.di.unimi.it/)
 // Copyright (C) 2010-2013 Sebastiano Vigna
 public final class ObjectBigArray<T>
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ObjectBigArray.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ObjectBigArray.class);
     private static final long SIZE_OF_SEGMENT = sizeOfObjectArray(SEGMENT_SIZE);
 
     private final Object initialValue;

--- a/lib/trino-array/src/main/java/io/trino/array/ReferenceCountMap.java
+++ b/lib/trino-array/src/main/java/io/trino/array/ReferenceCountMap.java
@@ -18,9 +18,8 @@ import io.airlift.slice.Slice;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.MapHashTables;
 import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
-import org.openjdk.jol.info.ClassLayout;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.String.format;
 import static java.lang.reflect.Array.getLength;
 
@@ -37,7 +36,7 @@ import static java.lang.reflect.Array.getLength;
 public final class ReferenceCountMap
         extends Long2IntOpenHashMap
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ReferenceCountMap.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ReferenceCountMap.class);
 
     /**
      * Increments the reference count of an object by 1 and returns the updated reference count

--- a/lib/trino-array/src/main/java/io/trino/array/ShortBigArray.java
+++ b/lib/trino-array/src/main/java/io/trino/array/ShortBigArray.java
@@ -14,22 +14,21 @@
 package io.trino.array;
 
 import io.airlift.slice.SizeOf;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOfShortArray;
 import static io.trino.array.BigArrays.INITIAL_SEGMENTS;
 import static io.trino.array.BigArrays.SEGMENT_SIZE;
 import static io.trino.array.BigArrays.offset;
 import static io.trino.array.BigArrays.segment;
-import static java.lang.Math.toIntExact;
 
 // Note: this code was forked from fastutil (http://fastutil.di.unimi.it/)
 // Copyright (C) 2010-2013 Sebastiano Vigna
 public final class ShortBigArray
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ShortBigArray.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ShortBigArray.class);
     private static final long SIZE_OF_SEGMENT = sizeOfShortArray(SEGMENT_SIZE);
 
     private final short initialValue;

--- a/lib/trino-array/src/main/java/io/trino/array/SliceBigArray.java
+++ b/lib/trino-array/src/main/java/io/trino/array/SliceBigArray.java
@@ -14,14 +14,13 @@
 package io.trino.array;
 
 import io.airlift.slice.Slice;
-import org.openjdk.jol.info.ClassLayout;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 public final class SliceBigArray
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SliceBigArray.class).instanceSize());
-    private static final int SLICE_INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(Slice.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SliceBigArray.class);
+    private static final int SLICE_INSTANCE_SIZE = instanceSize(Slice.class);
     private final ObjectBigArray<Slice> array;
     private final ReferenceCountMap trackedSlices = new ReferenceCountMap();
     private long sizeOfSlices;

--- a/lib/trino-array/src/test/java/io/trino/array/TestBlockBigArray.java
+++ b/lib/trino-array/src/test/java/io/trino/array/TestBlockBigArray.java
@@ -16,9 +16,9 @@ package io.trino.array;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.IntArrayBlockBuilder;
-import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static org.testng.Assert.assertEquals;
 
 public class TestBlockBigArray
@@ -44,10 +44,10 @@ public class TestBlockBigArray
 
         ReferenceCountMap referenceCountMap = new ReferenceCountMap();
         referenceCountMap.incrementAndGet(block);
-        long expectedSize = ClassLayout.parseClass(BlockBigArray.class).instanceSize()
+        long expectedSize = instanceSize(BlockBigArray.class)
                 + referenceCountMap.sizeOf()
                 + (new ObjectBigArray<>()).sizeOf()
-                + block.getRetainedSizeInBytes() + (arraySize - 1) * ClassLayout.parseClass(block.getClass()).instanceSize();
+                + block.getRetainedSizeInBytes() + (arraySize - 1) * instanceSize(block.getClass());
         assertEquals(blockBigArray.sizeOf(), expectedSize);
     }
 }

--- a/lib/trino-array/src/test/java/io/trino/array/TestSliceBigArray.java
+++ b/lib/trino-array/src/test/java/io/trino/array/TestSliceBigArray.java
@@ -14,10 +14,10 @@
 package io.trino.array;
 
 import io.airlift.slice.Slice;
-import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static org.testng.Assert.assertEquals;
@@ -25,8 +25,8 @@ import static org.testng.Assert.assertEquals;
 @Test(singleThreaded = true)
 public class TestSliceBigArray
 {
-    private static final long BIG_ARRAY_INSTANCE_SIZE = ClassLayout.parseClass(SliceBigArray.class).instanceSize() + new ReferenceCountMap().sizeOf() + new ObjectBigArray<Slice>().sizeOf();
-    private static final long SLICE_INSTANCE_SIZE = ClassLayout.parseClass(Slice.class).instanceSize();
+    private static final long BIG_ARRAY_INSTANCE_SIZE = instanceSize(SliceBigArray.class) + new ReferenceCountMap().sizeOf() + new ObjectBigArray<Slice>().sizeOf();
+    private static final long SLICE_INSTANCE_SIZE = instanceSize(Slice.class);
     private static final int CAPACITY = 32;
     private final byte[] firstBytes = new byte[1234];
     private final byte[] secondBytes = new byte[4567];

--- a/lib/trino-geospatial-toolkit/pom.xml
+++ b/lib/trino-geospatial-toolkit/pom.xml
@@ -73,11 +73,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.openjdk.jol</groupId>
-            <artifactId>jol-core</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-testing-services</artifactId>
             <scope>test</scope>

--- a/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/Rectangle.java
+++ b/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/Rectangle.java
@@ -15,20 +15,19 @@ package io.trino.geospatial;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public final class Rectangle
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(Rectangle.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(Rectangle.class);
 
     private final double xMin;
     private final double yMin;

--- a/lib/trino-hive-formats/pom.xml
+++ b/lib/trino-hive-formats/pom.xml
@@ -91,11 +91,6 @@
             <artifactId>modernizer-maven-annotations</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.openjdk.jol</groupId>
-            <artifactId>jol-core</artifactId>
-        </dependency>
-
         <!-- for hadoop compression -->
         <dependency>
             <groupId>io.trino.hadoop</groupId>

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/DataOutputStream.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/DataOutputStream.java
@@ -15,7 +15,6 @@ package io.trino.hive.formats;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.Closeable;
 import java.io.DataOutput;
@@ -29,7 +28,7 @@ import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 public final class DataOutputStream
         extends OutputStream
@@ -38,7 +37,7 @@ public final class DataOutputStream
     private static final int DEFAULT_BUFFER_SIZE = 4 * 1024;
     private static final int MINIMUM_CHUNK_SIZE = 1024;
 
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DataOutputStream.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DataOutputStream.class);
 
     private final OutputStream outputStream;
 

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/DataSeekableInputStream.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/DataSeekableInputStream.java
@@ -16,7 +16,6 @@ package io.trino.hive.formats;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.filesystem.SeekableInputStream;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.DataInput;
 import java.io.EOFException;
@@ -30,15 +29,15 @@ import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public final class DataSeekableInputStream
         extends InputStream
         implements DataInput
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DataSeekableInputStream.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DataSeekableInputStream.class);
     private static final int DEFAULT_BUFFER_SIZE = 4 * 1024;
     private static final int MINIMUM_CHUNK_SIZE = 1024;
 

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/compression/BufferedOutputStreamSliceOutput.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/compression/BufferedOutputStreamSliceOutput.java
@@ -16,7 +16,6 @@ package io.trino.hive.formats.compression;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,12 +29,13 @@ import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.Math.toIntExact;
 
 public class BufferedOutputStreamSliceOutput
         extends SliceOutput
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(BufferedOutputStreamSliceOutput.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(BufferedOutputStreamSliceOutput.class);
     private static final int CHUNK_SIZE = 4096;
 
     private final OutputStream outputStream;

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/compression/ChunkedSliceOutput.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/compression/ChunkedSliceOutput.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,6 +30,7 @@ import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.Math.min;
 import static java.lang.Math.multiplyExact;
 import static java.lang.Math.toIntExact;
@@ -38,7 +38,7 @@ import static java.lang.Math.toIntExact;
 public final class ChunkedSliceOutput
         extends SliceOutput
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ChunkedSliceOutput.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ChunkedSliceOutput.class);
     private static final int MINIMUM_CHUNK_SIZE = 4096;
     private static final int MAXIMUM_CHUNK_SIZE = 16 * 1024 * 1024;
     // This must not be larger than MINIMUM_CHUNK_SIZE/2

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/LineBuffer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/LineBuffer.java
@@ -13,8 +13,6 @@
  */
 package io.trino.hive.formats.line;
 
-import org.openjdk.jol.info.ClassLayout;
-
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,13 +22,13 @@ import java.util.Arrays;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.primitives.Ints.constrainToRange;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 
 public final class LineBuffer
         extends OutputStream
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(LineBuffer.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(LineBuffer.class);
 
     private final int maxLength;
     private byte[] buffer;

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/sequence/SequenceFileReader.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/sequence/SequenceFileReader.java
@@ -28,7 +28,6 @@ import io.trino.hive.formats.compression.CompressionKind;
 import io.trino.hive.formats.compression.ValueDecompressor;
 import io.trino.hive.formats.line.LineBuffer;
 import io.trino.hive.formats.line.LineReader;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -37,6 +36,7 @@ import java.util.Map;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.hive.formats.ReadWriteUtils.findFirstSyncPosition;
@@ -51,7 +51,7 @@ import static java.util.Objects.requireNonNull;
 public final class SequenceFileReader
         implements LineReader
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SequenceFileReader.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SequenceFileReader.class);
 
     private static final Slice SEQUENCE_FILE_MAGIC = utf8Slice("SEQ");
     private static final byte SEQUENCE_FILE_VERSION = 6;
@@ -279,7 +279,7 @@ public final class SequenceFileReader
     private static class SingleValueReader
             implements ValueReader
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleValueReader.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(SingleValueReader.class);
 
         private final String location;
         private final long fileSize;
@@ -392,7 +392,7 @@ public final class SequenceFileReader
     private static class BlockCompressedValueReader
             implements ValueReader
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(BlockCompressedValueReader.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(BlockCompressedValueReader.class);
 
         private final String location;
         private final long fileSize;
@@ -499,7 +499,7 @@ public final class SequenceFileReader
 
         private static class ValuesBlock
         {
-            private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ValuesBlock.class).instanceSize());
+            private static final int INSTANCE_SIZE = instanceSize(ValuesBlock.class);
 
             public static final ValuesBlock EMPTY_VALUES_BLOCK = new ValuesBlock(0, EMPTY_SLICE.getInput(), EMPTY_SLICE.getInput());
 
@@ -544,7 +544,7 @@ public final class SequenceFileReader
 
     private static class ReadBuffer
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ReadBuffer.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(ReadBuffer.class);
 
         private final DataSeekableInputStream input;
         private final ValueDecompressor decompressor;

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/sequence/SequenceFileWriter.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/sequence/SequenceFileWriter.java
@@ -23,7 +23,6 @@ import io.trino.hive.formats.compression.CompressionKind;
 import io.trino.hive.formats.compression.MemoryCompressedSliceOutput;
 import io.trino.hive.formats.compression.ValueCompressor;
 import io.trino.hive.formats.line.LineWriter;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -37,12 +36,12 @@ import java.util.function.LongSupplier;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.hive.formats.ReadWriteUtils.computeVIntLength;
 import static io.trino.hive.formats.ReadWriteUtils.writeLengthPrefixedString;
 import static io.trino.hive.formats.ReadWriteUtils.writeVInt;
 import static io.trino.hive.formats.compression.CompressionKind.LZOP;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -51,7 +50,7 @@ import static java.util.Objects.requireNonNull;
 public class SequenceFileWriter
         implements LineWriter
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SequenceFileWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SequenceFileWriter.class);
     private static final Slice SEQUENCE_FILE_MAGIC = utf8Slice("SEQ");
     private static final byte SEQUENCE_FILE_VERSION = 6;
 
@@ -171,7 +170,7 @@ public class SequenceFileWriter
     private static class SingleValueWriter
             implements ValueWriter
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleValueWriter.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(SingleValueWriter.class);
         private static final int SYNC_INTERVAL = 10 * 1024;
 
         private final DataOutputStream output;
@@ -269,7 +268,7 @@ public class SequenceFileWriter
     private static class BlockCompressionValueWriter
             implements ValueWriter
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(BlockCompressionValueWriter.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(BlockCompressionValueWriter.class);
 
         private static final int MAX_ROWS = 10_000_000;
         private static final int TARGET_BLOCK_SIZE = 1024 * 1024;

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/text/TextLineReader.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/text/TextLineReader.java
@@ -16,22 +16,21 @@ package io.trino.hive.formats.line.text;
 import com.google.common.io.CountingInputStream;
 import io.trino.hive.formats.line.LineBuffer;
 import io.trino.hive.formats.line.LineReader;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.io.InputStream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.addExact;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public final class TextLineReader
         implements LineReader
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TextLineReader.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(TextLineReader.class);
 
     private final CountingInputStream in;
     private final byte[] buffer;

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/text/TextLineWriter.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/text/TextLineWriter.java
@@ -17,19 +17,18 @@ import com.google.common.io.CountingOutputStream;
 import io.airlift.slice.Slice;
 import io.trino.hive.formats.compression.CompressionKind;
 import io.trino.hive.formats.line.LineWriter;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Optional;
 import java.util.function.LongSupplier;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 public class TextLineWriter
         implements LineWriter
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TextLineWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(TextLineWriter.class);
     private final LongSupplier writtenBytes;
     private final OutputStream outputStream;
 

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/rcfile/RcFileWriter.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/rcfile/RcFileWriter.java
@@ -31,7 +31,6 @@ import io.trino.hive.formats.rcfile.RcFileWriteValidation.RcFileWriteValidationB
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -47,6 +46,7 @@ import java.util.function.Consumer;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
@@ -60,7 +60,7 @@ import static java.util.Objects.requireNonNull;
 public class RcFileWriter
         implements Closeable
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(RcFileWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(RcFileWriter.class);
     private static final Slice RCFILE_MAGIC = utf8Slice("RCF");
     private static final int CURRENT_VERSION = 1;
     private static final String COLUMN_COUNT_METADATA_KEY = "hive.io.rcfile.column.number";
@@ -344,7 +344,7 @@ public class RcFileWriter
 
     private static class ColumnEncoder
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ColumnEncoder.class).instanceSize() + ClassLayout.parseClass(ColumnEncodeOutput.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(ColumnEncoder.class) + instanceSize(ColumnEncodeOutput.class);
 
         private final ColumnEncoding columnEncoding;
 

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/TestDataOutputStream.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/TestDataOutputStream.java
@@ -15,7 +15,6 @@ package io.trino.hive.formats;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -23,6 +22,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static org.testng.Assert.assertEquals;
 
 public class TestDataOutputStream
@@ -181,7 +181,7 @@ public class TestDataOutputStream
         DataOutputStream output = new DataOutputStream(new ByteArrayOutputStream(0), bufferSize);
 
         long originalRetainedSize = output.getRetainedSize();
-        assertEquals(originalRetainedSize, ClassLayout.parseClass(DataOutputStream.class).instanceSize() + Slices.allocate(bufferSize).getRetainedSize());
+        assertEquals(originalRetainedSize, instanceSize(DataOutputStream.class) + Slices.allocate(bufferSize).getRetainedSize());
         output.writeLong(0);
         output.writeShort(0);
         assertEquals(output.getRetainedSize(), originalRetainedSize);

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/TestDataSeekableInputStream.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/TestDataSeekableInputStream.java
@@ -20,7 +20,6 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.filesystem.SeekableInputStream;
 import io.trino.filesystem.memory.MemorySeekableInputStream;
-import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -35,6 +34,7 @@ import static io.airlift.slice.SizeOf.SIZE_OF_FLOAT;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOfByteArray;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
@@ -592,7 +592,7 @@ public class TestDataSeekableInputStream
         int bufferSize = 1024;
         SeekableInputStream inputStream = new MemorySeekableInputStream(Slices.wrappedBuffer(new byte[] {0, 1}));
         DataSeekableInputStream input = new DataSeekableInputStream(inputStream, bufferSize);
-        assertEquals(input.getRetainedSize(), ClassLayout.parseClass(DataSeekableInputStream.class).instanceSize() + sizeOfByteArray(bufferSize));
+        assertEquals(input.getRetainedSize(), instanceSize(DataSeekableInputStream.class) + sizeOfByteArray(bufferSize));
     }
 
     private static void testDataInput(DataInputTester tester)

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/TestLineBuffer.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/TestLineBuffer.java
@@ -14,23 +14,22 @@
 package io.trino.hive.formats.line;
 
 import com.google.common.primitives.Bytes;
-import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.min;
-import static java.lang.Math.toIntExact;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 public class TestLineBuffer
 {
-    private static final int LINE_BUFFER_INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(LineBuffer.class).instanceSize());
+    private static final int LINE_BUFFER_INSTANCE_SIZE = instanceSize(LineBuffer.class);
 
     @Test
     public void testInvalidConstructorArgs()

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/text/TestLineReader.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/text/TestLineReader.java
@@ -16,7 +16,6 @@ package io.trino.hive.formats.line.text;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.trino.hive.formats.line.LineBuffer;
-import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
@@ -27,17 +26,17 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getLast;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOfByteArray;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.join;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestLineReader
 {
-    private static final int LINE_READER_INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TextLineReader.class).instanceSize());
+    private static final int LINE_READER_INSTANCE_SIZE = instanceSize(TextLineReader.class);
     private static final int[] SKIP_SIZES = new int[] {1, 2, 3, 13, 101, 331, 443, 701, 853, 1021};
 
     @Test

--- a/lib/trino-orc/pom.xml
+++ b/lib/trino-orc/pom.xml
@@ -83,11 +83,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.openjdk.jol</groupId>
-            <artifactId>jol-core</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>
         </dependency>

--- a/lib/trino-orc/src/main/java/io/trino/orc/ChunkedSliceOutput.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/ChunkedSliceOutput.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,6 +30,7 @@ import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.Math.min;
 import static java.lang.Math.multiplyExact;
 import static java.lang.Math.toIntExact;
@@ -38,7 +38,7 @@ import static java.lang.Math.toIntExact;
 public final class ChunkedSliceOutput
         extends SliceOutput
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ChunkedSliceOutput.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ChunkedSliceOutput.class);
     private static final int MINIMUM_CHUNK_SIZE = 4096;
     private static final int MAXIMUM_CHUNK_SIZE = 16 * 1024 * 1024;
     // This must not be larger than MINIMUM_CHUNK_SIZE/2

--- a/lib/trino-orc/src/main/java/io/trino/orc/LazySliceInput.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/LazySliceInput.java
@@ -16,7 +16,6 @@ package io.trino.orc;
 import io.airlift.slice.FixedLengthSliceInput;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceInput;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -25,13 +24,14 @@ import java.util.function.Supplier;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 final class LazySliceInput
         extends FixedLengthSliceInput
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(LazySliceInput.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(LazySliceInput.class);
 
     private final int globalLength;
     private final Supplier<FixedLengthSliceInput> loader;

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcOutputBuffer.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcOutputBuffer.java
@@ -23,7 +23,6 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import io.trino.orc.checkpoint.InputStreamCheckpoint;
 import io.trino.orc.metadata.CompressionKind;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -38,6 +37,7 @@ import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -47,7 +47,7 @@ import static java.util.Objects.requireNonNull;
 public class OrcOutputBuffer
         extends SliceOutput
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(OrcOutputBuffer.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(OrcOutputBuffer.class);
     private static final int INITIAL_BUFFER_SIZE = 256;
     private static final int DIRECT_FLUSH_SIZE = 32 * 1024;
     private static final int MINIMUM_OUTPUT_BUFFER_CHUNK_SIZE = 4 * 1024;

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcRecordReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcRecordReader.java
@@ -42,7 +42,6 @@ import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
 import org.joda.time.DateTimeZone;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -59,6 +58,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.OrcDataSourceUtils.mergeAdjacentDiskRanges;
 import static io.trino.orc.OrcReader.BATCH_SIZE_GROWTH_FACTOR;
 import static io.trino.orc.OrcReader.MAX_BATCH_SIZE;
@@ -75,7 +75,7 @@ import static java.util.Objects.requireNonNull;
 public class OrcRecordReader
         implements Closeable
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(OrcRecordReader.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(OrcRecordReader.class);
 
     private final OrcDataSource orcDataSource;
 

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcWriteValidation.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcWriteValidation.java
@@ -56,7 +56,6 @@ import io.trino.spi.type.MapType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -76,6 +75,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.OrcWriteValidation.OrcWriteValidationMode.BOTH;
 import static io.trino.orc.OrcWriteValidation.OrcWriteValidationMode.DETAILED;
 import static io.trino.orc.OrcWriteValidation.OrcWriteValidationMode.HASHED;
@@ -104,7 +104,6 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.UuidType.UUID;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.Math.floorDiv;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
@@ -759,7 +758,7 @@ public class OrcWriteValidation
 
     private static class RowGroupStatistics
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(RowGroupStatistics.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(RowGroupStatistics.class);
 
         private final OrcWriteValidationMode validationMode;
         private final SortedMap<OrcColumnId, ColumnStatistics> columnStatistics;
@@ -818,7 +817,7 @@ public class OrcWriteValidation
 
     public static class OrcWriteValidationBuilder
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(OrcWriteValidationBuilder.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(OrcWriteValidationBuilder.class);
 
         private final OrcWriteValidationMode validationMode;
 

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcWriter.java
@@ -44,7 +44,6 @@ import io.trino.orc.writer.ColumnWriter;
 import io.trino.orc.writer.SliceDictionaryColumnWriter;
 import io.trino.spi.Page;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -67,6 +66,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.orc.OrcReader.validateFile;
 import static io.trino.orc.OrcWriterStats.FlushReason.CLOSED;
@@ -86,7 +86,7 @@ import static java.util.stream.Collectors.toList;
 public final class OrcWriter
         implements Closeable
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(OrcWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(OrcWriter.class);
 
     private static final String TRINO_ORC_WRITER_VERSION_METADATA_KEY = "trino.writer.version";
     private static final String TRINO_ORC_WRITER_VERSION;
@@ -612,7 +612,7 @@ public final class OrcWriter
 
     private static class ClosedStripe
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ClosedStripe.class).instanceSize() + ClassLayout.parseClass(StripeInformation.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(ClosedStripe.class) + instanceSize(StripeInformation.class);
 
         private final StripeInformation stripeInformation;
         private final StripeStatistics statistics;

--- a/lib/trino-orc/src/main/java/io/trino/orc/OutputStreamOrcDataSink.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OutputStreamOrcDataSink.java
@@ -17,20 +17,19 @@ import io.airlift.slice.OutputStreamSliceOutput;
 import io.trino.filesystem.TrinoOutputFile;
 import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.orc.stream.OrcDataOutput;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class OutputStreamOrcDataSink
         implements OrcDataSink
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(OutputStreamOrcDataSink.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(OutputStreamOrcDataSink.class);
 
     private final OutputStreamSliceOutput output;
     private final AggregatedMemoryContext memoryContext;

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/BinaryStatistics.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/BinaryStatistics.java
@@ -14,10 +14,9 @@
 package io.trino.orc.metadata.statistics;
 
 import io.trino.orc.metadata.statistics.StatisticsHasher.Hashable;
-import org.openjdk.jol.info.ClassLayout;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 public class BinaryStatistics
         implements Hashable
@@ -25,7 +24,7 @@ public class BinaryStatistics
     // 1 byte to denote if null + 4 bytes to denote offset
     public static final long BINARY_VALUE_BYTES_OVERHEAD = Byte.BYTES + Integer.BYTES;
 
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(BinaryStatistics.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(BinaryStatistics.class);
 
     private final long sum;
 

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/BloomFilter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/BloomFilter.java
@@ -17,14 +17,13 @@ import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.ByteArrays;
 import io.airlift.slice.Slice;
 import io.airlift.slice.UnsafeSlice;
-import org.openjdk.jol.info.ClassLayout;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Double.doubleToLongBits;
-import static java.lang.Math.toIntExact;
 
 /**
  * BloomFilter is a probabilistic data structure for set membership check. BloomFilters are
@@ -49,7 +48,7 @@ import static java.lang.Math.toIntExact;
 public class BloomFilter
         implements StatisticsHasher.Hashable
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(BloomFilter.class).instanceSize() + ClassLayout.parseClass(BitSet.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(BloomFilter.class) + instanceSize(BitSet.class);
 
     // from 64-bit linear congruential generator
     private static final long NULL_HASHCODE = 2862933555777941757L;

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/BooleanStatistics.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/BooleanStatistics.java
@@ -14,12 +14,11 @@
 package io.trino.orc.metadata.statistics;
 
 import io.trino.orc.metadata.statistics.StatisticsHasher.Hashable;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 public class BooleanStatistics
         implements Hashable
@@ -27,7 +26,7 @@ public class BooleanStatistics
     // 1 byte to denote if null + 1 byte for the value
     public static final long BOOLEAN_VALUE_BYTES = Byte.BYTES + Byte.BYTES;
 
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(BooleanStatistics.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(BooleanStatistics.class);
 
     private final long trueValueCount;
 

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/ColumnStatistics.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/ColumnStatistics.java
@@ -14,12 +14,12 @@
 package io.trino.orc.metadata.statistics;
 
 import io.trino.orc.metadata.statistics.StatisticsHasher.Hashable;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.metadata.statistics.BinaryStatisticsBuilder.mergeBinaryStatistics;
 import static io.trino.orc.metadata.statistics.BooleanStatisticsBuilder.mergeBooleanStatistics;
 import static io.trino.orc.metadata.statistics.DateStatisticsBuilder.mergeDateStatistics;
@@ -28,12 +28,11 @@ import static io.trino.orc.metadata.statistics.IntegerStatisticsBuilder.mergeInt
 import static io.trino.orc.metadata.statistics.LongDecimalStatisticsBuilder.mergeDecimalStatistics;
 import static io.trino.orc.metadata.statistics.StringStatisticsBuilder.mergeStringStatistics;
 import static io.trino.orc.metadata.statistics.TimestampStatisticsBuilder.mergeTimestampStatistics;
-import static java.lang.Math.toIntExact;
 
 public class ColumnStatistics
         implements Hashable
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ColumnStatistics.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ColumnStatistics.class);
 
     private final boolean hasNumberOfValues;
     private final long numberOfValues;

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/DateStatistics.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/DateStatistics.java
@@ -14,13 +14,12 @@
 package io.trino.orc.metadata.statistics;
 
 import io.trino.orc.metadata.statistics.StatisticsHasher.Hashable;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 public class DateStatistics
         implements RangeStatistics<Integer>, Hashable
@@ -28,7 +27,7 @@ public class DateStatistics
     // 1 byte to denote if null + 4 bytes for the value (date is of integer type)
     public static final long DATE_VALUE_BYTES = Byte.BYTES + Integer.BYTES;
 
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DateStatistics.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DateStatistics.class);
 
     private final boolean hasMinimum;
     private final boolean hasMaximum;

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/DecimalStatistics.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/DecimalStatistics.java
@@ -14,7 +14,6 @@
 package io.trino.orc.metadata.statistics;
 
 import io.trino.orc.metadata.statistics.StatisticsHasher.Hashable;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -22,8 +21,8 @@ import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 
 public class DecimalStatistics
         implements RangeStatistics<BigDecimal>, Hashable
@@ -31,10 +30,10 @@ public class DecimalStatistics
     // 1 byte to denote if null
     public static final long DECIMAL_VALUE_BYTES_OVERHEAD = Byte.BYTES;
 
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DecimalStatistics.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DecimalStatistics.class);
     // BigDecimal contains BigInteger and BigInteger contains an integer array.
     // The size of the integer array is not accessible from outside; thus rely on callers to tell how large the size is.
-    private static final long BIG_DECIMAL_INSTANCE_SIZE = ClassLayout.parseClass(BigDecimal.class).instanceSize() + ClassLayout.parseClass(BigInteger.class).instanceSize() + sizeOf(new int[0]);
+    private static final long BIG_DECIMAL_INSTANCE_SIZE = instanceSize(BigDecimal.class) + instanceSize(BigInteger.class) + sizeOf(new int[0]);
 
     // TODO: replace min/max with LongDecimal/ShortDecimal to calculate retained size
     private final BigDecimal minimum;

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/DoubleStatistics.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/DoubleStatistics.java
@@ -14,13 +14,12 @@
 package io.trino.orc.metadata.statistics;
 
 import io.trino.orc.metadata.statistics.StatisticsHasher.Hashable;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 public class DoubleStatistics
         implements RangeStatistics<Double>, Hashable
@@ -28,7 +27,7 @@ public class DoubleStatistics
     // 1 byte to denote if null + 8 bytes for the value
     public static final long DOUBLE_VALUE_BYTES = Byte.BYTES + Double.BYTES;
 
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DoubleStatistics.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DoubleStatistics.class);
 
     private final boolean hasMinimum;
     private final boolean hasMaximum;

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/IntegerStatistics.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/IntegerStatistics.java
@@ -14,13 +14,12 @@
 package io.trino.orc.metadata.statistics;
 
 import io.trino.orc.metadata.statistics.StatisticsHasher.Hashable;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 public class IntegerStatistics
         implements RangeStatistics<Long>, Hashable
@@ -28,7 +27,7 @@ public class IntegerStatistics
     // 1 byte to denote if null + 8 bytes for the value (integer is of long type)
     public static final long INTEGER_VALUE_BYTES = Byte.BYTES + Long.BYTES;
 
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(IntegerStatistics.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(IntegerStatistics.class);
 
     private final boolean hasMinimum;
     private final boolean hasMaximum;

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/StringStatistics.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/StringStatistics.java
@@ -15,7 +15,6 @@ package io.trino.orc.metadata.statistics;
 
 import io.airlift.slice.Slice;
 import io.trino.orc.metadata.statistics.StatisticsHasher.Hashable;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -23,7 +22,7 @@ import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.io.BaseEncoding.base16;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.String.format;
 
 public class StringStatistics
@@ -32,7 +31,7 @@ public class StringStatistics
     // 1 byte to denote if null + 4 bytes to denote offset
     public static final long STRING_VALUE_BYTES_OVERHEAD = Byte.BYTES + Integer.BYTES;
 
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(StringStatistics.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(StringStatistics.class);
 
     @Nullable
     private final Slice minimum;

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/StripeStatistics.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/StripeStatistics.java
@@ -14,16 +14,15 @@
 package io.trino.orc.metadata.statistics;
 
 import io.trino.orc.metadata.ColumnMetadata;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class StripeStatistics
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(StripeStatistics.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(StripeStatistics.class);
 
     private final ColumnMetadata<ColumnStatistics> columnStatistics;
     private final long retainedSizeInBytes;

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/TimestampStatistics.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/TimestampStatistics.java
@@ -14,13 +14,12 @@
 package io.trino.orc.metadata.statistics;
 
 import io.trino.orc.metadata.statistics.StatisticsHasher.Hashable;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 public class TimestampStatistics
         implements RangeStatistics<Long>, Hashable
@@ -28,7 +27,7 @@ public class TimestampStatistics
     // 1 byte to denote if null + 8 bytes for the value
     public static final long TIMESTAMP_VALUE_BYTES = Byte.BYTES + Long.BYTES;
 
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TimestampStatistics.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(TimestampStatistics.class);
 
     private final boolean hasMinimum;
     private final boolean hasMaximum;

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/BooleanColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/BooleanColumnReader.java
@@ -26,7 +26,6 @@ import io.trino.spi.block.ByteArrayBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.BooleanType;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -36,6 +35,7 @@ import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Verify.verifyNotNull;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.orc.metadata.Stream.StreamKind.DATA;
 import static io.trino.orc.metadata.Stream.StreamKind.PRESENT;
@@ -44,13 +44,12 @@ import static io.trino.orc.reader.ReaderUtils.unpackByteNulls;
 import static io.trino.orc.reader.ReaderUtils.verifyStreamType;
 import static io.trino.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class BooleanColumnReader
         implements ColumnReader
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(BooleanColumnReader.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(BooleanColumnReader.class);
 
     private final OrcColumn column;
 

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/ByteColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/ByteColumnReader.java
@@ -27,7 +27,6 @@ import io.trino.spi.block.ByteArrayBlock;
 import io.trino.spi.block.IntArrayBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -37,6 +36,7 @@ import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Verify.verifyNotNull;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.orc.metadata.Stream.StreamKind.DATA;
 import static io.trino.orc.metadata.Stream.StreamKind.PRESENT;
@@ -45,13 +45,12 @@ import static io.trino.orc.reader.ReaderUtils.verifyStreamType;
 import static io.trino.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.TinyintType.TINYINT;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class ByteColumnReader
         implements ColumnReader
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ByteColumnReader.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ByteColumnReader.class);
 
     private final Type type;
 

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/DecimalColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/DecimalColumnReader.java
@@ -31,7 +31,6 @@ import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Decimals;
 import io.trino.spi.type.Int128Math;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -41,6 +40,7 @@ import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Verify.verifyNotNull;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.orc.metadata.Stream.StreamKind.DATA;
 import static io.trino.orc.metadata.Stream.StreamKind.PRESENT;
@@ -51,13 +51,12 @@ import static io.trino.orc.reader.ReaderUtils.unpackLongNulls;
 import static io.trino.orc.reader.ReaderUtils.verifyStreamType;
 import static io.trino.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static io.trino.spi.type.DoubleType.DOUBLE;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class DecimalColumnReader
         implements ColumnReader
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DecimalColumnReader.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DecimalColumnReader.class);
 
     private final DecimalType type;
     private final OrcColumn column;

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/DoubleColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/DoubleColumnReader.java
@@ -27,7 +27,6 @@ import io.trino.spi.block.LongArrayBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.DoubleType;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -37,6 +36,7 @@ import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Verify.verifyNotNull;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.orc.metadata.Stream.StreamKind.DATA;
 import static io.trino.orc.metadata.Stream.StreamKind.PRESENT;
@@ -45,13 +45,12 @@ import static io.trino.orc.reader.ReaderUtils.unpackLongNulls;
 import static io.trino.orc.reader.ReaderUtils.verifyStreamType;
 import static io.trino.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static io.trino.spi.type.DoubleType.DOUBLE;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class DoubleColumnReader
         implements ColumnReader
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DoubleColumnReader.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DoubleColumnReader.class);
 
     private final OrcColumn column;
 

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/FloatColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/FloatColumnReader.java
@@ -27,7 +27,6 @@ import io.trino.spi.block.IntArrayBlock;
 import io.trino.spi.block.LongArrayBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -37,6 +36,7 @@ import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Verify.verifyNotNull;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.orc.metadata.Stream.StreamKind.DATA;
 import static io.trino.orc.metadata.Stream.StreamKind.PRESENT;
@@ -47,13 +47,12 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.RealType.REAL;
 import static java.lang.Double.doubleToRawLongBits;
 import static java.lang.Float.intBitsToFloat;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class FloatColumnReader
         implements ColumnReader
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(FloatColumnReader.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(FloatColumnReader.class);
 
     private final Type type;
 

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/ListColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/ListColumnReader.java
@@ -29,7 +29,6 @@ import io.trino.spi.block.ArrayBlock;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -39,6 +38,7 @@ import java.time.ZoneId;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.OrcReader.fullyProjectedLayout;
 import static io.trino.orc.metadata.Stream.StreamKind.LENGTH;
 import static io.trino.orc.metadata.Stream.StreamKind.PRESENT;
@@ -53,7 +53,7 @@ import static java.util.Objects.requireNonNull;
 public class ListColumnReader
         implements ColumnReader
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ListColumnReader.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ListColumnReader.class);
 
     private final Type elementType;
     private final OrcColumn column;

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/LongColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/LongColumnReader.java
@@ -33,7 +33,6 @@ import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.SmallintType;
 import io.trino.spi.type.TimeType;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -43,6 +42,7 @@ import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Verify.verifyNotNull;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.orc.metadata.Stream.StreamKind.DATA;
 import static io.trino.orc.metadata.Stream.StreamKind.PRESENT;
@@ -52,13 +52,12 @@ import static io.trino.orc.reader.ReaderUtils.unpackLongNulls;
 import static io.trino.orc.reader.ReaderUtils.unpackShortNulls;
 import static io.trino.orc.reader.ReaderUtils.verifyStreamType;
 import static io.trino.orc.stream.MissingInputStreamSource.missingStreamSource;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class LongColumnReader
         implements ColumnReader
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(LongColumnReader.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(LongColumnReader.class);
 
     private final Type type;
     private final OrcColumn column;

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/MapColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/MapColumnReader.java
@@ -29,7 +29,6 @@ import io.trino.spi.block.Block;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.Type;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -40,6 +39,7 @@ import java.time.ZoneId;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.OrcReader.fullyProjectedLayout;
 import static io.trino.orc.metadata.Stream.StreamKind.LENGTH;
 import static io.trino.orc.metadata.Stream.StreamKind.PRESENT;
@@ -54,7 +54,7 @@ import static java.util.Objects.requireNonNull;
 public class MapColumnReader
         implements ColumnReader
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(MapColumnReader.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(MapColumnReader.class);
 
     private final MapType type;
     private final OrcColumn column;

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/SliceColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/SliceColumnReader.java
@@ -27,13 +27,13 @@ import io.trino.spi.type.CharType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.ZoneId;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.metadata.ColumnEncoding.ColumnEncodingKind.DICTIONARY;
 import static io.trino.orc.metadata.ColumnEncoding.ColumnEncodingKind.DICTIONARY_V2;
 import static io.trino.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
@@ -41,13 +41,12 @@ import static io.trino.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT_V2;
 import static io.trino.orc.reader.ReaderUtils.verifyStreamType;
 import static io.trino.spi.type.Chars.byteCountWithoutTrailingSpace;
 import static io.trino.spi.type.Varchars.byteCount;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class SliceColumnReader
         implements ColumnReader
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SliceColumnReader.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SliceColumnReader.class);
 
     private final OrcColumn column;
     private final SliceDirectColumnReader directReader;

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/SliceDictionaryColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/SliceDictionaryColumnReader.java
@@ -28,7 +28,6 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.block.VariableWidthBlock;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -39,6 +38,7 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.base.Verify.verifyNotNull;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.airlift.slice.Slices.wrappedBuffer;
@@ -56,7 +56,7 @@ import static java.util.Objects.requireNonNull;
 public class SliceDictionaryColumnReader
         implements ColumnReader
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SliceDictionaryColumnReader.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SliceDictionaryColumnReader.class);
 
     private static final byte[] EMPTY_DICTIONARY_DATA = new byte[0];
     // add one extra entry for null after strip/rowGroup dictionary

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/SliceDirectColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/SliceDirectColumnReader.java
@@ -29,7 +29,6 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.block.VariableWidthBlock;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -40,6 +39,7 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.trino.orc.metadata.Stream.StreamKind.DATA;
@@ -57,7 +57,7 @@ import static java.util.Objects.requireNonNull;
 public class SliceDirectColumnReader
         implements ColumnReader
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SliceDirectColumnReader.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SliceDirectColumnReader.class);
     private static final int ONE_GIGABYTE = toIntExact(DataSize.of(1, GIGABYTE).toBytes());
 
     private final int maxCodePointCount;

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/StructColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/StructColumnReader.java
@@ -34,7 +34,6 @@ import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.RowType.Field;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -48,18 +47,18 @@ import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.metadata.Stream.StreamKind.PRESENT;
 import static io.trino.orc.reader.ColumnReaders.createColumnReader;
 import static io.trino.orc.reader.ReaderUtils.verifyStreamType;
 import static io.trino.orc.stream.MissingInputStreamSource.missingStreamSource;
-import static java.lang.Math.toIntExact;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public class StructColumnReader
         implements ColumnReader
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(StructColumnReader.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(StructColumnReader.class);
 
     private final OrcColumn column;
     private final OrcBlockFactory blockFactory;

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/TimestampColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/TimestampColumnReader.java
@@ -31,7 +31,6 @@ import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.TimeZoneKey;
 import io.trino.spi.type.Type;
 import org.joda.time.DateTimeZone;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -43,6 +42,7 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.metadata.Stream.StreamKind.DATA;
 import static io.trino.orc.metadata.Stream.StreamKind.PRESENT;
 import static io.trino.orc.metadata.Stream.StreamKind.SECONDARY;
@@ -100,7 +100,7 @@ public class TimestampColumnReader
 
     private static final long BASE_INSTANT_IN_SECONDS = ORC_EPOCH.toEpochSecond(ZoneOffset.UTC);
 
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TimestampColumnReader.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(TimestampColumnReader.class);
 
     private final Type type;
     private final OrcColumn column;

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/UnionColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/UnionColumnReader.java
@@ -35,7 +35,6 @@ import io.trino.spi.block.RowBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -49,6 +48,7 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.OrcReader.fullyProjectedLayout;
 import static io.trino.orc.metadata.Stream.StreamKind.DATA;
 import static io.trino.orc.metadata.Stream.StreamKind.PRESENT;
@@ -56,14 +56,13 @@ import static io.trino.orc.reader.ColumnReaders.createColumnReader;
 import static io.trino.orc.reader.ReaderUtils.verifyStreamType;
 import static io.trino.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static io.trino.spi.type.TinyintType.TINYINT;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 // Use row blocks to represent union objects when reading
 public class UnionColumnReader
         implements ColumnReader
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(UnionColumnReader.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(UnionColumnReader.class);
 
     private final OrcColumn column;
     private final OrcBlockFactory blockFactory;

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/UuidColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/UuidColumnReader.java
@@ -26,7 +26,6 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.Int128ArrayBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -38,6 +37,7 @@ import java.time.ZoneId;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.trino.orc.metadata.Stream.StreamKind.DATA;
 import static io.trino.orc.metadata.Stream.StreamKind.PRESENT;
@@ -50,7 +50,7 @@ import static java.util.Objects.requireNonNull;
 public class UuidColumnReader
         implements ColumnReader
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(UuidColumnReader.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(UuidColumnReader.class);
     private static final int ONE_GIGABYTE = toIntExact(DataSize.of(1, GIGABYTE).toBytes());
 
     private static final VarHandle LONG_ARRAY_HANDLE = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/BooleanOutputStream.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/BooleanOutputStream.java
@@ -19,7 +19,6 @@ import io.trino.orc.checkpoint.BooleanStreamCheckpoint;
 import io.trino.orc.checkpoint.ByteStreamCheckpoint;
 import io.trino.orc.metadata.CompressionKind;
 import io.trino.orc.metadata.OrcColumnId;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,12 +26,12 @@ import java.util.List;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 public class BooleanOutputStream
         implements ValueOutputStream<BooleanStreamCheckpoint>
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(BooleanOutputStream.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(BooleanOutputStream.class);
     private final ByteOutputStream byteOutputStream;
     private final List<Integer> checkpointBitOffsets = new ArrayList<>();
 

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/ByteArrayOutputStream.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/ByteArrayOutputStream.java
@@ -21,12 +21,12 @@ import io.trino.orc.metadata.CompressionKind;
 import io.trino.orc.metadata.OrcColumnId;
 import io.trino.orc.metadata.Stream;
 import io.trino.orc.metadata.Stream.StreamKind;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.metadata.Stream.StreamKind.DATA;
 import static java.lang.Math.toIntExact;
 
@@ -36,7 +36,7 @@ import static java.lang.Math.toIntExact;
 public class ByteArrayOutputStream
         implements ValueOutputStream<ByteArrayStreamCheckpoint>
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ByteArrayOutputStream.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ByteArrayOutputStream.class);
     private final OrcOutputBuffer buffer;
     private final List<ByteArrayStreamCheckpoint> checkpoints = new ArrayList<>();
     private final StreamKind streamKind;

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/ByteOutputStream.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/ByteOutputStream.java
@@ -20,19 +20,19 @@ import io.trino.orc.checkpoint.ByteStreamCheckpoint;
 import io.trino.orc.metadata.CompressionKind;
 import io.trino.orc.metadata.OrcColumnId;
 import io.trino.orc.metadata.Stream;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.metadata.Stream.StreamKind.DATA;
 import static java.lang.Math.toIntExact;
 
 public class ByteOutputStream
         implements ValueOutputStream<ByteStreamCheckpoint>
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ByteOutputStream.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ByteOutputStream.class);
 
     private static final int MIN_REPEAT_SIZE = 3;
     // A value out side of the range of a signed byte

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/DecimalOutputStream.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/DecimalOutputStream.java
@@ -20,13 +20,13 @@ import io.trino.orc.metadata.CompressionKind;
 import io.trino.orc.metadata.OrcColumnId;
 import io.trino.orc.metadata.Stream;
 import io.trino.spi.type.Int128;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.metadata.Stream.StreamKind.DATA;
 import static io.trino.orc.stream.LongDecode.writeVLong;
 import static java.lang.Math.toIntExact;
@@ -37,7 +37,7 @@ import static java.lang.Math.toIntExact;
 public class DecimalOutputStream
         implements ValueOutputStream<DecimalStreamCheckpoint>
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DecimalOutputStream.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DecimalOutputStream.class);
     private final OrcOutputBuffer buffer;
     private final List<DecimalStreamCheckpoint> checkpoints = new ArrayList<>();
 

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/DoubleOutputStream.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/DoubleOutputStream.java
@@ -19,19 +19,19 @@ import io.trino.orc.checkpoint.DoubleStreamCheckpoint;
 import io.trino.orc.metadata.CompressionKind;
 import io.trino.orc.metadata.OrcColumnId;
 import io.trino.orc.metadata.Stream;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.metadata.Stream.StreamKind.DATA;
 import static java.lang.Math.toIntExact;
 
 public class DoubleOutputStream
         implements ValueOutputStream<DoubleStreamCheckpoint>
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DoubleOutputStream.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DoubleOutputStream.class);
     private final OrcOutputBuffer buffer;
     private final List<DoubleStreamCheckpoint> checkpoints = new ArrayList<>();
 

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/FloatOutputStream.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/FloatOutputStream.java
@@ -19,19 +19,19 @@ import io.trino.orc.checkpoint.FloatStreamCheckpoint;
 import io.trino.orc.metadata.CompressionKind;
 import io.trino.orc.metadata.OrcColumnId;
 import io.trino.orc.metadata.Stream;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.metadata.Stream.StreamKind.DATA;
 import static java.lang.Math.toIntExact;
 
 public class FloatOutputStream
         implements ValueOutputStream<FloatStreamCheckpoint>
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(FloatOutputStream.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(FloatOutputStream.class);
     private final OrcOutputBuffer buffer;
     private final List<FloatStreamCheckpoint> checkpoints = new ArrayList<>();
 

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/LongOutputStreamV1.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/LongOutputStreamV1.java
@@ -22,13 +22,13 @@ import io.trino.orc.metadata.CompressionKind;
 import io.trino.orc.metadata.OrcColumnId;
 import io.trino.orc.metadata.Stream;
 import io.trino.orc.metadata.Stream.StreamKind;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.stream.LongDecode.writeVLong;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -36,7 +36,7 @@ import static java.util.Objects.requireNonNull;
 public class LongOutputStreamV1
         implements LongOutputStream
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(LongOutputStreamV1.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(LongOutputStreamV1.class);
     private static final int MIN_REPEAT_SIZE = 3;
     private static final long UNMATCHABLE_DELTA_VALUE = Long.MAX_VALUE;
     private static final int MAX_DELTA = 127;

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/LongOutputStreamV2.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/LongOutputStreamV2.java
@@ -23,13 +23,13 @@ import io.trino.orc.metadata.CompressionKind;
 import io.trino.orc.metadata.OrcColumnId;
 import io.trino.orc.metadata.Stream;
 import io.trino.orc.metadata.Stream.StreamKind;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.stream.LongOutputStreamV2.SerializationUtils.encodeBitWidth;
 import static io.trino.orc.stream.LongOutputStreamV2.SerializationUtils.findClosestNumBits;
 import static io.trino.orc.stream.LongOutputStreamV2.SerializationUtils.getClosestAlignedFixedBits;
@@ -55,7 +55,7 @@ public class LongOutputStreamV2
         }
     }
 
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(LongOutputStreamV2.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(LongOutputStreamV2.class);
     private static final int MAX_SCOPE = 512;
     private static final int MIN_REPEAT = 3;
     private static final int MAX_SHORT_REPEAT_LENGTH = 10;

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/PresentOutputStream.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/PresentOutputStream.java
@@ -18,7 +18,6 @@ import io.trino.orc.checkpoint.BooleanStreamCheckpoint;
 import io.trino.orc.metadata.CompressionKind;
 import io.trino.orc.metadata.OrcColumnId;
 import io.trino.orc.metadata.Stream;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -28,12 +27,13 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.metadata.Stream.StreamKind.PRESENT;
 import static java.lang.Math.toIntExact;
 
 public class PresentOutputStream
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(PresentOutputStream.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(PresentOutputStream.class);
     private final OrcOutputBuffer buffer;
 
     // boolean stream will only exist if null values being recorded

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/BooleanColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/BooleanColumnWriter.java
@@ -31,7 +31,6 @@ import io.trino.orc.stream.PresentOutputStream;
 import io.trino.orc.stream.StreamDataOutput;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -41,15 +40,15 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
 import static io.trino.orc.metadata.CompressionKind.NONE;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class BooleanColumnWriter
         implements ColumnWriter
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(BooleanColumnWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(BooleanColumnWriter.class);
     private static final ColumnEncoding COLUMN_ENCODING = new ColumnEncoding(DIRECT, 0);
 
     private final OrcColumnId columnId;

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/ByteColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/ByteColumnWriter.java
@@ -33,7 +33,6 @@ import io.trino.orc.stream.PresentOutputStream;
 import io.trino.orc.stream.StreamDataOutput;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -45,15 +44,15 @@ import java.util.Optional;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
 import static io.trino.orc.metadata.CompressionKind.NONE;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class ByteColumnWriter
         implements ColumnWriter
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ByteColumnWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ByteColumnWriter.class);
     private static final ColumnEncoding COLUMN_ENCODING = new ColumnEncoding(DIRECT, 0);
 
     private final OrcColumnId columnId;

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/DecimalColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/DecimalColumnWriter.java
@@ -38,7 +38,6 @@ import io.trino.spi.block.Block;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Int128;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -49,16 +48,16 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT_V2;
 import static io.trino.orc.metadata.CompressionKind.NONE;
 import static io.trino.orc.metadata.Stream.StreamKind.SECONDARY;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class DecimalColumnWriter
         implements ColumnWriter
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DecimalColumnWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DecimalColumnWriter.class);
     private final OrcColumnId columnId;
     private final DecimalType type;
     private final ColumnEncoding columnEncoding;

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/DictionaryBuilder.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/DictionaryBuilder.java
@@ -17,14 +17,13 @@ import io.trino.array.IntBigArray;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.VariableWidthBlockBuilder;
-import org.openjdk.jol.info.ClassLayout;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
 import static it.unimi.dsi.fastutil.HashCommon.arraySize;
 import static java.lang.Math.min;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 // TODO this class is not memory efficient.  We can bypass all of the Trino type and block code
@@ -33,7 +32,7 @@ import static java.util.Objects.requireNonNull;
 // can use store the data in multiple Slices to avoid a large contiguous allocation.
 public class DictionaryBuilder
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DictionaryBuilder.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DictionaryBuilder.class);
     private static final float FILL_RATIO = 0.75f;
     private static final int EMPTY_SLOT = -1;
     private static final int NULL_POSITION = 0;

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/DoubleColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/DoubleColumnWriter.java
@@ -33,7 +33,6 @@ import io.trino.orc.stream.PresentOutputStream;
 import io.trino.orc.stream.StreamDataOutput;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -46,15 +45,15 @@ import java.util.function.Supplier;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
 import static io.trino.orc.metadata.CompressionKind.NONE;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class DoubleColumnWriter
         implements ColumnWriter
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DoubleColumnWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DoubleColumnWriter.class);
     private static final ColumnEncoding COLUMN_ENCODING = new ColumnEncoding(DIRECT, 0);
 
     private final OrcColumnId columnId;

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/FloatColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/FloatColumnWriter.java
@@ -33,7 +33,6 @@ import io.trino.orc.stream.PresentOutputStream;
 import io.trino.orc.stream.StreamDataOutput;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -46,16 +45,16 @@ import java.util.function.Supplier;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
 import static io.trino.orc.metadata.CompressionKind.NONE;
 import static java.lang.Float.intBitsToFloat;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class FloatColumnWriter
         implements ColumnWriter
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(FloatColumnWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(FloatColumnWriter.class);
     private static final ColumnEncoding COLUMN_ENCODING = new ColumnEncoding(DIRECT, 0);
 
     private final OrcColumnId columnId;

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/ListColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/ListColumnWriter.java
@@ -31,7 +31,6 @@ import io.trino.orc.stream.PresentOutputStream;
 import io.trino.orc.stream.StreamDataOutput;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.ColumnarArray;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -41,17 +40,17 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT_V2;
 import static io.trino.orc.metadata.CompressionKind.NONE;
 import static io.trino.orc.stream.LongOutputStream.createLengthOutputStream;
 import static io.trino.spi.block.ColumnarArray.toColumnarArray;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class ListColumnWriter
         implements ColumnWriter
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ListColumnWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ListColumnWriter.class);
     private final OrcColumnId columnId;
     private final boolean compressed;
     private final ColumnEncoding columnEncoding;

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/LongColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/LongColumnWriter.java
@@ -34,7 +34,6 @@ import io.trino.orc.stream.PresentOutputStream;
 import io.trino.orc.stream.StreamDataOutput;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,16 +47,16 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT_V2;
 import static io.trino.orc.metadata.CompressionKind.NONE;
 import static io.trino.orc.metadata.Stream.StreamKind.DATA;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class LongColumnWriter
         implements ColumnWriter
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(LongColumnWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(LongColumnWriter.class);
     private final OrcColumnId columnId;
     private final Type type;
     private final boolean compressed;

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/MapColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/MapColumnWriter.java
@@ -31,7 +31,6 @@ import io.trino.orc.stream.PresentOutputStream;
 import io.trino.orc.stream.StreamDataOutput;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.ColumnarMap;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -41,17 +40,17 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT_V2;
 import static io.trino.orc.metadata.CompressionKind.NONE;
 import static io.trino.orc.stream.LongOutputStream.createLengthOutputStream;
 import static io.trino.spi.block.ColumnarMap.toColumnarMap;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class MapColumnWriter
         implements ColumnWriter
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(MapColumnWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(MapColumnWriter.class);
     private final OrcColumnId columnId;
     private final boolean compressed;
     private final ColumnEncoding columnEncoding;

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/SliceDictionaryColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/SliceDictionaryColumnWriter.java
@@ -40,7 +40,6 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.type.Type;
 import it.unimi.dsi.fastutil.ints.IntArrays;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -54,6 +53,7 @@ import java.util.function.Supplier;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.orc.DictionaryCompressionOptimizer.estimateIndexBytesPerValue;
 import static io.trino.orc.metadata.ColumnEncoding.ColumnEncodingKind.DICTIONARY_V2;
@@ -67,7 +67,7 @@ import static java.util.stream.Collectors.toList;
 public class SliceDictionaryColumnWriter
         implements ColumnWriter, DictionaryColumn
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SliceDictionaryColumnWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SliceDictionaryColumnWriter.class);
     private static final int DIRECT_CONVERSION_CHUNK_MAX_LOGICAL_BYTES = toIntExact(DataSize.of(32, MEGABYTE).toBytes());
 
     private final OrcColumnId columnId;

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/SliceDirectColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/SliceDirectColumnWriter.java
@@ -35,7 +35,6 @@ import io.trino.orc.stream.PresentOutputStream;
 import io.trino.orc.stream.StreamDataOutput;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,16 +47,16 @@ import java.util.function.Supplier;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT_V2;
 import static io.trino.orc.metadata.CompressionKind.NONE;
 import static io.trino.orc.stream.LongOutputStream.createLengthOutputStream;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class SliceDirectColumnWriter
         implements ColumnWriter
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SliceDirectColumnWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SliceDirectColumnWriter.class);
     private final OrcColumnId columnId;
     private final Type type;
     private final boolean compressed;

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/StructColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/StructColumnWriter.java
@@ -29,7 +29,6 @@ import io.trino.orc.stream.PresentOutputStream;
 import io.trino.orc.stream.StreamDataOutput;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.ColumnarRow;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,16 +38,16 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
 import static io.trino.orc.metadata.CompressionKind.NONE;
 import static io.trino.spi.block.ColumnarRow.toColumnarRow;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class StructColumnWriter
         implements ColumnWriter
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(StructColumnWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(StructColumnWriter.class);
     private static final ColumnEncoding COLUMN_ENCODING = new ColumnEncoding(DIRECT, 0);
 
     private final OrcColumnId columnId;

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/TimestampColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/TimestampColumnWriter.java
@@ -36,7 +36,6 @@ import io.trino.spi.block.Block;
 import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.LongTimestampWithTimeZone;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.time.OffsetDateTime;
@@ -48,6 +47,7 @@ import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT_V2;
 import static io.trino.orc.metadata.CompressionKind.NONE;
 import static io.trino.orc.metadata.Stream.StreamKind.DATA;
@@ -67,7 +67,6 @@ import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
 import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
-import static java.lang.Math.toIntExact;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Objects.requireNonNull;
 
@@ -106,7 +105,7 @@ public class TimestampColumnWriter
         INSTANT_NANOS,
     }
 
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TimestampColumnWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(TimestampColumnWriter.class);
 
     private static final long ORC_EPOCH_IN_SECONDS = OffsetDateTime.of(2015, 1, 1, 0, 0, 0, 0, UTC).toEpochSecond();
 

--- a/lib/trino-orc/src/test/java/io/trino/orc/metadata/statistics/TestDateStatistics.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/metadata/statistics/TestDateStatistics.java
@@ -13,17 +13,16 @@
  */
 package io.trino.orc.metadata.statistics;
 
-import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.Integer.MIN_VALUE;
-import static java.lang.Math.toIntExact;
 
 public class TestDateStatistics
         extends AbstractRangeStatisticsTest<DateStatistics, Integer>
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DateStatistics.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DateStatistics.class);
 
     @Override
     protected DateStatistics getCreateStatistics(Integer min, Integer max)

--- a/lib/trino-orc/src/test/java/io/trino/orc/metadata/statistics/TestDecimalStatistics.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/metadata/statistics/TestDecimalStatistics.java
@@ -13,22 +13,21 @@
  */
 package io.trino.orc.metadata.statistics;
 
-import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.orc.metadata.statistics.LongDecimalStatisticsBuilder.LONG_DECIMAL_VALUE_BYTES;
-import static java.lang.Math.toIntExact;
 import static java.math.BigDecimal.ZERO;
 
 public class TestDecimalStatistics
         extends AbstractRangeStatisticsTest<DecimalStatistics, BigDecimal>
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DecimalStatistics.class).instanceSize());
-    private static final long BIG_DECIMAL_INSTANCE_SIZE = ClassLayout.parseClass(BigDecimal.class).instanceSize() + ClassLayout.parseClass(BigInteger.class).instanceSize() + sizeOf(new int[0]);
+    private static final int INSTANCE_SIZE = instanceSize(DecimalStatistics.class);
+    private static final long BIG_DECIMAL_INSTANCE_SIZE = instanceSize(BigDecimal.class) + instanceSize(BigInteger.class) + sizeOf(new int[0]);
 
     private static final BigDecimal MEDIUM_VALUE = new BigDecimal("890.37492");
     private static final BigDecimal LARGE_POSITIVE_VALUE = new BigDecimal("123456789012345678901234567890.12345");

--- a/lib/trino-orc/src/test/java/io/trino/orc/metadata/statistics/TestDoubleStatistics.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/metadata/statistics/TestDoubleStatistics.java
@@ -13,19 +13,18 @@
  */
 package io.trino.orc.metadata.statistics;
 
-import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
-import static java.lang.Math.toIntExact;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestDoubleStatistics
         extends AbstractRangeStatisticsTest<DoubleStatistics, Double>
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DoubleStatistics.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DoubleStatistics.class);
 
     @Override
     protected DoubleStatistics getCreateStatistics(Double min, Double max)

--- a/lib/trino-orc/src/test/java/io/trino/orc/metadata/statistics/TestIntegerStatistics.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/metadata/statistics/TestIntegerStatistics.java
@@ -13,17 +13,16 @@
  */
 package io.trino.orc.metadata.statistics;
 
-import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.Long.MAX_VALUE;
 import static java.lang.Long.MIN_VALUE;
-import static java.lang.Math.toIntExact;
 
 public class TestIntegerStatistics
         extends AbstractRangeStatisticsTest<IntegerStatistics, Long>
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(IntegerStatistics.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(IntegerStatistics.class);
 
     @Override
     protected IntegerStatistics getCreateStatistics(Long min, Long max)

--- a/lib/trino-orc/src/test/java/io/trino/orc/metadata/statistics/TestStringStatistics.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/metadata/statistics/TestStringStatistics.java
@@ -14,18 +14,17 @@
 package io.trino.orc.metadata.statistics;
 
 import io.airlift.slice.Slice;
-import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.airlift.slice.Slices.utf8Slice;
-import static java.lang.Math.toIntExact;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestStringStatistics
         extends AbstractRangeStatisticsTest<StringStatistics, Slice>
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(StringStatistics.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(StringStatistics.class);
 
     // U+0000 to U+D7FF
     private static final Slice LOW_BOTTOM_VALUE = utf8Slice("foo \u0000");

--- a/lib/trino-orc/src/test/java/io/trino/orc/metadata/statistics/TestTimestampStatistics.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/metadata/statistics/TestTimestampStatistics.java
@@ -13,17 +13,16 @@
  */
 package io.trino.orc.metadata.statistics;
 
-import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.Long.MAX_VALUE;
 import static java.lang.Long.MIN_VALUE;
-import static java.lang.Math.toIntExact;
 
 public class TestTimestampStatistics
         extends AbstractRangeStatisticsTest<TimestampStatistics, Long>
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TimestampStatistics.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(TimestampStatistics.class);
 
     @Override
     protected TimestampStatistics getCreateStatistics(Long min, Long max)

--- a/lib/trino-parquet/pom.xml
+++ b/lib/trino-parquet/pom.xml
@@ -73,11 +73,6 @@
             <artifactId>joda-time</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.openjdk.jol</groupId>
-            <artifactId>jol-core</artifactId>
-        </dependency>
-
         <!-- used by tests but also needed transitively -->
         <dependency>
             <groupId>io.airlift</groupId>

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetWriteValidation.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetWriteValidation.java
@@ -33,7 +33,6 @@ import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.parquet.internal.hadoop.metadata.IndexReference;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.List;
@@ -48,11 +47,11 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.parquet.ColumnStatisticsValidation.ColumnStatistics;
 import static io.trino.parquet.ParquetValidationUtils.validateParquet;
 import static io.trino.parquet.ParquetWriteValidation.IndexReferenceValidation.fromIndexReference;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class ParquetWriteValidation
@@ -443,9 +442,9 @@ public class ParquetWriteValidation
 
     public static class ParquetWriteValidationBuilder
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ParquetWriteValidationBuilder.class).instanceSize());
-        private static final int COLUMN_DESCRIPTOR_INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ColumnDescriptor.class).instanceSize());
-        private static final int PRIMITIVE_TYPE_INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(PrimitiveType.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(ParquetWriteValidationBuilder.class);
+        private static final int COLUMN_DESCRIPTOR_INSTANCE_SIZE = instanceSize(ColumnDescriptor.class);
+        private static final int PRIMITIVE_TYPE_INSTANCE_SIZE = instanceSize(PrimitiveType.class);
 
         private final List<Type> types;
         private final List<String> columnNames;

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ArrayColumnWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ArrayColumnWriter.java
@@ -19,18 +19,17 @@ import io.trino.parquet.writer.repdef.DefLevelWriterProviders;
 import io.trino.parquet.writer.repdef.RepLevelIterable;
 import io.trino.parquet.writer.repdef.RepLevelIterables;
 import io.trino.spi.block.ColumnarArray;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.util.List;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class ArrayColumnWriter
         implements ColumnWriter
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ArrayColumnWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ArrayColumnWriter.class);
 
     private final ColumnWriter elementWriter;
     private final int maxDefinitionLevel;

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/MapColumnWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/MapColumnWriter.java
@@ -19,18 +19,17 @@ import io.trino.parquet.writer.repdef.DefLevelWriterProviders;
 import io.trino.parquet.writer.repdef.RepLevelIterable;
 import io.trino.parquet.writer.repdef.RepLevelIterables;
 import io.trino.spi.block.ColumnarMap;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.util.List;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class MapColumnWriter
         implements ColumnWriter
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(MapColumnWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(MapColumnWriter.class);
 
     private final ColumnWriter keyWriter;
     private final ColumnWriter valueWriter;

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -42,7 +42,6 @@ import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.io.MessageColumnIO;
 import org.apache.parquet.schema.MessageType;
 import org.joda.time.DateTimeZone;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -58,6 +57,7 @@ import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
@@ -78,7 +78,7 @@ import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_
 public class ParquetWriter
         implements Closeable
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ParquetWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ParquetWriter.class);
 
     private static final int CHUNK_MAX_BYTES = toIntExact(DataSize.of(128, MEGABYTE).toBytes());
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/PrimitiveColumnWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/PrimitiveColumnWriter.java
@@ -31,7 +31,6 @@ import org.apache.parquet.format.CompressionCodec;
 import org.apache.parquet.format.PageEncodingStats;
 import org.apache.parquet.format.PageType;
 import org.apache.parquet.format.converter.ParquetMetadataConverter;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -47,6 +46,7 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.parquet.writer.ParquetCompressor.getCompressor;
 import static io.trino.parquet.writer.ParquetDataOutput.createDataOutput;
 import static io.trino.parquet.writer.repdef.DefLevelWriterProvider.DefinitionLevelWriter;
@@ -57,7 +57,7 @@ import static java.util.Objects.requireNonNull;
 public class PrimitiveColumnWriter
         implements ColumnWriter
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(PrimitiveColumnWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(PrimitiveColumnWriter.class);
 
     private final ColumnDescriptor columnDescriptor;
     private final CompressionCodec compressionCodec;

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/StructColumnWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/StructColumnWriter.java
@@ -20,20 +20,19 @@ import io.trino.parquet.writer.repdef.RepLevelIterable;
 import io.trino.parquet.writer.repdef.RepLevelIterables;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.ColumnarRow;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.util.List;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.block.ColumnarRow.toColumnarRow;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 import static org.apache.parquet.Preconditions.checkArgument;
 
 public class StructColumnWriter
         implements ColumnWriter
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(StructColumnWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(StructColumnWriter.class);
 
     private final List<ColumnWriter> columnWriters;
     private final int maxDefinitionLevel;

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/model/AccumuloSplit.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/model/AccumuloSplit.java
@@ -21,7 +21,6 @@ import io.airlift.slice.SizeOf;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
 import org.apache.accumulo.core.data.Range;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Optional;
@@ -29,14 +28,14 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class AccumuloSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(AccumuloSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(AccumuloSplit.class);
 
     private final Optional<String> hostPort;
     private final List<HostAddress> addresses;

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/model/SerializedRange.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/model/SerializedRange.java
@@ -18,19 +18,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 import org.apache.accumulo.core.data.Range;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.DataInput;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class SerializedRange
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SerializedRange.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SerializedRange.class);
 
     private final byte[] bytes;
 

--- a/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopSplit.java
+++ b/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopSplit.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -26,14 +25,14 @@ import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.time.Instant.ofEpochSecond;
 import static java.util.Objects.requireNonNull;
 
 public class AtopSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(AtopSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(AtopSplit.class);
 
     private final HostAddress host;
     private final long epochSeconds;

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcColumnHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcColumnHandle.java
@@ -21,20 +21,19 @@ import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 import java.util.Optional;
 
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public final class JdbcColumnHandle
         implements ColumnHandle
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(JdbcColumnHandle.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(JdbcColumnHandle.class);
 
     private final String columnName;
     private final JdbcTypeHandle jdbcTypeHandle;

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcSplit.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcSplit.java
@@ -20,19 +20,18 @@ import io.airlift.slice.SizeOf;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.predicate.TupleDomain;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Optional;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class JdbcSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(JdbcSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(JdbcSplit.class);
 
     private final Optional<String> additionalPredicate;
     private final TupleDomain<JdbcColumnHandle> dynamicFilter;

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcTypeHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcTypeHandle.java
@@ -17,19 +17,18 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.airlift.slice.SizeOf;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public final class JdbcTypeHandle
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(JdbcTypeHandle.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(JdbcTypeHandle.class);
 
     private final int jdbcType;
     private final Optional<String> jdbcTypeName;

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryColumnHandle.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryColumnHandle.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableList;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Objects;
@@ -29,14 +28,14 @@ import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class BigQueryColumnHandle
         implements ColumnHandle
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(BigQueryColumnHandle.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(BigQueryColumnHandle.class);
 
     private final String name;
     private final Type trinoType;

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplit.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplit.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Objects;
@@ -27,15 +26,15 @@ import java.util.OptionalInt;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.bigquery.BigQuerySplit.Mode.QUERY;
 import static io.trino.plugin.bigquery.BigQuerySplit.Mode.STORAGE;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class BigQuerySplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(BigQuerySplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(BigQuerySplit.class);
 
     private static final int NO_ROWS_TO_GENERATE = -1;
 

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSplit.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSplit.java
@@ -19,19 +19,18 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class CassandraSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(CassandraSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(CassandraSplit.class);
 
     private final String partitionId;
     private final List<HostAddress> addresses;

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeColumnHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeColumnHandle.java
@@ -18,13 +18,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.deltalake.DeltaHiveTypeTranslator.toHiveType;
 import static io.trino.plugin.deltalake.DeltaLakeColumnType.SYNTHESIZED;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -32,13 +32,12 @@ import static io.trino.spi.type.RowType.field;
 import static io.trino.spi.type.RowType.rowType;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.VarcharType.VARCHAR;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class DeltaLakeColumnHandle
         implements ColumnHandle
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DeltaLakeColumnHandle.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DeltaLakeColumnHandle.class);
 
     public static final String ROW_ID_COLUMN_NAME = "$row_id";
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplit.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplit.java
@@ -22,7 +22,6 @@ import io.trino.spi.HostAddress;
 import io.trino.spi.SplitWeight;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.predicate.TupleDomain;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Map;
@@ -31,14 +30,14 @@ import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class DeltaLakeSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DeltaLakeSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DeltaLakeSplit.class);
 
     private final String path;
     private final long start;

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/AddFileEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/AddFileEntry.java
@@ -22,7 +22,6 @@ import io.airlift.slice.SizeOf;
 import io.trino.plugin.deltalake.transactionlog.statistics.DeltaLakeFileStatistics;
 import io.trino.plugin.deltalake.transactionlog.statistics.DeltaLakeJsonFileStatistics;
 import io.trino.plugin.deltalake.transactionlog.statistics.DeltaLakeParquetFileStatistics;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -32,6 +31,7 @@ import java.util.Optional;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.serializeStatsAsJson;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogAccess.canonicalizeColumnName;
 import static java.lang.String.format;
@@ -39,7 +39,7 @@ import static java.lang.String.format;
 public class AddFileEntry
 {
     private static final Logger LOG = Logger.get(AddFileEntry.class);
-    private static final long INSTANCE_SIZE = ClassLayout.parseClass(AddFileEntry.class).instanceSize();
+    private static final long INSTANCE_SIZE = instanceSize(AddFileEntry.class);
 
     private final String path;
     private final Map<String, String> partitionValues;

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/CanonicalColumnName.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/CanonicalColumnName.java
@@ -14,16 +14,15 @@
 package io.trino.plugin.deltalake.transactionlog;
 
 import io.airlift.slice.SizeOf;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class CanonicalColumnName
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(CanonicalColumnName.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(CanonicalColumnName.class);
 
     private int hash;
     private final String originalName;

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeDataFileCacheEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeDataFileCacheEntry.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.deltalake.transactionlog;
 
 import com.google.common.collect.ImmutableList;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -25,13 +24,13 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
 public final class DeltaLakeDataFileCacheEntry
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(DeltaLakeDataFileCacheEntry.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(DeltaLakeDataFileCacheEntry.class);
 
     private final long version;
     private final List<AddFileEntry> activeFiles;

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeJsonFileStatistics.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeJsonFileStatistics.java
@@ -25,7 +25,6 @@ import io.trino.plugin.deltalake.transactionlog.CanonicalColumnName;
 import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -37,6 +36,7 @@ import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.base.util.JsonUtils.parseJson;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogAccess.toCanonicalNameKeyedMap;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogParser.JSON_STATISTICS_TIMESTAMP_FORMATTER;
@@ -52,7 +52,7 @@ public class DeltaLakeJsonFileStatistics
         implements DeltaLakeFileStatistics
 {
     private static final Logger log = Logger.get(DeltaLakeJsonFileStatistics.class);
-    private static final long INSTANCE_SIZE = ClassLayout.parseClass(DeltaLakeJsonFileStatistics.class).instanceSize();
+    private static final long INSTANCE_SIZE = instanceSize(DeltaLakeJsonFileStatistics.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapperProvider().get();
 
     private final Optional<Long> numRecords;

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeParquetFileStatistics.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeParquetFileStatistics.java
@@ -19,7 +19,6 @@ import io.trino.plugin.deltalake.DeltaLakeColumnHandle;
 import io.trino.plugin.deltalake.transactionlog.CanonicalColumnName;
 import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
 import io.trino.spi.block.Block;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Map;
@@ -28,13 +27,14 @@ import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogAccess.toCanonicalNameKeyedMap;
 
 public class DeltaLakeParquetFileStatistics
         implements DeltaLakeFileStatistics
 {
     private static final Logger log = Logger.get(DeltaLakeParquetFileStatistics.class);
-    private static final long INSTANCE_SIZE = ClassLayout.parseClass(DeltaLakeParquetFileStatistics.class).instanceSize();
+    private static final long INSTANCE_SIZE = instanceSize(DeltaLakeParquetFileStatistics.class);
 
     private final Optional<Long> numRecords;
     private final Optional<Map<CanonicalColumnName, Object>> minValues;

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchSplit.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchSplit.java
@@ -19,21 +19,20 @@ import com.google.common.collect.ImmutableList;
 import io.airlift.slice.SizeOf;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class ElasticsearchSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ElasticsearchSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ElasticsearchSplit.class);
 
     private final String index;
     private final int shard;

--- a/plugin/trino-example-http/src/main/java/io/trino/plugin/example/ExampleSplit.java
+++ b/plugin/trino-example-http/src/main/java/io/trino/plugin/example/ExampleSplit.java
@@ -18,19 +18,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.net.URI;
 import java.util.List;
 
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class ExampleSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ExampleSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ExampleSplit.class);
 
     private final String uri;
     private final boolean remotelyAccessible;

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileStatus.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileStatus.java
@@ -15,7 +15,6 @@ package io.trino.plugin.exchange.filesystem;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -23,13 +22,13 @@ import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
 public class FileStatus
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(FileStatus.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(FileStatus.class);
 
     private final String filePath;
     private final long fileSize;

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeSink.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeSink.java
@@ -24,7 +24,6 @@ import io.airlift.slice.Slices;
 import io.trino.spi.TrinoException;
 import io.trino.spi.exchange.ExchangeSink;
 import io.trino.spi.exchange.ExchangeSinkInstanceHandle;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
@@ -50,11 +49,11 @@ import static io.airlift.concurrent.MoreFutures.addSuccessCallback;
 import static io.airlift.concurrent.MoreFutures.asVoid;
 import static io.airlift.concurrent.MoreFutures.toCompletableFuture;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.units.DataSize.succinctBytes;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -67,7 +66,7 @@ public class FileSystemExchangeSink
     public static final String COMMITTED_MARKER_FILE_NAME = "committed";
     public static final String DATA_FILE_SUFFIX = ".data";
 
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(FileSystemExchangeSink.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(FileSystemExchangeSink.class);
 
     private final FileSystemExchangeStorage exchangeStorage;
     private final FileSystemExchangeStats stats;
@@ -235,7 +234,7 @@ public class FileSystemExchangeSink
     @ThreadSafe
     private static class BufferedStorageWriter
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(BufferedStorageWriter.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(BufferedStorageWriter.class);
 
         private final FileSystemExchangeStorage exchangeStorage;
         private final FileSystemExchangeStats stats;
@@ -385,7 +384,7 @@ public class FileSystemExchangeSink
     @ThreadSafe
     private static class BufferPool
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(BufferPool.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(BufferPool.class);
 
         private final FileSystemExchangeStats stats;
         private final int maxNumBuffers;

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeSourceHandle.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeSourceHandle.java
@@ -18,20 +18,19 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.exchange.ExchangeId;
 import io.trino.spi.exchange.ExchangeSourceHandle;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class FileSystemExchangeSourceHandle
         implements ExchangeSourceHandle
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(FileSystemExchangeSourceHandle.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(FileSystemExchangeSourceHandle.class);
 
     private final ExchangeId exchangeId;
     private final int partitionId;
@@ -94,7 +93,7 @@ public class FileSystemExchangeSourceHandle
 
     public static class SourceFile
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SourceFile.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(SourceFile.class);
 
         private final String filePath;
         private final long fileSize;

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/azure/AzureBlobFileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/azure/AzureBlobFileSystemExchangeStorage.java
@@ -45,7 +45,6 @@ import io.trino.plugin.exchange.filesystem.ExchangeStorageReader;
 import io.trino.plugin.exchange.filesystem.ExchangeStorageWriter;
 import io.trino.plugin.exchange.filesystem.FileStatus;
 import io.trino.plugin.exchange.filesystem.FileSystemExchangeStorage;
-import org.openjdk.jol.info.ClassLayout;
 import reactor.core.publisher.Flux;
 
 import javax.annotation.PreDestroy;
@@ -78,6 +77,7 @@ import static io.airlift.concurrent.MoreFutures.asVoid;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.exchange.filesystem.FileSystemExchangeFutures.translateFailures;
 import static io.trino.plugin.exchange.filesystem.FileSystemExchangeManager.PATH_SEPARATOR;
 import static java.lang.Math.min;
@@ -265,7 +265,7 @@ public class AzureBlobFileSystemExchangeStorage
     private static class AzureExchangeStorageReader
             implements ExchangeStorageReader
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(AzureExchangeStorageReader.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(AzureExchangeStorageReader.class);
 
         private final BlobServiceAsyncClient blobServiceAsyncClient;
         @GuardedBy("this")
@@ -451,7 +451,7 @@ public class AzureBlobFileSystemExchangeStorage
     private static class AzureExchangeStorageWriter
             implements ExchangeStorageWriter
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(AzureExchangeStorageWriter.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(AzureExchangeStorageWriter.class);
 
         private final BlockBlobAsyncClient blockBlobAsyncClient;
         private final int blockSize;

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/local/LocalFileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/local/LocalFileSystemExchangeStorage.java
@@ -24,7 +24,6 @@ import io.trino.plugin.exchange.filesystem.ExchangeStorageReader;
 import io.trino.plugin.exchange.filesystem.ExchangeStorageWriter;
 import io.trino.plugin.exchange.filesystem.FileStatus;
 import io.trino.plugin.exchange.filesystem.FileSystemExchangeStorage;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -50,6 +49,7 @@ import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static java.lang.Math.toIntExact;
 import static java.nio.file.Files.createFile;
@@ -137,7 +137,7 @@ public class LocalFileSystemExchangeStorage
     private static class LocalExchangeStorageReader
             implements ExchangeStorageReader
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(LocalExchangeStorageReader.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(LocalExchangeStorageReader.class);
 
         @GuardedBy("this")
         private final Queue<ExchangeSourceFile> sourceFiles;
@@ -216,7 +216,7 @@ public class LocalFileSystemExchangeStorage
     private static class LocalExchangeStorageWriter
             implements ExchangeStorageWriter
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(LocalExchangeStorageWriter.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(LocalExchangeStorageWriter.class);
 
         private final OutputStream outputStream;
 

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/s3/S3FileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/s3/S3FileSystemExchangeStorage.java
@@ -39,7 +39,6 @@ import io.trino.plugin.exchange.filesystem.ExchangeStorageReader;
 import io.trino.plugin.exchange.filesystem.ExchangeStorageWriter;
 import io.trino.plugin.exchange.filesystem.FileStatus;
 import io.trino.plugin.exchange.filesystem.FileSystemExchangeStorage;
-import org.openjdk.jol.info.ClassLayout;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
@@ -112,6 +111,7 @@ import static io.airlift.concurrent.MoreFutures.asVoid;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
 import static io.airlift.concurrent.Threads.threadsNamed;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.exchange.filesystem.FileSystemExchangeFutures.translateFailures;
 import static io.trino.plugin.exchange.filesystem.FileSystemExchangeManager.PATH_SEPARATOR;
 import static io.trino.plugin.exchange.filesystem.s3.S3FileSystemExchangeStorage.CompatibilityMode.GCP;
@@ -486,7 +486,7 @@ public class S3FileSystemExchangeStorage
     private static class S3ExchangeStorageReader
             implements ExchangeStorageReader
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(S3ExchangeStorageReader.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(S3ExchangeStorageReader.class);
 
         private final S3FileSystemExchangeStorageStats stats;
         private final S3AsyncClient s3AsyncClient;
@@ -665,7 +665,7 @@ public class S3FileSystemExchangeStorage
     private static class S3ExchangeStorageWriter
             implements ExchangeStorageWriter
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(S3ExchangeStorageWriter.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(S3ExchangeStorageWriter.class);
 
         private final S3FileSystemExchangeStorageStats stats;
         private final S3AsyncClient s3AsyncClient;

--- a/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/HadoopFileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/HadoopFileSystemExchangeStorage.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -47,6 +46,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -148,7 +148,7 @@ public class HadoopFileSystemExchangeStorage
     private static class HadoopExchangeStorageReader
             implements ExchangeStorageReader
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(HadoopExchangeStorageReader.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(HadoopExchangeStorageReader.class);
 
         private final FileSystem fileSystem;
         @GuardedBy("this")
@@ -232,7 +232,7 @@ public class HadoopFileSystemExchangeStorage
     private static class HadoopExchangeStorageWriter
             implements ExchangeStorageWriter
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(HadoopExchangeStorageReader.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(HadoopExchangeStorageReader.class);
         private final OutputStream outputStream;
 
         public HadoopExchangeStorageWriter(FileSystem fileSystem, URI file)

--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/SpatialPartitioningStateFactory.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/SpatialPartitioningStateFactory.java
@@ -20,11 +20,11 @@ import io.trino.array.ObjectBigArray;
 import io.trino.geospatial.Rectangle;
 import io.trino.spi.function.AccumulatorStateFactory;
 import io.trino.spi.function.GroupedAccumulatorState;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.Math.toIntExact;
 
 public class SpatialPartitioningStateFactory
@@ -45,7 +45,7 @@ public class SpatialPartitioningStateFactory
     public static final class GroupedSpatialPartitioningState
             implements GroupedAccumulatorState, SpatialPartitioningState
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(GroupedSpatialPartitioningState.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(GroupedSpatialPartitioningState.class);
         private static final int ENVELOPE_SIZE = toIntExact(new Envelope(1, 2, 3, 4).estimateMemorySize());
 
         private long groupId;
@@ -137,7 +137,7 @@ public class SpatialPartitioningStateFactory
     public static final class SingleSpatialPartitioningState
             implements SpatialPartitioningState
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SingleSpatialPartitioningState.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(SingleSpatialPartitioningState.class);
 
         private int partitionCount;
         private long count;

--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/aggregation/GeometryStateFactory.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/aggregation/GeometryStateFactory.java
@@ -17,12 +17,13 @@ import com.esri.core.geometry.ogc.OGCGeometry;
 import io.trino.array.ObjectBigArray;
 import io.trino.spi.function.AccumulatorStateFactory;
 import io.trino.spi.function.GroupedAccumulatorState;
-import org.openjdk.jol.info.ClassLayout;
+
+import static io.airlift.slice.SizeOf.instanceSize;
 
 public class GeometryStateFactory
         implements AccumulatorStateFactory<GeometryState>
 {
-    private static final long OGC_GEOMETRY_BASE_INSTANCE_SIZE = ClassLayout.parseClass(OGCGeometry.class).instanceSize();
+    private static final long OGC_GEOMETRY_BASE_INSTANCE_SIZE = instanceSize(OGCGeometry.class);
 
     @Override
     public GeometryState createSingleState()

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsSplit.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsSplit.java
@@ -20,18 +20,17 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.SizeOf;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class SheetsSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SheetsSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SheetsSplit.class);
 
     private final String schemaName;
     private final String tableName;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/AcidInfo.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/AcidInfo.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import io.airlift.slice.SizeOf;
 import org.apache.hadoop.fs.Path;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,7 +30,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -39,7 +38,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class AcidInfo
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(AcidInfo.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(AcidInfo.class);
 
     private final String partitionLocation;
     private final List<String> deleteDeltas;
@@ -137,7 +136,7 @@ public class AcidInfo
 
     public static class OriginalFileInfo
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(OriginalFileInfo.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(OriginalFileInfo.class);
 
         private final String name;
         private final long fileSize;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveColumnHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveColumnHandle.java
@@ -20,13 +20,13 @@ import io.trino.plugin.hive.metastore.Column;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.SYNTHESIZED;
@@ -39,7 +39,6 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.VarcharType.VARCHAR;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -50,7 +49,7 @@ import static java.util.Objects.requireNonNull;
 public class HiveColumnHandle
         implements ColumnHandle
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(HiveColumnHandle.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(HiveColumnHandle.class);
 
     public static final int PATH_COLUMN_INDEX = -11;
     public static final String PATH_COLUMN_NAME = "$path";

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveColumnProjectionInfo.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveColumnProjectionInfo.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.airlift.slice.SizeOf;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Objects;
@@ -25,12 +24,12 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class HiveColumnProjectionInfo
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(HiveColumnProjectionInfo.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(HiveColumnProjectionInfo.class);
 
     private final List<Integer> dereferenceIndices;
     private final List<String> dereferenceNames;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionKey.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionKey.java
@@ -25,7 +25,7 @@ import static java.util.Objects.requireNonNull;
 
 public final class HivePartitionKey
 {
-    private static final int INSTANCE_SIZE = instanceSize(HivePartitionKey.class) + instanceSize(String.class) * 2;
+    private static final int INSTANCE_SIZE = instanceSize(HivePartitionKey.class);
 
     public static final String HIVE_DEFAULT_DYNAMIC_PARTITION = "__HIVE_DEFAULT_PARTITION__";
     private final String name;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionKey.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionKey.java
@@ -15,18 +15,17 @@ package io.trino.plugin.hive;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public final class HivePartitionKey
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(HivePartitionKey.class).instanceSize() + ClassLayout.parseClass(String.class).instanceSize() * 2);
+    private static final int INSTANCE_SIZE = instanceSize(HivePartitionKey.class) + instanceSize(String.class) * 2;
 
     public static final String HIVE_DEFAULT_DYNAMIC_PARTITION = "__HIVE_DEFAULT_PARTITION__";
     private final String name;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplit.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplit.java
@@ -21,7 +21,6 @@ import io.trino.plugin.hive.util.HiveBucketing.BucketingVersion;
 import io.trino.spi.HostAddress;
 import io.trino.spi.SplitWeight;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Objects;
@@ -32,15 +31,15 @@ import java.util.Properties;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.plugin.hive.util.HiveUtil.getDeserializerClassName;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class HiveSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(HiveSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(HiveSplit.class);
 
     private final String path;
     private final long start;
@@ -323,7 +322,7 @@ public class HiveSplit
 
     public static class BucketConversion
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(BucketConversion.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(BucketConversion.class);
 
         private final BucketingVersion bucketingVersion;
         private final int tableBucketCount;
@@ -398,7 +397,7 @@ public class HiveSplit
 
     public static class BucketValidation
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(BucketValidation.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(BucketValidation.class);
 
         private final BucketingVersion bucketingVersion;
         private final int bucketCount;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveType.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveType.java
@@ -27,7 +27,6 @@ import io.trino.plugin.hive.type.UnionTypeInfo;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.TypeSignature;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Optional;
@@ -35,6 +34,7 @@ import java.util.Optional;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.lenientFormat;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.hive.HiveStorageFormat.AVRO;
 import static io.trino.plugin.hive.HiveStorageFormat.ORC;
 import static io.trino.plugin.hive.HiveTimestampPrecision.DEFAULT_PRECISION;
@@ -58,12 +58,11 @@ import static io.trino.plugin.hive.util.SerdeConstants.SMALLINT_TYPE_NAME;
 import static io.trino.plugin.hive.util.SerdeConstants.STRING_TYPE_NAME;
 import static io.trino.plugin.hive.util.SerdeConstants.TIMESTAMP_TYPE_NAME;
 import static io.trino.plugin.hive.util.SerdeConstants.TINYINT_TYPE_NAME;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public final class HiveType
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(HiveType.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(HiveType.class);
 
     public static final HiveType HIVE_BOOLEAN = new HiveType(getPrimitiveTypeInfo(BOOLEAN_TYPE_NAME));
     public static final HiveType HIVE_BYTE = new HiveType(getPrimitiveTypeInfo(TINYINT_TYPE_NAME));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTypeName.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTypeName.java
@@ -24,7 +24,7 @@ import static java.util.Objects.requireNonNull;
 
 public final class HiveTypeName
 {
-    private static final int INSTANCE_SIZE = instanceSize(HiveTypeName.class) + instanceSize(String.class);
+    private static final int INSTANCE_SIZE = instanceSize(HiveTypeName.class);
 
     private final String value;
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTypeName.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTypeName.java
@@ -15,17 +15,16 @@ package io.trino.plugin.hive;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public final class HiveTypeName
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(HiveTypeName.class).instanceSize() + ClassLayout.parseClass(String.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(HiveTypeName.class) + instanceSize(String.class);
 
     private final String value;
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveSplit.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveSplit.java
@@ -39,11 +39,7 @@ import static java.util.Objects.requireNonNull;
 @NotThreadSafe
 public class InternalHiveSplit
 {
-    private static final int INSTANCE_SIZE = instanceSize(InternalHiveSplit.class) +
-            instanceSize(String.class) +
-            instanceSize(Properties.class) +
-            instanceSize(String.class) +
-            instanceSize(OptionalInt.class);
+    private static final int INSTANCE_SIZE = instanceSize(InternalHiveSplit.class) + instanceSize(Properties.class) + instanceSize(OptionalInt.class);
 
     private final String path;
     private final long end;
@@ -278,7 +274,7 @@ public class InternalHiveSplit
     public static class InternalHiveBlock
     {
         private static final int INSTANCE_SIZE = instanceSize(InternalHiveBlock.class);
-        private static final int HOST_ADDRESS_INSTANCE_SIZE = instanceSize(HostAddress.class) + instanceSize(String.class);
+        private static final int HOST_ADDRESS_INSTANCE_SIZE = instanceSize(HostAddress.class);
 
         private final long start;
         private final long end;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveSplit.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveSplit.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import io.trino.plugin.hive.HiveSplit.BucketConversion;
 import io.trino.plugin.hive.HiveSplit.BucketValidation;
 import io.trino.spi.HostAddress;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -33,17 +32,18 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 @NotThreadSafe
 public class InternalHiveSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(InternalHiveSplit.class).instanceSize() +
-            ClassLayout.parseClass(String.class).instanceSize() +
-            ClassLayout.parseClass(Properties.class).instanceSize() +
-            ClassLayout.parseClass(String.class).instanceSize() +
-            ClassLayout.parseClass(OptionalInt.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(InternalHiveSplit.class) +
+            instanceSize(String.class) +
+            instanceSize(Properties.class) +
+            instanceSize(String.class) +
+            instanceSize(OptionalInt.class);
 
     private final String path;
     private final long end;
@@ -277,9 +277,8 @@ public class InternalHiveSplit
 
     public static class InternalHiveBlock
     {
-        private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(InternalHiveBlock.class).instanceSize());
-        private static final int HOST_ADDRESS_INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(HostAddress.class).instanceSize() +
-                ClassLayout.parseClass(String.class).instanceSize());
+        private static final int INSTANCE_SIZE = instanceSize(InternalHiveBlock.class);
+        private static final int HOST_ADDRESS_INSTANCE_SIZE = instanceSize(HostAddress.class) + instanceSize(String.class);
 
         private final long start;
         private final long end;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriter.java
@@ -26,7 +26,6 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -40,16 +39,16 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_DATA_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITE_VALIDATION_FAILED;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class RcFileFileWriter
         implements FileWriter
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(RcFileFileWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(RcFileFileWriter.class);
     private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
 
     private final CountingOutputStream outputStream;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RecordFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RecordFileWriter.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.hive.serde2.objectinspector.SettableStructObjectInspect
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.mapred.JobConf;
 import org.joda.time.DateTimeZone;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -45,6 +44,7 @@ import java.util.Properties;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_DATA_ERROR;
 import static io.trino.plugin.hive.HiveSessionProperties.getTimestampPrecision;
@@ -54,7 +54,6 @@ import static io.trino.plugin.hive.util.HiveUtil.getColumnTypes;
 import static io.trino.plugin.hive.util.HiveWriteUtils.createRecordWriter;
 import static io.trino.plugin.hive.util.HiveWriteUtils.getRowColumnInspectors;
 import static io.trino.plugin.hive.util.HiveWriteUtils.initializeSerializer;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardStructObjectInspector;
@@ -62,7 +61,7 @@ import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFacto
 public class RecordFileWriter
         implements FileWriter
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(RecordFileWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(RecordFileWriter.class);
 
     private final Path path;
     private final JobConf conf;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/SortingFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/SortingFileWriter.java
@@ -35,7 +35,6 @@ import io.trino.spi.connector.SortOrder;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
 import org.apache.hadoop.fs.Path;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -54,10 +53,10 @@ import java.util.stream.IntStream;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_DATA_ERROR;
 import static java.lang.Math.min;
-import static java.lang.Math.toIntExact;
 import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
 
@@ -66,7 +65,7 @@ public class SortingFileWriter
 {
     private static final Logger log = Logger.get(SortingFileWriter.class);
 
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SortingFileWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SortingFileWriter.class);
 
     private final TrinoFileSystem fileSystem;
     private final Path tempFilePrefix;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TableToPartitionMapping.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TableToPartitionMapping.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Map;
 import java.util.Objects;
@@ -25,6 +24,7 @@ import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
@@ -41,9 +41,9 @@ public class TableToPartitionMapping
     }
 
     // Overhead of ImmutableMap is not accounted because of its complexity.
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TableToPartitionMapping.class).instanceSize());
-    private static final int INTEGER_INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(Integer.class).instanceSize());
-    private static final int OPTIONAL_INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(Optional.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(TableToPartitionMapping.class);
+    private static final int INTEGER_INSTANCE_SIZE = instanceSize(Integer.class);
+    private static final int OPTIONAL_INSTANCE_SIZE = instanceSize(Optional.class);
 
     private final Optional<Map<Integer, Integer>> tableToPartitionColumns;
     private final Map<Integer, HiveTypeName> partitionColumnCoercions;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LineFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LineFileWriter.java
@@ -24,21 +24,20 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_DATA_ERROR;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class LineFileWriter
         implements FileWriter
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(LineFileWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(LineFileWriter.class);
 
     private final LineWriter lineWriter;
     private final LineSerializer serializer;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LinePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LinePageSource.java
@@ -20,21 +20,20 @@ import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorPageSource;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.util.OptionalLong;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.base.util.Closables.closeAllSuppress;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_CURSOR_ERROR;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class LinePageSource
         implements ConnectorPageSource
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(LinePageSource.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(LinePageSource.class);
 
     private final LineReader lineReader;
     private final LineDeserializer deserializer;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcDeletedRows.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcDeletedRows.java
@@ -30,7 +30,6 @@ import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.EmptyPageSource;
 import io.trino.spi.security.ConnectorIdentity;
 import org.apache.hadoop.fs.Path;
-import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -46,6 +45,7 @@ import java.util.Set;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOfObjectArray;
 import static io.trino.plugin.hive.BackgroundHiveSplitLoader.hasAttemptId;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_BAD_DATA;
@@ -408,7 +408,7 @@ public class OrcDeletedRows
 
     private static class RowId
     {
-        public static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(RowId.class).instanceSize());
+        public static final int INSTANCE_SIZE = instanceSize(RowId.class);
 
         private final long originalTransaction;
         private final int bucket;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriter.java
@@ -36,7 +36,6 @@ import io.trino.spi.block.LongArrayBlock;
 import io.trino.spi.block.RowBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -53,12 +52,12 @@ import java.util.function.Supplier;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_DATA_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITE_VALIDATION_FAILED;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -66,7 +65,7 @@ public class OrcFileWriter
         implements FileWriter
 {
     private static final Logger log = Logger.get(OrcFileWriter.class);
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(OrcFileWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(OrcFileWriter.class);
     private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
 
     protected final OrcWriter orcWriter;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
@@ -29,7 +29,6 @@ import io.trino.spi.type.Type;
 import org.apache.parquet.format.CompressionCodec;
 import org.apache.parquet.schema.MessageType;
 import org.joda.time.DateTimeZone;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -43,18 +42,18 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.parquet.ParquetWriteValidation.ParquetWriteValidationBuilder;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_DATA_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITE_VALIDATION_FAILED;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class ParquetFileWriter
         implements FileWriter
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ParquetFileWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ParquetFileWriter.class);
     private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
 
     private final ParquetWriter parquetWriter;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/SortBuffer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/SortBuffer.java
@@ -22,7 +22,6 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.SortOrder;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,13 +30,13 @@ import java.util.function.Consumer;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.Math.addExact;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class SortBuffer
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SortBuffer.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SortBuffer.class);
 
     private final long maxMemoryBytes;
     private final List<Type> types;

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroFileWriter.java
@@ -25,24 +25,23 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.data.avro.DataWriter;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.OutputFile;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.iceberg.IcebergAvroDataConversion.toIcebergRecords;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_WRITER_CLOSE_ERROR;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_WRITER_OPEN_ERROR;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.TableProperties.AVRO_COMPRESSION;
 
 public class IcebergAvroFileWriter
         implements IcebergFileWriter
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(IcebergAvroFileWriter.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(IcebergAvroFileWriter.class);
 
     // Use static table name instead of the actual name because it becomes outdated once the table is renamed
     public static final String AVRO_TABLE_NAME = "table";

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
@@ -22,19 +22,18 @@ import io.trino.plugin.iceberg.delete.DeleteFile;
 import io.trino.spi.HostAddress;
 import io.trino.spi.SplitWeight;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(IcebergSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(IcebergSplit.class);
 
     private final String path;
     private final long start;

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/DeleteFile.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/DeleteFile.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.SizeOf;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileFormat;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -32,11 +31,12 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public final class DeleteFile
 {
-    private static final long INSTANCE_SIZE = ClassLayout.parseClass(DeleteFile.class).instanceSize();
+    private static final long INSTANCE_SIZE = instanceSize(DeleteFile.class);
 
     private final FileContent content;
     private final String path;

--- a/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxSplit.java
+++ b/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxSplit.java
@@ -18,18 +18,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class JmxSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(JmxSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(JmxSplit.class);
 
     private final List<HostAddress> addresses;
 

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaSplit.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaSplit.java
@@ -19,21 +19,20 @@ import com.google.common.collect.ImmutableList;
 import io.airlift.slice.SizeOf;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class KafkaSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(KafkaSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(KafkaSplit.class);
 
     private final String topicName;
     private final String keyDataFormat;

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/Range.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/Range.java
@@ -16,17 +16,16 @@ package io.trino.plugin.kafka;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.lang.Math.min;
-import static java.lang.Math.toIntExact;
 
 public class Range
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(Range.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(Range.class);
 
     private final long begin; // inclusive
     private final long end; // exclusive

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisSplit.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisSplit.java
@@ -18,13 +18,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -34,7 +33,7 @@ import static java.util.Objects.requireNonNull;
 public class KinesisSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(KinesisSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(KinesisSplit.class);
 
     private final String streamName;
     private final String messageDataFormat;

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduSplit.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduSplit.java
@@ -19,19 +19,18 @@ import com.google.common.collect.ImmutableList;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.SchemaTableName;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class KuduSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(KuduSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(KuduSplit.class);
 
     private final SchemaTableName schemaTableName;
     private final int primaryKeyColumnCount;

--- a/plugin/trino-local-file/src/main/java/io/trino/plugin/localfile/LocalFileSplit.java
+++ b/plugin/trino-local-file/src/main/java/io/trino/plugin/localfile/LocalFileSplit.java
@@ -18,18 +18,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class LocalFileSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(LocalFileSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(LocalFileSplit.class);
 
     private final HostAddress address;
 

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemorySplit.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemorySplit.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Objects;
@@ -26,14 +25,14 @@ import java.util.OptionalLong;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class MemorySplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(MemorySplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(MemorySplit.class);
 
     private final long table;
     private final int totalPartsPerWorker; // how many concurrent reads there will be from one worker

--- a/plugin/trino-ml/src/main/java/io/trino/plugin/ml/EvaluateClassifierPredictionsStateFactory.java
+++ b/plugin/trino-ml/src/main/java/io/trino/plugin/ml/EvaluateClassifierPredictionsStateFactory.java
@@ -16,15 +16,16 @@ package io.trino.plugin.ml;
 import io.trino.array.ObjectBigArray;
 import io.trino.spi.function.AccumulatorStateFactory;
 import io.trino.spi.function.GroupedAccumulatorState;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static io.airlift.slice.SizeOf.instanceSize;
+
 public class EvaluateClassifierPredictionsStateFactory
         implements AccumulatorStateFactory<EvaluateClassifierPredictionsState>
 {
-    private static final long HASH_MAP_SIZE = ClassLayout.parseClass(HashMap.class).instanceSize();
+    private static final long HASH_MAP_SIZE = instanceSize(HashMap.class);
 
     @Override
     public EvaluateClassifierPredictionsState createSingleState()

--- a/plugin/trino-ml/src/main/java/io/trino/plugin/ml/LearnStateFactory.java
+++ b/plugin/trino-ml/src/main/java/io/trino/plugin/ml/LearnStateFactory.java
@@ -21,18 +21,17 @@ import io.trino.array.SliceBigArray;
 import io.trino.spi.function.AccumulatorStateFactory;
 import io.trino.spi.function.GroupedAccumulatorState;
 import libsvm.svm_parameter;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 
 public class LearnStateFactory
         implements AccumulatorStateFactory<LearnState>
 {
-    private static final long ARRAY_LIST_SIZE = toIntExact(ClassLayout.parseClass(ArrayList.class).instanceSize());
-    private static final long SVM_PARAMETERS_SIZE = ClassLayout.parseClass(svm_parameter.class).instanceSize();
+    private static final long ARRAY_LIST_SIZE = instanceSize(ArrayList.class);
+    private static final long SVM_PARAMETERS_SIZE = instanceSize(svm_parameter.class);
 
     @Override
     public LearnState createSingleState()

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSplit.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSplit.java
@@ -18,18 +18,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class MongoSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(MongoSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(MongoSplit.class);
 
     private final List<HostAddress> addresses;
 

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplit.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplit.java
@@ -21,20 +21,19 @@ import io.airlift.slice.SizeOf;
 import io.trino.plugin.jdbc.JdbcSplit;
 import io.trino.spi.HostAddress;
 import org.apache.phoenix.mapreduce.PhoenixInputSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Optional;
 
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class PhoenixSplit
         extends JdbcSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(PhoenixSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(PhoenixSplit.class);
 
     private final List<HostAddress> addresses;
     private final SerializedPhoenixInputSplit serializedPhoenixInputSplit;

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/SerializedPhoenixInputSplit.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/SerializedPhoenixInputSplit.java
@@ -18,18 +18,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.io.ByteStreams;
 import org.apache.hadoop.io.WritableUtils;
 import org.apache.phoenix.mapreduce.PhoenixInputSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class SerializedPhoenixInputSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(SerializedPhoenixInputSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(SerializedPhoenixInputSplit.class);
 
     private final byte[] bytes;
 

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSplit.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSplit.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import io.airlift.slice.SizeOf;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Optional;
@@ -27,14 +26,14 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class PinotSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(PinotSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(PinotSplit.class);
 
     private final SplitType splitType;
     private final Optional<String> suffix;

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusSplit.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusSplit.java
@@ -18,19 +18,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.net.URI;
 import java.util.List;
 
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class PrometheusSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(PrometheusSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(PrometheusSplit.class);
 
     private final String uri;
     private final List<HostAddress> addresses;

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorSplit.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorSplit.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.OptionalInt;
@@ -28,15 +27,15 @@ import java.util.UUID;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class RaptorSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(RaptorSplit.class).instanceSize());
-    private static final int UUID_INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(UUID.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(RaptorSplit.class);
+    private static final int UUID_INSTANCE_SIZE = instanceSize(UUID.class);
 
     private final Set<UUID> shardUuids;
     private final OptionalInt bucketNumber;

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisColumnHandle.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisColumnHandle.java
@@ -18,20 +18,19 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.decoder.DecoderColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.type.Type;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public final class RedisColumnHandle
         implements DecoderColumnHandle, Comparable<RedisColumnHandle>
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(RedisColumnHandle.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(RedisColumnHandle.class);
 
     private final int ordinalPosition;
     private final String name;

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisSplit.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisSplit.java
@@ -20,13 +20,12 @@ import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.predicate.TupleDomain;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -35,7 +34,7 @@ import static java.util.Objects.requireNonNull;
 public final class RedisSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(RedisSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(RedisSplit.class);
 
     private final String schemaName;
     private final String tableName;

--- a/plugin/trino-thrift-api/pom.xml
+++ b/plugin/trino-thrift-api/pom.xml
@@ -49,11 +49,6 @@
             <artifactId>guava</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.openjdk.jol</groupId>
-            <artifactId>jol-core</artifactId>
-        </dependency>
-
         <!-- for testing -->
         <dependency>
             <groupId>io.trino</groupId>

--- a/plugin/trino-thrift-api/src/main/java/io/trino/plugin/thrift/api/TrinoThriftId.java
+++ b/plugin/trino-thrift-api/src/main/java/io/trino/plugin/thrift/api/TrinoThriftId.java
@@ -20,19 +20,18 @@ import com.google.common.io.BaseEncoding;
 import io.airlift.drift.annotations.ThriftConstructor;
 import io.airlift.drift.annotations.ThriftField;
 import io.airlift.drift.annotations.ThriftStruct;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 @ThriftStruct
 public final class TrinoThriftId
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TrinoThriftId.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(TrinoThriftId.class);
 
     private static final int PREFIX_SUFFIX_BYTES = 8;
     private static final String FILLER = "..";

--- a/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftConnectorSplit.java
+++ b/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftConnectorSplit.java
@@ -19,20 +19,19 @@ import com.google.common.collect.ImmutableList;
 import io.trino.plugin.thrift.api.TrinoThriftId;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class ThriftConnectorSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(ThriftConnectorSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(ThriftConnectorSplit.class);
 
     private final TrinoThriftId splitId;
     private final List<HostAddress> addresses;

--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsSplit.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsSplit.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Objects;
@@ -26,13 +25,13 @@ import java.util.Objects;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class TpcdsSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TpcdsSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(TpcdsSplit.class);
 
     private final int totalParts;
     private final int partNumber;

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchSplit.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchSplit.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Objects;
@@ -26,13 +25,13 @@ import java.util.Objects;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static java.lang.Math.toIntExact;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 public class TpchSplit
         implements ConnectorSplit
 {
-    private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(TpchSplit.class).instanceSize());
+    private static final int INSTANCE_SIZE = instanceSize(TpchSplit.class);
 
     private final int totalParts;
     private final int partNumber;

--- a/pom.xml
+++ b/pom.xml
@@ -46,10 +46,12 @@
 
         <air.release.preparation-goals>clean verify -DskipTests</air.release.preparation-goals>
 
+        <dep.slice.version>0.45</dep.slice.version>
         <dep.accumulo.version>1.10.2</dep.accumulo.version>
         <dep.accumulo-hadoop.version>2.7.7-1</dep.accumulo-hadoop.version>
         <dep.antlr.version>4.11.1</dep.antlr.version>
-        <dep.airlift.version>224</dep.airlift.version>
+        <!-- TODO remove after updating Airbase -->
+        <dep.airlift.version>225</dep.airlift.version>
         <dep.arrow.version>9.0.0</dep.arrow.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.aws-sdk.version>1.12.261</dep.aws-sdk.version>


### PR DESCRIPTION
JOL does not work new Java features like records or hidden classes.  This change introduces a utility that encapsulates instance size, and has a fallback that can estimate the size when JOL fails.

## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
