### PR TITLE
Call semanticException method as a format method in several places

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
@@ -79,7 +79,6 @@ import static io.trino.sql.analyzer.TypeSignatureTranslator.toTypeSignature;
 import static io.trino.sql.tree.LikeClause.PropertiesOption.EXCLUDING;
 import static io.trino.sql.tree.LikeClause.PropertiesOption.INCLUDING;
 import static io.trino.type.UnknownType.UNKNOWN;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class CreateTableTask
@@ -201,11 +200,18 @@ public class CreateTableTask
                 LikeClause.PropertiesOption propertiesOption = likeClause.getPropertiesOption().orElse(EXCLUDING);
                 QualifiedObjectName likeTableName = redirection.getRedirectedTableName().orElse(originalLikeTableName);
                 if (propertiesOption == INCLUDING && !catalogName.equals(likeTableName.getCatalogName())) {
-                    String message = "CREATE TABLE LIKE table INCLUDING PROPERTIES across catalogs is not supported";
                     if (!originalLikeTableName.equals(likeTableName)) {
-                        message += format(". LIKE table '%s' redirected to '%s'.", originalLikeTableName, likeTableName);
+                        throw semanticException(
+                                NOT_SUPPORTED,
+                                statement,
+                                "CREATE TABLE LIKE table INCLUDING PROPERTIES across catalogs is not supported. LIKE table '%s' redirected to '%s'.",
+                                originalLikeTableName,
+                                likeTableName);
                     }
-                    throw semanticException(NOT_SUPPORTED, statement, message);
+                    throw semanticException(
+                            NOT_SUPPORTED,
+                            statement,
+                            "CREATE TABLE LIKE table INCLUDING PROPERTIES across catalogs is not supported");
                 }
 
                 TableMetadata likeTableMetadata = plannerContext.getMetadata().getTableMetadata(session, likeTable);

--- a/core/trino-main/src/main/java/io/trino/execution/SetPropertiesTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetPropertiesTask.java
@@ -40,7 +40,6 @@ import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static io.trino.sql.tree.SetProperties.Type.MATERIALIZED_VIEW;
 import static io.trino.sql.tree.SetProperties.Type.TABLE;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class SetPropertiesTask
@@ -132,14 +131,17 @@ public class SetPropertiesTask
             Map<String, Optional<Object>> properties)
     {
         if (plannerContext.getMetadata().getMaterializedView(session, materializedViewName).isEmpty()) {
-            String exceptionMessage = format("Materialized View '%s' does not exist", materializedViewName);
+            String additionalInformation;
             if (plannerContext.getMetadata().getView(session, materializedViewName).isPresent()) {
-                exceptionMessage += ", but a view with that name exists.";
+                additionalInformation = ", but a view with that name exists.";
             }
             else if (plannerContext.getMetadata().getTableHandle(session, materializedViewName).isPresent()) {
-                exceptionMessage += ", but a table with that name exists. Did you mean ALTER TABLE " + materializedViewName + " SET PROPERTIES ...?";
+                additionalInformation = ", but a table with that name exists. Did you mean ALTER TABLE " + materializedViewName + " SET PROPERTIES ...?";
             }
-            throw semanticException(TABLE_NOT_FOUND, statement, exceptionMessage);
+            else {
+                additionalInformation = "";
+            }
+            throw semanticException(TABLE_NOT_FOUND, statement, "Materialized View '%s' does not exist%s", materializedViewName, additionalInformation);
         }
         accessControl.checkCanSetMaterializedViewProperties(session.toSecurityContext(), materializedViewName, properties);
         plannerContext.getMetadata().setMaterializedViewProperties(session, materializedViewName, properties);

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/Listeners.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/Listeners.java
@@ -24,7 +24,7 @@ final class Listeners
     /**
      * Print error to standard error and exit JVM.
      *
-     * @apiNote A TestNG listener cannot throw an exception, as this are not currently properly handlded by TestNG.
+     * @apiNote A TestNG listener cannot throw an exception, as this are not currently properly handled by TestNG.
      */
     public static void reportListenerFailure(Class<? extends ITestNGListener> listenerClass, String format, Object... args)
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The `semanticException` factory method is a format method - it takes a format string and format arguments - so it shoule be called as one. A future PR will enforce that using Error Prone, this PR collects fixes for the less trivial cases that need to be converted.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Better code quality.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
