### PR TITLE
Reduce margin for START_OF_MODERN_ERA in delta lake stats

### DIFF
--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -305,6 +305,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-tpcds</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-tpch</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogParser.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogParser.java
@@ -86,8 +86,8 @@ public final class TransactionLogParser
     private static final Logger log = Logger.get(TransactionLogParser.class);
 
     // Before 1900, Java Time and Joda Time are not consistent with java.sql.Date and java.util.Calendar
-    // Since January 1, 1900 UTC is still December 31, 1899 in other zones, we are adding a 1 year margin.
-    public static final LocalDate START_OF_MODERN_ERA = LocalDate.of(1901, 1, 1);
+    // Since January 1, 1900 UTC is still December 31, 1899 in other zones, we are adding a 1 day margin.
+    public static final LocalDate START_OF_MODERN_ERA = LocalDate.of(1900, 1, 2);
 
     public static final String LAST_CHECKPOINT_FILENAME = "_last_checkpoint";
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -19,6 +19,7 @@ import io.airlift.log.Logger;
 import io.trino.Session;
 import io.trino.plugin.hive.containers.HiveHadoop;
 import io.trino.plugin.hive.containers.HiveMinioDataLake;
+import io.trino.plugin.tpcds.TpcdsPlugin;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -98,6 +99,9 @@ public final class DeltaLakeQueryRunner
             try {
                 queryRunner.installPlugin(new TpchPlugin());
                 queryRunner.createCatalog("tpch", "tpch");
+
+                queryRunner.installPlugin(new TpcdsPlugin());
+                queryRunner.createCatalog("tpcds", "tpcds");
 
                 queryRunner.installPlugin(new TestingDeltaLakePlugin());
                 Map<String, String> deltaProperties = new HashMap<>(this.deltaProperties.buildOrThrow());


### PR DESCRIPTION
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

d_date column in TPCDS table date_dim has minimum value of `1900-01-02` 
This change allows delta lake to provide the correct lower bound instead of NULL in columns statistics to the CBO. 
This fixes the query plan for TPCDS q72.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Improve statistics for DATE columns in delta lake

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Improve statistics for DATE columns in delta lake. ({issue}`15005`)
```
