### PR TITLE
Exempt certain APIs from SPI backward compatibility check

### DIFF
--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -199,6 +199,15 @@
                                 <item>
                                     <code>java.field.enumConstantOrderChanged</code>
                                 </item>
+                                <!-- Allow arbitrary changes to unstable APIs -->
+                                <item>
+                                    <regex>true</regex>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>
+                                        <matcher>java</matcher>
+                                        <match>@io.trino.spi.Unstable *;</match>
+                                    </old>
+                                </item>
                                 <!-- Allow removing things that were previously deprecated -->
                                 <item>
                                     <regex>true</regex>

--- a/core/trino-spi/src/main/java/io/trino/spi/Unstable.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/Unstable.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Signifies that a public API (public class, method or field) is permanently subject to
+ * incompatible changes, or even removal, in any future release, without prior notice. An API
+ * bearing this annotation is exempt from any compatibility guarantees made by its containing
+ * library. Note that the presence of this annotation implies nothing about the quality or
+ * performance of the API in question, only the fact that it can evolve any time.
+ */
+@Retention(RUNTIME)
+@Target({TYPE, FIELD, METHOD, CONSTRUCTOR})
+@Documented
+public @interface Unstable {}

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ColumnDetail.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ColumnDetail.java
@@ -15,6 +15,7 @@ package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.Unstable;
 
 import java.util.Objects;
 
@@ -31,6 +32,7 @@ public class ColumnDetail
     private final String columnName;
 
     @JsonCreator
+    @Unstable
     public ColumnDetail(String catalog, String schema, String table, String columnName)
     {
         this.catalog = requireNonNull(catalog, "catalog is null");

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ColumnInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ColumnInfo.java
@@ -15,6 +15,7 @@ package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.Unstable;
 
 import java.util.List;
 
@@ -27,6 +28,7 @@ public class ColumnInfo
     private final List<String> masks;
 
     @JsonCreator
+    @Unstable
     public ColumnInfo(String column, List<String> masks)
     {
         this.column = column;

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/OutputColumnMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/OutputColumnMetadata.java
@@ -15,6 +15,7 @@ package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.Unstable;
 
 import java.util.Objects;
 import java.util.Set;
@@ -31,6 +32,7 @@ public class OutputColumnMetadata
     private final Set<ColumnDetail> sourceColumns;
 
     @JsonCreator
+    @Unstable
     public OutputColumnMetadata(String columnName, String columnType, Set<ColumnDetail> sourceColumns)
     {
         this.columnName = requireNonNull(columnName, "columnName is null");

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryCompletedEvent.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryCompletedEvent.java
@@ -16,6 +16,7 @@ package io.trino.spi.eventlistener;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.TrinoWarning;
+import io.trino.spi.Unstable;
 
 import java.time.Instant;
 import java.util.List;
@@ -41,6 +42,7 @@ public class QueryCompletedEvent
     private final Instant endTime;
 
     @JsonCreator
+    @Unstable
     public QueryCompletedEvent(
             QueryMetadata metadata,
             QueryStatistics statistics,

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryContext.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryContext.java
@@ -15,6 +15,7 @@ package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.Unstable;
 import io.trino.spi.resourcegroups.QueryType;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.spi.session.ResourceEstimates;
@@ -58,6 +59,7 @@ public class QueryContext
     private final String retryPolicy;
 
     @JsonCreator
+    @Unstable
     public QueryContext(
             String user,
             Optional<String> principal,

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryCreatedEvent.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryCreatedEvent.java
@@ -15,6 +15,7 @@ package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.Unstable;
 
 import java.time.Instant;
 import java.util.StringJoiner;
@@ -32,6 +33,7 @@ public class QueryCreatedEvent
     private final QueryMetadata metadata;
 
     @JsonCreator
+    @Unstable
     public QueryCreatedEvent(Instant createTime, QueryContext context, QueryMetadata metadata)
     {
         this.createTime = requireNonNull(createTime, "createTime is null");

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryFailureInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryFailureInfo.java
@@ -16,6 +16,7 @@ package io.trino.spi.eventlistener;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.ErrorCode;
+import io.trino.spi.Unstable;
 
 import java.util.Optional;
 
@@ -34,6 +35,7 @@ public class QueryFailureInfo
     private final String failuresJson;
 
     @JsonCreator
+    @Unstable
     public QueryFailureInfo(
             ErrorCode errorCode,
             Optional<String> failureType,

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryIOMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryIOMetadata.java
@@ -15,6 +15,7 @@ package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.Unstable;
 
 import java.util.List;
 import java.util.Optional;
@@ -30,6 +31,7 @@ public class QueryIOMetadata
     private final Optional<QueryOutputMetadata> output;
 
     @JsonCreator
+    @Unstable
     public QueryIOMetadata(List<QueryInputMetadata> inputs, Optional<QueryOutputMetadata> output)
     {
         this.inputs = requireNonNull(inputs, "inputs is null");

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryInputMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryInputMetadata.java
@@ -15,6 +15,7 @@ package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.Unstable;
 import io.trino.spi.metrics.Metrics;
 
 import java.util.List;
@@ -38,6 +39,7 @@ public class QueryInputMetadata
     private final OptionalLong physicalInputRows;
 
     @JsonCreator
+    @Unstable
     public QueryInputMetadata(String catalogName,
             String schema,
             String table,

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryMetadata.java
@@ -15,6 +15,7 @@ package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.Unstable;
 
 import java.net.URI;
 import java.util.List;
@@ -46,6 +47,7 @@ public class QueryMetadata
     private final Optional<String> payload;
 
     @JsonCreator
+    @Unstable
     public QueryMetadata(
             String queryId,
             Optional<String> transactionId,

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryOutputMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryOutputMetadata.java
@@ -15,6 +15,7 @@ package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.Unstable;
 
 import java.util.List;
 import java.util.Optional;
@@ -35,6 +36,7 @@ public class QueryOutputMetadata
     private final Optional<Boolean> jsonLengthLimitExceeded;
 
     @JsonCreator
+    @Unstable
     public QueryOutputMetadata(String catalogName, String schema, String table, Optional<List<OutputColumnMetadata>> columns, Optional<String> connectorOutputMetadata, Optional<Boolean> jsonLengthLimitExceeded)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryStatistics.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryStatistics.java
@@ -15,6 +15,7 @@ package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.Unstable;
 
 import java.time.Duration;
 import java.util.List;
@@ -81,6 +82,7 @@ public class QueryStatistics
     private final Optional<String> planNodeStatsAndCosts;
 
     @JsonCreator
+    @Unstable
     public QueryStatistics(
             Duration cpuTime,
             Duration failedCpuTime,

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/RoutineInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/RoutineInfo.java
@@ -15,6 +15,7 @@ package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.Unstable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -27,6 +28,7 @@ public class RoutineInfo
     private final String authorization;
 
     @JsonCreator
+    @Unstable
     public RoutineInfo(
             @JsonProperty("routine") String routine,
             @JsonProperty("authorization") String authorization)

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/SplitCompletedEvent.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/SplitCompletedEvent.java
@@ -15,6 +15,7 @@ package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.Unstable;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -42,6 +43,7 @@ public class SplitCompletedEvent
     private final String payload;
 
     @JsonCreator
+    @Unstable
     public SplitCompletedEvent(
             String queryId,
             String stageId,

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/SplitFailureInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/SplitFailureInfo.java
@@ -15,6 +15,7 @@ package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.Unstable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -27,6 +28,7 @@ public class SplitFailureInfo
     private final String failureMessage;
 
     @JsonCreator
+    @Unstable
     public SplitFailureInfo(String failureType, String failureMessage)
     {
         this.failureType = requireNonNull(failureType, "failureType is null");

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/SplitStatistics.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/SplitStatistics.java
@@ -15,6 +15,7 @@ package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.Unstable;
 
 import java.time.Duration;
 import java.util.Optional;
@@ -38,6 +39,7 @@ public class SplitStatistics
     private final Optional<Duration> timeToLastByte;
 
     @JsonCreator
+    @Unstable
     public SplitStatistics(
             Duration cpuTime,
             Duration wallTime,

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/StageCpuDistribution.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/StageCpuDistribution.java
@@ -15,6 +15,7 @@ package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.Unstable;
 
 /**
  * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
@@ -35,6 +36,7 @@ public class StageCpuDistribution
     private final double average;
 
     @JsonCreator
+    @Unstable
     public StageCpuDistribution(
             @JsonProperty("stageId") int stageId,
             @JsonProperty("tasks") int tasks,

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/StageGcStatistics.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/StageGcStatistics.java
@@ -15,6 +15,7 @@ package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.Unstable;
 
 /**
  * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
@@ -32,6 +33,7 @@ public class StageGcStatistics
     private final int averageFullGcSec;
 
     @JsonCreator
+    @Unstable
     public StageGcStatistics(
             @JsonProperty("stageId") int stageId,
             @JsonProperty("tasks") int tasks,

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/StageOutputBufferUtilization.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/StageOutputBufferUtilization.java
@@ -15,6 +15,7 @@ package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.Unstable;
 
 import java.time.Duration;
 
@@ -41,6 +42,7 @@ public class StageOutputBufferUtilization
     private final Duration duration;
 
     @JsonCreator
+    @Unstable
     public StageOutputBufferUtilization(
             int stageId,
             int tasks,

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/TableInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/TableInfo.java
@@ -15,6 +15,7 @@ package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.Unstable;
 
 import java.util.List;
 
@@ -35,6 +36,7 @@ public class TableInfo
     private final boolean directlyReferenced;
 
     @JsonCreator
+    @Unstable
     public TableInfo(String catalog, String schema, String table, String authorization, List<String> filters, List<ColumnInfo> columns, boolean directlyReferenced)
     {
         this.catalog = requireNonNull(catalog, "catalog is null");

--- a/core/trino-spi/src/main/java/io/trino/spi/metrics/Metrics.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/metrics/Metrics.java
@@ -16,6 +16,7 @@ package io.trino.spi.metrics;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.trino.spi.Mergeable;
+import io.trino.spi.Unstable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -31,6 +32,7 @@ public class Metrics
     private final Map<String, Metric<?>> metrics;
 
     @JsonCreator
+    @Unstable
     public Metrics(Map<String, Metric<?>> metrics)
     {
         this.metrics = Map.copyOf(requireNonNull(metrics, "metrics is null"));


### PR DESCRIPTION
Some SPI elements are not meant for backward compatibility, because they
are not meant for being invoked by plugins at all. Ideally we would make
them inaccessible to plugins, but that is not possible.

This commit introduces an annotation to mark these APIs as such. It
doesn't change the development practice, since we would just change
these APIs without a notice, but it makes it clear to the consumers that
they cannot rely on these APIs being stable. Moreover, it excepts these
APIs frmo revapi backward compatibility checks (note that the exclusion
is effective starting from the next release).
