### PR TITLE
Revert "Collect uncompressed data size for output statistics"

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/buffer/PagesSerde.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/PagesSerde.java
@@ -114,11 +114,6 @@ public class PagesSerde
         return serializedPage.getInt(SERIALIZED_PAGE_POSITION_COUNT_OFFSET);
     }
 
-    public static int getSerializedPageUncompressedSizeInBytes(Slice serializedPage)
-    {
-        return serializedPage.getInt(SERIALIZED_PAGE_UNCOMPRESSED_SIZE_OFFSET);
-    }
-
     public static boolean isSerializedPageEncrypted(Slice serializedPage)
     {
         return getSerializedPageMarkerSet(serializedPage).contains(ENCRYPTED);

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/SpoolingExchangeOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/SpoolingExchangeOutputBuffer.java
@@ -32,7 +32,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
 import static io.trino.execution.buffer.PagesSerde.getSerializedPagePositionCount;
-import static io.trino.execution.buffer.PagesSerde.getSerializedPageUncompressedSizeInBytes;
 import static java.util.Objects.requireNonNull;
 
 @ThreadSafe
@@ -194,7 +193,7 @@ public class SpoolingExchangeOutputBuffer
         checkState(sink != null, "exchangeSink is null");
         long dataSizeInBytes = 0;
         for (Slice page : pages) {
-            dataSizeInBytes += getSerializedPageUncompressedSizeInBytes(page);
+            dataSizeInBytes += page.length();
             sink.add(partition, page);
             totalRowsAdded.addAndGet(getSerializedPagePositionCount(page));
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The `AribitraryDistributionSplitAssigner` creates tasks based on the data size obtained from the `ExchangeSourceHandle` while the `HashDistributionSplitAssigner` creates tasks based on the data size estimates collected in SpoolingExchangeOutputBuffer. This introduces inconsistent meaning of `fault_tolerant_execution_target_task_input_size`, when depending on the stage it can either mean "physical compressed size" and in other cases "logical" size. 

It feels like it requires more work and we should probably revert this change for now.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
