### PR TITLE
Allow Coercion between hive Union and hive  struct for Hive ORC table

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
@@ -354,12 +354,10 @@ public class HivePageSource
             return Optional.of(new MapCoercer(typeManager, fromHiveType, toHiveType));
         }
         if (isRowType(fromType) && isRowType(toType)) {
-            if (fromHiveType.getCategory() == ObjectInspector.Category.UNION || toHiveType.getCategory() == ObjectInspector.Category.UNION) {
-                HiveType fromHiveTypeStruct = HiveType.toHiveType(fromType);
-                HiveType toHiveTypeStruct = HiveType.toHiveType(toType);
-                return Optional.of(new StructCoercer(typeManager, fromHiveTypeStruct, toHiveTypeStruct));
-            }
-            return Optional.of(new StructCoercer(typeManager, fromHiveType, toHiveType));
+            HiveType fromHiveTypeStruct = (fromHiveType.getCategory() == ObjectInspector.Category.UNION) ? HiveType.toHiveType(fromType) : fromHiveType;
+            HiveType toHiveTypeStruct = (toHiveType.getCategory() == ObjectInspector.Category.UNION) ? HiveType.toHiveType(toType) : toHiveType;
+
+            return Optional.of(new StructCoercer(typeManager, fromHiveTypeStruct, toHiveTypeStruct));
         }
 
         throw new TrinoException(NOT_SUPPORTED, format("Unsupported coercion from %s to %s", fromHiveType, toHiveType));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.hive.util;
 
+import io.trino.plugin.hive.HiveTimestampPrecision;
 import io.trino.plugin.hive.HiveType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Type;
@@ -25,6 +26,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 
 import java.util.List;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.plugin.hive.HiveType.HIVE_BYTE;
 import static io.trino.plugin.hive.HiveType.HIVE_DOUBLE;
 import static io.trino.plugin.hive.HiveType.HIVE_FLOAT;
@@ -33,6 +35,7 @@ import static io.trino.plugin.hive.HiveType.HIVE_LONG;
 import static io.trino.plugin.hive.HiveType.HIVE_SHORT;
 import static io.trino.plugin.hive.util.HiveUtil.extractStructFieldTypes;
 import static java.lang.Math.min;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public final class HiveCoercionPolicy
@@ -44,15 +47,15 @@ public final class HiveCoercionPolicy
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
     }
 
-    public static boolean canCoerce(TypeManager typeManager, HiveType fromHiveType, HiveType toHiveType)
+    public static boolean canCoerce(TypeManager typeManager, HiveType fromHiveType, HiveType toHiveType, HiveTimestampPrecision hiveTimestampPrecision)
     {
-        return new HiveCoercionPolicy(typeManager).canCoerce(fromHiveType, toHiveType);
+        return new HiveCoercionPolicy(typeManager).canCoerce(fromHiveType, toHiveType, hiveTimestampPrecision);
     }
 
-    private boolean canCoerce(HiveType fromHiveType, HiveType toHiveType)
+    private boolean canCoerce(HiveType fromHiveType, HiveType toHiveType, HiveTimestampPrecision hiveTimestampPrecision)
     {
-        Type fromType = typeManager.getType(fromHiveType.getTypeSignature());
-        Type toType = typeManager.getType(toHiveType.getTypeSignature());
+        Type fromType = typeManager.getType(fromHiveType.getTypeSignature(hiveTimestampPrecision));
+        Type toType = typeManager.getType(toHiveType.getTypeSignature(hiveTimestampPrecision));
         if (fromType instanceof VarcharType) {
             return toType instanceof VarcharType ||
                     toHiveType.equals(HIVE_BYTE) ||
@@ -82,25 +85,12 @@ public final class HiveCoercionPolicy
             return toType instanceof DecimalType || toHiveType.equals(HIVE_FLOAT) || toHiveType.equals(HIVE_DOUBLE);
         }
 
-        return canCoerceForList(fromHiveType, toHiveType)
-                || canCoerceForMap(fromHiveType, toHiveType)
-                || canCoerceForStruct(fromHiveType, toHiveType)
-                || canCoerceForUnionType(fromHiveType, toHiveType);
+        return canCoerceForList(fromHiveType, toHiveType, hiveTimestampPrecision)
+                || canCoerceForMap(fromHiveType, toHiveType, hiveTimestampPrecision)
+                || canCoerceForStructOrUnion(fromHiveType, toHiveType, hiveTimestampPrecision);
     }
 
-    private boolean canCoerceForUnionType(HiveType fromHiveType, HiveType toHiveType)
-    {
-        if (fromHiveType.getCategory() != Category.UNION || toHiveType.getCategory() != Category.UNION) {
-            return false;
-        }
-
-        // Delegate to the struct coercion logic, since Trino sees union types as structs.
-        HiveType fromHiveTypeStruct = HiveType.toHiveType(fromHiveType.getType(typeManager));
-        HiveType toHiveTypeStruct = HiveType.toHiveType(toHiveType.getType(typeManager));
-        return canCoerceForStruct(fromHiveTypeStruct, toHiveTypeStruct);
-    }
-
-    private boolean canCoerceForMap(HiveType fromHiveType, HiveType toHiveType)
+    private boolean canCoerceForMap(HiveType fromHiveType, HiveType toHiveType, HiveTimestampPrecision hiveTimestampPrecision)
     {
         if (fromHiveType.getCategory() != Category.MAP || toHiveType.getCategory() != Category.MAP) {
             return false;
@@ -109,29 +99,32 @@ public final class HiveCoercionPolicy
         HiveType fromValueType = HiveType.valueOf(((MapTypeInfo) fromHiveType.getTypeInfo()).getMapValueTypeInfo().getTypeName());
         HiveType toKeyType = HiveType.valueOf(((MapTypeInfo) toHiveType.getTypeInfo()).getMapKeyTypeInfo().getTypeName());
         HiveType toValueType = HiveType.valueOf(((MapTypeInfo) toHiveType.getTypeInfo()).getMapValueTypeInfo().getTypeName());
-        return (fromKeyType.equals(toKeyType) || canCoerce(fromKeyType, toKeyType)) &&
-                (fromValueType.equals(toValueType) || canCoerce(fromValueType, toValueType));
+        return (fromKeyType.equals(toKeyType) || canCoerce(fromKeyType, toKeyType, hiveTimestampPrecision)) &&
+                (fromValueType.equals(toValueType) || canCoerce(fromValueType, toValueType, hiveTimestampPrecision));
     }
 
-    private boolean canCoerceForList(HiveType fromHiveType, HiveType toHiveType)
+    private boolean canCoerceForList(HiveType fromHiveType, HiveType toHiveType, HiveTimestampPrecision hiveTimestampPrecision)
     {
         if (fromHiveType.getCategory() != Category.LIST || toHiveType.getCategory() != Category.LIST) {
             return false;
         }
         HiveType fromElementType = HiveType.valueOf(((ListTypeInfo) fromHiveType.getTypeInfo()).getListElementTypeInfo().getTypeName());
         HiveType toElementType = HiveType.valueOf(((ListTypeInfo) toHiveType.getTypeInfo()).getListElementTypeInfo().getTypeName());
-        return fromElementType.equals(toElementType) || canCoerce(fromElementType, toElementType);
+        return fromElementType.equals(toElementType) || canCoerce(fromElementType, toElementType, hiveTimestampPrecision);
     }
 
-    private boolean canCoerceForStruct(HiveType fromHiveType, HiveType toHiveType)
+    private boolean canCoerceForStructOrUnion(HiveType fromHiveType, HiveType toHiveType, HiveTimestampPrecision hiveTimestampPrecision)
     {
-        if (fromHiveType.getCategory() != Category.STRUCT || toHiveType.getCategory() != Category.STRUCT) {
+        if (!isStructOrUnion(fromHiveType) || !isStructOrUnion(toHiveType)) {
             return false;
         }
-        List<String> fromFieldNames = ((StructTypeInfo) fromHiveType.getTypeInfo()).getAllStructFieldNames();
-        List<String> toFieldNames = ((StructTypeInfo) toHiveType.getTypeInfo()).getAllStructFieldNames();
-        List<HiveType> fromFieldTypes = extractStructFieldTypes(fromHiveType);
-        List<HiveType> toFieldTypes = extractStructFieldTypes(toHiveType);
+        HiveType fromHiveTypeStruct = (fromHiveType.getCategory() == Category.UNION) ? convertUnionToStruct(fromHiveType, typeManager, hiveTimestampPrecision) : fromHiveType;
+        HiveType toHiveTypeStruct = (toHiveType.getCategory() == Category.UNION) ? convertUnionToStruct(toHiveType, typeManager, hiveTimestampPrecision) : toHiveType;
+
+        List<String> fromFieldNames = ((StructTypeInfo) fromHiveTypeStruct.getTypeInfo()).getAllStructFieldNames();
+        List<String> toFieldNames = ((StructTypeInfo) toHiveTypeStruct.getTypeInfo()).getAllStructFieldNames();
+        List<HiveType> fromFieldTypes = extractStructFieldTypes(fromHiveTypeStruct);
+        List<HiveType> toFieldTypes = extractStructFieldTypes(toHiveTypeStruct);
         // Rule:
         // * Fields may be added or dropped from the end.
         // * For all other field indices, the corresponding fields must have
@@ -140,10 +133,21 @@ public final class HiveCoercionPolicy
             if (!fromFieldNames.get(i).equalsIgnoreCase(toFieldNames.get(i))) {
                 return false;
             }
-            if (!fromFieldTypes.get(i).equals(toFieldTypes.get(i)) && !canCoerce(fromFieldTypes.get(i), toFieldTypes.get(i))) {
+            if (!fromFieldTypes.get(i).equals(toFieldTypes.get(i)) && !canCoerce(fromFieldTypes.get(i), toFieldTypes.get(i), hiveTimestampPrecision)) {
                 return false;
             }
         }
         return true;
+    }
+
+    private static boolean isStructOrUnion(HiveType hiveType)
+    {
+        return (hiveType.getCategory() == Category.STRUCT) || (hiveType.getCategory() == Category.UNION);
+    }
+
+    private static HiveType convertUnionToStruct(HiveType unionType, TypeManager typeManager, HiveTimestampPrecision hiveTimestampPrecision)
+    {
+        checkArgument(unionType.getCategory() == Category.UNION, format("Can only convert union type to struct type, given type: %s", unionType.getTypeSignature(hiveTimestampPrecision)));
+        return HiveType.toHiveType(unionType.getType(typeManager, hiveTimestampPrecision));
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Allow Coercion between hive Union and hive struct, at LinkedIn we have the need to declare the table schema as struct and reading some partitions in union definition. 

Since Trino internally treat union as struct, this PR allows coercions between struct and union(after union get converted to Struct)

Related PR:
https://github.com/trinodb/trino/pull/3483
https://github.com/trinodb/trino/commit/e071da402efb4b95f6c8b13b2a241e86e446e2a8

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Allow Coercion between hive Union and hive  struct

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
*Allow Coercion between Union and Struct typed columns.
```
