### PR TITLE
Support unwrap date to timestamp with time zone

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
@@ -424,7 +424,7 @@ public class UnwrapCastInComparison
 
             if (target instanceof TimestampWithTimeZoneType timestampWithTimeZoneType) {
                 if (source instanceof TimestampType) {
-                    // Cast from TIMESTAMP WITH TIME ZONE to TIMESTAMP and back to TIMESTAMP WITH TIME ZONE does not round trip, unless the value's zone is equal to sesion zone
+                    // Cast from TIMESTAMP WITH TIME ZONE to TIMESTAMP and back to TIMESTAMP WITH TIME ZONE does not round trip, unless the value's zone is equal to session zone
                     if (!getTimeZone(timestampWithTimeZoneType, value).equals(session.getTimeZoneKey())) {
                         return false;
                     }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestUnwrapCastInComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestUnwrapCastInComparison.java
@@ -21,7 +21,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -35,6 +37,7 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 public class TestUnwrapCastInComparison
 {
     private static final List<String> COMPARISON_OPERATORS = asList("=", "<>", ">=", ">", "<=", "<", "IS DISTINCT FROM");
+    private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss[.SSS]");
 
     private QueryAssertions assertions;
 
@@ -217,6 +220,95 @@ public class TestUnwrapCastInComparison
         for (String operator : COMPARISON_OPERATORS) {
             for (String to : asList("'" + "a".repeat(200) + "'", "'" + "b".repeat(200) + "'")) {
                 validate(operator, "VARCHAR(200)", "'" + "a".repeat(200) + "'", "VARCHAR(300)", to);
+            }
+        }
+    }
+
+    @Test
+    public void testCastDateToTimestampWithTimeZone()
+    {
+        // The values in this test are chosen for Pacific/Apia's DST changes
+        Session session = Session.builder(assertions.getDefaultSession())
+                .setTimeZoneKey(TimeZoneKey.getTimeZoneKey("Pacific/Apia"))
+                .build();
+
+        for (String operator : COMPARISON_OPERATORS) {
+            validate(session, operator, "date", "DATE '2020-07-03'", "timestamp(3) with time zone", "TIMESTAMP '2020-07-03 00:00:00 Europe/Warsaw'");
+            validate(session, operator, "date", "DATE '2020-07-03'", "timestamp(3) with time zone", "TIMESTAMP '2020-07-03 01:23:45 UTC'");
+            validate(session, operator, "date", "DATE '2020-07-03'", "timestamp(6) with time zone", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'");
+            validate(session, operator, "date", "DATE '2020-07-03'", "timestamp(6) with time zone", "TIMESTAMP '2020-07-03 01:23:45 UTC'");
+            validate(session, operator, "date", "DATE '2020-07-03'", "timestamp(9) with time zone", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'");
+            validate(session, operator, "date", "DATE '2020-07-03'", "timestamp(9) with time zone", "TIMESTAMP '2020-07-03 01:23:45 UTC'");
+            validate(session, operator, "date", "DATE '2020-07-03'", "timestamp(12) with time zone", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'");
+            validate(session, operator, "date", "DATE '2020-07-03'", "timestamp(12) with time zone", "TIMESTAMP '2020-07-03 01:23:45 UTC'");
+        }
+
+        List<LocalDateTime> toLocalDateTimes = asList(
+                // julian->gregorian switch
+                LocalDateTime.parse("1582-10-04T23:59:59.999999999"),
+                LocalDateTime.parse("1582-10-05T00:00:00.000000000"),
+                LocalDateTime.parse("1582-10-14T23:59:59.999999999"),
+                LocalDateTime.parse("1582-10-15T00:00:00.000000000"),
+                // 2017-09-24 02:59:00 Pacific/Apia is 2017-09-23T13:59:00Z
+                LocalDateTime.parse("2017-04-01T13:59:59.999999999"),
+                // 2017-09-24 04:00:00 Pacific/Apia is 2017-09-23T14:00:00Z
+                // 2017-09-24 03:00:00 gets interpreted as 2017-09-23T14:00:00Z too
+                LocalDateTime.parse("2017-04-01T14:00:00"),
+                LocalDateTime.parse("2017-04-01T14:00:00.000000001"),
+                LocalDateTime.parse("2017-04-01T14:00:00.000000002"),
+                LocalDateTime.parse("2017-04-01T14:59:59.999999999"),
+                LocalDateTime.parse("2017-04-01T15:00:00"),
+                LocalDateTime.parse("2017-04-01T15:00:00.000000001"),
+                LocalDateTime.parse("2017-04-01T15:00:00.000000002"));
+
+        for (LocalDateTime toLocalDateTime : toLocalDateTimes) {
+            for (int timestampPrecision : asList(0, 3, 6, 9, 12)) {
+                for (String operator : COMPARISON_OPERATORS) {
+                    validate(
+                            session,
+                            operator,
+                            "date",
+                            "DATE '2017-09-24'",
+                            format("timestamp(%s) with time zone", timestampPrecision),
+                            format("TIMESTAMP '%s'", DATE_TIME_FORMAT.format(toLocalDateTime)));
+                }
+            }
+        }
+
+        toLocalDateTimes = asList(
+                // julian->gregorian switch
+                LocalDateTime.parse("1582-10-04T23:59:59.999999999"),
+                LocalDateTime.parse("1582-10-05T00:00:00.000000000"),
+                LocalDateTime.parse("1582-10-14T23:59:59.999999999"),
+                LocalDateTime.parse("1582-10-15T00:00:00.000000000"),
+                // 2017-04-02 02:59:00 Pacific/Apia is 2017-04-01T12:59:00Z
+                LocalDateTime.parse("2017-04-01T12:59:59.999999999"),
+                // 2017-04-02 03:00:00 Pacific/Apia is 2017-04-01T13:00:00Z
+                LocalDateTime.parse("2017-04-01T13:00:00"),
+                LocalDateTime.parse("2017-04-01T13:00:00.000000001"),
+                LocalDateTime.parse("2017-04-01T13:00:00.000000002"),
+                LocalDateTime.parse("2017-04-01T13:59:59.999999999"),
+                // [2017-04-01T14:00:00Z - 2017-04-01T15:00:00Z) range is not addressable with TIMESTAMP to TIMESTAMP WITH TIME ZONE cast in Pacific/Apia zone
+                LocalDateTime.parse("2017-04-01T14:00:00"),
+                LocalDateTime.parse("2017-04-01T14:00:00.000000001"),
+                LocalDateTime.parse("2017-04-01T14:00:00.000000002"),
+                LocalDateTime.parse("2017-04-01T14:59:59.999999999"),
+                // 2017-04-02 04:00:00 Pacific/Apia is 2017-04-01T15:00:00Z
+                LocalDateTime.parse("2017-04-01T15:00:00"),
+                LocalDateTime.parse("2017-04-01T15:00:00.000000001"),
+                LocalDateTime.parse("2017-04-01T15:00:00.000000002"));
+
+        for (LocalDateTime toLocalDateTime : toLocalDateTimes) {
+            for (int timestampPrecision : asList(0, 3, 6, 9, 12)) {
+                for (String operator : COMPARISON_OPERATORS) {
+                    validate(
+                            session,
+                            operator,
+                            "date",
+                            "DATE '2017-09-24'",
+                            format("timestamp(%s) with time zone", timestampPrecision),
+                            format("TIMESTAMP '%s'", DATE_TIME_FORMAT.format(toLocalDateTime)));
+                }
             }
         }
     }


### PR DESCRIPTION
## Description

Fixes #5798


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Improve performance of specific queries which compare table columns of type 
  `date` with `timestamp with time zone` literals. ({issue}`5798`)
```
