### PR TITLE
Add an example JDBC connector plugin

### DIFF
--- a/docs/src/main/sphinx/develop.rst
+++ b/docs/src/main/sphinx/develop.rst
@@ -10,6 +10,7 @@ This guide is intended for Trino contributors and plugin developers.
     develop/spi-overview
     develop/connectors
     develop/example-http
+    develop/example-jdbc
     develop/insert
     develop/supporting-merge
     develop/types

--- a/docs/src/main/sphinx/develop/example-jdbc.rst
+++ b/docs/src/main/sphinx/develop/example-jdbc.rst
@@ -1,0 +1,72 @@
+======================
+Example JDBC connector
+======================
+
+The Example JDBC connector shows how to extend the base ``JdbcPlugin``
+to read data from a source using a JDBC driver, without having
+to implement different Trino SPI services, like ``ConnectorMetadata``
+or ``ConnectorRecordSetProvider``.
+
+.. note::
+
+  This connector is just an example. It supports a very limited set of data
+  types and does not support any advanced functions, like predicacte or other
+  kind of pushdowns.
+
+Code
+----
+
+The Example JDBC connector can be found in the `trino-example-jdbc
+<https://github.com/trinodb/trino/tree/master/plugin/trino-example-jdbc>`_
+directory within the Trino source tree.
+
+Plugin implementation
+---------------------
+
+The plugin implementation in the Example JDBC connector extends
+the ``JdbcPlugin`` class and uses the ``ExampleClientModule``.
+
+The module:
+
+* binds the ``ExampleClient`` class so it can be used by the base JDBC
+  connector;
+* provides a connection factory that will create new connections using a JDBC
+  driver based on the JDBC URL specified in configuration properties.
+
+JdbcClient implementation
+-------------------------
+
+The base JDBC plugin maps the Trino SPI calls to the JDBC API. Operations like
+reading table and columns names are well defined in JDBC so the base JDBC plugin
+can implement it in a way that works for most JDBC drivers.
+
+One behavior that is not implemented by default is mapping of the data types
+when reading and writing data. The Example JDBC connector implements
+the ``JdbcClient`` interface in the ``ExampleClient`` class that extends
+the ``BaseJdbcClient`` and implements two methods.
+
+toColumnMapping
+^^^^^^^^^^^^^^^
+
+``toColumnMapping`` is used when reading data from the connector.
+Given a ``ConnectorSession``, ``Connection`` and a ``JdbcTypeHandle``,
+it returns a ``ColumnMapping``, if there is a matching data type.
+
+The column mapping includes:
+
+* a Trino type,
+* a write function, used to set query parameter values when preparing a
+  JDBC statement to execute in the data source,
+* and a read function, used to read a value from the JDBC statement result set,
+  and return it using an internal Trino representation (for example, a Slice).
+
+toWriteMapping
+^^^^^^^^^^^^^^
+
+``toWriteMapping`` is used when writing data to the connector. Given a
+``ConnectorSession`` and a Trino type, it returns a ``WriteMapping``.
+
+The mapping includes:
+
+* a data type name
+* a write function

--- a/plugin/trino-example-jdbc/pom.xml
+++ b/plugin/trino-example-jdbc/pom.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.trino</groupId>
+        <artifactId>trino-root</artifactId>
+        <version>411-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>trino-example-jdbc</artifactId>
+    <description>Trino - Example JDBC Connector</description>
+    <packaging>trino-plugin</packaging>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-base-jdbc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <!-- used by tests but also needed transitively -->
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Trino SPI -->
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>http-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty.toolchain</groupId>
+            <artifactId>jetty-servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/plugin/trino-example-jdbc/src/main/java/io/trino/plugin/example/ExampleClient.java
+++ b/plugin/trino-example-jdbc/src/main/java/io/trino/plugin/example/ExampleClient.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.example;
+
+import io.trino.plugin.jdbc.BaseJdbcClient;
+import io.trino.plugin.jdbc.BaseJdbcConfig;
+import io.trino.plugin.jdbc.ColumnMapping;
+import io.trino.plugin.jdbc.ConnectionFactory;
+import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.QueryBuilder;
+import io.trino.plugin.jdbc.WriteMapping;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
+import io.trino.plugin.jdbc.mapping.IdentifierMapping;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+
+import javax.inject.Inject;
+
+import java.sql.Connection;
+import java.sql.Types;
+import java.util.Optional;
+
+import static io.trino.plugin.jdbc.PredicatePushdownController.DISABLE_PUSHDOWN;
+import static io.trino.plugin.jdbc.StandardColumnMappings.bigintColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.bigintWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.charReadFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.charWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.doubleColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.doubleWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.integerColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.integerWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.realColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.realWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.smallintColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.smallintWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.varcharReadFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
+import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.getUnsupportedTypeHandling;
+import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.CharType.createCharType;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+
+public class ExampleClient
+        extends BaseJdbcClient
+{
+    @Inject
+    public ExampleClient(
+            BaseJdbcConfig config,
+            ConnectionFactory connectionFactory,
+            QueryBuilder queryBuilder,
+            IdentifierMapping identifierMapping,
+            RemoteQueryModifier remoteQueryModifier)
+    {
+        super("\"", connectionFactory, queryBuilder, config.getJdbcTypesMappedToVarchar(), identifierMapping, remoteQueryModifier, true);
+    }
+
+    @Override
+    public Optional<ColumnMapping> toColumnMapping(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
+    {
+        Optional<ColumnMapping> mapping = getForcedMappingToVarchar(typeHandle);
+        if (mapping.isPresent()) {
+            return mapping;
+        }
+        switch (typeHandle.getJdbcType()) {
+            case Types.SMALLINT:
+                return Optional.of(smallintColumnMapping());
+
+            case Types.INTEGER:
+                return Optional.of(integerColumnMapping());
+
+            case Types.BIGINT:
+                return Optional.of(bigintColumnMapping());
+
+            case Types.REAL:
+                return Optional.of(realColumnMapping());
+
+            case Types.DOUBLE:
+                return Optional.of(doubleColumnMapping());
+
+            case Types.CHAR:
+                return Optional.of(charColumnMapping(typeHandle.getRequiredColumnSize()));
+
+            case Types.VARCHAR:
+                return Optional.of(varcharColumnMapping(typeHandle.getRequiredColumnSize()));
+        }
+
+        if (getUnsupportedTypeHandling(session) == CONVERT_TO_VARCHAR) {
+            return mapToUnboundedVarchar(typeHandle);
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public WriteMapping toWriteMapping(ConnectorSession session, Type type)
+    {
+        if (type == SMALLINT) {
+            return WriteMapping.longMapping("smallint", smallintWriteFunction());
+        }
+        if (type == INTEGER) {
+            return WriteMapping.longMapping("integer", integerWriteFunction());
+        }
+        if (type == BIGINT) {
+            return WriteMapping.longMapping("bigint", bigintWriteFunction());
+        }
+
+        if (type == REAL) {
+            return WriteMapping.longMapping("real", realWriteFunction());
+        }
+        if (type == DOUBLE) {
+            return WriteMapping.doubleMapping("double precision", doubleWriteFunction());
+        }
+
+        if (type instanceof CharType) {
+            return WriteMapping.sliceMapping("char(" + ((CharType) type).getLength() + ")", charWriteFunction());
+        }
+
+        if (type instanceof VarcharType varcharType) {
+            String dataType;
+            if (varcharType.isUnbounded()) {
+                dataType = "varchar";
+            }
+            else {
+                dataType = "varchar(" + varcharType.getBoundedLength() + ")";
+            }
+            return WriteMapping.sliceMapping(dataType, varcharWriteFunction());
+        }
+
+        throw new TrinoException(NOT_SUPPORTED, "Unsupported column type: " + type.getDisplayName());
+    }
+
+    private static ColumnMapping charColumnMapping(int charLength)
+    {
+        if (charLength > CharType.MAX_LENGTH) {
+            return varcharColumnMapping(charLength);
+        }
+        CharType charType = createCharType(charLength);
+        return ColumnMapping.sliceMapping(
+                charType,
+                charReadFunction(charType),
+                charWriteFunction(),
+                DISABLE_PUSHDOWN);
+    }
+
+    private static ColumnMapping varcharColumnMapping(int varcharLength)
+    {
+        VarcharType varcharType = varcharLength <= VarcharType.MAX_LENGTH
+                ? createVarcharType(varcharLength)
+                : createUnboundedVarcharType();
+        return ColumnMapping.sliceMapping(
+                varcharType,
+                varcharReadFunction(varcharType),
+                varcharWriteFunction(),
+                DISABLE_PUSHDOWN);
+    }
+}

--- a/plugin/trino-example-jdbc/src/main/java/io/trino/plugin/example/ExampleClientModule.java
+++ b/plugin/trino-example-jdbc/src/main/java/io/trino/plugin/example/ExampleClientModule.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.example;
+
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.plugin.jdbc.BaseJdbcConfig;
+import io.trino.plugin.jdbc.ConnectionFactory;
+import io.trino.plugin.jdbc.DriverConnectionFactory;
+import io.trino.plugin.jdbc.ForBaseJdbc;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.credential.CredentialProvider;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+
+public class ExampleClientModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    public void setup(Binder binder)
+    {
+        binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(ExampleClient.class).in(Scopes.SINGLETON);
+    }
+
+    @Provides
+    @Singleton
+    @ForBaseJdbc
+    public static ConnectionFactory getConnectionFactory(BaseJdbcConfig config, CredentialProvider credentialProvider)
+            throws SQLException
+    {
+        Properties connectionProperties = new Properties();
+        return new DriverConnectionFactory(DriverManager.getDriver(config.getConnectionUrl()), config.getConnectionUrl(), connectionProperties, credentialProvider);
+    }
+}

--- a/plugin/trino-example-jdbc/src/main/java/io/trino/plugin/example/ExamplePlugin.java
+++ b/plugin/trino-example-jdbc/src/main/java/io/trino/plugin/example/ExamplePlugin.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.example;
+
+import io.trino.plugin.jdbc.JdbcPlugin;
+
+public class ExamplePlugin
+        extends JdbcPlugin
+{
+    public ExamplePlugin()
+    {
+        super("example_jdbc", new ExampleClientModule());
+    }
+}

--- a/plugin/trino-example-jdbc/src/test/java/io/trino/plugin/example/ExampleQueryRunner.java
+++ b/plugin/trino-example-jdbc/src/test/java/io/trino/plugin/example/ExampleQueryRunner.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.example;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.log.Level;
+import io.airlift.log.Logger;
+import io.airlift.log.Logging;
+import io.trino.Session;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+
+import java.util.Map;
+
+import static io.trino.testing.TestingSession.testSessionBuilder;
+
+public class ExampleQueryRunner
+{
+    private ExampleQueryRunner() {}
+
+    public static QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session defaultSession = testSessionBuilder()
+                .setCatalog("example")
+                .setSchema("default")
+                .build();
+
+        Map<String, String> extraProperties = ImmutableMap.<String, String>builder()
+                .put("http-server.http.port", "8080")
+                .buildOrThrow();
+        QueryRunner queryRunner = DistributedQueryRunner.builder(defaultSession)
+                .setExtraProperties(extraProperties)
+                .setNodeCount(1)
+                .build();
+        queryRunner.installPlugin(new ExamplePlugin());
+
+        Map<String, String> connectorProperties = Map.of(
+                "connection-url", "jdbc:h2:mem:test;init=CREATE TABLE IF NOT EXISTS TEST AS SELECT * FROM (VALUES (1, 'one'), (2, 'two')) AS t(id, name)",
+                "connection-user", "test",
+                "connection-password", "");
+        queryRunner.createCatalog(
+                "example",
+                "example_jdbc",
+                connectorProperties);
+
+        return queryRunner;
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        Logging logger = Logging.initialize();
+        logger.setLevel("io.trino.plugin.example_jdbc", Level.DEBUG);
+        logger.setLevel("io.trino", Level.INFO);
+
+        QueryRunner queryRunner = createQueryRunner();
+
+        Logger log = Logger.get(ExampleQueryRunner.class);
+        log.info("======== SERVER STARTED ========");
+        log.info("\n====\n%s\n====", ((DistributedQueryRunner) queryRunner).getCoordinator().getBaseUrl());
+    }
+}

--- a/plugin/trino-example-jdbc/src/test/java/io/trino/plugin/example/TestExampleQueries.java
+++ b/plugin/trino-example-jdbc/src/test/java/io/trino/plugin/example/TestExampleQueries.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.example;
+
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.Test;
+
+public class TestExampleQueries
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return ExampleQueryRunner.createQueryRunner();
+    }
+
+    @Test
+    public void showTables()
+    {
+        assertQuery("SHOW SCHEMAS FROM example", "VALUES 'information_schema', 'public'");
+        assertQuery("SHOW TABLES FROM example.public", "VALUES 'test'");
+    }
+
+    @Test
+    public void selectFromTable()
+    {
+        assertQuery("SELECT name FROM example.public.test",
+                "VALUES 'one', 'two'");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,7 @@
         <module>plugin/trino-druid</module>
         <module>plugin/trino-elasticsearch</module>
         <module>plugin/trino-example-http</module>
+        <module>plugin/trino-example-jdbc</module>
         <module>plugin/trino-exchange-filesystem</module>
         <module>plugin/trino-exchange-hdfs</module>
         <module>plugin/trino-geospatial</module>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Add an example JDBC plugin and a new section in the docs. My main intention is to have a docs section where we could start capturing nuances of correct type mapping (rounding, validation, etc.). 

This is **not** related to #2910

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

An example JDBC plugin can be used as an example when creating a new third-party JDBC connector.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: