### PR TITLE
Suppress access denied exception when listing all tables/views in a Glue database

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -23,6 +23,7 @@ import com.amazonaws.handlers.RequestHandler2;
 import com.amazonaws.metrics.RequestMetricCollector;
 import com.amazonaws.services.glue.AWSGlueAsync;
 import com.amazonaws.services.glue.AWSGlueAsyncClientBuilder;
+import com.amazonaws.services.glue.model.AccessDeniedException;
 import com.amazonaws.services.glue.model.AlreadyExistsException;
 import com.amazonaws.services.glue.model.BatchCreatePartitionRequest;
 import com.amazonaws.services.glue.model.BatchCreatePartitionResult;
@@ -427,8 +428,8 @@ public class GlueHiveMetastore
                     .collect(toImmutableList());
             return tableNames;
         }
-        catch (EntityNotFoundException e) {
-            // database does not exist
+        catch (EntityNotFoundException | AccessDeniedException e) {
+            // database does not exist or permission denied
             return ImmutableList.of();
         }
         catch (AmazonServiceException e) {
@@ -461,8 +462,8 @@ public class GlueHiveMetastore
                     .collect(toImmutableList());
             return views;
         }
-        catch (EntityNotFoundException e) {
-            // database does not exist
+        catch (EntityNotFoundException | AccessDeniedException e) {
+            // database does not exist or permission denied
             return ImmutableList.of();
         }
         catch (AmazonServiceException e) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description


Fix https://github.com/trinodb/trino/issues/14746

As per offline discussion due to difficulties which may be caused by the fact that the permission policy for the Glue database which has `glue:GetTables` permission denied we've decided to put up this PR without corresponding tests. Do note however that the PR changes have been locally tested against AWS Glue.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Suppress access denied exception when listing all tables/views in a Glue database
```
