### PR TITLE
Enable authorizedDatabases & authorizedCollections for fetching metadata in MongoDB

### DIFF
--- a/plugin/trino-mongodb/pom.xml
+++ b/plugin/trino-mongodb/pom.xml
@@ -198,6 +198,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/AuthenticatedMongoServer.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/AuthenticatedMongoServer.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.mongodb.ConnectionString;
+import org.bson.Document;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.io.Closeable;
+
+import static java.util.Objects.requireNonNull;
+
+public class AuthenticatedMongoServer
+        implements Closeable
+{
+    private static final int MONGODB_INTERNAL_PORT = 27017;
+    private static final String ROOT_USER = "root";
+    private static final String ROOT_PASSWORD = "password";
+    private static final String TEST_USER = "testUser";
+    private static final String TEST_PASSWORD = "pass";
+    private static final String TEST_ROLE = "testRole";
+    public static final String TEST_DATABASE = "test";
+    public static final String TEST_COLLECTION = "testCollection";
+    private final GenericContainer<?> dockerContainer;
+
+    public AuthenticatedMongoServer(String mongoVersion)
+    {
+        dockerContainer = new GenericContainer<>("mongo:" + requireNonNull(mongoVersion, "mongoVersion is null"))
+                .withStartupAttempts(3)
+                .waitingFor(Wait.forLogMessage(".*Listening on 0\\.0\\.0\\.0.*", 1))
+                .withEnv("MONGO_INITDB_ROOT_USERNAME", ROOT_USER)
+                .withEnv("MONGO_INITDB_ROOT_PASSWORD", ROOT_PASSWORD)
+                .withEnv("MONGO_INITDB_DATABASE", "admin")
+                .withExposedPorts(MONGODB_INTERNAL_PORT)
+                .withCommand("--auth --bind_ip 0.0.0.0");
+        dockerContainer.start();
+    }
+
+    public ConnectionString rootUserConnectionString()
+    {
+        return new ConnectionString("mongodb://%s:%s@%s:%d".formatted(
+                ROOT_USER,
+                ROOT_PASSWORD,
+                dockerContainer.getHost(),
+                dockerContainer.getMappedPort(MONGODB_INTERNAL_PORT)));
+    }
+
+    public ConnectionString testUserConnectionString()
+    {
+        return new ConnectionString("mongodb://%s:%s@%s:%d/%s".formatted(
+                TEST_USER,
+                TEST_PASSWORD,
+                dockerContainer.getHost(),
+                dockerContainer.getMappedPort(MONGODB_INTERNAL_PORT),
+                TEST_DATABASE));
+    }
+
+    public static Document createTestRole()
+    {
+        return new Document(ImmutableMap.of(
+                "createRole", TEST_ROLE,
+                "privileges", ImmutableList.of(privilege("_schema"), privilege(TEST_COLLECTION)),
+                "roles", ImmutableList.of()));
+    }
+
+    private static Document privilege(String collectionName)
+    {
+        return new Document(ImmutableMap.of(
+                "resource", resource(collectionName),
+                "actions", ImmutableList.of("find")));
+    }
+
+    private static Document resource(String collectionName)
+    {
+        return new Document(ImmutableMap.of(
+                "db", TEST_DATABASE,
+                "collection", collectionName));
+    }
+
+    public static Document createTestUser()
+    {
+        return new Document(ImmutableMap.of(
+                "createUser", TEST_USER,
+                "pwd", TEST_PASSWORD,
+                "roles", ImmutableList.of(role())));
+    }
+
+    private static Document role()
+    {
+        return new Document(ImmutableMap.of(
+                "role", TEST_ROLE,
+                "db", TEST_DATABASE));
+    }
+
+    @Override
+    public void close()
+    {
+        dockerContainer.close();
+    }
+}

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.mongodb.DBRef;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.CreateCollectionOptions;
 import io.trino.sql.planner.plan.LimitNode;
@@ -822,6 +823,17 @@ public class TestMongoConnectorTest
                 "ALTER TABLE " + sourceTableName + " RENAME TO \"" + targetTableName + "\"",
                 "Qualified identifier name must be shorter than or equal to '120' bytes: .*");
         assertUpdate("DROP TABLE \"" + sourceTableName + "\"");
+    }
+
+    @Test
+    public void testListTablesFromSchemaWithBigAmountOfTables()
+    {
+        MongoDatabase database = client.getDatabase("huge_schema");
+        for (int i = 0; i < 10_000; i++) {
+            database.createCollection("table_" + i);
+        }
+
+        assertThat(getQueryRunner().execute("SHOW TABLES FROM mongodb.huge_schema").getRowCount()).isEqualTo(10_000);
     }
 
     @Override

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoPrivileges.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoPrivileges.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb;
+
+import com.google.common.collect.ImmutableMap;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoDatabase;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.bson.Document;
+import org.testng.annotations.Test;
+
+import java.util.Locale;
+import java.util.Optional;
+
+import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.trino.plugin.mongodb.AuthenticatedMongoServer.TEST_COLLECTION;
+import static io.trino.plugin.mongodb.AuthenticatedMongoServer.TEST_DATABASE;
+import static io.trino.plugin.mongodb.AuthenticatedMongoServer.createTestRole;
+import static io.trino.plugin.mongodb.AuthenticatedMongoServer.createTestUser;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestMongoPrivileges
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        AuthenticatedMongoServer mongoServer = closeAfterClass(setupMongoServer());
+        return createMongoQueryRunner(mongoServer.testUserConnectionString().getConnectionString());
+    }
+
+    @Test
+    public void testTablesVisibility()
+    {
+        assertQuery("SHOW TABLES FROM mongodb." + TEST_DATABASE, "VALUES '%s'".formatted(TEST_COLLECTION.toLowerCase(Locale.ENGLISH)));
+    }
+
+    private static AuthenticatedMongoServer setupMongoServer()
+    {
+        AuthenticatedMongoServer mongoServer = new AuthenticatedMongoServer("4.2.0");
+        try (MongoClient client = MongoClients.create(mongoServer.rootUserConnectionString())) {
+            MongoDatabase testDatabase = client.getDatabase(TEST_DATABASE);
+            runCommand(testDatabase, createTestRole());
+            runCommand(testDatabase, createTestUser());
+            testDatabase.createCollection("_schema");
+            testDatabase.createCollection(TEST_COLLECTION);
+            testDatabase.createCollection("anotherCollection"); // this collection/table should not be visible
+            client.getDatabase("another").createCollection("_schema"); // this database/schema should not be visible
+        }
+        return mongoServer;
+    }
+
+    private static void runCommand(MongoDatabase database, Document document)
+    {
+        Double commandStatus = database.runCommand(document)
+                .get("ok", Double.class);
+        assertThat(commandStatus).isEqualTo(1.0);
+    }
+
+    private static DistributedQueryRunner createMongoQueryRunner(String connectionUrl)
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = null;
+        try {
+            queryRunner = DistributedQueryRunner.builder(testSessionBuilder()
+                            .setCatalog(Optional.empty())
+                            .setSchema(Optional.empty())
+                            .build())
+                    .build();
+            queryRunner.installPlugin(new MongoPlugin());
+            queryRunner.createCatalog("mongodb", "mongodb", ImmutableMap.of(
+                    "mongodb.case-insensitive-name-matching", "true",
+                    "mongodb.connection-url", connectionUrl));
+            return queryRunner;
+        }
+        catch (Throwable e) {
+            closeAllSuppress(e, queryRunner);
+            throw e;
+        }
+    }
+}

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoPrivileges.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoPrivileges.java
@@ -46,6 +46,12 @@ public class TestMongoPrivileges
     }
 
     @Test
+    public void testSchemasVisibility()
+    {
+        assertQuery("SHOW SCHEMAS FROM mongodb", "VALUES 'information_schema','%s'".formatted(TEST_DATABASE));
+    }
+
+    @Test
     public void testTablesVisibility()
     {
         assertQuery("SHOW TABLES FROM mongodb." + TEST_DATABASE, "VALUES '%s'".formatted(TEST_COLLECTION.toLowerCase(Locale.ENGLISH)));


### PR DESCRIPTION
## Description
Enable authorizedDatabases & authorizedCollections for fetching metadata in MongoDB

## Fixes
https://github.com/trinodb/trino/issues/1398

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# MongoDB
* Fix failure when an unauthorized exception happens while listing schemas or tables. ({issue}`1398`)
```
