### PR TITLE
Documented differences between INTERVAL expression on Trino versus Hive

### DIFF
--- a/docs/src/main/sphinx/appendix/from-hive.rst
+++ b/docs/src/main/sphinx/appendix/from-hive.rst
@@ -110,6 +110,23 @@ Trino query::
     FROM tests
     CROSS JOIN UNNEST(scores) AS t (score);
 
+Use ANSI SQL syntax for date and time INTERVAL expressions
+----------------------------------------------------------
+
+Trino supports the ANSI SQL style ``INTERVAL`` expressions that differs from the implementation used in Hive.
+
+* The ``INTERVAL`` keyword is required and is not optional.
+* Date and time units must be singular. For example ``day`` and not ``days``.
+* Values must be quoted.
+
+Hive query::
+
+    SELECT cast('2000-08-19' as date) + 14 days;
+
+Equivalent Trino query::
+
+    SELECT cast('2000-08-19' as date) + INTERVAL '14' day;
+
 Caution with datediff
 ---------------------
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Hive uses a non-ANSI SQL syntax for date and time INTERVAL expressions. This PR contains a brief explanation of these differences and an example for comparison.


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
Added documentation to the Hive migration docs page


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
