### PR TITLE
Fix the order of parameters listed by DESCRIBE INPUT

### DIFF
--- a/core/trino-main/src/test/java/io/trino/execution/TestParameterExtractor.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestParameterExtractor.java
@@ -65,4 +65,16 @@ public class TestParameterExtractor
 
         assertThat(ParameterExtractor.getParameterCount(statement)).isEqualTo(1);
     }
+
+    @Test
+    public void testWith()
+    {
+        // The parameter from CTE has id=0. The parameter from the query has id=1. In the DESCRIBE statement they will be listed following this order.
+        Statement statement = sqlParser.createStatement("WITH t(a) AS (VALUES ?) SELECT a + ? FROM t", new ParsingOptions());
+        assertThat(ParameterExtractor.getParameters(statement))
+                .containsExactly(
+                        new Parameter(new NodeLocation(1, 22), 0),
+                        new Parameter(new NodeLocation(1, 38), 1));
+        assertThat(ParameterExtractor.getParameterCount(statement)).isEqualTo(2);
+    }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/QueryUtil.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/QueryUtil.java
@@ -45,6 +45,7 @@ import io.trino.sql.tree.TableSubquery;
 import io.trino.sql.tree.Values;
 import io.trino.sql.tree.WhenClause;
 import io.trino.sql.tree.WindowDefinition;
+import io.trino.sql.tree.With;
 
 import java.util.List;
 import java.util.Optional;
@@ -292,6 +293,25 @@ public final class QueryUtil
         return new Query(
                 Optional.empty(),
                 body,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    public static Query query(With with, Select select, Relation from)
+    {
+        return new Query(
+                Optional.of(with),
+                new QuerySpecification(
+                        select,
+                        Optional.of(from),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -913,11 +913,12 @@ class AstBuilder
     @Override
     public Node visitQuery(SqlBaseParser.QueryContext context)
     {
+        Optional<With> with = visitIfPresent(context.with(), With.class);
         Query body = (Query) visit(context.queryNoWith());
 
         return new Query(
                 getLocation(context),
-                visitIfPresent(context.with(), With.class),
+                with,
                 body.getQueryBody(),
                 body.getOrderBy(),
                 body.getOffset(),

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -2770,6 +2770,20 @@ public class TestSqlParser
                         Optional.empty(),
                         Optional.of(new Offset(new Parameter(1))),
                         Optional.of(new FetchFirst(new Parameter(2), true)))));
+
+        // The parameter from CTE has id=0. The parameter from the query has id=1. In the DESCRIBE statement they will be listed following this order.
+        assertStatement("PREPARE myquery FROM WITH t(a) AS (VALUES ROW(?)) SELECT a + ? FROM t",
+                new Prepare(
+                        identifier("myquery"),
+                        query(
+                                new With(
+                                        false,
+                                        ImmutableList.of(new WithQuery(
+                                                identifier("t"),
+                                                query(values(row(new Parameter(0)))),
+                                                Optional.of(ImmutableList.of(identifier("a")))))),
+                                selectList(new ArithmeticBinaryExpression(ADD, identifier("a"), new Parameter(1))),
+                                table(QualifiedName.of("t")))));
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -253,6 +253,10 @@ import static io.trino.sql.parser.TreeNodes.qualifiedName;
 import static io.trino.sql.parser.TreeNodes.rowType;
 import static io.trino.sql.parser.TreeNodes.simpleType;
 import static io.trino.sql.testing.TreeAssertions.assertFormattedSql;
+import static io.trino.sql.tree.ArithmeticBinaryExpression.Operator.ADD;
+import static io.trino.sql.tree.ArithmeticBinaryExpression.Operator.DIVIDE;
+import static io.trino.sql.tree.ArithmeticBinaryExpression.Operator.MULTIPLY;
+import static io.trino.sql.tree.ArithmeticBinaryExpression.Operator.SUBTRACT;
 import static io.trino.sql.tree.ArithmeticUnaryExpression.negative;
 import static io.trino.sql.tree.ArithmeticUnaryExpression.positive;
 import static io.trino.sql.tree.ComparisonExpression.Operator.EQUAL;
@@ -896,25 +900,32 @@ public class TestSqlParser
                 new NotExpression(new LongLiteral("1")),
                 new LongLiteral("2")));
 
-        assertExpression("-1 + 2", new ArithmeticBinaryExpression(ArithmeticBinaryExpression.Operator.ADD,
+        assertExpression("-1 + 2", new ArithmeticBinaryExpression(
+                ADD,
                 new LongLiteral("-1"),
                 new LongLiteral("2")));
 
-        assertExpression("1 - 2 - 3", new ArithmeticBinaryExpression(ArithmeticBinaryExpression.Operator.SUBTRACT,
-                new ArithmeticBinaryExpression(ArithmeticBinaryExpression.Operator.SUBTRACT,
+        assertExpression("1 - 2 - 3", new ArithmeticBinaryExpression(
+                SUBTRACT,
+                new ArithmeticBinaryExpression(
+                        SUBTRACT,
                         new LongLiteral("1"),
                         new LongLiteral("2")),
                 new LongLiteral("3")));
 
-        assertExpression("1 / 2 / 3", new ArithmeticBinaryExpression(ArithmeticBinaryExpression.Operator.DIVIDE,
-                new ArithmeticBinaryExpression(ArithmeticBinaryExpression.Operator.DIVIDE,
+        assertExpression("1 / 2 / 3", new ArithmeticBinaryExpression(
+                DIVIDE,
+                new ArithmeticBinaryExpression(
+                        DIVIDE,
                         new LongLiteral("1"),
                         new LongLiteral("2")),
                 new LongLiteral("3")));
 
-        assertExpression("1 + 2 * 3", new ArithmeticBinaryExpression(ArithmeticBinaryExpression.Operator.ADD,
+        assertExpression("1 + 2 * 3", new ArithmeticBinaryExpression(
+                ADD,
                 new LongLiteral("1"),
-                new ArithmeticBinaryExpression(ArithmeticBinaryExpression.Operator.MULTIPLY,
+                new ArithmeticBinaryExpression(
+                        MULTIPLY,
                         new LongLiteral("2"),
                         new LongLiteral("3"))));
     }
@@ -1874,7 +1885,7 @@ public class TestSqlParser
                                         Optional.of(equal(nameReference("c", "action"), new StringLiteral("mod"))),
                                         ImmutableList.of(
                                                 new MergeUpdate.Assignment(new Identifier("qty"), new ArithmeticBinaryExpression(
-                                                        ArithmeticBinaryExpression.Operator.ADD,
+                                                        ADD,
                                                         nameReference("qty"),
                                                         nameReference("c", "qty"))),
                                                 new MergeUpdate.Assignment(new Identifier("ts"), new CurrentTime(CurrentTime.Function.TIMESTAMP)))),

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -1364,6 +1364,17 @@ public abstract class AbstractTestEngineOnlyQueries
                 .row(4, "decimal(3,2)")
                 .build();
         assertEqualsIgnoreOrder(actual, expected);
+
+        session = Session.builder(getSession())
+                .addPreparedStatement("my_query", "WITH t(a) AS (VALUES lower(?)) SELECT NOT ? FROM t")
+                .build();
+        actual = computeActual(session, "DESCRIBE INPUT my_query");
+        // The parameter from CTE is listed first with id=0. The parameter from the query is listed next with id=1.
+        expected = resultBuilder(session, BIGINT, VARCHAR)
+                .row(0, "varchar(0)")
+                .row(1, "boolean")
+                .build();
+        assertEquals(actual, expected);
     }
 
     @Test


### PR DESCRIPTION
Before this change, if a prepared query contained a CTE,
the parameters from the CTE were listed last by DESCRIBE
INPUT, preceded by all parameters from the enclosing query.
It was incorrect, since CTE is first in the query text.

This fix changes the order in which the CTE and the enclosing
query body are visited in the AST builder, thus changing the
order of parameters in the DESCRIBE INPUT result.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix the order of parameters listed by DESCRIBE INPUT for certain prepared queries containing a WITH clause.
```
