### PR TITLE
Verify tests do not allocate resources early

### DIFF
--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraServer.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraServer.java
@@ -196,9 +196,7 @@ public class CassandraServer
     @Override
     public void close()
     {
-        if (session != null) {
-            session.close();
-        }
+        session.close();
         dockerContainer.close();
     }
 }

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraServer.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraServer.java
@@ -25,6 +25,7 @@ import com.google.common.io.Resources;
 import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
+import io.trino.testing.ResourcePresence;
 import org.testcontainers.containers.GenericContainer;
 
 import java.io.Closeable;
@@ -198,5 +199,11 @@ public class CassandraServer
     {
         session.close();
         dockerContainer.close();
+    }
+
+    @ResourcePresence
+    public boolean isRunning()
+    {
+        return dockerContainer.getContainerId() != null;
     }
 }

--- a/plugin/trino-mariadb/pom.xml
+++ b/plugin/trino-mariadb/pom.xml
@@ -125,6 +125,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-tpch</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestingMariaDbServer.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestingMariaDbServer.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.mariadb;
 
+import io.trino.testing.ResourcePresence;
 import org.testcontainers.containers.MariaDBContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -83,5 +84,11 @@ public class TestingMariaDbServer
     public void close()
     {
         container.close();
+    }
+
+    @ResourcePresence
+    public boolean isRunning()
+    {
+        return container.getContainerId() != null;
     }
 }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoServer.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoServer.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.mongodb;
 
 import com.mongodb.ConnectionString;
+import io.trino.testing.ResourcePresence;
 import org.testcontainers.containers.MongoDBContainer;
 
 import java.io.Closeable;
@@ -46,5 +47,11 @@ public class MongoServer
     public void close()
     {
         dockerContainer.close();
+    }
+
+    @ResourcePresence
+    public boolean isRunning()
+    {
+        return dockerContainer.getContainerId() != null;
     }
 }

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestingMySqlServer.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestingMySqlServer.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.mysql;
 
+import io.trino.testing.ResourcePresence;
 import org.testcontainers.containers.MySQLContainer;
 
 import java.io.Closeable;
@@ -116,5 +117,11 @@ public class TestingMySqlServer
         catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    @ResourcePresence
+    public boolean isRunning()
+    {
+        return container.getContainerId() != null;
     }
 }

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleServer.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleServer.java
@@ -21,6 +21,7 @@ import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.DriverConnectionFactory;
 import io.trino.plugin.jdbc.RetryingConnectionFactory;
 import io.trino.plugin.jdbc.credential.StaticCredentialProvider;
+import io.trino.testing.ResourcePresence;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
 import oracle.jdbc.OracleDriver;
@@ -131,5 +132,11 @@ public class TestingOracleServer
     public void close()
     {
         container.stop();
+    }
+
+    @ResourcePresence
+    public boolean isRunning()
+    {
+        return container.getContainerId() != null;
     }
 }

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlServer.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlServer.java
@@ -15,6 +15,7 @@ package io.trino.plugin.postgresql;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.plugin.jdbc.RemoteDatabaseEvent;
+import io.trino.testing.ResourcePresence;
 import org.intellij.lang.annotations.Language;
 import org.testcontainers.containers.PostgreSQLContainer;
 
@@ -145,5 +146,11 @@ public class TestingPostgreSqlServer
     public void close()
     {
         dockerContainer.close();
+    }
+
+    @ResourcePresence
+    public boolean isRunning()
+    {
+        return dockerContainer.getContainerId() != null;
     }
 }

--- a/plugin/trino-singlestore/pom.xml
+++ b/plugin/trino-singlestore/pom.xml
@@ -136,6 +136,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-tpch</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestingSingleStoreServer.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestingSingleStoreServer.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.singlestore;
 
 import com.google.common.collect.ImmutableSet;
+import io.trino.testing.ResourcePresence;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -46,11 +47,11 @@ public class TestingSingleStoreServer
         addEnv("ROOT_PASSWORD", "memsql_root_password");
         withCommand("sh", "-xeuc",
                 "/startup && " +
-                // Lower the size of pre-allocated log files to 1MB (minimum allowed) to reduce disk footprint
-                "memsql-admin update-config --yes --all --set-global --key \"log_file_size_partitions\" --value \"1048576\" && " +
-                "memsql-admin update-config --yes --all --set-global --key \"log_file_size_ref_dbs\" --value \"1048576\" && " +
-                // re-execute startup to actually start the nodes (first run performs setup but doesn't start the nodes)
-                "exec /startup");
+                        // Lower the size of pre-allocated log files to 1MB (minimum allowed) to reduce disk footprint
+                        "memsql-admin update-config --yes --all --set-global --key \"log_file_size_partitions\" --value \"1048576\" && " +
+                        "memsql-admin update-config --yes --all --set-global --key \"log_file_size_ref_dbs\" --value \"1048576\" && " +
+                        // re-execute startup to actually start the nodes (first run performs setup but doesn't start the nodes)
+                        "exec /startup");
         start();
     }
 
@@ -101,6 +102,12 @@ public class TestingSingleStoreServer
     public void execute(String sql)
     {
         execute(sql, getUsername(), getPassword());
+    }
+
+    @ResourcePresence
+    public boolean isResourcePresent()
+    {
+        return isRunning() || getContainerId() != null;
     }
 
     public void execute(String sql, String user, String password)

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestingSqlServer.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestingSqlServer.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.sqlserver;
 
 import io.airlift.log.Logger;
+import io.trino.testing.ResourcePresence;
 import io.trino.testing.sql.SqlExecutor;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
@@ -211,6 +212,12 @@ public final class TestingSqlServer
         catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    @ResourcePresence
+    public boolean isRunning()
+    {
+        return container.getContainerId() != null;
     }
 
     private static class InitializedState

--- a/testing/trino-testing-services/pom.xml
+++ b/testing/trino-testing-services/pom.xml
@@ -38,6 +38,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/testing/trino-testing-services/src/main/java/io/trino/testing/ResourcePresence.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testing/ResourcePresence.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Specifies a method that determines whether given resource-like class currently holds on to resources.
+ * The annotated method must not take parameters and must return a boolean, {@code true} indicating
+ * that a resource is present.
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface ResourcePresence {}

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/Listeners.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/Listeners.java
@@ -13,6 +13,7 @@
  */
 package io.trino.testng.services;
 
+import com.google.errorprone.annotations.FormatMethod;
 import org.testng.ITestNGListener;
 
 import static java.lang.String.format;
@@ -26,6 +27,7 @@ final class Listeners
      *
      * @apiNote A TestNG listener cannot throw an exception, as this are not currently properly handled by TestNG.
      */
+    @FormatMethod
     public static void reportListenerFailure(Class<? extends ITestNGListener> listenerClass, String format, Object... args)
     {
         System.err.println(format("FATAL: %s: ", listenerClass.getName()) + format(format, args));

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/ReportResourceHungryTests.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/ReportResourceHungryTests.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testng.services;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.testing.ResourcePresence;
+import org.intellij.lang.annotations.Language;
+import org.testng.ITestClass;
+import org.testng.ITestContext;
+import org.testng.ITestListener;
+import org.testng.ITestNGMethod;
+import org.testng.ITestResult;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Throwables.getStackTraceAsString;
+import static com.google.common.collect.MoreCollectors.toOptional;
+import static io.trino.testng.services.Listeners.reportListenerFailure;
+import static io.trino.testng.services.ReportResourceHungryTests.Stage.AFTER_CLASS;
+import static io.trino.testng.services.ReportResourceHungryTests.Stage.BEFORE_CLASS;
+
+public class ReportResourceHungryTests
+        implements ITestListener
+{
+    private final List<Rule> rules;
+
+    public ReportResourceHungryTests()
+    {
+        ImmutableList.Builder<Rule> rules = ImmutableList.builder();
+
+        isInstance("io.trino.cli.QueryRunner").ifPresent(rules::add);
+
+        // see https://github.com/trinodb/trino/commit/9e3b45b743e1cc350e759c1bed3cfb336b1cf610
+        isInstance("io.trino.transaction.TransactionManager").ifPresent(rules::add);
+
+        // any testcontainers resources
+        rules.add(declaredClassPattern("org\\.testcontainers\\..*"));
+
+        // any docker-java API's resources
+        rules.add(declaredClassPattern("com\\.github\\.dockerjava\\..*"));
+
+        // anything that looks like a "Server"
+        rules.add(ReportResourceHungryTests::isRunningServer);
+
+        this.rules = rules.build();
+    }
+
+    @Override
+    public void onStart(ITestContext context)
+    {
+        try {
+            reportResources(context, BEFORE_CLASS);
+        }
+        catch (ReflectiveOperationException | Error e) {
+            reportListenerFailure(
+                    ReportResourceHungryTests.class,
+                    "Failed to process %s: \n%s",
+                    context,
+                    getStackTraceAsString(e));
+        }
+    }
+
+    @Override
+    public void onTestStart(ITestResult result) {}
+
+    @Override
+    public void onTestSuccess(ITestResult result) {}
+
+    @Override
+    public void onTestFailure(ITestResult result) {}
+
+    @Override
+    public void onTestSkipped(ITestResult result) {}
+
+    @Override
+    public void onTestFailedButWithinSuccessPercentage(ITestResult result) {}
+
+    @Override
+    public void onFinish(ITestContext context)
+    {
+        try {
+            reportResources(context, AFTER_CLASS);
+        }
+        catch (ReflectiveOperationException | Error e) {
+            reportListenerFailure(
+                    ReportResourceHungryTests.class,
+                    "Failed to process %s: \n%s",
+                    context,
+                    getStackTraceAsString(e));
+        }
+    }
+
+    private void reportResources(ITestContext context, Stage stage)
+            throws ReflectiveOperationException
+    {
+        for (ITestNGMethod testMethod : context.getAllTestMethods()) {
+            reportResources(testMethod.getTestClass(), stage);
+        }
+    }
+
+    private void reportResources(ITestClass testClass, Stage stage)
+            throws ReflectiveOperationException
+    {
+        for (Object instance : testClass.getInstances(false)) {
+            for (Class<?> clazz = instance.getClass(); clazz != null; clazz = clazz.getSuperclass()) {
+                for (Field field : clazz.getDeclaredFields()) {
+                    field.setAccessible(true);
+                    Object value = field.get(instance);
+                    if (value == null) {
+                        continue;
+                    }
+                    for (Rule rule : rules) {
+                        if (rule.isExpensiveResource(field, value, stage)) {
+                            reportListenerFailure(
+                                    ReportResourceHungryTests.class,
+                                    "Field %s of %s [%s] is set (to %s) before class is started, or after class is finished. \n" +
+                                            "Resources must not be allocated in field initializer or test constructor, and must be freed when test class is completed. \n" +
+                                            "Depending which rule has been violated, if the reported class holds on to resources only conditionally, you can add @ResourcePresence to declare that.",
+                                    field,
+                                    instance,
+                                    testClass.getRealClass(),
+                                    value);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    enum Stage
+    {
+        BEFORE_CLASS,
+        AFTER_CLASS,
+    }
+
+    @FunctionalInterface
+    private interface Rule
+    {
+        boolean isExpensiveResource(Field field, Object value, Stage stage);
+    }
+
+    private static Optional<Rule> isInstance(String className)
+    {
+        return tryLoadClass(className)
+                .map(clazz -> (field, value, stage) -> clazz.isInstance(value));
+    }
+
+    private static Rule declaredClassPattern(@Language("RegExp") String classNamePattern)
+    {
+        Pattern pattern = Pattern.compile(classNamePattern);
+        return (field, value, stage) -> pattern.matcher(field.getType().getName()).matches();
+    }
+
+    /**
+     * Report anything that looks like a "Server" and does not appear to be stopped after class is finished.
+     */
+    private static boolean isRunningServer(Field field, Object value, Stage stage)
+    {
+        if (!field.getType().getName().endsWith("Server")) {
+            return false;
+        }
+
+        boolean resourceStopped = Stream.of(field.getType().getMethods())
+                .filter(method -> method.isAnnotationPresent(ResourcePresence.class))
+                .collect(toOptional())
+                .map(resourcePresence -> {
+                    try {
+                        return !(boolean) resourcePresence.invoke(value);
+                    }
+                    catch (ReflectiveOperationException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .orElse(false); // assume not stopped
+
+        // Disallow "*Server" instances, even if not started, before class is run.
+        // Allow stopped instances to be work nicely with `AbstractTestQueryFramework.closeAfterClass` usages.
+        return !(stage == AFTER_CLASS && resourceStopped);
+    }
+
+    private static Optional<Class<?>> tryLoadClass(String className)
+    {
+        try {
+            return Optional.of(Thread.currentThread().getContextClassLoader().loadClass(className));
+        }
+        catch (ClassNotFoundException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/testing/trino-testing-services/src/main/resources/META-INF/services/org.testng.ITestNGListener
+++ b/testing/trino-testing-services/src/main/resources/META-INF/services/org.testng.ITestNGListener
@@ -3,6 +3,7 @@ io.trino.testng.services.ReportPrivateMethods
 io.trino.testng.services.ReportUnannotatedMethods
 io.trino.testng.services.ReportIllNamedTest
 io.trino.testng.services.ReportMultiThreadedBeforeOrAfterMethod
+io.trino.testng.services.ReportResourceHungryTests
 io.trino.testng.services.LogTestDurationListener
 io.trino.testng.services.RetryAnnotationTransformer
 io.trino.testng.services.FlakyAnnotationVerifier


### PR DESCRIPTION
When running TestNG tests with surefire, the test class instance
initialization (class initializer, test instance construction) happens
before tests are run, for all instances. Allocating resources during
this phase is bad for these reasons:

- resources are allocated long before they are needed, so tests may
  exhaust available memory even if every single test is not memory-hungry
- failure reporting during this phase is imperfect (it was observed that
  actual failure stacktrace may not be reported in the logs), so
  diagnosing failures is hard.

This commit adds a runtime verification attempting to ensure that test
instances do not hold on to any "resourceful" classes before the test is
started. Of course, we don't want to prohibit any field initialization
in test instances (that would affect readability and would be
frustrating), so "resourceful" classes are some known ones. The list can
be extended in the future.

Besides checking test instances before test is run, it also checks
instances after test class is completed, to catch any resources that
were left behind and not closed.

Adds test coverage for https://github.com/trinodb/trino/pull/15133
