### PR TITLE
Hive - with schema builder(copy constructor)

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplit.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplit.java
@@ -131,6 +131,33 @@ public class HiveSplit
         this.splitWeight = requireNonNull(splitWeight, "splitWeight is null");
     }
 
+    public HiveSplit withSchema(Properties schema)
+    {
+        return new HiveSplit(
+                database,
+                table,
+                partitionName,
+                path,
+                start,
+                length,
+                estimatedFileSize,
+                fileModifiedTime,
+                schema,
+                partitionKeys,
+                addresses,
+                readBucketNumber,
+                tableBucketNumber,
+                statementId,
+                forceLocalScheduling,
+                tableToPartitionMapping,
+                bucketConversion,
+                bucketValidation,
+                s3SelectPushdownEnabled,
+                acidInfo,
+                splitNumber,
+                splitWeight);
+    }
+
     @JsonProperty
     public String getDatabase()
     {


### PR DESCRIPTION
with schema builder(copy constructor). 
in some scenarios we want to pass a slimmer schema to reduce data transfer over the network.
for example a table with thousands of columns has a huge impact on network.