### PR TITLE
Round `TimeWithTimeZone` when `supportsParametricDateTime` is `false`

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/protocol/QueryResultRows.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/QueryResultRows.java
@@ -29,9 +29,11 @@ import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.SqlTime;
+import io.trino.spi.type.SqlTimeWithTimeZone;
 import io.trino.spi.type.SqlTimestamp;
 import io.trino.spi.type.SqlTimestampWithTimeZone;
 import io.trino.spi.type.TimeType;
+import io.trino.spi.type.TimeWithTimeZoneType;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
@@ -364,6 +366,10 @@ public class QueryResultRows
 
                 if (type instanceof TimeType) {
                     return ((SqlTime) value).roundTo(3);
+                }
+
+                if (type instanceof TimeWithTimeZoneType) {
+                    return ((SqlTimeWithTimeZone) value).roundTo(3);
                 }
             }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/type/SqlTimeWithTimeZone.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/SqlTimeWithTimeZone.java
@@ -26,6 +26,7 @@ import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_SECOND;
 import static io.trino.spi.type.Timestamps.POWERS_OF_TEN;
 import static io.trino.spi.type.Timestamps.SECONDS_PER_MINUTE;
 import static io.trino.spi.type.Timestamps.rescale;
+import static io.trino.spi.type.Timestamps.round;
 import static java.lang.Math.abs;
 import static java.lang.String.format;
 
@@ -69,6 +70,11 @@ public final class SqlTimeWithTimeZone
     public int getOffsetMinutes()
     {
         return offsetMinutes;
+    }
+
+    public SqlTimeWithTimeZone roundTo(int precision)
+    {
+        return new SqlTimeWithTimeZone(precision, round(picos, 12 - precision), offsetMinutes);
     }
 
     @Override

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestSqlTime.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestSqlTime.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestSqlTime
+{
+    @Test
+    public void testToString()
+    {
+        assertThat(SqlTime.newInstance(0, 0).toString()).isEqualTo("00:00:00");
+        assertThat(SqlTime.newInstance(1, 0).toString()).isEqualTo("00:00:00.0");
+        assertThat(SqlTime.newInstance(2, 0).toString()).isEqualTo("00:00:00.00");
+        assertThat(SqlTime.newInstance(3, 0).toString()).isEqualTo("00:00:00.000");
+        assertThat(SqlTime.newInstance(4, 0).toString()).isEqualTo("00:00:00.0000");
+        assertThat(SqlTime.newInstance(5, 0).toString()).isEqualTo("00:00:00.00000");
+        assertThat(SqlTime.newInstance(6, 0).toString()).isEqualTo("00:00:00.000000");
+        assertThat(SqlTime.newInstance(7, 0).toString()).isEqualTo("00:00:00.0000000");
+        assertThat(SqlTime.newInstance(8, 0).toString()).isEqualTo("00:00:00.00000000");
+        assertThat(SqlTime.newInstance(9, 0).toString()).isEqualTo("00:00:00.000000000");
+        assertThat(SqlTime.newInstance(10, 0).toString()).isEqualTo("00:00:00.0000000000");
+        assertThat(SqlTime.newInstance(11, 0).toString()).isEqualTo("00:00:00.00000000000");
+        assertThat(SqlTime.newInstance(12, 0).toString()).isEqualTo("00:00:00.000000000000");
+    }
+
+    @Test
+    public void testRoundTo()
+    {
+        // round down
+        assertThat(SqlTime.newInstance(12, 111111111111L).roundTo(0)).isEqualTo(SqlTime.newInstance(0, 0));
+        assertThat(SqlTime.newInstance(12, 111111111111L).roundTo(1)).isEqualTo(SqlTime.newInstance(1, 100000000000L));
+        assertThat(SqlTime.newInstance(12, 111111111111L).roundTo(2)).isEqualTo(SqlTime.newInstance(2, 110000000000L));
+        assertThat(SqlTime.newInstance(12, 111111111111L).roundTo(3)).isEqualTo(SqlTime.newInstance(3, 111000000000L));
+        assertThat(SqlTime.newInstance(12, 111111111111L).roundTo(4)).isEqualTo(SqlTime.newInstance(4, 111100000000L));
+        assertThat(SqlTime.newInstance(12, 111111111111L).roundTo(5)).isEqualTo(SqlTime.newInstance(5, 111110000000L));
+        assertThat(SqlTime.newInstance(12, 111111111111L).roundTo(6)).isEqualTo(SqlTime.newInstance(6, 111111000000L));
+        assertThat(SqlTime.newInstance(12, 111111111111L).roundTo(7)).isEqualTo(SqlTime.newInstance(7, 111111100000L));
+        assertThat(SqlTime.newInstance(12, 111111111111L).roundTo(8)).isEqualTo(SqlTime.newInstance(8, 111111110000L));
+        assertThat(SqlTime.newInstance(12, 111111111111L).roundTo(9)).isEqualTo(SqlTime.newInstance(9, 111111111000L));
+        assertThat(SqlTime.newInstance(12, 111111111111L).roundTo(10)).isEqualTo(SqlTime.newInstance(10, 111111111100L));
+        assertThat(SqlTime.newInstance(12, 111111111111L).roundTo(11)).isEqualTo(SqlTime.newInstance(11, 111111111110L));
+        assertThat(SqlTime.newInstance(12, 111111111111L).roundTo(12)).isEqualTo(SqlTime.newInstance(12, 111111111111L));
+
+        // round up
+        assertThat(SqlTime.newInstance(12, 555555555555L).roundTo(0)).isEqualTo(SqlTime.newInstance(0, 1000000000000L));
+        assertThat(SqlTime.newInstance(12, 555555555555L).roundTo(1)).isEqualTo(SqlTime.newInstance(1, 600000000000L));
+        assertThat(SqlTime.newInstance(12, 555555555555L).roundTo(2)).isEqualTo(SqlTime.newInstance(2, 560000000000L));
+        assertThat(SqlTime.newInstance(12, 555555555555L).roundTo(3)).isEqualTo(SqlTime.newInstance(3, 556000000000L));
+        assertThat(SqlTime.newInstance(12, 555555555555L).roundTo(4)).isEqualTo(SqlTime.newInstance(4, 555600000000L));
+        assertThat(SqlTime.newInstance(12, 555555555555L).roundTo(5)).isEqualTo(SqlTime.newInstance(5, 555560000000L));
+        assertThat(SqlTime.newInstance(12, 555555555555L).roundTo(6)).isEqualTo(SqlTime.newInstance(6, 555556000000L));
+        assertThat(SqlTime.newInstance(12, 555555555555L).roundTo(7)).isEqualTo(SqlTime.newInstance(7, 555555600000L));
+        assertThat(SqlTime.newInstance(12, 555555555555L).roundTo(8)).isEqualTo(SqlTime.newInstance(8, 555555560000L));
+        assertThat(SqlTime.newInstance(12, 555555555555L).roundTo(9)).isEqualTo(SqlTime.newInstance(9, 555555556000L));
+        assertThat(SqlTime.newInstance(12, 555555555555L).roundTo(10)).isEqualTo(SqlTime.newInstance(10, 555555555600L));
+        assertThat(SqlTime.newInstance(12, 555555555555L).roundTo(11)).isEqualTo(SqlTime.newInstance(11, 555555555560L));
+        assertThat(SqlTime.newInstance(12, 555555555555L).roundTo(12)).isEqualTo(SqlTime.newInstance(12, 555555555555L));
+    }
+}

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestSqlTimeWithTimeZone.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestSqlTimeWithTimeZone.java
@@ -43,4 +43,38 @@ public class TestSqlTimeWithTimeZone
         assertThat(SqlTimeWithTimeZone.newInstance(12, 0, 0))
                 .isNotEqualTo(SqlTimeWithTimeZone.newInstance(12, 0, 1));
     }
+
+    @Test
+    public void testRoundTo()
+    {
+        // round down
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 111111111111L, 1).roundTo(0)).isEqualTo(SqlTimeWithTimeZone.newInstance(0, 0, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 111111111111L, 1).roundTo(1)).isEqualTo(SqlTimeWithTimeZone.newInstance(1, 100000000000L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 111111111111L, 1).roundTo(2)).isEqualTo(SqlTimeWithTimeZone.newInstance(2, 110000000000L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 111111111111L, 1).roundTo(3)).isEqualTo(SqlTimeWithTimeZone.newInstance(3, 111000000000L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 111111111111L, 1).roundTo(4)).isEqualTo(SqlTimeWithTimeZone.newInstance(4, 111100000000L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 111111111111L, 1).roundTo(5)).isEqualTo(SqlTimeWithTimeZone.newInstance(5, 111110000000L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 111111111111L, 1).roundTo(6)).isEqualTo(SqlTimeWithTimeZone.newInstance(6, 111111000000L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 111111111111L, 1).roundTo(7)).isEqualTo(SqlTimeWithTimeZone.newInstance(7, 111111100000L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 111111111111L, 1).roundTo(8)).isEqualTo(SqlTimeWithTimeZone.newInstance(8, 111111110000L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 111111111111L, 1).roundTo(9)).isEqualTo(SqlTimeWithTimeZone.newInstance(9, 111111111000L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 111111111111L, 1).roundTo(10)).isEqualTo(SqlTimeWithTimeZone.newInstance(10, 111111111100L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 111111111111L, 1).roundTo(11)).isEqualTo(SqlTimeWithTimeZone.newInstance(11, 111111111110L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 111111111111L, 1).roundTo(12)).isEqualTo(SqlTimeWithTimeZone.newInstance(12, 111111111111L, 1));
+
+        // round up
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 555555555555L, 1).roundTo(0)).isEqualTo(SqlTimeWithTimeZone.newInstance(0, 1000000000000L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 555555555555L, 1).roundTo(1)).isEqualTo(SqlTimeWithTimeZone.newInstance(1, 600000000000L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 555555555555L, 1).roundTo(2)).isEqualTo(SqlTimeWithTimeZone.newInstance(2, 560000000000L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 555555555555L, 1).roundTo(3)).isEqualTo(SqlTimeWithTimeZone.newInstance(3, 556000000000L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 555555555555L, 1).roundTo(4)).isEqualTo(SqlTimeWithTimeZone.newInstance(4, 555600000000L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 555555555555L, 1).roundTo(5)).isEqualTo(SqlTimeWithTimeZone.newInstance(5, 555560000000L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 555555555555L, 1).roundTo(6)).isEqualTo(SqlTimeWithTimeZone.newInstance(6, 555556000000L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 555555555555L, 1).roundTo(7)).isEqualTo(SqlTimeWithTimeZone.newInstance(7, 555555600000L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 555555555555L, 1).roundTo(8)).isEqualTo(SqlTimeWithTimeZone.newInstance(8, 555555560000L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 555555555555L, 1).roundTo(9)).isEqualTo(SqlTimeWithTimeZone.newInstance(9, 555555556000L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 555555555555L, 1).roundTo(10)).isEqualTo(SqlTimeWithTimeZone.newInstance(10, 555555555600L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 555555555555L, 1).roundTo(11)).isEqualTo(SqlTimeWithTimeZone.newInstance(11, 555555555560L, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 555555555555L, 1).roundTo(12)).isEqualTo(SqlTimeWithTimeZone.newInstance(12, 555555555555L, 1));
+    }
 }

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestSqlTimeWithTimeZone.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestSqlTimeWithTimeZone.java
@@ -13,12 +13,30 @@
  */
 package io.trino.spi.type;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestSqlTimeWithTimeZone
 {
+    @Test
+    public void testToString()
+    {
+        assertThat(SqlTimeWithTimeZone.newInstance(0, 0, 1).toString()).isEqualTo("00:00:00+00:01");
+        assertThat(SqlTimeWithTimeZone.newInstance(1, 0, 1).toString()).isEqualTo("00:00:00.0+00:01");
+        assertThat(SqlTimeWithTimeZone.newInstance(2, 0, 1).toString()).isEqualTo("00:00:00.00+00:01");
+        assertThat(SqlTimeWithTimeZone.newInstance(3, 0, 1).toString()).isEqualTo("00:00:00.000+00:01");
+        assertThat(SqlTimeWithTimeZone.newInstance(4, 0, 1).toString()).isEqualTo("00:00:00.0000+00:01");
+        assertThat(SqlTimeWithTimeZone.newInstance(5, 0, 1).toString()).isEqualTo("00:00:00.00000+00:01");
+        assertThat(SqlTimeWithTimeZone.newInstance(6, 0, 1).toString()).isEqualTo("00:00:00.000000+00:01");
+        assertThat(SqlTimeWithTimeZone.newInstance(7, 0, 1).toString()).isEqualTo("00:00:00.0000000+00:01");
+        assertThat(SqlTimeWithTimeZone.newInstance(8, 0, 1).toString()).isEqualTo("00:00:00.00000000+00:01");
+        assertThat(SqlTimeWithTimeZone.newInstance(9, 0, 1).toString()).isEqualTo("00:00:00.000000000+00:01");
+        assertThat(SqlTimeWithTimeZone.newInstance(10, 0, 1).toString()).isEqualTo("00:00:00.0000000000+00:01");
+        assertThat(SqlTimeWithTimeZone.newInstance(11, 0, 1).toString()).isEqualTo("00:00:00.00000000000+00:01");
+        assertThat(SqlTimeWithTimeZone.newInstance(12, 0, 1).toString()).isEqualTo("00:00:00.000000000000+00:01");
+    }
+
     @Test
     public void testEqualsDifferentZone()
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

When `PARAMETRIC_DATETIME` is not set, all temporal types should be rounded up to precision 3. However TimeWithTimeZone is not rounded.



<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Round TimeWithTimeZone values when `PARAMETRIC_DATETIME` is not set
```
