### PR TITLE
Add failover to accessToken for OAuth2 with refresh token

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/JweTokenSerializer.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/JweTokenSerializer.java
@@ -109,7 +109,7 @@ public class JweTokenSerializer
                     claims.get(REFRESH_TOKEN_KEY, String.class));
         }
         catch (ParseException ex) {
-            throw new IllegalArgumentException("Malformed jwt token", ex);
+            return TokenPair.accessToken(token);
         }
         catch (JOSEException ex) {
             throw new IllegalArgumentException("Decryption failed", ex);

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestJweTokenSerializer.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestJweTokenSerializer.java
@@ -91,6 +91,19 @@ public class TestJweTokenSerializer
                 .isExactlyInstanceOf(ExpiredJwtException.class);
     }
 
+    @Test
+    public void testTokenDeserializationWhenNonJWETokenIsPassed()
+            throws Exception
+    {
+        JweTokenSerializer serializer = tokenSerializer(new TestingClock(), succinctDuration(12, MINUTES));
+        String nonJWEToken = "non_jwe_token";
+
+        TokenPair tokenPair = serializer.deserialize(nonJWEToken);
+
+        assertThat(tokenPair.getAccessToken()).isEqualTo(nonJWEToken);
+        assertThat(tokenPair.getRefreshToken()).isEmpty();
+    }
+
     private JweTokenSerializer tokenSerializer(Clock clock, Duration tokenExpiration)
             throws GeneralSecurityException, KeyLengthException
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Right now when we can't deserialize tokens, that we expect to be encrypted we are failing authentication and send challenges to clients. With this change we will allow for further processing, in case when the format of the token is not parsable
- meaning that it's not an JWEToken, but might be a valid OAuth2 token that could be handled by further processing.

This case occurs for cases when a tool sends valid accessToken obtained outside from Trino, but has configured Oauth2 with refresh tokens enabled, for other clients that benefit from that flow directly
<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
This allows people to send valid accessTokens through our clients, without the need to configure separate jwt authentication, which in terms allow for a single oauth2 implementation to support both direct and passthrough usages.
<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix issue with plain accessToken passthrough when only oauth2 with refresh-token is configured.
```
