### PR TITLE
Populate a nulls fraction when NDV is known in TableScanStatsRule

### DIFF
--- a/core/trino-main/src/test/java/io/trino/cost/StatsCalculatorAssertion.java
+++ b/core/trino-main/src/test/java/io/trino/cost/StatsCalculatorAssertion.java
@@ -45,6 +45,8 @@ public class StatsCalculatorAssertion
 
     private final Map<PlanNode, PlanNodeStatsEstimate> sourcesStats;
 
+    private Optional<TableStatsProvider> tableStatsProvider = Optional.empty();
+
     public StatsCalculatorAssertion(Metadata metadata, StatsCalculator statsCalculator, Session session, PlanNode planNode, TypeProvider types)
     {
         this.metadata = requireNonNull(metadata, "metadata cannot be null");
@@ -83,11 +85,23 @@ public class StatsCalculatorAssertion
         return this;
     }
 
+    public StatsCalculatorAssertion withTableStatisticsProvider(TableStatsProvider tableStatsProvider)
+    {
+        this.tableStatsProvider = Optional.of(tableStatsProvider);
+        return this;
+    }
+
     public StatsCalculatorAssertion check(Consumer<PlanNodeStatsAssertion> statisticsAssertionConsumer)
     {
         PlanNodeStatsEstimate statsEstimate = transaction(new TestingTransactionManager(), new AllowAllAccessControl())
                 .execute(session, transactionSession -> {
-                    return statsCalculator.calculateStats(planNode, this::getSourceStats, noLookup(), transactionSession, types, new CachingTableStatsProvider(metadata, session));
+                    return statsCalculator.calculateStats(
+                            planNode,
+                            this::getSourceStats,
+                            noLookup(),
+                            transactionSession,
+                            types,
+                            tableStatsProvider.orElse(new CachingTableStatsProvider(metadata, session)));
                 });
         statisticsAssertionConsumer.accept(PlanNodeStatsAssertion.assertThat(statsEstimate));
         return this;
@@ -95,7 +109,14 @@ public class StatsCalculatorAssertion
 
     public StatsCalculatorAssertion check(Rule<?> rule, Consumer<PlanNodeStatsAssertion> statisticsAssertionConsumer)
     {
-        Optional<PlanNodeStatsEstimate> statsEstimate = calculatedStats(rule, planNode, this::getSourceStats, noLookup(), session, types, new CachingTableStatsProvider(metadata, session));
+        Optional<PlanNodeStatsEstimate> statsEstimate = calculatedStats(
+                rule,
+                planNode,
+                this::getSourceStats,
+                noLookup(),
+                session,
+                types,
+                tableStatsProvider.orElse(new CachingTableStatsProvider(metadata, session)));
         checkState(statsEstimate.isPresent(), "Expected stats estimates to be present");
         statisticsAssertionConsumer.accept(PlanNodeStatsAssertion.assertThat(statsEstimate.get()));
         return this;

--- a/core/trino-main/src/test/java/io/trino/cost/TestTableScanStatsRule.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestTableScanStatsRule.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.cost;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.TestingColumnHandle;
+import io.trino.spi.statistics.ColumnStatistics;
+import io.trino.spi.statistics.DoubleRange;
+import io.trino.spi.statistics.Estimate;
+import io.trino.spi.statistics.TableStatistics;
+import io.trino.sql.planner.Symbol;
+import org.testng.annotations.Test;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+
+public class TestTableScanStatsRule
+        extends BaseStatsCalculatorTest
+{
+    @Test
+    public void testStatsForTableScan()
+    {
+        ColumnHandle columnA = new TestingColumnHandle("a");
+        ColumnHandle columnB = new TestingColumnHandle("b");
+        ColumnHandle columnC = new TestingColumnHandle("c");
+        ColumnHandle columnD = new TestingColumnHandle("d");
+        ColumnHandle columnE = new TestingColumnHandle("e");
+        ColumnHandle unknownColumn = new TestingColumnHandle("unknown");
+        tester()
+                .assertStatsFor(pb -> {
+                    Symbol a = pb.symbol("a", BIGINT);
+                    Symbol b = pb.symbol("b", DOUBLE);
+                    Symbol c = pb.symbol("c", DOUBLE);
+                    Symbol d = pb.symbol("d", DOUBLE);
+                    Symbol e = pb.symbol("e", INTEGER);
+                    Symbol unknown = pb.symbol("unknown", INTEGER);
+                    return pb.tableScan(
+                            ImmutableList.of(a, b, c, d, e, unknown),
+                            ImmutableMap.of(a, columnA, b, columnB, c, columnC, d, columnD, e, columnE, unknown, unknownColumn));
+                })
+                .withTableStatisticsProvider(tableHandle -> TableStatistics.builder()
+                        .setRowCount(Estimate.of(33))
+                        .setColumnStatistics(
+                                columnA,
+                                ColumnStatistics.builder().setDistinctValuesCount(Estimate.of(20)).build())
+                        .setColumnStatistics(
+                                columnB,
+                                ColumnStatistics.builder().setNullsFraction(Estimate.of(0.3)).setDistinctValuesCount(Estimate.of(23.1)).build())
+                        .setColumnStatistics(
+                                columnC,
+                                ColumnStatistics.builder().setRange(new DoubleRange(15, 20)).build())
+                        .setColumnStatistics(
+                                columnD,
+                                ColumnStatistics.builder().setDistinctValuesCount(Estimate.of(33)).build())
+                        .setColumnStatistics(
+                                columnE,
+                                ColumnStatistics.builder().setDistinctValuesCount(Estimate.of(31)).build())
+                        .setColumnStatistics(unknownColumn, ColumnStatistics.empty())
+                        .build())
+                .check(check -> check
+                        .outputRowsCount(33)
+                        .symbolStats("a", assertion -> assertion
+                                .distinctValuesCount(20)
+                                // UNKNOWN_NULLS_FRACTION populated to allow CBO to use NDV for estimation
+                                .nullsFraction(0.1))
+                        .symbolStats("b", assertion -> assertion
+                                .distinctValuesCount(23.1)
+                                .nullsFraction(0.3))
+                        .symbolStats("c", assertion -> assertion
+                                .distinctValuesCountUnknown()
+                                .nullsFractionUnknown()
+                                .lowValue(15)
+                                .highValue(20))
+                        .symbolStats("d", assertion -> assertion
+                                .distinctValuesCount(33)
+                                .nullsFraction(0))
+                        .symbolStats("e", assertion -> assertion
+                                .distinctValuesCount(31)
+                                .nullsFraction(0.06060606))
+                        .symbolStats("unknown", assertion -> assertion
+                                .unknownRange()
+                                .distinctValuesCountUnknown()
+                                .nullsFractionUnknown()
+                                .dataSizeUnknown()));
+    }
+
+    @Test
+    public void testZeroStatsForTableScan()
+    {
+        ColumnHandle columnHandle = new TestingColumnHandle("zero");
+        tester()
+                .assertStatsFor(pb -> {
+                    Symbol column = pb.symbol("zero", INTEGER);
+                    return pb.tableScan(
+                            ImmutableList.of(column),
+                            ImmutableMap.of(column, columnHandle));
+                })
+                .withTableStatisticsProvider(tableHandle -> TableStatistics.builder()
+                        .setRowCount(Estimate.zero())
+                        .setColumnStatistics(
+                                columnHandle,
+                                ColumnStatistics.builder().setDistinctValuesCount(Estimate.zero()).build())
+                        .build())
+                .check(check -> check
+                        .outputRowsCount(0)
+                        .symbolStats("zero", assertion -> assertion.isEqualTo(SymbolStatsEstimate.zero())));
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -3128,9 +3128,9 @@ public abstract class BaseIcebergConnectorTest
 
         String statsWithNdv = format == AVRO
                 ? ("VALUES " +
-                "  ('regionkey', NULL, 5e0, NULL, NULL, NULL, NULL), " +
-                "  ('name', NULL, 5e0, NULL, NULL, NULL, NULL), " +
-                "  ('comment', NULL, 5e0, NULL, NULL, NULL, NULL), " +
+                "  ('regionkey', NULL, 5e0, 0e0, NULL, NULL, NULL), " +
+                "  ('name', NULL, 5e0, 0e0, NULL, NULL, NULL), " +
+                "  ('comment', NULL, 5e0, 0e0, NULL, NULL, NULL), " +
                 "  (NULL, NULL, NULL, NULL, 5e0, NULL, NULL)")
                 : ("VALUES " +
                 "  ('regionkey', NULL, 5e0, 0e0, NULL, '0', '4'), " +
@@ -4019,20 +4019,20 @@ public abstract class BaseIcebergConnectorTest
             assertThat(query(extendedStatisticsEnabled, "SHOW STATS FOR test_all_types"))
                     .skippingTypesCheck()
                     .matches("VALUES " +
-                            "  ('a_boolean', NULL, 1e0, NULL, NULL, NULL, NULL), " +
-                            "  ('an_integer', NULL, 1e0, NULL, NULL, NULL, NULL), " +
-                            "  ('a_bigint', NULL, 1e0, NULL, NULL, NULL, NULL), " +
-                            "  ('a_real', NULL, 1e0, NULL, NULL, NULL, NULL), " +
-                            "  ('a_double', NULL, 1e0, NULL, NULL, NULL, NULL), " +
-                            "  ('a_short_decimal', NULL, 1e0, NULL, NULL, NULL, NULL), " +
-                            "  ('a_long_decimal', NULL, 1e0, NULL, NULL, NULL, NULL), " +
-                            "  ('a_varchar', NULL, 1e0, NULL, NULL, NULL, NULL), " +
-                            "  ('a_varbinary', NULL, 1e0, NULL, NULL, NULL, NULL), " +
-                            "  ('a_date', NULL, 1e0, NULL, NULL, NULL, NULL), " +
-                            "  ('a_time', NULL, 1e0, NULL, NULL, NULL, NULL), " +
-                            "  ('a_timestamp', NULL, 1e0, NULL, NULL, NULL, NULL), " +
-                            "  ('a_timestamptz', NULL, 1e0, NULL, NULL, NULL, NULL), " +
-                            "  ('a_uuid', NULL, 1e0, NULL, NULL, NULL, NULL), " +
+                            "  ('a_boolean', NULL, 1e0, 0.1e0, NULL, NULL, NULL), " +
+                            "  ('an_integer', NULL, 1e0, 0.1e0, NULL, NULL, NULL), " +
+                            "  ('a_bigint', NULL, 1e0, 0.1e0, NULL, NULL, NULL), " +
+                            "  ('a_real', NULL, 1e0, 0.1e0, NULL, NULL, NULL), " +
+                            "  ('a_double', NULL, 1e0, 0.1e0, NULL, NULL, NULL), " +
+                            "  ('a_short_decimal', NULL, 1e0, 0.1e0, NULL, NULL, NULL), " +
+                            "  ('a_long_decimal', NULL, 1e0, 0.1e0, NULL, NULL, NULL), " +
+                            "  ('a_varchar', NULL, 1e0, 0.1e0, NULL, NULL, NULL), " +
+                            "  ('a_varbinary', NULL, 1e0, 0.1e0, NULL, NULL, NULL), " +
+                            "  ('a_date', NULL, 1e0, 0.1e0, NULL, NULL, NULL), " +
+                            "  ('a_time', NULL, 1e0, 0.1e0, NULL, NULL, NULL), " +
+                            "  ('a_timestamp', NULL, 1e0, 0.1e0, NULL, NULL, NULL), " +
+                            "  ('a_timestamptz', NULL, 1e0, 0.1e0, NULL, NULL, NULL), " +
+                            "  ('a_uuid', NULL, 1e0, 0.1e0, NULL, NULL, NULL), " +
                             "  ('a_row', NULL, NULL, NULL, NULL, NULL, NULL), " +
                             "  ('an_array', NULL, NULL, NULL, NULL, NULL, NULL), " +
                             "  ('a_map', NULL, NULL, NULL, NULL, NULL, NULL), " +

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -189,9 +189,6 @@ public class MySqlClient
 
     private static final JsonCodec<ColumnHistogram> HISTOGRAM_CODEC = jsonCodec(ColumnHistogram.class);
 
-    // We don't know null fraction, but having no null fraction will make CBO useless. Assume some arbitrary value.
-    private static final Estimate UNKNOWN_NULL_FRACTION_REPLACEMENT = Estimate.of(0.1);
-
     private final Type jsonType;
     private final boolean statisticsEnabled;
     private final ConnectorExpressionRewriter<String> connectorExpressionRewriter;
@@ -798,13 +795,7 @@ public class MySqlClient
                     rowCount = max(rowCount, columnIndexStatistics.getCardinality());
                 }
 
-                ColumnStatistics columnStatistics = columnStatisticsBuilder.build();
-                if (!columnStatistics.getDistinctValuesCount().isUnknown() && columnStatistics.getNullsFraction().isUnknown()) {
-                    columnStatisticsBuilder.setNullsFraction(UNKNOWN_NULL_FRACTION_REPLACEMENT);
-                    columnStatistics = columnStatisticsBuilder.build();
-                }
-
-                tableStatistics.setColumnStatistics(column, columnStatistics);
+                tableStatistics.setColumnStatistics(column, columnStatisticsBuilder.build());
             }
 
             tableStatistics.setRowCount(Estimate.of(rowCount));


### PR DESCRIPTION
## Description

If a connector provides NDV but is missing nulls fraction statistic for a column
(e.g. Delta Lake after "delta.dataSkippingNumIndexedCols" columns and MySql), populate a
10% guess value so that the CBO can still produce some estimates rather than
failing to make any estimates due to lack of nulls fraction.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Delta
* Improve CBO estimates when the nulls fraction statistic is not available for some columns. ({issue}`15132`)
```
