### PR TITLE
Fix set-milestone failure when latest milestone is closed

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -34,22 +34,26 @@ jobs:
                 commit_sha: context.sha
             })
             if (pr_response.data.length === 0) {
-                console.log('Pull request not found')
+                console.log('Pull request not found for commit', context.sha)
                 return
             }
             if (pr_response.data.length > 1) {
                 console.log(pr_response.data)
-                throw 'Expect 1 pull request but found: ' + pr_response.data.length
+                throw 'Expected 1 pull request but found: ' + pr_response.data.length
             }
+            const pr_number = pr_response.data[0].number
+            console.log('Found pull request', pr_number, 'for commit', context.sha)
 
             // Get milestone
             const {
                 MILESTONE_NUMBER
             } = process.env
+            console.log('Milestone number to set', MILESTONE_NUMBER)
 
             // Find milestone
             const response = await github.rest.issues.listMilestones(context.repo)
             let milestone = response.data.find(milestoneResponse => milestoneResponse.title === MILESTONE_NUMBER)
+            console.log('Found milestone with title', MILESTONE_NUMBER, milestone)
 
             // Create new milestone if it doesn't exist
             if (!milestone) {
@@ -59,6 +63,7 @@ jobs:
                     title: MILESTONE_NUMBER
                 })
                 milestone = create_response.data
+                console.log('Created new milestone with title', MILESTONE_NUMBER, milestone)
             }
 
             // Set milestone to PR
@@ -66,5 +71,6 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 milestone: milestone.number,
-                issue_number: pr_response.data[0].number
+                issue_number: pr_number
             })
+            console.log('Added PR', pr_number, 'to milestone', MILESTONE_NUMBER)

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -50,9 +50,14 @@ jobs:
             } = process.env
             console.log('Milestone number to set', MILESTONE_NUMBER)
 
-            // Find milestone
-            const response = await github.rest.issues.listMilestones(context.repo)
-            let milestone = response.data.find(milestoneResponse => milestoneResponse.title === MILESTONE_NUMBER)
+            // Find milestone with matching title
+            // See https://octokit.github.io/rest.js/v19#pagination
+            const milestones = await github.paginate(github.rest.issues.listMilestones, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'all'
+            })
+            let milestone = milestones.find(milestone => milestone.title === MILESTONE_NUMBER)
             console.log('Found milestone with title', MILESTONE_NUMBER, milestone)
 
             // Create new milestone if it doesn't exist


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

There can be situation where the latest milestone is closed but there
are still some PRs for which this workflow is pending. The  API by
default only lists open milestones. This commit changes it to list all
milestones so that even if the target milestone is closed it can be
found and the PR added to it.

This is correct reimplementation of
c38490bad7baa07953a24f69bc1be85da01dde00.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.