### PR TITLE
Prevent query from deadlocking when task output buffer is full

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/policy/PhasedExecutionSchedule.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/policy/PhasedExecutionSchedule.java
@@ -215,15 +215,15 @@ public class PhasedExecutionSchedule
                 .filter(dependentFragmentId -> fragmentDependency.inDegreeOf(dependentFragmentId) == 1)
                 .collect(toImmutableSet());
         fragmentDependency.removeVertex(fragmentId);
-        fragmentTopology.removeVertex(fragmentId);
         activeStages.remove(stage);
         return fragmentsToExecute;
     }
 
     private Set<PlanFragmentId> unblockStagesWithFullOutputBuffer()
     {
-        // find stages that are blocked on full task output buffer
-        Set<PlanFragmentId> blockedFragments = activeStages.stream()
+        // iterate over all stages, not only scheduled ones; stages which are scheduled but still running
+        // (e.g. partitioned stage with broadcast output buffer) might have blocked task output buffer
+        Set<PlanFragmentId> blockedFragments = stagesByFragmentId.values().stream()
                 .filter(StageExecution::isAnyTaskBlocked)
                 .map(stage -> stage.getFragment().getId())
                 .collect(toImmutableSet());


### PR DESCRIPTION
When query is of shape:

SourceStage
           \
        PartitionedStage(broadcast output buffer)
        /     \
  ProbeStage  BuildStage

Then it might happen that task output buffer for
PartitionedStage gets full blocking upstream stages (ProbeStage and BuildStage).

Previously, phased scheduled did not schedule SourceStage in such situation because PartitionedStage was already considered completed.

This commit makes PhasedExecutionSchedule#unblockStagesWithFullOutputBuffer check to be run for all stages (including scheduled, but running stages).

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
