### PR TITLE
Fix ClassCastException in DomainTranslator

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
@@ -1072,6 +1072,17 @@ public class TestDomainTranslator
                                 Range.greaterThan(VARCHAR, utf8Slice("2004"))),
                         false)));
 
+        // Regression test for https://github.com/trinodb/trino/issues/14954
+        assertPredicateTranslates(
+                greaterThan(new GenericLiteral("DATE", "2001-01-31"), cast(C_VARCHAR, DATE)),
+                tupleDomain(
+                        C_VARCHAR,
+                        Domain.create(ValueSet.ofRanges(
+                                        Range.lessThan(VARCHAR, utf8Slice("2002")),
+                                        Range.greaterThan(VARCHAR, utf8Slice("9"))),
+                                false)),
+                greaterThan(new GenericLiteral("DATE", "2001-01-31"), cast(C_VARCHAR, DATE)));
+
         // BETWEEN
         assertPredicateTranslates(
                 between(cast(C_VARCHAR, DATE), new GenericLiteral("DATE", "2001-01-31"), new GenericLiteral("DATE", "2005-09-10")),
@@ -1083,6 +1094,24 @@ public class TestDomainTranslator
                 and(
                         greaterThanOrEqual(cast(C_VARCHAR, DATE), new GenericLiteral("DATE", "2001-01-31")),
                         lessThanOrEqual(cast(C_VARCHAR, DATE), new GenericLiteral("DATE", "2005-09-10"))));
+
+        // Regression test for https://github.com/trinodb/trino/issues/14954
+        assertPredicateTranslates(
+                between(new GenericLiteral("DATE", "2001-01-31"), cast(C_VARCHAR, DATE), cast(C_VARCHAR_1, DATE)),
+                tupleDomain(
+                        C_VARCHAR,
+                        Domain.create(ValueSet.ofRanges(
+                                        Range.lessThan(VARCHAR, utf8Slice("2002")),
+                                        Range.greaterThan(VARCHAR, utf8Slice("9"))),
+                                false),
+                        C_VARCHAR_1,
+                        Domain.create(ValueSet.ofRanges(
+                                        Range.lessThan(VARCHAR, utf8Slice("1")),
+                                        Range.greaterThan(VARCHAR, utf8Slice("2000"))),
+                                false)),
+                and(
+                        greaterThanOrEqual(new GenericLiteral("DATE", "2001-01-31"), cast(C_VARCHAR, DATE)),
+                        lessThanOrEqual(new GenericLiteral("DATE", "2001-01-31"), cast(C_VARCHAR_1, DATE))));
     }
 
     @Test


### PR DESCRIPTION
When theres's an expression such as:

    CAST('2022-01-01') AS date) BETWEEN CAST(start_date AS date) AND CAST(end_date AS date)

There's a call to visitComparisonExpression with the term:

    DATE '2022-01-01' >= CAST(start_date AS date)

Inside that method, the expression is normalized to have the symbol on the left and the constant on the right. However, the createVarcharCastToDateComparisonExtractionResult pulls the elements from the unnormalized ComparisonExpression node and expects the left subexpression to be cast, which results in a failure due to ClassCastException

Fixes #14954 


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix failure for queries involving BETWEEN predicates over `varchar` columns that contain temporal data. ({issue}`14954`)
```
