### PR TITLE
Improve client JSON value adapters

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/Row.java
+++ b/client/trino-client/src/main/java/io/trino/client/Row.java
@@ -106,8 +106,9 @@ public final class Row
             return addField(Optional.empty(), value);
         }
 
-        private Builder addField(Optional<String> name, @Nullable Object value)
+        public Builder addField(Optional<String> name, @Nullable Object value)
         {
+            requireNonNull(name, "name is null");
             fields.add(new RowField(size++, name, value));
             return this;
         }


### PR DESCRIPTION
Avoids a per-data cell switch over client type signatures when fixing query result data by converting the type specific behaviors into an interface instead.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Avoids a per-data cell switch over client type signatures when adapting query result data from JSON based on client type signature.

Also includes minor efficiency improvements to `Row` construction by sharing the same `Optional<String>` field name instance across all rows instead of constructing a per-row `Optional` wrapping.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
No non-technical explanation should be necessary as this is an internal implementation detail for client value decoding.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

