### PR TITLE
Rename randomTableSuffix to randomNameSuffix

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -98,8 +98,8 @@ import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_PREDICATE_PUSHD
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_ROW_LEVEL_DELETE;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_TOPN_PUSHDOWN;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_TOPN_PUSHDOWN_WITH_VARCHAR;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.assertions.Assert.assertEventually;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -1785,7 +1785,7 @@ public abstract class BaseJdbcConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE_WITH_DATA));
         skipTestUnless(hasBehavior(SUPPORTS_DYNAMIC_FILTER_PUSHDOWN));
-        String tableName = "orderkeys_" + randomTableSuffix();
+        String tableName = "orderkeys_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " (orderkey) AS VALUES 30000, 60000", 2);
         @Language("SQL") String query = "SELECT * FROM orders a JOIN " + tableName + " b ON a.orderkey = b.orderkey";
 

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcTableStatisticsTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcTableStatisticsTest.java
@@ -24,7 +24,7 @@ import org.testng.annotations.Test;
 import java.util.Locale;
 
 import static com.google.common.base.Throwables.getStackTraceAsString;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -74,7 +74,7 @@ public abstract class BaseJdbcTableStatisticsTest
     @Test
     public void testEmptyTable()
     {
-        String tableName = "test_stats_table_empty_" + randomTableSuffix();
+        String tableName = "test_stats_table_empty_" + randomNameSuffix();
         computeActual(format("CREATE TABLE %s AS SELECT orderkey, custkey, orderpriority, comment FROM tpch.tiny.orders WHERE false", tableName));
         try {
             gatherStats(tableName);

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryCaseInsensitiveMapping.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryCaseInsensitiveMapping.java
@@ -27,7 +27,7 @@ import org.testng.annotations.Test;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -63,7 +63,7 @@ public class TestBigQueryCaseInsensitiveMapping
             throws Exception
     {
         // Ensure schema name starts with a letter and is prefixed with a random string to make sure LIKE 'schema%' returns a single result
-        String fixedRandom = "a" + randomTableSuffix();
+        String fixedRandom = "a" + randomNameSuffix();
         String bigQuerySchema = fixedRandom + "_NonLowerCaseSchema";
         String trinoSchema = bigQuerySchema.toLowerCase(ENGLISH);
         try (AutoCloseable ignore1 = withSchema(bigQuerySchema);
@@ -86,7 +86,7 @@ public class TestBigQueryCaseInsensitiveMapping
     public void testNonLowerCaseTableName()
             throws Exception
     {
-        String bigQuerySchema = "SomeSchema_" + randomTableSuffix();
+        String bigQuerySchema = "SomeSchema_" + randomNameSuffix();
         String trinoSchema = bigQuerySchema.toLowerCase(ENGLISH);
         try (AutoCloseable ignore1 = withSchema(bigQuerySchema);
                 AutoCloseable ignore2 = withTable(
@@ -129,7 +129,7 @@ public class TestBigQueryCaseInsensitiveMapping
     public void testNonLowerCaseViewName()
             throws Exception
     {
-        String bigQuerySchema = "SomeSchema_" + randomTableSuffix();
+        String bigQuerySchema = "SomeSchema_" + randomNameSuffix();
         String trinoSchema = bigQuerySchema.toLowerCase(ENGLISH);
         String namePrefix = format("%s.Test_Case", bigQuerySchema);
 
@@ -164,7 +164,7 @@ public class TestBigQueryCaseInsensitiveMapping
             throws Exception
     {
         // Ensure schema names start with a letter
-        String random = "a" + randomTableSuffix();
+        String random = "a" + randomNameSuffix();
         String[] nameVariants = {random + "_casesensitivename", random + "_CaseSensitiveName", random + "_CASESENSITIVENAME"};
         assertThat(Stream.of(nameVariants)
                 .map(name -> name.toLowerCase(ENGLISH))
@@ -201,7 +201,7 @@ public class TestBigQueryCaseInsensitiveMapping
             throws Exception
     {
         // Ensure schema name starts with a letter and is lowercase to only test table name code path
-        String schema = ("a" + randomTableSuffix() + "_tpch").toLowerCase(ENGLISH);
+        String schema = ("a" + randomNameSuffix() + "_tpch").toLowerCase(ENGLISH);
         String[] nameVariants = {"casesensitivename", "CaseSensitiveName", "CASESENSITIVENAME"};
         assertThat(Stream.of(nameVariants)
                 .map(name -> name.toLowerCase(ENGLISH))
@@ -231,7 +231,7 @@ public class TestBigQueryCaseInsensitiveMapping
     @Test
     public void testCreateSchema()
     {
-        String schemaName = "Test_Create_Case_Sensitive_" + randomTableSuffix();
+        String schemaName = "Test_Create_Case_Sensitive_" + randomNameSuffix();
         assertUpdate("CREATE SCHEMA " + schemaName.toLowerCase(ENGLISH));
         assertQuery(format("SELECT schema_name FROM information_schema.schemata WHERE schema_name = '%s'", schemaName.toLowerCase(ENGLISH)), format("VALUES '%s'", schemaName.toLowerCase(ENGLISH)));
         assertUpdate("DROP SCHEMA " + schemaName.toLowerCase(ENGLISH));
@@ -241,7 +241,7 @@ public class TestBigQueryCaseInsensitiveMapping
     public void testCreateSchemaNameClash()
             throws Exception
     {
-        String schemaName = "Test_Create_Case_Sensitive_Clash_" + randomTableSuffix();
+        String schemaName = "Test_Create_Case_Sensitive_Clash_" + randomNameSuffix();
         try (AutoCloseable schema = withSchema(schemaName)) {
             assertQueryFails("CREATE SCHEMA " + schemaName.toLowerCase(ENGLISH), ".*Schema 'bigquery\\.\\Q" + schemaName.toLowerCase(ENGLISH) + "\\E' already exists");
         }
@@ -251,7 +251,7 @@ public class TestBigQueryCaseInsensitiveMapping
     public void testDropSchema()
             throws Exception
     {
-        String schemaName = "Test_Drop_Case_Sensitive_" + randomTableSuffix();
+        String schemaName = "Test_Drop_Case_Sensitive_" + randomNameSuffix();
         try (AutoCloseable schema = withSchema(schemaName)) {
             assertUpdate("DROP SCHEMA " + schemaName.toLowerCase(ENGLISH));
         }
@@ -261,7 +261,7 @@ public class TestBigQueryCaseInsensitiveMapping
     public void testDropSchemaNameClash()
             throws Exception
     {
-        String schemaName = "Test_Drop_Case_Sensitive_Clash_" + randomTableSuffix();
+        String schemaName = "Test_Drop_Case_Sensitive_Clash_" + randomNameSuffix();
         try (AutoCloseable schema = withSchema(schemaName);
                 AutoCloseable secondSchema = withSchema(schemaName.toLowerCase(ENGLISH))) {
             assertQueryFails("DROP SCHEMA " + schemaName.toLowerCase(ENGLISH), "Found ambiguous names in BigQuery.*");

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
@@ -36,9 +36,9 @@ import static com.google.common.base.Strings.nullToEmpty;
 import static io.trino.plugin.bigquery.BigQueryQueryRunner.BigQuerySqlExecutor;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.MaterializedResult.resultBuilder;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.assertions.Assert.assertEquals;
 import static io.trino.testing.assertions.Assert.assertEventually;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -174,7 +174,7 @@ public class TestBigQueryConnectorTest
     @Test(dataProvider = "createTableUnsupportedTypes")
     public void testCreateTableUnsupportedType(String createType)
     {
-        String tableName = format("test_create_table_unsupported_type_%s_%s", createType.replaceAll("[^a-zA-Z0-9]", ""), randomTableSuffix());
+        String tableName = format("test_create_table_unsupported_type_%s_%s", createType.replaceAll("[^a-zA-Z0-9]", ""), randomNameSuffix());
         assertQueryFails(format("CREATE TABLE %s (col1 %s)", tableName, createType), "Unsupported column type: " + createType);
         assertUpdate("DROP TABLE IF EXISTS " + tableName);
     }
@@ -192,7 +192,7 @@ public class TestBigQueryConnectorTest
     @Test
     public void testCreateTableWithRowTypeWithoutField()
     {
-        String tableName = "test_row_type_table_" + randomTableSuffix();
+        String tableName = "test_row_type_table_" + randomNameSuffix();
         assertQueryFails(
                 "CREATE TABLE " + tableName + "(col1 row(int))",
                 "\\QROW type does not have field names declared: row(integer)\\E");
@@ -429,7 +429,7 @@ public class TestBigQueryConnectorTest
     @Test
     public void testSelectTableWithRowAccessPolicyFilterAll()
     {
-        String policyName = "test_policy" + randomTableSuffix();
+        String policyName = "test_policy" + randomNameSuffix();
         try (TestTable table = new TestTable(this::onBigQuery, "test.test_row_access_policy", "AS SELECT 1 col")) {
             assertQuery("SELECT * FROM " + table.getName(), "VALUES 1");
 
@@ -445,7 +445,7 @@ public class TestBigQueryConnectorTest
     @Test
     public void testSelectTableWithRowAccessPolicyFilterPartialRow()
     {
-        String policyName = "test_policy" + randomTableSuffix();
+        String policyName = "test_policy" + randomNameSuffix();
         try (TestTable table = new TestTable(this::onBigQuery, "test.test_row_access_policy", "AS (SELECT 1 col UNION ALL SELECT 2 col)")) {
             assertQuery("SELECT * FROM " + table.getName(), "VALUES (1), (2)");
 
@@ -462,8 +462,8 @@ public class TestBigQueryConnectorTest
     public void testViewDefinitionSystemTable()
     {
         String schemaName = "test";
-        String tableName = "views_system_table_base_" + randomTableSuffix();
-        String viewName = "views_system_table_view_" + randomTableSuffix();
+        String tableName = "views_system_table_base_" + randomNameSuffix();
+        String viewName = "views_system_table_view_" + randomNameSuffix();
 
         onBigQuery(format("CREATE TABLE %s.%s (a INT64, b INT64, c INT64)", schemaName, tableName));
         onBigQuery(format("CREATE VIEW %s.%s AS SELECT * FROM %s.%s", schemaName, viewName, schemaName, tableName));
@@ -534,7 +534,7 @@ public class TestBigQueryConnectorTest
     @Test
     public void testBigQueryMaterializedView()
     {
-        String materializedView = "test_materialized_view" + randomTableSuffix();
+        String materializedView = "test_materialized_view" + randomNameSuffix();
         try {
             onBigQuery("CREATE MATERIALIZED VIEW test." + materializedView + " AS SELECT count(1) AS cnt FROM tpch.region");
             assertQuery("SELECT table_type FROM information_schema.tables WHERE table_schema = 'test' AND table_name = '" + materializedView + "'", "VALUES 'BASE TABLE'");
@@ -553,7 +553,7 @@ public class TestBigQueryConnectorTest
     @Test
     public void testBigQuerySnapshotTable()
     {
-        String snapshotTable = "test_snapshot" + randomTableSuffix();
+        String snapshotTable = "test_snapshot" + randomNameSuffix();
         try {
             onBigQuery("CREATE SNAPSHOT TABLE test." + snapshotTable + " CLONE tpch.region");
             assertQuery("SELECT table_type FROM information_schema.tables WHERE table_schema = 'test' AND table_name = '" + snapshotTable + "'", "VALUES 'BASE TABLE'");
@@ -574,7 +574,7 @@ public class TestBigQueryConnectorTest
     public void testBigQueryExternalTable(String gcpStorageBucket)
     {
         // Prerequisite: upload region.csv in resources directory to gs://{testing.gcp-storage-bucket}/tpch/tiny/region.csv
-        String externalTable = "test_external" + randomTableSuffix();
+        String externalTable = "test_external" + randomNameSuffix();
         try {
             onBigQuery("CREATE EXTERNAL TABLE test." + externalTable + " OPTIONS (format = 'CSV', uris = ['gs://" + gcpStorageBucket + "/tpch/tiny/region.csv'])");
             assertQuery("SELECT table_type FROM information_schema.tables WHERE table_schema = 'test' AND table_name = '" + externalTable + "'", "VALUES 'BASE TABLE'");
@@ -601,7 +601,7 @@ public class TestBigQueryConnectorTest
                 .setCatalogSessionProperty("bigquery", "create_disposition_type", "create_never")
                 .build();
 
-        String materializedView = "test_materialized_view" + randomTableSuffix();
+        String materializedView = "test_materialized_view" + randomNameSuffix();
         try {
             onBigQuery("CREATE MATERIALIZED VIEW test." + materializedView + " AS SELECT count(1) AS cnt FROM tpch.region");
 
@@ -622,7 +622,7 @@ public class TestBigQueryConnectorTest
     @Test
     public void testWildcardTable()
     {
-        String suffix = randomTableSuffix();
+        String suffix = randomNameSuffix();
         String firstTable = format("test_wildcard_%s_1", suffix);
         String secondTable = format("test_wildcard_%s_2", suffix);
         String wildcardTable = format("test_wildcard_%s_*", suffix);
@@ -648,7 +648,7 @@ public class TestBigQueryConnectorTest
     @Test
     public void testWildcardTableWithDifferentColumnDefinition()
     {
-        String suffix = randomTableSuffix();
+        String suffix = randomNameSuffix();
         String firstTable = format("test_invalid_wildcard_%s_1", suffix);
         String secondTable = format("test_invalid_wildcard_%s_2", suffix);
         String wildcardTable = format("test_invalid_wildcard_%s_*", suffix);
@@ -722,7 +722,7 @@ public class TestBigQueryConnectorTest
     @Test
     public void testNativeQuerySelectFromTestTable()
     {
-        String tableName = "test.test_select" + randomTableSuffix();
+        String tableName = "test.test_select" + randomNameSuffix();
         try {
             onBigQuery("CREATE TABLE " + tableName + "(col BIGINT)");
             onBigQuery("INSERT INTO " + tableName + " VALUES (1), (2)");
@@ -738,7 +738,7 @@ public class TestBigQueryConnectorTest
     @Test
     public void testNativeQuerySelectUnsupportedType()
     {
-        String tableName = "test_unsupported" + randomTableSuffix();
+        String tableName = "test_unsupported" + randomNameSuffix();
         try {
             onBigQuery("CREATE TABLE test." + tableName + "(one BIGINT, two BIGNUMERIC(40,2), three STRING)");
             // Check that column 'two' is not supported.
@@ -754,7 +754,7 @@ public class TestBigQueryConnectorTest
     @Test
     public void testNativeQueryCreateStatement()
     {
-        String tableName = "test_create" + randomTableSuffix();
+        String tableName = "test_create" + randomNameSuffix();
         assertFalse(getQueryRunner().tableExists(getSession(), tableName));
         assertThatThrownBy(() -> query("SELECT * FROM TABLE(bigquery.system.query(query => 'CREATE TABLE test." + tableName + "(n INTEGER)'))"))
                 .hasMessage("Unsupported statement type: CREATE_TABLE");
@@ -764,7 +764,7 @@ public class TestBigQueryConnectorTest
     @Test
     public void testNativeQueryInsertStatementTableDoesNotExist()
     {
-        String tableName = "test_insert" + randomTableSuffix();
+        String tableName = "test_insert" + randomNameSuffix();
         assertFalse(getQueryRunner().tableExists(getSession(), tableName));
         assertThatThrownBy(() -> query("SELECT * FROM TABLE(bigquery.system.query(query => 'INSERT INTO test." + tableName + " VALUES (1)'))"))
                 .hasMessageContaining("Failed to get schema for query")
@@ -774,7 +774,7 @@ public class TestBigQueryConnectorTest
     @Test
     public void testNativeQueryInsertStatementTableExists()
     {
-        String tableName = "test_insert" + randomTableSuffix();
+        String tableName = "test_insert" + randomNameSuffix();
         try {
             onBigQuery("CREATE TABLE test." + tableName + "(col BIGINT)");
             assertThatThrownBy(() -> query("SELECT * FROM TABLE(bigquery.system.query(query => 'INSERT INTO test." + tableName + " VALUES (3)'))"))

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryMetadataCaching.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryMetadataCaching.java
@@ -20,7 +20,7 @@ import io.trino.testing.QueryRunner;
 import org.testng.annotations.Test;
 
 import static io.trino.plugin.bigquery.BigQueryQueryRunner.BigQuerySqlExecutor;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.testng.Assert.assertEquals;
 
 public class TestBigQueryMetadataCaching
@@ -42,7 +42,7 @@ public class TestBigQueryMetadataCaching
     @Test
     public void testMetadataCaching()
     {
-        String schema = "test_metadata_caching_" + randomTableSuffix();
+        String schema = "test_metadata_caching_" + randomNameSuffix();
         try {
             getQueryRunner().execute("CREATE SCHEMA " + schema);
             assertEquals(getQueryRunner().execute("SHOW SCHEMAS IN bigquery LIKE '" + schema + "'").getOnlyValue(), schema);

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryTypeMapping.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryTypeMapping.java
@@ -44,7 +44,7 @@ import static io.trino.spi.type.TimestampType.createTimestampType;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -277,7 +277,7 @@ public class TestBigQueryTypeMapping
     @Test
     public void testInvalidNumericScaleType()
     {
-        String tableName = "test.invalid_numeric_scale_" + randomTableSuffix();
+        String tableName = "test.invalid_numeric_scale_" + randomNameSuffix();
         try {
             assertThatThrownBy(() -> getBigQuerySqlExecutor().execute(format("CREATE TABLE %s (invalid_type NUMERIC(38, 10))", tableName)))
                     .hasMessageContaining("In NUMERIC(P, S), S must be between 0 and 9");

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorTest.java
@@ -43,8 +43,8 @@ import static io.trino.plugin.clickhouse.ClickHouseTableProperties.SAMPLE_BY_PRO
 import static io.trino.plugin.jdbc.JdbcMetadataSessionProperties.DOMAIN_COMPACTION_THRESHOLD;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.MaterializedResult.resultBuilder;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.assertions.Assert.assertEquals;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -140,7 +140,7 @@ public abstract class BaseClickHouseConnectorTest
     @Override
     public void testDropColumn()
     {
-        String tableName = "test_drop_column_" + randomTableSuffix();
+        String tableName = "test_drop_column_" + randomNameSuffix();
 
         // only MergeTree engine table can drop column
         assertUpdate("CREATE TABLE " + tableName + "(x int NOT NULL, y int, a int) WITH (engine = 'MergeTree', order_by = ARRAY['x'])");
@@ -174,7 +174,7 @@ public abstract class BaseClickHouseConnectorTest
     @Override
     public void testAddColumn()
     {
-        String tableName = "test_add_column_" + randomTableSuffix();
+        String tableName = "test_add_column_" + randomNameSuffix();
         // Only MergeTree engine table can add column
         assertUpdate("CREATE TABLE " + tableName + " (id int NOT NULL, x VARCHAR) WITH (engine = 'MergeTree', order_by = ARRAY['id'])");
         assertUpdate("INSERT INTO " + tableName + " (id, x) VALUES(1, 'first')", 1);
@@ -324,7 +324,7 @@ public abstract class BaseClickHouseConnectorTest
     @Test
     public void testDifferentEngine()
     {
-        String tableName = "test_add_column_" + randomTableSuffix();
+        String tableName = "test_add_column_" + randomNameSuffix();
         // MergeTree
         assertUpdate("CREATE TABLE " + tableName + " (id int NOT NULL, x VARCHAR) WITH (engine = 'MergeTree', order_by = ARRAY['id'])");
         assertTrue(getQueryRunner().tableExists(getSession(), tableName));
@@ -357,7 +357,7 @@ public abstract class BaseClickHouseConnectorTest
     @Test
     public void testTableProperty()
     {
-        String tableName = "test_add_column_" + randomTableSuffix();
+        String tableName = "test_add_column_" + randomNameSuffix();
         // no table property, it should create a table with default Log engine table
         assertUpdate("CREATE TABLE " + tableName + " (id int NOT NULL, x VARCHAR)");
         assertTrue(getQueryRunner().tableExists(getSession(), tableName));
@@ -769,7 +769,7 @@ public abstract class BaseClickHouseConnectorTest
     public void testCreateTableWithLongTableName()
     {
         // Override because ClickHouse connector can create a table which can't be dropped
-        String baseTableName = "test_create_" + randomTableSuffix();
+        String baseTableName = "test_create_" + randomNameSuffix();
         String validTableName = baseTableName + "z".repeat(maxTableNameLength().orElseThrow() - baseTableName.length());
 
         assertUpdate("CREATE TABLE " + validTableName + " (a bigint)");
@@ -788,10 +788,10 @@ public abstract class BaseClickHouseConnectorTest
     public void testRenameSchemaToLongName()
     {
         // Override because the max length is different from CREATE SCHEMA case
-        String sourceTableName = "test_rename_source_" + randomTableSuffix();
+        String sourceTableName = "test_rename_source_" + randomNameSuffix();
         assertUpdate("CREATE SCHEMA " + sourceTableName);
 
-        String baseSchemaName = "test_rename_target_" + randomTableSuffix();
+        String baseSchemaName = "test_rename_target_" + randomNameSuffix();
 
         // The numeric value depends on file system
         int maxLength = 255 - ".sql".length();
@@ -825,10 +825,10 @@ public abstract class BaseClickHouseConnectorTest
     public void testRenameTableToLongTableName()
     {
         // Override because ClickHouse connector can rename to a table which can't be dropped
-        String sourceTableName = "test_source_long_table_name_" + randomTableSuffix();
+        String sourceTableName = "test_source_long_table_name_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + sourceTableName + " AS SELECT 123 x", 1);
 
-        String baseTableName = "test_target_long_table_name_" + randomTableSuffix();
+        String baseTableName = "test_target_long_table_name_" + randomNameSuffix();
         // The max length is different from CREATE TABLE case
         String validTargetTableName = baseTableName + "z".repeat(255 - ".sql".length() - baseTableName.length());
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/AbstractTestDeltaLakeCreateTableStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/AbstractTestDeltaLakeCreateTableStatistics.java
@@ -48,7 +48,7 @@ import static io.trino.spi.type.Decimals.encodeScaledValue;
 import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.POSITIVE_INFINITY;
 import static java.lang.String.format;
@@ -67,7 +67,7 @@ public abstract class AbstractTestDeltaLakeCreateTableStatistics
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        this.bucketName = "delta-test-create-table-statistics-" + randomTableSuffix();
+        this.bucketName = "delta-test-create-table-statistics-" + randomNameSuffix();
         HiveMinioDataLake hiveMinioDataLake = closeAfterClass(new HiveMinioDataLake(bucketName));
         hiveMinioDataLake.start();
         ImmutableMap.Builder<String, String> queryRunnerProperties = ImmutableMap.<String, String>builder()
@@ -458,7 +458,7 @@ public abstract class AbstractTestDeltaLakeCreateTableStatistics
 
         public TestTable(String name, List<String> columnNames, List<String> partitionNames, String values, Session session)
         {
-            this.name = name + randomTableSuffix();
+            this.name = name + randomNameSuffix();
             String columns = columnNames.isEmpty() ? "" :
                     "(" + String.join(",", columnNames) + ")";
             String partitionedBy = partitionNames.isEmpty() ? "" :

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -59,10 +59,10 @@ import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.INSERT_TABLE;
 import static io.trino.testing.TestingAccessControlManager.privilege;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_DELETE;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static io.trino.testing.assertions.Assert.assertEquals;
 import static io.trino.testing.assertions.Assert.assertEventually;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static io.trino.tpch.TpchTable.CUSTOMER;
 import static io.trino.tpch.TpchTable.LINE_ITEM;
 import static io.trino.tpch.TpchTable.ORDERS;
@@ -108,7 +108,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     // to be outdated.
     private static final int TEST_METADATA_CACHE_TTL_SECONDS = 15;
 
-    protected final String bucketName = "test-delta-lake-integration-smoke-test-" + randomTableSuffix();
+    protected final String bucketName = "test-delta-lake-integration-smoke-test-" + randomNameSuffix();
 
     protected HiveMinioDataLake hiveMinioDataLake;
 
@@ -230,7 +230,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testCharTypeIsNotSupported()
     {
-        String tableName = "test_char_type_not_supported" + randomTableSuffix();
+        String tableName = "test_char_type_not_supported" + randomNameSuffix();
         assertQueryFails("CREATE TABLE " + tableName + " (a int, b CHAR(5)) WITH (location = '" + getLocationForTable(bucketName, tableName) + "')",
                 "Unsupported type: char\\(5\\)");
     }
@@ -238,7 +238,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testCreateTableInNonexistentSchemaFails()
     {
-        String tableName = "test_create_table_in_nonexistent_schema_" + randomTableSuffix();
+        String tableName = "test_create_table_in_nonexistent_schema_" + randomNameSuffix();
         String location = getLocationForTable(bucketName, tableName);
         assertQueryFails(
                 "CREATE TABLE doesnotexist." + tableName + " (a int, b int) WITH (location = '" + location + "')",
@@ -254,7 +254,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testCreatePartitionedTable()
     {
-        String tableName = "test_create_table_" + randomTableSuffix();
+        String tableName = "test_create_table_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " (a int, b VARCHAR, c TIMESTAMP WITH TIME ZONE) " +
                 "WITH (location = '" + getLocationForTable(bucketName, tableName) + "', partitioned_by = ARRAY['b'])");
         assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'a', TIMESTAMP '2020-01-01 01:22:34.000 UTC')", 1);
@@ -266,7 +266,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testCreateTablePartitionValidation()
     {
-        String tableName = "test_create_table_partition_validation_" + randomTableSuffix();
+        String tableName = "test_create_table_partition_validation_" + randomNameSuffix();
         assertQueryFails("CREATE TABLE " + tableName + " (a int, b VARCHAR, c TIMESTAMP WITH TIME ZONE) " +
                         "WITH (location = '" + getLocationForTable(bucketName, tableName) + "', partitioned_by = ARRAY['a', 'd', 'e'])",
                 "Table property 'partition_by' contained column names which do not exist: \\[d, e]");
@@ -287,7 +287,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testCreateTablePartitionOrdering()
     {
-        String tableName = "test_create_table_partition_ordering_" + randomTableSuffix();
+        String tableName = "test_create_table_partition_ordering_" + randomNameSuffix();
         assertUpdate(
                 "CREATE TABLE " + tableName + " WITH (location = '" + getLocationForTable(bucketName, tableName) + "', " +
                         "partitioned_by = ARRAY['nationkey', 'regionkey']) AS SELECT regionkey, nationkey, name, comment FROM nation",
@@ -407,7 +407,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testDropAndRecreateTable()
     {
-        String tableName = "testDropAndRecreate_" + randomTableSuffix();
+        String tableName = "testDropAndRecreate_" + randomNameSuffix();
         assertUpdate(format("CREATE TABLE %s (dummy int) WITH (location = '%s')", tableName, getLocationForTable(bucketName, "nation")));
         assertQuery("SELECT * FROM " + tableName, "SELECT * FROM nation");
 
@@ -427,7 +427,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testCreatePartitionedTableAs()
     {
-        String tableName = "test_create_partitioned_table_as_" + randomTableSuffix();
+        String tableName = "test_create_partitioned_table_as_" + randomNameSuffix();
         assertUpdate(
                 format("CREATE TABLE " + tableName + " WITH (location = '%s', partitioned_by = ARRAY['regionkey']) AS SELECT name, regionkey, comment from nation",
                         getLocationForTable(bucketName, tableName)),
@@ -451,7 +451,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testCreatePartitionedDefaultPartitionKeys()
     {
-        String tableName = "test_create_partitioned_table_default_as_" + randomTableSuffix();
+        String tableName = "test_create_partitioned_table_default_as_" + randomNameSuffix();
         assertUpdate(
                 format("CREATE TABLE " + tableName + "(number_partition, string_partition, a_value) " +
                                 "WITH (location = '%s', " +
@@ -467,7 +467,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testCreateTablePartitionedByDate()
     {
-        String tableName = "test_create_table_partitioned_by_date_" + randomTableSuffix();
+        String tableName = "test_create_table_partitioned_by_date_" + randomNameSuffix();
         assertUpdate(
                 format("CREATE TABLE %s (i, d) WITH (location = '%s', partitioned_by = ARRAY['d']) AS VALUES (1, DATE '2020-01-01'), (2, DATE '1700-01-01')",
                         tableName, getLocationForTable(bucketName, tableName)),
@@ -506,13 +506,13 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testCleanupForFailedCreateTableAs()
     {
-        String controlTableName = "test_cleanup_for_failed_create_table_as_control_" + randomTableSuffix();
+        String controlTableName = "test_cleanup_for_failed_create_table_as_control_" + randomNameSuffix();
         assertUpdate(format("CREATE TABLE " + controlTableName + " WITH (location = '%s') AS " +
                         "SELECT nationkey from tpch.sf1.nation", getLocationForTable(bucketName, controlTableName)),
                 25);
         assertThat(getTableFiles(controlTableName)).isNotEmpty();
 
-        String tableName = "test_cleanup_for_failed_create_table_as_" + randomTableSuffix();
+        String tableName = "test_cleanup_for_failed_create_table_as_" + randomNameSuffix();
         assertThatThrownBy(() -> query(
                 format("CREATE TABLE " + tableName + " WITH (location = '%s') AS " +
                                 "SELECT nationkey from tpch.sf1.nation " + // writer for this part finishes quickly
@@ -526,7 +526,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testCleanupForFailedPartitionedCreateTableAs()
     {
-        String tableName = "test_cleanup_for_failed_partitioned_create_table_as_" + randomTableSuffix();
+        String tableName = "test_cleanup_for_failed_partitioned_create_table_as_" + randomNameSuffix();
         assertThatThrownBy(() -> query(
                 format("CREATE TABLE " + tableName + "(a, b) WITH (location = '%s', partitioned_by = ARRAY['b']) AS " +
                                 "SELECT nationkey, regionkey from tpch.sf1.nation " + // writer for this part finishes quickly
@@ -540,7 +540,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testCreateTableAsExistingLocation()
     {
-        String tableName = "test_create_table_as_existing_location_" + randomTableSuffix();
+        String tableName = "test_create_table_as_existing_location_" + randomNameSuffix();
         String createTableStatement = format("CREATE TABLE " + tableName + " WITH (location = '%s') AS SELECT name from nation", getLocationForTable(bucketName, tableName));
 
         // run create without table directory
@@ -560,7 +560,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testCreateSchemaWithLocation()
     {
-        String schemaName = "test_create_schema_with_location_" + randomTableSuffix();
+        String schemaName = "test_create_schema_with_location_" + randomNameSuffix();
         assertQuerySucceeds(
                 format("CREATE SCHEMA %s WITH ( location = '%s' )",
                         schemaName,
@@ -570,9 +570,9 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testCreateTableAsWithSchemaLocation()
     {
-        String tableName = "table1_with_curr_schema_loc_" + randomTableSuffix();
-        String tableName2 = "table2_with_curr_schema_loc_" + randomTableSuffix();
-        String schemaName = "test_schema" + randomTableSuffix();
+        String tableName = "table1_with_curr_schema_loc_" + randomNameSuffix();
+        String tableName2 = "table2_with_curr_schema_loc_" + randomNameSuffix();
+        String schemaName = "test_schema" + randomNameSuffix();
         String schemaLocation = getLocationForTable(bucketName, schemaName);
 
         assertUpdate(
@@ -590,9 +590,9 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testCreateTableWithSchemaLocation()
     {
-        String tableName = "table1_with_curr_schema_loc_" + randomTableSuffix();
-        String tableName2 = "table2_with_curr_schema_loc_" + randomTableSuffix();
-        String schemaName = "test_schema" + randomTableSuffix();
+        String tableName = "table1_with_curr_schema_loc_" + randomNameSuffix();
+        String tableName2 = "table2_with_curr_schema_loc_" + randomNameSuffix();
+        String schemaName = "test_schema" + randomNameSuffix();
         String schemaLocation = getLocationForTable(bucketName, schemaName);
         assertUpdate(
                 format("CREATE SCHEMA %s WITH ( location = '%s' )",
@@ -628,13 +628,13 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testRenameExternalTable()
     {
-        String oldTable = "test_external_table_rename_old_" + randomTableSuffix();
+        String oldTable = "test_external_table_rename_old_" + randomNameSuffix();
 
         assertUpdate(format("CREATE TABLE %s (a bigint, b double) WITH (location = '%s')", oldTable, getLocationForTable(bucketName, oldTable)));
         assertUpdate("INSERT INTO " + oldTable + " VALUES (42, 43)", 1);
         String oldLocation = (String) computeScalar("SELECT \"$path\" FROM " + oldTable);
 
-        String newTable = "test_rename_new_" + randomTableSuffix();
+        String newTable = "test_rename_new_" + randomNameSuffix();
         assertUpdate("ALTER TABLE " + oldTable + " RENAME TO " + newTable);
 
         assertThat(query("SHOW TABLES LIKE '" + oldTable + "'"))
@@ -662,15 +662,15 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testRenameExternalTableAcrossSchemas()
     {
-        String oldTable = "test_rename_old_" + randomTableSuffix();
+        String oldTable = "test_rename_old_" + randomNameSuffix();
         assertUpdate(format("CREATE TABLE %s (a bigint, b double) WITH (location = '%s')", oldTable, getLocationForTable(bucketName, oldTable)));
         assertUpdate("INSERT INTO " + oldTable + " VALUES (42, 43)", 1);
         String oldLocation = (String) computeScalar("SELECT \"$path\" FROM " + oldTable);
 
-        String schemaName = "test_schema_" + randomTableSuffix();
+        String schemaName = "test_schema_" + randomNameSuffix();
         assertUpdate(createSchemaSql(schemaName));
 
-        String newTableName = "test_rename_new_" + randomTableSuffix();
+        String newTableName = "test_rename_new_" + randomNameSuffix();
         String newTable = schemaName + "." + newTableName;
         assertUpdate("ALTER TABLE " + oldTable + " RENAME TO " + newTable);
 
@@ -695,8 +695,8 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testOverrideSchemaLocation()
     {
-        String tableName = "test_override_schema_location_" + randomTableSuffix();
-        String schemaName = "test_override_schema_location_schema_" + randomTableSuffix();
+        String tableName = "test_override_schema_location_" + randomNameSuffix();
+        String schemaName = "test_override_schema_location_schema_" + randomNameSuffix();
         String schemaLocation = getLocationForTable(bucketName, schemaName);
         assertUpdate(
                 format("CREATE SCHEMA %s WITH ( location = '%s' )",
@@ -713,8 +713,8 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testManagedTableFilesCleanedOnDrop()
     {
-        String tableName = "test_managed_table_cleanup_" + randomTableSuffix();
-        String schemaName = "test_managed_table_cleanup_" + randomTableSuffix();
+        String tableName = "test_managed_table_cleanup_" + randomNameSuffix();
+        String schemaName = "test_managed_table_cleanup_" + randomNameSuffix();
         String schemaLocation = getLocationForTable(bucketName, schemaName);
         assertUpdate(format("CREATE SCHEMA %s WITH (location = '%s')", schemaName, schemaLocation));
         assertUpdate(format("CREATE TABLE %s.%s AS SELECT * FROM nation", schemaName, tableName), "SELECT count(*) FROM nation");
@@ -726,8 +726,8 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testExternalTableFilesRetainedOnDrop()
     {
-        String tableName = "test_external_table_files_retained_" + randomTableSuffix();
-        String schemaName = "test_external_table_files_retained_" + randomTableSuffix();
+        String tableName = "test_external_table_files_retained_" + randomNameSuffix();
+        String schemaName = "test_external_table_files_retained_" + randomNameSuffix();
         String tableLocation = getLocationForTable(bucketName, tableName);
         String schemaLocation = getLocationForTable(bucketName, schemaName);
         assertUpdate(format("CREATE SCHEMA %s WITH (location = '%s')", schemaName, schemaLocation));
@@ -742,7 +742,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testTimestampWithTimeZoneMillis()
     {
-        String tableName = "test_timestamp_with_time_zone_" + randomTableSuffix();
+        String tableName = "test_timestamp_with_time_zone_" + randomNameSuffix();
         assertUpdate(
                 format("CREATE TABLE " + tableName + " (ts_tz) WITH (location = '%s') AS " +
                                 "VALUES timestamp '2012-10-31 01:00:00.123 America/New_York', timestamp '2012-10-31 01:00:00.123 America/Los_Angeles', timestamp '2012-10-31 01:00:00.123 UTC'",
@@ -759,7 +759,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testTimestampWithTimeZoneMicro()
     {
-        String tableName = "test_timestamp_with_time_zone_micro_" + randomTableSuffix();
+        String tableName = "test_timestamp_with_time_zone_micro_" + randomNameSuffix();
         assertQueryFails(
                 format("CREATE TABLE " + tableName + " (ts_tz) WITH (location = '%s') AS " +
                                 "VALUES timestamp '2012-10-31 01:00:00.123456 America/New_York', timestamp '2012-10-31 01:00:00.123456 America/Los_Angeles'",
@@ -963,7 +963,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testInsertIntoPartitionedTable()
     {
-        String tableName = "test_insert_partitioned_" + randomTableSuffix();
+        String tableName = "test_insert_partitioned_" + randomNameSuffix();
         assertUpdate(
                 format("CREATE TABLE %s (a_number, a_string) " +
                                 " WITH (location = '%s', " +
@@ -1026,7 +1026,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testPartialInsert()
     {
-        String tableName = "test_partial_insert_" + randomTableSuffix();
+        String tableName = "test_partial_insert_" + randomNameSuffix();
         assertUpdate(
                 format("CREATE TABLE %s (a_number, a_string) WITH (location = '%s') AS " +
                                 "VALUES (1, 'ala')",
@@ -1041,7 +1041,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testPartialInsertIntoPartitionedTable()
     {
-        String tableName = "test_partial_insert_partitioned_" + randomTableSuffix();
+        String tableName = "test_partial_insert_partitioned_" + randomNameSuffix();
         assertUpdate(
                 format("CREATE TABLE %s (a_number, a_string) " +
                                 " WITH (location = '%s', " +
@@ -1061,7 +1061,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testInsertColumnOrdering()
     {
-        String tableName = "test_insert_column_ordering_" + randomTableSuffix();
+        String tableName = "test_insert_column_ordering_" + randomNameSuffix();
         assertUpdate(
                 format("CREATE TABLE %s (a INT, b INT, c INT) WITH (location = '%s', partitioned_by = ARRAY['a', 'b'])",
                         tableName,
@@ -1097,7 +1097,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testCheckpointing()
     {
-        String tableName = "test_insert_checkpointing_" + randomTableSuffix();
+        String tableName = "test_insert_checkpointing_" + randomNameSuffix();
         assertUpdate(
                 format("CREATE TABLE %s (a_number, a_string) " +
                                 " WITH (location = '%s', " +
@@ -1134,7 +1134,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test(dataProvider = "testCheckpointWriteStatsAsStructDataProvider")
     public void testCheckpointWriteStatsAsStruct(String type, String inputValue, String nullsFraction, String statsValue)
     {
-        String tableName = "test_checkpoint_write_stats_as_struct_" + randomTableSuffix();
+        String tableName = "test_checkpoint_write_stats_as_struct_" + randomNameSuffix();
 
         // Set 'checkpoint_interval' as 1 to write 'stats_parsed' field every INSERT
         assertUpdate(
@@ -1179,7 +1179,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testCheckpointWriteStatsAsStructWithPartiallyUnsupportedColumnStats()
     {
-        String tableName = "test_checkpoint_write_stats_as_struct_partially_unsupported_" + randomTableSuffix();
+        String tableName = "test_checkpoint_write_stats_as_struct_partially_unsupported_" + randomNameSuffix();
 
         // Column statistics on boolean column is unsupported
         assertUpdate(
@@ -1233,7 +1233,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
             throws Exception
     {
         // Create a table with a bunch of transaction log entries
-        String tableName = "test_table_location_changed_" + randomTableSuffix();
+        String tableName = "test_table_location_changed_" + randomNameSuffix();
         String initialLocation = getLocationForTable(bucketName, tableName);
         assertUpdate(format(
                 "CREATE TABLE %s (a_number int, a_string varchar) WITH (location = '%s' %s)",
@@ -1257,7 +1257,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
         String newLocation;
         try (QueryRunner independentQueryRunner = createDeltaLakeQueryRunner(Map.of())) {
             // Change table's location without main Delta Lake connector (main query runner) knowing about this
-            newLocation = getLocationForTable(bucketName, "test_table_location_changed_new_" + randomTableSuffix());
+            newLocation = getLocationForTable(bucketName, "test_table_location_changed_new_" + randomNameSuffix());
 
             independentQueryRunner.execute("DROP TABLE " + tableName);
             independentQueryRunner.execute(format(
@@ -1326,7 +1326,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testAnalyze()
     {
-        String tableName = "test_analyze_" + randomTableSuffix();
+        String tableName = "test_analyze_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName
                 + " WITH ("
                 + "location = '" + getLocationForTable(bucketName, tableName) + "'"
@@ -1357,7 +1357,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testStatsSplitPruningBasedOnSepCreatedCheckpoint()
     {
-        String tableName = "test_sep_checkpoint_stats_pruning_" + randomTableSuffix();
+        String tableName = "test_sep_checkpoint_stats_pruning_" + randomNameSuffix();
         String transactionLogDirectory = format("%s/_delta_log", tableName);
         assertUpdate(
                 format("CREATE TABLE %s (a_number, a_string)" +
@@ -1396,7 +1396,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testStatsSplitPruningBasedOnSepCreatedCheckpointOnTopOfCheckpointWithJustStructStats()
     {
-        String tableName = "test_sep_checkpoint_stats_pruning_struct_stats_" + randomTableSuffix();
+        String tableName = "test_sep_checkpoint_stats_pruning_struct_stats_" + randomNameSuffix();
         createTableFromResources(tableName, "databricks/pruning/parquet_struct_statistics", getQueryRunner());
         String transactionLogDirectory = format("%s/_delta_log", tableName);
 
@@ -1433,7 +1433,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
             throws Exception
     {
         String catalog = getSession().getCatalog().orElseThrow();
-        String tableName = "test_vacuum" + randomTableSuffix();
+        String tableName = "test_vacuum" + randomNameSuffix();
         String tableLocation = getLocationForTable(bucketName, tableName);
         Session sessionWithShortRetentionUnlocked = Session.builder(getSession())
                 .setCatalogSessionProperty(catalog, "vacuum_min_retention", "0s")
@@ -1478,7 +1478,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     public void testVacuumParameterValidation()
     {
         String catalog = getSession().getCatalog().orElseThrow();
-        String tableName = "test_vacuum_parameter_validation_" + randomTableSuffix();
+        String tableName = "test_vacuum_parameter_validation_" + randomNameSuffix();
         assertUpdate(
                 format("CREATE TABLE %s WITH (location = '%s') AS SELECT * FROM tpch.tiny.nation", tableName, getLocationForTable(bucketName, tableName)),
                 25);
@@ -1498,7 +1498,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testVacuumAccessControl()
     {
-        String tableName = "test_deny_vacuum_" + randomTableSuffix();
+        String tableName = "test_deny_vacuum_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (location = '" + getLocationForTable(bucketName, tableName) + "') " +
                 "AS SELECT * FROM orders", "SELECT count(*) FROM orders");
 
@@ -1517,7 +1517,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testOptimize()
     {
-        String tableName = "test_optimize_" + randomTableSuffix();
+        String tableName = "test_optimize_" + randomNameSuffix();
         String tableLocation = getLocationForTable(bucketName, tableName);
         assertUpdate("CREATE TABLE " + tableName + " (key integer, value varchar) WITH (location = '" + tableLocation + "')");
         try {
@@ -1579,7 +1579,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testOptimizeWithPartitionedTable()
     {
-        String tableName = "test_optimize_partitioned_table_" + randomTableSuffix();
+        String tableName = "test_optimize_partitioned_table_" + randomNameSuffix();
         String tableLocation = getLocationForTable(bucketName, tableName);
         assertUpdate("CREATE TABLE " + tableName + " (key integer, value varchar) WITH (location = '" + tableLocation + "', partitioned_by = ARRAY['value'])");
         try {
@@ -1620,7 +1620,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
                 .setSystemProperty("use_preferred_write_partitioning", "true")
                 .setSystemProperty("preferred_write_partitioning_min_number_of_partitions", "1")
                 .build();
-        String tableName = "test_optimize_partitioned_table_" + randomTableSuffix();
+        String tableName = "test_optimize_partitioned_table_" + randomNameSuffix();
         String tableLocation = getLocationForTable(bucketName, tableName);
         assertUpdate(currentSession, "CREATE TABLE " + tableName + " (key integer, value varchar) WITH (location = '" + tableLocation + "', partitioned_by = ARRAY['value'])");
         try {
@@ -1702,7 +1702,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
             throw new SkipException("testDelete requires DELETE support");
         }
 
-        String tableName = "test_delete_" + randomTableSuffix();
+        String tableName = "test_delete_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (location = '" + getLocationForTable(bucketName, tableName) + "') " +
                 "AS SELECT * FROM orders", "SELECT count(*) FROM orders");
 
@@ -1719,7 +1719,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     @Test
     public void testOptimizeUsingForcedPartitioning()
     {
-        String tableName = "test_optimize_partitioned_table_" + randomTableSuffix();
+        String tableName = "test_optimize_partitioned_table_" + randomNameSuffix();
         String tableLocation = getLocationForTable(bucketName, tableName);
         assertUpdate("CREATE TABLE " + tableName + " (key varchar, value1 integer, value2 varchar, value3 integer) WITH (location = '" + tableLocation + "', partitioned_by = ARRAY['key', 'value2', 'value3'])");
         assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1, 'test1', 9)", 1);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
@@ -48,8 +48,8 @@ import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.TRANSACTION_LOG_DIRECTORY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_CREATE_SCHEMA;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.assertions.Assert.assertEquals;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -265,7 +265,7 @@ public abstract class BaseDeltaLakeMinioConnectorTest
     @Test
     public void testQueryNullPartitionWithNotPushdownablePredicate()
     {
-        String tableName = "test_null_partitions_" + randomTableSuffix();
+        String tableName = "test_null_partitions_" + randomNameSuffix();
         assertUpdate("" +
                         "CREATE TABLE " + tableName + " (a, b, c) WITH (location = '" + format("s3://%s/%s", bucketName, tableName) + "', partitioned_by = ARRAY['c']) " +
                         "AS VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3), (null, null, null), (4, 4, 4)",
@@ -276,7 +276,7 @@ public abstract class BaseDeltaLakeMinioConnectorTest
     @Test
     public void testPartitionColumnOrderIsDifferentFromTableDefinition()
     {
-        String tableName = "test_partition_order_is_different_from_table_definition_" + randomTableSuffix();
+        String tableName = "test_partition_order_is_different_from_table_definition_" + randomNameSuffix();
         assertUpdate("" +
                 "CREATE TABLE " + tableName + "(data int, first varchar, second varchar) " +
                 "WITH (" +
@@ -348,7 +348,7 @@ public abstract class BaseDeltaLakeMinioConnectorTest
     @Override
     public void testDropNonEmptySchemaWithTable()
     {
-        String schemaName = "test_drop_non_empty_schema_" + randomTableSuffix();
+        String schemaName = "test_drop_non_empty_schema_" + randomNameSuffix();
         if (!hasBehavior(SUPPORTS_CREATE_SCHEMA)) {
             return;
         }
@@ -371,7 +371,7 @@ public abstract class BaseDeltaLakeMinioConnectorTest
     @Test(dataProvider = "timestampValues")
     public void testTimestampPredicatePushdown(String value)
     {
-        String tableName = "test_parquet_timestamp_predicate_pushdown_" + randomTableSuffix();
+        String tableName = "test_parquet_timestamp_predicate_pushdown_" + randomNameSuffix();
 
         assertUpdate("DROP TABLE IF EXISTS " + tableName);
         assertUpdate("CREATE TABLE " + tableName + " (t TIMESTAMP WITH TIME ZONE)");
@@ -505,7 +505,7 @@ public abstract class BaseDeltaLakeMinioConnectorTest
     @Test
     public void testTargetMaxFileSize()
     {
-        String tableName = "test_default_max_file_size" + randomTableSuffix();
+        String tableName = "test_default_max_file_size" + randomNameSuffix();
         @Language("SQL") String createTableSql = format("CREATE TABLE %s AS SELECT * FROM tpch.sf1.lineitem LIMIT 100000", tableName);
 
         Session session = Session.builder(getSession())
@@ -579,8 +579,8 @@ public abstract class BaseDeltaLakeMinioConnectorTest
     @Test
     public void testMergeSimpleSelectPartitioned()
     {
-        String targetTable = "merge_simple_target_" + randomTableSuffix();
-        String sourceTable = "merge_simple_source_" + randomTableSuffix();
+        String targetTable = "merge_simple_target_" + randomNameSuffix();
+        String sourceTable = "merge_simple_source_" + randomNameSuffix();
         assertUpdate(format("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR) WITH (location = 's3://%s/%s', partitioned_by = ARRAY['address'])", targetTable, bucketName, targetTable));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Buena'), ('Carol', 3, 'Cambridge'), ('Dave', 11, 'Devon')", targetTable), 4);
@@ -605,8 +605,8 @@ public abstract class BaseDeltaLakeMinioConnectorTest
     @Test(dataProvider = "partitionedProvider")
     public void testMergeUpdateWithVariousLayouts(String partitionPhase)
     {
-        String targetTable = "merge_formats_target_" + randomTableSuffix();
-        String sourceTable = "merge_formats_source_" + randomTableSuffix();
+        String targetTable = "merge_formats_target_" + randomNameSuffix();
+        String sourceTable = "merge_formats_source_" + randomNameSuffix();
         assertUpdate(format("CREATE TABLE %s (customer VARCHAR, purchase VARCHAR) WITH (location = 's3://%s/%s'%s)", targetTable, bucketName, targetTable, partitionPhase));
 
         assertUpdate(format("INSERT INTO %s (customer, purchase) VALUES ('Dave', 'dates'), ('Lou', 'limes'), ('Carol', 'candles')", targetTable), 3);
@@ -642,7 +642,7 @@ public abstract class BaseDeltaLakeMinioConnectorTest
     public void testMergeMultipleOperations(String partitioning)
     {
         int targetCustomerCount = 32;
-        String targetTable = "merge_multiple_" + randomTableSuffix();
+        String targetTable = "merge_multiple_" + randomNameSuffix();
         assertUpdate(format("CREATE TABLE %s (purchase INT, zipcode INT, spouse VARCHAR, address VARCHAR, customer VARCHAR) WITH (location = 's3://%s/%s'%s)", targetTable, bucketName, targetTable, partitioning));
         String originalInsertFirstHalf = IntStream.range(1, targetCustomerCount / 2)
                 .mapToObj(intValue -> format("('joe_%s', %s, %s, 'jan_%s', '%s Poe Ct')", intValue, 1000, 91000, intValue, intValue))
@@ -704,7 +704,7 @@ public abstract class BaseDeltaLakeMinioConnectorTest
     @Test
     public void testMergeSimpleQueryPartitioned()
     {
-        String targetTable = "merge_simple_" + randomTableSuffix();
+        String targetTable = "merge_simple_" + randomNameSuffix();
         assertUpdate(format("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR) WITH (location = 's3://%s/%s', partitioned_by = ARRAY['address'])", targetTable, bucketName, targetTable));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Buena'), ('Carol', 3, 'Cambridge'), ('Dave', 11, 'Devon')", targetTable), 4);
@@ -726,8 +726,8 @@ public abstract class BaseDeltaLakeMinioConnectorTest
     @Test(dataProvider = "targetWithDifferentPartitioning")
     public void testMergeMultipleRowsMatchFails(String createTableSql)
     {
-        String targetTable = "merge_multiple_target_" + randomTableSuffix();
-        String sourceTable = "merge_multiple_source_" + randomTableSuffix();
+        String targetTable = "merge_multiple_target_" + randomNameSuffix();
+        String sourceTable = "merge_multiple_source_" + randomNameSuffix();
         assertUpdate(format(createTableSql, targetTable, bucketName, targetTable));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Antioch')", targetTable), 2);
@@ -763,8 +763,8 @@ public abstract class BaseDeltaLakeMinioConnectorTest
     @Test(dataProvider = "targetAndSourceWithDifferentPartitioning")
     public void testMergeWithDifferentPartitioning(String testDescription, String createTargetTableSql, String createSourceTableSql)
     {
-        String targetTable = format("%s_target_%s", testDescription, randomTableSuffix());
-        String sourceTable = format("%s_source_%s", testDescription, randomTableSuffix());
+        String targetTable = format("%s_target_%s", testDescription, randomNameSuffix());
+        String sourceTable = format("%s_source_%s", testDescription, randomNameSuffix());
 
         assertUpdate(format(createTargetTableSql, targetTable, bucketName, targetTable));
 
@@ -831,7 +831,7 @@ public abstract class BaseDeltaLakeMinioConnectorTest
     @Test
     public void testTableWithNonNullableColumns()
     {
-        String tableName = "test_table_with_non_nullable_columns_" + randomTableSuffix();
+        String tableName = "test_table_with_non_nullable_columns_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + "(col1 INTEGER NOT NULL, col2 INTEGER, col3 INTEGER)");
         assertUpdate("INSERT INTO " + tableName + " VALUES(1, 10, 100)", 1);
         assertUpdate("INSERT INTO " + tableName + " VALUES(2, 20, 200)", 1);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeSharedMetastoreWithTableRedirectionsTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeSharedMetastoreWithTableRedirectionsTest.java
@@ -16,14 +16,14 @@ package io.trino.plugin.deltalake;
 import io.trino.testing.AbstractTestQueryFramework;
 import org.testng.annotations.Test;
 
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 public abstract class BaseDeltaLakeSharedMetastoreWithTableRedirectionsTest
         extends AbstractTestQueryFramework
 {
-    protected final String schema = "test_shared_schema_" + randomTableSuffix();
+    protected final String schema = "test_shared_schema_" + randomNameSuffix();
 
     protected abstract String getExpectedHiveCreateSchema(String catalogName);
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeTableWithCustomLocation.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeTableWithCustomLocation.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
@@ -39,7 +39,7 @@ import static org.testng.Assert.assertTrue;
 public abstract class BaseDeltaLakeTableWithCustomLocation
         extends AbstractTestQueryFramework
 {
-    protected static final String SCHEMA = "test_tables_with_custom_location" + randomTableSuffix();
+    protected static final String SCHEMA = "test_tables_with_custom_location" + randomNameSuffix();
     protected static final String CATALOG_NAME = "delta_with_custom_location";
     protected File metastoreDir;
     protected HiveMetastore metastore;
@@ -48,7 +48,7 @@ public abstract class BaseDeltaLakeTableWithCustomLocation
     @Test
     public void testTableHasUuidSuffixInLocation()
     {
-        String tableName = "table_with_uuid" + randomTableSuffix();
+        String tableName = "table_with_uuid" + randomNameSuffix();
         assertQuerySucceeds(format("CREATE TABLE %s AS SELECT 1 as val", tableName));
         Optional<Table> table = metastore.getTable(SCHEMA, tableName);
         assertTrue(table.isPresent(), "Table should exists");
@@ -60,7 +60,7 @@ public abstract class BaseDeltaLakeTableWithCustomLocation
     public void testCreateAndDrop()
             throws IOException
     {
-        String tableName = "test_create_and_drop" + randomTableSuffix();
+        String tableName = "test_create_and_drop" + randomNameSuffix();
         assertQuerySucceeds(format("CREATE TABLE %s AS SELECT 1 as val", tableName));
         Table table = metastore.getTable(SCHEMA, tableName).orElseThrow();
         assertThat(table.getTableType()).isEqualTo(TableType.MANAGED_TABLE.name());

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAnalyze.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAnalyze.java
@@ -33,7 +33,7 @@ import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.TPCH_SCHEMA;
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.createDeltaLakeQueryRunner;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.INSERT_TABLE;
 import static io.trino.testing.TestingAccessControlManager.privilege;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -66,7 +66,7 @@ public class TestDeltaLakeAnalyze
 
     private void testAnalyze(Optional<Integer> checkpointInterval)
     {
-        String tableName = "test_analyze_" + randomTableSuffix();
+        String tableName = "test_analyze_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName
                 + (checkpointInterval.isPresent() ? format(" WITH (checkpoint_interval = %s)", checkpointInterval.get()) : "")
                 + " AS SELECT * FROM tpch.sf1.nation", 25);
@@ -146,7 +146,7 @@ public class TestDeltaLakeAnalyze
     @Test
     public void testAnalyzePartitioned()
     {
-        String tableName = "test_analyze_" + randomTableSuffix();
+        String tableName = "test_analyze_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName
                 + " WITH ("
                 + "   partitioned_by = ARRAY['regionkey']"
@@ -215,7 +215,7 @@ public class TestDeltaLakeAnalyze
     @Test
     public void testAnalyzeEmpty()
     {
-        String tableName = "test_analyze_empty_" + randomTableSuffix();
+        String tableName = "test_analyze_empty_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.sf1.nation WHERE false", 0);
 
         assertQuery(
@@ -256,7 +256,7 @@ public class TestDeltaLakeAnalyze
     @Test
     public void testAnalyzeExtendedStatisticsDisabled()
     {
-        String tableName = "test_analyze_extended_stats_disabled" + randomTableSuffix();
+        String tableName = "test_analyze_extended_stats_disabled" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.sf1.nation", 25);
 
@@ -274,7 +274,7 @@ public class TestDeltaLakeAnalyze
     public void testAnalyzeWithFilesModifiedAfter()
             throws InterruptedException
     {
-        String tableName = "test_analyze_" + randomTableSuffix();
+        String tableName = "test_analyze_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.sf1.nation", 25);
 
@@ -305,7 +305,7 @@ public class TestDeltaLakeAnalyze
     @Test
     public void testAnalyzeSomeColumns()
     {
-        String tableName = "test_analyze_some_columns" + randomTableSuffix();
+        String tableName = "test_analyze_some_columns" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.sf1.nation", 25);
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorSmokeTest.java
@@ -33,8 +33,8 @@ import java.util.concurrent.TimeUnit;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.assertions.Assert.assertEventually;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -66,7 +66,7 @@ public class TestDeltaLakeConnectorSmokeTest
     public void testWritesLocked(String writeStatement)
             throws Exception
     {
-        String tableName = "test_writes_locked" + randomTableSuffix();
+        String tableName = "test_writes_locked" + randomNameSuffix();
         try {
             assertUpdate(
                     format("CREATE TABLE %s (a_number, a_string) WITH (location = 's3://%s/%s') AS " +
@@ -112,7 +112,7 @@ public class TestDeltaLakeConnectorSmokeTest
     public void testWritesLockExpired(String writeStatement, String expectedValues)
             throws Exception
     {
-        String tableName = "test_writes_locked" + randomTableSuffix();
+        String tableName = "test_writes_locked" + randomNameSuffix();
         assertUpdate(
                 format("CREATE TABLE %s (a_number, a_string) WITH (location = 's3://%s/%s') AS " +
                                 "VALUES (1, 'ala'), (2, 'ma')",
@@ -142,7 +142,7 @@ public class TestDeltaLakeConnectorSmokeTest
     @Test(dataProvider = "writesLockInvalidContentsValuesProvider")
     public void testWritesLockInvalidContents(String writeStatement, String expectedValues)
     {
-        String tableName = "test_writes_locked" + randomTableSuffix();
+        String tableName = "test_writes_locked" + randomNameSuffix();
         assertUpdate(
                 format("CREATE TABLE %s (a_number, a_string) WITH (location = 's3://%s/%s') AS " +
                                 "VALUES (1, 'ala'), (2, 'ma')",
@@ -172,7 +172,7 @@ public class TestDeltaLakeConnectorSmokeTest
     @Test
     public void testSchemaEvolutionOnTableWithColumnInvariant()
     {
-        String tableName = "test_schema_evolution_on_table_with_column_invariant_" + randomTableSuffix();
+        String tableName = "test_schema_evolution_on_table_with_column_invariant_" + randomNameSuffix();
         hiveMinioDataLake.copyResources("databricks/invariants", tableName);
         getQueryRunner().execute(format("CREATE TABLE %s (ignored int) WITH (location = '%s')",
                 tableName,

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeDelete.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeDelete.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,7 +34,7 @@ public class TestDeltaLakeDelete
         extends AbstractTestQueryFramework
 {
     private static final String SCHEMA = "default";
-    private final String bucketName = "test-delta-lake-connector-test-" + randomTableSuffix();
+    private final String bucketName = "test-delta-lake-connector-test-" + randomNameSuffix();
 
     private HiveMinioDataLake hiveMinioDataLake;
 
@@ -62,7 +62,7 @@ public class TestDeltaLakeDelete
     @Test
     public void testTargetedDeleteWhenTableIsPartitionedWithColumnContainingSpecialCharacters()
     {
-        String tableName = "test_specific_delete_" + randomTableSuffix();
+        String tableName = "test_specific_delete_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " (id, col_name) " +
                 "WITH (partitioned_by = ARRAY['col_name'], location = '" + getLocationForTable(tableName) + "')  " +
                 "AS VALUES " +
@@ -76,7 +76,7 @@ public class TestDeltaLakeDelete
     @Test
     public void testTargetedDelete()
     {
-        String tableName = "test_specific_delete_" + randomTableSuffix();
+        String tableName = "test_specific_delete_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (location = '" + getLocationForTable(tableName) + "')  AS SELECT * FROM orders", "SELECT count(*) FROM orders");
         assertUpdate("DELETE FROM " + tableName + " WHERE orderkey = 60000", "VALUES 1");
         assertQuery("SELECT * FROM " + tableName, "SELECT * FROM orders WHERE orderkey != 60000");
@@ -86,7 +86,7 @@ public class TestDeltaLakeDelete
     public void testDeleteDatabricksMultiFile()
     {
         testDeleteMultiFile(
-                "multi_file_databricks" + randomTableSuffix(),
+                "multi_file_databricks" + randomNameSuffix(),
                 "io/trino/plugin/deltalake/testing/resources/databricks");
     }
 
@@ -94,7 +94,7 @@ public class TestDeltaLakeDelete
     public void testDeleteOssDeltaLakeMultiFile()
     {
         testDeleteMultiFile(
-                "multi_file_deltalake" + randomTableSuffix(),
+                "multi_file_deltalake" + randomNameSuffix(),
                 "io/trino/plugin/deltalake/testing/resources/ossdeltalake");
     }
 
@@ -113,7 +113,7 @@ public class TestDeltaLakeDelete
     @Test
     public void testDeleteOnPartitionKey()
     {
-        String tableName = "test_delete_on_partition_key_" + randomTableSuffix();
+        String tableName = "test_delete_on_partition_key_" + randomNameSuffix();
         assertUpdate("" +
                 "CREATE TABLE " + tableName + " (a, p_key) WITH (location = '" + getLocationForTable(tableName) + "', partitioned_by = ARRAY['p_key']) " +
                 "AS VALUES (1, 'a'), (2, 'b'), (3, 'c'), (2, 'a'), (null, null), (1, null)",
@@ -125,7 +125,7 @@ public class TestDeltaLakeDelete
     @Test
     public void testDeleteFromPartitionedTable()
     {
-        String tableName = "test_delete_from_partitioned_table_" + randomTableSuffix();
+        String tableName = "test_delete_from_partitioned_table_" + randomNameSuffix();
         assertUpdate("" +
                 "CREATE TABLE " + tableName + " (a, p_key) WITH (location = '" + getLocationForTable(tableName) + "', partitioned_by = ARRAY['p_key']) " +
                 "AS VALUES (1, 'a'), (2, 'b'), (3, 'c'), (2, 'a'), (null, null), (1, null)",
@@ -137,7 +137,7 @@ public class TestDeltaLakeDelete
     @Test
     public void testDeleteTimestamps()
     {
-        String tableName = "test_delete_timestamps_" + randomTableSuffix();
+        String tableName = "test_delete_timestamps_" + randomNameSuffix();
         assertUpdate(
                 format("CREATE TABLE %s (ts) WITH (location = '%s') AS VALUES TIMESTAMP '2021-02-03 01:02:03.456 UTC', TIMESTAMP '2021-02-04 01:02:03.456 UTC'",
                         tableName,
@@ -150,7 +150,7 @@ public class TestDeltaLakeDelete
     @Test
     public void testDeleteOnRowType()
     {
-        String tableName = "test_delete_on_row_type_" + randomTableSuffix();
+        String tableName = "test_delete_on_row_type_" + randomNameSuffix();
         assertUpdate("" +
                 "CREATE TABLE " + tableName + " (nested, a, b) " +
                 "WITH (location = '" + getLocationForTable(tableName) + " ') " +
@@ -168,7 +168,7 @@ public class TestDeltaLakeDelete
     @Test
     public void testDeleteAllDatabricks()
     {
-        String tableName = "test_delete_all_databricks" + randomTableSuffix();
+        String tableName = "test_delete_all_databricks" + randomNameSuffix();
         Set<String> originalFiles = testDeleteAllAndReturnInitialDataLakeFilesSet(
                 tableName,
                 "io/trino/plugin/deltalake/testing/resources/databricks");
@@ -183,7 +183,7 @@ public class TestDeltaLakeDelete
     @Test
     public void testDeleteAllOssDeltaLake()
     {
-        String tableName = "test_delete_all_deltalake" + randomTableSuffix();
+        String tableName = "test_delete_all_deltalake" + randomNameSuffix();
         Set<String> originalFiles = testDeleteAllAndReturnInitialDataLakeFilesSet(
                 tableName,
                 "io/trino/plugin/deltalake/testing/resources/ossdeltalake");
@@ -210,7 +210,7 @@ public class TestDeltaLakeDelete
     @Test
     public void testStatsAfterDelete()
     {
-        String tableName = "test_stats_after_delete_" + randomTableSuffix();
+        String tableName = "test_stats_after_delete_" + randomNameSuffix();
         assertUpdate("" +
                 "CREATE TABLE " + tableName + " (a, b, c) " +
                 "WITH (location = '" + getLocationForTable(tableName) + "') " +
@@ -234,7 +234,7 @@ public class TestDeltaLakeDelete
     @Test
     public void testDeleteWithHiddenColumn()
     {
-        String tableName = "test_delete_with_hidden_column_" + randomTableSuffix();
+        String tableName = "test_delete_with_hidden_column_" + randomNameSuffix();
         assertUpdate("" +
                         "CREATE TABLE " + tableName + " (a, b, c) " +
                         "WITH (location = '" + getLocationForTable(tableName) + "') " +
@@ -247,7 +247,7 @@ public class TestDeltaLakeDelete
     @Test
     public void testDeleteWithRowFilter()
     {
-        String tableName = "test_delete_with_row_filter_" + randomTableSuffix();
+        String tableName = "test_delete_with_row_filter_" + randomNameSuffix();
         assertUpdate("" +
                 "CREATE TABLE " + tableName + " WITH (location = '" + getLocationForTable(tableName) + "', partitioned_by = ARRAY['regionkey']) " +
                 "AS SELECT nationkey, regionkey FROM nation",
@@ -259,7 +259,7 @@ public class TestDeltaLakeDelete
     @Test
     public void testDeleteMultiplePartitionKeys()
     {
-        String tableName = "test_delete_multiple_partition_keys_" + randomTableSuffix();
+        String tableName = "test_delete_multiple_partition_keys_" + randomNameSuffix();
         assertUpdate("" +
                         "CREATE TABLE " + tableName + " (a, b, c) WITH (location = '" + getLocationForTable(tableName) + "', partitioned_by = ARRAY['b', 'c']) " +
                         "AS VALUES (1, 2, 3), (1, 2, 4), (3, 2, 1), (null, null, null), (1, 1, 1)",

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePartitioning.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePartitioning.java
@@ -20,7 +20,7 @@ import org.testng.annotations.Test;
 
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.createDeltaLakeQueryRunner;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 
 public class TestDeltaLakePartitioning
@@ -146,7 +146,7 @@ public class TestDeltaLakePartitioning
     @Test
     public void testPartitioningWithSpecialCharactersInPartitionColumn()
     {
-        String dataPath = getClass().getClassLoader().getResource("deltalake").toExternalForm() + "/special_char" + randomTableSuffix();
+        String dataPath = getClass().getClassLoader().getResource("deltalake").toExternalForm() + "/special_char" + randomNameSuffix();
         assertUpdate(
                 "CREATE TABLE special_chars (id, col_name) " +
                         "WITH(partitioned_by = ARRAY['col_name'], " +

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSharedHiveMetastoreWithViews.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSharedHiveMetastoreWithViews.java
@@ -26,15 +26,15 @@ import java.util.Map;
 
 import static io.trino.plugin.hive.containers.HiveMinioDataLake.MINIO_ACCESS_KEY;
 import static io.trino.plugin.hive.containers.HiveMinioDataLake.MINIO_SECRET_KEY;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestDeltaLakeSharedHiveMetastoreWithViews
         extends AbstractTestQueryFramework
 {
-    protected final String schema = "test_shared_schema_with_hive_views_" + randomTableSuffix();
-    private final String bucketName = "delta-lake-shared-hive-with-views-" + randomTableSuffix();
+    protected final String schema = "test_shared_schema_with_hive_views_" + randomNameSuffix();
+    private final String bucketName = "delta-lake-shared-hive-with-views-" + randomNameSuffix();
 
     private HiveMinioDataLake hiveMinioDataLake;
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeUpdate.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeUpdate.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 
 // An Update test is run against all supported file systems from AbstractTestDeltaLakeIntegrationSmokeTest#testUpdate
@@ -35,7 +35,7 @@ public class TestDeltaLakeUpdate
 
     public TestDeltaLakeUpdate()
     {
-        this.bucketName = "test-delta-lake-connector-test-" + randomTableSuffix();
+        this.bucketName = "test-delta-lake-connector-test-" + randomNameSuffix();
     }
 
     @Override
@@ -62,7 +62,7 @@ public class TestDeltaLakeUpdate
     @Test
     public void testSimpleUpdate()
     {
-        String tableName = "test_simple_update_" + randomTableSuffix();
+        String tableName = "test_simple_update_" + randomNameSuffix();
         assertUpdate("" +
                         "CREATE TABLE " + tableName + " (a, b, c) WITH (location = '" + getLocationForTable(tableName) + "') " +
                         "AS VALUES (1, 2, 3), (1, 2, 4), (3, 2, 1), (null, null, null), (1, 1, 1)",
@@ -98,7 +98,7 @@ public class TestDeltaLakeUpdate
     @Test
     public void testUpdateAll()
     {
-        String tableName = "test_update_all_" + randomTableSuffix();
+        String tableName = "test_update_all_" + randomNameSuffix();
         assertUpdate("" +
                         "CREATE TABLE " + tableName + " (a, b) WITH (location = '" + getLocationForTable(tableName) + "') " +
                         "AS VALUES (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)",
@@ -110,7 +110,7 @@ public class TestDeltaLakeUpdate
     @Test
     public void testUpdateSingleRow()
     {
-        String tableName = "test_update_single_row_" + randomTableSuffix();
+        String tableName = "test_update_single_row_" + randomNameSuffix();
         assertUpdate("" +
                         "CREATE TABLE " + tableName + " (a, b) WITH (location = '" + getLocationForTable(tableName) + "') " +
                         "AS VALUES (1, 2)",
@@ -122,7 +122,7 @@ public class TestDeltaLakeUpdate
     @Test
     public void testUpdateNone()
     {
-        String tableName = "test_update_none_" + randomTableSuffix();
+        String tableName = "test_update_none_" + randomNameSuffix();
         assertUpdate("" +
                         "CREATE TABLE " + tableName + " (a, b) WITH (location = '" + getLocationForTable(tableName) + "') " +
                         "AS VALUES (1, 2)",
@@ -134,7 +134,7 @@ public class TestDeltaLakeUpdate
     @Test
     public void testUpdateOnPartitionKey()
     {
-        String tableName = "test_update_on_partition_key_" + randomTableSuffix();
+        String tableName = "test_update_on_partition_key_" + randomNameSuffix();
         assertUpdate("" +
                         "CREATE TABLE " + tableName + " (a, b, c) WITH (location = '" + getLocationForTable(tableName) + "', partitioned_by = ARRAY['b']) " +
                         "AS VALUES (1, 2, 3), (1, 2, 4), (3, 2, 1), (null, null, null), (1, 1, 1)",
@@ -148,7 +148,7 @@ public class TestDeltaLakeUpdate
     @Test
     public void testUpdateWithPartitionKeyPredicate()
     {
-        String tableName = "test_update_with_partition_key_predicate_" + randomTableSuffix();
+        String tableName = "test_update_with_partition_key_predicate_" + randomNameSuffix();
         assertUpdate("" +
                         "CREATE TABLE " + tableName + " (a, b, c) WITH (location = '" + getLocationForTable(tableName) + "', partitioned_by = ARRAY['b']) " +
                         "AS VALUES (1, 2, 3), (1, 2, 4), (3, 2, 1), (null, null, null), (1, 1, 1)",
@@ -163,7 +163,7 @@ public class TestDeltaLakeUpdate
     @Test
     public void testUpdateNull()
     {
-        String tableName = "test_update_null_" + randomTableSuffix();
+        String tableName = "test_update_null_" + randomNameSuffix();
         assertUpdate("" +
                         "CREATE TABLE " + tableName + " (a, b, c) WITH (location = '" + getLocationForTable(tableName) + "') " +
                         "AS VALUES (1, 2, 3), (1, 2, 4), (3, 2, 1), (null, null, null), (1, 1, 1)",
@@ -178,7 +178,7 @@ public class TestDeltaLakeUpdate
     @Test
     public void testUpdateAllColumns()
     {
-        String tableName = "test_update_all_columns_" + randomTableSuffix();
+        String tableName = "test_update_all_columns_" + randomNameSuffix();
         assertUpdate("" +
                         "CREATE TABLE " + tableName + " (a, b, c) WITH (location = '" + getLocationForTable(tableName) + "') " +
                         "AS VALUES (1, 2, 3), (1, 2, 4), (3, 2, 1), (null, null, null), (1, 1, 1)",

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestPredicatePushdown.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestPredicatePushdown.java
@@ -32,7 +32,7 @@ import java.util.Set;
 
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.createS3DeltaLakeQueryRunner;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 
@@ -225,7 +225,7 @@ public class TestPredicatePushdown
          */
         String create(String namePrefix)
         {
-            String name = format("%s_%s", namePrefix, randomTableSuffix());
+            String name = format("%s_%s", namePrefix, randomNameSuffix());
             hiveMinioDataLake.copyResources(RESOURCE_PATH.resolve(resourcePath).toString(), name);
             getQueryRunner().execute(format(
                     "CREATE TABLE %2$s (%3$s) WITH (location = 's3://%1$s/%2$s')",

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeRenameToWithGlueMetastore.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeRenameToWithGlueMetastore.java
@@ -24,14 +24,14 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 
 public class TestDeltaLakeRenameToWithGlueMetastore
         extends AbstractTestQueryFramework
 {
-    protected static final String SCHEMA = "test_delta_lake_rename_to_with_glue_" + randomTableSuffix();
+    protected static final String SCHEMA = "test_delta_lake_rename_to_with_glue_" + randomNameSuffix();
     protected static final String CATALOG_NAME = "test_delta_lake_rename_to_with_glue";
 
     private File schemaLocation;
@@ -58,8 +58,8 @@ public class TestDeltaLakeRenameToWithGlueMetastore
     @Test
     public void testRenameOfExternalTable()
     {
-        String oldTable = "test_table_external_to_be_renamed_" + randomTableSuffix();
-        String newTable = "test_table_external_renamed_" + randomTableSuffix();
+        String oldTable = "test_table_external_to_be_renamed_" + randomNameSuffix();
+        String newTable = "test_table_external_renamed_" + randomNameSuffix();
         String location = schemaLocation.getPath() + "/tableLocation/";
         try {
             assertUpdate(format("CREATE TABLE %s WITH (location = '%s') AS SELECT 1 AS val ", oldTable, location), 1);
@@ -80,8 +80,8 @@ public class TestDeltaLakeRenameToWithGlueMetastore
     @Test
     public void testRenameOfManagedTable()
     {
-        String oldTable = "test_table_managed_to_be_renamed_" + randomTableSuffix();
-        String newTable = "test_table_managed_renamed_" + randomTableSuffix();
+        String oldTable = "test_table_managed_to_be_renamed_" + randomNameSuffix();
+        String newTable = "test_table_managed_renamed_" + randomNameSuffix();
         try {
             assertUpdate(format("CREATE TABLE %s AS SELECT 1 AS val ", oldTable), 1);
             String oldLocation = (String) computeScalar("SELECT \"$path\" FROM " + oldTable);

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/DruidTable.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/DruidTable.java
@@ -15,7 +15,7 @@ package io.trino.plugin.druid;
 
 import io.trino.testing.sql.TemporaryRelation;
 
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.util.Objects.requireNonNull;
 
 public class DruidTable
@@ -26,7 +26,7 @@ public class DruidTable
     public DruidTable(String namePrefix)
     {
         requireNonNull(namePrefix, "namePrefix is null");
-        this.tableName = namePrefix + randomTableSuffix();
+        this.tableName = namePrefix + randomNameSuffix();
     }
 
     @Override

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -46,8 +46,8 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.MaterializedResult.resultBuilder;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.assertions.Assert.assertEquals;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -476,7 +476,7 @@ public abstract class BaseElasticsearchConnectorTest
     public void testAsRawJson()
             throws IOException
     {
-        String indexName = "raw_json_" + randomTableSuffix();
+        String indexName = "raw_json_" + randomNameSuffix();
 
         @Language("JSON")
         String mapping = "" +
@@ -726,7 +726,7 @@ public abstract class BaseElasticsearchConnectorTest
     public void testAsRawJsonForAllPrimitiveTypes()
             throws IOException
     {
-        String indexName = "raw_json_primitive_" + randomTableSuffix();
+        String indexName = "raw_json_primitive_" + randomNameSuffix();
 
         @Language("JSON")
         String mapping = "" +
@@ -832,7 +832,7 @@ public abstract class BaseElasticsearchConnectorTest
     public void testAsRawJsonCases()
             throws IOException
     {
-        String indexName = "raw_json_cases_" + randomTableSuffix();
+        String indexName = "raw_json_cases_" + randomNameSuffix();
 
         @Language("JSON")
         String mapping = "" +
@@ -893,7 +893,7 @@ public abstract class BaseElasticsearchConnectorTest
     public void testAsRawJsonAndIsArraySameFieldException()
             throws IOException
     {
-        String indexName = "raw_json_array_exception" + randomTableSuffix();
+        String indexName = "raw_json_array_exception" + randomNameSuffix();
 
         @Language("JSON")
         String mapping = "" +
@@ -1731,7 +1731,7 @@ public abstract class BaseElasticsearchConnectorTest
     public void testAlias()
             throws IOException
     {
-        String aliasName = format("alias_%s", randomTableSuffix());
+        String aliasName = format("alias_%s", randomNameSuffix());
         addAlias("orders", aliasName);
 
         assertQuery(

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHiveThriftMetastoreWithS3.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHiveThriftMetastoreWithS3.java
@@ -37,7 +37,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.List;
 
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -70,7 +70,7 @@ public class TestHiveThriftMetastoreWithS3
         this.awsAccessKey = requireNonNull(awsAccessKey, "awsAccessKey is null");
         this.awsSecretKey = requireNonNull(awsSecretKey, "awsSecretKey is null");
         this.writableBucket = requireNonNull(writableBucket, "writableBucket is null");
-        this.schemaName = "test_thrift_s3_" + randomTableSuffix();
+        this.schemaName = "test_thrift_s3_" + randomNameSuffix();
 
         String coreSiteXmlContent = Resources.toString(Resources.getResource("s3/hive-core-site.template.xml"), UTF_8)
                 .replace("%S3_BUCKET_ENDPOINT%", s3endpoint)
@@ -124,7 +124,7 @@ public class TestHiveThriftMetastoreWithS3
     @Test
     public void testRecreateTable()
     {
-        String tableName = "test_recreate_table_" + randomTableSuffix();
+        String tableName = "test_recreate_table_" + randomNameSuffix();
         String schemaTableName = "%s.%s".formatted(schemaName, tableName);
         String tableLocation = "%s/%s".formatted(schemaName, tableName);
 
@@ -150,7 +150,7 @@ public class TestHiveThriftMetastoreWithS3
     @Test
     public void testRecreatePartition()
     {
-        String tableName = "test_recreate_partition_" + randomTableSuffix();
+        String tableName = "test_recreate_partition_" + randomNameSuffix();
         String schemaTableName = "%s.%s".formatted(schemaName, tableName);
         String partitionLocation = "%s/%s/part=1".formatted(schemaName, tableName);
 
@@ -181,7 +181,7 @@ public class TestHiveThriftMetastoreWithS3
     public void testUnregisterPartitionNotRemoveData()
     {
         // Verify unregister_partition procedure doesn't remove physical data even when 'hive.metastore.thrift.delete-files-on-drop' config property is true
-        String tableName = "test_recreate_partition_" + randomTableSuffix();
+        String tableName = "test_recreate_partition_" + randomNameSuffix();
         String schemaTableName = "%s.%s".formatted(schemaName, tableName);
 
         assertUpdate("CREATE TABLE " + schemaTableName + "(col int, part int) WITH (partitioned_by = ARRAY['part'])");

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -151,9 +151,9 @@ import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SHOW_COLUMNS;
 import static io.trino.testing.TestingAccessControlManager.privilege;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static io.trino.testing.assertions.Assert.assertEquals;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static io.trino.transaction.TransactionBuilder.transaction;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static java.lang.String.format;
@@ -447,7 +447,7 @@ public abstract class BaseHiveConnectorTest
     @Test
     public void testRequiredPartitionFilterAppliedOnDifferentSchema()
     {
-        String schemaName = "schema_" + randomTableSuffix();
+        String schemaName = "schema_" + randomNameSuffix();
         Session session = Session.builder(getSession())
                 .setIdentity(Identity.forUser("hive")
                         .withRole("hive", new SelectedRole(ROLE, Optional.of("admin")))
@@ -873,7 +873,7 @@ public abstract class BaseHiveConnectorTest
                 .setIdentity(Identity.forUser("alice").build())
                 .build();
 
-        String schema = "test_view_authorization" + TestTable.randomTableSuffix();
+        String schema = "test_view_authorization" + randomNameSuffix();
 
         assertUpdate(admin, "CREATE SCHEMA " + schema);
         assertUpdate(admin, "CREATE VIEW " + schema + ".test_view AS SELECT current_user AS user");
@@ -902,7 +902,7 @@ public abstract class BaseHiveConnectorTest
                 .setIdentity(Identity.forUser("alice").build())
                 .build();
 
-        String schema = "test_view_authorization" + TestTable.randomTableSuffix();
+        String schema = "test_view_authorization" + randomNameSuffix();
 
         assertUpdate(admin, "CREATE SCHEMA " + schema);
         assertUpdate(admin, "CREATE TABLE " + schema + ".test_table (col int)");
@@ -933,7 +933,7 @@ public abstract class BaseHiveConnectorTest
                 .setIdentity(Identity.forUser("alice").build())
                 .build();
 
-        String schema = "test_view_authorization" + TestTable.randomTableSuffix();
+        String schema = "test_view_authorization" + randomNameSuffix();
 
         assertUpdate(admin, "CREATE SCHEMA " + schema);
         assertUpdate(admin, "CREATE TABLE " + schema + ".test_table (col int)");
@@ -964,7 +964,7 @@ public abstract class BaseHiveConnectorTest
                 .setIdentity(Identity.forUser("alice").build())
                 .build();
 
-        String schema = "test_view_authorization" + TestTable.randomTableSuffix();
+        String schema = "test_view_authorization" + randomNameSuffix();
 
         assertUpdate(admin, "CREATE SCHEMA " + schema);
         assertUpdate(admin, "CREATE TABLE " + schema + ".test_table (col int)");
@@ -2164,7 +2164,7 @@ public abstract class BaseHiveConnectorTest
     @Test(dataProvider = "bucketFilteringDataTypesSetupProvider")
     public void testFilterOnBucketedTable(BucketedFilterTestSetup testSetup)
     {
-        String tableName = "test_filter_on_bucketed_table_" + randomTableSuffix();
+        String tableName = "test_filter_on_bucketed_table_" + randomNameSuffix();
         assertUpdate(
                 """
                 CREATE TABLE %s (bucket_key %s, other_data double)
@@ -2281,7 +2281,7 @@ public abstract class BaseHiveConnectorTest
     @Test(dataProvider = "bucketedUnsupportedTypes")
     public void testBucketedTableUnsupportedTypes(String typeName)
     {
-        String tableName = "test_bucketed_table_for_unsupported_types_" + randomTableSuffix();
+        String tableName = "test_bucketed_table_for_unsupported_types_" + randomNameSuffix();
         assertThatThrownBy(() -> assertUpdate(
                 """
                 CREATE TABLE %s (bucket_key %s, other_data double)
@@ -2304,7 +2304,7 @@ public abstract class BaseHiveConnectorTest
     @Test
     public void testBucketedTableWithTimestampColumn()
     {
-        String tableName = "test_bucketed_table_with_timestamp_" + randomTableSuffix();
+        String tableName = "test_bucketed_table_with_timestamp_" + randomNameSuffix();
 
         String createTable = "" +
                 "CREATE TABLE " + tableName + " (" +
@@ -4021,7 +4021,7 @@ public abstract class BaseHiveConnectorTest
             int taskMaxScaleWriterCount,
             boolean scaleWriters)
     {
-        String tableName = "task_scale_writers_" + randomTableSuffix();
+        String tableName = "task_scale_writers_" + randomNameSuffix();
         try {
             @Language("SQL") String createTableSql = format(
                     "CREATE TABLE %s WITH (format = 'ORC') AS SELECT * FROM tpch.sf5.orders",
@@ -5015,7 +5015,7 @@ public abstract class BaseHiveConnectorTest
     private void doTestParquetTimestampPredicatePushdown(Session baseSession, HiveTimestampPrecision timestampPrecision, LocalDateTime value)
     {
         Session session = withTimestampPrecision(baseSession, timestampPrecision);
-        String tableName = "test_parquet_timestamp_predicate_pushdown_" + randomTableSuffix();
+        String tableName = "test_parquet_timestamp_predicate_pushdown_" + randomNameSuffix();
         assertUpdate("DROP TABLE IF EXISTS " + tableName);
         assertUpdate("CREATE TABLE " + tableName + " (t TIMESTAMP) WITH (format = 'PARQUET')");
         assertUpdate(session, format("INSERT INTO %s VALUES (%s)", tableName, formatTimestamp(value)), 1);
@@ -5126,7 +5126,7 @@ public abstract class BaseHiveConnectorTest
 
     private void testParquetDictionaryPredicatePushdown(Session session)
     {
-        String tableName = "test_parquet_dictionary_pushdown_" + randomTableSuffix();
+        String tableName = "test_parquet_dictionary_pushdown_" + randomNameSuffix();
         assertUpdate(session, "DROP TABLE IF EXISTS " + tableName);
         assertUpdate(session, "CREATE TABLE " + tableName + " (n BIGINT) WITH (format = 'PARQUET')");
         assertUpdate(session, "INSERT INTO " + tableName + " VALUES 1, 1, 2, 2, 4, 4, 5, 5", 8);
@@ -7804,7 +7804,7 @@ public abstract class BaseHiveConnectorTest
     @Test
     public void testOptimize()
     {
-        String tableName = "test_optimize_" + randomTableSuffix();
+        String tableName = "test_optimize_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.sf1.nation WITH NO DATA", 0);
 
         insertNationNTimes(tableName, 10);
@@ -7846,7 +7846,7 @@ public abstract class BaseHiveConnectorTest
     @Test
     public void testOptimizeWithWriterScaling()
     {
-        String tableName = "test_optimize_witer_scaling" + randomTableSuffix();
+        String tableName = "test_optimize_witer_scaling" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.sf1.nation WITH NO DATA", 0);
 
         insertNationNTimes(tableName, 4);
@@ -7876,7 +7876,7 @@ public abstract class BaseHiveConnectorTest
         int insertCount = 4;
         int partitionsCount = 5;
 
-        String tableName = "test_optimize_with_partitioning_" + randomTableSuffix();
+        String tableName = "test_optimize_with_partitioning_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + "(" +
                 "  nationkey BIGINT, " +
                 "  name VARCHAR, " +
@@ -7933,7 +7933,7 @@ public abstract class BaseHiveConnectorTest
     public void testOptimizeWithBucketing()
     {
         int insertCount = 4;
-        String tableName = "test_optimize_with_bucketing_" + randomTableSuffix();
+        String tableName = "test_optimize_with_bucketing_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + "(" +
                 "  nationkey BIGINT, " +
                 "  name VARCHAR, " +
@@ -7965,7 +7965,7 @@ public abstract class BaseHiveConnectorTest
     @Test
     public void testOptimizeHiveSystemTable()
     {
-        String tableName = "test_optimize_system_table_" + randomTableSuffix();
+        String tableName = "test_optimize_system_table_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + "(a bigint, b bigint) WITH (partitioned_by = ARRAY['b'])");
 
         assertQuery("SELECT count(*) FROM " + tableName, "SELECT 0");
@@ -8014,7 +8014,7 @@ public abstract class BaseHiveConnectorTest
             return;
         }
 
-        String tableName = "test_timestamp_precision_" + randomTableSuffix();
+        String tableName = "test_timestamp_precision_" + randomNameSuffix();
         String createTable = "CREATE TABLE " + tableName + " (ts TIMESTAMP) WITH (format = '%s')";
         @Language("SQL") String insert = "INSERT INTO " + tableName + " VALUES (TIMESTAMP '%s')";
 
@@ -8041,7 +8041,7 @@ public abstract class BaseHiveConnectorTest
             return;
         }
 
-        String tableName = "test_timestamp_precision_" + randomTableSuffix();
+        String tableName = "test_timestamp_precision_" + randomNameSuffix();
         String createTableAs = "CREATE TABLE " + tableName + " WITH (format = '%s') AS SELECT TIMESTAMP '%s' ts";
 
         testTimestampPrecisionWrites(
@@ -8086,7 +8086,7 @@ public abstract class BaseHiveConnectorTest
     @Test
     public void testSelectFromViewWithoutDefaultCatalogAndSchema()
     {
-        String viewName = "select_from_view_without_catalog_and_schema_" + randomTableSuffix();
+        String viewName = "select_from_view_without_catalog_and_schema_" + randomNameSuffix();
         assertUpdate("CREATE VIEW " + viewName + " AS SELECT * FROM nation WHERE nationkey=1");
         assertQuery("SELECT count(*) FROM " + viewName, "VALUES 1");
         assertQuery("SELECT count(*) FROM hive.tpch." + viewName, "VALUES 1");
@@ -8112,14 +8112,14 @@ public abstract class BaseHiveConnectorTest
                 .build();
 
         // Hive views tests covered in TestHiveViews.testTimestampHiveView and TestHiveViesLegacy.testTimestampHiveView
-        String tableName = "ts_hive_table_" + randomTableSuffix();
+        String tableName = "ts_hive_table_" + randomNameSuffix();
         assertUpdate(
                 withTimestampPrecision(defaultSession, HiveTimestampPrecision.NANOSECONDS),
                 "CREATE TABLE " + tableName + " AS SELECT TIMESTAMP '1990-01-02 12:13:14.123456789' ts",
                 1);
 
         // Presto view created with config property set to MILLIS and session property not set
-        String prestoViewNameDefault = "presto_view_ts_default_" + randomTableSuffix();
+        String prestoViewNameDefault = "presto_view_ts_default_" + randomNameSuffix();
         assertUpdate(defaultSession, "CREATE VIEW " + prestoViewNameDefault + " AS SELECT *  FROM " + tableName);
 
         assertThat(query(defaultSession, "SELECT ts FROM " + prestoViewNameDefault)).matches("VALUES TIMESTAMP '1990-01-02 12:13:14.123'");
@@ -8140,7 +8140,7 @@ public abstract class BaseHiveConnectorTest
         assertThat(query(nanosSessions, "SELECT ts FROM hive_timestamp_nanos.tpch." + prestoViewNameDefault)).matches("VALUES TIMESTAMP '1990-01-02 12:13:14.123'");
 
         // Presto view created with config property set to MILLIS and session property set to NANOS
-        String prestoViewNameNanos = "presto_view_ts_nanos_" + randomTableSuffix();
+        String prestoViewNameNanos = "presto_view_ts_nanos_" + randomNameSuffix();
         assertUpdate(nanosSessions, "CREATE VIEW " + prestoViewNameNanos + " AS SELECT *  FROM " + tableName);
 
         // TODO(https://github.com/trinodb/trino/issues/6295) Presto view schema is fixed on creation
@@ -8177,7 +8177,7 @@ public abstract class BaseHiveConnectorTest
             builder.setCatalogSessionProperty(catalog, lowerCaseFormat + "_use_column_names", String.valueOf(formatUseColumnNames));
         }
         Session admin = builder.build();
-        String tableName = format("test_renames_%s_%s_%s", lowerCaseFormat, formatUseColumnNames, randomTableSuffix());
+        String tableName = format("test_renames_%s_%s_%s", lowerCaseFormat, formatUseColumnNames, randomNameSuffix());
         assertUpdate(admin, format("CREATE TABLE %s (id BIGINT, old_name VARCHAR, age INT, state VARCHAR) WITH (format = '%s', partitioned_by = ARRAY['state'])", tableName, format));
         assertUpdate(admin, format("INSERT INTO %s VALUES(111, 'Katy', 57, 'CA')", tableName), 1);
         assertQuery(admin, "SELECT * FROM " + tableName, "VALUES(111, 'Katy', 57, 'CA')");
@@ -8232,7 +8232,7 @@ public abstract class BaseHiveConnectorTest
             builder.setCatalogSessionProperty(catalog, lowerCaseFormat + "_use_column_names", String.valueOf(formatUseColumnNames));
         }
         Session admin = builder.build();
-        String tableName = format("test_add_drop_%s_%s_%s", lowerCaseFormat, formatUseColumnNames, randomTableSuffix());
+        String tableName = format("test_add_drop_%s_%s_%s", lowerCaseFormat, formatUseColumnNames, randomNameSuffix());
         assertUpdate(admin, format("CREATE TABLE %s (id BIGINT, old_name VARCHAR, age INT, state VARCHAR) WITH (format = '%s')", tableName, format));
         assertUpdate(admin, format("INSERT INTO %s VALUES(111, 'Katy', 57, 'CA')", tableName), 1);
         assertQuery(admin, "SELECT * FROM " + tableName, "VALUES(111, 'Katy', 57, 'CA')");

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.plugin.hive.TestingThriftHiveMetastoreBuilder.testingThriftHiveMetastoreBuilder;
 import static io.trino.testing.MaterializedResult.resultBuilder;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.time.temporal.ChronoUnit.MINUTES;
@@ -76,7 +76,7 @@ public abstract class BaseTestHiveOnDataLake
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        this.bucketName = "test-hive-insert-overwrite-" + randomTableSuffix();
+        this.bucketName = "test-hive-insert-overwrite-" + randomNameSuffix();
         this.hiveMinioDataLake = closeAfterClass(
                 new HiveMinioDataLake(bucketName, hiveHadoopImage));
         this.hiveMinioDataLake.start();
@@ -200,7 +200,7 @@ public abstract class BaseTestHiveOnDataLake
     @Test
     public void testFlushPartitionCache()
     {
-        String tableName = "nation_" + randomTableSuffix();
+        String tableName = "nation_" + randomNameSuffix();
         String fullyQualifiedTestTableName = getFullyQualifiedTestTableName(tableName);
         String partitionColumn = "regionkey";
 
@@ -218,7 +218,7 @@ public abstract class BaseTestHiveOnDataLake
     @Test
     public void testFlushPartitionCacheWithDeprecatedPartitionParams()
     {
-        String tableName = "nation_" + randomTableSuffix();
+        String tableName = "nation_" + randomNameSuffix();
         String fullyQualifiedTestTableName = getFullyQualifiedTestTableName(tableName);
         String partitionColumn = "regionkey";
 
@@ -312,7 +312,7 @@ public abstract class BaseTestHiveOnDataLake
     @Test
     public void testEnumPartitionProjectionOnVarcharColumnWithWhitespace()
     {
-        String tableName = "nation_" + randomTableSuffix();
+        String tableName = "nation_" + randomNameSuffix();
         String fullyQualifiedTestTableName = getFullyQualifiedTestTableName(tableName);
 
         computeActual(
@@ -567,7 +567,7 @@ public abstract class BaseTestHiveOnDataLake
     @Test
     public void testIntegerPartitionProjectionOnVarcharColumnWithDigitsAlignCreatedOnHive()
     {
-        String tableName = "nation_" + randomTableSuffix();
+        String tableName = "nation_" + randomNameSuffix();
         hiveMinioDataLake.getHiveHadoop().runOnHive(
                 "CREATE TABLE " + getHiveTestTableName(tableName) + " ( " +
                         "  name varchar(25), " +
@@ -747,7 +747,7 @@ public abstract class BaseTestHiveOnDataLake
     @Test
     public void testDatePartitionProjectionOnDateColumnWithDefaults()
     {
-        String tableName = "nation_" + randomTableSuffix();
+        String tableName = "nation_" + randomNameSuffix();
         String fullyQualifiedTestTableName = getFullyQualifiedTestTableName(tableName);
 
         computeActual(
@@ -1311,7 +1311,7 @@ public abstract class BaseTestHiveOnDataLake
     public void testPartitionProjectionInvalidTableProperties()
     {
         assertThatThrownBy(() -> getQueryRunner().execute(
-                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomTableSuffix()) + " ( " +
+                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomNameSuffix()) + " ( " +
                         "  name varchar " +
                         ") WITH ( " +
                         "  partition_projection_enabled=true " +
@@ -1319,7 +1319,7 @@ public abstract class BaseTestHiveOnDataLake
                 .hasMessage("Partition projection can't be enabled when no partition columns are defined.");
 
         assertThatThrownBy(() -> getQueryRunner().execute(
-                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomTableSuffix()) + " ( " +
+                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomNameSuffix()) + " ( " +
                         "  name varchar WITH ( " +
                         "    partition_projection_type='enum', " +
                         "    partition_projection_values=ARRAY['PL1', 'CZ1']" +
@@ -1332,7 +1332,7 @@ public abstract class BaseTestHiveOnDataLake
                 .hasMessage("Partition projection can't be defined for non partition column: 'name'");
 
         assertThatThrownBy(() -> getQueryRunner().execute(
-                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomTableSuffix()) + " ( " +
+                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomNameSuffix()) + " ( " +
                         "  name varchar, " +
                         "  short_name1 varchar WITH ( " +
                         "    partition_projection_type='enum', " +
@@ -1346,7 +1346,7 @@ public abstract class BaseTestHiveOnDataLake
                 .hasMessage("Partition projection definition for column: 'short_name2' missing");
 
         assertThatThrownBy(() -> getQueryRunner().execute(
-                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomTableSuffix()) + " ( " +
+                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomNameSuffix()) + " ( " +
                         "  name varchar, " +
                         "  short_name1 varchar WITH (" +
                         "    partition_projection_type='enum', " +
@@ -1364,7 +1364,7 @@ public abstract class BaseTestHiveOnDataLake
                         "is missing partition column: 'short_name2' placeholder");
 
         assertThatThrownBy(() -> getQueryRunner().execute(
-                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomTableSuffix()) + " ( " +
+                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomNameSuffix()) + " ( " +
                         "  name varchar, " +
                         "  short_name1 varchar WITH (" +
                         "    partition_projection_type='integer', " +
@@ -1381,7 +1381,7 @@ public abstract class BaseTestHiveOnDataLake
                 .hasMessage("Column projection for column 'short_name1' failed. Property: 'partition_projection_range' needs to be list of 2 integers");
 
         assertThatThrownBy(() -> getQueryRunner().execute(
-                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomTableSuffix()) + " ( " +
+                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomNameSuffix()) + " ( " +
                         "  name varchar, " +
                         "  short_name1 varchar WITH (" +
                         "    partition_projection_type='date', " +
@@ -1394,7 +1394,7 @@ public abstract class BaseTestHiveOnDataLake
                 .hasMessage("Column projection for column 'short_name1' failed. Missing required property: 'partition_projection_format'");
 
         assertThatThrownBy(() -> getQueryRunner().execute(
-                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomTableSuffix()) + " ( " +
+                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomNameSuffix()) + " ( " +
                         "  name varchar, " +
                         "  short_name1 varchar WITH (" +
                         "    partition_projection_type='date', " +
@@ -1409,7 +1409,7 @@ public abstract class BaseTestHiveOnDataLake
                         "or '^\\s*NOW\\s*(([+-])\\s*([0-9]+)\\s*(DAY|HOUR|MINUTE|SECOND)S?\\s*)?$' that are sequential. Unparseable date: \"2001-01-01\"");
 
         assertThatThrownBy(() -> getQueryRunner().execute(
-                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomTableSuffix()) + " ( " +
+                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomNameSuffix()) + " ( " +
                         "  name varchar, " +
                         "  short_name1 varchar WITH (" +
                         "    partition_projection_type='date', " +
@@ -1424,7 +1424,7 @@ public abstract class BaseTestHiveOnDataLake
                         "or '^\\s*NOW\\s*(([+-])\\s*([0-9]+)\\s*(DAY|HOUR|MINUTE|SECOND)S?\\s*)?$' that are sequential. Unparseable date: \"NOW*3DAYS\"");
 
         assertThatThrownBy(() -> getQueryRunner().execute(
-                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomTableSuffix()) + " ( " +
+                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomNameSuffix()) + " ( " +
                         "  name varchar, " +
                         "  short_name1 varchar WITH (" +
                         "    partition_projection_type='date', " +
@@ -1439,7 +1439,7 @@ public abstract class BaseTestHiveOnDataLake
                         "or '^\\s*NOW\\s*(([+-])\\s*([0-9]+)\\s*(DAY|HOUR|MINUTE|SECOND)S?\\s*)?$' that are sequential");
 
         assertThatThrownBy(() -> getQueryRunner().execute(
-                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomTableSuffix()) + " ( " +
+                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomNameSuffix()) + " ( " +
                         "  name varchar, " +
                         "  short_name1 varchar WITH (" +
                         "    partition_projection_type='date', " +
@@ -1455,7 +1455,7 @@ public abstract class BaseTestHiveOnDataLake
                         "Available options: [Days, Hours, Minutes, Seconds]");
 
         assertThatThrownBy(() -> getQueryRunner().execute(
-                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomTableSuffix()) + " ( " +
+                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomNameSuffix()) + " ( " +
                         "  name varchar, " +
                         "  short_name1 varchar WITH (" +
                         "    partition_projection_type='date', " +
@@ -1471,7 +1471,7 @@ public abstract class BaseTestHiveOnDataLake
                         "Interval defaults to 1 day or 1 month, respectively. Otherwise, interval is required");
 
         assertThatThrownBy(() -> getQueryRunner().execute(
-                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomTableSuffix()) + " ( " +
+                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomNameSuffix()) + " ( " +
                         "  name varchar, " +
                         "  short_name1 varchar WITH (" +
                         "    partition_projection_type='date', " +
@@ -1486,7 +1486,7 @@ public abstract class BaseTestHiveOnDataLake
         // Verify that ignored flag is only interpreted for pre-existing tables where configuration is loaded from metastore.
         // It should not allow creating corrupted config via Trino. It's a kill switch to run away when we have compatibility issues.
         assertThatThrownBy(() -> getQueryRunner().execute(
-                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomTableSuffix()) + " ( " +
+                "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomNameSuffix()) + " ( " +
                         "  name varchar, " +
                         "  short_name1 varchar WITH (" +
                         "    partition_projection_type='date', " +
@@ -1506,7 +1506,7 @@ public abstract class BaseTestHiveOnDataLake
     @Test
     public void testPartitionProjectionIgnore()
     {
-        String tableName = "nation_" + randomTableSuffix();
+        String tableName = "nation_" + randomNameSuffix();
         String hiveTestTableName = getHiveTestTableName(tableName);
         String fullyQualifiedTestTableName = getFullyQualifiedTestTableName(tableName);
 
@@ -1646,7 +1646,7 @@ public abstract class BaseTestHiveOnDataLake
 
     protected String getRandomTestTableName()
     {
-        return "nation_" + randomTableSuffix();
+        return "nation_" + randomNameSuffix();
     }
 
     protected String getFullyQualifiedTestTableName()

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveAnalyzeCorruptStatistics.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveAnalyzeCorruptStatistics.java
@@ -21,7 +21,7 @@ import io.trino.testing.QueryRunner;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
@@ -47,7 +47,7 @@ public class TestHiveAnalyzeCorruptStatistics
     @Test
     public void testAnalyzeCorruptColumnStatisticsOnEmptyTable()
     {
-        String tableName = "test_analyze_corrupt_column_statistics_" + randomTableSuffix();
+        String tableName = "test_analyze_corrupt_column_statistics_" + randomNameSuffix();
 
         // Concurrent ANALYZE statements generate duplicated rows in Thrift metastore's TAB_COL_STATS table when column statistics is empty
         prepareBrokenColumnStatisticsTable(tableName);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestParquetPageSkipping.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestParquetPageSkipping.java
@@ -34,7 +34,7 @@ import java.util.Map;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.trino.parquet.reader.ParquetReader.COLUMN_INDEX_ROWS_FILTERED;
 import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -94,7 +94,7 @@ public class TestParquetPageSkipping
     @Test
     public void testAndPredicates()
     {
-        String tableName = "test_and_predicate_" + randomTableSuffix();
+        String tableName = "test_and_predicate_" + randomNameSuffix();
         buildSortedTables(tableName, "totalprice", "double");
         int rowCount = assertColumnIndexResults("SELECT * FROM " + tableName + " WHERE totalprice BETWEEN 100000 AND 131280 AND clerk = 'Clerk#000000624'");
         assertThat(rowCount).isGreaterThan(0);
@@ -108,7 +108,7 @@ public class TestParquetPageSkipping
     @Test
     public void testPageSkippingWithNonSequentialOffsets()
     {
-        String tableName = "test_random_" + randomTableSuffix();
+        String tableName = "test_random_" + randomNameSuffix();
         int updateCount = 8192;
         assertUpdate(
                 "CREATE TABLE " + tableName + " (col) WITH (format = 'PARQUET') AS " +
@@ -132,7 +132,7 @@ public class TestParquetPageSkipping
     public void testFilteringOnColumnNameWithDot()
     {
         String nameInSql = "\"a.dot\"";
-        String tableName = "test_column_name_with_dot_" + randomTableSuffix();
+        String tableName = "test_column_name_with_dot_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + "(key varchar(50), " + nameInSql + " varchar(50)) WITH (format = 'PARQUET')");
         assertUpdate("INSERT INTO " + tableName + " VALUES ('null value', NULL), ('sample value', 'abc'), ('other value', 'xyz')", 3);
@@ -146,7 +146,7 @@ public class TestParquetPageSkipping
     @Test(dataProvider = "dataType")
     public void testPageSkipping(String sortByColumn, String sortByColumnType, Object[][] valuesArray)
     {
-        String tableName = "test_page_skipping_" + randomTableSuffix();
+        String tableName = "test_page_skipping_" + randomNameSuffix();
         buildSortedTables(tableName, sortByColumn, sortByColumnType);
         for (Object[] values : valuesArray) {
             Object lowValue = values[0];
@@ -173,7 +173,7 @@ public class TestParquetPageSkipping
     @Test
     public void testFilteringWithColumnIndex()
     {
-        String tableName = "test_page_filtering_" + randomTableSuffix();
+        String tableName = "test_page_filtering_" + randomNameSuffix();
         String catalog = getSession().getCatalog().orElseThrow();
         assertUpdate(
                 Session.builder(getSession())

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestS3WrongRegionPicked.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestS3WrongRegionPicked.java
@@ -18,7 +18,7 @@ import io.trino.plugin.hive.containers.HiveMinioDataLake;
 import io.trino.testing.QueryRunner;
 import org.testng.annotations.Test;
 
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestS3WrongRegionPicked
@@ -28,14 +28,14 @@ public class TestS3WrongRegionPicked
             throws Exception
     {
         // Bucket names are global so a unique one needs to be used.
-        String bucketName = "test-bucket" + randomTableSuffix();
+        String bucketName = "test-bucket" + randomNameSuffix();
 
         try (HiveMinioDataLake dataLake = new HiveMinioDataLake(bucketName)) {
             dataLake.start();
             try (QueryRunner queryRunner = S3HiveQueryRunner.builder(dataLake)
                     .setHiveProperties(ImmutableMap.of("hive.s3.region", "eu-central-1")) // Different than the default one
                     .build()) {
-                String tableName = "s3_region_test_" + randomTableSuffix();
+                String tableName = "s3_region_test_" + randomNameSuffix();
                 queryRunner.execute("CREATE TABLE default." + tableName + " (a int) WITH (external_location = 's3://" + bucketName + "/" + tableName + "')");
                 assertThatThrownBy(() -> queryRunner.execute("SELECT * FROM default." + tableName))
                         .getRootCause()

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiCopyOnWriteMinioConnectorTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiCopyOnWriteMinioConnectorTest.java
@@ -19,7 +19,7 @@ import io.trino.plugin.hudi.testing.TpchHudiTablesInitializer;
 import io.trino.testing.QueryRunner;
 
 import static io.trino.plugin.hive.containers.HiveHadoop.HIVE3_IMAGE;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
 
 public class TestHudiCopyOnWriteMinioConnectorTest
@@ -29,7 +29,7 @@ public class TestHudiCopyOnWriteMinioConnectorTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        String bucketName = "test-hudi-connector-" + randomTableSuffix();
+        String bucketName = "test-hudi-connector-" + randomNameSuffix();
         hiveMinioDataLake = closeAfterClass(new HiveMinioDataLake(bucketName, HIVE3_IMAGE));
         hiveMinioDataLake.start();
         hiveMinioDataLake.getMinioClient().ensureBucketExists(bucketName);

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiMergeOnReadMinioConnectorTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiMergeOnReadMinioConnectorTest.java
@@ -19,7 +19,7 @@ import io.trino.plugin.hudi.testing.TpchHudiTablesInitializer;
 import io.trino.testing.QueryRunner;
 
 import static io.trino.plugin.hive.containers.HiveHadoop.HIVE3_IMAGE;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.apache.hudi.common.model.HoodieTableType.MERGE_ON_READ;
 
 public class TestHudiMergeOnReadMinioConnectorTest
@@ -29,7 +29,7 @@ public class TestHudiMergeOnReadMinioConnectorTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        String bucketName = "test-hudi-connector-" + randomTableSuffix();
+        String bucketName = "test-hudi-connector-" + randomNameSuffix();
         hiveMinioDataLake = closeAfterClass(new HiveMinioDataLake(bucketName, HIVE3_IMAGE));
         hiveMinioDataLake.start();
         hiveMinioDataLake.getMinioClient().ensureBucketExists(bucketName);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -28,7 +28,7 @@ import java.util.stream.IntStream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newFixedThreadPool;
@@ -147,7 +147,7 @@ public abstract class BaseIcebergConnectorSmokeTest
     @Test
     public void testRegisterTableWithTableLocation()
     {
-        String tableName = "test_register_table_with_table_location_" + randomTableSuffix();
+        String tableName = "test_register_table_with_table_location_" + randomNameSuffix();
 
         assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean)", tableName));
         assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
@@ -169,7 +169,7 @@ public abstract class BaseIcebergConnectorSmokeTest
     @Test
     public void testRegisterTableWithComments()
     {
-        String tableName = "test_register_table_with_comments_" + randomTableSuffix();
+        String tableName = "test_register_table_with_comments_" + randomNameSuffix();
 
         assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean)", tableName));
         assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
@@ -194,7 +194,7 @@ public abstract class BaseIcebergConnectorSmokeTest
     @Test
     public void testRegisterTableWithShowCreateTable()
     {
-        String tableName = "test_register_table_with_show_create_table_" + randomTableSuffix();
+        String tableName = "test_register_table_with_show_create_table_" + randomNameSuffix();
 
         assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean)", tableName));
         assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
@@ -214,7 +214,7 @@ public abstract class BaseIcebergConnectorSmokeTest
     @Test
     public void testRegisterTableWithReInsert()
     {
-        String tableName = "test_register_table_with_re_insert_" + randomTableSuffix();
+        String tableName = "test_register_table_with_re_insert_" + randomNameSuffix();
 
         assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean)", tableName));
         assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
@@ -238,7 +238,7 @@ public abstract class BaseIcebergConnectorSmokeTest
     @Test
     public void testRegisterTableWithDroppedTable()
     {
-        String tableName = "test_register_table_with_dropped_table_" + randomTableSuffix();
+        String tableName = "test_register_table_with_dropped_table_" + randomNameSuffix();
 
         assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean)", tableName));
         assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
@@ -255,7 +255,7 @@ public abstract class BaseIcebergConnectorSmokeTest
     @Test
     public void testRegisterTableWithDifferentTableName()
     {
-        String tableName = "test_register_table_with_different_table_name_" + randomTableSuffix();
+        String tableName = "test_register_table_with_different_table_name_" + randomNameSuffix();
 
         assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean)", tableName));
         assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
@@ -280,7 +280,7 @@ public abstract class BaseIcebergConnectorSmokeTest
     @Test
     public void testRegisterTableWithMetadataFile()
     {
-        String tableName = "test_register_table_with_metadata_file_" + randomTableSuffix();
+        String tableName = "test_register_table_with_metadata_file_" + randomNameSuffix();
 
         assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean)", tableName));
         assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -111,10 +111,10 @@ import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
 import static io.trino.testing.MaterializedResult.resultBuilder;
 import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static io.trino.testing.assertions.Assert.assertEquals;
 import static io.trino.testing.assertions.Assert.assertEventually;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static io.trino.tpch.TpchTable.LINE_ITEM;
 import static io.trino.transaction.TransactionBuilder.transaction;
 import static java.lang.String.format;
@@ -973,7 +973,7 @@ public abstract class BaseIcebergConnectorTest
     public void testCreatePartitionedTableAs()
     {
         File tempDir = getDistributedQueryRunner().getCoordinator().getBaseDataDir().toFile();
-        String tempDirPath = tempDir.toURI().toASCIIString() + randomTableSuffix();
+        String tempDirPath = tempDir.toURI().toASCIIString() + randomNameSuffix();
         assertUpdate(
                 "CREATE TABLE test_create_partitioned_table_as " +
                         "WITH (" +
@@ -1037,7 +1037,7 @@ public abstract class BaseIcebergConnectorTest
     @Test(dataProvider = "partitionedTableWithQuotedIdentifierCasing")
     public void testCreatePartitionedTableWithQuotedIdentifierCasing(String columnName, String partitioningField, boolean success)
     {
-        String tableName = "partitioning_" + randomTableSuffix();
+        String tableName = "partitioning_" + randomNameSuffix();
         @Language("SQL") String sql = format("CREATE TABLE %s (%s bigint) WITH (partitioning = ARRAY['%s'])", tableName, columnName, partitioningField);
         if (success) {
             assertUpdate(sql);
@@ -1052,7 +1052,7 @@ public abstract class BaseIcebergConnectorTest
     public void testTableComments()
     {
         File tempDir = getDistributedQueryRunner().getCoordinator().getBaseDataDir().toFile();
-        String tempDirPath = tempDir.toURI().toASCIIString() + randomTableSuffix();
+        String tempDirPath = tempDir.toURI().toASCIIString() + randomNameSuffix();
         String createTableTemplate = "" +
                 "CREATE TABLE iceberg.tpch.test_table_comments (\n" +
                 "   _x bigint\n" +
@@ -1237,8 +1237,8 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testTableNameCollision()
     {
-        String tableName = "test_rename_table_" + randomTableSuffix();
-        String tmpName = "test_rename_table_tmp_" + randomTableSuffix();
+        String tableName = "test_rename_table_" + randomNameSuffix();
+        String tmpName = "test_rename_table_tmp_" + randomNameSuffix();
         try {
             assertUpdate("CREATE TABLE " + tmpName + " AS SELECT 1 as a", 1);
             assertUpdate("ALTER TABLE " + tmpName + " RENAME TO " + tableName);
@@ -1256,7 +1256,7 @@ public abstract class BaseIcebergConnectorTest
     public void testCreateTableSucceedsOnEmptyDirectory()
     {
         File tempDir = getDistributedQueryRunner().getCoordinator().getBaseDataDir().toFile();
-        String tmpName = "test_rename_table_tmp_" + randomTableSuffix();
+        String tmpName = "test_rename_table_tmp_" + randomNameSuffix();
         Path newPath = tempDir.toPath().resolve(tmpName);
         File directory = newPath.toFile();
         verify(directory.mkdirs(), "Could not make directory on filesystem");
@@ -1278,7 +1278,7 @@ public abstract class BaseIcebergConnectorTest
     private void testCreateTableLikeForFormat(IcebergFileFormat otherFormat)
     {
         File tempDir = getDistributedQueryRunner().getCoordinator().getBaseDataDir().toFile();
-        String tempDirPath = tempDir.toURI().toASCIIString() + randomTableSuffix();
+        String tempDirPath = tempDir.toURI().toASCIIString() + randomNameSuffix();
 
         // LIKE source INCLUDING PROPERTIES copies all the properties of the source table, including the `location`.
         // For this reason the source and the copied table will share the same directory.
@@ -4218,7 +4218,7 @@ public abstract class BaseIcebergConnectorTest
                 "_" + sourceRelation.replaceAll("[^a-zA-Z0-9]", "") +
                 (ctas ? "ctas" : "insert") +
                 "_" + partitioning.replaceAll("[^a-zA-Z0-9]", "") +
-                "_" + randomTableSuffix();
+                "_" + randomNameSuffix();
 
         long rowCount = (long) computeScalar(session, "SELECT count(*) FROM " + sourceRelation);
 
@@ -4583,7 +4583,7 @@ public abstract class BaseIcebergConnectorTest
     public void testOptimize(int formatVersion)
             throws Exception
     {
-        String tableName = "test_optimize_" + randomTableSuffix();
+        String tableName = "test_optimize_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " (key integer, value varchar) WITH (format_version = " + formatVersion + ")");
 
         // DistributedQueryRunner sets node-scheduler.include-coordinator by default, so include coordinator
@@ -4645,7 +4645,7 @@ public abstract class BaseIcebergConnectorTest
                 .setSystemProperty("use_preferred_write_partitioning", "true")
                 .setSystemProperty("preferred_write_partitioning_min_number_of_partitions", "100")
                 .build();
-        String tableName = "test_repartitiong_during_optimize_" + randomTableSuffix();
+        String tableName = "test_repartitiong_during_optimize_" + randomNameSuffix();
         assertUpdate(session, "CREATE TABLE " + tableName + " (key varchar, value integer) WITH (format_version = " + formatVersion + ", partitioning = ARRAY['key'])");
         // optimize an empty table
         assertQuerySucceeds(session, "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
@@ -4771,7 +4771,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testOptimizeTableAfterDeleteWithFormatVersion2()
     {
-        String tableName = "test_optimize_" + randomTableSuffix();
+        String tableName = "test_optimize_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM nation", 25);
 
         List<String> initialFiles = getActiveFiles(tableName);
@@ -4800,7 +4800,7 @@ public abstract class BaseIcebergConnectorTest
     public void testOptimizeCleansUpDeleteFiles()
             throws IOException
     {
-        String tableName = "test_optimize_" + randomTableSuffix();
+        String tableName = "test_optimize_" + randomNameSuffix();
         Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
         assertUpdate("CREATE TABLE " + tableName + " WITH (partitioning = ARRAY['regionkey']) AS SELECT * FROM nation", 25);
 
@@ -4853,7 +4853,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testOptimizeSnapshot()
     {
-        String tableName = "test_optimize_snapshot_" + randomTableSuffix();
+        String tableName = "test_optimize_snapshot_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + " (a) AS VALUES 11", 1);
         long snapshotId = getCurrentSnapshotId(tableName);
@@ -4924,7 +4924,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testTargetMaxFileSize()
     {
-        String tableName = "test_default_max_file_size" + randomTableSuffix();
+        String tableName = "test_default_max_file_size" + randomNameSuffix();
         @Language("SQL") String createTableSql = format("CREATE TABLE %s AS SELECT * FROM tpch.sf1.lineitem LIMIT 100000", tableName);
 
         Session session = Session.builder(getSession())
@@ -4972,7 +4972,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testPathHiddenColumn()
     {
-        String tableName = "test_path_" + randomTableSuffix();
+        String tableName = "test_path_" + randomNameSuffix();
         @Language("SQL") String createTable = "CREATE TABLE " + tableName + " " +
                 "WITH ( partitioning = ARRAY['zip'] ) AS " +
                 "SELECT * FROM (VALUES " +
@@ -5020,7 +5020,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testOptimizeWithPathColumn()
     {
-        String tableName = "test_optimize_with_path_" + randomTableSuffix();
+        String tableName = "test_optimize_with_path_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " (id integer)");
 
         assertUpdate("INSERT INTO " + tableName + " VALUES (1)", 1);
@@ -5106,7 +5106,7 @@ public abstract class BaseIcebergConnectorTest
     public void testOptimizeWithFileModifiedTimeColumn()
             throws Exception
     {
-        String tableName = "test_optimize_with_file_modified_time_" + randomTableSuffix();
+        String tableName = "test_optimize_with_file_modified_time_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " (id integer)");
 
         assertUpdate("INSERT INTO " + tableName + " VALUES (1)", 1);
@@ -5158,7 +5158,7 @@ public abstract class BaseIcebergConnectorTest
     public void testExpireSnapshots()
             throws Exception
     {
-        String tableName = "test_expiring_snapshots_" + randomTableSuffix();
+        String tableName = "test_expiring_snapshots_" + randomNameSuffix();
         Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
         assertUpdate("CREATE TABLE " + tableName + " (key varchar, value integer)");
         assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
@@ -5185,7 +5185,7 @@ public abstract class BaseIcebergConnectorTest
     public void testExpireSnapshotsPartitionedTable()
             throws Exception
     {
-        String tableName = "test_expiring_snapshots_partitioned_table" + randomTableSuffix();
+        String tableName = "test_expiring_snapshots_partitioned_table" + randomNameSuffix();
         Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
         assertUpdate("CREATE TABLE " + tableName + " (col1 BIGINT, col2 BIGINT) WITH (partitioning = ARRAY['col1'])");
         assertUpdate("INSERT INTO " + tableName + " VALUES(1, 100), (1, 101), (1, 102), (2, 200), (2, 201), (3, 300)", 6);
@@ -5207,7 +5207,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testExpireSnapshotsOnSnapshot()
     {
-        String tableName = "test_expire_snapshots_on_snapshot_" + randomTableSuffix();
+        String tableName = "test_expire_snapshots_on_snapshot_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + " (a) AS VALUES 11", 1);
         long snapshotId = getCurrentSnapshotId(tableName);
@@ -5232,7 +5232,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testExplainExpireSnapshotOutput()
     {
-        String tableName = "test_expiring_snapshots_output" + randomTableSuffix();
+        String tableName = "test_expiring_snapshots_output" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " (key varchar, value integer) WITH (partitioning = ARRAY['key'])");
         assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
         assertUpdate("INSERT INTO " + tableName + " VALUES ('two', 2)", 1);
@@ -5262,7 +5262,7 @@ public abstract class BaseIcebergConnectorTest
     public void testRemoveOrphanFiles()
             throws Exception
     {
-        String tableName = "test_deleting_orphan_files_unnecessary_files" + randomTableSuffix();
+        String tableName = "test_deleting_orphan_files_unnecessary_files" + randomNameSuffix();
         Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
         assertUpdate("CREATE TABLE " + tableName + " (key varchar, value integer)");
         assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
@@ -5284,7 +5284,7 @@ public abstract class BaseIcebergConnectorTest
     public void testIfRemoveOrphanFilesCleansUnnecessaryDataFilesInPartitionedTable()
             throws Exception
     {
-        String tableName = "test_deleting_orphan_files_unnecessary_files" + randomTableSuffix();
+        String tableName = "test_deleting_orphan_files_unnecessary_files" + randomNameSuffix();
         Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
         assertUpdate("CREATE TABLE " + tableName + " (key varchar, value integer) WITH (partitioning = ARRAY['key'])");
         assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
@@ -5304,7 +5304,7 @@ public abstract class BaseIcebergConnectorTest
     public void testIfRemoveOrphanFilesCleansUnnecessaryMetadataFilesInPartitionedTable()
             throws Exception
     {
-        String tableName = "test_deleting_orphan_files_unnecessary_files" + randomTableSuffix();
+        String tableName = "test_deleting_orphan_files_unnecessary_files" + randomNameSuffix();
         Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
         assertUpdate("CREATE TABLE " + tableName + " (key varchar, value integer) WITH (partitioning = ARRAY['key'])");
         assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
@@ -5334,8 +5334,8 @@ public abstract class BaseIcebergConnectorTest
             throws IOException
     {
         File tempDir = getDistributedQueryRunner().getCoordinator().getBaseDataDir().toFile();
-        String tempDirPath = tempDir.toURI().toASCIIString() + randomTableSuffix() + suffix;
-        String tableName = "test_table_cleaning_up_with_location" + randomTableSuffix();
+        String tempDirPath = tempDir.toURI().toASCIIString() + randomNameSuffix() + suffix;
+        String tableName = "test_table_cleaning_up_with_location" + randomNameSuffix();
 
         assertUpdate(format("CREATE TABLE %s (key varchar, value integer) WITH(location = '%s')", tableName, tempDirPath));
         assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
@@ -5358,7 +5358,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testExplainRemoveOrphanFilesOutput()
     {
-        String tableName = "test_remove_orphan_files_output" + randomTableSuffix();
+        String tableName = "test_remove_orphan_files_output" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " (key varchar, value integer) WITH (partitioning = ARRAY['key'])");
         assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
         assertUpdate("INSERT INTO " + tableName + " VALUES ('two', 2)", 1);
@@ -5387,7 +5387,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testRemoveOrphanFilesOnSnapshot()
     {
-        String tableName = "test_remove_orphan_files_on_snapshot_" + randomTableSuffix();
+        String tableName = "test_remove_orphan_files_on_snapshot_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + " (a) AS VALUES 11", 1);
         long snapshotId = getCurrentSnapshotId(tableName);
@@ -5412,7 +5412,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testIfDeletesReturnsNumberOfRemovedRows()
     {
-        String tableName = "test_delete_returns_number_of_rows_" + randomTableSuffix();
+        String tableName = "test_delete_returns_number_of_rows_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " (key varchar, value integer) WITH (partitioning = ARRAY['key'])");
         assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
         assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 2)", 1);
@@ -5428,7 +5428,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testUpdatingFileFormat()
     {
-        String tableName = "test_updating_file_format_" + randomTableSuffix();
+        String tableName = "test_updating_file_format_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + " WITH (format = 'orc') AS SELECT * FROM nation WHERE nationkey < 10", "SELECT count(*) FROM nation WHERE nationkey < 10");
         assertQuery("SELECT value FROM \"" + tableName + "$properties\" WHERE key = 'write.format.default'", "VALUES 'ORC'");
@@ -5447,7 +5447,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testUpdatingInvalidTableProperty()
     {
-        String tableName = "test_updating_invalid_table_property_" + randomTableSuffix();
+        String tableName = "test_updating_invalid_table_property_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " (a INT, b INT)");
         assertThatThrownBy(() -> query("ALTER TABLE " + tableName + " SET PROPERTIES not_a_valid_table_property = 'a value'"))
                 .hasMessage("Catalog 'iceberg' table property 'not_a_valid_table_property' does not exist");
@@ -5457,7 +5457,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testEmptyCreateTableAsSelect()
     {
-        String tableName = "test_empty_ctas_" + randomTableSuffix();
+        String tableName = "test_empty_ctas_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM nation WHERE false", 0);
         List<Long> initialTableSnapshots = getSnapshotIds(tableName);
@@ -5472,7 +5472,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testEmptyInsert()
     {
-        String tableName = "test_empty_insert_" + randomTableSuffix();
+        String tableName = "test_empty_insert_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM nation", "SELECT count(*) FROM nation");
         List<Long> initialTableSnapshots = getSnapshotIds(tableName);
@@ -5491,7 +5491,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testEmptyUpdate()
     {
-        String tableName = "test_empty_update_" + randomTableSuffix();
+        String tableName = "test_empty_update_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM nation", "SELECT count(*) FROM nation");
         List<Long> initialTableSnapshots = getSnapshotIds(tableName);
@@ -5510,7 +5510,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testEmptyDelete()
     {
-        String tableName = "test_empty_delete_" + randomTableSuffix();
+        String tableName = "test_empty_delete_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + " WITH (format = '" + format.name() + "') AS SELECT * FROM nation", "SELECT count(*) FROM nation");
         List<Long> initialTableSnapshots = getSnapshotIds(tableName);
@@ -5529,7 +5529,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testModifyingOldSnapshotIsNotPossible()
     {
-        String tableName = "test_modifying_old_snapshot_" + randomTableSuffix();
+        String tableName = "test_modifying_old_snapshot_" + randomNameSuffix();
         assertUpdate(format("CREATE TABLE %s (col int)", tableName));
         assertUpdate(format("INSERT INTO %s VALUES 1,2,3", tableName), 3);
         long oldSnapshotId = getCurrentSnapshotId(tableName);
@@ -5558,9 +5558,9 @@ public abstract class BaseIcebergConnectorTest
     public void testCreateTableAsSelectFromVersionedTable()
             throws Exception
     {
-        String sourceTableName = "test_ctas_versioned_source_" + randomTableSuffix();
-        String snapshotVersionedSinkTableName = "test_ctas_snapshot_versioned_sink_" + randomTableSuffix();
-        String timestampVersionedSinkTableName = "test_ctas_timestamp_versioned_sink_" + randomTableSuffix();
+        String sourceTableName = "test_ctas_versioned_source_" + randomNameSuffix();
+        String snapshotVersionedSinkTableName = "test_ctas_snapshot_versioned_sink_" + randomNameSuffix();
+        String timestampVersionedSinkTableName = "test_ctas_timestamp_versioned_sink_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + sourceTableName + "(an_integer integer)");
         // Enforce having exactly one snapshot of the table at the timestamp corresponding to `afterInsert123EpochMillis`
@@ -5588,7 +5588,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testReadingFromSpecificSnapshot()
     {
-        String tableName = "test_reading_snapshot" + randomTableSuffix();
+        String tableName = "test_reading_snapshot" + randomNameSuffix();
         assertUpdate(format("CREATE TABLE %s (a bigint, b bigint)", tableName));
         assertUpdate(format("INSERT INTO %s VALUES(1, 1)", tableName), 1);
         List<Long> ids = getSnapshotsIdsByCreationOrder(tableName);
@@ -5601,7 +5601,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testSelectWithMoreThanOneSnapshotOfTheSameTable()
     {
-        String tableName = "test_reading_snapshot" + randomTableSuffix();
+        String tableName = "test_reading_snapshot" + randomNameSuffix();
         assertUpdate(format("CREATE TABLE %s (a bigint, b bigint)", tableName));
         assertUpdate(format("INSERT INTO %s VALUES(1, 1)", tableName), 1);
         assertUpdate(format("INSERT INTO %s VALUES(2, 2)", tableName), 1);
@@ -5618,7 +5618,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testInsertingIntoTablesWithColumnsWithQuotesInName()
     {
-        String tableName = "test_inserting_into_tables_with_quotes_" + randomTableSuffix();
+        String tableName = "test_inserting_into_tables_with_quotes_" + randomNameSuffix();
         assertUpdate(format("CREATE TABLE %s (\"an identifier with \"\"quotes\"\" \" INTEGER, x row (\"another identifier\" INTEGER))", tableName));
         assertUpdate(format("INSERT INTO %s VALUES (1, row(11))", tableName), 1);
         assertThat(query(format("SELECT * FROM %s", tableName)))
@@ -5636,7 +5636,7 @@ public abstract class BaseIcebergConnectorTest
                 .setSystemProperty(TASK_PARTITIONED_WRITER_COUNT, String.valueOf(taskWriterCount))
                 .build();
 
-        String tableName = "test_inserting_into_bucketed_column_task_writer_count_" + randomTableSuffix();
+        String tableName = "test_inserting_into_bucketed_column_task_writer_count_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " (x INT) WITH (partitioning = ARRAY['bucket(x, 7)'])");
 
         assertUpdate(session, "INSERT INTO " + tableName + " SELECT nationkey FROM nation", 25);
@@ -5648,7 +5648,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testReadFromVersionedTableWithSchemaEvolution()
     {
-        String tableName = "test_versioned_table_schema_evolution_" + randomTableSuffix();
+        String tableName = "test_versioned_table_schema_evolution_" + randomNameSuffix();
 
         assertQuerySucceeds("CREATE TABLE " + tableName + "(col1 varchar)");
         long v1SnapshotId = getCurrentSnapshotId(tableName);
@@ -5697,7 +5697,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testReadFromVersionedTableWithSchemaEvolutionDropColumn()
     {
-        String tableName = "test_versioned_table_schema_evolution_drop_column_" + randomTableSuffix();
+        String tableName = "test_versioned_table_schema_evolution_drop_column_" + randomNameSuffix();
 
         assertQuerySucceeds("CREATE TABLE " + tableName + "(col1 varchar, col2 integer, col3 boolean)");
         long v1SnapshotId = getCurrentSnapshotId(tableName);
@@ -5747,7 +5747,7 @@ public abstract class BaseIcebergConnectorTest
     public void testReadFromVersionedTableWithPartitionSpecEvolution()
             throws Exception
     {
-        String tableName = "test_version_table_with_partition_spec_evolution_" + randomTableSuffix();
+        String tableName = "test_version_table_with_partition_spec_evolution_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " (day varchar, views bigint) WITH(partitioning = ARRAY['day'])");
         long v1SnapshotId = getCurrentSnapshotId(tableName);
         long v1EpochMillis = getCommittedAtInEpochMilliseconds(tableName, v1SnapshotId);
@@ -5789,7 +5789,7 @@ public abstract class BaseIcebergConnectorTest
     public void testReadFromVersionedTableWithExpiredHistory()
             throws Exception
     {
-        String tableName = "test_version_table_with_expired_snapshots_" + randomTableSuffix();
+        String tableName = "test_version_table_with_expired_snapshots_" + randomNameSuffix();
         Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
         assertUpdate("CREATE TABLE " + tableName + " (key varchar, value integer)");
         long v1SnapshotId = getCurrentSnapshotId(tableName);
@@ -5824,7 +5824,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testDeleteRetainsTableHistory()
     {
-        String tableName = "test_delete_retains_table_history_" + randomTableSuffix();
+        String tableName = "test_delete_retains_table_history_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + "(c1 INT, c2 INT)");
         assertUpdate("INSERT INTO " + tableName + " VALUES (1, 1), (2, 2), (3, 3)", 3);
         assertUpdate("INSERT INTO " + tableName + " VALUES (3, 3), (4, 4), (5, 5)", 3);
@@ -5840,8 +5840,8 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testMergeSimpleSelectPartitioned()
     {
-        String targetTable = "merge_simple_target_" + randomTableSuffix();
-        String sourceTable = "merge_simple_source_" + randomTableSuffix();
+        String targetTable = "merge_simple_target_" + randomNameSuffix();
+        String sourceTable = "merge_simple_source_" + randomNameSuffix();
         assertUpdate(format("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR) WITH (partitioning = ARRAY['address'])", targetTable));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Buena'), ('Carol', 3, 'Cambridge'), ('Dave', 11, 'Devon')", targetTable), 4);
@@ -5870,8 +5870,8 @@ public abstract class BaseIcebergConnectorTest
                 .setSystemProperty(TASK_WRITER_COUNT, String.valueOf(writers))
                 .build();
 
-        String targetTable = "merge_formats_target_" + randomTableSuffix();
-        String sourceTable = "merge_formats_source_" + randomTableSuffix();
+        String targetTable = "merge_formats_target_" + randomNameSuffix();
+        String sourceTable = "merge_formats_source_" + randomNameSuffix();
         assertUpdate(format("CREATE TABLE %s (customer VARCHAR, purchase VARCHAR) %s", targetTable, partioning));
 
         assertUpdate(format("INSERT INTO %s (customer, purchase) VALUES ('Dave', 'dates'), ('Lou', 'limes'), ('Carol', 'candles')", targetTable), 3);
@@ -5923,7 +5923,7 @@ public abstract class BaseIcebergConnectorTest
                 .build();
 
         int targetCustomerCount = 32;
-        String targetTable = "merge_multiple_" + randomTableSuffix();
+        String targetTable = "merge_multiple_" + randomNameSuffix();
         assertUpdate(format("CREATE TABLE %s (purchase INT, zipcode INT, spouse VARCHAR, address VARCHAR, customer VARCHAR) %s", targetTable, partitioning));
         String originalInsertFirstHalf = range(1, targetCustomerCount / 2)
                 .mapToObj(intValue -> format("('joe_%s', %s, %s, 'jan_%s', '%s Poe Ct')", intValue, 1000, 91000, intValue, intValue))
@@ -5987,7 +5987,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testMergeSimpleQueryPartitioned()
     {
-        String targetTable = "merge_simple_" + randomTableSuffix();
+        String targetTable = "merge_simple_" + randomNameSuffix();
         assertUpdate(format("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR) WITH (partitioning = ARRAY['address'])", targetTable));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Buena'), ('Carol', 3, 'Cambridge'), ('Dave', 11, 'Devon')", targetTable), 4);
@@ -6009,8 +6009,8 @@ public abstract class BaseIcebergConnectorTest
     @Test(dataProvider = "partitionedBucketedFailure")
     public void testMergeMultipleRowsMatchFails(String createTableSql)
     {
-        String targetTable = "merge_multiple_target_" + randomTableSuffix();
-        String sourceTable = "merge_multiple_source_" + randomTableSuffix();
+        String targetTable = "merge_multiple_target_" + randomNameSuffix();
+        String sourceTable = "merge_multiple_source_" + randomNameSuffix();
         assertUpdate(format(createTableSql, targetTable));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Antioch')", targetTable), 2);
@@ -6046,8 +6046,8 @@ public abstract class BaseIcebergConnectorTest
     @Test(dataProvider = "targetAndSourceWithDifferentPartitioning")
     public void testMergeWithDifferentPartitioning(String testDescription, String createTargetTableSql, String createSourceTableSql)
     {
-        String targetTable = format("%s_target_%s", testDescription, randomTableSuffix());
-        String sourceTable = format("%s_source_%s", testDescription, randomTableSuffix());
+        String targetTable = format("%s_target_%s", testDescription, randomNameSuffix());
+        String sourceTable = format("%s_source_%s", testDescription, randomNameSuffix());
 
         assertUpdate(format(createTargetTableSql, targetTable));
 
@@ -6123,10 +6123,10 @@ public abstract class BaseIcebergConnectorTest
     public void testRenameTableToLongTableName()
     {
         // Override because the max name length is different from CREATE TABLE case
-        String sourceTableName = "test_rename_source_" + randomTableSuffix();
+        String sourceTableName = "test_rename_source_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + sourceTableName + " AS SELECT 123 x", 1);
 
-        String baseTableName = "test_rename_target_" + randomTableSuffix();
+        String baseTableName = "test_rename_target_" + randomNameSuffix();
 
         int maxLength = 255;
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -41,8 +41,8 @@ import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.UPDATE_TABLE;
 import static io.trino.testing.TestingAccessControlManager.privilege;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.assertions.Assert.assertEquals;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.anyOf;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,7 +51,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public abstract class BaseIcebergMaterializedViewTest
         extends AbstractTestQueryFramework
 {
-    protected final String storageSchemaName = "testing_storage_schema_" + randomTableSuffix();
+    protected final String storageSchemaName = "testing_storage_schema_" + randomNameSuffix();
 
     protected abstract String getSchemaName();
 
@@ -91,7 +91,7 @@ public abstract class BaseIcebergMaterializedViewTest
     {
         String catalogName = getSession().getCatalog().orElseThrow();
         String schemaName = getSession().getSchema().orElseThrow();
-        String materializedViewName = format("test_materialized_view_%s", randomTableSuffix());
+        String materializedViewName = format("test_materialized_view_%s", randomNameSuffix());
 
         computeActual("CREATE TABLE small_region AS SELECT * FROM tpch.tiny.region LIMIT 1");
         computeActual(format("CREATE MATERIALIZED VIEW %s AS SELECT * FROM small_region LIMIT 1", materializedViewName));

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
@@ -34,7 +34,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.plugin.hive.TestingThriftHiveMetastoreBuilder.testingThriftHiveMetastoreBuilder;
 import static io.trino.plugin.hive.containers.HiveMinioDataLake.MINIO_ACCESS_KEY;
 import static io.trino.plugin.hive.containers.HiveMinioDataLake.MINIO_SECRET_KEY;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,7 +51,7 @@ public abstract class BaseIcebergMinioConnectorSmokeTest
     {
         super(format);
         this.schemaName = "tpch_" + format.name().toLowerCase(ENGLISH);
-        this.bucketName = "test-iceberg-minio-smoke-test-" + randomTableSuffix();
+        this.bucketName = "test-iceberg-minio-smoke-test-" + randomNameSuffix();
     }
 
     @Override
@@ -95,7 +95,7 @@ public abstract class BaseIcebergMinioConnectorSmokeTest
     public void testRenameSchema()
     {
         assertQueryFails(
-                format("ALTER SCHEMA %s RENAME TO %s", schemaName, schemaName + randomTableSuffix()),
+                format("ALTER SCHEMA %s RENAME TO %s", schemaName, schemaName + randomNameSuffix()),
                 "Hive metastore does not support renaming schemas");
     }
 
@@ -104,7 +104,7 @@ public abstract class BaseIcebergMinioConnectorSmokeTest
     {
         // Verify data and metadata files' uri don't contain fragments
         String schemaName = getSession().getSchema().orElseThrow();
-        String tableName = "test_s3_location_with_trailing_slash_" + randomTableSuffix();
+        String tableName = "test_s3_location_with_trailing_slash_" + randomNameSuffix();
         String location = "s3://%s/%s/%s/".formatted(bucketName, schemaName, tableName);
         assertThat(location).doesNotContain("#");
 
@@ -128,7 +128,7 @@ public abstract class BaseIcebergMinioConnectorSmokeTest
     {
         // Regression test for https://github.com/trinodb/trino/issues/14299
         String schemaName = getSession().getSchema().orElseThrow();
-        String tableName = "test_meatdata_location_with_double_slash_" + randomTableSuffix();
+        String tableName = "test_meatdata_location_with_double_slash_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT 1 col", 1);
 
@@ -151,7 +151,7 @@ public abstract class BaseIcebergMinioConnectorSmokeTest
     @Test
     public void testExpireSnapshotsBatchDeletes()
     {
-        String tableName = "test_expiring_snapshots_" + randomTableSuffix();
+        String tableName = "test_expiring_snapshots_" + randomNameSuffix();
         Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
         String location = "s3://%s/%s/%s/".formatted(bucketName, schemaName, tableName);
         Queue<Event> events = new ConcurrentLinkedQueue<>();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseSharedMetastoreTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseSharedMetastoreTest.java
@@ -20,7 +20,7 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,7 +30,7 @@ import static org.testng.Assert.assertEquals;
 public abstract class BaseSharedMetastoreTest
         extends AbstractTestQueryFramework
 {
-    protected final String schema = "test_shared_schema_" + randomTableSuffix();
+    protected final String schema = "test_shared_schema_" + randomNameSuffix();
 
     protected abstract String getExpectedHiveCreateSchema(String catalogName);
 
@@ -139,7 +139,7 @@ public abstract class BaseSharedMetastoreTest
     public void testTimeTravelWithRedirection()
             throws InterruptedException
     {
-        String testLocalSchema = "test_schema_" + randomTableSuffix();
+        String testLocalSchema = "test_schema_" + randomNameSuffix();
         try {
             assertUpdate("CREATE SCHEMA iceberg. " + testLocalSchema);
             assertUpdate(format("CREATE TABLE iceberg.%s.nation_test AS SELECT * FROM nation", testLocalSchema), 25);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAnalyze.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAnalyze.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.EXECUTE_TABLE_PROCEDURE;
 import static io.trino.testing.TestingAccessControlManager.privilege;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.tpch.TpchTable.NATION;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -385,7 +385,7 @@ public class TestIcebergAnalyze
     @Test
     public void testAnalyzeSnapshot()
     {
-        String tableName = "test_analyze_snapshot_" + randomTableSuffix();
+        String tableName = "test_analyze_snapshot_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + " (a) AS VALUES 11", 1);
         long snapshotId = getCurrentSnapshotId(tableName);
@@ -487,7 +487,7 @@ public class TestIcebergAnalyze
     @Test
     public void testDropStatsSnapshot()
     {
-        String tableName = "test_drop_stats_snapshot_" + randomTableSuffix();
+        String tableName = "test_drop_stats_snapshot_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + " (a) AS VALUES 11", 1);
         long snapshotId = getCurrentSnapshotId(tableName);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGcsConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGcsConnectorSmokeTest.java
@@ -44,7 +44,7 @@ import java.util.Base64;
 
 import static io.trino.plugin.hive.TestingThriftHiveMetastoreBuilder.testingThriftHiveMetastoreBuilder;
 import static io.trino.plugin.hive.containers.HiveHadoop.HIVE3_IMAGE;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -67,7 +67,7 @@ public class TestIcebergGcsConnectorSmokeTest
     public TestIcebergGcsConnectorSmokeTest(String gcpStorageBucket, String gcpCredentialKey)
     {
         super(ORC);
-        this.schema = "test_iceberg_gcs_connector_smoke_test_" + randomTableSuffix();
+        this.schema = "test_iceberg_gcs_connector_smoke_test_" + randomNameSuffix();
         this.gcpStorageBucket = requireNonNull(gcpStorageBucket, "gcpStorageBucket is null");
 
         requireNonNull(gcpCredentialKey, "gcpCredentialKey is null");
@@ -171,7 +171,7 @@ public class TestIcebergGcsConnectorSmokeTest
     {
         String schemaName = getSession().getSchema().orElseThrow();
         assertQueryFails(
-                format("ALTER SCHEMA %s RENAME TO %s", schemaName, schemaName + randomTableSuffix()),
+                format("ALTER SCHEMA %s RENAME TO %s", schemaName, schemaName + randomNameSuffix()),
                 "Hive metastore does not support renaming schemas");
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergInputInfo.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergInputInfo.java
@@ -25,7 +25,7 @@ import org.testng.annotations.Test;
 import java.util.Optional;
 
 import static io.trino.plugin.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestIcebergInputInfo
@@ -43,7 +43,7 @@ public class TestIcebergInputInfo
     @Test
     public void testInputWithPartitioning()
     {
-        String tableName = "test_input_info_with_part_" + randomTableSuffix();
+        String tableName = "test_input_info_with_part_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (partitioning = ARRAY['regionkey', 'truncate(name, 1)']) AS SELECT * FROM nation WHERE nationkey < 10", 10);
         assertInputInfo(tableName, true, "ORC");
         assertUpdate("DROP TABLE " + tableName);
@@ -52,7 +52,7 @@ public class TestIcebergInputInfo
     @Test
     public void testInputWithoutPartitioning()
     {
-        String tableName = "test_input_info_without_part_" + randomTableSuffix();
+        String tableName = "test_input_info_without_part_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM nation WHERE nationkey < 10", 10);
         assertInputInfo(tableName, false, "ORC");
         assertUpdate("DROP TABLE " + tableName);
@@ -61,7 +61,7 @@ public class TestIcebergInputInfo
     @Test
     public void testInputWithParquetFileFormat()
     {
-        String tableName = "test_input_info_with_parquet_file_format_" + randomTableSuffix();
+        String tableName = "test_input_info_with_parquet_file_format_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (format = 'PARQUET') AS SELECT * FROM nation WHERE nationkey < 10", 10);
         assertInputInfo(tableName, false, "PARQUET");
         assertUpdate("DROP TABLE " + tableName);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
@@ -48,8 +48,8 @@ import static io.trino.plugin.iceberg.TrackingFileSystemFactory.OperationType.OU
 import static io.trino.plugin.iceberg.TrackingFileSystemFactory.OperationType.OUTPUT_FILE_LOCATION;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
@@ -388,7 +388,7 @@ public class TestIcebergMetadataFileOperations
     @Test
     public void testRemoveOrphanFiles()
     {
-        String tableName = "test_remove_orphan_files_" + randomTableSuffix();
+        String tableName = "test_remove_orphan_files_" + randomNameSuffix();
         Session sessionWithShortRetentionUnlocked = Session.builder(getSession())
                 .setCatalogSessionProperty("iceberg", "remove_orphan_files_min_retention", "0s")
                 .build();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPartitionEvolution.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPartitionEvolution.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 import java.util.List;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.Math.toIntExact;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
@@ -43,7 +43,7 @@ public class TestIcebergPartitionEvolution
     @Test
     public void testRemovePartitioning()
     {
-        String tableName = "test_remove_partition_" + randomTableSuffix();
+        String tableName = "test_remove_partition_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (partitioning = ARRAY['regionkey', 'truncate(name, 1)']) AS SELECT * FROM nation WHERE nationkey < 10", 10);
         assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES partitioning = ARRAY[]");
         assertUpdate("INSERT INTO " + tableName + " SELECT * FROM nation WHERE nationkey >= 10", 15);
@@ -73,7 +73,7 @@ public class TestIcebergPartitionEvolution
     @Test
     public void testAddPartitionColumn()
     {
-        String tableName = "test_add_partition_column_" + randomTableSuffix();
+        String tableName = "test_add_partition_column_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (partitioning = ARRAY['regionkey']) AS SELECT * FROM nation WHERE nationkey < 10", 10);
         assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES partitioning = ARRAY['regionkey', 'truncate(name, 1)']");
         assertUpdate("INSERT INTO " + tableName + " SELECT * FROM nation WHERE nationkey >= 10", 15);
@@ -128,7 +128,7 @@ public class TestIcebergPartitionEvolution
     @Test
     public void testChangePartitionTransform()
     {
-        String tableName = "test_change_partition_transform_" + randomTableSuffix();
+        String tableName = "test_change_partition_transform_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " (ts, a) WITH (partitioning = ARRAY['year(ts)']) " +
                 "AS VALUES (TIMESTAMP '2021-01-01 01:01:01.111111', 1), (TIMESTAMP '2022-02-02 02:02:02.222222', 2), (TIMESTAMP '2023-03-03 03:03:03.333333', 3)", 3);
         assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES partitioning = ARRAY['month(ts)']");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergProjectionPushdownPlans.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergProjectionPushdownPlans.java
@@ -53,8 +53,8 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -109,7 +109,7 @@ public class TestIcebergProjectionPushdownPlans
     @Test
     public void testPushdownDisabled()
     {
-        String testTable = "test_disabled_pushdown" + randomTableSuffix();
+        String testTable = "test_disabled_pushdown" + randomNameSuffix();
 
         Session session = Session.builder(getQueryRunner().getDefaultSession())
                 .setCatalogSessionProperty(CATALOG, "projection_pushdown_enabled", "false")
@@ -131,7 +131,7 @@ public class TestIcebergProjectionPushdownPlans
     @Test
     public void testDereferencePushdown()
     {
-        String testTable = "test_simple_projection_pushdown" + randomTableSuffix();
+        String testTable = "test_simple_projection_pushdown" + randomNameSuffix();
         QualifiedObjectName completeTableName = new QualifiedObjectName(CATALOG, SCHEMA, testTable);
 
         getQueryRunner().execute(format(

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergRegisterTableProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergRegisterTableProcedure.java
@@ -38,7 +38,7 @@ import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
 import static io.trino.plugin.iceberg.IcebergUtil.METADATA_FOLDER_NAME;
 import static io.trino.plugin.iceberg.procedure.RegisterTableProcedure.getLatestMetadataLocation;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -82,7 +82,7 @@ public class TestIcebergRegisterTableProcedure
     @Test(dataProvider = "fileFormats")
     public void testRegisterTableWithTableLocation(IcebergFileFormat icebergFileFormat)
     {
-        String tableName = "test_register_table_with_table_location_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomTableSuffix();
+        String tableName = "test_register_table_with_table_location_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomNameSuffix();
 
         assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean) with (format = '%s')", tableName, icebergFileFormat));
         assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
@@ -104,7 +104,7 @@ public class TestIcebergRegisterTableProcedure
     @Test(dataProvider = "fileFormats")
     public void testRegisterTableWithComments(IcebergFileFormat icebergFileFormat)
     {
-        String tableName = "test_register_table_with_comments_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomTableSuffix();
+        String tableName = "test_register_table_with_comments_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomNameSuffix();
 
         assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean) with (format = '%s')", tableName, icebergFileFormat));
         assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
@@ -130,7 +130,7 @@ public class TestIcebergRegisterTableProcedure
     @Test(dataProvider = "fileFormats")
     public void testRegisterTableWithShowCreateTable(IcebergFileFormat icebergFileFormat)
     {
-        String tableName = "test_register_table_with_show_create_table_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomTableSuffix();
+        String tableName = "test_register_table_with_show_create_table_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomNameSuffix();
 
         assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean) with (format = '%s')", tableName, icebergFileFormat));
         assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
@@ -150,7 +150,7 @@ public class TestIcebergRegisterTableProcedure
     @Test(dataProvider = "fileFormats")
     public void testRegisterTableWithReInsert(IcebergFileFormat icebergFileFormat)
     {
-        String tableName = "test_register_table_with_re_insert_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomTableSuffix();
+        String tableName = "test_register_table_with_re_insert_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomNameSuffix();
 
         assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean) with (format = '%s')", tableName, icebergFileFormat));
         assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
@@ -174,7 +174,7 @@ public class TestIcebergRegisterTableProcedure
     @Test(dataProvider = "fileFormats")
     public void testRegisterTableWithDroppedTable(IcebergFileFormat icebergFileFormat)
     {
-        String tableName = "test_register_table_with_dropped_table_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomTableSuffix();
+        String tableName = "test_register_table_with_dropped_table_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomNameSuffix();
 
         assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean) with (format = '%s')", tableName, icebergFileFormat));
         assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
@@ -192,7 +192,7 @@ public class TestIcebergRegisterTableProcedure
     @Test(dataProvider = "fileFormats")
     public void testRegisterTableWithDifferentTableName(IcebergFileFormat icebergFileFormat)
     {
-        String tableName = "test_register_table_with_different_table_name_old_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomTableSuffix();
+        String tableName = "test_register_table_with_different_table_name_old_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomNameSuffix();
 
         assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean) with (format = '%s')", tableName, icebergFileFormat));
         assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
@@ -217,7 +217,7 @@ public class TestIcebergRegisterTableProcedure
     @Test(dataProvider = "fileFormats")
     public void testRegisterTableWithMetadataFile(IcebergFileFormat icebergFileFormat)
     {
-        String tableName = "test_register_table_with_metadata_file_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomTableSuffix();
+        String tableName = "test_register_table_with_metadata_file_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomNameSuffix();
 
         assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean) with (format = '%s')", tableName, icebergFileFormat));
         assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
@@ -245,7 +245,7 @@ public class TestIcebergRegisterTableProcedure
             throws IOException
     {
         IcebergFileFormat icebergFileFormat = IcebergFileFormat.ORC;
-        String tableName = "test_register_table_with_no_metadata_file_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomTableSuffix();
+        String tableName = "test_register_table_with_no_metadata_file_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomNameSuffix();
 
         assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean) with (format = '%s')", tableName, icebergFileFormat));
         assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
@@ -266,7 +266,7 @@ public class TestIcebergRegisterTableProcedure
     public void testRegisterTableWithInvalidMetadataFile()
             throws IOException
     {
-        String tableName = "test_register_table_with_invalid_metadata_file_" + randomTableSuffix();
+        String tableName = "test_register_table_with_invalid_metadata_file_" + randomNameSuffix();
 
         assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean)", tableName));
         assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
@@ -295,7 +295,7 @@ public class TestIcebergRegisterTableProcedure
     @Test
     public void testRegisterTableWithNonExistingTableLocation()
     {
-        String tableName = "test_register_table_with_non_existing_table_location_" + randomTableSuffix();
+        String tableName = "test_register_table_with_non_existing_table_location_" + randomNameSuffix();
         String tableLocation = "/test/iceberg/hive/warehouse/orders_5-581fad8517934af6be1857a903559d44";
         assertQueryFails("CALL iceberg.system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "')",
                 ".*No versioned metadata file exists at location.*");
@@ -304,7 +304,7 @@ public class TestIcebergRegisterTableProcedure
     @Test
     public void testRegisterTableWithNonExistingMetadataFile()
     {
-        String tableName = "test_register_table_with_non_existing_metadata_file_" + randomTableSuffix();
+        String tableName = "test_register_table_with_non_existing_metadata_file_" + randomNameSuffix();
         String nonExistingMetadataFileName = "00003-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json";
         String tableLocation = "/test/iceberg/hive/warehouse/orders_5-581fad8517934af6be1857a903559d44";
         assertQueryFails("CALL iceberg.system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "', '" + nonExistingMetadataFileName + "')",
@@ -322,7 +322,7 @@ public class TestIcebergRegisterTableProcedure
     @Test
     public void testRegisterTableWithExistingTable()
     {
-        String tableName = "test_register_table_with_existing_table_" + randomTableSuffix();
+        String tableName = "test_register_table_with_existing_table_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + " (a int, b varchar, c boolean)");
         assertUpdate("INSERT INTO " + tableName + " values(1, 'INDIA', true)", 1);
@@ -336,7 +336,7 @@ public class TestIcebergRegisterTableProcedure
     @Test
     public void testRegisterTableWithInvalidURIScheme()
     {
-        String tableName = "test_register_table_with_invalid_uri_scheme_" + randomTableSuffix();
+        String tableName = "test_register_table_with_invalid_uri_scheme_" + randomNameSuffix();
         String nonExistedMetadataFileName = "00003-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json";
         String tableLocation = "invalid://hadoop-master:9000/test/iceberg/hive/orders_5-581fad8517934af6be1857a903559d44";
         assertQueryFails("CALL iceberg.system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "', '" + nonExistedMetadataFileName + "')",
@@ -348,7 +348,7 @@ public class TestIcebergRegisterTableProcedure
     @Test
     public void testRegisterTableWithInvalidParameter()
     {
-        String tableName = "test_register_table_with_invalid_parameter_" + randomTableSuffix();
+        String tableName = "test_register_table_with_invalid_parameter_" + randomNameSuffix();
         String tableLocation = "/test/iceberg/hive/table1/";
 
         assertQueryFails(format("CALL iceberg.system.register_table (CURRENT_SCHEMA, '%s')", tableName),
@@ -378,7 +378,7 @@ public class TestIcebergRegisterTableProcedure
     @Test
     public void testRegisterTableWithInvalidMetadataFileName()
     {
-        String tableName = "test_register_table_with_invalid_metadata_file_name_" + randomTableSuffix();
+        String tableName = "test_register_table_with_invalid_metadata_file_name_" + randomNameSuffix();
         String tableLocation = "/test/iceberg/hive";
 
         String[] invalidMetadataFileNames = {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableWithExternalLocation.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableWithExternalLocation.java
@@ -43,7 +43,7 @@ import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.plugin.iceberg.DataFileRecord.toDataFileRecord;
 import static io.trino.plugin.iceberg.catalog.hms.IcebergHiveMetastoreCatalogModule.HIDE_DELTA_LAKE_TABLES_IN_ICEBERG;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
@@ -94,7 +94,7 @@ public class TestIcebergTableWithExternalLocation
     {
         String tableName = "test_table_external_create_and_drop";
         File tempDir = getDistributedQueryRunner().getCoordinator().getBaseDataDir().toFile();
-        String tempDirPath = tempDir.toURI().toASCIIString() + randomTableSuffix();
+        String tempDirPath = tempDir.toURI().toASCIIString() + randomNameSuffix();
         assertQuerySucceeds(format("CREATE TABLE %s ( x bigint) WITH (location = '%s')", tableName, tempDirPath));
         assertQuerySucceeds(format("INSERT INTO %s VALUES (1), (2), (3)", tableName));
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -73,7 +73,7 @@ import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
 import static io.trino.plugin.iceberg.IcebergUtil.loadIcebergTable;
 import static io.trino.testing.TestingConnectorSession.SESSION;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.tpch.TpchTable.NATION;
 import static java.lang.String.format;
 import static org.apache.iceberg.TableProperties.SPLIT_SIZE;
@@ -118,7 +118,7 @@ public class TestIcebergV2
     @Test
     public void testSettingFormatVersion()
     {
-        String tableName = "test_seting_format_version_" + randomTableSuffix();
+        String tableName = "test_seting_format_version_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (format_version = 2) AS SELECT * FROM tpch.tiny.nation", 25);
         assertThat(loadTable(tableName).operations().current().formatVersion()).isEqualTo(2);
         assertUpdate("DROP TABLE " + tableName);
@@ -131,7 +131,7 @@ public class TestIcebergV2
     @Test
     public void testDefaultFormatVersion()
     {
-        String tableName = "test_default_format_version_" + randomTableSuffix();
+        String tableName = "test_default_format_version_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.tiny.nation", 25);
         assertThat(loadTable(tableName).operations().current().formatVersion()).isEqualTo(2);
         assertUpdate("DROP TABLE " + tableName);
@@ -140,7 +140,7 @@ public class TestIcebergV2
     @Test
     public void testV2TableRead()
     {
-        String tableName = "test_v2_table_read" + randomTableSuffix();
+        String tableName = "test_v2_table_read" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.tiny.nation", 25);
         updateTableToV2(tableName);
         assertQuery("SELECT * FROM " + tableName, "SELECT * FROM nation");
@@ -150,7 +150,7 @@ public class TestIcebergV2
     public void testV2TableWithPositionDelete()
             throws Exception
     {
-        String tableName = "test_v2_row_delete" + randomTableSuffix();
+        String tableName = "test_v2_row_delete" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.tiny.nation", 25);
         Table icebergTable = updateTableToV2(tableName);
 
@@ -181,7 +181,7 @@ public class TestIcebergV2
     public void testV2TableWithEqualityDelete()
             throws Exception
     {
-        String tableName = "test_v2_equality_delete" + randomTableSuffix();
+        String tableName = "test_v2_equality_delete" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.tiny.nation", 25);
         Table icebergTable = updateTableToV2(tableName);
         writeEqualityDeleteToNationTable(icebergTable, Optional.of(icebergTable.spec()), Optional.of(new PartitionData(new Long[]{1L})));
@@ -195,7 +195,7 @@ public class TestIcebergV2
             throws Exception
     {
         // Specify equality delete filter with different column order from table definition
-        String tableName = "test_v2_equality_delete_different_order" + randomTableSuffix();
+        String tableName = "test_v2_equality_delete_different_order" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.tiny.nation", 25);
         Table icebergTable = updateTableToV2(tableName);
         writeEqualityDeleteToNationTable(icebergTable, Optional.of(icebergTable.spec()), Optional.empty(), ImmutableMap.of("regionkey", 1L, "name", "ARGENTINA"));
@@ -208,7 +208,7 @@ public class TestIcebergV2
     public void testOptimizingV2TableRemovesEqualityDeletesWhenWholeTableIsScanned()
             throws Exception
     {
-        String tableName = "test_optimize_table_cleans_equality_delete_file_when_whole_table_is_scanned" + randomTableSuffix();
+        String tableName = "test_optimize_table_cleans_equality_delete_file_when_whole_table_is_scanned" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (partitioning = ARRAY['regionkey']) AS SELECT * FROM tpch.tiny.nation", 25);
         Table icebergTable = updateTableToV2(tableName);
         Assertions.assertThat(icebergTable.currentSnapshot().summary().get("total-equality-deletes")).isEqualTo("0");
@@ -227,7 +227,7 @@ public class TestIcebergV2
     public void testOptimizingV2TableDoesntRemoveEqualityDeletesWhenOnlyPartOfTheTableIsOptimized()
             throws Exception
     {
-        String tableName = "test_optimize_table_with_equality_delete_file_for_different_partition_" + randomTableSuffix();
+        String tableName = "test_optimize_table_with_equality_delete_file_for_different_partition_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (partitioning = ARRAY['regionkey']) AS SELECT * FROM tpch.tiny.nation", 25);
         Table icebergTable = updateTableToV2(tableName);
         Assertions.assertThat(icebergTable.currentSnapshot().summary().get("total-equality-deletes")).isEqualTo("0");
@@ -246,7 +246,7 @@ public class TestIcebergV2
     public void testSelectivelyOptimizingLeavesEqualityDeletes()
             throws Exception
     {
-        String tableName = "test_selectively_optimizing_leaves_eq_deletes_" + randomTableSuffix();
+        String tableName = "test_selectively_optimizing_leaves_eq_deletes_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (partitioning = ARRAY['nationkey']) AS SELECT * FROM tpch.tiny.nation", 25);
         Table icebergTable = loadTable(tableName);
         writeEqualityDeleteToNationTable(icebergTable, Optional.of(icebergTable.spec()), Optional.of(new PartitionData(new Long[]{1L})));
@@ -259,7 +259,7 @@ public class TestIcebergV2
     public void testOptimizingWholeTableRemovesEqualityDeletes()
             throws Exception
     {
-        String tableName = "test_optimizing_whole_table_removes_eq_deletes_" + randomTableSuffix();
+        String tableName = "test_optimizing_whole_table_removes_eq_deletes_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (partitioning = ARRAY['nationkey']) AS SELECT * FROM tpch.tiny.nation", 25);
         Table icebergTable = loadTable(tableName);
         writeEqualityDeleteToNationTable(icebergTable, Optional.of(icebergTable.spec()), Optional.of(new PartitionData(new Long[]{1L})));
@@ -272,7 +272,7 @@ public class TestIcebergV2
     public void testOptimizingV2TableWithEmptyPartitionSpec()
             throws Exception
     {
-        String tableName = "test_optimize_table_with_global_equality_delete_file_" + randomTableSuffix();
+        String tableName = "test_optimize_table_with_global_equality_delete_file_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.tiny.nation", 25);
         Table icebergTable = updateTableToV2(tableName);
         Assertions.assertThat(icebergTable.currentSnapshot().summary().get("total-equality-deletes")).isEqualTo("0");
@@ -291,7 +291,7 @@ public class TestIcebergV2
     public void testOptimizingPartitionsOfV2TableWithGlobalEqualityDeleteFile()
             throws Exception
     {
-        String tableName = "test_optimize_partitioned_table_with_global_equality_delete_file_" + randomTableSuffix();
+        String tableName = "test_optimize_partitioned_table_with_global_equality_delete_file_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (partitioning = ARRAY['regionkey']) AS SELECT * FROM tpch.tiny.nation", 25);
         Table icebergTable = updateTableToV2(tableName);
         Assertions.assertThat(icebergTable.currentSnapshot().summary().get("total-equality-deletes")).isEqualTo("0");
@@ -313,7 +313,7 @@ public class TestIcebergV2
     @Test
     public void testUpgradeTableToV2FromTrino()
     {
-        String tableName = "test_upgrade_table_to_v2_from_trino_" + randomTableSuffix();
+        String tableName = "test_upgrade_table_to_v2_from_trino_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (format_version = 1) AS SELECT * FROM tpch.tiny.nation", 25);
         assertEquals(loadTable(tableName).operations().current().formatVersion(), 1);
         assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES format_version = 2");
@@ -324,7 +324,7 @@ public class TestIcebergV2
     @Test
     public void testDowngradingV2TableToV1Fails()
     {
-        String tableName = "test_downgrading_v2_table_to_v1_fails_" + randomTableSuffix();
+        String tableName = "test_downgrading_v2_table_to_v1_fails_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (format_version = 2) AS SELECT * FROM tpch.tiny.nation", 25);
         assertEquals(loadTable(tableName).operations().current().formatVersion(), 2);
         assertThatThrownBy(() -> query("ALTER TABLE " + tableName + " SET PROPERTIES format_version = 1"))
@@ -336,7 +336,7 @@ public class TestIcebergV2
     @Test
     public void testUpgradingToInvalidVersionFails()
     {
-        String tableName = "test_upgrading_to_invalid_version_fails_" + randomTableSuffix();
+        String tableName = "test_upgrading_to_invalid_version_fails_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (format_version = 2) AS SELECT * FROM tpch.tiny.nation", 25);
         assertEquals(loadTable(tableName).operations().current().formatVersion(), 2);
         assertThatThrownBy(() -> query("ALTER TABLE " + tableName + " SET PROPERTIES format_version = 42"))
@@ -346,7 +346,7 @@ public class TestIcebergV2
     @Test
     public void testUpdatingAllTableProperties()
     {
-        String tableName = "test_updating_all_table_properties_" + randomTableSuffix();
+        String tableName = "test_updating_all_table_properties_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (format_version = 1, format = 'ORC') AS SELECT * FROM tpch.tiny.nation", 25);
         BaseTable table = loadTable(tableName);
         assertEquals(table.operations().current().formatVersion(), 1);
@@ -368,7 +368,7 @@ public class TestIcebergV2
     @Test
     public void testUnsettingAllTableProperties()
     {
-        String tableName = "test_unsetting_all_table_properties_" + randomTableSuffix();
+        String tableName = "test_unsetting_all_table_properties_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (format_version = 1, format = 'PARQUET', partitioning = ARRAY['regionkey']) AS SELECT * FROM tpch.tiny.nation", 25);
         BaseTable table = loadTable(tableName);
         assertEquals(table.operations().current().formatVersion(), 1);
@@ -390,7 +390,7 @@ public class TestIcebergV2
     @Test
     public void testDeletingEntireFile()
     {
-        String tableName = "test_deleting_entire_file_" + randomTableSuffix();
+        String tableName = "test_deleting_entire_file_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.tiny.nation WITH NO DATA", 0);
         assertUpdate("INSERT INTO " + tableName + " SELECT * FROM tpch.tiny.nation WHERE regionkey = 1", "SELECT count(*) FROM nation WHERE regionkey = 1");
         assertUpdate("INSERT INTO " + tableName + " SELECT * FROM tpch.tiny.nation WHERE regionkey != 1", "SELECT count(*) FROM nation WHERE regionkey != 1");
@@ -404,7 +404,7 @@ public class TestIcebergV2
     @Test
     public void testDeletingEntireFileFromPartitionedTable()
     {
-        String tableName = "test_deleting_entire_file_from_partitioned_table_" + randomTableSuffix();
+        String tableName = "test_deleting_entire_file_from_partitioned_table_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " (a INT, b INT) WITH (partitioning = ARRAY['a'])");
         assertUpdate("INSERT INTO " + tableName + " VALUES (1, 1), (1, 3), (1, 5), (2, 1), (2, 3), (2, 5)", 6);
         assertUpdate("INSERT INTO " + tableName + " VALUES (1, 2), (1, 4), (1, 6), (2, 2), (2, 4), (2, 6)", 6);
@@ -418,7 +418,7 @@ public class TestIcebergV2
     @Test
     public void testDeletingEntireFileWithNonTupleDomainConstraint()
     {
-        String tableName = "test_deleting_entire_file_with_non_tuple_domain_constraint" + randomTableSuffix();
+        String tableName = "test_deleting_entire_file_with_non_tuple_domain_constraint" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.tiny.nation WITH NO DATA", 0);
         assertUpdate("INSERT INTO " + tableName + " SELECT * FROM tpch.tiny.nation WHERE regionkey = 1", "SELECT count(*) FROM nation WHERE regionkey = 1");
         assertUpdate("INSERT INTO " + tableName + " SELECT * FROM tpch.tiny.nation WHERE regionkey != 1", "SELECT count(*) FROM nation WHERE regionkey != 1");
@@ -432,7 +432,7 @@ public class TestIcebergV2
     @Test
     public void testDeletingEntireFileWithMultipleSplits()
     {
-        String tableName = "test_deleting_entire_file_with_multiple_splits" + randomTableSuffix();
+        String tableName = "test_deleting_entire_file_with_multiple_splits" + randomNameSuffix();
         assertUpdate(
                 Session.builder(getSession()).setCatalogSessionProperty("iceberg", "orc_writer_max_stripe_rows", "5").build(),
                 "CREATE TABLE " + tableName + " WITH (format = 'ORC') AS SELECT * FROM tpch.tiny.nation", 25);
@@ -453,7 +453,7 @@ public class TestIcebergV2
     public void testMultipleDeletes()
     {
         // Deletes only remove entire data files from the table if the whole file is removed in a single operation
-        String tableName = "test_multiple_deletes_" + randomTableSuffix();
+        String tableName = "test_multiple_deletes_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.tiny.nation", 25);
         assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(1);
         // Ensure only one snapshot is committed to the table
@@ -470,7 +470,7 @@ public class TestIcebergV2
     @Test
     public void testDeletingEntirePartitionedTable()
     {
-        String tableName = "test_deleting_entire_partitioned_table_" + randomTableSuffix();
+        String tableName = "test_deleting_entire_partitioned_table_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (partitioning = ARRAY['regionkey']) AS SELECT * FROM tpch.tiny.nation", 25);
 
         assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(5);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
@@ -46,8 +46,8 @@ import static io.trino.plugin.iceberg.IcebergSchemaProperties.LOCATION_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergUtil.quotedTableName;
 import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
 import static io.trino.testing.TestingConnectorSession.SESSION;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.assertions.Assert.assertEquals;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertNotEquals;
@@ -67,7 +67,7 @@ public abstract class BaseTrinoCatalogTest
     public void testCreateNamespaceWithLocation()
     {
         TrinoCatalog catalog = createTrinoCatalog(false);
-        String namespace = "test_create_namespace_with_location_" + randomTableSuffix();
+        String namespace = "test_create_namespace_with_location_" + randomNameSuffix();
         Map<String, Object> namespaceProperties = new HashMap<>(defaultNamespaceProperties(namespace));
         String namespaceLocation = (String) namespaceProperties.computeIfAbsent(LOCATION_PROPERTY, ignored -> "/a/path/");
         namespaceProperties = ImmutableMap.copyOf(namespaceProperties);
@@ -84,7 +84,7 @@ public abstract class BaseTrinoCatalogTest
     {
         TrinoCatalog catalog = createTrinoCatalog(false);
 
-        String namespace = "testNonLowercaseNamespace" + randomTableSuffix();
+        String namespace = "testNonLowercaseNamespace" + randomNameSuffix();
         // Trino schema names are always lowercase (until https://github.com/trinodb/trino/issues/17)
         String schema = namespace.toLowerCase(ENGLISH);
 
@@ -126,7 +126,7 @@ public abstract class BaseTrinoCatalogTest
             throws Exception
     {
         TrinoCatalog catalog = createTrinoCatalog(false);
-        String namespace = "test_create_table_" + randomTableSuffix();
+        String namespace = "test_create_table_" + randomNameSuffix();
         String table = "tableName";
         SchemaTableName schemaTableName = new SchemaTableName(namespace, table);
         try {
@@ -170,8 +170,8 @@ public abstract class BaseTrinoCatalogTest
             throws Exception
     {
         TrinoCatalog catalog = createTrinoCatalog(false);
-        String namespace = "test_rename_table_" + randomTableSuffix();
-        String targetNamespace = "test_rename_table_" + randomTableSuffix();
+        String namespace = "test_rename_table_" + randomNameSuffix();
+        String targetNamespace = "test_rename_table_" + randomNameSuffix();
 
         String table = "tableName";
         SchemaTableName sourceSchemaTableName = new SchemaTableName(namespace, table);
@@ -219,7 +219,7 @@ public abstract class BaseTrinoCatalogTest
             throws IOException
     {
         TrinoCatalog catalog = createTrinoCatalog(true);
-        String namespace = "test_unique_table_locations_" + randomTableSuffix();
+        String namespace = "test_unique_table_locations_" + randomNameSuffix();
         String table = "tableName";
         SchemaTableName schemaTableName = new SchemaTableName(namespace, table);
         Map<String, Object> namespaceProperties = new HashMap<>(defaultNamespaceProperties(namespace));
@@ -263,7 +263,7 @@ public abstract class BaseTrinoCatalogTest
         Path tmpDirectory = Files.createTempDirectory("iceberg_catalog_test_create_view_");
         tmpDirectory.toFile().deleteOnExit();
 
-        String namespace = "test_create_view_" + randomTableSuffix();
+        String namespace = "test_create_view_" + randomNameSuffix();
         String viewName = "viewName";
         String renamedViewName = "renamedViewName";
         SchemaTableName schemaTableName = new SchemaTableName(namespace, viewName);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
@@ -63,8 +63,8 @@ import static io.trino.plugin.iceberg.catalog.glue.GlueMetastoreMethod.CREATE_TA
 import static io.trino.plugin.iceberg.catalog.glue.GlueMetastoreMethod.GET_DATABASE;
 import static io.trino.plugin.iceberg.catalog.glue.GlueMetastoreMethod.GET_TABLE;
 import static io.trino.plugin.iceberg.catalog.glue.GlueMetastoreMethod.UPDATE_TABLE;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.lang.annotation.ElementType.FIELD;
@@ -84,7 +84,7 @@ import static org.testng.Assert.fail;
 public class TestIcebergGlueCatalogAccessOperations
         extends AbstractTestQueryFramework
 {
-    private final String testSchema = "test_schema_" + randomTableSuffix();
+    private final String testSchema = "test_schema_" + randomNameSuffix();
     private final Session testSession = testSessionBuilder()
             .setCatalog("iceberg")
             .setSchema(testSchema)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogConnectorSmokeTest.java
@@ -39,7 +39,7 @@ import java.util.List;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.hive.metastore.glue.AwsSdkUtil.getPaginatedResults;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,7 +62,7 @@ public class TestIcebergGlueCatalogConnectorSmokeTest
     {
         super(FileFormat.PARQUET);
         this.bucketName = requireNonNull(bucketName, "bucketName is null");
-        this.schemaName = "test_iceberg_smoke_" + randomTableSuffix();
+        this.schemaName = "test_iceberg_smoke_" + randomNameSuffix();
         glueClient = AWSGlueAsyncClientBuilder.defaultClient();
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogMaterializedViewTest.java
@@ -36,12 +36,12 @@ import java.util.Set;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.plugin.hive.metastore.glue.AwsSdkUtil.getPaginatedResults;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 
 public class TestIcebergGlueCatalogMaterializedViewTest
         extends BaseIcebergMaterializedViewTest
 {
-    private final String schemaName = "test_iceberg_materialized_view_" + randomTableSuffix();
+    private final String schemaName = "test_iceberg_materialized_view_" + randomNameSuffix();
 
     private File schemaDirectory;
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogSkipArchive.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogSkipArchive.java
@@ -42,7 +42,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.plugin.hive.metastore.glue.AwsSdkUtil.getPaginatedResults;
 import static io.trino.plugin.iceberg.catalog.glue.GlueIcebergUtil.getTableInput;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /*
@@ -53,7 +53,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestIcebergGlueCatalogSkipArchive
         extends AbstractTestQueryFramework
 {
-    private final String schemaName = "test_iceberg_skip_archive_" + randomTableSuffix();
+    private final String schemaName = "test_iceberg_skip_archive_" + randomNameSuffix();
     private AWSGlueAsync glueClient;
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueTableOperationsInsertFailure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueTableOperationsInsertFailure.java
@@ -39,8 +39,8 @@ import static com.google.common.reflect.Reflection.newProxy;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.inject.util.Modules.EMPTY_MODULE;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -56,7 +56,7 @@ public class TestIcebergGlueTableOperationsInsertFailure
 
     private static final String ICEBERG_CATALOG = "iceberg";
 
-    private final String schemaName = "test_iceberg_glue_" + randomTableSuffix();
+    private final String schemaName = "test_iceberg_glue_" + randomNameSuffix();
 
     private GlueHiveMetastore glueHiveMetastore;
 
@@ -129,7 +129,7 @@ public class TestIcebergGlueTableOperationsInsertFailure
     @Test
     public void testInsertFailureDoesNotCorruptTheTableMetadata()
     {
-        String tableName = "test_insert_failure" + randomTableSuffix();
+        String tableName = "test_insert_failure" + randomNameSuffix();
 
         getQueryRunner().execute(format("CREATE TABLE %s (a_varchar) AS VALUES ('Trino')", tableName));
         assertThatThrownBy(() -> getQueryRunner().execute("INSERT INTO " + tableName + " VALUES 'rocks'"))

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
@@ -45,7 +45,7 @@ import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
 import static io.trino.testing.TestingConnectorSession.SESSION;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
@@ -81,7 +81,7 @@ public class TestTrinoGlueCatalog
     @Test
     public void testNonLowercaseGlueDatabase()
     {
-        String databaseName = "testNonLowercaseDatabase" + randomTableSuffix();
+        String databaseName = "testNonLowercaseDatabase" + randomNameSuffix();
         // Trino schema names are always lowercase (until https://github.com/trinodb/trino/issues/17)
         String trinoSchemaName = databaseName.toLowerCase(ENGLISH);
 
@@ -146,7 +146,7 @@ public class TestTrinoGlueCatalog
                 Optional.of(tmpDirectory.toAbsolutePath().toString()),
                 false);
 
-        String namespace = "test_default_location_" + randomTableSuffix();
+        String namespace = "test_default_location_" + randomNameSuffix();
         String table = "tableName";
         SchemaTableName schemaTableName = new SchemaTableName(namespace, table);
         catalogWithDefaultLocation.createNamespace(SESSION, namespace, ImmutableMap.of(), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestTrinoHiveCatalogWithHiveMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestTrinoHiveCatalogWithHiveMetastore.java
@@ -48,13 +48,13 @@ import static io.trino.plugin.hive.containers.HiveHadoop.HIVE3_IMAGE;
 import static io.trino.plugin.hive.containers.HiveMinioDataLake.MINIO_ACCESS_KEY;
 import static io.trino.plugin.hive.containers.HiveMinioDataLake.MINIO_SECRET_KEY;
 import static io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.memoizeMetastore;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class TestTrinoHiveCatalogWithHiveMetastore
         extends BaseTrinoCatalogTest
 {
-    private static final String bucketName = "test-hive-catalog-with-hms-" + randomTableSuffix();
+    private static final String bucketName = "test-hive-catalog-with-hms-" + randomNameSuffix();
 
     // Use MinIO for storage, since HDFS is hard to get working in a unit test
     private HiveMinioDataLake dataLake;

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestInternalFieldConflict.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestInternalFieldConflict.java
@@ -26,7 +26,7 @@ import static io.trino.plugin.kafka.util.TestUtils.createOneFieldDescription;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.VarcharType.createVarcharType;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 
 @Test(singleThreaded = true)
 public class TestInternalFieldConflict
@@ -40,8 +40,8 @@ public class TestInternalFieldConflict
             throws Exception
     {
         TestingKafka testingKafka = closeAfterClass(TestingKafka.create());
-        topicWithDefaultPrefixes = new SchemaTableName("default", "test_" + randomTableSuffix());
-        topicWithCustomPrefixes = new SchemaTableName("default", "test_" + randomTableSuffix());
+        topicWithDefaultPrefixes = new SchemaTableName("default", "test_" + randomNameSuffix());
+        topicWithCustomPrefixes = new SchemaTableName("default", "test_" + randomNameSuffix());
         return KafkaQueryRunner.builder(testingKafka)
                 .setExtraTopicDescription(ImmutableMap.of(
                         topicWithDefaultPrefixes, createDescription(

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaConnectorTest.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaConnectorTest.java
@@ -59,8 +59,8 @@ import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.testing.DataProviders.toDataProvider;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_CREATE_TABLE_WITH_DATA;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.assertions.Assert.assertEquals;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -86,14 +86,14 @@ public class TestKafkaConnectorTest
     private static final String JSON_SECONDS_TABLE_NAME = "seconds_since_epoch_table";
 
     // These tables must not be reused because the data will be modified during tests
-    private static final SchemaTableName TABLE_INSERT_NEGATIVE_DATE = new SchemaTableName("write_test", "test_insert_negative_date_" + randomTableSuffix());
-    private static final SchemaTableName TABLE_INSERT_CUSTOMER = new SchemaTableName("write_test", "test_insert_customer_" + randomTableSuffix());
-    private static final SchemaTableName TABLE_INSERT_ARRAY = new SchemaTableName("write_test", "test_insert_array_" + randomTableSuffix());
-    private static final SchemaTableName TABLE_INSERT_UNICODE_1 = new SchemaTableName("write_test", "test_unicode_1_" + randomTableSuffix());
-    private static final SchemaTableName TABLE_INSERT_UNICODE_2 = new SchemaTableName("write_test", "test_unicode_2_" + randomTableSuffix());
-    private static final SchemaTableName TABLE_INSERT_UNICODE_3 = new SchemaTableName("write_test", "test_unicode_3_" + randomTableSuffix());
-    private static final SchemaTableName TABLE_INSERT_HIGHEST_UNICODE = new SchemaTableName("write_test", "test_highest_unicode_" + randomTableSuffix());
-    private static final SchemaTableName TABLE_INTERNAL_FIELD_PREFIX = new SchemaTableName("write_test", "test_internal_fields_prefix_" + randomTableSuffix());
+    private static final SchemaTableName TABLE_INSERT_NEGATIVE_DATE = new SchemaTableName("write_test", "test_insert_negative_date_" + randomNameSuffix());
+    private static final SchemaTableName TABLE_INSERT_CUSTOMER = new SchemaTableName("write_test", "test_insert_customer_" + randomNameSuffix());
+    private static final SchemaTableName TABLE_INSERT_ARRAY = new SchemaTableName("write_test", "test_insert_array_" + randomNameSuffix());
+    private static final SchemaTableName TABLE_INSERT_UNICODE_1 = new SchemaTableName("write_test", "test_unicode_1_" + randomNameSuffix());
+    private static final SchemaTableName TABLE_INSERT_UNICODE_2 = new SchemaTableName("write_test", "test_unicode_2_" + randomNameSuffix());
+    private static final SchemaTableName TABLE_INSERT_UNICODE_3 = new SchemaTableName("write_test", "test_unicode_3_" + randomNameSuffix());
+    private static final SchemaTableName TABLE_INSERT_HIGHEST_UNICODE = new SchemaTableName("write_test", "test_highest_unicode_" + randomNameSuffix());
+    private static final SchemaTableName TABLE_INTERNAL_FIELD_PREFIX = new SchemaTableName("write_test", "test_internal_fields_prefix_" + randomNameSuffix());
 
     @Override
     protected QueryRunner createQueryRunner()

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestKafkaWithConfluentSchemaRegistryMinimalFunctionality.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestKafkaWithConfluentSchemaRegistryMinimalFunctionality.java
@@ -42,7 +42,7 @@ import java.util.stream.IntStream;
 
 import static io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG;
 import static io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig.VALUE_SUBJECT_NAME_STRATEGY;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.Math.multiplyExact;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
@@ -86,7 +86,7 @@ public class TestKafkaWithConfluentSchemaRegistryMinimalFunctionality
     @Test
     public void testBasicTopic()
     {
-        String topic = "topic-basic-MixedCase-" + randomTableSuffix();
+        String topic = "topic-basic-MixedCase-" + randomNameSuffix();
         assertTopic(
                 testingKafka, topic,
                 format("SELECT col_1, col_2 FROM %s", toDoubleQuoted(topic)),
@@ -101,7 +101,7 @@ public class TestKafkaWithConfluentSchemaRegistryMinimalFunctionality
     @Test
     public void testTopicWithKeySubject()
     {
-        String topic = "topic-Key-Subject-" + randomTableSuffix();
+        String topic = "topic-Key-Subject-" + randomNameSuffix();
         assertTopic(
                 testingKafka, topic,
                 format("SELECT \"%s-key\", col_1, col_2 FROM %s", topic, toDoubleQuoted(topic)),
@@ -116,7 +116,7 @@ public class TestKafkaWithConfluentSchemaRegistryMinimalFunctionality
     @Test
     public void testTopicWithRecordNameStrategy()
     {
-        String topic = "topic-Record-Name-Strategy-" + randomTableSuffix();
+        String topic = "topic-Record-Name-Strategy-" + randomNameSuffix();
         assertTopic(
                 testingKafka, topic,
                 format("SELECT \"%1$s-key\", col_1, col_2 FROM \"%1$s&value-subject=%2$s\"", topic, RECORD_NAME),
@@ -132,7 +132,7 @@ public class TestKafkaWithConfluentSchemaRegistryMinimalFunctionality
     @Test
     public void testTopicWithTopicRecordNameStrategy()
     {
-        String topic = "topic-Topic-Record-Name-Strategy-" + randomTableSuffix();
+        String topic = "topic-Topic-Record-Name-Strategy-" + randomNameSuffix();
         assertTopic(
                 testingKafka, topic,
                 format("SELECT \"%1$s-key\", col_1, col_2 FROM \"%1$s&value-subject=%1$s-%2$s\"", topic, RECORD_NAME),
@@ -148,7 +148,7 @@ public class TestKafkaWithConfluentSchemaRegistryMinimalFunctionality
     @Test
     public void testUnsupportedInsert()
     {
-        String topicName = "topic-unsupported-insert-" + randomTableSuffix();
+        String topicName = "topic-unsupported-insert-" + randomNameSuffix();
 
         assertNotExists(topicName);
 
@@ -169,7 +169,7 @@ public class TestKafkaWithConfluentSchemaRegistryMinimalFunctionality
     @Test
     public void testUnsupportedFormat()
     {
-        String topicName = "topic-unsupported-format-" + randomTableSuffix();
+        String topicName = "topic-unsupported-format-" + randomNameSuffix();
 
         assertNotExists(topicName);
 

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
@@ -31,8 +31,8 @@ import java.util.regex.Pattern;
 import static io.trino.plugin.kudu.KuduQueryRunnerFactory.createKuduQueryRunnerTpch;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.MaterializedResult.resultBuilder;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.assertions.Assert.assertEquals;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -286,7 +286,7 @@ public class TestKuduConnectorTest
         if (delimited) {
             nameInSql = "\"" + columnName.replace("\"", "\"\"") + "\"";
         }
-        String tableName = "tcn_" + nameInSql.toLowerCase(ENGLISH).replaceAll("[^a-z0-9]", "") + randomTableSuffix();
+        String tableName = "tcn_" + nameInSql.toLowerCase(ENGLISH).replaceAll("[^a-z0-9]", "") + randomNameSuffix();
 
         try {
             // TODO test with both CTAS *and* CREATE TABLE + INSERT, since they use different connector API methods.
@@ -341,7 +341,7 @@ public class TestKuduConnectorTest
     @Override
     public void testExplainAnalyzeWithDeleteWithSubquery()
     {
-        String tableName = "test_delete_" + randomTableSuffix();
+        String tableName = "test_delete_" + randomNameSuffix();
 
         // delete using a subquery
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM nation", 25);
@@ -355,7 +355,7 @@ public class TestKuduConnectorTest
     public void testCreateTable()
     {
         // TODO Remove this overriding test once kudu connector can create tables with default partitions
-        String tableName = "test_create_" + randomTableSuffix();
+        String tableName = "test_create_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + " (" +
                 "id INT WITH (primary_key=true)," +
@@ -375,7 +375,7 @@ public class TestKuduConnectorTest
                 ".* Unknown type 'bad_type' for column 'a'");
         assertFalse(getQueryRunner().tableExists(getSession(), tableName));
 
-        tableName = "test_create_if_not_exists_" + randomTableSuffix();
+        tableName = "test_create_if_not_exists_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " (" +
                 "id INT WITH (primary_key=true)," +
                 "a bigint, b varchar(50), c double)" +
@@ -395,7 +395,7 @@ public class TestKuduConnectorTest
         assertFalse(getQueryRunner().tableExists(getSession(), tableName));
 
         // Test CREATE TABLE LIKE
-        tableName = "test_create_origin_" + randomTableSuffix();
+        tableName = "test_create_origin_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " (" +
                 "id INT WITH (primary_key=true)," +
                 "a bigint, b double, c varchar(50))" +
@@ -406,7 +406,7 @@ public class TestKuduConnectorTest
         // TODO: remove assertThatThrownBy and uncomment the commented lines
         //  and replace finalTableName with tableName
         //  after (https://github.com/trinodb/trino/issues/12469) is fixed
-        String tableNameLike = "test_create_like_" + randomTableSuffix();
+        String tableNameLike = "test_create_like_" + randomNameSuffix();
         final String finalTableName = tableName;
         assertThatThrownBy(() -> assertUpdate(
                 "CREATE TABLE " + tableNameLike + " (LIKE " + finalTableName + ", " +
@@ -427,7 +427,7 @@ public class TestKuduConnectorTest
     public void testCreateTableWithLongTableName()
     {
         // Overridden because DDL in base class can't create Kudu table due to lack of primary key and required table properties
-        String baseTableName = "test_create_" + randomTableSuffix();
+        String baseTableName = "test_create_" + randomNameSuffix();
         String validTableName = baseTableName + "z".repeat(256 - baseTableName.length());
 
         assertUpdate("CREATE TABLE " + validTableName + "(" +
@@ -450,7 +450,7 @@ public class TestKuduConnectorTest
     public void testCreateTableWithLongColumnName()
     {
         // Overridden because DDL in base class can't create Kudu table due to lack of primary key and required table properties
-        String tableName = "test_long_column" + randomTableSuffix();
+        String tableName = "test_long_column" + randomNameSuffix();
         String baseColumnName = "col";
 
         int maxLength = maxColumnNameLength().orElseThrow();
@@ -476,7 +476,7 @@ public class TestKuduConnectorTest
     public void testCreateTableWithColumnComment()
     {
         // TODO https://github.com/trinodb/trino/issues/12469 Support column comment when creating tables
-        String tableName = "test_create_" + randomTableSuffix();
+        String tableName = "test_create_" + randomNameSuffix();
 
         assertQueryFails(
                 "CREATE TABLE " + tableName + "(" +
@@ -492,7 +492,7 @@ public class TestKuduConnectorTest
     public void testDropTable()
     {
         // TODO Remove this overriding test once kudu connector can create tables with default partitions
-        String tableName = "test_drop_table_" + randomTableSuffix();
+        String tableName = "test_drop_table_" + randomNameSuffix();
         assertUpdate(
                 "CREATE TABLE " + tableName + "(" +
                     "id INT WITH (primary_key=true)," +
@@ -514,7 +514,7 @@ public class TestKuduConnectorTest
     @Override
     public void testAddColumnWithComment()
     {
-        String tableName = "test_add_column_with_comment" + randomTableSuffix();
+        String tableName = "test_add_column_with_comment" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE IF NOT EXISTS " + tableName + " (" +
                 "id INT WITH (primary_key=true), " +
@@ -667,7 +667,7 @@ public class TestKuduConnectorTest
     public void testCreateTableAsSelectNegativeDate()
     {
         // Map date column type to varchar
-        String tableName = "negative_date_" + randomTableSuffix();
+        String tableName = "negative_date_" + randomNameSuffix();
 
         try {
             assertUpdate(format("CREATE TABLE %s AS SELECT DATE '-0001-01-01' AS dt", tableName), 1);

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
@@ -43,7 +43,7 @@ import java.util.OptionalInt;
 
 import static com.mongodb.client.model.CollationCaseFirst.LOWER;
 import static com.mongodb.client.model.CollationStrength.PRIMARY;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -649,7 +649,7 @@ public abstract class BaseMongoConnectorTest
     @Test
     public void testCollationAccent()
     {
-        String tableName = "test_collation_accent" + randomTableSuffix();
+        String tableName = "test_collation_accent" + randomNameSuffix();
         Collation collation = Collation.builder().locale("en_US").collationStrength(PRIMARY).build();
         client.getDatabase("test").createCollection(tableName, new CreateCollectionOptions().collation(collation));
         client.getDatabase("test").getCollection(tableName)
@@ -662,7 +662,7 @@ public abstract class BaseMongoConnectorTest
     @Test
     public void testCollationCaseSensitivity()
     {
-        String tableName = "test_collation_case_sensitivity" + randomTableSuffix();
+        String tableName = "test_collation_case_sensitivity" + randomNameSuffix();
         Collation collation = Collation.builder().locale("en_US").collationCaseFirst(LOWER).build();
         client.getDatabase("test").createCollection(tableName, new CreateCollectionOptions().collation(collation));
         client.getDatabase("test").getCollection(tableName)
@@ -675,7 +675,7 @@ public abstract class BaseMongoConnectorTest
     @Test
     public void testCollationNumericOrdering()
     {
-        String tableName = "test_collation_numeric_ordering" + randomTableSuffix();
+        String tableName = "test_collation_numeric_ordering" + randomNameSuffix();
         Collation collation = Collation.builder().locale("en_US").numericOrdering(true).build();
         client.getDatabase("test").createCollection(tableName, new CreateCollectionOptions().collation(collation));
         client.getDatabase("test").getCollection(tableName)
@@ -706,7 +706,7 @@ public abstract class BaseMongoConnectorTest
     @Test
     public void testNativeQueryArray()
     {
-        String tableName = "test_array" + randomTableSuffix();
+        String tableName = "test_array" + randomNameSuffix();
         MongoCollection<Document> collection = client.getDatabase("tpch").getCollection(tableName);
         collection.insertOne(new Document("array_field", ImmutableList.of("zero", "one", "two")));
         collection.insertOne(new Document("array_field", ImmutableList.of("0", "1", "2")));
@@ -718,7 +718,7 @@ public abstract class BaseMongoConnectorTest
     @Test
     public void testNativeQueryNestedRow()
     {
-        String tableName = "test_nested_row" + randomTableSuffix();
+        String tableName = "test_nested_row" + randomNameSuffix();
         MongoCollection<Document> collection = client.getDatabase("tpch").getCollection(tableName);
         collection.insertOne(new Document("row_field", new Document("first", new Document("second", 1))));
         collection.insertOne(new Document("row_field", new Document("first", new Document("second", 2))));
@@ -791,7 +791,7 @@ public abstract class BaseMongoConnectorTest
     @Test
     public void testRenameTableTo120bytesTableName()
     {
-        String sourceTableName = "test_rename_source_" + randomTableSuffix();
+        String sourceTableName = "test_rename_source_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + sourceTableName + " AS SELECT 123 x", 1);
 
         // The new table has 120 bytes as fully qualified identifier (あ is 3 bytes char)

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseTestMySqlTableStatisticsTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseTestMySqlTableStatisticsTest.java
@@ -36,8 +36,8 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Streams.stream;
 import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.sql.TestTable.fromColumns;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static io.trino.tpch.TpchTable.ORDERS;
 import static java.lang.Math.min;
 import static java.lang.String.format;
@@ -83,7 +83,7 @@ public abstract class BaseTestMySqlTableStatisticsTest
     @Test
     public void testNotAnalyzed()
     {
-        String tableName = "test_not_analyzed_" + randomTableSuffix();
+        String tableName = "test_not_analyzed_" + randomNameSuffix();
         assertUpdate("DROP TABLE IF EXISTS " + tableName);
         computeActual(format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.orders", tableName));
         try {
@@ -115,7 +115,7 @@ public abstract class BaseTestMySqlTableStatisticsTest
     @Test
     public void testBasic()
     {
-        String tableName = "test_stats_orders_" + randomTableSuffix();
+        String tableName = "test_stats_orders_" + randomNameSuffix();
         assertUpdate("DROP TABLE IF EXISTS " + tableName);
         computeActual(format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.orders", tableName));
         try {
@@ -143,7 +143,7 @@ public abstract class BaseTestMySqlTableStatisticsTest
     @Test
     public void testAllNulls()
     {
-        String tableName = "test_stats_table_all_nulls_" + randomTableSuffix();
+        String tableName = "test_stats_table_all_nulls_" + randomNameSuffix();
         assertUpdate("DROP TABLE IF EXISTS " + tableName);
         computeActual(format("CREATE TABLE %s AS SELECT orderkey, custkey, orderpriority, comment FROM tpch.tiny.orders WHERE false", tableName));
         try {
@@ -192,7 +192,7 @@ public abstract class BaseTestMySqlTableStatisticsTest
     @Test
     public void testNullsFraction()
     {
-        String tableName = "test_stats_table_with_nulls_" + randomTableSuffix();
+        String tableName = "test_stats_table_with_nulls_" + randomNameSuffix();
         assertUpdate("DROP TABLE IF EXISTS " + tableName);
         assertUpdate("" +
                         "CREATE TABLE " + tableName + " AS " +
@@ -242,7 +242,7 @@ public abstract class BaseTestMySqlTableStatisticsTest
     @Test
     public void testView()
     {
-        String tableName = "test_stats_view_" + randomTableSuffix();
+        String tableName = "test_stats_view_" + randomNameSuffix();
         executeInMysql("CREATE OR REPLACE VIEW " + tableName + " AS SELECT orderkey, custkey, orderpriority, comment FROM orders");
         try {
             assertQuery(

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorSmokeTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorSmokeTest.java
@@ -17,7 +17,7 @@ import io.trino.plugin.jdbc.BaseJdbcConnectorSmokeTest;
 import io.trino.testing.TestingConnectorBehavior;
 import org.testng.annotations.Test;
 
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class BaseOracleConnectorSmokeTest
@@ -42,7 +42,7 @@ public abstract class BaseOracleConnectorSmokeTest
     @Test
     public void testCommentColumn()
     {
-        String tableName = "test_comment_column_" + randomTableSuffix();
+        String tableName = "test_comment_column_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + "(a integer)");
 

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
@@ -33,8 +33,8 @@ import java.util.OptionalInt;
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_USER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.MaterializedResult.resultBuilder;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.assertions.Assert.assertEquals;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -169,7 +169,7 @@ public abstract class BaseOracleConnectorTest
     @Override
     public void testCommentColumn()
     {
-        String tableName = "test_comment_column_" + randomTableSuffix();
+        String tableName = "test_comment_column_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + "(a integer)");
 

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOraclePoolRemarksReportingConnectorSmokeTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOraclePoolRemarksReportingConnectorSmokeTest.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_PASS;
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_USER;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -67,7 +67,7 @@ public class TestOraclePoolRemarksReportingConnectorSmokeTest
     @Override
     public void testCommentColumn()
     {
-        String tableName = "test_comment_column_" + randomTableSuffix();
+        String tableName = "test_comment_column_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + "(a integer)");
 

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestSynonym.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestSynonym.java
@@ -17,7 +17,7 @@ import io.trino.testing.sql.SqlExecutor;
 
 import java.io.Closeable;
 
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 
 public class TestSynonym
@@ -29,7 +29,7 @@ public class TestSynonym
     public TestSynonym(SqlExecutor sqlExecutor, String namePrefix, String definition)
     {
         this.sqlExecutor = sqlExecutor;
-        this.name = namePrefix + "_" + randomTableSuffix();
+        this.name = namePrefix + "_" + randomNameSuffix();
         sqlExecutor.execute(format("CREATE SYNONYM %s %s", name, definition));
     }
 

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
@@ -57,7 +57,7 @@ import static io.trino.sql.tree.SortItem.NullOrdering.FIRST;
 import static io.trino.sql.tree.SortItem.NullOrdering.LAST;
 import static io.trino.sql.tree.SortItem.Ordering.ASCENDING;
 import static io.trino.sql.tree.SortItem.Ordering.DESCENDING;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -361,7 +361,7 @@ public class TestPhoenixConnectorTest
         // Skipping the ą test case because it is not supported
         List<String> rows = Streams.mapWithIndex(Stream.of("a", "b", "A", "B", " a ", "a", "b", " b "), (value, idx) -> String.format("%d, '%2$s', '%2$s'", idx, value))
                 .collect(toImmutableList());
-        String tableName = "count_distinct_strings" + randomTableSuffix();
+        String tableName = "count_distinct_strings" + randomNameSuffix();
 
         try (TestTable testTable = new TestTable(getQueryRunner()::execute, tableName, "(id int, t_char CHAR(5), t_varchar VARCHAR(5)) WITH (ROWKEYS='id')", rows)) {
             assertQuery("SELECT count(DISTINCT t_varchar) FROM " + testTable.getName(), "VALUES 6");

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -64,7 +64,7 @@ import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_AGGREGATION_PUS
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_LIMIT_PUSHDOWN;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_EQUALITY;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_TOPN_PUSHDOWN;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.Math.round;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -866,7 +866,7 @@ public class TestPostgreSqlConnectorTest
     public void testTopNWithEnum()
     {
         // Create an enum with non-lexicographically sorted entries
-        String enumType = "test_enum_" + randomTableSuffix();
+        String enumType = "test_enum_" + randomNameSuffix();
         onRemoteDatabase().execute("CREATE TYPE " + enumType + " AS ENUM ('A', 'b', 'B', 'a')");
         try (TestTable testTable = new TestTable(
                 onRemoteDatabase(),

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/BaseRaptorConnectorTest.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/BaseRaptorConnectorTest.java
@@ -52,8 +52,8 @@ import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.assertions.Assert.assertEquals;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.function.Function.identity;
@@ -127,12 +127,12 @@ public abstract class BaseRaptorConnectorTest
     public void testRenameTableAcrossSchema()
     {
         // Raptor allows renaming to a schema it doesn't exist https://github.com/trinodb/trino/issues/11110
-        String tableName = "test_rename_old_" + randomTableSuffix();
+        String tableName = "test_rename_old_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT 123 x", 1);
 
-        String schemaName = "test_schema_" + randomTableSuffix();
+        String schemaName = "test_schema_" + randomNameSuffix();
 
-        String renamedTable = "test_rename_new_" + randomTableSuffix();
+        String renamedTable = "test_rename_new_" + randomNameSuffix();
         assertUpdate("ALTER TABLE " + tableName + " RENAME TO " + schemaName + "." + renamedTable);
 
         assertFalse(getQueryRunner().tableExists(getSession(), tableName));
@@ -952,7 +952,7 @@ public abstract class BaseRaptorConnectorTest
     @Test
     public void testMergeMultipleOperationsUnbucketed()
     {
-        String targetTable = "merge_multiple_" + randomTableSuffix();
+        String targetTable = "merge_multiple_" + randomNameSuffix();
         assertUpdate(format("CREATE TABLE %s (customer VARCHAR, purchases INT, zipcode INT, spouse VARCHAR, address VARCHAR)", targetTable));
         testMergeMultipleOperationsInternal(targetTable, 32);
     }
@@ -960,7 +960,7 @@ public abstract class BaseRaptorConnectorTest
     @Test
     public void testMergeMultipleOperationsBucketed()
     {
-        String targetTable = "merge_multiple_" + randomTableSuffix();
+        String targetTable = "merge_multiple_" + randomNameSuffix();
         assertUpdate(format("CREATE TABLE %s (customer VARCHAR, purchases INT, zipcode INT, spouse VARCHAR, address VARCHAR)" +
                 "   WITH (bucket_count=4, bucketed_on=ARRAY['customer'])", targetTable));
         testMergeMultipleOperationsInternal(targetTable, 32);
@@ -1026,7 +1026,7 @@ public abstract class BaseRaptorConnectorTest
     @Test
     public void testMergeSimpleQueryBucketed()
     {
-        String targetTable = "merge_simple_target_" + randomTableSuffix();
+        String targetTable = "merge_simple_target_" + randomNameSuffix();
         assertUpdate(format("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR) WITH (bucket_count=7, bucketed_on=ARRAY['address'])", targetTable));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Buena'), ('Carol', 3, 'Cambridge'), ('Dave', 11, 'Devon')", targetTable), 4);
@@ -1046,12 +1046,12 @@ public abstract class BaseRaptorConnectorTest
     @Test(dataProvider = "partitionedBucketedFailure")
     public void testMergeMultipleRowsMatchFails(String createTableSql)
     {
-        String targetTable = "merge_all_matches_deleted_target_" + randomTableSuffix();
+        String targetTable = "merge_all_matches_deleted_target_" + randomNameSuffix();
         assertUpdate(format(createTableSql, targetTable));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Antioch')", targetTable), 2);
 
-        String sourceTable = "merge_all_matches_deleted_source_" + randomTableSuffix();
+        String sourceTable = "merge_all_matches_deleted_source_" + randomNameSuffix();
         assertUpdate(format("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)", sourceTable));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 6, 'Adelphi'), ('Aaron', 8, 'Ashland')", sourceTable), 2);
@@ -1087,12 +1087,12 @@ public abstract class BaseRaptorConnectorTest
 
     private void testMergeWithDifferentBucketingInternal(String testDescription, String createTargetTableSql, String createSourceTableSql)
     {
-        String targetTable = format("%s_target_%s", testDescription, randomTableSuffix());
+        String targetTable = format("%s_target_%s", testDescription, randomNameSuffix());
         assertUpdate(format(createTargetTableSql, targetTable));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Buena'), ('Carol', 3, 'Cambridge'), ('Dave', 11, 'Devon')", targetTable), 4);
 
-        String sourceTable = format("%s_source_%s", testDescription, randomTableSuffix());
+        String sourceTable = format("%s_source_%s", testDescription, randomNameSuffix());
         assertUpdate(format(createSourceTableSql, sourceTable));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 6, 'Arches'), ('Ed', 7, 'Etherville'), ('Carol', 9, 'Centreville'), ('Dave', 11, 'Darbyshire')", sourceTable), 4);
@@ -1140,7 +1140,7 @@ public abstract class BaseRaptorConnectorTest
     @Test
     public void testMergeOverManySplits()
     {
-        String targetTable = "merge_delete_select_" + randomTableSuffix();
+        String targetTable = "merge_delete_select_" + randomNameSuffix();
         assertUpdate(format("CREATE TABLE %s (orderkey bigint, custkey bigint, orderstatus varchar(1), totalprice double, orderdate date, orderpriority varchar(15), clerk varchar(15), shippriority integer, comment varchar(79))", targetTable));
 
         assertUpdate(format("INSERT INTO %s SELECT * FROM tpch.\"sf0.1\".orders", targetTable), 150000);

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
@@ -42,7 +42,7 @@ import static io.trino.plugin.sqlserver.DataCompression.ROW;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.IntStream.range;
@@ -409,7 +409,7 @@ public abstract class BaseSqlServerConnectorTest
     @Test(dataProvider = "dataCompression")
     public void testCreateWithDataCompression(DataCompression dataCompression)
     {
-        String tableName = "test_create_with_compression_" + randomTableSuffix();
+        String tableName = "test_create_with_compression_" + randomNameSuffix();
         String createQuery = format("CREATE TABLE sqlserver.dbo.%s (\n" +
                         "   a bigint,\n" +
                         "   b bigint\n" +

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerTypeMapping.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerTypeMapping.java
@@ -53,7 +53,7 @@ import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTim
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -492,7 +492,7 @@ public abstract class BaseSqlServerTypeMapping
     {
         // SQL Server does not support > 4 digit years, this test will fail once > 4 digit years support will be added
         String unsupportedDate = "\'11111-01-01\'";
-        String tableName = "test_date_unsupported" + randomTableSuffix();
+        String tableName = "test_date_unsupported" + randomNameSuffix();
         assertUpdate(format("CREATE TABLE %s (test_date date)", tableName));
         try {
             assertQueryFails(format("INSERT INTO %s VALUES (date %s)", tableName, unsupportedDate),

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorTest.java
@@ -37,7 +37,7 @@ import static io.trino.plugin.sqlserver.SqlServerSessionProperties.BULK_COPY_FOR
 import static io.trino.testing.DataProviders.cartesianProduct;
 import static io.trino.testing.DataProviders.toDataProvider;
 import static io.trino.testing.DataProviders.trueFalse;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.stream.Collectors.joining;
@@ -69,7 +69,7 @@ public class TestSqlServerConnectorTest
     public void testCreateTableAsSelectWriteBulkiness(boolean bulkCopyForWrite, boolean bulkCopyLock)
             throws SQLException
     {
-        String table = "bulk_copy_ctas_" + randomTableSuffix();
+        String table = "bulk_copy_ctas_" + randomNameSuffix();
         Session session = Session.builder(getSession())
                 .setCatalogSessionProperty(CATALOG, BULK_COPY_FOR_WRITE, Boolean.toString(bulkCopyForWrite))
                 .setCatalogSessionProperty(CATALOG, BULK_COPY_FOR_WRITE_LOCK_DESTINATION_TABLE, Boolean.toString(bulkCopyLock))
@@ -98,7 +98,7 @@ public class TestSqlServerConnectorTest
     public void testInsertWriteBulkiness(boolean nonTransactionalInsert, boolean bulkCopyForWrite, boolean bulkCopyForWriteLockDestinationTable)
             throws SQLException
     {
-        String table = "bulk_copy_insert_" + randomTableSuffix();
+        String table = "bulk_copy_insert_" + randomNameSuffix();
         assertQuerySucceeds(format("CREATE TABLE %s as SELECT * FROM tpch.tiny.customer WHERE 0 = 1", table));
         Session session = Session.builder(getSession())
                 .setCatalogSessionProperty(CATALOG, NON_TRANSACTIONAL_INSERT, Boolean.toString(nonTransactionalInsert))
@@ -177,7 +177,7 @@ public class TestSqlServerConnectorTest
     public void testRenameColumnNameAdditionalTests(String columnName)
     {
         String nameInSql = "\"" + columnName.replace("\"", "\"\"") + "\"";
-        String tableName = "tcn_" + nameInSql.replaceAll("[^a-z0-9]", "") + randomTableSuffix();
+        String tableName = "tcn_" + nameInSql.replaceAll("[^a-z0-9]", "") + randomNameSuffix();
         // Use complex identifier to test a source column name when renaming columns
         String sourceColumnName = "a;b$c";
 
@@ -195,7 +195,7 @@ public class TestSqlServerConnectorTest
     public void testRenameFromToTableWithSpecialCharacterName(String tableName)
     {
         String tableNameInSql = "\"" + tableName.replace("\"", "\"\"") + "\"";
-        String sourceTableName = "test_rename_source_" + randomTableSuffix();
+        String sourceTableName = "test_rename_source_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + sourceTableName + " AS SELECT 123 x", 1);
 
         assertUpdate("ALTER TABLE " + sourceTableName + " RENAME TO " + tableNameInSql);

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/BaseFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/BaseFailureRecoveryTest.java
@@ -68,7 +68,7 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.planner.OptimizerConfig.JoinDistributionType.PARTITIONED;
 import static io.trino.sql.planner.OptimizerConfig.JoinReorderingStrategy.NONE;
 import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.tpch.TpchTable.CUSTOMER;
 import static io.trino.tpch.TpchTable.NATION;
 import static io.trino.tpch.TpchTable.ORDERS;
@@ -595,7 +595,7 @@ public abstract class BaseFailureRecoveryTest
 
         private ExecutionResult execute(Session session, String query, Optional<String> traceToken)
         {
-            String tableName = "table_" + randomTableSuffix();
+            String tableName = "table_" + randomNameSuffix();
             setup.ifPresent(sql -> getQueryRunner().execute(noRetries(session), resolveTableName(sql, tableName)));
 
             MaterializedResultWithQueryId resultWithQueryId = null;

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/delta/TestDeltaTaskFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/delta/TestDeltaTaskFailureRecoveryTest.java
@@ -28,14 +28,14 @@ import java.util.Map;
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.createS3DeltaLakeQueryRunner;
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 
 public class TestDeltaTaskFailureRecoveryTest
         extends BaseDeltaFailureRecoveryTest
 {
     private static final String SCHEMA = "task_failure_recovery";
-    private final String bucketName = "test-delta-lake-task-failure-recovery-" + randomTableSuffix();
+    private final String bucketName = "test-delta-lake-task-failure-recovery-" + randomNameSuffix();
 
     protected TestDeltaTaskFailureRecoveryTest()
     {
@@ -51,7 +51,7 @@ public class TestDeltaTaskFailureRecoveryTest
     {
         HiveMinioDataLake hiveMinioDataLake = closeAfterClass(new HiveMinioDataLake(bucketName));
         hiveMinioDataLake.start();
-        MinioStorage minioStorage = closeAfterClass(new MinioStorage("test-exchange-spooling-" + randomTableSuffix()));
+        MinioStorage minioStorage = closeAfterClass(new MinioStorage("test-exchange-spooling-" + randomNameSuffix()));
         minioStorage.start();
 
         DistributedQueryRunner queryRunner = createS3DeltaLakeQueryRunner(

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveFaultTolerantExecutionAggregations.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveFaultTolerantExecutionAggregations.java
@@ -23,7 +23,7 @@ import org.testng.annotations.AfterClass;
 import java.util.Map;
 
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.tpch.TpchTable.getTables;
 
 public class TestHiveFaultTolerantExecutionAggregations
@@ -35,7 +35,7 @@ public class TestHiveFaultTolerantExecutionAggregations
     protected QueryRunner createQueryRunner(Map<String, String> extraProperties)
             throws Exception
     {
-        this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomTableSuffix());
+        this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomNameSuffix());
         minioStorage.start();
 
         return HiveQueryRunner.builder()

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveFaultTolerantExecutionConnectorTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveFaultTolerantExecutionConnectorTest.java
@@ -26,7 +26,7 @@ import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.trino.SystemSessionProperties.FAULT_TOLERANT_EXECUTION_PARTITION_COUNT;
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
 import static io.trino.testing.FaultTolerantExecutionConnectorTestHelper.getExtraProperties;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestHiveFaultTolerantExecutionConnectorTest
@@ -38,7 +38,7 @@ public class TestHiveFaultTolerantExecutionConnectorTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomTableSuffix());
+        this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomNameSuffix());
         minioStorage.start();
 
         return BaseHiveConnectorTest.createHiveQueryRunner(

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveFaultTolerantExecutionJoinQueries.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveFaultTolerantExecutionJoinQueries.java
@@ -26,7 +26,7 @@ import java.util.Map;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.tpch.TpchTable.getTables;
 
 public class TestHiveFaultTolerantExecutionJoinQueries
@@ -38,7 +38,7 @@ public class TestHiveFaultTolerantExecutionJoinQueries
     protected QueryRunner createQueryRunner(Map<String, String> extraProperties)
             throws Exception
     {
-        this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomTableSuffix());
+        this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomNameSuffix());
         minioStorage.start();
 
         verify(new DynamicFilterConfig().isEnableDynamicFiltering(), "this class assumes dynamic filtering is enabled by default");

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveFaultTolerantExecutionOrderByQueries.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveFaultTolerantExecutionOrderByQueries.java
@@ -24,7 +24,7 @@ import org.testng.annotations.Test;
 import java.util.Map;
 
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.tpch.TpchTable.getTables;
 
 public class TestHiveFaultTolerantExecutionOrderByQueries
@@ -36,7 +36,7 @@ public class TestHiveFaultTolerantExecutionOrderByQueries
     protected QueryRunner createQueryRunner(Map<String, String> extraProperties)
             throws Exception
     {
-        this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomTableSuffix());
+        this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomNameSuffix());
         minioStorage.start();
 
         return HiveQueryRunner.builder()

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveFaultTolerantExecutionWindowQueries.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveFaultTolerantExecutionWindowQueries.java
@@ -23,7 +23,7 @@ import org.testng.annotations.AfterClass;
 import java.util.Map;
 
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.tpch.TpchTable.getTables;
 
 public class TestHiveFaultTolerantExecutionWindowQueries
@@ -35,7 +35,7 @@ public class TestHiveFaultTolerantExecutionWindowQueries
     protected QueryRunner createQueryRunner(Map<String, String> extraProperties)
             throws Exception
     {
-        this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomTableSuffix());
+        this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomNameSuffix());
         minioStorage.start();
 
         return HiveQueryRunner.builder()

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveQueryFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveQueryFailureRecoveryTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 
 public class TestHiveQueryFailureRecoveryTest
         extends BaseHiveFailureRecoveryTest
@@ -47,11 +47,11 @@ public class TestHiveQueryFailureRecoveryTest
             Map<String, String> coordinatorProperties)
             throws Exception
     {
-        String bucketName = "test-hive-insert-overwrite-" + randomTableSuffix(); // randomizing bucket name to ensure cached TrinoS3FileSystem objects are not reused
+        String bucketName = "test-hive-insert-overwrite-" + randomNameSuffix(); // randomizing bucket name to ensure cached TrinoS3FileSystem objects are not reused
         this.hiveMinioDataLake = new HiveMinioDataLake(bucketName);
         hiveMinioDataLake.start();
 
-        this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomTableSuffix());
+        this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomNameSuffix());
         minioStorage.start();
 
         return S3HiveQueryRunner.builder(hiveMinioDataLake)

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveTaskFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveTaskFailureRecoveryTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 
 public class TestHiveTaskFailureRecoveryTest
         extends BaseHiveFailureRecoveryTest
@@ -47,11 +47,11 @@ public class TestHiveTaskFailureRecoveryTest
             Map<String, String> coordinatorProperties)
             throws Exception
     {
-        String bucketName = "test-hive-insert-overwrite-" + randomTableSuffix(); // randomizing bucket name to ensure cached TrinoS3FileSystem objects are not reused
+        String bucketName = "test-hive-insert-overwrite-" + randomNameSuffix(); // randomizing bucket name to ensure cached TrinoS3FileSystem objects are not reused
         this.hiveMinioDataLake = new HiveMinioDataLake(bucketName);
         hiveMinioDataLake.start();
 
-        this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomTableSuffix());
+        this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomNameSuffix());
         minioStorage.start();
 
         return S3HiveQueryRunner.builder(hiveMinioDataLake)

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/iceberg/TestIcebergParquetFaultTolerantExecutionConnectorTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/iceberg/TestIcebergParquetFaultTolerantExecutionConnectorTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.AfterClass;
 
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
 import static io.trino.testing.FaultTolerantExecutionConnectorTestHelper.getExtraProperties;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestIcebergParquetFaultTolerantExecutionConnectorTest
@@ -33,7 +33,7 @@ public class TestIcebergParquetFaultTolerantExecutionConnectorTest
     @Override
     protected IcebergQueryRunner.Builder createQueryRunnerBuilder()
     {
-        this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomTableSuffix());
+        this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomNameSuffix());
         minioStorage.start();
 
         IcebergQueryRunner.Builder builder = super.createQueryRunnerBuilder();

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/iceberg/TestIcebergQueryFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/iceberg/TestIcebergQueryFailureRecoveryTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 
 public class TestIcebergQueryFailureRecoveryTest
         extends BaseIcebergFailureRecoveryTest
@@ -44,7 +44,7 @@ public class TestIcebergQueryFailureRecoveryTest
             Map<String, String> coordinatorProperties)
             throws Exception
     {
-        this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomTableSuffix());
+        this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomNameSuffix());
         minioStorage.start();
 
         return IcebergQueryRunner.builder()

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/iceberg/TestIcebergTaskFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/iceberg/TestIcebergTaskFailureRecoveryTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 
 public class TestIcebergTaskFailureRecoveryTest
         extends BaseIcebergFailureRecoveryTest
@@ -44,7 +44,7 @@ public class TestIcebergTaskFailureRecoveryTest
             Map<String, String> coordinatorProperties)
             throws Exception
     {
-        this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomTableSuffix());
+        this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomNameSuffix());
         minioStorage.start();
 
         return IcebergQueryRunner.builder()

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractDistributedEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractDistributedEngineOnlyQueries.java
@@ -33,8 +33,8 @@ import static io.trino.SystemSessionProperties.ENABLE_DYNAMIC_FILTERING;
 import static io.trino.SystemSessionProperties.ENABLE_LARGE_DYNAMIC_FILTERS;
 import static io.trino.execution.QueryState.RUNNING;
 import static io.trino.sql.planner.OptimizerConfig.JoinDistributionType.BROADCAST;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.assertions.Assert.assertEventually;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -233,7 +233,7 @@ public abstract class AbstractDistributedEngineOnlyQueries
     @Test
     public void testInsertWithCoercion()
     {
-        String tableName = "test_insert_with_coercion_" + randomTableSuffix();
+        String tableName = "test_insert_with_coercion_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + " (" +
                 "tinyint_column tinyint, " +
@@ -338,7 +338,7 @@ public abstract class AbstractDistributedEngineOnlyQueries
         String query = format(
                 // use random marker in query for unique matching below
                 "SELECT count(*) c_%s FROM lineitem CROSS JOIN lineitem CROSS JOIN lineitem",
-                randomTableSuffix());
+                randomNameSuffix());
         DistributedQueryRunner queryRunner = getDistributedQueryRunner();
         ListenableFuture<?> queryFuture = Futures.submit(
                 () -> queryRunner.execute(getSession(), query), executorService);

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
@@ -35,7 +35,7 @@ import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_RENAME_TABLE;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_RENAME_TABLE_ACROSS_SCHEMAS;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_ROW_LEVEL_DELETE;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_UPDATE;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.tpch.TpchTable.NATION;
 import static io.trino.tpch.TpchTable.REGION;
 import static java.lang.String.format;
@@ -137,7 +137,7 @@ public abstract class BaseConnectorSmokeTest
             return;
         }
 
-        String tableName = "test_create_" + randomTableSuffix();
+        String tableName = "test_create_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " " + getCreateTableDefaultDefinition());
         assertThat(query("SELECT a, b FROM " + tableName))
                 .returnsEmptyResult();
@@ -162,7 +162,7 @@ public abstract class BaseConnectorSmokeTest
             return;
         }
 
-        String tableName = "test_create_" + randomTableSuffix();
+        String tableName = "test_create_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT BIGINT '42' a, DOUBLE '-38.5' b", 1);
         assertThat(query("SELECT CAST(a AS bigint), b FROM " + tableName))
                 .matches("VALUES (BIGINT '42', -385e-1)");
@@ -301,7 +301,7 @@ public abstract class BaseConnectorSmokeTest
     @Test
     public void testCreateSchema()
     {
-        String schemaName = "test_schema_create_" + randomTableSuffix();
+        String schemaName = "test_schema_create_" + randomNameSuffix();
         if (!hasBehavior(SUPPORTS_CREATE_SCHEMA)) {
             assertQueryFails(createSchemaSql(schemaName), "This connector does not support creating schemas");
             return;
@@ -320,7 +320,7 @@ public abstract class BaseConnectorSmokeTest
         if (!hasBehavior(SUPPORTS_RENAME_SCHEMA)) {
             String schemaName = getSession().getSchema().orElseThrow();
             assertQueryFails(
-                    format("ALTER SCHEMA %s RENAME TO %s", schemaName, schemaName + randomTableSuffix()),
+                    format("ALTER SCHEMA %s RENAME TO %s", schemaName, schemaName + randomNameSuffix()),
                     "This connector does not support renaming schemas");
             return;
         }
@@ -329,7 +329,7 @@ public abstract class BaseConnectorSmokeTest
             throw new SkipException("Skipping as connector does not support CREATE SCHEMA");
         }
 
-        String schemaName = "test_rename_schema_" + randomTableSuffix();
+        String schemaName = "test_rename_schema_" + randomNameSuffix();
         try {
             assertUpdate("CREATE SCHEMA " + schemaName);
             assertUpdate("ALTER SCHEMA " + schemaName + " RENAME TO " + schemaName + "_renamed");
@@ -353,10 +353,10 @@ public abstract class BaseConnectorSmokeTest
             throw new AssertionError("Cannot test ALTER TABLE RENAME without CREATE TABLE, the test needs to be implemented in a connector-specific way");
         }
 
-        String oldTable = "test_rename_old_" + randomTableSuffix();
+        String oldTable = "test_rename_old_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + oldTable + " " + getCreateTableDefaultDefinition());
 
-        String newTable = "test_rename_new_" + randomTableSuffix();
+        String newTable = "test_rename_new_" + randomNameSuffix();
         try {
             assertUpdate("ALTER TABLE " + oldTable + " RENAME TO " + newTable);
         }
@@ -402,13 +402,13 @@ public abstract class BaseConnectorSmokeTest
             throw new AssertionError("Cannot test ALTER TABLE RENAME across schemas without CREATE TABLE, the test needs to be implemented in a connector-specific way");
         }
 
-        String oldTable = "test_rename_old_" + randomTableSuffix();
+        String oldTable = "test_rename_old_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + oldTable + " " + getCreateTableDefaultDefinition());
 
-        String schemaName = "test_schema_" + randomTableSuffix();
+        String schemaName = "test_schema_" + randomNameSuffix();
         assertUpdate(createSchemaSql(schemaName));
 
-        String newTable = schemaName + ".test_rename_new_" + randomTableSuffix();
+        String newTable = schemaName + ".test_rename_new_" + randomNameSuffix();
         try {
             assertUpdate("ALTER TABLE " + oldTable + " RENAME TO " + newTable);
         }
@@ -477,7 +477,7 @@ public abstract class BaseConnectorSmokeTest
 
         String catalogName = getSession().getCatalog().orElseThrow();
         String schemaName = getSession().getSchema().orElseThrow();
-        String viewName = "test_view_" + randomTableSuffix();
+        String viewName = "test_view_" + randomNameSuffix();
         assertUpdate("CREATE VIEW " + viewName + " AS SELECT * FROM nation");
 
         assertThat(query("SELECT * FROM " + viewName))
@@ -505,7 +505,7 @@ public abstract class BaseConnectorSmokeTest
 
         String catalogName = getSession().getCatalog().orElseThrow();
         String schemaName = getSession().getSchema().orElseThrow();
-        String viewName = "test_materialized_view_" + randomTableSuffix();
+        String viewName = "test_materialized_view_" + randomNameSuffix();
         assertUpdate("CREATE MATERIALIZED VIEW " + viewName + " AS SELECT * FROM nation");
 
         // reading

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -109,10 +109,10 @@ import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_ROW_TYPE;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_TOPN_PUSHDOWN;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_TRUNCATE;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_UPDATE;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.assertions.Assert.assertEquals;
 import static io.trino.testing.assertions.Assert.assertEventually;
 import static io.trino.testing.assertions.TestUtil.verifyResultOrFailure;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static io.trino.transaction.TransactionBuilder.transaction;
 import static java.lang.String.format;
 import static java.lang.String.join;
@@ -182,7 +182,7 @@ public abstract class BaseConnectorTest
     @Test
     public void testCreateSchema()
     {
-        String schemaName = "test_schema_create_" + randomTableSuffix();
+        String schemaName = "test_schema_create_" + randomNameSuffix();
         if (!hasBehavior(SUPPORTS_CREATE_SCHEMA)) {
             assertQueryFails(createSchemaSql(schemaName), "This connector does not support creating schemas");
             return;
@@ -210,7 +210,7 @@ public abstract class BaseConnectorTest
     @Test
     public void testDropNonEmptySchemaWithTable()
     {
-        String schemaName = "test_drop_non_empty_schema_table_" + randomTableSuffix();
+        String schemaName = "test_drop_non_empty_schema_table_" + randomNameSuffix();
         // A connector either supports CREATE SCHEMA and DROP SCHEMA or none of them.
         if (!hasBehavior(SUPPORTS_CREATE_SCHEMA)) {
             return;
@@ -237,7 +237,7 @@ public abstract class BaseConnectorTest
             return;
         }
 
-        String schemaName = "test_drop_non_empty_schema_view_" + randomTableSuffix();
+        String schemaName = "test_drop_non_empty_schema_view_" + randomNameSuffix();
 
         try {
             assertUpdate(createSchemaSql(schemaName));
@@ -261,7 +261,7 @@ public abstract class BaseConnectorTest
             return;
         }
 
-        String schemaName = "test_drop_non_empty_schema_mv_" + randomTableSuffix();
+        String schemaName = "test_drop_non_empty_schema_mv_" + randomNameSuffix();
 
         try {
             assertUpdate(createSchemaSql(schemaName));
@@ -608,7 +608,7 @@ public abstract class BaseConnectorTest
     {
         String catalog = getSession().getCatalog().orElseThrow();
         String schema = getSession().getSchema().orElseThrow();
-        String tableName = "foo_" + randomTableSuffix();
+        String tableName = "foo_" + randomNameSuffix();
         assertThatThrownBy(() -> query("SELECT * FROM " + tableName + " FOR TIMESTAMP AS OF TIMESTAMP '2021-03-01 00:00:01'"))
                 .hasMessage(format("line 1:15: Table '%s.%s.%s' does not exist", catalog, schema, tableName));
         assertThatThrownBy(() -> query("SELECT * FROM " + tableName + " FOR VERSION AS OF 'version1'"))
@@ -747,8 +747,8 @@ public abstract class BaseConnectorTest
 
         String catalogName = getSession().getCatalog().orElseThrow();
         String schemaName = getSession().getSchema().orElseThrow();
-        String testView = "test_view_" + randomTableSuffix();
-        String testViewWithComment = "test_view_with_comment_" + randomTableSuffix();
+        String testView = "test_view_" + randomNameSuffix();
+        String testViewWithComment = "test_view_with_comment_" + randomNameSuffix();
         assertUpdate("CREATE VIEW " + testView + " AS SELECT 123 x");
         assertUpdate("CREATE OR REPLACE VIEW " + testView + " AS " + query);
 
@@ -892,8 +892,8 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_VIEW));
 
-        String schemaName = "test_schema_" + randomTableSuffix();
-        String viewName = "test_view_create_no_schema_" + randomTableSuffix();
+        String schemaName = "test_schema_" + randomNameSuffix();
+        String viewName = "test_view_create_no_schema_" + randomNameSuffix();
         try {
             assertQueryFails(
                     format("CREATE VIEW %s.%s AS SELECT 1 AS c1", schemaName, viewName),
@@ -912,8 +912,8 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_VIEW));
 
-        String upperCaseView = "test_view_uppercase_" + randomTableSuffix();
-        String mixedCaseView = "test_view_mixedcase_" + randomTableSuffix();
+        String upperCaseView = "test_view_uppercase_" + randomNameSuffix();
+        String mixedCaseView = "test_view_mixedcase_" + randomNameSuffix();
 
         computeActual("CREATE VIEW " + upperCaseView + " AS SELECT X FROM (SELECT 123 X)");
         computeActual("CREATE VIEW " + mixedCaseView + " AS SELECT XyZ FROM (SELECT 456 XyZ)");
@@ -932,21 +932,21 @@ public abstract class BaseConnectorTest
             return;
         }
 
-        String otherSchema = "other_schema" + randomTableSuffix();
+        String otherSchema = "other_schema" + randomNameSuffix();
         assertUpdate(createSchemaSql(otherSchema));
 
         QualifiedObjectName view = new QualifiedObjectName(
                 getSession().getCatalog().orElseThrow(),
                 getSession().getSchema().orElseThrow(),
-                "test_materialized_view_" + randomTableSuffix());
+                "test_materialized_view_" + randomNameSuffix());
         QualifiedObjectName otherView = new QualifiedObjectName(
                 getSession().getCatalog().orElseThrow(),
                 otherSchema,
-                "test_materialized_view_" + randomTableSuffix());
+                "test_materialized_view_" + randomNameSuffix());
         QualifiedObjectName viewWithComment = new QualifiedObjectName(
                 getSession().getCatalog().orElseThrow(),
                 getSession().getSchema().orElseThrow(),
-                "test_materialized_view_with_comment_" + randomTableSuffix());
+                "test_materialized_view_with_comment_" + randomNameSuffix());
 
         createTestingMaterializedView(view, Optional.empty());
         createTestingMaterializedView(otherView, Optional.of("sarcastic comment"));
@@ -1124,8 +1124,8 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_VIEW));
 
-        String tableName = "test_table_" + randomTableSuffix();
-        String viewName = "test_view_" + randomTableSuffix();
+        String tableName = "test_table_" + randomNameSuffix();
+        String viewName = "test_view_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT 'abcdefg' a", 1);
         assertUpdate("CREATE VIEW " + viewName + " AS SELECT a FROM " + tableName);
@@ -1147,8 +1147,8 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_VIEW));
 
-        String tableName = "test_table_" + randomTableSuffix();
-        String viewName = "test_view_" + randomTableSuffix();
+        String tableName = "test_table_" + randomNameSuffix();
+        String viewName = "test_view_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT BIGINT '1' v", 1);
         assertUpdate("CREATE VIEW " + viewName + " AS SELECT * FROM " + tableName);
@@ -1170,7 +1170,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_VIEW));
 
-        String viewName = "meta_test_view_" + randomTableSuffix();
+        String viewName = "meta_test_view_" + randomNameSuffix();
 
         @Language("SQL") String query = "SELECT BIGINT '123' x, 'foo' y";
         assertUpdate("CREATE VIEW " + viewName + securityClauseInCreate + " AS " + query);
@@ -1259,7 +1259,7 @@ public abstract class BaseConnectorTest
         checkState(getSession().getCatalog().isPresent(), "catalog is not set");
         checkState(getSession().getSchema().isPresent(), "schema is not set");
 
-        String viewName = "test_show_create_view" + randomTableSuffix();
+        String viewName = "test_show_create_view" + randomNameSuffix();
         assertUpdate("DROP VIEW IF EXISTS " + viewName);
         String ddl = format(
                 "CREATE VIEW %s.%s.%s SECURITY DEFINER AS\n" +
@@ -1285,7 +1285,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_MATERIALIZED_VIEW));
 
-        String schema = "rename_mv_test_" + randomTableSuffix();
+        String schema = "rename_mv_test_" + randomNameSuffix();
         Session session = Session.builder(getSession())
                 .setSchema(schema)
                 .build();
@@ -1294,11 +1294,11 @@ public abstract class BaseConnectorTest
         QualifiedObjectName originalMaterializedView = new QualifiedObjectName(
                 session.getCatalog().orElseThrow(),
                 session.getSchema().orElseThrow(),
-                "test_materialized_view_rename_" + randomTableSuffix());
+                "test_materialized_view_rename_" + randomNameSuffix());
 
         createTestingMaterializedView(originalMaterializedView, Optional.empty());
 
-        String renamedMaterializedView = "test_materialized_view_rename_new_" + randomTableSuffix();
+        String renamedMaterializedView = "test_materialized_view_rename_new_" + randomNameSuffix();
         if (!hasBehavior(SUPPORTS_RENAME_MATERIALIZED_VIEW)) {
             assertQueryFails(session, "ALTER MATERIALIZED VIEW " + originalMaterializedView + " RENAME TO " + renamedMaterializedView, "This connector does not support renaming materialized views");
             assertUpdate(session, "DROP MATERIALIZED VIEW " + originalMaterializedView);
@@ -1314,16 +1314,16 @@ public abstract class BaseConnectorTest
         assertQueryReturnsEmptyResult(session, listMaterializedViewsSql("name = '" + originalMaterializedView.getObjectName() + "'"));
 
         // rename with IF EXISTS on existing materialized view
-        String testExistsMaterializedViewName = "test_materialized_view_rename_exists_" + randomTableSuffix();
+        String testExistsMaterializedViewName = "test_materialized_view_rename_exists_" + randomNameSuffix();
         assertUpdate(session, "ALTER MATERIALIZED VIEW IF EXISTS " + renamedMaterializedView + " RENAME TO " + testExistsMaterializedViewName);
         assertTestingMaterializedViewQuery(schema, testExistsMaterializedViewName);
 
         // rename with upper-case, not delimited identifier
-        String uppercaseName = "TEST_MATERIALIZED_VIEW_RENAME_UPPERCASE_" + randomTableSuffix();
+        String uppercaseName = "TEST_MATERIALIZED_VIEW_RENAME_UPPERCASE_" + randomNameSuffix();
         assertUpdate(session, "ALTER MATERIALIZED VIEW " + testExistsMaterializedViewName + " RENAME TO " + uppercaseName);
         assertTestingMaterializedViewQuery(schema, uppercaseName.toLowerCase(ENGLISH)); // Ensure select allows for lower-case, not delimited identifier
 
-        String otherSchema = "rename_mv_other_schema_" + randomTableSuffix();
+        String otherSchema = "rename_mv_other_schema_" + randomNameSuffix();
         assertUpdate(createSchemaSql(otherSchema));
         if (hasBehavior(SUPPORTS_RENAME_MATERIALIZED_VIEW_ACROSS_SCHEMAS)) {
             assertUpdate(session, "ALTER MATERIALIZED VIEW " + uppercaseName + " RENAME TO " + otherSchema + "." + originalMaterializedView.getObjectName());
@@ -1421,10 +1421,10 @@ public abstract class BaseConnectorTest
 
         String schemaName = getSession().getSchema().orElseThrow();
 
-        String regularViewName = "test_views_together_normal_" + randomTableSuffix();
+        String regularViewName = "test_views_together_normal_" + randomNameSuffix();
         assertUpdate("CREATE VIEW " + regularViewName + " AS SELECT * FROM region");
 
-        String materializedViewName = "test_views_together_materialized_" + randomTableSuffix();
+        String materializedViewName = "test_views_together_materialized_" + randomNameSuffix();
         assertUpdate("CREATE MATERIALIZED VIEW " + materializedViewName + " AS SELECT * FROM nation");
 
         // both should be accessible via information_schema.views
@@ -1587,14 +1587,14 @@ public abstract class BaseConnectorTest
                 int objectsToKeep = 3;
                 Deque<String> liveObjects = new ArrayDeque<>(objectsToKeep);
                 for (int i = 0; i < objectsToKeep; i++) {
-                    String name = namePrefix + "_" + randomTableSuffix();
+                    String name = namePrefix + "_" + randomNameSuffix();
                     assertUpdate(format(createTemplate, name));
                     liveObjects.addLast(name);
                 }
                 initReady.run();
                 while (!done.get()) {
                     assertUpdate(format(dropTemplate, liveObjects.removeFirst()));
-                    String name = namePrefix + "_" + randomTableSuffix();
+                    String name = namePrefix + "_" + randomNameSuffix();
                     assertUpdate(format(createTemplate, name));
                     liveObjects.addLast(name);
                 }
@@ -1816,7 +1816,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MULTI_STATEMENT_WRITES));
 
-        String table = "test_rollback_" + randomTableSuffix();
+        String table = "test_rollback_" + randomNameSuffix();
         computeActual(format("CREATE TABLE %s (x int)", table));
 
         assertThatThrownBy(() ->
@@ -1864,7 +1864,7 @@ public abstract class BaseConnectorTest
         if (!hasBehavior(SUPPORTS_RENAME_SCHEMA)) {
             String schemaName = getSession().getSchema().orElseThrow();
             assertQueryFails(
-                    format("ALTER SCHEMA %s RENAME TO %s", schemaName, schemaName + randomTableSuffix()),
+                    format("ALTER SCHEMA %s RENAME TO %s", schemaName, schemaName + randomNameSuffix()),
                     "This connector does not support renaming schemas");
             return;
         }
@@ -1873,7 +1873,7 @@ public abstract class BaseConnectorTest
             throw new SkipException("Skipping as connector does not support CREATE SCHEMA");
         }
 
-        String schemaName = "test_rename_schema_" + randomTableSuffix();
+        String schemaName = "test_rename_schema_" + randomNameSuffix();
         try {
             assertUpdate(createSchemaSql(schemaName));
             assertUpdate("ALTER SCHEMA " + schemaName + " RENAME TO " + schemaName + "_renamed");
@@ -2075,7 +2075,7 @@ public abstract class BaseConnectorTest
     @Test
     public void testCreateTable()
     {
-        String tableName = "test_create_" + randomTableSuffix();
+        String tableName = "test_create_" + randomNameSuffix();
         if (!hasBehavior(SUPPORTS_CREATE_TABLE)) {
             assertQueryFails("CREATE TABLE " + tableName + " (a bigint, b double, c varchar(50))", "This connector does not support creating tables");
             return;
@@ -2093,7 +2093,7 @@ public abstract class BaseConnectorTest
         assertFalse(getQueryRunner().tableExists(getSession(), tableName));
 
         // TODO (https://github.com/trinodb/trino/issues/5901) revert to longer name when Oracle version is updated
-        tableName = "test_cr_not_exists_" + randomTableSuffix();
+        tableName = "test_cr_not_exists_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " (a bigint, b varchar(50), c double)");
         assertTrue(getQueryRunner().tableExists(getSession(), tableName));
         assertTableColumnNames(tableName, "a", "b", "c");
@@ -2106,12 +2106,12 @@ public abstract class BaseConnectorTest
         assertFalse(getQueryRunner().tableExists(getSession(), tableName));
 
         // Test CREATE TABLE LIKE
-        tableName = "test_create_orig_" + randomTableSuffix();
+        tableName = "test_create_orig_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " (a bigint, b double, c varchar(50))");
         assertTrue(getQueryRunner().tableExists(getSession(), tableName));
         assertTableColumnNames(tableName, "a", "b", "c");
 
-        String tableNameLike = "test_create_like_" + randomTableSuffix();
+        String tableNameLike = "test_create_like_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableNameLike + " (LIKE " + tableName + ", d bigint, e varchar(50))");
         assertTrue(getQueryRunner().tableExists(getSession(), tableNameLike));
         assertTableColumnNames(tableNameLike, "a", "b", "c", "d", "e");
@@ -2128,7 +2128,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_SCHEMA));
 
-        String baseSchemaName = "test_create_" + randomTableSuffix();
+        String baseSchemaName = "test_create_" + randomNameSuffix();
 
         int maxLength = maxSchemaNameLength()
                 // Assume 2^16 is enough for most use cases. Add a bit more to ensure 2^16 isn't actual limit.
@@ -2154,10 +2154,10 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_RENAME_SCHEMA));
 
-        String sourceSchemaName = "test_rename_source_" + randomTableSuffix();
+        String sourceSchemaName = "test_rename_source_" + randomNameSuffix();
         assertUpdate(createSchemaSql(sourceSchemaName));
 
-        String baseSchemaName = "test_rename_target_" + randomTableSuffix();
+        String baseSchemaName = "test_rename_target_" + randomNameSuffix();
 
         int maxLength = maxSchemaNameLength()
                 // Assume 2^16 is enough for most use cases. Add a bit more to ensure 2^16 isn't actual limit.
@@ -2194,7 +2194,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE));
 
-        String baseTableName = "test_create_" + randomTableSuffix();
+        String baseTableName = "test_create_" + randomNameSuffix();
 
         int maxLength = maxTableNameLength()
                 // Assume 2^16 is enough for most use cases. Add a bit more to ensure 2^16 isn't actual limit.
@@ -2220,10 +2220,10 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_RENAME_TABLE));
 
-        String sourceTableName = "test_rename_source_" + randomTableSuffix();
+        String sourceTableName = "test_rename_source_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + sourceTableName + " AS SELECT 123 x", 1);
 
-        String baseTableName = "test_rename_target_" + randomTableSuffix();
+        String baseTableName = "test_rename_target_" + randomNameSuffix();
 
         int maxLength = maxTableNameLength()
                 // Assume 2^16 is enough for most use cases. Add a bit more to ensure 2^16 isn't actual limit.
@@ -2261,7 +2261,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE));
 
-        String tableName = "test_long_column" + randomTableSuffix();
+        String tableName = "test_long_column" + randomNameSuffix();
         String baseColumnName = "col";
 
         int maxLength = maxColumnNameLength()
@@ -2290,7 +2290,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_ADD_COLUMN));
 
-        String tableName = "test_long_column" + randomTableSuffix();
+        String tableName = "test_long_column" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT 123 x", 1);
 
         String baseColumnName = "col";
@@ -2320,7 +2320,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_RENAME_COLUMN));
 
-        String tableName = "test_long_column" + randomTableSuffix();
+        String tableName = "test_long_column" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT 123 x", 1);
 
         String baseColumnName = "col";
@@ -2369,7 +2369,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE));
 
-        String tableName = "test_create_" + randomTableSuffix();
+        String tableName = "test_create_" + randomNameSuffix();
 
         if (!hasBehavior(SUPPORTS_CREATE_TABLE_WITH_TABLE_COMMENT)) {
             assertQueryFails("CREATE TABLE " + tableName + " (a bigint) COMMENT 'test comment'", "This connector does not support creating tables with table comment");
@@ -2387,7 +2387,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE));
 
-        String tableName = "test_create_" + randomTableSuffix();
+        String tableName = "test_create_" + randomNameSuffix();
 
         if (!hasBehavior(SUPPORTS_CREATE_TABLE_WITH_COLUMN_COMMENT)) {
             assertQueryFails("CREATE TABLE " + tableName + " (a bigint COMMENT 'test comment')", "This connector does not support creating tables with column comment");
@@ -2405,8 +2405,8 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE));
 
-        String schemaName = "test_schema_" + randomTableSuffix();
-        String tableName = "test_create_no_schema_" + randomTableSuffix();
+        String schemaName = "test_schema_" + randomNameSuffix();
+        String tableName = "test_create_no_schema_" + randomNameSuffix();
         try {
             assertQueryFails(
                     format("CREATE TABLE %s.%s (a bigint)", schemaName, tableName),
@@ -2420,7 +2420,7 @@ public abstract class BaseConnectorTest
     @Test
     public void testCreateTableAsSelect()
     {
-        String tableName = "test_ctas" + randomTableSuffix();
+        String tableName = "test_ctas" + randomNameSuffix();
         if (!hasBehavior(SUPPORTS_CREATE_TABLE)) {
             assertQueryFails("CREATE TABLE IF NOT EXISTS " + tableName + " AS SELECT name, regionkey FROM nation", "This connector does not support creating tables with data");
             return;
@@ -2485,7 +2485,7 @@ public abstract class BaseConnectorTest
                 "SELECT count(*) + 1 FROM customer");
 
         // TODO: BigQuery throws table not found at BigQueryClient.insert if we reuse the same table name
-        tableName = "test_ctas" + randomTableSuffix();
+        tableName = "test_ctas" + randomNameSuffix();
         assertExplainAnalyze("EXPLAIN ANALYZE CREATE TABLE " + tableName + " AS SELECT mktsegment FROM customer");
         assertQuery("SELECT * from " + tableName, "SELECT mktsegment FROM customer");
         assertUpdate("DROP TABLE " + tableName);
@@ -2496,7 +2496,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE_WITH_DATA));
 
-        String tableName = "test_ctas_" + randomTableSuffix();
+        String tableName = "test_ctas_" + randomNameSuffix();
 
         if (!hasBehavior(SUPPORTS_CREATE_TABLE_WITH_TABLE_COMMENT)) {
             assertQueryFails("CREATE TABLE " + tableName + " COMMENT 'test comment' AS SELECT name FROM nation", "This connector does not support creating tables with table comment");
@@ -2514,8 +2514,8 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE_WITH_DATA));
 
-        String schemaName = "test_schema_" + randomTableSuffix();
-        String tableName = "test_ctas_no_schema_" + randomTableSuffix();
+        String schemaName = "test_schema_" + randomNameSuffix();
+        String tableName = "test_ctas_no_schema_" + randomNameSuffix();
         try {
             assertQueryFails(
                     format("CREATE TABLE %s.%s AS SELECT name FROM nation", schemaName, tableName),
@@ -2548,7 +2548,7 @@ public abstract class BaseConnectorTest
 
     protected void assertCreateTableAsSelect(Session session, @Language("SQL") String query, @Language("SQL") String expectedQuery, @Language("SQL") String rowCountQuery)
     {
-        String table = "test_ctas_" + randomTableSuffix();
+        String table = "test_ctas_" + randomNameSuffix();
         assertUpdate(session, "CREATE TABLE " + table + " AS " + query, rowCountQuery);
         assertQuery(session, "SELECT * FROM " + table, expectedQuery);
         assertUpdate(session, "DROP TABLE " + table);
@@ -2559,7 +2559,7 @@ public abstract class BaseConnectorTest
     @Test
     public void testCreateTableAsSelectNegativeDate()
     {
-        String tableName = "negative_date_" + randomTableSuffix();
+        String tableName = "negative_date_" + randomNameSuffix();
 
         if (!hasBehavior(SUPPORTS_CREATE_TABLE_WITH_DATA)) {
             assertQueryFails(format("CREATE TABLE %s AS SELECT DATE '-0001-01-01' AS dt", tableName), "This connector does not support creating tables with data");
@@ -2591,10 +2591,10 @@ public abstract class BaseConnectorTest
             throws Exception
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE));
-        String tableName = "test_rename_" + randomTableSuffix();
+        String tableName = "test_rename_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT 123 x", 1);
 
-        String renamedTable = "test_rename_new_" + randomTableSuffix();
+        String renamedTable = "test_rename_new_" + randomNameSuffix();
         if (!hasBehavior(SUPPORTS_RENAME_TABLE)) {
             assertQueryFails("ALTER TABLE " + tableName + " RENAME TO " + renamedTable, "This connector does not support renaming tables");
             assertUpdate("DROP TABLE " + tableName);
@@ -2611,11 +2611,11 @@ public abstract class BaseConnectorTest
         }
         assertQuery("SELECT x FROM " + renamedTable, "VALUES 123");
 
-        String testExistsTableName = "test_rename_exists_" + randomTableSuffix();
+        String testExistsTableName = "test_rename_exists_" + randomNameSuffix();
         assertUpdate("ALTER TABLE IF EXISTS " + renamedTable + " RENAME TO " + testExistsTableName);
         assertQuery("SELECT x FROM " + testExistsTableName, "VALUES 123");
 
-        String uppercaseName = "TEST_RENAME_" + randomTableSuffix(); // Test an upper-case, not delimited identifier
+        String uppercaseName = "TEST_RENAME_" + randomNameSuffix(); // Test an upper-case, not delimited identifier
         assertUpdate("ALTER TABLE " + testExistsTableName + " RENAME TO " + uppercaseName);
         assertQuery(
                 "SELECT x FROM " + uppercaseName.toLowerCase(ENGLISH), // Ensure select allows for lower-case, not delimited identifier
@@ -2651,13 +2651,13 @@ public abstract class BaseConnectorTest
             throw new AssertionError("Cannot test ALTER TABLE RENAME across schemas without CREATE TABLE, the test needs to be implemented in a connector-specific way");
         }
 
-        String tableName = "test_rename_old_" + randomTableSuffix();
+        String tableName = "test_rename_old_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT 123 x", 1);
 
-        String schemaName = "test_schema_" + randomTableSuffix();
+        String schemaName = "test_schema_" + randomNameSuffix();
         assertUpdate(createSchemaSql(schemaName));
 
-        String renamedTable = "test_rename_new_" + randomTableSuffix();
+        String renamedTable = "test_rename_new_" + randomNameSuffix();
         try {
             assertUpdate("ALTER TABLE " + tableName + " RENAME TO " + schemaName + "." + renamedTable);
         }
@@ -2683,13 +2683,13 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_SCHEMA) && hasBehavior(SUPPORTS_CREATE_TABLE) && hasBehavior(SUPPORTS_RENAME_TABLE));
 
-        String sourceSchemaName = "test_source_schema_" + randomTableSuffix();
+        String sourceSchemaName = "test_source_schema_" + randomNameSuffix();
         assertUpdate(createSchemaSql(sourceSchemaName));
 
-        String tableName = "test_rename_unqualified_name_" + randomTableSuffix();
+        String tableName = "test_rename_unqualified_name_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + sourceSchemaName + "." + tableName + " AS SELECT 123 x", 1);
 
-        String renamedTable = "test_rename_unqualified_name_new_" + randomTableSuffix();
+        String renamedTable = "test_rename_unqualified_name_new_" + randomNameSuffix();
         try {
             assertUpdate("ALTER TABLE " + sourceSchemaName + "." + tableName + " RENAME TO " + renamedTable);
         }
@@ -2741,7 +2741,7 @@ public abstract class BaseConnectorTest
             assertThat(getTableComment(catalogName, schemaName, table.getName())).isEqualTo(null);
         }
 
-        String tableName = "test_comment_" + randomTableSuffix();
+        String tableName = "test_comment_" + randomNameSuffix();
         try {
             // comment set when creating a table
             assertUpdate("CREATE TABLE " + tableName + "(key integer) COMMENT 'new table comment'");
@@ -2794,7 +2794,7 @@ public abstract class BaseConnectorTest
             assertThat(getTableComment(catalogName, schemaName, view.getName())).isEqualTo(null);
         }
 
-        String viewName = "test_comment_view" + randomTableSuffix();
+        String viewName = "test_comment_view" + randomNameSuffix();
         try {
             // comment set when creating a table
             assertUpdate("CREATE VIEW " + viewName + " COMMENT 'new view comment' AS SELECT * FROM region");
@@ -2987,7 +2987,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_INSERT));
 
-        String tableName = "test_insert_array_" + randomTableSuffix();
+        String tableName = "test_insert_array_" + randomNameSuffix();
         if (!hasBehavior(SUPPORTS_ARRAY)) {
             assertThatThrownBy(() -> query("CREATE TABLE " + tableName + " (a array(bigint))"))
                     // TODO Unify failure message across connectors
@@ -3210,7 +3210,7 @@ public abstract class BaseConnectorTest
             assertUpdate("DELETE FROM " + table.getName() + " WHERE orderkey > 5 AND orderkey < 4", 0);
         }
 
-        String tableName = "test_delete_" + randomTableSuffix();
+        String tableName = "test_delete_" + randomNameSuffix();
         try {
             // test EXPLAIN ANALYZE with CTAS
             assertExplainAnalyze("EXPLAIN ANALYZE CREATE TABLE " + tableName + " AS SELECT CAST(orderstatus AS VARCHAR(15)) orderstatus FROM orders");
@@ -3302,7 +3302,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_DELETE));
 
-        String tableName = "test_delete_" + randomTableSuffix();
+        String tableName = "test_delete_" + randomNameSuffix();
 
         // delete using a subquery
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM nation", 25);
@@ -3692,7 +3692,7 @@ public abstract class BaseConnectorTest
     public void testDropTable()
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE));
-        String tableName = "test_drop_table_" + randomTableSuffix();
+        String tableName = "test_drop_table_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + "(col bigint)");
         assertTrue(getQueryRunner().tableExists(getSession(), tableName));
 
@@ -3748,7 +3748,7 @@ public abstract class BaseConnectorTest
             DispatchManager dispatchManager = ((DistributedQueryRunner) getQueryRunner()).getCoordinator().getDispatchManager();
             long beforeCompletedQueriesCount = waitUntilStable(() -> dispatchManager.getStats().getCompletedQueries().getTotalCount(), new Duration(5, SECONDS));
             long beforeSubmittedQueriesCount = dispatchManager.getStats().getSubmittedQueries().getTotalCount();
-            String tableName = "test_logging_count" + randomTableSuffix();
+            String tableName = "test_logging_count" + randomNameSuffix();
             assertUpdate("CREATE TABLE " + tableName + tableDefinitionForQueryLoggingCount());
             assertQueryReturnsEmptyResult("SELECT foo_1, foo_2_4 FROM " + tableName);
             assertUpdate("DROP TABLE " + tableName);
@@ -3799,7 +3799,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE));
 
-        String tableName = "test_symbol_aliasing" + randomTableSuffix();
+        String tableName = "test_symbol_aliasing" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT 1 foo_1, 2 foo_2_4", 1);
         assertQuery("SELECT foo_1, foo_2_4 FROM " + tableName, "SELECT 1, 2");
         assertUpdate("DROP TABLE " + tableName);
@@ -3811,7 +3811,7 @@ public abstract class BaseConnectorTest
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE));
         skipTestUnless(hasBehavior(SUPPORTS_INSERT));
 
-        String tableName = "test_written_stats_" + randomTableSuffix();
+        String tableName = "test_written_stats_" + randomNameSuffix();
         try {
             String sql = "CREATE TABLE " + tableName + " AS SELECT * FROM nation";
             MaterializedResultWithQueryId resultResultWithQueryId = getDistributedQueryRunner().executeWithQueryId(getSession(), sql);
@@ -3848,7 +3848,7 @@ public abstract class BaseConnectorTest
     protected void testColumnName(String columnName, boolean delimited)
     {
         String nameInSql = toColumnNameInSql(columnName, delimited);
-        String tableName = "tcn_" + nameInSql.toLowerCase(ENGLISH).replaceAll("[^a-z0-9]", "") + randomTableSuffix();
+        String tableName = "tcn_" + nameInSql.toLowerCase(ENGLISH).replaceAll("[^a-z0-9]", "") + randomNameSuffix();
 
         try {
             // TODO test with both CTAS *and* CREATE TABLE + INSERT, since they use different connector API methods.
@@ -3893,7 +3893,7 @@ public abstract class BaseConnectorTest
     protected void testAddAndDropColumnName(String columnName, boolean delimited)
     {
         String nameInSql = toColumnNameInSql(columnName, delimited);
-        String tableName = "tcn_" + nameInSql.toLowerCase(ENGLISH).replaceAll("[^a-z0-9]", "") + randomTableSuffix();
+        String tableName = "tcn_" + nameInSql.toLowerCase(ENGLISH).replaceAll("[^a-z0-9]", "") + randomNameSuffix();
 
         try {
             assertUpdate("CREATE TABLE " + tableName + "(" + nameInSql + " varchar(50), value varchar(50))");
@@ -3930,7 +3930,7 @@ public abstract class BaseConnectorTest
     protected void testRenameColumnName(String columnName, boolean delimited)
     {
         String nameInSql = toColumnNameInSql(columnName, delimited);
-        String tableName = "tcn_" + nameInSql.replaceAll("[^a-z0-9]", "") + randomTableSuffix();
+        String tableName = "tcn_" + nameInSql.replaceAll("[^a-z0-9]", "") + randomNameSuffix();
         // Use complex identifier to test a source column name when renaming columns
         String sourceColumnName = "a;b$c";
 
@@ -4014,7 +4014,7 @@ public abstract class BaseConnectorTest
 
     protected String dataMappingTableName(String trinoTypeName)
     {
-        return "test_data_mapping_smoke_" + trinoTypeName.replaceAll("[^a-zA-Z0-9]", "_") + "_" + randomTableSuffix();
+        return "test_data_mapping_smoke_" + trinoTypeName.replaceAll("[^a-zA-Z0-9]", "_") + "_" + randomNameSuffix();
     }
 
     @Test(dataProvider = "testCommentDataProvider")
@@ -4253,7 +4253,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE_WITH_DATA));
 
-        String tableName = "test_dup_deref_" + randomTableSuffix();
+        String tableName = "test_dup_deref_" + randomNameSuffix();
         String createTable = "CREATE TABLE " + tableName + " AS SELECT CAST(ROW('abc', 1) AS row(a varchar, b bigint)) r";
         if (!hasBehavior(SUPPORTS_ROW_TYPE)) {
             try {
@@ -4308,7 +4308,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE) && hasBehavior(SUPPORTS_INSERT));
 
-        String tableName = "test_merge_" + randomTableSuffix();
+        String tableName = "test_merge_" + randomNameSuffix();
 
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (orderkey BIGINT, custkey BIGINT, totalprice DOUBLE)", tableName)));
 
@@ -4344,8 +4344,8 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "merge_simple_target_" + randomTableSuffix();
-        String sourceTable = "merge_simple_source_" + randomTableSuffix();
+        String targetTable = "merge_simple_target_" + randomNameSuffix();
+        String sourceTable = "merge_simple_source_" + randomNameSuffix();
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)", targetTable)));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Buena'), ('Carol', 3, 'Cambridge'), ('Dave', 11, 'Devon')", targetTable), 4);
@@ -4370,8 +4370,8 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "merge_various_target_" + randomTableSuffix();
-        String sourceTable = "merge_various_source_" + randomTableSuffix();
+        String targetTable = "merge_various_target_" + randomNameSuffix();
+        String sourceTable = "merge_various_source_" + randomNameSuffix();
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (customer VARCHAR, purchase VARCHAR)", targetTable)));
 
         assertUpdate(format("INSERT INTO %s (customer, purchase) VALUES ('Dave', 'dates'), ('Lou', 'limes'), ('Carol', 'candles')", targetTable), 3);
@@ -4397,7 +4397,7 @@ public abstract class BaseConnectorTest
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
         int targetCustomerCount = 32;
-        String targetTable = "merge_multiple_" + randomTableSuffix();
+        String targetTable = "merge_multiple_" + randomNameSuffix();
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (customer VARCHAR, purchases INT, zipcode INT, spouse VARCHAR, address VARCHAR)", targetTable)));
 
         String originalInsertFirstHalf = IntStream.range(1, targetCustomerCount / 2)
@@ -4462,7 +4462,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "merge_query_" + randomTableSuffix();
+        String targetTable = "merge_query_" + randomNameSuffix();
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)", targetTable)));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Buena'), ('Carol', 3, 'Cambridge'), ('Dave', 11, 'Devon')", targetTable), 4);
@@ -4485,7 +4485,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "merge_inserts_" + randomTableSuffix();
+        String targetTable = "merge_inserts_" + randomNameSuffix();
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)", targetTable)));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 11, 'Antioch'), ('Bill', 7, 'Buena')", targetTable), 2);
@@ -4506,7 +4506,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "merge_join_false_" + randomTableSuffix();
+        String targetTable = "merge_join_false_" + randomNameSuffix();
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)", targetTable)));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 11, 'Antioch'), ('Bill', 7, 'Buena')", targetTable), 2);
@@ -4550,8 +4550,8 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "merge_all_columns_updated_target_" + randomTableSuffix();
-        String sourceTable = "merge_all_columns_updated_source_" + randomTableSuffix();
+        String targetTable = "merge_all_columns_updated_target_" + randomNameSuffix();
+        String sourceTable = "merge_all_columns_updated_source_" + randomNameSuffix();
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)", targetTable)));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Dave', 11, 'Devon'), ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Buena'), ('Carol', 3, 'Cambridge')", targetTable), 4);
@@ -4575,8 +4575,8 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "merge_all_matches_deleted_target_" + randomTableSuffix();
-        String sourceTable = "merge_all_matches_deleted_source_" + randomTableSuffix();
+        String targetTable = "merge_all_matches_deleted_target_" + randomNameSuffix();
+        String sourceTable = "merge_all_matches_deleted_source_" + randomNameSuffix();
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)", targetTable)));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Buena'), ('Carol', 3, 'Cambridge'), ('Dave', 11, 'Devon')", targetTable), 4);
@@ -4600,8 +4600,8 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "merge_multiple_fail_target_" + randomTableSuffix();
-        String sourceTable = "merge_multiple_fail_source_" + randomTableSuffix();
+        String targetTable = "merge_multiple_fail_target_" + randomNameSuffix();
+        String sourceTable = "merge_multiple_fail_source_" + randomNameSuffix();
 
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)", targetTable)));
 
@@ -4629,7 +4629,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "merge_strange_capitalization_" + randomTableSuffix();
+        String targetTable = "merge_strange_capitalization_" + randomNameSuffix();
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)", targetTable)));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Buena'), ('Carol', 3, 'Cambridge'), ('Dave', 11, 'Devon')", targetTable), 4);
@@ -4652,8 +4652,8 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "test_without_aliases_target_" + randomTableSuffix();
-        String sourceTable = "test_without_aliases_source_" + randomTableSuffix();
+        String targetTable = "test_without_aliases_target_" + randomNameSuffix();
+        String sourceTable = "test_without_aliases_source_" + randomNameSuffix();
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)", targetTable)));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Buena'), ('Carol', 3, 'Cambridge'), ('Dave', 11, 'Devon')", targetTable), 4);
@@ -4680,8 +4680,8 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "merge_predicates_target_" + randomTableSuffix();
-        String sourceTable = "merge_predicates_source_" + randomTableSuffix();
+        String targetTable = "merge_predicates_target_" + randomNameSuffix();
+        String sourceTable = "merge_predicates_source_" + randomNameSuffix();
 
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (id INT, customer VARCHAR, purchases INT, address VARCHAR)", targetTable)));
 
@@ -4728,8 +4728,8 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "merge_predicates_target_" + randomTableSuffix();
-        String sourceTable = "merge_predicates_source_" + randomTableSuffix();
+        String targetTable = "merge_predicates_target_" + randomNameSuffix();
+        String sourceTable = "merge_predicates_source_" + randomNameSuffix();
 
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (id INT, customer VARCHAR, purchases INT, address VARCHAR)", targetTable)));
 
@@ -4756,8 +4756,8 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "merge_cast_target_" + randomTableSuffix();
-        String sourceTable = "merge_cast_source_" + randomTableSuffix();
+        String targetTable = "merge_cast_target_" + randomNameSuffix();
+        String sourceTable = "merge_cast_source_" + randomNameSuffix();
 
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (col1 INT, col2 DOUBLE, col3 INT, col4 BIGINT, col5 REAL, col6 DOUBLE)", targetTable)));
 
@@ -4783,8 +4783,8 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "merge_nation_target_" + randomTableSuffix();
-        String sourceTable = "merge_nation_source_" + randomTableSuffix();
+        String targetTable = "merge_nation_target_" + randomNameSuffix();
+        String sourceTable = "merge_nation_source_" + randomNameSuffix();
 
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (nation_name VARCHAR, region_name VARCHAR)", targetTable)));
 
@@ -4813,7 +4813,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE) && hasBehavior(SUPPORTS_NOT_NULL_CONSTRAINT));
 
-        String targetTable = "merge_non_nullable_target_" + randomTableSuffix();
+        String targetTable = "merge_non_nullable_target_" + randomNameSuffix();
 
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (nation_name VARCHAR, region_name VARCHAR NOT NULL)", targetTable)));
 
@@ -4870,7 +4870,7 @@ public abstract class BaseConnectorTest
         if (delimited) {
             nameInSql = "\"" + columnName.replace("\"", "\"\"") + "\"";
         }
-        String viewName = "tcn_" + nameInSql.toLowerCase(ENGLISH).replaceAll("[^a-z0-9]", "_") + "_" + randomTableSuffix();
+        String viewName = "tcn_" + nameInSql.toLowerCase(ENGLISH).replaceAll("[^a-z0-9]", "_") + "_" + randomNameSuffix();
 
         try {
             assertUpdate("CREATE MATERIALIZED VIEW " + viewName + " AS SELECT 'sample value' key, 'abc' " + nameInSql);

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseOrcWithBloomFiltersTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseOrcWithBloomFiltersTest.java
@@ -17,7 +17,7 @@ import io.trino.Session;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -30,7 +30,7 @@ public abstract class BaseOrcWithBloomFiltersTest
     @Test
     public void testOrcBloomFilterIsWrittenDuringCreate()
     {
-        String tableName = "create_orc_with_bloom_filters_" + randomTableSuffix();
+        String tableName = "create_orc_with_bloom_filters_" + randomNameSuffix();
         assertUpdate(
                 format(
                         "CREATE TABLE %s WITH (%s) AS SELECT orderstatus, totalprice FROM tpch.tiny.orders",
@@ -46,7 +46,7 @@ public abstract class BaseOrcWithBloomFiltersTest
     @Test
     public void testInvalidOrcBloomFilterColumnsDuringCreate()
     {
-        String tableName = "create_orc_with_bloom_filters_" + randomTableSuffix();
+        String tableName = "create_orc_with_bloom_filters_" + randomNameSuffix();
         assertThatThrownBy(() -> computeActual(
                 format(
                         "CREATE TABLE %s WITH (%s) AS SELECT orderstatus FROM tpch.tiny.orders",
@@ -58,7 +58,7 @@ public abstract class BaseOrcWithBloomFiltersTest
     @Test
     public void testOrcBloomFilterIsWrittenDuringInsert()
     {
-        String tableName = "insert_orc_with_bloom_filters_" + randomTableSuffix();
+        String tableName = "insert_orc_with_bloom_filters_" + randomNameSuffix();
         assertUpdate(
                 format(
                         "CREATE TABLE %s (totalprice DOUBLE, orderstatus VARCHAR) WITH (%s)",

--- a/testing/trino-testing/src/main/java/io/trino/testing/TestingNames.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/TestingNames.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing;
+
+import java.security.SecureRandom;
+
+import static java.lang.Character.MAX_RADIX;
+import static java.lang.Math.abs;
+import static java.lang.Math.min;
+
+public final class TestingNames
+{
+    private TestingNames() {}
+
+    private static final SecureRandom random = new SecureRandom();
+
+    // The suffix needs to be long enough to "prevent" collisions in practice.
+    // The length of 5 was proven not to be long enough for tables names in tests.
+    private static final int RANDOM_SUFFIX_LENGTH = 10;
+
+    public static String randomNameSuffix()
+    {
+        String randomSuffix = Long.toString(abs(random.nextLong()), MAX_RADIX);
+        return randomSuffix.substring(0, min(RANDOM_SUFFIX_LENGTH, randomSuffix.length()));
+    }
+}

--- a/testing/trino-testing/src/main/java/io/trino/testing/sql/TestTable.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/sql/TestTable.java
@@ -15,25 +15,18 @@ package io.trino.testing.sql;
 
 import com.google.common.collect.ImmutableList;
 
-import java.security.SecureRandom;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static java.lang.Character.MAX_RADIX;
-import static java.lang.Math.abs;
-import static java.lang.Math.min;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static java.lang.String.join;
 
 public class TestTable
         implements TemporaryRelation
 {
-    private static final SecureRandom random = new SecureRandom();
-    // The suffix needs to be long enough to "prevent" collisions in practice. The length of 5 was proven not to be long enough
-    private static final int RANDOM_SUFFIX_LENGTH = 10;
-
     protected final SqlExecutor sqlExecutor;
     protected final String tableDefinition;
     protected final String name;
@@ -46,7 +39,7 @@ public class TestTable
     public TestTable(SqlExecutor sqlExecutor, String namePrefix, String tableDefinition, List<String> rowsToInsert)
     {
         this.sqlExecutor = sqlExecutor;
-        this.name = namePrefix + randomTableSuffix();
+        this.name = namePrefix + randomNameSuffix();
         this.tableDefinition = tableDefinition;
         createAndInsert(rowsToInsert);
     }
@@ -130,9 +123,9 @@ public class TestTable
         sqlExecutor.execute("DROP TABLE " + name);
     }
 
+    @Deprecated
     public static String randomTableSuffix()
     {
-        String randomSuffix = Long.toString(abs(random.nextLong()), MAX_RADIX);
-        return randomSuffix.substring(0, min(RANDOM_SUFFIX_LENGTH, randomSuffix.length()));
+        return randomNameSuffix();
     }
 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/sql/TestView.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/sql/TestView.java
@@ -13,7 +13,7 @@
  */
 package io.trino.testing.sql;
 
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 
 public class TestView
@@ -25,7 +25,7 @@ public class TestView
     public TestView(SqlExecutor sqlExecutor, String namePrefix, String viewBody)
     {
         this.sqlExecutor = sqlExecutor;
-        this.name = namePrefix + "_" + randomTableSuffix();
+        this.name = namePrefix + "_" + randomNameSuffix();
         sqlExecutor.execute(format("CREATE VIEW %s AS %s", name, viewBody));
     }
 

--- a/testing/trino-tests/src/test/java/io/trino/security/TestAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestAccessControl.java
@@ -72,8 +72,8 @@ import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.TRUNCATE_TABLE;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.UPDATE_TABLE;
 import static io.trino.testing.TestingAccessControlManager.privilege;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -191,7 +191,7 @@ public class TestAccessControl
                 .setSchema(getSession().getSchema())
                 .build();
 
-        String columnAccessViewName = "test_view_column_access_" + randomTableSuffix();
+        String columnAccessViewName = "test_view_column_access_" + randomNameSuffix();
 
         // TEST COLUMN-LEVEL PRIVILEGES
         // view creation permissions are only checked at query time, not at creation
@@ -226,7 +226,7 @@ public class TestAccessControl
                 .setSchema(getSession().getSchema())
                 .build();
 
-        String nestedViewName = "test_nested_view_column_access_" + randomTableSuffix();
+        String nestedViewName = "test_nested_view_column_access_" + randomNameSuffix();
         // view creation permissions are only checked at query time, not at creation
         assertAccessAllowed(
                 nestedViewOwnerSession,
@@ -248,7 +248,7 @@ public class TestAccessControl
                 privilege(getSession().getUser(), columnAccessViewName, SELECT_COLUMN));
 
         // verify that INVOKER security runs as session user
-        String invokerViewName = "test_invoker_view_column_access_" + randomTableSuffix();
+        String invokerViewName = "test_invoker_view_column_access_" + randomNameSuffix();
         assertAccessAllowed(
                 viewOwnerSession,
                 "CREATE VIEW " + invokerViewName + " SECURITY INVOKER AS SELECT * FROM orders",
@@ -299,7 +299,7 @@ public class TestAccessControl
 
         // TEST FUNCTION PRIVILEGES
         // view creation permissions are only checked at query time, not at creation
-        String functionAccessViewName = "test_view_function_access_" + randomTableSuffix();
+        String functionAccessViewName = "test_view_function_access_" + randomNameSuffix();
         assertAccessAllowed(
                 viewOwnerSession,
                 "CREATE VIEW " + functionAccessViewName + " AS SELECT abs(1) AS c",
@@ -317,7 +317,7 @@ public class TestAccessControl
 
         // TEST SECURITY INVOKER
         // view creation permissions are only checked at query time, not at creation
-        String invokerFunctionAccessViewName = "test_invoker_view_function_access_" + randomTableSuffix();
+        String invokerFunctionAccessViewName = "test_invoker_view_function_access_" + randomNameSuffix();
         assertAccessAllowed(
                 viewOwnerSession,
                 "CREATE VIEW " + invokerFunctionAccessViewName + " SECURITY INVOKER AS SELECT abs(1) AS c",
@@ -359,7 +359,7 @@ public class TestAccessControl
     @Test
     public void testCommentView()
     {
-        String viewName = "comment_view" + randomTableSuffix();
+        String viewName = "comment_view" + randomNameSuffix();
         assertUpdate("CREATE VIEW " + viewName + " COMMENT 'old comment' AS SELECT * FROM orders");
         assertAccessDenied("COMMENT ON VIEW " + viewName + " IS 'new comment'", "Cannot comment view to .*", privilege(viewName, COMMENT_VIEW));
         assertThatThrownBy(() -> getQueryRunner().execute(getSession(), "COMMENT ON VIEW " + viewName + " IS 'new comment'"))
@@ -400,7 +400,7 @@ public class TestAccessControl
     @Test
     public void testCommentColumnView()
     {
-        String viewName = "comment_view" + randomTableSuffix();
+        String viewName = "comment_view" + randomNameSuffix();
         assertUpdate("CREATE VIEW " + viewName + " AS SELECT * FROM orders");
         assertAccessDenied("COMMENT ON COLUMN " + viewName + ".orderkey IS 'new order key comment'", "Cannot comment column to .*", privilege(viewName, COMMENT_COLUMN));
         assertUpdate(getSession(), "COMMENT ON COLUMN " + viewName + ".orderkey IS 'new comment'");
@@ -442,9 +442,9 @@ public class TestAccessControl
         String catalogName = getSession().getCatalog().orElseThrow();
         String schemaName = getSession().getSchema().orElseThrow();
 
-        String targetTable = "merge_nation_target_" + randomTableSuffix();
+        String targetTable = "merge_nation_target_" + randomNameSuffix();
         String targetName = format("%s.%s.%s", catalogName, schemaName, targetTable);
-        String sourceTable = "merge_nation_source_" + randomTableSuffix();
+        String sourceTable = "merge_nation_source_" + randomNameSuffix();
         String sourceName = format("%s.%s.%s", catalogName, schemaName, sourceTable);
 
         assertUpdate(format("CREATE TABLE %s (nation_name VARCHAR, region_name VARCHAR)", targetTable));
@@ -549,7 +549,7 @@ public class TestAccessControl
     @Test
     public void testDescribeForViews()
     {
-        String viewName = "describe_orders_view" + randomTableSuffix();
+        String viewName = "describe_orders_view" + randomNameSuffix();
         assertUpdate("CREATE VIEW " + viewName + " AS SELECT * FROM orders");
         assertAccessDenied("DESCRIBE " + viewName, "Cannot show columns of table default.*", privilege(viewName, SHOW_COLUMNS));
         executeExclusively(() -> {


### PR DESCRIPTION
`randomTableSuffix()` is currently used for names of many things other than tables -- views, schemas or S3 bucket names.

Let's give the method a better name.

(PR with secrets)