### PR TITLE
Allow replacement string to substitute against original user in impersonation

### DIFF
--- a/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
+++ b/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
@@ -19,6 +19,7 @@ import io.trino.metadata.QualifiedObjectName;
 import io.trino.plugin.base.security.DefaultSystemAccessControl;
 import io.trino.plugin.base.security.FileBasedSystemAccessControl;
 import io.trino.spi.QueryId;
+import io.trino.spi.TrinoException;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.AccessDeniedException;
@@ -116,11 +117,11 @@ public class TestFileBasedSystemAccessControl
 
         accessControlManager.checkCanImpersonateUser(Identity.ofUser("missing_replacement_group"), "anything");
         assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(Identity.ofUser("incorrect_number_of_replacements_groups_group"), "$2_group_prod"))
-                .isInstanceOf(IndexOutOfBoundsException.class)
-                .hasMessageContaining("No group 2");
+                .isInstanceOf(TrinoException.class)
+                .hasMessageContaining("new_user in impersonation rule refers to a capturing group that does not exist in original_user");
         assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(Identity.ofUser("incorrect_number_of_replacements_groups_group"), "group_group_prod"))
-                .isInstanceOf(IndexOutOfBoundsException.class)
-                .hasMessageContaining("No group 2");
+                .isInstanceOf(TrinoException.class)
+                .hasMessageContaining("new_user in impersonation rule refers to a capturing group that does not exist in original_user");
 
         AccessControlManager accessControlManagerWithPrincipal = newAccessControlManager(transactionManager, "catalog_principal.json");
         accessControlManagerWithPrincipal.checkCanImpersonateUser(Identity.ofUser("anything"), "anythingElse");

--- a/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
+++ b/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
@@ -108,9 +108,17 @@ public class TestFileBasedSystemAccessControl
         assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(Identity.ofUser("svc_tenant"), "svc_other_prod"))
                 .isInstanceOf(AccessDeniedException.class);
 
-        accessControlManager.checkCanImpersonateUser(Identity.ofUser("external_corp_dept"), "internal-corp-dept-sandbox");
+        accessControlManager.checkCanImpersonateUser(Identity.ofUser("external_corp_dept"), "internal-dept-corp-sandbox");
+        assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(Identity.ofUser("external_corp_dept"), "internal-corp-dept-sandbox"))
+                .isInstanceOf(AccessDeniedException.class);
         assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(Identity.ofUser("external_corp_dept"), "invalid"))
                 .isInstanceOf(AccessDeniedException.class);
+
+        accessControlManager.checkCanImpersonateUser(Identity.ofUser("abc_group"), "anything");
+        assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(Identity.ofUser("def_group"), "$2_group_prod"))
+                .isInstanceOf(IndexOutOfBoundsException.class);
+        assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(Identity.ofUser("def_group"), "group_group_prod"))
+                .isInstanceOf(IndexOutOfBoundsException.class);
 
         AccessControlManager accessControlManagerWithPrincipal = newAccessControlManager(transactionManager, "catalog_principal.json");
         accessControlManagerWithPrincipal.checkCanImpersonateUser(Identity.ofUser("anything"), "anythingElse");

--- a/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
+++ b/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
@@ -114,11 +114,13 @@ public class TestFileBasedSystemAccessControl
         assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(Identity.ofUser("external_corp_dept"), "invalid"))
                 .isInstanceOf(AccessDeniedException.class);
 
-        accessControlManager.checkCanImpersonateUser(Identity.ofUser("abc_group"), "anything");
-        assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(Identity.ofUser("def_group"), "$2_group_prod"))
-                .isInstanceOf(IndexOutOfBoundsException.class);
-        assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(Identity.ofUser("def_group"), "group_group_prod"))
-                .isInstanceOf(IndexOutOfBoundsException.class);
+        accessControlManager.checkCanImpersonateUser(Identity.ofUser("missing_replacement_group"), "anything");
+        assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(Identity.ofUser("incorrect_number_of_replacements_groups_group"), "$2_group_prod"))
+                .isInstanceOf(IndexOutOfBoundsException.class)
+                .hasMessageContaining("No group 2");
+        assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(Identity.ofUser("incorrect_number_of_replacements_groups_group"), "group_group_prod"))
+                .isInstanceOf(IndexOutOfBoundsException.class)
+                .hasMessageContaining("No group 2");
 
         AccessControlManager accessControlManagerWithPrincipal = newAccessControlManager(transactionManager, "catalog_principal.json");
         accessControlManagerWithPrincipal.checkCanImpersonateUser(Identity.ofUser("anything"), "anythingElse");

--- a/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
+++ b/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
@@ -102,6 +102,16 @@ public class TestFileBasedSystemAccessControl
         assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(Identity.ofUser("invalid-other"), "test"))
                 .isInstanceOf(AccessDeniedException.class);
 
+        accessControlManager.checkCanImpersonateUser(Identity.ofUser("svc_tenant"), "svc_tenant_prod");
+        assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(Identity.ofUser("svc_tenant"), "svc_tenant_other"))
+                .isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(Identity.ofUser("svc_tenant"), "svc_other_prod"))
+                .isInstanceOf(AccessDeniedException.class);
+
+        accessControlManager.checkCanImpersonateUser(Identity.ofUser("external_corp_dept"), "internal-corp-dept-sandbox");
+        assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(Identity.ofUser("external_corp_dept"), "invalid"))
+                .isInstanceOf(AccessDeniedException.class);
+
         AccessControlManager accessControlManagerWithPrincipal = newAccessControlManager(transactionManager, "catalog_principal.json");
         accessControlManagerWithPrincipal.checkCanImpersonateUser(Identity.ofUser("anything"), "anythingElse");
     }

--- a/core/trino-main/src/test/resources/catalog_impersonation.json
+++ b/core/trino-main/src/test/resources/catalog_impersonation.json
@@ -33,12 +33,12 @@
             "allow": true
         },
         {
-            "original_user": "abc_(.*)",
+            "original_user": "missing_replacement_(.*)",
             "new_user": ".*",
             "allow": true
         },
         {
-            "original_user": "def_(.*)",
+            "original_user": "incorrect_number_of_replacements_groups_(.*)",
             "new_user": "$2_$1_prod",
             "allow": true
         }

--- a/core/trino-main/src/test/resources/catalog_impersonation.json
+++ b/core/trino-main/src/test/resources/catalog_impersonation.json
@@ -29,7 +29,17 @@
         },
         {
             "original_user": "external_(.*)_(.*)",
-            "new_user": "internal-$1-$2-sandbox",
+            "new_user": "internal-$2-$1-sandbox",
+            "allow": true
+        },
+        {
+            "original_user": "abc_(.*)",
+            "new_user": ".*",
+            "allow": true
+        },
+        {
+            "original_user": "def_(.*)",
+            "new_user": "$2_$1_prod",
             "allow": true
         }
     ]

--- a/core/trino-main/src/test/resources/catalog_impersonation.json
+++ b/core/trino-main/src/test/resources/catalog_impersonation.json
@@ -21,6 +21,16 @@
         {
             "original_user": ".*",
             "new_user": "test"
+        },
+        {
+            "original_user": "svc_(.*)",
+            "new_user": "svc_$1_prod",
+            "allow": true
+        },
+        {
+            "original_user": "external_(.*)_(.*)",
+            "new_user": "internal-$1-$2-sandbox",
+            "allow": true
         }
     ]
 }

--- a/docs/src/main/sphinx/security/file-system-access-control.rst
+++ b/docs/src/main/sphinx/security/file-system-access-control.rst
@@ -544,8 +544,9 @@ Each impersonation rule is composed of the following fields:
 * ``original_role`` (optional): regex to match against role names of the
   requesting impersonation. Defaults to ``.*``.
 * ``new_user`` (required): regex to match against the user that will be
-  impersonated. Supports replacement string to substitute against
-  *original_user*.
+  impersonated. May contain references to subsequences captured during the match
+  against *original_user*, and each reference will be replaced by the result of
+  evaluating the corresponding group respectively.
 * ``allow`` (optional): boolean indicating if the authentication should be
   allowed. Defaults to ``true``.
 

--- a/docs/src/main/sphinx/security/file-system-access-control.rst
+++ b/docs/src/main/sphinx/security/file-system-access-control.rst
@@ -544,7 +544,8 @@ Each impersonation rule is composed of the following fields:
 * ``original_role`` (optional): regex to match against role names of the
   requesting impersonation. Defaults to ``.*``.
 * ``new_user`` (required): regex to match against the user that will be
-  impersonated.
+  impersonated. Supports replacement string to substitute against
+  *original_user*.
 * ``allow`` (optional): boolean indicating if the authentication should be
   allowed. Defaults to ``true``.
 
@@ -553,7 +554,9 @@ The impersonation rules are a bit different than the other rules: The attribute
 Doing so it was possible to make the attribute ``allow`` optional.
 
 The following example allows the ``admin`` role, to impersonate any user, except
-for ``bob``. It also allows any user to impersonate the ``test`` user:
+for ``bob``. It also allows any user to impersonate the ``test`` user. It also
+allows a user in the form ``team_backend`` to impersonate the
+``team_backend_sandbox`` user, but not arbitrary users:
 
 .. literalinclude:: user-impersonation.json
     :language: json

--- a/docs/src/main/sphinx/security/user-impersonation.json
+++ b/docs/src/main/sphinx/security/user-impersonation.json
@@ -12,6 +12,11 @@
         {
             "original_user": ".*",
             "new_user": "test"
+        },
+        {
+            "original_user": "team_(.*)",
+            "new_user": "team_$1_sandbox",
+            "allow": true
         }
     ]
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ImpersonationRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ImpersonationRule.java
@@ -32,7 +32,6 @@ public class ImpersonationRule
     private final Optional<Pattern> originalRolePattern;
     private final Pattern newUserPattern;
     private final boolean allow;
-    private final StringBuilder stringBuilder;
 
     @JsonCreator
     public ImpersonationRule(
@@ -45,7 +44,6 @@ public class ImpersonationRule
         this.originalRolePattern = requireNonNull(originalRolePattern, "originalRolePattern is null");
         this.newUserPattern = requireNonNull(newUserPattern, "newUserPattern is null");
         this.allow = firstNonNull(allow, TRUE);
-        this.stringBuilder = new StringBuilder();
     }
 
     public Optional<Boolean> match(String originalUser, Set<String> originalRoles, String newUser)
@@ -54,7 +52,7 @@ public class ImpersonationRule
         if (originalUserPattern.isPresent()) {
             Matcher matcher = originalUserPattern.get().matcher(originalUser);
             if (matcher.matches()) {
-                stringBuilder.setLength(0);
+                StringBuilder stringBuilder = new StringBuilder();
                 matcher.appendReplacement(stringBuilder, newUserPattern.pattern());
                 replacedNewUserPattern = Pattern.compile(stringBuilder.toString());
             }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Allow replacement string to substitute against original user in impersonation


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Support replacement string in `new_user` to substitute against `original_user` in impersonation rules. E.g., the following rule allows a user in the form team_backend to impersonate the team_backend_sandbox user, but not arbitrary users:

```
{
    "impersonation": [
        {
            "original_user": "team_(.*)",
            "new_user": "team_$1_sandbox",
            "allow": true
        }
    ]
}
```
Relevant Trino doc on impersonation: https://trino.io/docs/current/security/file-system-access-control.html#impersonation-rules

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
