### PR TITLE
Rename config properties in Google Sheets

### DIFF
--- a/docs/src/main/sphinx/connector/googlesheets.rst
+++ b/docs/src/main/sphinx/connector/googlesheets.rst
@@ -18,8 +18,8 @@ replacing the properties as appropriate:
 .. code-block:: text
 
     connector.name=gsheets
-    credentials-path=/path/to/google-sheets-credentials.json
-    metadata-sheet-id=exampleId
+    gsheets.credentials-path=/path/to/google-sheets-credentials.json
+    gsheets.metadata-sheet-id=exampleId
 
 Configuration properties
 ------------------------
@@ -29,10 +29,10 @@ The following configuration properties are available:
 =================================== =====================================================================
 Property name                       Description
 =================================== =====================================================================
-``credentials-path``                Path to the Google API JSON key file
-``metadata-sheet-id``               Sheet ID of the spreadsheet, that contains the table mapping
-``sheets-data-max-cache-size``      Maximum number of spreadsheets to cache, defaults to ``1000``
-``sheets-data-expire-after-write``  How long to cache spreadsheet data or metadata, defaults to ``5m``
+``gsheets.credentials-path``        Path to the Google API JSON key file
+``gsheets.metadata-sheet-id``       Sheet ID of the spreadsheet, that contains the table mapping
+``gsheets.max-data-cache-size``     Maximum number of spreadsheets to cache, defaults to ``1000``
+``gsheets.data-cache-ttl``          How long to cache spreadsheet data or metadata, defaults to ``5m``
 =================================== =====================================================================
 
 Credentials
@@ -52,7 +52,7 @@ The connector requires credentials in order to access the Google Sheets API.
    On the *Create key* step, create and download a key in JSON format.
 
 The key file needs to be available on the Trino coordinator and workers.
-Set the ``credentials-path`` configuration property to point to this file.
+Set the ``gsheets.credentials-path`` configuration property to point to this file.
 The exact name of the file does not matter -- it can be named anything.
 
 Metadata sheet
@@ -74,7 +74,7 @@ The metadata sheet must be shared with the service account user,
 the one for which the key credentials file was created. Click the *Share*
 button to share the sheet with the email address of the service account.
 
-Set the ``metadata-sheet-id`` configuration property to the ID of this sheet.
+Set the ``gsheets.metadata-sheet-id`` configuration property to the ID of this sheet.
 
 Querying sheets
 ---------------

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsConfig.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsConfig.java
@@ -15,6 +15,7 @@ package io.trino.plugin.google.sheets;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.LegacyConfig;
 import io.airlift.configuration.validation.FileExists;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
@@ -38,7 +39,8 @@ public class SheetsConfig
         return credentialsFilePath;
     }
 
-    @Config("credentials-path")
+    @Config("gsheets.credentials-path")
+    @LegacyConfig("credentials-path")
     @ConfigDescription("Credential file path to google service account")
     public SheetsConfig setCredentialsFilePath(String credentialsFilePath)
     {
@@ -52,7 +54,8 @@ public class SheetsConfig
         return metadataSheetId;
     }
 
-    @Config("metadata-sheet-id")
+    @Config("gsheets.metadata-sheet-id")
+    @LegacyConfig("metadata-sheet-id")
     @ConfigDescription("Metadata sheet id containing table sheet mapping")
     public SheetsConfig setMetadataSheetId(String metadataSheetId)
     {
@@ -66,7 +69,8 @@ public class SheetsConfig
         return sheetsDataMaxCacheSize;
     }
 
-    @Config("sheets-data-max-cache-size")
+    @Config("gsheets.max-data-cache-size")
+    @LegacyConfig("sheets-data-max-cache-size")
     @ConfigDescription("Sheet data max cache size")
     public SheetsConfig setSheetsDataMaxCacheSize(int sheetsDataMaxCacheSize)
     {
@@ -80,7 +84,8 @@ public class SheetsConfig
         return sheetsDataExpireAfterWrite;
     }
 
-    @Config("sheets-data-expire-after-write")
+    @Config("gsheets.data-cache-ttl")
+    @LegacyConfig("sheets-data-expire-after-write")
     @ConfigDescription("Sheets data expire after write duration")
     public SheetsConfig setSheetsDataExpireAfterWrite(Duration sheetsDataExpireAfterWriteMinutes)
     {

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/SheetsQueryRunner.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/SheetsQueryRunner.java
@@ -44,10 +44,10 @@ public class SheetsQueryRunner
         try {
             // note: additional copy via ImmutableList so that if fails on nulls
             connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));
-            connectorProperties.putIfAbsent("credentials-path", getTestCredentialsPath());
-            connectorProperties.putIfAbsent("metadata-sheet-id", TEST_METADATA_SHEET_ID);
-            connectorProperties.putIfAbsent("sheets-data-max-cache-size", "1000");
-            connectorProperties.putIfAbsent("sheets-data-expire-after-write", "5m");
+            connectorProperties.putIfAbsent("gsheets.credentials-path", getTestCredentialsPath());
+            connectorProperties.putIfAbsent("gsheets.metadata-sheet-id", TEST_METADATA_SHEET_ID);
+            connectorProperties.putIfAbsent("gsheets.max-data-cache-size", "1000");
+            connectorProperties.putIfAbsent("gsheets.data-cache-ttl", "5m");
 
             queryRunner.installPlugin(new SheetsPlugin());
             queryRunner.createCatalog(GOOGLE_SHEETS, GOOGLE_SHEETS, connectorProperties);

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestSheetsConfig.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestSheetsConfig.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static io.airlift.configuration.testing.ConfigAssertions.assertDeprecatedEquivalence;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
@@ -46,10 +47,10 @@ public class TestSheetsConfig
         Path credentialsFile = Files.createTempFile(null, null);
 
         Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("credentials-path", credentialsFile.toString())
-                .put("metadata-sheet-id", "foo_bar_sheet_id#Sheet1")
-                .put("sheets-data-max-cache-size", "2000")
-                .put("sheets-data-expire-after-write", "10m")
+                .put("gsheets.credentials-path", credentialsFile.toString())
+                .put("gsheets.metadata-sheet-id", "foo_bar_sheet_id#Sheet1")
+                .put("gsheets.max-data-cache-size", "2000")
+                .put("gsheets.data-cache-ttl", "10m")
                 .buildOrThrow();
 
         SheetsConfig expected = new SheetsConfig()
@@ -59,5 +60,28 @@ public class TestSheetsConfig
                 .setSheetsDataExpireAfterWrite(new Duration(10, TimeUnit.MINUTES));
 
         assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testLegacyPropertyMappings()
+            throws IOException
+    {
+        Path credentialsFile = Files.createTempFile(null, null);
+
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("gsheets.credentials-path", credentialsFile.toString())
+                .put("gsheets.metadata-sheet-id", "foo_bar_sheet_id#Sheet1")
+                .put("gsheets.max-data-cache-size", "2000")
+                .put("gsheets.data-cache-ttl", "10m")
+                .buildOrThrow();
+
+        Map<String, String> oldProperties = ImmutableMap.<String, String>builder()
+                .put("credentials-path", credentialsFile.toString())
+                .put("metadata-sheet-id", "foo_bar_sheet_id#Sheet1")
+                .put("sheets-data-max-cache-size", "2000")
+                .put("sheets-data-expire-after-write", "10m")
+                .buildOrThrow();
+
+        assertDeprecatedEquivalence(SheetsConfig.class, properties, oldProperties);
     }
 }

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestSheetsPlugin.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestSheetsPlugin.java
@@ -52,7 +52,7 @@ public class TestSheetsPlugin
     {
         Plugin plugin = new SheetsPlugin();
         ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
-        ImmutableMap.Builder<String, String> propertiesMap = ImmutableMap.<String, String>builder().put("credentials-path", getTestCredentialsPath()).put("metadata-sheet-id", TEST_METADATA_SHEET_ID);
+        ImmutableMap.Builder<String, String> propertiesMap = ImmutableMap.<String, String>builder().put("gsheets.credentials-path", getTestCredentialsPath()).put("gsheets.metadata-sheet-id", TEST_METADATA_SHEET_ID);
         Connector connector = factory.create(GOOGLE_SHEETS, propertiesMap.buildOrThrow(), new TestingConnectorContext());
         assertNotNull(connector);
         connector.shutdown();


### PR DESCRIPTION
## Description

Rename config properties in Google Sheets

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Google Sheets
* Rename config properties from `credentials-path` to `gsheets.credentials-path`, 
  from `metadata-sheet-id` to `gsheets.metadata-sheet-id`, 
  from `sheets-data-max-cache-size` to `gsheets.max-data-cache-size` and 
  from `sheets-data-expire-after-write` to `gsheets.data-cache-ttl`. ({issue}`15042`)
```
