### PR TITLE
Always create new identity for view owner

### DIFF
--- a/core/trino-main/src/main/java/io/trino/security/ViewAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/ViewAccessControl.java
@@ -48,6 +48,11 @@ public class ViewAccessControl
     @Override
     public void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columnNames)
     {
+        if (context.getIdentity().getUser().equals(invoker.getUser())) {
+            // view owner does not need to grant themselves access to a table
+            delegate.checkCanSelectFromColumns(context, tableName, columnNames);
+            return;
+        }
         // This is intentional and matches the SQL standard for view security.
         // In SQL, views are special in that they execute with permissions of the owner.
         // This means that the owner of the view is effectively granting permissions to the user running the query,
@@ -70,12 +75,22 @@ public class ViewAccessControl
     @Override
     public void checkCanExecuteFunction(SecurityContext context, String functionName)
     {
+        if (context.getIdentity().getUser().equals(invoker.getUser())) {
+            // view owner does not need to grant themselves access to a funtion
+            delegate.checkCanExecuteFunction(context, functionName);
+            return;
+        }
         wrapAccessDeniedException(() -> delegate.checkCanGrantExecuteFunctionPrivilege(context, functionName, invoker, false));
     }
 
     @Override
     public void checkCanExecuteFunction(SecurityContext context, FunctionKind functionKind, QualifiedObjectName functionName)
     {
+        if (context.getIdentity().getUser().equals(invoker.getUser())) {
+            // view owner does not need to grant themselves access to a funtion
+            delegate.checkCanExecuteFunction(context, functionKind, functionName);
+            return;
+        }
         wrapAccessDeniedException(() -> delegate.checkCanGrantExecuteFunctionPrivilege(context, functionKind, functionName, invoker, false));
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -4378,7 +4378,7 @@ class StatementAnalyzer
                 // run view as view owner if set; otherwise, run as session user
                 Identity identity;
                 AccessControl viewAccessControl;
-                if (owner.isPresent() && !owner.get().getUser().equals(session.getIdentity().getUser())) {
+                if (owner.isPresent()) {
                     identity = Identity.from(owner.get())
                             .withGroups(groupProvider.getGroups(owner.get().getUser()))
                             .build();


### PR DESCRIPTION
Always create new identity for view owner

Previously we were reusing identity when user who is the view owner was
the same as session user. This is incorrect as enabled roles in session
may be different that ones got for a view owner.

So depending if who executes the view and with what privileges, if it is
a view owner or someone else then access control could be different when
executing view.
