### PR TITLE
Allow Iceberg writes to use either append or fastAppend

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -196,6 +196,7 @@ import static io.trino.plugin.iceberg.IcebergMetadataColumn.isMetadataColumnId;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getExpireSnapshotMinRetention;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getRemoveOrphanFilesMinRetention;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isExtendedStatisticsEnabled;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.isMergeManifestsOnWrite;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isProjectionPushdownEnabled;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isStatisticsEnabled;
 import static io.trino.plugin.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
@@ -803,7 +804,7 @@ public class IcebergMetadata
                         icebergTable.schema().findType(field.sourceId())))
                 .toArray(Type[]::new);
 
-        AppendFiles appendFiles = transaction.newAppend();
+        AppendFiles appendFiles = isMergeManifestsOnWrite(session) ? transaction.newAppend() : transaction.newFastAppend();
         ImmutableSet.Builder<String> writtenFiles = ImmutableSet.builder();
         for (CommitTaskData task : commitTasks) {
             DataFiles.Builder builder = DataFiles.builder(icebergTable.spec())

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -79,6 +79,7 @@ public final class IcebergSessionProperties
     private static final String MINIMUM_ASSIGNED_SPLIT_WEIGHT = "minimum_assigned_split_weight";
     public static final String EXPIRE_SNAPSHOTS_MIN_RETENTION = "expire_snapshots_min_retention";
     public static final String REMOVE_ORPHAN_FILES_MIN_RETENTION = "remove_orphan_files_min_retention";
+    private static final String MERGE_MANIFESTS_ON_WRITE = "merge_manifests_on_write";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -258,6 +259,11 @@ public final class IcebergSessionProperties
                         "Minimal retention period for remove_orphan_files procedure",
                         icebergConfig.getRemoveOrphanFilesMinRetention(),
                         false))
+                .add(booleanProperty(
+                        MERGE_MANIFESTS_ON_WRITE,
+                        "Compact manifest files when performing write operations",
+                        true,
+                        false))
                 .build();
     }
 
@@ -427,5 +433,10 @@ public final class IcebergSessionProperties
     public static double getMinimumAssignedSplitWeight(ConnectorSession session)
     {
         return session.getProperty(MINIMUM_ASSIGNED_SPLIT_WEIGHT, Double.class);
+    }
+
+    public static boolean isMergeManifestsOnWrite(ConnectorSession session)
+    {
+        return session.getProperty(MERGE_MANIFESTS_ON_WRITE, Boolean.class);
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Closes  #14822 
Allow Iceberg writes to use either append or fastAppend. Users in certain use cases may want to do compaction of Manifests async from writes. We should allow configuring fastAppend for that situation on a session level basis.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
New IcebergSessionProperty _iceberg.merge_manifests_on_write_ . Default value - "true". 
_SET SESSION iceberg.merge_manifests_on_write = false_ to force fastAppend()
_SET SESSION iceberg.merge_manifests_on_write = true_ to force append()


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

# Iceberg
* Allow to do compaction of Manifests asynchronously from writes by configuring property _iceberg.merge_manifests_on_write_ on a session level. ({issue}`14822`)
```markdown
# Section
```
![Test_trino_cli](https://user-images.githubusercontent.com/58150048/202607508-cd700161-e5ec-4e20-9988-a0b6d5b94e72.jpg)
![Test_IcebergQueryRunner](https://user-images.githubusercontent.com/58150048/202607555-bbc3ff7c-beae-45c6-8313-af2518c176f8.jpg)
