### PR TITLE
Reword docs to avoid mention of a/an SQL

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -190,7 +190,7 @@ In order to enable language injection inside Intellij IDEA, some code elements c
 
 Even if the IDE does not support language injection this annotation is useful for documenting the API's intent. Considering the above, we recommend annotating with `@Language`:
 
-- All API parameters which are expecting to take a `String` containing an SQL statement (or any other language, like regular expressions),
+- All API parameters which are expecting to take a `String` containing a statement written in SQL (or any other language, like regular expressions),
 - Local variables which otherwise would not be properly recognized by IDE for language injection.
 
 ## Building the Web UI

--- a/docs/README.md
+++ b/docs/README.md
@@ -208,8 +208,8 @@ contribution](https://trino.io/development/process.html).
 
 2. You might select a GitHub doc issue to work on that requires you to verify
    how Trino handles a situation, such as [adding
-   documentation](https://github.com/trinodb/trino/issues/7660) for an SQL
-   language function.
+   documentation](https://github.com/trinodb/trino/issues/7660) for SQL
+   functions.
 
    In this case, the five-minute video [Learning Trino SQL with
    Docker](https://www.youtube.com/watch?v=y58sb9bW2mA) gives you a starting

--- a/docs/src/main/sphinx/appendix/from-hive.rst
+++ b/docs/src/main/sphinx/appendix/from-hive.rst
@@ -2,7 +2,9 @@
 Migrating from Hive
 ===================
 
-Trino uses ANSI SQL syntax and semantics, whereas Hive uses an SQL-like language called HiveQL which is loosely modeled after MySQL (which itself has many differences from ANSI SQL).
+Trino uses ANSI SQL syntax and semantics, whereas Hive uses a language similar
+to SQL called HiveQL which is loosely modeled after MySQL (which itself has many
+differences from ANSI SQL).
 
 Use subscript for accessing a dynamic index of an array instead of a udf
 ------------------------------------------------------------------------

--- a/docs/src/main/sphinx/connector/accumulo.rst
+++ b/docs/src/main/sphinx/connector/accumulo.rst
@@ -13,7 +13,7 @@ Installing the iterator dependency
 ----------------------------------
 
 The Accumulo connector uses custom Accumulo iterators in
-order to push various information in an SQL predicate clause to Accumulo for
+order to push various information in SQL predicate clauses to Accumulo for
 server-side filtering, known as *predicate pushdown*. In order
 for the server-side iterators to work, you need to add the ``trino-accumulo-iterators``
 JAR file to Accumulo's ``lib/ext`` directory on each TabletServer node.

--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -738,7 +738,7 @@ Use the ``$snapshots`` metadata table to determine the latest snapshot ID of the
     FROM iceberg.testdb."customer_orders$snapshots"
     ORDER BY committed_at DESC LIMIT 1
 
-An SQL procedure ``system.rollback_to_snapshot`` allows the caller to roll back
+The procedure ``system.rollback_to_snapshot`` allows the caller to roll back
 the state of the table to a previous snapshot id::
 
     CALL iceberg.system.rollback_to_snapshot('testdb', 'customer_orders', 8954597067493422955)
@@ -755,8 +755,9 @@ Register table
 --------------
 The connector can register existing Iceberg tables with the catalog.
 
-An SQL procedure ``system.register_table`` allows the caller to register an existing Iceberg
-table in the metastore, using its existing metadata and data files::
+The procedure ``system.register_table`` allows the caller to register an
+existing Iceberg table in the metastore, using its existing metadata and data
+files::
 
     CALL iceberg.system.register_table(schema_name => 'testdb', table_name => 'customer_orders', table_location => 'hdfs://hadoop-master:9000/user/hive/warehouse/customer_orders-581fad8517934af6be1857a903559d44')
 

--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -23,8 +23,8 @@ To connect to SQL Server, you need:
 Configuration
 -------------
 
-The connector can query a single database on an SQL server instance. Create a
-catalog properties file that specifies the SQL server connector by setting the
+The connector can query a single database on a given SQL Server instance. Create
+a catalog properties file that specifies the SQL server connector by setting the
 ``connector.name`` to ``sqlserver``.
 
 For example, to access a database as ``sqlserver``, create the file
@@ -152,7 +152,7 @@ each direction.
 SQL Server type to Trino type mapping
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The connector maps SQL server types to the corresponding Trino types following this table:
+The connector maps SQL Server types to the corresponding Trino types following this table:
 
 .. list-table:: SQL Server type to Trino type mapping
   :widths: 30, 20, 50

--- a/docs/src/main/sphinx/develop/connectors.rst
+++ b/docs/src/main/sphinx/develop/connectors.rst
@@ -287,7 +287,7 @@ limit, it should return a non-empty result with the "limit guaranteed" or
   The ``applyTopN`` is the only method that receives sort items from the
   ``Sort`` operation.
 
-In an SQL query, the ``ORDER BY`` section can include any column with any order.
+In a query, the ``ORDER BY`` section can include any column with any order.
 But the data source for the connector might only support limited combinations.
 Plugin authors have to decide if the connector should ignore the pushdown,
 return all the data and let the engine sort it, or throw an exception

--- a/docs/src/main/sphinx/develop/example-http.rst
+++ b/docs/src/main/sphinx/develop/example-http.rst
@@ -5,7 +5,7 @@ Example HTTP connector
 The Example HTTP connector has a simple goal: it reads comma-separated
 data over HTTP. For example, if you have a large amount of data in a
 CSV format, you can point the example HTTP connector at this data and
-write an SQL query to process it.
+write a query to process it.
 
 Code
 ----

--- a/docs/src/main/sphinx/develop/functions.rst
+++ b/docs/src/main/sphinx/develop/functions.rst
@@ -310,8 +310,8 @@ Deprecated function
 -------------------
 
 The ``@Deprecated`` annotation has to be used on any function that should no longer be
-used. The annotation causes Trino to generate a warning whenever an SQL statement
-uses a deprecated function. When a function is deprecated, the ``@Description``
+used. The annotation causes Trino to generate a warning whenever SQL statements
+use a deprecated function. When a function is deprecated, the ``@Description``
 needs to be replaced with a note about the deprecation and the replacement function:
 
 .. code-block:: java

--- a/docs/src/main/sphinx/functions/json.rst
+++ b/docs/src/main/sphinx/functions/json.rst
@@ -27,7 +27,7 @@ JSON path language
 
 The JSON path language is a special language, used exclusively by certain SQL
 operators to specify the query to perform on the JSON input. Although JSON path
-expressions are embedded in an SQL query, their syntax significantly differs
+expressions are embedded in SQL queries, their syntax significantly differs
 from SQL. The semantics of predicates, operators, etc. in JSON path expressions
 generally follow the semantics of SQL. The JSON path language is case-sensitive
 for keywords and identifiers.
@@ -37,13 +37,13 @@ for keywords and identifiers.
 JSON path syntax and semantics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A JSON path expression, similar to an SQL expression, is a recursive structure.
-Although the name "path" suggests a linear sequence of operations going step by
-step deeper into the JSON structure, a JSON path expression is in fact a tree.
-It can access the input JSON item multiple times, in multiple ways, and combine
-the results. Moreover, the result of a JSON path expression is not a single
-item, but an ordered sequence of items. Each of the sub-expressions takes one
-or more input sequences, and returns a sequence as the result.
+JSON path expressions are recursive structures. Although the name "path"
+suggests a linear sequence of operations going step by step deeper into the JSON
+structure, a JSON path expression is in fact a tree. It can access the input
+JSON item multiple times, in multiple ways, and combine the results. Moreover,
+the result of a JSON path expression is not a single item, but an ordered
+sequence of items. Each of the sub-expressions takes one or more input
+sequences, and returns a sequence as the result.
 
 .. note::
 
@@ -993,7 +993,7 @@ to the ``ON ERROR`` clause are:
 json_value
 ----------
 
-The ``json_value`` function extracts an SQL scalar from a JSON value.
+The ``json_value`` function extracts a scalar SQL value from a JSON value.
 
 .. code-block:: text
 
@@ -1492,7 +1492,7 @@ The following examples show the behavior of casting to JSON with these types::
     -- JSON '{"v1":123,"v2":"abc","v3":true}'
 
 Casting from NULL to ``JSON`` is not straightforward. Casting
-from a standalone ``NULL`` will produce an SQL ``NULL`` instead of
+from a standalone ``NULL`` will produce SQL ``NULL`` instead of
 ``JSON 'null'``. However, when casting from arrays or map containing
 ``NULL``\s, the produced ``JSON`` will have ``null``\s in it.
 

--- a/docs/src/main/sphinx/overview/concepts.rst
+++ b/docs/src/main/sphinx/overview/concepts.rst
@@ -108,8 +108,8 @@ Catalog
 
 A Trino catalog contains schemas and references a data source via a
 connector.  For example, you can configure a JMX catalog to provide
-access to JMX information via the JMX connector. When you run an SQL
-statement in Trino, you are running it against one or more catalogs.
+access to JMX information via the JMX connector. When you run SQL
+statements in Trino, you are running them against one or more catalogs.
 Other examples of catalogs include the Hive catalog to connect to a
 Hive data source.
 
@@ -154,8 +154,8 @@ expressions, and predicates.
 
 Some readers might be curious why this section lists separate concepts
 for statements and queries. This is necessary because, in Trino,
-statements simply refer to the textual representation of an SQL
-statement. When a statement is executed, Trino creates a query along
+statements simply refer to the textual representation of a statement written
+in SQL. When a statement is executed, Trino creates a query along
 with a query plan that is then distributed across a series of Trino
 workers.
 

--- a/docs/src/main/sphinx/release/release-0.113.rst
+++ b/docs/src/main/sphinx/release/release-0.113.rst
@@ -20,10 +20,10 @@ for internal Presto data structures and temporary allocations.
 Session properties
 ------------------
 
-All session properties now have an SQL type, default value and description.  The
-value for :doc:`/sql/set-session` can now be any constant expression, and the
-:doc:`/sql/show-session` command prints the current effective value and default
-value for all session properties.
+All session properties have a type, default value, and description.
+The value for :doc:`/sql/set-session` can now be any constant expression, and
+the :doc:`/sql/show-session` command prints the current effective value and
+default value for all session properties.
 
 This type safety extends to the :doc:`SPI </develop/spi-overview>` where properties
 can be validated and converted to any Java type using

--- a/docs/src/main/sphinx/release/release-0.166.rst
+++ b/docs/src/main/sphinx/release/release-0.166.rst
@@ -7,7 +7,7 @@ General
 
 * Fix failure due to implicit coercion issue in ``IN`` expressions for
   certain combinations of data types (e.g., ``double`` and ``decimal``).
-* Add ``query.max-length`` config flag to set the maximum length of an SQL query.
+* Add ``query.max-length`` config flag to set the maximum length of a query.
   The default maximum length is 1MB.
 * Improve performance of :func:`approx_percentile`.
 

--- a/docs/src/main/sphinx/release/release-0.205.rst
+++ b/docs/src/main/sphinx/release/release-0.205.rst
@@ -74,7 +74,7 @@ SPI
 * Disallow non-static methods to be annotated with ``@ScalarFunction``. Non-static SQL function
   implementations must now be declared in a class annotated with ``@ScalarFunction``.
 * Disallow having multiple public constructors in ``@ScalarFunction`` classes. All non-static
-  implementations of an SQL function will now be associated with a single constructor.
+  implementations of SQL functions will now be associated with a single constructor.
   This improves support for providing specialized implementations of SQL functions with generic arguments.
 * Deprecate ``checkCanSelectFromTable/checkCanSelectFromView`` and
   ``checkCanCreateViewWithSelectFromTable/checkCanCreateViewWithSelectFromView`` in ``ConnectorAccessControl``


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Rather than take a side on whether it's "a SQL" or "an SQL," we can simply avoid the issue and any correctness concerns related to it by rewriting things. The only time we're losing any meaning is changing "an SQL query" to "a query" (which is redundant IMO), and in all other situations, it's either neutral or even an improvement/correction over what is currently written.

In principle, I am happy to admit that is an extremely terrible thing to do, but in practice, it does solve the problem!

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

solving the war of "a SQL statement" vs. "an SQL statement"

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
