### PR TITLE
Big query retries during create read session

### DIFF
--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -232,6 +232,11 @@
         </dependency>
 
         <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>failsafe</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
         </dependency>

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
@@ -69,6 +69,7 @@ public class BigQuerySplitManager
     private final boolean viewEnabled;
     private final Duration viewExpiration;
     private final NodeManager nodeManager;
+    private final int maxReadRowsRetries;
 
     @Inject
     public BigQuerySplitManager(
@@ -83,6 +84,7 @@ public class BigQuerySplitManager
         this.viewEnabled = config.isViewsEnabled();
         this.viewExpiration = config.getViewExpireDuration();
         this.nodeManager = requireNonNull(nodeManager, "nodeManager cannot be null");
+        this.maxReadRowsRetries = config.getMaxReadRowsRetries();
     }
 
     @Override
@@ -136,7 +138,7 @@ public class BigQuerySplitManager
         if (isSkipViewMaterialization(session) && type == VIEW) {
             return ImmutableList.of(BigQuerySplit.forViewStream(columns, filter));
         }
-        ReadSession readSession = new ReadSessionCreator(bigQueryClientFactory, bigQueryReadClientFactory, viewEnabled, viewExpiration)
+        ReadSession readSession = new ReadSessionCreator(bigQueryClientFactory, bigQueryReadClientFactory, viewEnabled, viewExpiration, maxReadRowsRetries)
                 .create(session, remoteTableId, projectedColumnsNames, filter, actualParallelism);
 
         return readSession.getStreamsList().stream()

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryUtil.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryUtil.java
@@ -36,7 +36,8 @@ public final class BigQueryUtil
     private static final Set<String> INTERNAL_ERROR_MESSAGES = ImmutableSet.of(
             "HTTP/2 error code: INTERNAL_ERROR",
             "Connection closed with unknown cause",
-            "Received unexpected EOS on DATA frame from server");
+            "Received unexpected EOS on DATA frame from server",
+            "INTERNAL: request failed: internal error");
 
     private BigQueryUtil() {}
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

After some code investigation I found out that we have some logic of retries in bigquery connector. But as far as I understand this retry logic is applied only after we successfully create read session and executing read itself (during getting next page) :

```
@Overridepublic ReadRowsResponse next()
{
    do {
        try {
            ReadRowsResponse response = serverResponses.next();
              ...
        }
        catch (Exception e) {
            // if relevant, retry the read, from the last read position            
            if (BigQueryUtil.isRetryable(e) && retries < helper.maxReadRowsRetries) {
                log.debug("Request failed, retrying: %s", e);
                serverResponses = helper.fetchResponses(nextOffset);
                retries++;
            }
            ...
        }
    }
    while (serverResponses.hasNext());
```
Similar exception could occur during Read Session creation.
So this PR introduce exact same retry logic for read session creation as we have for read pages.

Maybe we should go with Failsafe here. 


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# BigQuery
* Add support for retrying to create a BigQuery read session. ({issue}`15013`)
```
