### PR TITLE
Time out getting stats from connector

### DIFF
--- a/core/trino-main/src/main/java/io/trino/cost/ForStatsProvider.java
+++ b/core/trino-main/src/main/java/io/trino/cost/ForStatsProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.cost;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForStatsProvider {}

--- a/core/trino-main/src/main/java/io/trino/cost/SimpleTableStatsProvider.java
+++ b/core/trino-main/src/main/java/io/trino/cost/SimpleTableStatsProvider.java
@@ -13,33 +13,28 @@
  */
 package io.trino.cost;
 
+import io.trino.Session;
+import io.trino.metadata.Metadata;
 import io.trino.metadata.TableHandle;
 import io.trino.spi.statistics.TableStatistics;
 
-import java.util.Map;
-import java.util.WeakHashMap;
-
 import static java.util.Objects.requireNonNull;
 
-public class CachingTableStatsProvider
+public final class SimpleTableStatsProvider
         implements TableStatsProvider
 {
-    private final TableStatsProvider delegate;
-    private final Map<TableHandle, TableStatistics> cache = new WeakHashMap<>();
+    private final Metadata metadata;
+    private final Session session;
 
-    public CachingTableStatsProvider(TableStatsProvider delegate)
+    public SimpleTableStatsProvider(Metadata metadata, Session session)
     {
-        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.session = requireNonNull(session, "session is null");
     }
 
     @Override
     public TableStatistics getTableStatistics(TableHandle tableHandle)
     {
-        TableStatistics stats = cache.get(tableHandle);
-        if (stats == null) {
-            stats = delegate.getTableStatistics(tableHandle);
-            cache.put(tableHandle, stats);
-        }
-        return stats;
+        return metadata.getTableStatistics(session, tableHandle);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/cost/TimingTableStatsProvider.java
+++ b/core/trino-main/src/main/java/io/trino/cost/TimingTableStatsProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.cost;
+
+import io.airlift.concurrent.SetThreadName;
+import io.trino.Session;
+import io.trino.metadata.TableHandle;
+import io.trino.spi.statistics.TableStatistics;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public final class TimingTableStatsProvider
+        implements TableStatsProvider
+{
+    private final TableStatsProvider delegate;
+    private final Session session;
+    private final ExecutorService executor;
+    private final long timeoutMillis;
+
+    public TimingTableStatsProvider(TableStatsProvider delegate, Session session, ExecutorService executor, long timeoutMillis)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.session = requireNonNull(session, "session is null");
+        this.executor = requireNonNull(executor, "executor is null");
+        this.timeoutMillis = timeoutMillis;
+    }
+
+    @Override
+    public TableStatistics getTableStatistics(TableHandle tableHandle)
+    {
+        Future<TableStatistics> future = executor.submit(() -> {
+            try (SetThreadName ignored = new SetThreadName("Query-%s", session.getQueryId())) {
+                return delegate.getTableStatistics(tableHandle);
+            }
+        });
+        try {
+            return future.get(timeoutMillis, MILLISECONDS);
+        }
+        catch (InterruptedException e) {
+            future.cancel(true);
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted", e);
+        }
+        catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+        catch (TimeoutException e) {
+            future.cancel(true);
+            return TableStatistics.empty();
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
@@ -59,6 +59,7 @@ import io.trino.sql.planner.PlanFragment;
 import io.trino.sql.planner.PlanFragmenter;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.PlanOptimizersFactory;
+import io.trino.sql.planner.QueryTableStatsProviderFactory;
 import io.trino.sql.planner.SplitSourceFactory;
 import io.trino.sql.planner.SubPlan;
 import io.trino.sql.planner.TypeAnalyzer;
@@ -128,6 +129,7 @@ public class SqlQueryExecution
     private final ExecutionPolicy executionPolicy;
     private final SplitSchedulerStats schedulerStats;
     private final Analysis analysis;
+    private final QueryTableStatsProviderFactory queryTableStatsProviderFactory;
     private final StatsCalculator statsCalculator;
     private final CostCalculator costCalculator;
     private final DynamicFilterService dynamicFilterService;
@@ -161,6 +163,7 @@ public class SqlQueryExecution
             NodeTaskMap nodeTaskMap,
             ExecutionPolicy executionPolicy,
             SplitSchedulerStats schedulerStats,
+            QueryTableStatsProviderFactory queryTableStatsProviderFactory,
             StatsCalculator statsCalculator,
             CostCalculator costCalculator,
             DynamicFilterService dynamicFilterService,
@@ -190,6 +193,7 @@ public class SqlQueryExecution
             this.nodeTaskMap = requireNonNull(nodeTaskMap, "nodeTaskMap is null");
             this.executionPolicy = requireNonNull(executionPolicy, "executionPolicy is null");
             this.schedulerStats = requireNonNull(schedulerStats, "schedulerStats is null");
+            this.queryTableStatsProviderFactory = requireNonNull(queryTableStatsProviderFactory, "queryTableStatsProviderFactory is null");
             this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
             this.costCalculator = requireNonNull(costCalculator, "costCalculator is null");
             this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");
@@ -469,6 +473,7 @@ public class SqlQueryExecution
                 idAllocator,
                 plannerContext,
                 typeAnalyzer,
+                queryTableStatsProviderFactory,
                 statsCalculator,
                 costCalculator,
                 stateMachine.getWarningCollector());
@@ -770,6 +775,7 @@ public class SqlQueryExecution
         private final FailureDetector failureDetector;
         private final NodeTaskMap nodeTaskMap;
         private final Map<String, ExecutionPolicy> executionPolicies;
+        private final QueryTableStatsProviderFactory queryTableStatsProviderFactory;
         private final StatsCalculator statsCalculator;
         private final CostCalculator costCalculator;
         private final DynamicFilterService dynamicFilterService;
@@ -801,6 +807,7 @@ public class SqlQueryExecution
                 NodeTaskMap nodeTaskMap,
                 Map<String, ExecutionPolicy> executionPolicies,
                 SplitSchedulerStats schedulerStats,
+                QueryTableStatsProviderFactory queryTableStatsProviderFactory,
                 StatsCalculator statsCalculator,
                 CostCalculator costCalculator,
                 DynamicFilterService dynamicFilterService,
@@ -830,6 +837,7 @@ public class SqlQueryExecution
             this.nodeTaskMap = requireNonNull(nodeTaskMap, "nodeTaskMap is null");
             this.executionPolicies = requireNonNull(executionPolicies, "executionPolicies is null");
             this.planOptimizers = planOptimizersFactory.get();
+            this.queryTableStatsProviderFactory = requireNonNull(queryTableStatsProviderFactory, "queryTableStatsProviderFactory is null");
             this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
             this.costCalculator = requireNonNull(costCalculator, "costCalculator is null");
             this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");
@@ -875,6 +883,7 @@ public class SqlQueryExecution
                     nodeTaskMap,
                     executionPolicy,
                     schedulerStats,
+                    queryTableStatsProviderFactory,
                     statsCalculator,
                     costCalculator,
                     dynamicFilterService,

--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -29,6 +29,7 @@ import io.trino.cost.CostCalculator.EstimatedExchanges;
 import io.trino.cost.CostCalculatorUsingExchanges;
 import io.trino.cost.CostCalculatorWithEstimatedExchanges;
 import io.trino.cost.CostComparator;
+import io.trino.cost.ForStatsProvider;
 import io.trino.cost.StatsAndCosts;
 import io.trino.cost.StatsCalculatorModule;
 import io.trino.cost.TaskCountEstimator;
@@ -383,6 +384,14 @@ public class CoordinatorModule
     public static ScheduledExecutorService createStatementTimeoutExecutor(TaskManagerConfig config)
     {
         return newScheduledThreadPool(config.getHttpTimeoutThreads(), daemonThreadsNamed("statement-timeout-%s"));
+    }
+
+    @Provides
+    @Singleton
+    @ForStatsProvider
+    public static ExecutorService createStatsProviderCoreExecutor()
+    {
+        return newCachedThreadPool(daemonThreadsNamed("stats-provider-%s"));
     }
 
     private void bindLowMemoryQueryKiller(LowMemoryQueryKillerPolicy policy, Class<? extends LowMemoryKiller> clazz)

--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -105,6 +105,7 @@ import io.trino.sql.planner.OptimizerStatsMBeanExporter;
 import io.trino.sql.planner.PlanFragmenter;
 import io.trino.sql.planner.PlanOptimizers;
 import io.trino.sql.planner.PlanOptimizersFactory;
+import io.trino.sql.planner.QueryTableStatsProviderFactory;
 import io.trino.sql.planner.RuleStatsRecorder;
 import io.trino.sql.planner.SplitSourceFactory;
 import io.trino.sql.rewrite.DescribeInputRewrite;
@@ -247,6 +248,7 @@ public class CoordinatorModule
         newExporter(binder).export(ClusterSizeMonitor.class).withGeneratedName();
 
         // statistics calculator
+        binder.bind(QueryTableStatsProviderFactory.class).in(Scopes.SINGLETON);
         binder.install(new StatsCalculatorModule());
 
         // cost calculator

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/QueryExplainer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/QueryExplainer.java
@@ -25,6 +25,7 @@ import io.trino.sql.planner.Plan;
 import io.trino.sql.planner.PlanFragmenter;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.PlanOptimizersFactory;
+import io.trino.sql.planner.QueryTableStatsProviderFactory;
 import io.trino.sql.planner.SubPlan;
 import io.trino.sql.planner.TypeAnalyzer;
 import io.trino.sql.planner.optimizations.PlanOptimizer;
@@ -60,6 +61,7 @@ public class QueryExplainer
     private final PlannerContext plannerContext;
     private final AnalyzerFactory analyzerFactory;
     private final StatementAnalyzerFactory statementAnalyzerFactory;
+    private final QueryTableStatsProviderFactory queryTableStatsProviderFactory;
     private final StatsCalculator statsCalculator;
     private final CostCalculator costCalculator;
 
@@ -69,6 +71,7 @@ public class QueryExplainer
             PlannerContext plannerContext,
             AnalyzerFactory analyzerFactory,
             StatementAnalyzerFactory statementAnalyzerFactory,
+            QueryTableStatsProviderFactory queryTableStatsProviderFactory,
             StatsCalculator statsCalculator,
             CostCalculator costCalculator)
     {
@@ -77,6 +80,7 @@ public class QueryExplainer
         this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
         this.analyzerFactory = requireNonNull(analyzerFactory, "analyzerFactory is null");
         this.statementAnalyzerFactory = requireNonNull(statementAnalyzerFactory, "statementAnalyzerFactory is null");
+        this.queryTableStatsProviderFactory = requireNonNull(queryTableStatsProviderFactory, "queryTableStatsProviderFactory is null");
         this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
         this.costCalculator = requireNonNull(costCalculator, "costCalculator is null");
     }
@@ -164,6 +168,7 @@ public class QueryExplainer
                 idAllocator,
                 plannerContext,
                 new TypeAnalyzer(plannerContext, statementAnalyzerFactory),
+                queryTableStatsProviderFactory,
                 statsCalculator,
                 costCalculator,
                 warningCollector);

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/QueryExplainerFactory.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/QueryExplainerFactory.java
@@ -18,6 +18,7 @@ import io.trino.cost.StatsCalculator;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.PlanFragmenter;
 import io.trino.sql.planner.PlanOptimizersFactory;
+import io.trino.sql.planner.QueryTableStatsProviderFactory;
 
 import javax.inject.Inject;
 
@@ -29,6 +30,7 @@ public class QueryExplainerFactory
     private final PlanFragmenter planFragmenter;
     private final PlannerContext plannerContext;
     private final StatementAnalyzerFactory statementAnalyzerFactory;
+    private final QueryTableStatsProviderFactory queryTableStatsProviderFactory;
     private final StatsCalculator statsCalculator;
     private final CostCalculator costCalculator;
 
@@ -38,6 +40,7 @@ public class QueryExplainerFactory
             PlanFragmenter planFragmenter,
             PlannerContext plannerContext,
             StatementAnalyzerFactory statementAnalyzerFactory,
+            QueryTableStatsProviderFactory queryTableStatsProviderFactory,
             StatsCalculator statsCalculator,
             CostCalculator costCalculator)
     {
@@ -45,6 +48,7 @@ public class QueryExplainerFactory
         this.planFragmenter = requireNonNull(planFragmenter, "planFragmenter is null");
         this.plannerContext = requireNonNull(plannerContext, "metadata is null");
         this.statementAnalyzerFactory = requireNonNull(statementAnalyzerFactory, "statementAnalyzerFactory is null");
+        this.queryTableStatsProviderFactory = requireNonNull(queryTableStatsProviderFactory, "queryTableStatsProviderFactory is null");
         this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
         this.costCalculator = requireNonNull(costCalculator, "costCalculator is null");
     }
@@ -57,6 +61,7 @@ public class QueryExplainerFactory
                 plannerContext,
                 analyzerFactory,
                 statementAnalyzerFactory,
+                queryTableStatsProviderFactory,
                 statsCalculator,
                 costCalculator);
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
@@ -23,6 +23,7 @@ import io.trino.cost.CachingStatsProvider;
 import io.trino.cost.CachingTableStatsProvider;
 import io.trino.cost.CostCalculator;
 import io.trino.cost.CostProvider;
+import io.trino.cost.SimpleTableStatsProvider;
 import io.trino.cost.StatsAndCosts;
 import io.trino.cost.StatsCalculator;
 import io.trino.cost.StatsProvider;
@@ -240,7 +241,7 @@ public class LogicalPlanner
 
         planSanityChecker.validateIntermediatePlan(root, session, plannerContext, typeAnalyzer, symbolAllocator.getTypes(), warningCollector);
 
-        TableStatsProvider tableStatsProvider = new CachingTableStatsProvider(metadata, session);
+        TableStatsProvider tableStatsProvider = new CachingTableStatsProvider(new SimpleTableStatsProvider(metadata, session));
 
         if (stage.ordinal() >= OPTIMIZED.ordinal()) {
             for (PlanOptimizer optimizer : planOptimizers) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
@@ -23,9 +23,12 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
+import java.util.Optional;
+
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class OptimizerConfig
 {
@@ -41,6 +44,7 @@ public class OptimizerConfig
     private int maxReorderedJoins = 9;
 
     private boolean enableStatsCalculator = true;
+    private Optional<Duration> connectorStatsProvisioningTimeout = Optional.of(new Duration(20, SECONDS));
     private boolean statisticsPrecalculationForPushdownEnabled = true;
     private boolean collectPlanStatisticsForAllQueries;
     private boolean ignoreStatsCalculatorFailures = true;
@@ -227,6 +231,27 @@ public class OptimizerConfig
     public OptimizerConfig setEnableStatsCalculator(boolean enableStatsCalculator)
     {
         this.enableStatsCalculator = enableStatsCalculator;
+        return this;
+    }
+
+    @NotNull
+    public Optional<Duration> getConnectorStatsProvisioningTimeout()
+    {
+        return connectorStatsProvisioningTimeout;
+    }
+
+    @Config("connector-statistics-provisioning-timeout")
+    public OptimizerConfig setConnectorStatsProvisioningTimeout(String connectorStatsProvisioningTimeout)
+    {
+        if ("infinity".equals(connectorStatsProvisioningTimeout)) {
+            return setConnectorStatsProvisioningTimeout(Optional.empty());
+        }
+        return setConnectorStatsProvisioningTimeout(Optional.of(Duration.valueOf(connectorStatsProvisioningTimeout)));
+    }
+
+    public OptimizerConfig setConnectorStatsProvisioningTimeout(Optional<Duration> connectorStatsProvisioningTimeout)
+    {
+        this.connectorStatsProvisioningTimeout = connectorStatsProvisioningTimeout;
         return this;
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryTableStatsProviderFactory.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryTableStatsProviderFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import io.trino.Session;
+import io.trino.cost.CachingTableStatsProvider;
+import io.trino.cost.SimpleTableStatsProvider;
+import io.trino.cost.TableStatsProvider;
+import io.trino.metadata.Metadata;
+
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class QueryTableStatsProviderFactory
+{
+    private final Metadata metadata;
+
+    @Inject
+    public QueryTableStatsProviderFactory(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    public TableStatsProvider create(Session session)
+    {
+        return new CachingTableStatsProvider(new SimpleTableStatsProvider(metadata, session));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowStatsRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowStatsRewrite.java
@@ -18,6 +18,7 @@ import io.trino.Session;
 import io.trino.cost.CachingStatsProvider;
 import io.trino.cost.CachingTableStatsProvider;
 import io.trino.cost.PlanNodeStatsEstimate;
+import io.trino.cost.SimpleTableStatsProvider;
 import io.trino.cost.StatsCalculator;
 import io.trino.cost.SymbolStatsEstimate;
 import io.trino.execution.warnings.WarningCollector;
@@ -138,7 +139,11 @@ public class ShowStatsRewrite
         {
             Query query = getRelation(node);
             Plan plan = queryExplainer.getLogicalPlan(session, query, parameters, warningCollector);
-            CachingStatsProvider cachingStatsProvider = new CachingStatsProvider(statsCalculator, session, plan.getTypes(), new CachingTableStatsProvider(metadata, session));
+            CachingStatsProvider cachingStatsProvider = new CachingStatsProvider(
+                    statsCalculator,
+                    session,
+                    plan.getTypes(),
+                    new CachingTableStatsProvider(new SimpleTableStatsProvider(metadata, session)));
             PlanNodeStatsEstimate stats = cachingStatsProvider.getStats(plan.getRoot());
             return rewriteShowStats(plan, stats);
         }

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -170,6 +170,7 @@ import io.trino.sql.planner.Plan;
 import io.trino.sql.planner.PlanFragmenter;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.PlanOptimizers;
+import io.trino.sql.planner.QueryTableStatsProviderFactory;
 import io.trino.sql.planner.RuleStatsRecorder;
 import io.trino.sql.planner.SubPlan;
 import io.trino.sql.planner.TypeAnalyzer;
@@ -266,6 +267,7 @@ public class LocalQueryRunner
     private final TypeRegistry typeRegistry;
     private final GlobalFunctionCatalog globalFunctionCatalog;
     private final FunctionManager functionManager;
+    private final QueryTableStatsProviderFactory queryTableStatsProviderFactory;
     private final StatsCalculator statsCalculator;
     private final ScalarStatsCalculator scalarStatsCalculator;
     private final CostCalculator costCalculator;
@@ -441,6 +443,7 @@ public class LocalQueryRunner
                 analyzePropertyManager,
                 tableProceduresPropertyManager);
         TypeAnalyzer typeAnalyzer = new TypeAnalyzer(plannerContext, statementAnalyzerFactory);
+        this.queryTableStatsProviderFactory = new QueryTableStatsProviderFactory(plannerContext.getMetadata());
         this.statsCalculator = createNewStatsCalculator(plannerContext, typeAnalyzer);
         this.scalarStatsCalculator = new ScalarStatsCalculator(plannerContext, typeAnalyzer);
         this.taskCountEstimator = new TaskCountEstimator(() -> nodeCountForStats);
@@ -1092,6 +1095,7 @@ public class LocalQueryRunner
                 idAllocator,
                 getPlannerContext(),
                 new TypeAnalyzer(plannerContext, statementAnalyzerFactory),
+                queryTableStatsProviderFactory,
                 statsCalculator,
                 costCalculator,
                 warningCollector);
@@ -1108,6 +1112,7 @@ public class LocalQueryRunner
                 planFragmenter,
                 plannerContext,
                 statementAnalyzerFactory,
+                queryTableStatsProviderFactory,
                 statsCalculator,
                 costCalculator);
     }

--- a/core/trino-main/src/test/java/io/trino/cost/StatsCalculatorAssertion.java
+++ b/core/trino-main/src/test/java/io/trino/cost/StatsCalculatorAssertion.java
@@ -87,7 +87,13 @@ public class StatsCalculatorAssertion
     {
         PlanNodeStatsEstimate statsEstimate = transaction(new TestingTransactionManager(), new AllowAllAccessControl())
                 .execute(session, transactionSession -> {
-                    return statsCalculator.calculateStats(planNode, this::getSourceStats, noLookup(), transactionSession, types, new CachingTableStatsProvider(metadata, session));
+                    return statsCalculator.calculateStats(
+                            planNode,
+                            this::getSourceStats,
+                            noLookup(),
+                            transactionSession,
+                            types,
+                            new CachingTableStatsProvider(new SimpleTableStatsProvider(metadata, session)));
                 });
         statisticsAssertionConsumer.accept(PlanNodeStatsAssertion.assertThat(statsEstimate));
         return this;
@@ -95,7 +101,14 @@ public class StatsCalculatorAssertion
 
     public StatsCalculatorAssertion check(Rule<?> rule, Consumer<PlanNodeStatsAssertion> statisticsAssertionConsumer)
     {
-        Optional<PlanNodeStatsEstimate> statsEstimate = calculatedStats(rule, planNode, this::getSourceStats, noLookup(), session, types, new CachingTableStatsProvider(metadata, session));
+        Optional<PlanNodeStatsEstimate> statsEstimate = calculatedStats(
+                rule,
+                planNode,
+                this::getSourceStats,
+                noLookup(),
+                session,
+                types,
+                new CachingTableStatsProvider(new SimpleTableStatsProvider(metadata, session)));
         checkState(statsEstimate.isPresent(), "Expected stats estimates to be present");
         statisticsAssertionConsumer.accept(PlanNodeStatsAssertion.assertThat(statsEstimate.get()));
         return this;

--- a/core/trino-main/src/test/java/io/trino/cost/TestCostCalculator.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestCostCalculator.java
@@ -585,7 +585,11 @@ public class TestCostCalculator
     {
         TypeProvider typeProvider = TypeProvider.copyOf(types.entrySet().stream()
                 .collect(toImmutableMap(entry -> new Symbol(entry.getKey()), Map.Entry::getValue)));
-        StatsProvider statsProvider = new CachingStatsProvider(statsCalculator(stats), session, typeProvider, new CachingTableStatsProvider(localQueryRunner.getMetadata(), session));
+        StatsProvider statsProvider = new CachingStatsProvider(
+                statsCalculator(stats),
+                session,
+                typeProvider,
+                new CachingTableStatsProvider(new SimpleTableStatsProvider(localQueryRunner.getMetadata(), session)));
         CostProvider costProvider = new TestingCostProvider(costs, costCalculatorUsingExchanges, statsProvider, session, typeProvider);
         SubPlan subPlan = fragment(new Plan(node, typeProvider, StatsAndCosts.create(node, statsProvider, costProvider)));
         return new CostAssertionBuilder(subPlan.getFragment().getStatsAndCosts().getCosts().getOrDefault(node.getId(), PlanCostEstimate.unknown()));
@@ -708,7 +712,11 @@ public class TestCostCalculator
     {
         TypeProvider typeProvider = TypeProvider.copyOf(types.entrySet().stream()
                 .collect(toImmutableMap(entry -> new Symbol(entry.getKey()), Map.Entry::getValue)));
-        StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, typeProvider, new CachingTableStatsProvider(localQueryRunner.getMetadata(), session));
+        StatsProvider statsProvider = new CachingStatsProvider(
+                statsCalculator,
+                session,
+                typeProvider,
+                new CachingTableStatsProvider(new SimpleTableStatsProvider(localQueryRunner.getMetadata(), session)));
         CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, Optional.empty(), session, typeProvider);
         return costProvider.getCost(node);
     }
@@ -717,7 +725,11 @@ public class TestCostCalculator
     {
         TypeProvider typeProvider = TypeProvider.copyOf(types.entrySet().stream()
                 .collect(toImmutableMap(entry -> new Symbol(entry.getKey()), Map.Entry::getValue)));
-        StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, typeProvider, new CachingTableStatsProvider(localQueryRunner.getMetadata(), session));
+        StatsProvider statsProvider = new CachingStatsProvider(
+                statsCalculator,
+                session,
+                typeProvider,
+                new CachingTableStatsProvider(new SimpleTableStatsProvider(localQueryRunner.getMetadata(), session)));
         CostProvider costProvider = new CachingCostProvider(costCalculatorUsingExchanges, statsProvider, Optional.empty(), session, typeProvider);
         SubPlan subPlan = fragment(new Plan(node, typeProvider, StatsAndCosts.create(node, statsProvider, costProvider)));
         return subPlan.getFragment().getStatsAndCosts().getCosts().getOrDefault(node.getId(), PlanCostEstimate.unknown());

--- a/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
@@ -22,6 +22,7 @@ import io.trino.sql.planner.OptimizerConfig.JoinReorderingStrategy;
 import org.testng.annotations.Test;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
@@ -53,6 +54,7 @@ public class TestOptimizerConfig
                 .setUsePreferredWritePartitioning(true)
                 .setPreferredWritePartitioningMinNumberOfPartitions(50)
                 .setEnableStatsCalculator(true)
+                .setConnectorStatsProvisioningTimeout("20s")
                 .setStatisticsPrecalculationForPushdownEnabled(true)
                 .setCollectPlanStatisticsForAllQueries(false)
                 .setIgnoreStatsCalculatorFailures(true)
@@ -100,6 +102,7 @@ public class TestOptimizerConfig
                 .put("memory-cost-weight", "0.3")
                 .put("network-cost-weight", "0.2")
                 .put("enable-stats-calculator", "false")
+                .put("connector-statistics-provisioning-timeout", "infinity")
                 .put("statistics-precalculation-for-pushdown.enabled", "false")
                 .put("collect-plan-statistics-for-all-queries", "true")
                 .put("optimizer.ignore-stats-calculator-failures", "false")
@@ -154,6 +157,7 @@ public class TestOptimizerConfig
                 .setMemoryCostWeight(0.3)
                 .setNetworkCostWeight(0.2)
                 .setEnableStatsCalculator(false)
+                .setConnectorStatsProvisioningTimeout(Optional.empty())
                 .setStatisticsPrecalculationForPushdownEnabled(false)
                 .setCollectPlanStatisticsForAllQueries(true)
                 .setIgnoreStatsCalculatorFailures(false)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanAssert.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanAssert.java
@@ -16,6 +16,7 @@ package io.trino.sql.planner.assertions;
 import io.trino.Session;
 import io.trino.cost.CachingStatsProvider;
 import io.trino.cost.CachingTableStatsProvider;
+import io.trino.cost.SimpleTableStatsProvider;
 import io.trino.cost.StatsAndCosts;
 import io.trino.cost.StatsCalculator;
 import io.trino.cost.StatsProvider;
@@ -45,7 +46,11 @@ public final class PlanAssert
 
     public static void assertPlan(Session session, Metadata metadata, FunctionManager functionManager, StatsCalculator statsCalculator, Plan actual, Lookup lookup, PlanMatchPattern pattern)
     {
-        StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, actual.getTypes(), new CachingTableStatsProvider(metadata, session));
+        StatsProvider statsProvider = new CachingStatsProvider(
+                statsCalculator,
+                session,
+                actual.getTypes(),
+                new CachingTableStatsProvider(new SimpleTableStatsProvider(metadata, session)));
         assertPlan(session, metadata, functionManager, statsProvider, actual, lookup, pattern);
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestJoinEnumerator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestJoinEnumerator.java
@@ -23,6 +23,7 @@ import io.trino.cost.CachingTableStatsProvider;
 import io.trino.cost.CostComparator;
 import io.trino.cost.CostProvider;
 import io.trino.cost.PlanCostEstimate;
+import io.trino.cost.SimpleTableStatsProvider;
 import io.trino.cost.StatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.sql.planner.PlanNodeIdAllocator;
@@ -119,7 +120,7 @@ public class TestJoinEnumerator
                 noLookup(),
                 queryRunner.getDefaultSession(),
                 symbolAllocator.getTypes(),
-                new CachingTableStatsProvider(queryRunner.getMetadata(), queryRunner.getDefaultSession()));
+                new CachingTableStatsProvider(new SimpleTableStatsProvider(queryRunner.getMetadata(), queryRunner.getDefaultSession())));
         CachingCostProvider costProvider = new CachingCostProvider(
                 queryRunner.getCostCalculator(),
                 statsProvider,

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/RuleAssert.java
@@ -21,6 +21,7 @@ import io.trino.cost.CachingTableStatsProvider;
 import io.trino.cost.CostCalculator;
 import io.trino.cost.CostProvider;
 import io.trino.cost.PlanNodeStatsEstimate;
+import io.trino.cost.SimpleTableStatsProvider;
 import io.trino.cost.StatsAndCosts;
 import io.trino.cost.StatsCalculator;
 import io.trino.cost.StatsProvider;
@@ -206,7 +207,7 @@ public class RuleAssert
     private String formatPlan(PlanNode plan, TypeProvider types)
     {
         return inTransaction(session -> {
-            StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, types, new CachingTableStatsProvider(metadata, session));
+            StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, types, new CachingTableStatsProvider(new SimpleTableStatsProvider(metadata, session)));
             CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, session, types);
             return textLogicalPlan(plan, types, metadata, functionManager, StatsAndCosts.create(plan, statsProvider, costProvider), session, 2, false);
         });
@@ -225,7 +226,13 @@ public class RuleAssert
 
     private Rule.Context ruleContext(StatsCalculator statsCalculator, CostCalculator costCalculator, SymbolAllocator symbolAllocator, Memo memo, Lookup lookup, Session session)
     {
-        StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, Optional.of(memo), lookup, session, symbolAllocator.getTypes(), new CachingTableStatsProvider(metadata, session));
+        StatsProvider statsProvider = new CachingStatsProvider(
+                statsCalculator,
+                Optional.of(memo),
+                lookup,
+                session,
+                symbolAllocator.getTypes(),
+                new CachingTableStatsProvider(new SimpleTableStatsProvider(metadata, session)));
         CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, Optional.of(memo), session, symbolAllocator.getTypes());
 
         return new Rule.Context()

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestBeginTableWrite.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestBeginTableWrite.java
@@ -16,6 +16,7 @@ package io.trino.sql.planner.optimizations;
 import com.google.common.collect.ImmutableList;
 import io.trino.Session;
 import io.trino.cost.CachingTableStatsProvider;
+import io.trino.cost.SimpleTableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.AbstractMockMetadata;
 import io.trino.metadata.Metadata;
@@ -144,7 +145,7 @@ public class TestBeginTableWrite
                         new SymbolAllocator(),
                         new PlanNodeIdAllocator(),
                         WarningCollector.NOOP,
-                        new CachingTableStatsProvider(metadata, session));
+                        new CachingTableStatsProvider(new SimpleTableStatsProvider(metadata, session)));
     }
 
     private static class MockMetadata

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.connector.CatalogHandle;
 import io.trino.cost.CachingTableStatsProvider;
+import io.trino.cost.SimpleTableStatsProvider;
 import io.trino.cost.StatsAndCosts;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
@@ -484,7 +485,7 @@ public class TestRemoveUnsupportedDynamicFilters
                     new SymbolAllocator(),
                     new PlanNodeIdAllocator(),
                     WarningCollector.NOOP,
-                    new CachingTableStatsProvider(metadata, session));
+                    new CachingTableStatsProvider(new SimpleTableStatsProvider(metadata, session)));
             new DynamicFiltersChecker().validate(rewrittenPlan,
                     session,
                     plannerContext, createTestingTypeAnalyzer(plannerContext),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestUnaliasSymbolReferences.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestUnaliasSymbolReferences.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.cost.CachingTableStatsProvider;
+import io.trino.cost.SimpleTableStatsProvider;
 import io.trino.cost.StatsAndCosts;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
@@ -133,7 +134,7 @@ public class TestUnaliasSymbolReferences
                     symbolAllocator,
                     idAllocator,
                     WarningCollector.NOOP,
-                    new CachingTableStatsProvider(metadata, session));
+                    new CachingTableStatsProvider(new SimpleTableStatsProvider(metadata, session)));
 
             Plan actual = new Plan(optimized, planBuilder.getTypes(), StatsAndCosts.empty());
             PlanAssert.assertPlan(session, queryRunner.getMetadata(), queryRunner.getFunctionManager(), queryRunner.getStatsCalculator(), actual, pattern);


### PR DESCRIPTION
Limit time taken for getting stats from a connector. Instead of e.g. failing
query plan (e.g. due to optimizer timeout), continue without stats.