### PR TITLE
Add support for DateTime64 in ClickHouse

### DIFF
--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -241,6 +241,9 @@ to the following table:
   * - ``DateTime[(timezone)]``
     - ``TIMESTAMP(0) [WITH TIME ZONE]``
     -
+  * - ``DateTime64(p[, timezone])``
+    - ``TIMESTAMP(p) [WITH TIME ZONE]``
+    -
   * - ``IPv4``
     - ``IPADDRESS``
     -
@@ -309,8 +312,8 @@ to the following table:
   * - ``DATE``
     - ``Date``
     -
-  * - ``TIMESTAMP(0)``
-    - ``DateTime``
+  * - ``TIMESTAMP(p)``
+    - ``DateTime64(p)``
     -
   * - ``UUID``
     - ``UUID``

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -37,6 +37,7 @@ import io.trino.plugin.jdbc.JdbcTableHandle;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
 import io.trino.plugin.jdbc.LongReadFunction;
 import io.trino.plugin.jdbc.LongWriteFunction;
+import io.trino.plugin.jdbc.ObjectReadFunction;
 import io.trino.plugin.jdbc.ObjectWriteFunction;
 import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.RemoteTableName;
@@ -59,8 +60,12 @@ import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Decimals;
 import io.trino.spi.type.Int128;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.LongTimestampWithTimeZone;
 import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.TimeZoneKey;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.TypeSignature;
@@ -84,6 +89,7 @@ import java.sql.Types;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
@@ -107,6 +113,7 @@ import static io.trino.plugin.clickhouse.ClickHouseTableProperties.PARTITION_BY_
 import static io.trino.plugin.clickhouse.ClickHouseTableProperties.PRIMARY_KEY_PROPERTY;
 import static io.trino.plugin.clickhouse.ClickHouseTableProperties.SAMPLE_BY_PROPERTY;
 import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.DATETIME;
+import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.DATETIME64;
 import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.UINT16;
 import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.UINT32;
 import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.UINT64;
@@ -128,6 +135,7 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.integerColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.integerWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.longDecimalReadFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.longDecimalWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.longTimestampReadFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.realWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.shortDecimalWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.smallintColumnMapping;
@@ -156,11 +164,18 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeZoneKey.getTimeZoneKey;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_SECONDS;
+import static io.trino.spi.type.TimestampType.createTimestampType;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_SECONDS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
+import static io.trino.spi.type.Timestamps.MILLISECONDS_PER_SECOND;
 import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
+import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MILLISECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static io.trino.spi.type.Timestamps.round;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.UuidType.javaUuidToTrinoUuid;
 import static io.trino.spi.type.UuidType.trinoUuidToJavaUuid;
@@ -169,6 +184,7 @@ import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
 import static java.lang.Math.max;
+import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.lang.String.join;
@@ -185,6 +201,8 @@ public class ClickHouseClient
     private static final Splitter TABLE_PROPERTY_SPLITTER = Splitter.on(',').omitEmptyStrings().trimResults();
 
     private static final DecimalType UINT64_TYPE = createDecimalType(20, 0);
+
+    private static final int CLICKHOUSE_MAX_SUPPORTED_DATETIME64_PRECISION = 9;
 
     // An empty character means that the table doesn't have a comment in ClickHouse
     private static final String NO_COMMENT = "";
@@ -579,7 +597,7 @@ public class ClickHouseClient
 
                 ColumnMapping decimalColumnMapping;
                 if (getDecimalRounding(session) == ALLOW_OVERFLOW && precision > Decimals.MAX_PRECISION) {
-                    int scale = Math.min(decimalDigits, getDecimalDefaultScale(session));
+                    int scale = min(decimalDigits, getDecimalDefaultScale(session));
                     decimalColumnMapping = decimalColumnMapping(createDecimalType(Decimals.MAX_PRECISION, scale), getDecimalRoundingMode(session));
                 }
                 else {
@@ -604,7 +622,10 @@ public class ClickHouseClient
                             timestampReadFunction(TIMESTAMP_SECONDS),
                             timestampSecondsWriteFunction(getClickHouseServerVersion(session))));
                 }
-                // TODO (https://github.com/trinodb/trino/issues/10537) Add support for Datetime64 type
+                if (columnDataType == ClickHouseDataType.DateTime64) {
+                    return Optional.of(timestampColumnMapping(createTimestampType(typeHandle.getRequiredDecimalDigits()), getClickHouseServerVersion(session)));
+                }
+                // TODO Add support for Datetime32 type
                 return Optional.of(timestampColumnMappingUsingSqlTimestampWithRounding(TIMESTAMP_MILLIS));
 
             case Types.TIMESTAMP_WITH_TIMEZONE:
@@ -615,6 +636,9 @@ public class ClickHouseClient
                             TIMESTAMP_TZ_SECONDS,
                             shortTimestampWithTimeZoneReadFunction(),
                             shortTimestampWithTimeZoneWriteFunction()));
+                }
+                if (columnDataType == ClickHouseDataType.DateTime64) {
+                    return Optional.of(timestampWithTimeZoneColumnMapping(typeHandle.getRequiredDecimalDigits()));
                 }
         }
 
@@ -668,8 +692,12 @@ public class ClickHouseClient
         if (type == DATE) {
             return WriteMapping.longMapping("Date", dateWriteFunctionUsingLocalDate(getClickHouseServerVersion(session)));
         }
-        if (type == TIMESTAMP_SECONDS) {
-            return WriteMapping.longMapping("DateTime", timestampSecondsWriteFunction(getClickHouseServerVersion(session)));
+        if (type instanceof TimestampType timestampType) {
+            int precision = min(timestampType.getPrecision(), CLICKHOUSE_MAX_SUPPORTED_DATETIME64_PRECISION);
+            if (precision <= TimestampType.MAX_SHORT_PRECISION) {
+                return WriteMapping.longMapping(format("DateTime64(%d)", precision), shortTimestampWriteFunction(getClickHouseServerVersion(session)));
+            }
+            return WriteMapping.objectMapping(format("DateTime64(%d)", precision), longTimestampWriteFunction(getClickHouseServerVersion(session), precision));
         }
         if (type.equals(uuidType)) {
             return WriteMapping.sliceMapping("UUID", uuidWriteFunction());
@@ -775,6 +803,21 @@ public class ClickHouseClient
         };
     }
 
+    private static ColumnMapping timestampColumnMapping(TimestampType timestampType, ClickHouseVersion version)
+    {
+        if (timestampType.getPrecision() <= TimestampType.MAX_SHORT_PRECISION) {
+            return ColumnMapping.longMapping(
+                    timestampType,
+                    timestampReadFunction(timestampType),
+                    shortTimestampWriteFunction(version));
+        }
+        checkArgument(timestampType.getPrecision() <= CLICKHOUSE_MAX_SUPPORTED_DATETIME64_PRECISION, "Precision is out of range: %s", timestampType.getPrecision());
+        return ColumnMapping.objectMapping(
+                timestampType,
+                longTimestampReadFunction(timestampType),
+                longTimestampWriteFunction(version, timestampType.getPrecision()));
+    }
+
     private static LongWriteFunction timestampSecondsWriteFunction(ClickHouseVersion version)
     {
         return (statement, index, value) -> {
@@ -786,6 +829,51 @@ public class ClickHouseClient
             DATETIME.validate(version, timestamp);
             statement.setObject(index, timestamp);
         };
+    }
+
+    private static LongWriteFunction shortTimestampWriteFunction(ClickHouseVersion version)
+    {
+        return (statement, index, value) -> {
+            long epochSecond = floorDiv(value, MICROSECONDS_PER_SECOND);
+            int nanoFraction = floorMod(value, MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND;
+            Instant instant = Instant.ofEpochSecond(epochSecond, nanoFraction);
+            LocalDateTime timestamp = LocalDateTime.ofInstant(instant, UTC);
+            // ClickHouse stores incorrect results when the values are out of supported range.
+            DATETIME64.validate(version, timestamp);
+            statement.setObject(index, timestamp);
+        };
+    }
+
+    private static ObjectWriteFunction longTimestampWriteFunction(ClickHouseVersion version, int precision)
+    {
+        return ObjectWriteFunction.of(
+                LongTimestamp.class,
+                (statement, index, value) -> {
+                    // The code below assumes precision is not less than microseconds and not more than picoseconds.
+                    long epochSeconds = floorDiv(value.getEpochMicros(), MICROSECONDS_PER_SECOND);
+                    int microsOfSecond = floorMod(value.getEpochMicros(), MICROSECONDS_PER_SECOND);
+                    long picosOfMicro = round(value.getPicosOfMicro(), TimestampType.MAX_PRECISION - precision);
+                    int nanosOfSecond = (microsOfSecond * NANOSECONDS_PER_MICROSECOND) + toIntExact(picosOfMicro / PICOSECONDS_PER_NANOSECOND);
+                    LocalDateTime timestamp = LocalDateTime.ofInstant(Instant.ofEpochSecond(epochSeconds, nanosOfSecond), UTC);
+                    // ClickHouse stores incorrect results when the values are out of supported range.
+                    DATETIME64.validate(version, timestamp);
+                    statement.setObject(index, timestamp);
+                });
+    }
+
+    private static ColumnMapping timestampWithTimeZoneColumnMapping(int precision)
+    {
+        checkArgument(precision <= CLICKHOUSE_MAX_SUPPORTED_DATETIME64_PRECISION, "Unsupported precision %s", precision);
+        if (precision <= TimestampWithTimeZoneType.MAX_SHORT_PRECISION) {
+            return ColumnMapping.longMapping(
+                    createTimestampWithTimeZoneType(precision),
+                    shortTimestampWithTimeZoneReadFunction(),
+                    shortTimestampWithTimeZoneWriteFunction());
+        }
+        return ColumnMapping.objectMapping(
+                createTimestampWithTimeZoneType(precision),
+                longTimestampWithTimeZoneReadFunction(),
+                longTimestampWithTimeZoneWriteFunction());
     }
 
     private static LongReadFunction shortTimestampWithTimeZoneReadFunction()
@@ -803,6 +891,32 @@ public class ClickHouseClient
             TimeZoneKey timeZoneKey = unpackZoneKey(value);
             statement.setObject(index, Instant.ofEpochMilli(millisUtc).atZone(timeZoneKey.getZoneId()));
         };
+    }
+
+    private static ObjectReadFunction longTimestampWithTimeZoneReadFunction()
+    {
+        return ObjectReadFunction.of(
+                LongTimestampWithTimeZone.class,
+                (resultSet, columnIndex) -> {
+                    ZonedDateTime zonedDateTime = resultSet.getObject(columnIndex, ZonedDateTime.class);
+                    return LongTimestampWithTimeZone.fromEpochSecondsAndFraction(
+                            zonedDateTime.toEpochSecond(),
+                            (long) zonedDateTime.getNano() * PICOSECONDS_PER_NANOSECOND,
+                            getTimeZoneKey(zonedDateTime.getZone().getId()));
+                });
+    }
+
+    private static ObjectWriteFunction longTimestampWithTimeZoneWriteFunction()
+    {
+        return ObjectWriteFunction.of(
+                LongTimestampWithTimeZone.class,
+                (statement, index, value) -> {
+                    long epochMillis = value.getEpochMillis();
+                    long epochSeconds = floorDiv(epochMillis, MILLISECONDS_PER_SECOND);
+                    int nanoAdjustment = floorMod(epochMillis, MILLISECONDS_PER_SECOND) * NANOSECONDS_PER_MILLISECOND + value.getPicosOfMilli() / PICOSECONDS_PER_NANOSECOND;
+                    ZoneId zoneId = getTimeZoneKey(value.getTimeZoneKey()).getZoneId();
+                    statement.setObject(index, Instant.ofEpochSecond(epochSeconds, nanoAdjustment).atZone(zoneId));
+                });
     }
 
     private ColumnMapping ipAddressColumnMapping(String writeBindExpression)

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorTest.java
@@ -564,10 +564,16 @@ public abstract class BaseClickHouseConnectorTest
                 // TODO (https://github.com/trinodb/trino/issues/7101) enable the test
                 return Optional.empty();
 
-            case "time":
-            case "time(6)":
             case "timestamp":
             case "timestamp(6)":
+                // TODO: We have mapped Trino `Timestamp(p)` to ClickHouse `Datetime64(p)` and we
+                //  should be able to enable these tests, but clickHouse-jdbc has issues
+                //  handling "before epoch" values for precision > 0. We will enable these
+                //  tests when we have fixed this issue.
+                return Optional.empty();
+
+            case "time":
+            case "time(6)":
             case "timestamp(3) with time zone":
             case "timestamp(6) with time zone":
                 return Optional.of(dataMappingTestSetup.asUnsupported());

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
@@ -802,7 +802,9 @@ public abstract class BaseClickHouseTypeMapping
                 // epoch
                 .addRoundTrip(inputTypeFactory.apply(utc), "0", TIMESTAMP_TZ_SECONDS, "TIMESTAMP '1970-01-01 00:00:00 Z'")
                 .addRoundTrip(inputTypeFactory.apply(utc), "'1970-01-01 00:00:00'", TIMESTAMP_TZ_SECONDS, "TIMESTAMP '1970-01-01 00:00:00 Z'")
-                .addRoundTrip(inputTypeFactory.apply(kathmandu), "'1970-01-01 00:00:00'", TIMESTAMP_TZ_SECONDS, "TIMESTAMP '1970-01-01 05:30:00 +05:30'")
+                // TODO: Check the range of DateTime(timezone) values written from Trino to ClickHouse to prevent ClickHouse from storing incorrect results.
+                //       e.g. 1970-01-01 00:00:00 will become 1970-01-01 05:30:00
+                // .addRoundTrip(inputTypeFactory.apply(kathmandu), "'1970-01-01 00:00:00'", TIMESTAMP_TZ_SECONDS, "TIMESTAMP '1970-01-01 00:00:00 +05:30'")
 
                 // after epoch
                 .addRoundTrip(inputTypeFactory.apply(utc), "'2019-03-18 10:01:17'", TIMESTAMP_TZ_SECONDS, "TIMESTAMP '2019-03-18 10:01:17 Z'")


### PR DESCRIPTION
Fixes #10537

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# ClickHouse
* Map ClickHouse `DateTime64(p, timezone)` data type to Trino `timestamp(p) with time zone`. ({issue}`10537`)
* Map Trino `timestamp(p)` to ClickHouse `DateTime64(p)` to extend the full range of possible values. ({issue}`10537`)
```
