### PR TITLE
Make Iceberg schemaFromHandles keep field ids from IcebergColumnHandle to avoid id conflicts

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -243,7 +243,7 @@ public final class IcebergUtil
     public static Schema schemaFromHandles(List<IcebergColumnHandle> columns)
     {
         List<NestedField> icebergColumns = columns.stream()
-                .map(column -> NestedField.optional(column.getId(), column.getName(), toIcebergType(column.getType())))
+                .map(column -> NestedField.optional(column.getId(), column.getName(), toIcebergType(column.getType(), Optional.of(column.getColumnIdentity().getChildren()))))
                 .collect(toImmutableList());
         return new Schema(StructType.of(icebergColumns).asStructType().fields());
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

When reading from an Iceberg table containing columns of ROW type, and with equality delete files, we sometimes get error like:
java.lang.IllegalArgumentException: Multiple entries with same key: 2=complex_struct.element.f2.value and 2=complex_struct.element.f2

After trace it down, we found that schemaFromHandles ignores children ColumnIdentity passed in from IcebergColumnHandle when constructing struct type NestedField. This would result in a conflict. between top level fields ids and filed ids within a struct column.

This PR propose a fix for the problem.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Fix issue when reading from an Iceberg table containing columns of ROW type and deleted by equality delete file.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:
Fix issue when reading from an Iceberg table containing columns of ROW type and deleted by equality delete file.

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
