### PR TITLE
Fix use of project ID in BigQuery connector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,7 +623,10 @@ jobs:
           BIGQUERY_CREDENTIALS_KEY: ${{ secrets.BIGQUERY_CREDENTIALS_KEY }}
         if: matrix.modules == 'plugin/trino-bigquery' && env.BIGQUERY_CREDENTIALS_KEY != ''
         run: |
-          $MAVEN test ${MAVEN_TEST} -pl :trino-bigquery -Pcloud-tests -Dbigquery.credentials-key="${BIGQUERY_CREDENTIALS_KEY}" -Dtesting.gcp-storage-bucket="trino-ci-test"
+          $MAVEN test ${MAVEN_TEST} -pl :trino-bigquery -Pcloud-tests \
+            -Dbigquery.credentials-key="${BIGQUERY_CREDENTIALS_KEY}" \
+            -Dtesting.gcp-storage-bucket="trino-ci-test" \
+            -Dtesting.alternate-bq-project-id=bigquery-cicd-alternate
       - name: Cloud BigQuery Case Insensitive Mapping Tests
         env:
           BIGQUERY_CASE_INSENSITIVE_CREDENTIALS_KEY: ${{ secrets.BIGQUERY_CASE_INSENSITIVE_CREDENTIALS_KEY }}

--- a/plugin/trino-bigquery/README.md
+++ b/plugin/trino-bigquery/README.md
@@ -22,6 +22,9 @@ You can follow the steps below to be able to run the integration tests locally.
   **BigQuery Admin** role assigned.
 * Get the base64 encoded text of the service account credentials file using `base64
   /path/to/service_account_credentials.json`.
-* Set the VM option `bigquery.credentials-key` and `testing.gcp-storage-bucket` in the IntelliJ "Run Configuration" (or on the CLI if using Maven
-  directly). It should look something like `-Dbigquery.credentials-key=base64-text -Dtesting.gcp-storage-bucket=DESTINATION_BUCKET_NAME`.
+* The `TestBigQueryWithDifferentProjectIdConnectorSmokeTest` requires an alternate project ID which is different from the
+  project ID attached to the service account but the service account still has access to.
+* Set the VM options `bigquery.credentials-key`, `testing.gcp-storage-bucket`, and `testing.alternate-bq-project-id` in the IntelliJ "Run Configuration"
+  (or on the CLI if using Maven directly). It should look something like
+  `-Dbigquery.credentials-key=base64-text -Dtesting.gcp-storage-bucket=DESTINATION_BUCKET_NAME -Dtesting.alternate-bq-project-id=bigquery-cicd-alternate`.
 * Run any test of your choice.

--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -387,6 +387,7 @@
                             <excludes>
                                 <!-- If you are adding entry here also add an entry to cloud-tests or cloud-tests-case-insensitive-mapping profile below -->
                                 <exclude>**/TestBigQueryConnectorTest.java</exclude>
+                                <exclude>**/TestBigQueryWithDifferentProjectIdConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestBigQueryMetadataCaching.java</exclude>
                                 <exclude>**/TestBigQueryTypeMapping.java</exclude>
                                 <exclude>**/TestBigQueryMetadata.java</exclude>
@@ -422,6 +423,7 @@
                         <configuration>
                             <includes>
                                 <include>**/TestBigQueryConnectorTest.java</include>
+                                <include>**/TestBigQueryWithDifferentProjectIdConnectorSmokeTest.java</include>
                                 <include>**/TestBigQueryMetadataCaching.java</include>
                                 <include>**/TestBigQueryTypeMapping.java</include>
                                 <include>**/TestBigQueryMetadata.java</include>

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClientFactory.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClientFactory.java
@@ -37,6 +37,7 @@ public class BigQueryClientFactory
     private final IdentityCacheMapping identityCacheMapping;
     private final BigQueryCredentialsSupplier credentialsSupplier;
     private final Optional<String> parentProjectId;
+    private final Optional<String> projectId;
     private final boolean caseInsensitiveNameMatching;
     private final ViewMaterializationCache materializationCache;
     private final HeaderProvider headerProvider;
@@ -55,6 +56,7 @@ public class BigQueryClientFactory
         this.credentialsSupplier = requireNonNull(credentialsSupplier, "credentialsSupplier is null");
         requireNonNull(bigQueryConfig, "bigQueryConfig is null");
         this.parentProjectId = bigQueryConfig.getParentProjectId();
+        this.projectId = bigQueryConfig.getProjectId();
         this.caseInsensitiveNameMatching = bigQueryConfig.isCaseInsensitiveNameMatching();
         this.materializationCache = requireNonNull(materializationCache, "materializationCache is null");
         this.headerProvider = requireNonNull(headerProvider, "headerProvider is null");
@@ -75,7 +77,7 @@ public class BigQueryClientFactory
 
     protected BigQueryClient createBigQueryClient(ConnectorSession session)
     {
-        return new BigQueryClient(createBigQuery(session), caseInsensitiveNameMatching, materializationCache, metadataCacheTtl);
+        return new BigQueryClient(createBigQuery(session), caseInsensitiveNameMatching, materializationCache, metadataCacheTtl, projectId);
     }
 
     protected BigQuery createBigQuery(ConnectorSession session)

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryWithDifferentProjectIdConnectorSmokeTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryWithDifferentProjectIdConnectorSmokeTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.BaseConnectorSmokeTest;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.TestingConnectorBehavior;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestBigQueryWithDifferentProjectIdConnectorSmokeTest
+        extends BaseConnectorSmokeTest
+{
+    private static final String ALTERNATE_PROJECT_CATALOG = "bigquery";
+    private static final String SERVICE_ACCOUNT_CATALOG = "service_account_bigquery";
+
+    protected String alternateProjectId;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        this.alternateProjectId = requireNonNull(System.getProperty("testing.alternate-bq-project-id"), "testing.alternate-bq-project-id system property not set");
+
+        QueryRunner queryRunner = BigQueryQueryRunner.createQueryRunner(
+                ImmutableMap.of(),
+                ImmutableMap.of("bigquery.project-id", alternateProjectId),
+                REQUIRED_TPCH_TABLES);
+        queryRunner.createCatalog(SERVICE_ACCOUNT_CATALOG, "bigquery", Map.of());
+        return queryRunner;
+    }
+
+    @SuppressWarnings("DuplicateBranchesInSwitch")
+    @Override
+    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
+    {
+        switch (connectorBehavior) {
+            case SUPPORTS_RENAME_SCHEMA:
+                return false;
+
+            case SUPPORTS_RENAME_TABLE:
+                return false;
+
+            default:
+                return super.hasBehavior(connectorBehavior);
+        }
+    }
+
+    @Test
+    public void testCreateSchemasInDifferentProjectIdCatalog()
+    {
+        // This test case would fail without the bug fix https://github.com/trinodb/trino/issues/14083
+        // It would create a schema in the wrong project, not the one defined in the catalog properties
+        String serviceAccountSchema = "service_account_schema" + randomNameSuffix();
+        String projectIdSchema = "project_id_schema" + randomNameSuffix();
+        try {
+            assertThat(computeActual("SHOW CATALOGS").getOnlyColumnAsSet())
+                    .contains(ALTERNATE_PROJECT_CATALOG, SERVICE_ACCOUNT_CATALOG);
+
+            assertUpdate("CREATE SCHEMA " + SERVICE_ACCOUNT_CATALOG + "." + serviceAccountSchema);
+            assertQuery("SHOW SCHEMAS FROM " + SERVICE_ACCOUNT_CATALOG + " LIKE '" + serviceAccountSchema + "'", "VALUES '" + serviceAccountSchema + "'");
+
+            assertUpdate("CREATE SCHEMA " + ALTERNATE_PROJECT_CATALOG + "." + projectIdSchema);
+            assertQuery("SHOW SCHEMAS FROM " + ALTERNATE_PROJECT_CATALOG + " LIKE '" + projectIdSchema + "'", "VALUES '" + projectIdSchema + "'");
+        }
+        finally {
+            assertUpdate("DROP SCHEMA IF EXISTS " + SERVICE_ACCOUNT_CATALOG + "." + serviceAccountSchema);
+            assertUpdate("DROP SCHEMA IF EXISTS " + ALTERNATE_PROJECT_CATALOG + "." + projectIdSchema);
+        }
+    }
+
+    @Test
+    public void testNativeQuerySelectFromTestTable()
+    {
+        String suffix = randomNameSuffix();
+        String tableName = ALTERNATE_PROJECT_CATALOG + ".test.test_select" + suffix;
+        String bigQueryTableName = "`" + alternateProjectId + "`.test.test_select" + suffix;
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (col BIGINT)");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1), (2)", 2);
+            assertQuery(
+                    "SELECT * FROM TABLE(bigquery.system.query(query => 'SELECT * FROM " + bigQueryTableName + "'))",
+                    "VALUES 1, 2");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This commit addresses an issue where multiple catalogs using the same service credentials but different project IDs attempt to create schemas and tables in either catalog. The project ID attached to the credential is used, ignoring the project ID specified in the connector configuration.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# BigQuery Connector
* Fixed an issue creating schemas and tables when using multiple catalogs with the same credentials key but different project IDs
```

Fixes https://github.com/trinodb/trino/issues/14083
