### PR TITLE
Fix failure when BigQuery row access policy return empty result

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryStoragePageSource.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryStoragePageSource.java
@@ -135,6 +135,9 @@ public class BigQueryStoragePageSource
     public Page getNextPage()
     {
         checkState(pageBuilder.isEmpty(), "PageBuilder is not empty at the beginning of a new page");
+        if (!responses.hasNext()) {
+            return null;
+        }
         ReadRowsResponse response = responses.next();
         Iterable<GenericRecord> records = parse(response);
         for (GenericRecord record : records) {

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
@@ -37,6 +37,7 @@ import static io.trino.plugin.bigquery.BigQueryQueryRunner.BigQuerySqlExecutor;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.MaterializedResult.resultBuilder;
 import static io.trino.testing.assertions.Assert.assertEquals;
+import static io.trino.testing.assertions.Assert.assertEventually;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -421,6 +422,38 @@ public class TestBigQueryConnectorTest
             onBigQuery("INSERT INTO " + table.getName() + " VALUES ('a', 1, '2021-01-01')");
             // Adding a CAST makes BigQuery return columns in a different order
             assertQuery("SELECT c_varchar, CAST(c_int AS SMALLINT), c_date FROM " + table.getName(), "VALUES ('a', 1, '2021-01-01')");
+        }
+    }
+
+    @Test
+    public void testSelectTableWithRowAccessPolicyFilterAll()
+    {
+        String policyName = "test_policy" + randomTableSuffix();
+        try (TestTable table = new TestTable(this::onBigQuery, "test.test_row_access_policy", "AS SELECT 1 col")) {
+            assertQuery("SELECT * FROM " + table.getName(), "VALUES 1");
+
+            // Use assertEventually because there's delay until new row access policies become effective
+            onBigQuery("CREATE ROW ACCESS POLICY " + policyName + " ON " + table.getName() + " FILTER USING (true)");
+            assertEventually(() -> assertQueryReturnsEmptyResult("SELECT * FROM " + table.getName()));
+
+            onBigQuery("DROP ALL ROW ACCESS POLICIES ON " + table.getName());
+            assertEventually(() -> assertQuery("SELECT * FROM " + table.getName(), "VALUES 1"));
+        }
+    }
+
+    @Test
+    public void testSelectTableWithRowAccessPolicyFilterPartialRow()
+    {
+        String policyName = "test_policy" + randomTableSuffix();
+        try (TestTable table = new TestTable(this::onBigQuery, "test.test_row_access_policy", "AS (SELECT 1 col UNION ALL SELECT 2 col)")) {
+            assertQuery("SELECT * FROM " + table.getName(), "VALUES (1), (2)");
+
+            // Use assertEventually because there's delay until new row access policies become effective
+            onBigQuery("CREATE ROW ACCESS POLICY " + policyName + " ON " + table.getName() + " GRANT TO (\"allAuthenticatedUsers\") FILTER USING (col = 1)");
+            assertEventually(() -> assertQuery("SELECT * FROM " + table.getName(), "VALUES 1"));
+
+            onBigQuery("DROP ALL ROW ACCESS POLICIES ON " + table.getName());
+            assertEventually(() -> assertQuery("SELECT * FROM " + table.getName(), "VALUES (1), (2)"));
         }
     }
 


### PR DESCRIPTION
## Description

Fixes #14760

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# BigQuery
* Fix failure when [row access policy](https://cloud.google.com/bigquery/docs/row-level-security-intro) returns an empty result. ({issue}`14760`)
```
