### PR TITLE
Enable Hive Connector reading nested struct using name based mapping

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeColumnProjectionInfo.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeColumnProjectionInfo.java
@@ -89,7 +89,7 @@ public class DeltaLakeColumnProjectionInfo
 
     public HiveColumnProjectionInfo toHiveColumnProjectionInfo()
     {
-        return new HiveColumnProjectionInfo(dereferenceIndices, dereferencePhysicalNames, toHiveType(type), type);
+        return new HiveColumnProjectionInfo(dereferenceIndices, dereferencePhysicalNames, toHiveType(type), type, false);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveApplyProjectionUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveApplyProjectionUtil.java
@@ -62,6 +62,11 @@ public final class HiveApplyProjectionUtil
                 (expression instanceof FieldDereference fieldDereference && isPushDownSupported(fieldDereference.getTarget()));
     }
 
+    /**
+     * Generate dereference chain, by recursively referencing FieldDereference expression until the expression became variable type
+     *
+     * @return ProjectedColumnRepresentation records the child variable types and sequences of indexes that used in the lookup
+     */
     public static ProjectedColumnRepresentation createProjectedColumnRepresentation(ConnectorExpression expression)
     {
         ImmutableList.Builder<Integer> ordinals = ImmutableList.builder();
@@ -160,6 +165,7 @@ public final class HiveApplyProjectionUtil
     public static class ProjectedColumnRepresentation
     {
         private final Variable variable;
+        // sequence of indexes to do the lookup from the top level column until it became the primitive variable
         private final List<Integer> dereferenceIndices;
 
         public ProjectedColumnRepresentation(Variable variable, List<Integer> dereferenceIndices)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveColumnProjectionInfo.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveColumnProjectionInfo.java
@@ -30,22 +30,28 @@ import static java.util.Objects.requireNonNull;
 public class HiveColumnProjectionInfo
 {
     private static final int INSTANCE_SIZE = instanceSize(HiveColumnProjectionInfo.class);
-
     private final List<Integer> dereferenceIndices;
     private final List<String> dereferenceNames;
     private final HiveType hiveType;
     private final Type type;
     private final String partialName;
 
+    /**
+     * using dereferenceNames for dereferencing, the order might be different from {@link #getDereferenceIndices()}
+     */
+    private final boolean nestedStructNameBasedMapping;
+
     @JsonCreator
     public HiveColumnProjectionInfo(
             @JsonProperty("dereferenceIndices") List<Integer> dereferenceIndices,
             @JsonProperty("dereferenceNames") List<String> dereferenceNames,
             @JsonProperty("hiveType") HiveType hiveType,
-            @JsonProperty("type") Type type)
+            @JsonProperty("type") Type type,
+            @JsonProperty("nestedStructNameBasedMapping") boolean nestedStructNameBasedMapping)
     {
         this.dereferenceIndices = requireNonNull(dereferenceIndices, "dereferenceIndices is null");
         this.dereferenceNames = requireNonNull(dereferenceNames, "dereferenceNames is null");
+
         checkArgument(dereferenceIndices.size() > 0, "dereferenceIndices should not be empty");
         checkArgument(dereferenceIndices.size() == dereferenceNames.size(), "dereferenceIndices and dereferenceNames should have the same sizes");
 
@@ -53,6 +59,7 @@ public class HiveColumnProjectionInfo
         this.type = requireNonNull(type, "type is null");
 
         this.partialName = generatePartialName(dereferenceNames);
+        this.nestedStructNameBasedMapping = nestedStructNameBasedMapping;
     }
 
     public String getPartialName()
@@ -76,6 +83,12 @@ public class HiveColumnProjectionInfo
     public HiveType getHiveType()
     {
         return hiveType;
+    }
+
+    @JsonProperty
+    public boolean isNestedStructNameBasedMapping()
+    {
+        return nestedStructNameBasedMapping;
     }
 
     @JsonProperty

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -3085,7 +3085,8 @@ public class HiveMetadata
                         .addAll(oldHiveType.getHiveDereferenceNames(indices))
                         .build(),
                 newHiveType,
-                newHiveType.getType(typeManager));
+                newHiveType.getType(typeManager),
+                false);
 
         return new HiveColumnHandle(
                 column.getBaseColumnName(),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
@@ -438,7 +438,7 @@ public class HiveSplitManager
             HiveType tableType = tableColumns.get(i).getType();
             HiveType partitionType = partitionColumns.get(i).getType();
             if (!tableType.equals(partitionType)) {
-                if (!canCoerce(typeManager, partitionType, tableType, hiveTimestampPrecision)) {
+                if (!canCoerce(typeManager, partitionType, tableType, hiveTimestampPrecision, false)) {
                     throw tablePartitionColumnMismatchException(tableName, partName, tableColumns.get(i).getName(), tableType, partitionColumns.get(i).getName(), partitionType);
                 }
                 columnCoercions.put(i, partitionType.getHiveTypeName());
@@ -481,14 +481,14 @@ public class HiveSplitManager
             Column partitionColumn = partitionColumns.get(partitionColumnIndex);
             HiveType partitionType = partitionColumn.getType();
             if (!tableType.equals(partitionType)) {
-                if (!canCoerce(typeManager, partitionType, tableType, hiveTimestampPrecision)) {
+                if (!canCoerce(typeManager, partitionType, tableType, hiveTimestampPrecision, true)) {
                     throw tablePartitionColumnMismatchException(tableName, partName, tableColumn.getName(), tableType, partitionColumn.getName(), partitionType);
                 }
                 columnCoercions.put(partitionColumnIndex, partitionType.getHiveTypeName());
             }
         }
 
-        return new TableToPartitionMapping(Optional.of(tableToPartitionColumns.buildOrThrow()), columnCoercions.buildOrThrow());
+        return new TableToPartitionMapping(Optional.of(tableToPartitionColumns.buildOrThrow()), columnCoercions.buildOrThrow(), true);
     }
 
     private static TrinoException tablePartitionColumnMismatchException(SchemaTableName tableName, String partName, String tableColumnName, HiveType tableType, String partitionColumnName, HiveType partitionType)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TableToPartitionMapping.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TableToPartitionMapping.java
@@ -32,12 +32,12 @@ public class TableToPartitionMapping
 {
     public static TableToPartitionMapping empty()
     {
-        return new TableToPartitionMapping(Optional.empty(), ImmutableMap.of());
+        return new TableToPartitionMapping(Optional.empty(), ImmutableMap.of(), false);
     }
 
     public static TableToPartitionMapping mapColumnsByIndex(Map<Integer, HiveTypeName> columnCoercions)
     {
-        return new TableToPartitionMapping(Optional.empty(), columnCoercions);
+        return new TableToPartitionMapping(Optional.empty(), columnCoercions, false);
     }
 
     // Overhead of ImmutableMap is not accounted because of its complexity.
@@ -48,10 +48,13 @@ public class TableToPartitionMapping
     private final Optional<Map<Integer, Integer>> tableToPartitionColumns;
     private final Map<Integer, HiveTypeName> partitionColumnCoercions;
 
+    private final boolean nestedStructNameBasedMapping;
+
     @JsonCreator
     public TableToPartitionMapping(
             @JsonProperty("tableToPartitionColumns") Optional<Map<Integer, Integer>> tableToPartitionColumns,
-            @JsonProperty("partitionColumnCoercions") Map<Integer, HiveTypeName> partitionColumnCoercions)
+            @JsonProperty("partitionColumnCoercions") Map<Integer, HiveTypeName> partitionColumnCoercions,
+            @JsonProperty("nestedStructNameBasedMapping") boolean nestedStructNameBasedMapping)
     {
         if (tableToPartitionColumns.map(TableToPartitionMapping::isIdentityMapping).orElse(true)) {
             this.tableToPartitionColumns = Optional.empty();
@@ -60,6 +63,7 @@ public class TableToPartitionMapping
             this.tableToPartitionColumns = tableToPartitionColumns.map(ImmutableMap::copyOf);
         }
         this.partitionColumnCoercions = ImmutableMap.copyOf(requireNonNull(partitionColumnCoercions, "partitionColumnCoercions is null"));
+        this.nestedStructNameBasedMapping = nestedStructNameBasedMapping;
     }
 
     @VisibleForTesting
@@ -77,6 +81,12 @@ public class TableToPartitionMapping
     public Map<Integer, HiveTypeName> getPartitionColumnCoercions()
     {
         return partitionColumnCoercions;
+    }
+
+    @JsonProperty
+    public boolean isNestedStructNameBasedMapping()
+    {
+        return nestedStructNameBasedMapping;
     }
 
     @JsonProperty
@@ -117,6 +127,7 @@ public class TableToPartitionMapping
         return toStringHelper(this)
                 .add("columnCoercions", partitionColumnCoercions)
                 .add("tableToPartitionColumns", tableToPartitionColumns)
+                .add("nestedStructNameBasedMapping", nestedStructNameBasedMapping)
                 .toString();
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileFormats.java
@@ -517,7 +517,8 @@ public abstract class AbstractTestHiveFileFormats
                                 testColumn.getDereferenceIndices(),
                                 testColumn.getDereferenceNames(),
                                 partialHiveType,
-                                partialHiveType.getType(TESTING_TYPE_MANAGER))),
+                                partialHiveType.getType(TESTING_TYPE_MANAGER),
+                                false)),
                         testColumn.isPartitionKey() ? PARTITION_KEY : REGULAR,
                         Optional.empty());
                 columns.add(hiveColumnHandle);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveColumnHandle.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveColumnHandle.java
@@ -70,7 +70,8 @@ public class TestHiveColumnHandle
                 ImmutableList.of(1),
                 ImmutableList.of("b"),
                 HiveType.HIVE_LONG,
-                BIGINT);
+                BIGINT,
+                false);
 
         HiveColumnHandle projectedColumn = new HiveColumnHandle(
                 "struct_col",

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveReaderProjectionsUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveReaderProjectionsUtil.java
@@ -70,9 +70,10 @@ public class TestHiveReaderProjectionsUtil
 
         HiveType baseHiveType = column.getHiveType();
         List<String> names = baseHiveType.getHiveDereferenceNames(indices);
+        // todo: test
         HiveType hiveType = baseHiveType.getHiveTypeForDereferences(indices).get();
 
-        HiveColumnProjectionInfo columnProjection = new HiveColumnProjectionInfo(indices, names, hiveType, hiveType.getType(TESTING_TYPE_MANAGER));
+        HiveColumnProjectionInfo columnProjection = new HiveColumnProjectionInfo(indices, names, hiveType, hiveType.getType(TESTING_TYPE_MANAGER), false);
 
         return new HiveColumnHandle(
                 column.getBaseColumnName(),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestTimestampCoercer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestTimestampCoercer.java
@@ -141,7 +141,7 @@ public class TestTimestampCoercer
 
     public static void assertCoercions(Type fromType, Object valueToBeCoerced, Type toType, Object expectedValue, HiveTimestampPrecision timestampPrecision)
     {
-        Block coercedValue = createCoercer(TESTING_TYPE_MANAGER, toHiveType(fromType), toHiveType(toType), timestampPrecision).orElseThrow()
+        Block coercedValue = createCoercer(TESTING_TYPE_MANAGER, toHiveType(fromType), toHiveType(toType), timestampPrecision, false).orElseThrow()
                 .apply(nativeValueToBlock(fromType, valueToBeCoerced));
         assertThat(blockToNativeValue(toType, coercedValue))
                 .isEqualTo(expectedValue);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
@@ -144,7 +144,8 @@ public class TestConnectorPushdownRulesWithHive
                         ImmutableList.of(0),
                         ImmutableList.of("a"),
                         toHiveType(BIGINT),
-                        BIGINT)),
+                        BIGINT,
+                        false)),
                 REGULAR,
                 Optional.empty());
 
@@ -300,7 +301,8 @@ public class TestConnectorPushdownRulesWithHive
                         ImmutableList.of(0),
                         ImmutableList.of("a"),
                         toHiveType(BIGINT),
-                        BIGINT)),
+                        BIGINT,
+                        false)),
                 REGULAR,
                 Optional.empty());
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetPageSourceFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetPageSourceFactory.java
@@ -56,7 +56,8 @@ public class TestParquetPageSourceFactory
                         ImmutableList.of(1, 1),
                         ImmutableList.of("optional_level2", "required_level3"),
                         toHiveType(IntegerType.INTEGER),
-                        IntegerType.INTEGER)),
+                        IntegerType.INTEGER,
+                        false)),
                 REGULAR,
                 Optional.empty());
         MessageType fileSchema = new MessageType(

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/predicate/TestParquetPredicateUtils.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/predicate/TestParquetPredicateUtils.java
@@ -142,7 +142,8 @@ public class TestParquetPredicateUtils
                 ImmutableList.of(1),
                 ImmutableList.of("b"),
                 HiveType.HIVE_INT,
-                INTEGER);
+                INTEGER,
+                false);
 
         HiveColumnHandle projectedColumn = new HiveColumnHandle(
                 "row_field",
@@ -183,7 +184,8 @@ public class TestParquetPredicateUtils
                 ImmutableList.of(2),
                 ImmutableList.of("C"),
                 HiveType.toHiveType(c1Type),
-                c1Type);
+                c1Type,
+                false);
 
         HiveColumnHandle projectedColumn = new HiveColumnHandle(
                 "row_field",
@@ -223,7 +225,8 @@ public class TestParquetPredicateUtils
                 ImmutableList.of(2),
                 ImmutableList.of("non_exist"),
                 HiveType.HIVE_INT,
-                INTEGER);
+                INTEGER,
+                false);
 
         HiveColumnHandle projectedColumn = new HiveColumnHandle(
                 "row_field",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description


This PR addressed an issue when doing coercion between Trino nested row types and hive nested struct types. Currently, for the mentioned coercion, new fields can only be added at the end of the row type. And fields that are coercible must have the same index in the Trino nested row type.

The current policy prevents users from reading hive partitions, which containing struct fields that are added with fields in the middle of the struct . This PR enables Trino doing coercion via name based mapping, such that new fields can be added in the middle of struct and fields with same name will be coerced regardless if they have same index within the hive nested struct. 

Trino's current hive coercion policy for struct:
```
// Rule:
// * Fields may be added or dropped from the end.
// * For all other field indices, the corresponding fields must have
//   the same name, and the type must be coercible.
```
And the newly proposed policy is: 
```
// Rule:
// * Fields may be added or dropped
// * For all other field with the same name, the corresponding fields must have
//   the same name, and the type must be coercible.
```
For top-level columns, Trino can be configured to use name based or index based coercion based on file type, such as:
<img width="1093" alt="2023-06-16_08-14-45" src="https://github.com/trinodb/trino/assets/4726688/d2f46b93-1cc2-4110-86d3-4ee715f2adb1">


This feature followed the same pattern, via configuring should Trino use name based mapping for different columns, the configuration further enabled Trino using name based mapping for different fields within the same nested column. 

For example, on ORC type, this feature can be turned on and off via configuring session property:` hive.orc_use_column_names`. For AVRO, since we always use column name for coercion, this feature is also always on.



<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Enable Hive Connector reading nested struct using name based mapping 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
