### PR TITLE
fix(sec): upgrade org.apache.thrift:libthrift to 0.14.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1640,7 +1640,7 @@
             <dependency>
                 <groupId>org.apache.thrift</groupId>
                 <artifactId>libthrift</artifactId>
-                <version>0.9.3-1</version>
+                <version>0.14.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.thrift:libthrift 0.9.3-1
- [CVE-2018-1320](https://www.oscs1024.com/hd/CVE-2018-1320)


### What did I do？
Upgrade org.apache.thrift:libthrift from 0.9.3-1 to 0.14.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS