### PR TITLE
Fix incorrect plan property derivations

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
@@ -659,10 +659,11 @@ public final class PropertyDerivations
                     if (inputProperty.isEffectivelySingleStream() && node.getOrderingScheme().isEmpty()) {
                         verify(node.getInputs().size() == 1);
                         Map<Symbol, Symbol> inputToOutput = exchangeInputToOutput(node, 0);
-                        // Single stream input's local sorting and grouping properties are preserved
-                        // In case of merging exchange, it's orderingScheme takes precedence
+                        // Effectively single stream inputs will preserve constant grouping properties
                         localProperties.addAll(LocalProperties.translate(
-                                inputProperty.getLocalProperties(),
+                                inputProperty.getLocalProperties().stream()
+                                        .filter(property -> property instanceof ConstantProperty<Symbol>)
+                                        .toList(),
                                 symbol -> Optional.ofNullable(inputToOutput.get(symbol))));
                     }
                 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
@@ -283,8 +283,6 @@ public final class PropertyDerivations
                 localProperties.add(new GroupingProperty<>(node.getPartitionBy()));
             }
 
-            orderingScheme.ifPresent(ordering -> localProperties.addAll(ordering.toLocalProperties()));
-
             return ActualProperties.builderFrom(properties)
                     .local(LocalProperties.normalizeAndPrune(localProperties.build()))
                     .build();

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestPartialTopNWithPresortedInput.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestPartialTopNWithPresortedInput.java
@@ -160,13 +160,10 @@ public class TestPartialTopNWithPresortedInput
                 output(
                         topN(5, orderBy, FINAL,
                                 exchange(LOCAL, GATHER, ImmutableList.of(),
-                                        limit(
+                                        topN(
                                                 5,
-                                                ImmutableList.of(),
-                                                true,
-                                                orderBy.stream()
-                                                        .map(PlanMatchPattern.Ordering::getField)
-                                                        .collect(toImmutableList()),
+                                                orderBy,
+                                                PARTIAL,
                                                 exchange(LOCAL, REPARTITION, ImmutableList.of(),
                                                         window(
                                                                 p -> p.specification(


### PR DESCRIPTION
## Description
Fix a correctness issue associated with local exchange properties incorrectly propagating non-constant local properties inappropriately.

**Example Query:**
```
WITH students_results(student_id, course_id, grade) AS (VALUES
    (1000, 100, 17),
    (2000, 200, 16),
    (3000, 300, 18),
    (1000, 100, 18),
    (2000, 100, 10),
    (3000, 200, 20),
    (1000, 200, 16),
    (2000, 300, 12),
    (3000, 100, 17),
    (2000, 200, 15),
    (3000, 100, 18),
    (1000, 300, 12),
    (3000, 100, 20),
    (1000, 300, 16),
    (2000, 100, 12))
SELECT student_id, course_id, cnt, avg_w_sum,
    avg(sum_w_sum) OVER (
        ORDER BY student_id, course_id
        ROWS BETWEEN 2 PRECEDING AND 1 FOLLOWING
    ) AS avg_w
FROM (
    SELECT
        student_id, course_id, count(*) AS cnt,
        sum(sum(grade)) OVER (
            ORDER BY student_id, course_id
            ROWS BETWEEN 2 PRECEDING AND 1 FOLLOWING
        ) AS avg_w_sum,
        sum(sum(grade)) OVER (
            PARTITION BY student_id
        ) AS sum_w_sum
    FROM students_results
    GROUP BY student_id, course_id
) AS t
ORDER BY student_id, course_id
```

Before this fix, trino would produce incorrect (but not deterministic) results like the following:
```
 student_id | course_id | cnt | avg_w_sum | avg_w
------------+-----------+-----+-----------+-------
       2000 |       100 |   2 |        97 |  65.0
       2000 |       200 |   2 |        93 |  65.0
       2000 |       300 |   1 |       120 |  68.5
       1000 |       100 |   2 |        51 |  72.0
       1000 |       200 |   1 |        79 |  75.5
       1000 |       300 |   2 |       101 |  82.5
       3000 |       100 |   3 |       118 |  86.0
       3000 |       200 |   1 |       105 |  89.5
       3000 |       300 |   1 |        93 |  93.0
```

Instead of the expected correct output:
```
 student_id | course_id | cnt | avg_w_sum | avg_w
------------+-----------+-----+-----------+-------
       1000 |       100 |   2 |        51 |  79.0
       1000 |       200 |   1 |        79 |  79.0
       1000 |       300 |   2 |       101 |  75.5
       2000 |       100 |   2 |        97 |  72.0
       2000 |       200 |   2 |        93 |  68.5
       2000 |       300 |   1 |       120 |  72.0
       3000 |       100 |   3 |       118 |  79.0
       3000 |       200 |   1 |       105 |  86.0
       3000 |       300 |   1 |        93 |  93.0
```

Note that in this example, the query results are in the incorrect order according to the top-level `ORDER BY` _and_ the window function results are incorrect because the `WindowNode` in the plan was constructed with a `preSortedOrderPrefix=2` essentially declaring that the input was pre-sorted by `student_id, course_id` which was not. As a result, the `WindowOperator` does not think it needs to sort its output (causing the incorrect row order in the results) and attempts to find window frame boundaries in its input (causing incorrect window function results).

This bug was caused by commit https://github.com/trinodb/trino/commit/f57b8a42f8735a1fb6821a9f667bb2ad67661325 introduced as part of https://github.com/trinodb/trino/pull/6634 and released in Trino 358, which incorrectly propagated sort and partitioning local properties across the exchange boundary.

As @martint is correctly noted below, [`ActualProperties.isEffectivelySingleStream()`](https://github.com/trinodb/trino/commit/f57b8a42f8735a1fb6821a9f667bb2ad67661325#diff-213345bf703bddf351a74c47cfb73d0429fae55b92bd72b3d262d5e22c595cc4R627) does not mean is _actually_ single stream (and is probably poorly named). In the case of a gathering exchange, if multiple sub-streams each produce data in sort order before the local exchange, the rows will not be emitted from the exchange preserving that order unless that exchange is a "merging" exchange (which in this case it is not, because of the `ExchangeNode#getOrderingScheme().isEmpty()`) check). Only "constant" local properties can safely and correctly be be propagated across local exchanges like this.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:


I'm not sure exactly how to characterize this for the purposes of release notes since the scope of the potential impact of this bug on query correctness is potentially very broad. Suggestions for the release note welcome.

```markdown
# General
* Fix a correctness bug introduced in Trino 358 by ({issue}`6634`)
```
