### PR TITLE
Rename isMultipleWritersPerPartitionSupported to supportsMultipleWritersPerPartition

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableWriterNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableWriterNode.java
@@ -244,7 +244,7 @@ public class TableWriterNode
         @Override
         public boolean supportsMultipleWritersPerPartition(Metadata metadata, Session session)
         {
-            return layout.map(tableLayout -> tableLayout.getLayout().isMultipleWritersPerPartitionSupported()).orElse(true);
+            return layout.map(tableLayout -> tableLayout.getLayout().supportsMultipleWritersPerPartition()).orElse(true);
         }
 
         public Optional<TableLayout> getLayout()
@@ -367,7 +367,7 @@ public class TableWriterNode
         public boolean supportsMultipleWritersPerPartition(Metadata metadata, Session session)
         {
             return metadata.getInsertLayout(session, handle)
-                    .map(layout -> layout.getLayout().isMultipleWritersPerPartitionSupported())
+                    .map(layout -> layout.getLayout().supportsMultipleWritersPerPartition())
                     .orElse(true);
         }
     }
@@ -481,7 +481,7 @@ public class TableWriterNode
         public boolean supportsMultipleWritersPerPartition(Metadata metadata, Session session)
         {
             return metadata.getInsertLayout(session, storageTableHandle)
-                    .map(layout -> layout.getLayout().isMultipleWritersPerPartitionSupported())
+                    .map(layout -> layout.getLayout().supportsMultipleWritersPerPartition())
                     .orElse(true);
         }
     }
@@ -547,7 +547,7 @@ public class TableWriterNode
         public boolean supportsMultipleWritersPerPartition(Metadata metadata, Session session)
         {
             return metadata.getInsertLayout(session, tableHandle)
-                    .map(layout -> layout.getLayout().isMultipleWritersPerPartitionSupported())
+                    .map(layout -> layout.getLayout().supportsMultipleWritersPerPartition())
                     .orElse(true);
         }
     }
@@ -741,7 +741,7 @@ public class TableWriterNode
         public boolean supportsMultipleWritersPerPartition(Metadata metadata, Session session)
         {
             return metadata.getLayoutForTableExecute(session, executeHandle)
-                    .map(layout -> layout.getLayout().isMultipleWritersPerPartitionSupported())
+                    .map(layout -> layout.getLayout().supportsMultipleWritersPerPartition())
                     .orElse(true);
         }
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableLayout.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableLayout.java
@@ -59,7 +59,7 @@ public class ConnectorTableLayout
         return partitionColumns;
     }
 
-    public boolean isMultipleWritersPerPartitionSupported()
+    public boolean supportsMultipleWritersPerPartition()
     {
         return multipleWritersPerPartitionSupported;
     }


### PR DESCRIPTION
The previous name was a grammatically incorrect phrase (is vs are) and unnecessarily convoluted.

Follow up for #14956

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
