### PR TITLE
Fix param name in MockConnector listTables lambdas

### DIFF
--- a/core/trino-main/src/test/java/io/trino/metadata/TestInformationSchemaMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestInformationSchemaMetadata.java
@@ -63,7 +63,7 @@ public class TestInformationSchemaMetadata
         LocalQueryRunner queryRunner = LocalQueryRunner.create(TEST_SESSION);
         MockConnectorFactory mockConnectorFactory = MockConnectorFactory.builder()
                 .withListSchemaNames(connectorSession -> ImmutableList.of("test_schema"))
-                .withListTables((connectorSession, schemaNameOrNull) ->
+                .withListTables((connectorSession, schemaName) ->
                         ImmutableList.of(
                                 new SchemaTableName("test_schema", "test_view"),
                                 new SchemaTableName("test_schema", "another_table")))

--- a/testing/trino-tests/src/test/java/io/trino/connector/informationschema/BenchmarkInformationSchema.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/informationschema/BenchmarkInformationSchema.java
@@ -98,20 +98,12 @@ public class BenchmarkInformationSchema
                             .map(i -> "stream_" + i)
                             .collect(toImmutableList());
 
-                    BiFunction<ConnectorSession, String, List<SchemaTableName>> listTables = (session, schemaNameOrNull) -> {
+                    BiFunction<ConnectorSession, String, List<SchemaTableName>> listTables = (session, schemaName) -> {
                         List<String> tables = IntStream.range(0, Integer.parseInt(tablesCount))
                                 .boxed()
                                 .map(i -> "table_" + i)
                                 .collect(toImmutableList());
-                        List<String> schemas;
-                        if (schemaNameOrNull == null) {
-                            schemas = listSchemaNames.apply(session);
-                        }
-                        else {
-                            schemas = ImmutableList.of(schemaNameOrNull);
-                        }
-                        return schemas.stream()
-                                .flatMap(schema -> tables.stream().map(table -> new SchemaTableName(schema, table)))
+                        return tables.stream().map(table -> new SchemaTableName(schemaName, table))
                                 .collect(toImmutableList());
                     };
 

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataManager.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataManager.java
@@ -80,7 +80,7 @@ public class TestMetadataManager
 
                             return new MockConnectorTableHandle(schemaTableName);
                         })
-                        .withListTables((session, schemaNameOrNull) ->
+                        .withListTables((session, schemaName) ->
                                 ImmutableList.of(new SchemaTableName("UPPER_CASE_SCHEMA", "UPPER_CASE_TABLE")))
                         .withGetViews((session, prefix) -> ImmutableMap.of(viewTableName, getConnectorViewDefinition()))
                         .build();


### PR DESCRIPTION
`listTables` is never called with a null schema name.
