### PR TITLE
Fix rounding of `SqlTime` and `SqlTimeWithTimeZone` overflow

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/type/SqlTime.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/SqlTime.java
@@ -62,7 +62,7 @@ public final class SqlTime
 
     public SqlTime roundTo(int precision)
     {
-        return new SqlTime(precision, round(picos, 12 - precision));
+        return new SqlTime(precision, round(picos, 12 - precision) % PICOSECONDS_PER_DAY);
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/type/SqlTimeWithTimeZone.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/SqlTimeWithTimeZone.java
@@ -74,7 +74,7 @@ public final class SqlTimeWithTimeZone
 
     public SqlTimeWithTimeZone roundTo(int precision)
     {
-        return new SqlTimeWithTimeZone(precision, round(picos, 12 - precision), offsetMinutes);
+        return new SqlTimeWithTimeZone(precision, round(picos, 12 - precision) % PICOSECONDS_PER_DAY, offsetMinutes);
     }
 
     @Override

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestSqlTime.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestSqlTime.java
@@ -15,6 +15,7 @@ package io.trino.spi.type;
 
 import org.junit.jupiter.api.Test;
 
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_DAY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestSqlTime
@@ -69,5 +70,20 @@ public class TestSqlTime
         assertThat(SqlTime.newInstance(12, 555555555555L).roundTo(10)).isEqualTo(SqlTime.newInstance(10, 555555555600L));
         assertThat(SqlTime.newInstance(12, 555555555555L).roundTo(11)).isEqualTo(SqlTime.newInstance(11, 555555555560L));
         assertThat(SqlTime.newInstance(12, 555555555555L).roundTo(12)).isEqualTo(SqlTime.newInstance(12, 555555555555L));
+
+        // round up to next day
+        assertThat(SqlTime.newInstance(12, PICOSECONDS_PER_DAY - 1L).roundTo(0)).isEqualTo(SqlTime.newInstance(0, 0));
+        assertThat(SqlTime.newInstance(12, PICOSECONDS_PER_DAY - 1L).roundTo(1)).isEqualTo(SqlTime.newInstance(1, 0));
+        assertThat(SqlTime.newInstance(12, PICOSECONDS_PER_DAY - 1L).roundTo(2)).isEqualTo(SqlTime.newInstance(2, 0));
+        assertThat(SqlTime.newInstance(12, PICOSECONDS_PER_DAY - 1L).roundTo(3)).isEqualTo(SqlTime.newInstance(3, 0));
+        assertThat(SqlTime.newInstance(12, PICOSECONDS_PER_DAY - 1L).roundTo(4)).isEqualTo(SqlTime.newInstance(4, 0));
+        assertThat(SqlTime.newInstance(12, PICOSECONDS_PER_DAY - 1L).roundTo(5)).isEqualTo(SqlTime.newInstance(5, 0));
+        assertThat(SqlTime.newInstance(12, PICOSECONDS_PER_DAY - 1L).roundTo(6)).isEqualTo(SqlTime.newInstance(6, 0));
+        assertThat(SqlTime.newInstance(12, PICOSECONDS_PER_DAY - 1L).roundTo(7)).isEqualTo(SqlTime.newInstance(7, 0));
+        assertThat(SqlTime.newInstance(12, PICOSECONDS_PER_DAY - 1L).roundTo(8)).isEqualTo(SqlTime.newInstance(8, 0));
+        assertThat(SqlTime.newInstance(12, PICOSECONDS_PER_DAY - 1L).roundTo(9)).isEqualTo(SqlTime.newInstance(9, 0));
+        assertThat(SqlTime.newInstance(12, PICOSECONDS_PER_DAY - 1L).roundTo(10)).isEqualTo(SqlTime.newInstance(10, 0));
+        assertThat(SqlTime.newInstance(12, PICOSECONDS_PER_DAY - 1L).roundTo(11)).isEqualTo(SqlTime.newInstance(11, 0));
+        assertThat(SqlTime.newInstance(12, PICOSECONDS_PER_DAY - 1L).roundTo(12)).isEqualTo(SqlTime.newInstance(12, PICOSECONDS_PER_DAY - 1L));
     }
 }

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestSqlTimeWithTimeZone.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestSqlTimeWithTimeZone.java
@@ -15,6 +15,7 @@ package io.trino.spi.type;
 
 import org.junit.jupiter.api.Test;
 
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_DAY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestSqlTimeWithTimeZone
@@ -76,5 +77,20 @@ public class TestSqlTimeWithTimeZone
         assertThat(SqlTimeWithTimeZone.newInstance(12, 555555555555L, 1).roundTo(10)).isEqualTo(SqlTimeWithTimeZone.newInstance(10, 555555555600L, 1));
         assertThat(SqlTimeWithTimeZone.newInstance(12, 555555555555L, 1).roundTo(11)).isEqualTo(SqlTimeWithTimeZone.newInstance(11, 555555555560L, 1));
         assertThat(SqlTimeWithTimeZone.newInstance(12, 555555555555L, 1).roundTo(12)).isEqualTo(SqlTimeWithTimeZone.newInstance(12, 555555555555L, 1));
+
+        // round up to next day
+        assertThat(SqlTimeWithTimeZone.newInstance(12, PICOSECONDS_PER_DAY - 1L, 1).roundTo(0)).isEqualTo(SqlTimeWithTimeZone.newInstance(0, 0, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, PICOSECONDS_PER_DAY - 1L, 1).roundTo(1)).isEqualTo(SqlTimeWithTimeZone.newInstance(1, 0, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, PICOSECONDS_PER_DAY - 1L, 1).roundTo(2)).isEqualTo(SqlTimeWithTimeZone.newInstance(2, 0, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, PICOSECONDS_PER_DAY - 1L, 1).roundTo(3)).isEqualTo(SqlTimeWithTimeZone.newInstance(3, 0, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, PICOSECONDS_PER_DAY - 1L, 1).roundTo(4)).isEqualTo(SqlTimeWithTimeZone.newInstance(4, 0, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, PICOSECONDS_PER_DAY - 1L, 1).roundTo(5)).isEqualTo(SqlTimeWithTimeZone.newInstance(5, 0, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, PICOSECONDS_PER_DAY - 1L, 1).roundTo(6)).isEqualTo(SqlTimeWithTimeZone.newInstance(6, 0, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, PICOSECONDS_PER_DAY - 1L, 1).roundTo(7)).isEqualTo(SqlTimeWithTimeZone.newInstance(7, 0, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, PICOSECONDS_PER_DAY - 1L, 1).roundTo(8)).isEqualTo(SqlTimeWithTimeZone.newInstance(8, 0, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, PICOSECONDS_PER_DAY - 1L, 1).roundTo(9)).isEqualTo(SqlTimeWithTimeZone.newInstance(9, 0, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, PICOSECONDS_PER_DAY - 1L, 1).roundTo(10)).isEqualTo(SqlTimeWithTimeZone.newInstance(10, 0, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, PICOSECONDS_PER_DAY - 1L, 1).roundTo(11)).isEqualTo(SqlTimeWithTimeZone.newInstance(11, 0, 1));
+        assertThat(SqlTimeWithTimeZone.newInstance(12, PICOSECONDS_PER_DAY - 1L, 1).roundTo(12)).isEqualTo(SqlTimeWithTimeZone.newInstance(12, PICOSECONDS_PER_DAY - 1L, 1));
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

When a time value overflows it should not overflow into the maximum picos per day as this is not a valid value. However currently Trino rounding can return this value. 

```
trino> select time '24:00:00.000';
Query 20221121_151354_00001_cya5k failed: line 1:8: '24:00:00.000' is not a valid time literal
select time '24:00:00.000'
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix rounding of TIME and TIME WITH TIME ZONE to return a zero time in case of overflow.
```
