### PR TITLE
Update TrinoFileSystemCache to represent latest hadoop implementation

### DIFF
--- a/lib/trino-hdfs/pom.xml
+++ b/lib/trino-hdfs/pom.xml
@@ -100,6 +100,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>
             <scope>test</scope>
@@ -108,6 +114,18 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/lib/trino-hdfs/src/main/java/io/trino/hdfs/TrinoFileSystemCache.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/hdfs/TrinoFileSystemCache.java
@@ -14,7 +14,6 @@
 package io.trino.hdfs;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.log.Logger;
 import org.apache.hadoop.conf.Configuration;
@@ -36,21 +35,20 @@ import org.apache.hadoop.util.Progressable;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.gaul.modernizer_maven_annotations.SuppressModernizer;
 
-import javax.annotation.concurrent.GuardedBy;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Strings.nullToEmpty;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -70,17 +68,13 @@ public class TrinoFileSystemCache
 
     private final TrinoFileSystemCacheStats stats;
 
-    @GuardedBy("this")
-    private final Map<FileSystemKey, FileSystemHolder> map = new HashMap<>();
+    private final Map<FileSystemKey, FileSystemHolder> cache = new ConcurrentHashMap<>();
+    private final AtomicLong cacheSize = new AtomicLong();
 
     @VisibleForTesting
     TrinoFileSystemCache()
     {
-        this.stats = new TrinoFileSystemCacheStats(() -> {
-            synchronized (this) {
-                return map.size();
-            }
-        });
+        this.stats = new TrinoFileSystemCacheStats(cache::size);
     }
 
     @Override
@@ -102,55 +96,45 @@ public class TrinoFileSystemCache
     @VisibleForTesting
     int getCacheSize()
     {
-        return map.size();
+        return cache.size();
     }
 
-    private synchronized FileSystem getInternal(URI uri, Configuration conf, long unique)
+    private FileSystem getInternal(URI uri, Configuration conf, long unique)
             throws IOException
     {
         UserGroupInformation userGroupInformation = UserGroupInformation.getCurrentUser();
         FileSystemKey key = createFileSystemKey(uri, userGroupInformation, unique);
         Set<?> privateCredentials = getPrivateCredentials(userGroupInformation);
 
-        FileSystemHolder fileSystemHolder = map.get(key);
-        if (fileSystemHolder == null) {
-            int maxSize = conf.getInt("fs.cache.max-size", 1000);
-            if (map.size() >= maxSize) {
-                stats.newGetCallFailed();
-                throw new IOException(format("FileSystem max cache size has been reached: %s", maxSize));
-            }
-            try {
-                FileSystem fileSystem = createFileSystem(uri, conf);
-                fileSystemHolder = new FileSystemHolder(fileSystem, privateCredentials);
-                map.put(key, fileSystemHolder);
-            }
-            catch (IOException e) {
-                stats.newGetCallFailed();
-                throw e;
-            }
-        }
+        int maxSize = conf.getInt("fs.cache.max-size", 1000);
+        FileSystemHolder fileSystemHolder;
+        try {
+            fileSystemHolder = cache.compute(key, (k, currFileSystemHolder) -> {
+                if (currFileSystemHolder == null) {
+                    if (cacheSize.getAndUpdate(curr -> curr < maxSize ? (curr + 1) : curr) >= maxSize) {
+                        throw new RuntimeException(
+                                new IOException(format("FileSystem max cache size has been reached: %s", maxSize)));
+                    }
+                    return new FileSystemHolder(uri, conf, privateCredentials);
+                }
+                else {
+                    // Update file system instance when credentials change.
+                    if (currFileSystemHolder.credentialsChanged(uri, conf, privateCredentials)) {
+                        return new FileSystemHolder(uri, conf, privateCredentials);
+                    }
+                    else {
+                        return currFileSystemHolder;
+                    }
+                }
+            });
 
-        // Update file system instance when credentials change.
-        // - Private credentials are only set when using Kerberos authentication.
-        // When the user is the same, but the private credentials are different,
-        // that means that Kerberos ticket has expired and re-login happened.
-        // To prevent cache leak in such situation, the privateCredentials are not
-        // a part of the FileSystemKey, but part of the FileSystemHolder. When a
-        // Kerberos re-login occurs, re-create the file system and cache it using
-        // the same key.
-        // - Extra credentials are used to authenticate with certain file systems.
-        if ((isHdfs(uri) && !fileSystemHolder.getPrivateCredentials().equals(privateCredentials)) ||
-                extraCredentialsChanged(fileSystemHolder.getFileSystem(), conf)) {
-            map.remove(key);
-            try {
-                FileSystem fileSystem = createFileSystem(uri, conf);
-                fileSystemHolder = new FileSystemHolder(fileSystem, privateCredentials);
-                map.put(key, fileSystemHolder);
-            }
-            catch (IOException e) {
-                stats.newGetCallFailed();
-                throw e;
-            }
+            fileSystemHolder.createFileSystemOnce();
+        }
+        catch (RuntimeException | IOException e) {
+            stats.newGetCallFailed();
+            throwIfInstanceOf(e, IOException.class);
+            throwIfInstanceOf(e.getCause(), IOException.class);
+            throw e;
         }
 
         return fileSystemHolder.getFileSystem();
@@ -178,20 +162,49 @@ public class TrinoFileSystemCache
     }
 
     @Override
-    public synchronized void remove(FileSystem fileSystem)
+    public void remove(FileSystem fileSystem)
     {
         stats.newRemoveCall();
-        map.values().removeIf(holder -> holder.getFileSystem().equals(fileSystem));
+        cache.forEach((key, holder) -> {
+            if (fileSystem.equals(holder.getFileSystem())) {
+                // decrement cacheSize only if the key is
+                // still mapped after acquiring the lock
+                cache.compute(key, (k, currFileSystemHolder) -> {
+                    if (currFileSystemHolder != null) {
+                        cacheSize.decrementAndGet();
+                    }
+                    return null;
+                });
+            }
+        });
     }
 
     @Override
-    public synchronized void closeAll()
+    public void closeAll()
             throws IOException
     {
-        for (FileSystemHolder fileSystemHolder : ImmutableList.copyOf(map.values())) {
-            closeFileSystem(fileSystemHolder.getFileSystem());
+        try {
+            cache.forEach((key, holder) -> {
+                try {
+                    cache.compute(key, (k, currFileSystemHolder) -> {
+                        if (currFileSystemHolder != null) {
+                            cacheSize.decrementAndGet();
+                        }
+                        return null;
+                    });
+                    if (holder.getFileSystem() != null) {
+                        closeFileSystem(holder.getFileSystem());
+                    }
+                }
+                catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
         }
-        map.clear();
+        catch (RuntimeException e) {
+            throwIfInstanceOf(e.getCause(), IOException.class);
+            throw e;
+        }
     }
 
     @SuppressModernizer
@@ -243,12 +256,6 @@ public class TrinoFileSystemCache
     {
         String scheme = uri.getScheme();
         return "hdfs".equals(scheme) || "viewfs".equals(scheme);
-    }
-
-    private static boolean extraCredentialsChanged(FileSystem fileSystem, Configuration configuration)
-    {
-        return !configuration.get(CACHE_KEY, "").equals(
-                fileSystem.getConf().get(CACHE_KEY, ""));
     }
 
     private static class FileSystemKey
@@ -306,23 +313,49 @@ public class TrinoFileSystemCache
 
     private static class FileSystemHolder
     {
-        private final FileSystem fileSystem;
+        private final URI uri;
+        private final Configuration conf;
         private final Set<?> privateCredentials;
+        private final String cacheCredentials;
+        private volatile FileSystem fileSystem;
 
-        public FileSystemHolder(FileSystem fileSystem, Set<?> privateCredentials)
+        public FileSystemHolder(URI uri, Configuration conf, Set<?> privateCredentials)
         {
-            this.fileSystem = requireNonNull(fileSystem, "fileSystem is null");
+            this.uri = requireNonNull(uri, "uri is null");
+            this.conf = requireNonNull(conf, "conf is null");
             this.privateCredentials = ImmutableSet.copyOf(requireNonNull(privateCredentials, "privateCredentials is null"));
+            this.cacheCredentials = conf.get(CACHE_KEY, "");
+        }
+
+        public void createFileSystemOnce()
+                throws IOException
+        {
+            if (fileSystem == null) {
+                synchronized (this) {
+                    if (fileSystem == null) {
+                        fileSystem = TrinoFileSystemCache.createFileSystem(uri, conf);
+                    }
+                }
+            }
+        }
+
+        public boolean credentialsChanged(URI newUri, Configuration newConf, Set<?> newPrivateCredentials)
+        {
+            // - Private credentials are only set when using Kerberos authentication.
+            // When the user is the same, but the private credentials are different,
+            // that means that Kerberos ticket has expired and re-login happened.
+            // To prevent cache leak in such situation, the privateCredentials are not
+            // a part of the FileSystemKey, but part of the FileSystemHolder. When a
+            // Kerberos re-login occurs, re-create the file system and cache it using
+            // the same key.
+            // - Extra credentials are used to authenticate with certain file systems.
+            return (isHdfs(newUri) && !this.privateCredentials.equals(newPrivateCredentials))
+                    || !this.cacheCredentials.equals(newConf.get(CACHE_KEY, ""));
         }
 
         public FileSystem getFileSystem()
         {
             return fileSystem;
-        }
-
-        public Set<?> getPrivateCredentials()
-        {
-            return privateCredentials;
         }
 
         @Override
@@ -331,6 +364,7 @@ public class TrinoFileSystemCache
             return toStringHelper(this)
                     .add("fileSystem", fileSystem)
                     .add("privateCredentials", privateCredentials)
+                    .add("cacheCredentials", cacheCredentials)
                     .toString();
         }
     }

--- a/lib/trino-hdfs/src/test/java/io/trino/hdfs/BenchmarkGetFileSystem.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/hdfs/BenchmarkGetFileSystem.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hdfs;
+
+import io.trino.jmh.Benchmarks;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SplittableRandom;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 5000, timeUnit = MILLISECONDS)
+@Fork(2)
+@Measurement(iterations = 5, time = 5000, timeUnit = MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkGetFileSystem
+{
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        @Param({"10", "100", "1000"})
+        private int numUsers;
+
+        @Param({"1", "16"})
+        private int numThreads;
+
+        @Param("1000")
+        private int numGetCallsPerInvocation;
+
+        public List<Callable<Void>> callableTasks;
+        public ExecutorService executor;
+        public Blackhole blackhole;
+
+        @Setup(Level.Invocation)
+        public void setUp(Blackhole blackhole)
+        {
+            this.blackhole = blackhole;
+
+            this.callableTasks = new ArrayList<>();
+            for (int i = 0; i < numThreads; i++) {
+                this.callableTasks.add(new TestFileSystemCache.CreateFileSystemAndConsume(
+                        new SplittableRandom(i), numUsers, numGetCallsPerInvocation, fs -> {}));
+            }
+
+            this.executor = Executors.newFixedThreadPool(numThreads);
+        }
+
+        @TearDown(Level.Invocation)
+        public void tearDown()
+                throws IOException
+        {
+            TrinoFileSystemCache.INSTANCE.closeAll();
+            executor.shutdown();
+        }
+    }
+
+    @Benchmark
+    public void benchmark(BenchmarkData data)
+            throws InterruptedException, ExecutionException
+    {
+        List<Future<Void>> futures = data.executor.invokeAll(data.callableTasks);
+        for (Future<Void> fut : futures) {
+            data.blackhole.consume(fut.get());
+        }
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        Benchmarks.benchmark(BenchmarkGetFileSystem.class).run();
+    }
+}

--- a/lib/trino-hdfs/src/test/java/io/trino/hdfs/TestFileSystemCache.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/hdfs/TestFileSystemCache.java
@@ -20,20 +20,41 @@ import io.trino.hdfs.authentication.SimpleUserNameProvider;
 import io.trino.spi.security.ConnectorIdentity;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.gaul.modernizer_maven_annotations.SuppressModernizer;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SplittableRandom;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
 
+@Test(singleThreaded = true)
 public class TestFileSystemCache
 {
+    @AfterClass(alwaysRun = true)
+    public void cleanup()
+            throws IOException
+    {
+        FileSystem.closeAll();
+    }
+
     @Test
     public void testFileSystemCache()
             throws IOException
     {
+        FileSystem.closeAll();
         HdfsEnvironment environment = new HdfsEnvironment(
                 new DynamicHdfsConfiguration(new HdfsConfigurationInitializer(new HdfsConfig()), ImmutableSet.of()),
                 new HdfsConfig(),
@@ -56,9 +77,110 @@ public class TestFileSystemCache
         assertNotSame(fs5, fs1);
     }
 
-    private FileSystem getFileSystem(HdfsEnvironment environment, ConnectorIdentity identity)
+    @Test
+    public void testFileSystemCacheException() throws IOException
+    {
+        FileSystem.closeAll();
+        HdfsEnvironment environment = new HdfsEnvironment(
+                new DynamicHdfsConfiguration(new HdfsConfigurationInitializer(new HdfsConfig()), ImmutableSet.of()),
+                new HdfsConfig(),
+                new ImpersonatingHdfsAuthentication(new SimpleHadoopAuthentication(), new SimpleUserNameProvider()));
+
+        int maxCacheSize = 1000;
+        for (int i = 0; i < maxCacheSize; ++i) {
+            assertEquals(TrinoFileSystemCache.INSTANCE.getFileSystemCacheStats().getCacheSize(), i);
+            getFileSystem(environment, ConnectorIdentity.ofUser("user" + String.valueOf(i)));
+        }
+        assertEquals(TrinoFileSystemCache.INSTANCE.getFileSystemCacheStats().getCacheSize(), maxCacheSize);
+
+        try {
+            getFileSystem(environment, ConnectorIdentity.ofUser("user" + String.valueOf(maxCacheSize)));
+            fail("Should have thrown IOException from above");
+        }
+        catch (IOException e) {
+            assertEquals(e.getMessage(), "FileSystem max cache size has been reached: " + maxCacheSize);
+        }
+    }
+
+    @Test
+    public void testFileSystemCacheConcurrency() throws InterruptedException, ExecutionException, IOException
+    {
+        int numThreads = 20;
+        List<Callable<Void>> callableTasks = new ArrayList<>();
+        for (int i = 0; i < numThreads; i++) {
+            callableTasks.add(
+                    new CreateFileSystemAndConsume(
+                            new SplittableRandom(i),
+                            10,
+                            1000,
+                            new FileSystemCloser()));
+        }
+
+        FileSystem.closeAll();
+        ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+
+        assertEquals(TrinoFileSystemCache.INSTANCE.getFileSystemCacheStats().getCacheSize(), 0);
+        List<Future<Void>> futures = executor.invokeAll(callableTasks);
+        for (Future<Void> fut : futures) {
+            fut.get();
+        }
+        executor.shutdown();
+        assertEquals(TrinoFileSystemCache.INSTANCE.getFileSystemCacheStats().getCacheSize(), 0, "Cache size is non zero");
+    }
+
+    private static FileSystem getFileSystem(HdfsEnvironment environment, ConnectorIdentity identity)
             throws IOException
     {
         return environment.getFileSystem(identity, new Path("/"), newEmptyConfiguration());
+    }
+
+    @FunctionalInterface
+    public interface FileSystemConsumer
+    {
+        void consume(FileSystem fileSystem) throws IOException;
+    }
+
+    private static class FileSystemCloser
+            implements FileSystemConsumer
+    {
+        @Override
+        @SuppressModernizer
+        public void consume(FileSystem fileSystem) throws IOException
+        {
+            fileSystem.close();  /* triggers fscache.remove() */
+        }
+    }
+
+    // A callable that creates (and consumes) filesystem objects X times for Y users
+    public static class CreateFileSystemAndConsume
+            implements Callable<Void>
+    {
+        private final SplittableRandom random;
+        private final int numUsers;
+        private final int numGetCallsPerInvocation;
+        private final FileSystemConsumer consumer;
+
+        private HdfsEnvironment environment = new HdfsEnvironment(
+                new DynamicHdfsConfiguration(new HdfsConfigurationInitializer(new HdfsConfig()), ImmutableSet.of()),
+                new HdfsConfig(),
+                new ImpersonatingHdfsAuthentication(new SimpleHadoopAuthentication(), new SimpleUserNameProvider()));
+
+        CreateFileSystemAndConsume(SplittableRandom random, int numUsers, int numGetCallsPerInvocation, FileSystemConsumer consumer)
+        {
+            this.random = random;
+            this.numUsers = numUsers;
+            this.numGetCallsPerInvocation = numGetCallsPerInvocation;
+            this.consumer = consumer;
+        }
+
+        @Override
+        public Void call() throws IOException
+        {
+            for (int i = 0; i < numGetCallsPerInvocation; ++i) {
+                FileSystem fs = getFileSystem(environment, ConnectorIdentity.ofUser("user" + String.valueOf(random.nextInt(numUsers))));
+                consumer.consume(fs);
+            }
+            return null;
+        }
     }
 }


### PR DESCRIPTION
 - Use ConcurrentHashMap to cache filesystem objects - improves concurrency by removing synchronized blocks
 - Filesystem object is created outside cache's lock - similar to latest hadoop fs cache impl, further reducing code in critical section. Helps with systems where filesystem creation is expensive.
 - Only one thread exclusively creates the filesystem object for a given key. Avoids speculative creation and then later discarding of filesystem objects compared to hadoop fs cache impl.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
