### PR TITLE
Fix set-milestone failure when latest milestone is closed

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -48,7 +48,7 @@ jobs:
             } = process.env
 
             // Find milestone
-            const response = await github.rest.issues.listMilestones(context.repo)
+            const response = await github.rest.issues.listMilestones(context.repo, state: 'all')
             let milestone = response.data.find(milestoneResponse => milestoneResponse.title === MILESTONE_NUMBER)
 
             // Create new milestone if it doesn't exist


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

There can be situation where the latest milestone is closed but there are still some PRs for which this workflow is pending. The  API by default only lists open milestones. This commit changes it to list all milestones so that even if the target milestone is closed it can be found and the PR added to it.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Fix occasional set-milestone failure.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.