### PR TITLE
Fault tolerant execution for Mongo connector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,6 +396,7 @@ jobs:
             - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-hive-2 }
             - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-iceberg }
             - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-postgresql }
+            - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-mongodb }
             - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-mysql }
             - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-sqlserver }
             - { modules: testing/trino-tests }

--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
@@ -52,6 +52,7 @@ depending on the desired :ref:`retry policy <fte-retry-policy>`.
     * :doc:`/connector/delta-lake`
     * :doc:`/connector/hive`
     * :doc:`/connector/iceberg`
+    * :doc:`/connector/mongodb`
     * :doc:`/connector/mysql`
     * :doc:`/connector/postgresql`
     * :doc:`/connector/sqlserver`

--- a/docs/src/main/sphinx/connector/mongodb.rst
+++ b/docs/src/main/sphinx/connector/mongodb.rst
@@ -14,7 +14,7 @@ Requirements
 
 To connect to MongoDB, you need:
 
-* MongoDB 4.0 or higher.
+* MongoDB 4.2 or higher.
 * Network access from the Trino coordinator and workers to MongoDB.
   Port 27017 is the default port.
 * Write access to the :ref:`schema information collection <table-definition-label>`

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoInsertTableHandle.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoInsertTableHandle.java
@@ -19,7 +19,9 @@ import com.google.common.collect.ImmutableList;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
 
 import java.util.List;
+import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class MongoInsertTableHandle
@@ -27,14 +29,22 @@ public class MongoInsertTableHandle
 {
     private final RemoteTableName remoteTableName;
     private final List<MongoColumnHandle> columns;
+    private final Optional<String> temporaryTableName;
+    private final Optional<String> pageSinkIdColumnName;
 
     @JsonCreator
     public MongoInsertTableHandle(
             @JsonProperty("remoteTableName") RemoteTableName remoteTableName,
-            @JsonProperty("columns") List<MongoColumnHandle> columns)
+            @JsonProperty("columns") List<MongoColumnHandle> columns,
+            @JsonProperty("temporaryTableName") Optional<String> temporaryTableName,
+            @JsonProperty("pageSinkIdColumnName") Optional<String> pageSinkIdColumnName)
     {
         this.remoteTableName = requireNonNull(remoteTableName, "remoteTableName is null");
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
+        this.temporaryTableName = requireNonNull(temporaryTableName, "temporaryTableName is null");
+        this.pageSinkIdColumnName = requireNonNull(pageSinkIdColumnName, "pageSinkIdColumnName is null");
+        checkArgument(temporaryTableName.isPresent() == pageSinkIdColumnName.isPresent(),
+                "temporaryTableName.isPresent is not equal to pageSinkIdColumnName.isPresent");
     }
 
     @JsonProperty
@@ -47,5 +57,22 @@ public class MongoInsertTableHandle
     public List<MongoColumnHandle> getColumns()
     {
         return columns;
+    }
+
+    @JsonProperty
+    public Optional<String> getTemporaryTableName()
+    {
+        return temporaryTableName;
+    }
+
+    public Optional<RemoteTableName> getTemporaryRemoteTableName()
+    {
+        return temporaryTableName.map(tableName -> new RemoteTableName(remoteTableName.getDatabaseName(), tableName));
+    }
+
+    @JsonProperty
+    public Optional<String> getPageSinkIdColumnName()
+    {
+        return pageSinkIdColumnName;
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoOutputTableHandle.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoOutputTableHandle.java
@@ -19,7 +19,9 @@ import com.google.common.collect.ImmutableList;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
 
 import java.util.List;
+import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class MongoOutputTableHandle
@@ -27,14 +29,22 @@ public class MongoOutputTableHandle
 {
     private final RemoteTableName remoteTableName;
     private final List<MongoColumnHandle> columns;
+    private final Optional<String> temporaryTableName;
+    private final Optional<String> pageSinkIdColumnName;
 
     @JsonCreator
     public MongoOutputTableHandle(
             @JsonProperty("remoteTableName") RemoteTableName remoteTableName,
-            @JsonProperty("columns") List<MongoColumnHandle> columns)
+            @JsonProperty("columns") List<MongoColumnHandle> columns,
+            @JsonProperty("temporaryTableName") Optional<String> temporaryTableName,
+            @JsonProperty("pageSinkIdColumnName") Optional<String> pageSinkIdColumnName)
     {
         this.remoteTableName = requireNonNull(remoteTableName, "remoteTableName is null");
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
+        this.temporaryTableName = requireNonNull(temporaryTableName, "temporaryTableName is null");
+        this.pageSinkIdColumnName = requireNonNull(pageSinkIdColumnName, "pageSinkIdColumnName is null");
+        checkArgument(temporaryTableName.isPresent() == pageSinkIdColumnName.isPresent(),
+                "temporaryTableName.isPresent is not equal to pageSinkIdColumnName.isPresent");
     }
 
     @JsonProperty
@@ -47,5 +57,22 @@ public class MongoOutputTableHandle
     public List<MongoColumnHandle> getColumns()
     {
         return columns;
+    }
+
+    @JsonProperty
+    public Optional<String> getTemporaryTableName()
+    {
+        return temporaryTableName;
+    }
+
+    public Optional<RemoteTableName> getTemporaryRemoteTableName()
+    {
+        return temporaryTableName.map(tableName -> new RemoteTableName(remoteTableName.getDatabaseName(), tableName));
+    }
+
+    @JsonProperty
+    public Optional<String> getPageSinkIdColumnName()
+    {
+        return pageSinkIdColumnName;
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSinkProvider.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSinkProvider.java
@@ -40,13 +40,13 @@ public class MongoPageSinkProvider
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle, ConnectorPageSinkId pageSinkId)
     {
         MongoOutputTableHandle handle = (MongoOutputTableHandle) outputTableHandle;
-        return new MongoPageSink(config, mongoSession, handle.getRemoteTableName(), handle.getColumns());
+        return new MongoPageSink(config, mongoSession, handle.getTemporaryRemoteTableName().orElseGet(handle::getRemoteTableName), handle.getColumns(), handle.getPageSinkIdColumnName(), pageSinkId);
     }
 
     @Override
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle, ConnectorPageSinkId pageSinkId)
     {
         MongoInsertTableHandle handle = (MongoInsertTableHandle) insertTableHandle;
-        return new MongoPageSink(config, mongoSession, handle.getRemoteTableName(), handle.getColumns());
+        return new MongoPageSink(config, mongoSession, handle.getTemporaryRemoteTableName().orElseGet(handle::getRemoteTableName), handle.getColumns(), handle.getPageSinkIdColumnName(), pageSinkId);
     }
 }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
@@ -21,9 +21,12 @@ import io.airlift.log.Logger;
 import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
@@ -45,21 +48,35 @@ public final class MongoQueryRunner
     public static DistributedQueryRunner createMongoQueryRunner(MongoServer server, Map<String, String> extraProperties, Iterable<TpchTable<?>> tables)
             throws Exception
     {
+        return createMongoQueryRunner(server, extraProperties, ImmutableMap.of(), ImmutableMap.of(), tables, runner -> {});
+    }
+
+    public static DistributedQueryRunner createMongoQueryRunner(
+            MongoServer server,
+            Map<String, String> extraProperties,
+            Map<String, String> coordinatorProperties,
+            Map<String, String> connectorProperties,
+            Iterable<TpchTable<?>> tables,
+            Consumer<QueryRunner> moreSetup)
+            throws Exception
+    {
         DistributedQueryRunner queryRunner = null;
         try {
             queryRunner = DistributedQueryRunner.builder(createSession())
                     .setExtraProperties(extraProperties)
+                    .setCoordinatorProperties(coordinatorProperties)
+                    .setAdditionalSetup(moreSetup)
                     .build();
 
             queryRunner.installPlugin(new TpchPlugin());
             queryRunner.createCatalog("tpch", "tpch");
 
-            Map<String, String> properties = ImmutableMap.of(
-                    "mongodb.case-insensitive-name-matching", "true",
-                    "mongodb.connection-url", server.getConnectionString().toString());
+            connectorProperties = new HashMap(ImmutableMap.copyOf(connectorProperties));
+            connectorProperties.putIfAbsent("mongodb.case-insensitive-name-matching", "true");
+            connectorProperties.putIfAbsent("mongodb.connection-url", server.getConnectionString().toString());
 
             queryRunner.installPlugin(new MongoPlugin());
-            queryRunner.createCatalog("mongodb", "mongodb", properties);
+            queryRunner.createCatalog("mongodb", "mongodb", connectorProperties);
             queryRunner.execute("CREATE SCHEMA mongodb." + TPCH_SCHEMA);
 
             copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoServer.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoServer.java
@@ -25,7 +25,7 @@ public class MongoServer
 
     public MongoServer()
     {
-        this("4.0.0");
+        this("4.2.0");
     }
 
     public MongoServer(String mongoVersion)

--- a/pom.xml
+++ b/pom.xml
@@ -440,6 +440,13 @@
 
             <dependency>
                 <groupId>io.trino</groupId>
+                <artifactId>trino-mongodb</artifactId>
+                <type>test-jar</type>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
                 <artifactId>trino-mysql</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/testing/trino-faulttolerant-tests/pom.xml
+++ b/testing/trino-faulttolerant-tests/pom.xml
@@ -255,6 +255,19 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-mongodb</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-mysql</artifactId>
             <scope>test</scope>
         </dependency>
@@ -405,6 +418,12 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
+            <artifactId>mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
             <artifactId>mssqlserver</artifactId>
             <scope>test</scope>
         </dependency>
@@ -469,6 +488,7 @@
                                 <exclude>**/io/trino/faulttolerant/delta/Test*.java</exclude>
                                 <exclude>**/io/trino/faulttolerant/hive/Test*.java</exclude>
                                 <exclude>**/io/trino/faulttolerant/iceberg/Test*.java</exclude>
+                                <exclude>**/io/trino/faulttolerant/mongodb/Test*.java</exclude>
                                 <exclude>**/io/trino/faulttolerant/mysql/Test*.java</exclude>
                                 <exclude>**/io/trino/faulttolerant/postgresql/Test*.java</exclude>
                                 <exclude>**/io/trino/faulttolerant/sqlserver/Test*.java</exclude>
@@ -602,6 +622,24 @@
                             <threadCount>4</threadCount>
                             <includes>
                                 <include>**/io/trino/faulttolerant/sqlserver/Test*.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>test-fault-tolerant-mongodb</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <threadCount>4</threadCount>
+                            <includes>
+                                <include>**/io/trino/faulttolerant/mongodb/Test*.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/mongodb/BaseMongoFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/mongodb/BaseMongoFailureRecoveryTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.faulttolerant.mongodb;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.faulttolerant.BaseFailureRecoveryTest;
+import io.trino.operator.RetryPolicy;
+import io.trino.plugin.exchange.filesystem.FileSystemExchangePlugin;
+import io.trino.plugin.mongodb.MongoServer;
+import io.trino.testing.QueryRunner;
+import io.trino.tpch.TpchTable;
+import org.testng.SkipException;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.trino.plugin.mongodb.MongoQueryRunner.createMongoQueryRunner;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public abstract class BaseMongoFailureRecoveryTest
+        extends BaseFailureRecoveryTest
+{
+    public BaseMongoFailureRecoveryTest(RetryPolicy retryPolicy)
+    {
+        super(retryPolicy);
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner(
+            List<TpchTable<?>> requiredTpchTables,
+            Map<String, String> configProperties,
+            Map<String, String> coordinatorProperties)
+            throws Exception
+    {
+        return createMongoQueryRunner(
+                closeAfterClass(new MongoServer()),
+                configProperties,
+                coordinatorProperties,
+                Map.of(),
+                requiredTpchTables,
+                runner -> {
+                    runner.installPlugin(new FileSystemExchangePlugin());
+                    runner.loadExchangeManager("filesystem", ImmutableMap.of(
+                            "exchange.base-directories", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager"));
+                });
+    }
+
+    @Override
+    protected void createPartitionedLineitemTable(String tableName, List<String> columns, String partitionColumn)
+    {
+    }
+
+    @Override
+    public void testJoinDynamicFilteringDisabled()
+    {
+        assertThatThrownBy(super::testJoinDynamicFilteringDisabled)
+                .hasMessageContaining("Unknown session property mongodb.dynamic_filtering_wait_timeout");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    public void testJoinDynamicFilteringEnabled()
+    {
+        assertThatThrownBy(super::testJoinDynamicFilteringEnabled)
+                .hasMessageContaining("Unknown session property mongodb.dynamic_filtering_wait_timeout");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    public void testAnalyzeTable()
+    {
+        assertThatThrownBy(super::testAnalyzeTable).hasMessageMatching("This connector does not support analyze");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    public void testDelete()
+    {
+        assertThatThrownBy(super::testDeleteWithSubquery).hasMessageContaining("This connector does not support modifying table rows");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    public void testDeleteWithSubquery()
+    {
+        assertThatThrownBy(super::testDeleteWithSubquery).hasMessageContaining("This connector does not support modifying table rows");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    public void testMerge()
+    {
+        assertThatThrownBy(super::testMerge).hasMessageContaining("This connector does not support modifying table rows");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    public void testRefreshMaterializedView()
+    {
+        assertThatThrownBy(super::testRefreshMaterializedView)
+                .hasMessageContaining("This connector does not support creating materialized views");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    public void testUpdate()
+    {
+        assertThatThrownBy(super::testUpdate).hasMessageContaining("This connector does not support modifying table rows");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    public void testUpdateWithSubquery()
+    {
+        assertThatThrownBy(super::testUpdateWithSubquery).hasMessageContaining("This connector does not support modifying table rows");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    protected boolean areWriteRetriesSupported()
+    {
+        return true;
+    }
+}

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/mongodb/TestMongoQueryFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/mongodb/TestMongoQueryFailureRecoveryTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.faulttolerant.mongodb;
+
+import io.trino.operator.RetryPolicy;
+
+public class TestMongoQueryFailureRecoveryTest
+        extends BaseMongoFailureRecoveryTest
+{
+    public TestMongoQueryFailureRecoveryTest()
+    {
+        super(RetryPolicy.QUERY);
+    }
+}

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/mongodb/TestMongoTaskFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/mongodb/TestMongoTaskFailureRecoveryTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.faulttolerant.mongodb;
+
+import io.trino.operator.RetryPolicy;
+
+public class TestMongoTaskFailureRecoveryTest
+        extends BaseMongoFailureRecoveryTest
+{
+    public TestMongoTaskFailureRecoveryTest()
+    {
+        super(RetryPolicy.TASK);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This provides support for FTE with the Mongo connector. It uses the same paradigm as my [previous](https://github.com/trinodb/trino/pull/14730) PR. We only use this new paradigm with retries enabled, otherwise we use the old paradigm. This is important because this also increases our minimum mongo version from 4.0 to 4.2, but _only_ when FTE is enabled - this allows clients using Mongo on 4.0 to continue upgrading their trino version without having to upgrade their mongo, so long as they can live without FTE.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

This provides support for fault tolerant execution on MongoDB. If you want to enable FTE, we require a minimum of Mongo version 4.2, otherwise we still support 4.0.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# MongoDB
* Upgrade minimum required MongoDB version to 4.2. ({issue}`15062`)
* Add support for writes when [fault-tolerant
  execution](/admin/fault-tolerant-execution) is enabled. ({issue}`15062`)
```
