### PR TITLE
Verify tests do not allocate resources early and do not leave them behind

### DIFF
--- a/client/trino-cli/src/test/java/io/trino/cli/TestInsecureQueryRunner.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestInsecureQueryRunner.java
@@ -57,6 +57,7 @@ public class TestInsecureQueryRunner
             throws Exception
     {
         server.close();
+        server = null;
     }
 
     @Test

--- a/client/trino-cli/src/test/java/io/trino/cli/TestQueryRunner.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestQueryRunner.java
@@ -67,6 +67,7 @@ public class TestQueryRunner
             throws IOException
     {
         server.close();
+        server = null;
     }
 
     @Test

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcConnection.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcConnection.java
@@ -116,6 +116,7 @@ public class TestJdbcConnection
         closeAll(
                 server,
                 executor::shutdownNow);
+        server = null;
     }
 
     @Test

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcPreparedStatement.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcPreparedStatement.java
@@ -107,6 +107,7 @@ public class TestJdbcPreparedStatement
             throws Exception
     {
         server.close();
+        server = null;
     }
 
     @Test

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcResultSet.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcResultSet.java
@@ -49,6 +49,7 @@ public class TestJdbcResultSet
             throws Exception
     {
         server.close();
+        server = null;
     }
 
     @Override

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcStatement.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcStatement.java
@@ -75,6 +75,7 @@ public class TestJdbcStatement
         closeAll(
                 server,
                 executor::shutdownNow);
+        server = null;
     }
 
     @Test(timeOut = 60_000)

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcWarnings.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcWarnings.java
@@ -100,6 +100,7 @@ public class TestJdbcWarnings
             throws Exception
     {
         server.close();
+        server = null;
     }
 
     @SuppressWarnings("JDBCResourceOpenedButNotSafelyClosed")
@@ -117,8 +118,11 @@ public class TestJdbcWarnings
             throws Exception
     {
         executor.shutdownNow();
+        executor = null;
         statement.close();
+        statement = null;
         connection.close();
+        connection = null;
     }
 
     @Test

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestProgressMonitor.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestProgressMonitor.java
@@ -65,6 +65,7 @@ public class TestProgressMonitor
             throws IOException
     {
         server.close();
+        server = null;
     }
 
     private List<String> createResults()

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
@@ -166,6 +166,7 @@ public class TestTrinoDatabaseMetaData
             throws Exception
     {
         connection.close();
+        connection = null;
     }
 
     @Test

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriver.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriver.java
@@ -130,6 +130,7 @@ public class TestTrinoDriver
         executorService.shutdownNow();
         executorService = null;
         server.close();
+        server = null;
     }
 
     @Test

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverAuth.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverAuth.java
@@ -93,6 +93,7 @@ public class TestTrinoDriverAuth
             throws Exception
     {
         server.close();
+        server = null;
     }
 
     @Test

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverImpersonateUser.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverImpersonateUser.java
@@ -79,6 +79,7 @@ public class TestTrinoDriverImpersonateUser
             throws Exception
     {
         server.close();
+        server = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/cost/TestStatsCalculator.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestStatsCalculator.java
@@ -22,6 +22,8 @@ import io.trino.sql.planner.assertions.PlanAssert;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.testing.LocalQueryRunner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static io.trino.sql.planner.LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED;
@@ -32,11 +34,12 @@ import static io.trino.testing.TestingSession.testSessionBuilder;
 
 public class TestStatsCalculator
 {
-    private final LocalQueryRunner queryRunner;
+    private LocalQueryRunner queryRunner;
 
-    public TestStatsCalculator()
+    @BeforeClass
+    public void setUp()
     {
-        this.queryRunner = LocalQueryRunner.create(testSessionBuilder()
+        queryRunner = LocalQueryRunner.create(testSessionBuilder()
                 .setCatalog(TEST_CATALOG_NAME)
                 .setSchema("tiny")
                 .setSystemProperty("task_concurrency", "1") // these tests don't handle exchanges from local parallel
@@ -46,6 +49,13 @@ public class TestStatsCalculator
                 queryRunner.getDefaultSession().getCatalog().get(),
                 new TpchConnectorFactory(1),
                 ImmutableMap.of());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        queryRunner.close();
+        queryRunner = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
@@ -128,7 +128,14 @@ public abstract class BaseDataDefinitionTaskTest
     {
         if (queryRunner != null) {
             queryRunner.close();
+            queryRunner = null;
         }
+        testSession = null;
+        metadata = null;
+        plannerContext = null;
+        materializedViewPropertyManager = null;
+        transactionManager = null;
+        queryStateMachine = null;
     }
 
     protected static QualifiedObjectName qualifiedObjectName(String objectName)

--- a/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
@@ -82,6 +82,7 @@ public class TestCallTask
     {
         if (queryRunner != null) {
             queryRunner.close();
+            queryRunner = null;
         }
         executor.shutdownNow();
         executor = null;

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateMaterializedViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateMaterializedViewTask.java
@@ -155,6 +155,15 @@ public class TestCreateMaterializedViewTask
         if (queryRunner != null) {
             queryRunner.close();
         }
+        testSession = null;
+        metadata = null;
+        plannerContext = null;
+        transactionManager = null;
+        parser = null;
+        queryStateMachine = null;
+        analyzerFactory = null;
+        materializedViewPropertyManager = null;
+        queryRunner = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateTableTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateTableTask.java
@@ -142,6 +142,12 @@ public class TestCreateTableTask
         if (queryRunner != null) {
             queryRunner.close();
         }
+        queryRunner = null;
+        transactionManager = null;
+        tablePropertyManager = null;
+        columnPropertyManager = null;
+        metadata = null;
+        plannerContext = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/TestMemoryRevokingScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestMemoryRevokingScheduler.java
@@ -71,10 +71,11 @@ public class TestMemoryRevokingScheduler
     private final SpillSpaceTracker spillSpaceTracker = new SpillSpaceTracker(DataSize.of(10, GIGABYTE));
     private final Map<QueryId, QueryContext> queryContexts = new HashMap<>();
 
+    private MemoryPool memoryPool;
+    private TaskExecutor taskExecutor;
     private ScheduledExecutorService executor;
     private ScheduledExecutorService scheduledExecutor;
     private SqlTaskExecutionFactory sqlTaskExecutionFactory;
-    private MemoryPool memoryPool;
 
     private Set<OperatorContext> allOperatorContexts;
 
@@ -83,7 +84,7 @@ public class TestMemoryRevokingScheduler
     {
         memoryPool = new MemoryPool(DataSize.ofBytes(10));
 
-        TaskExecutor taskExecutor = new TaskExecutor(8, 16, 3, 4, Ticker.systemTicker());
+        taskExecutor = new TaskExecutor(8, 16, 3, 4, Ticker.systemTicker());
         taskExecutor.start();
 
         // Must be single threaded
@@ -107,8 +108,12 @@ public class TestMemoryRevokingScheduler
     {
         queryContexts.clear();
         memoryPool = null;
+        taskExecutor.stop();
+        taskExecutor = null;
         executor.shutdownNow();
         scheduledExecutor.shutdownNow();
+        sqlTaskExecutionFactory = null;
+        allOperatorContexts = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/TestPlannerWarnings.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestPlannerWarnings.java
@@ -76,6 +76,7 @@ public class TestPlannerWarnings
     public void tearDown()
     {
         queryRunner.close();
+        queryRunner = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/TestResetSessionTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestResetSessionTask.java
@@ -28,6 +28,7 @@ import io.trino.sql.tree.ResetSession;
 import io.trino.testing.LocalQueryRunner;
 import io.trino.transaction.TransactionManager;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.net.URI;
@@ -48,14 +49,16 @@ public class TestResetSessionTask
 {
     private static final String CATALOG_NAME = "my_catalog";
     private ExecutorService executor = newCachedThreadPool(daemonThreadsNamed(getClass().getSimpleName() + "-%s"));
-    private final TransactionManager transactionManager;
-    private final AccessControl accessControl;
-    private final Metadata metadata;
-    private final SessionPropertyManager sessionPropertyManager;
+    private LocalQueryRunner queryRunner;
+    private TransactionManager transactionManager;
+    private AccessControl accessControl;
+    private Metadata metadata;
+    private SessionPropertyManager sessionPropertyManager;
 
-    public TestResetSessionTask()
+    @BeforeClass
+    public void setUp()
     {
-        LocalQueryRunner queryRunner = LocalQueryRunner.builder(TEST_SESSION)
+        queryRunner = LocalQueryRunner.builder(TEST_SESSION)
                 .withExtraSystemSessionProperties(ImmutableSet.of(() -> ImmutableList.of(
                         stringProperty(
                                 "foo",
@@ -84,6 +87,8 @@ public class TestResetSessionTask
     @AfterClass(alwaysRun = true)
     public void tearDown()
     {
+        queryRunner.close();
+        queryRunner = null;
         executor.shutdownNow();
         executor = null;
     }

--- a/core/trino-main/src/test/java/io/trino/execution/TestResetSessionTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestResetSessionTask.java
@@ -87,10 +87,14 @@ public class TestResetSessionTask
     @AfterClass(alwaysRun = true)
     public void tearDown()
     {
-        queryRunner.close();
-        queryRunner = null;
         executor.shutdownNow();
         executor = null;
+        queryRunner.close();
+        queryRunner = null;
+        transactionManager = null;
+        accessControl = null;
+        metadata = null;
+        sessionPropertyManager = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetPathTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetPathTask.java
@@ -26,6 +26,7 @@ import io.trino.sql.tree.PathSpecification;
 import io.trino.sql.tree.SetPath;
 import io.trino.transaction.TransactionManager;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.net.URI;
@@ -44,13 +45,14 @@ import static org.testng.Assert.assertEquals;
 
 public class TestSetPathTask
 {
-    private final TransactionManager transactionManager;
-    private final AccessControl accessControl;
-    private final Metadata metadata;
+    private TransactionManager transactionManager;
+    private AccessControl accessControl;
+    private Metadata metadata;
 
     private ExecutorService executor = newCachedThreadPool(daemonThreadsNamed(getClass().getSimpleName() + "-%s"));
 
-    public TestSetPathTask()
+    @BeforeClass
+    public void setUp()
     {
         transactionManager = createTestTransactionManager();
         accessControl = new AllowAllAccessControl();
@@ -65,6 +67,9 @@ public class TestSetPathTask
     {
         executor.shutdownNow();
         executor = null;
+        transactionManager = null;
+        accessControl = null;
+        metadata = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetSessionTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetSessionTask.java
@@ -76,6 +76,7 @@ public class TestSetSessionTask
     private Metadata metadata;
     private PlannerContext plannerContext;
     private SessionPropertyManager sessionPropertyManager;
+    private ExecutorService executor = newCachedThreadPool(daemonThreadsNamed(getClass().getSimpleName() + "-%s"));
 
     @BeforeClass
     public void setUp()
@@ -126,8 +127,6 @@ public class TestSetSessionTask
             throw new TrinoException(INVALID_SESSION_PROPERTY, MUST_BE_POSITIVE);
         }
     }
-
-    private ExecutorService executor = newCachedThreadPool(daemonThreadsNamed(getClass().getSimpleName() + "-%s"));
 
     @AfterClass(alwaysRun = true)
     public void tearDown()

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetSessionTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetSessionTask.java
@@ -136,6 +136,11 @@ public class TestSetSessionTask
         queryRunner = null;
         executor.shutdownNow();
         executor = null;
+        transactionManager = null;
+        accessControl = null;
+        metadata = null;
+        plannerContext = null;
+        sessionPropertyManager = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetSessionTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetSessionTask.java
@@ -35,6 +35,7 @@ import io.trino.sql.tree.StringLiteral;
 import io.trino.testing.LocalQueryRunner;
 import io.trino.transaction.TransactionManager;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.net.URI;
@@ -69,15 +70,17 @@ public class TestSetSessionTask
         LARGE,
     }
 
-    private final TransactionManager transactionManager;
-    private final AccessControl accessControl;
-    private final Metadata metadata;
-    private final PlannerContext plannerContext;
-    private final SessionPropertyManager sessionPropertyManager;
+    private LocalQueryRunner queryRunner;
+    private TransactionManager transactionManager;
+    private AccessControl accessControl;
+    private Metadata metadata;
+    private PlannerContext plannerContext;
+    private SessionPropertyManager sessionPropertyManager;
 
-    public TestSetSessionTask()
+    @BeforeClass
+    public void setUp()
     {
-        LocalQueryRunner queryRunner = LocalQueryRunner.builder(TEST_SESSION)
+        queryRunner = LocalQueryRunner.builder(TEST_SESSION)
                 .withExtraSystemSessionProperties(ImmutableSet.of(() -> ImmutableList.of(
                         stringProperty(
                                 "foo",
@@ -129,6 +132,8 @@ public class TestSetSessionTask
     @AfterClass(alwaysRun = true)
     public void tearDown()
     {
+        queryRunner.close();
+        queryRunner = null;
         executor.shutdownNow();
         executor = null;
     }

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetTimeZoneTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetTimeZoneTask.java
@@ -27,6 +27,7 @@ import io.trino.sql.tree.SetTimeZone;
 import io.trino.sql.tree.StringLiteral;
 import io.trino.testing.LocalQueryRunner;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.net.URI;
@@ -50,10 +51,11 @@ import static org.testng.Assert.assertEquals;
 
 public class TestSetTimeZoneTask
 {
-    private final LocalQueryRunner localQueryRunner;
     private ExecutorService executor = newCachedThreadPool(daemonThreadsNamed(getClass().getSimpleName() + "-%s"));
+    private LocalQueryRunner localQueryRunner;
 
-    public TestSetTimeZoneTask()
+    @BeforeClass
+    public void setUp()
     {
         localQueryRunner = LocalQueryRunner.create(TEST_SESSION);
     }
@@ -63,6 +65,8 @@ public class TestSetTimeZoneTask
     {
         executor.shutdownNow();
         executor = null;
+        localQueryRunner.close();
+        localQueryRunner = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTask.java
@@ -37,6 +37,7 @@ import io.trino.spi.predicate.Domain;
 import io.trino.spiller.SpillSpaceTracker;
 import io.trino.sql.planner.LocalExecutionPlanner;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.net.URI;
@@ -81,14 +82,16 @@ import static org.testng.Assert.assertTrue;
 public class TestSqlTask
 {
     public static final OutputBufferId OUT = new OutputBufferId(0);
-    private final TaskExecutor taskExecutor;
-    private final ScheduledExecutorService taskNotificationExecutor;
-    private final ScheduledExecutorService driverYieldExecutor;
-    private final SqlTaskExecutionFactory sqlTaskExecutionFactory;
+
+    private TaskExecutor taskExecutor;
+    private ScheduledExecutorService taskNotificationExecutor;
+    private ScheduledExecutorService driverYieldExecutor;
+    private SqlTaskExecutionFactory sqlTaskExecutionFactory;
 
     private final AtomicInteger nextTaskId = new AtomicInteger();
 
-    public TestSqlTask()
+    @BeforeClass
+    public void setUp()
     {
         taskExecutor = new TaskExecutor(8, 16, 3, 4, Ticker.systemTicker());
         taskExecutor.start();
@@ -110,8 +113,10 @@ public class TestSqlTask
     public void destroy()
     {
         taskExecutor.stop();
+        taskExecutor = null;
         taskNotificationExecutor.shutdownNow();
         driverYieldExecutor.shutdown();
+        sqlTaskExecutionFactory = null;
     }
 
     @Test(timeOut = 30_000)

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
@@ -103,8 +103,8 @@ public class TestSqlTaskExecution
         ScheduledExecutorService taskNotificationExecutor = newScheduledThreadPool(10, threadsNamed("task-notification-%s"));
         ScheduledExecutorService driverYieldExecutor = newScheduledThreadPool(2, threadsNamed("driver-yield-%s"));
         TaskExecutor taskExecutor = new TaskExecutor(5, 10, 3, 4, Ticker.systemTicker());
-        taskExecutor.start();
 
+        taskExecutor.start();
         try {
             TaskStateMachine taskStateMachine = new TaskStateMachine(TASK_ID, taskNotificationExecutor);
             PartitionedOutputBuffer outputBuffer = newTestingOutputBuffer(taskNotificationExecutor);

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManager.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManager.java
@@ -52,6 +52,7 @@ import io.trino.spiller.LocalSpillManager;
 import io.trino.spiller.NodeSpillConfig;
 import io.trino.version.EmbedVersion;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -90,12 +91,13 @@ public class TestSqlTaskManager
     private static final TaskId TASK_ID = new TaskId(new StageId("query", 0), 1, 0);
     public static final OutputBufferId OUT = new OutputBufferId(0);
 
-    private final TaskExecutor taskExecutor;
-    private final TaskManagementExecutor taskManagementExecutor;
-    private final LocalMemoryManager localMemoryManager;
-    private final LocalSpillManager localSpillManager;
+    private TaskExecutor taskExecutor;
+    private TaskManagementExecutor taskManagementExecutor;
+    private LocalMemoryManager localMemoryManager;
+    private LocalSpillManager localSpillManager;
 
-    public TestSqlTaskManager()
+    @BeforeClass
+    public void setUp()
     {
         localMemoryManager = new LocalMemoryManager(new NodeMemoryConfig());
         localSpillManager = new LocalSpillManager(new NodeSpillConfig());
@@ -108,7 +110,9 @@ public class TestSqlTaskManager
     public void tearDown()
     {
         taskExecutor.stop();
+        taskExecutor = null;
         taskManagementExecutor.close();
+        taskManagementExecutor = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/executor/TestTaskExecutor.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/TestTaskExecutor.java
@@ -58,10 +58,10 @@ public class TestTaskExecutor
         Duration splitProcessingDurationThreshold = new Duration(10, MINUTES);
 
         TaskExecutor taskExecutor = new TaskExecutor(4, 8, 3, 4, ticker);
-        taskExecutor.start();
-        ticker.increment(20, MILLISECONDS);
 
+        taskExecutor.start();
         try {
+            ticker.increment(20, MILLISECONDS);
             TaskId taskId = new TaskId(new StageId("test", 0), 0, 0);
             TaskHandle taskHandle = taskExecutor.addTask(taskId, () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
 
@@ -156,10 +156,10 @@ public class TestTaskExecutor
     {
         TestingTicker ticker = new TestingTicker();
         TaskExecutor taskExecutor = new TaskExecutor(1, 2, 3, 4, ticker);
-        taskExecutor.start();
-        ticker.increment(20, MILLISECONDS);
 
+        taskExecutor.start();
         try {
+            ticker.increment(20, MILLISECONDS);
             TaskHandle shortQuantaTaskHandle = taskExecutor.addTask(new TaskId(new StageId("short_quanta", 0), 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
             TaskHandle longQuantaTaskHandle = taskExecutor.addTask(new TaskId(new StageId("long_quanta", 0), 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
 
@@ -190,10 +190,10 @@ public class TestTaskExecutor
     {
         TestingTicker ticker = new TestingTicker();
         TaskExecutor taskExecutor = new TaskExecutor(2, 2, 3, 4, ticker);
-        taskExecutor.start();
-        ticker.increment(20, MILLISECONDS);
 
+        taskExecutor.start();
         try {
+            ticker.increment(20, MILLISECONDS);
             TaskHandle testTaskHandle = taskExecutor.addTask(new TaskId(new StageId("test", 0), 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
 
             Phaser globalPhaser = new Phaser();
@@ -229,10 +229,10 @@ public class TestTaskExecutor
     {
         TestingTicker ticker = new TestingTicker();
         TaskExecutor taskExecutor = new TaskExecutor(6, 3, 3, 4, new MultilevelSplitQueue(2), ticker);
-        taskExecutor.start();
-        ticker.increment(20, MILLISECONDS);
 
+        taskExecutor.start();
         try {
+            ticker.increment(20, MILLISECONDS);
             for (int i = 0; i < (LEVEL_THRESHOLD_SECONDS.length - 1); i++) {
                 TaskHandle[] taskHandles = {
                         taskExecutor.addTask(new TaskId(new StageId("test1", 0), 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty()),
@@ -307,8 +307,8 @@ public class TestTaskExecutor
     {
         TestingTicker ticker = new TestingTicker();
         TaskExecutor taskExecutor = new TaskExecutor(4, 8, 3, 4, ticker);
-        taskExecutor.start();
 
+        taskExecutor.start();
         try {
             TaskId taskId = new TaskId(new StageId("test", 0), 0, 0);
             TaskHandle taskHandle = taskExecutor.addTask(taskId, () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
@@ -382,6 +382,7 @@ public class TestTaskExecutor
         MultilevelSplitQueue splitQueue = new MultilevelSplitQueue(2);
         TestingTicker ticker = new TestingTicker();
         TaskExecutor taskExecutor = new TaskExecutor(4, 16, 1, maxDriversPerTask, splitQueue, ticker);
+
         taskExecutor.start();
         try {
             TaskHandle testTaskHandle = taskExecutor.addTask(new TaskId(new StageId("test", 0), 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
@@ -422,6 +423,7 @@ public class TestTaskExecutor
         TestingTicker ticker = new TestingTicker();
         // create a task executor with min/max drivers per task to be 2 and 4
         TaskExecutor taskExecutor = new TaskExecutor(4, 16, 2, 4, splitQueue, ticker);
+
         taskExecutor.start();
         try {
             // overwrite the max drivers per task to be 1
@@ -461,8 +463,8 @@ public class TestTaskExecutor
         TestingTicker ticker = new TestingTicker();
         // create a task executor with min/max drivers per task to be 2
         TaskExecutor taskExecutor = new TaskExecutor(4, 1, 2, 2, splitQueue, ticker);
-        taskExecutor.start();
 
+        taskExecutor.start();
         try {
             TaskHandle testTaskHandle = taskExecutor.addTask(
                     new TaskId(new StageId(new QueryId("test"), 0), 0, 0),

--- a/core/trino-main/src/test/java/io/trino/metadata/TestDiscoveryNodeManager.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestDiscoveryNodeManager.java
@@ -30,6 +30,7 @@ import io.trino.connector.CatalogManagerConfig;
 import io.trino.connector.system.GlobalSystemConnector;
 import io.trino.failuredetector.NoOpFailureDetector;
 import io.trino.server.InternalCommunicationConfig;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -85,6 +86,13 @@ public class TestDiscoveryNodeManager
                 new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.4.9"), new NodeVersion("2"), false));
 
         selector.announceNodes(activeNodes, inactiveNodes);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown()
+    {
+        testHttpClient.close();
+        testHttpClient = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/server/TestGenerateTokenFilter.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestGenerateTokenFilter.java
@@ -76,6 +76,8 @@ public class TestGenerateTokenFilter
             throws Exception
     {
         closeAll(server, httpClient);
+        server = null;
+        httpClient = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/server/TestNodeResource.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestNodeResource.java
@@ -47,6 +47,8 @@ public class TestNodeResource
             throws Exception
     {
         closeAll(server, client);
+        server = null;
+        client = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/server/TestQueryResource.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestQueryResource.java
@@ -82,6 +82,8 @@ public class TestQueryResource
             throws Exception
     {
         closeAll(server, client);
+        server = null;
+        client = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/server/TestQueryStateInfoResource.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestQueryStateInfoResource.java
@@ -119,6 +119,8 @@ public class TestQueryStateInfoResource
         closer.register(server);
         closer.register(client);
         closer.close();
+        server = null;
+        client = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/BaseOAuth2WebUiAuthenticationFilterTest.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/BaseOAuth2WebUiAuthenticationFilterTest.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.inject.Key;
 import io.airlift.log.Level;
 import io.airlift.log.Logging;
-import io.airlift.testing.Closeables;
 import io.jsonwebtoken.impl.DefaultClaims;
 import io.trino.server.testing.TestingTrinoServer;
 import io.trino.server.ui.OAuth2WebUiAuthenticationFilter;
@@ -49,6 +48,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static io.airlift.testing.Closeables.closeAll;
 import static io.trino.client.OkHttpUtil.setupInsecureSsl;
 import static io.trino.server.security.jwt.JwtUtil.newJwtBuilder;
 import static io.trino.server.security.oauth2.TokenEndpointAuthMethod.CLIENT_SECRET_BASIC;
@@ -142,7 +142,9 @@ public abstract class BaseOAuth2WebUiAuthenticationFilterTest
     {
         logging.clearLevel(OAuth2WebUiAuthenticationFilter.class.getName());
         logging.clearLevel(OAuth2Service.class.getName());
-        Closeables.closeAll(server, hydraIdP);
+        closeAll(server, hydraIdP);
+        server = null;
+        hydraIdP = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/spiller/TestFileSingleStreamSpillerFactory.java
+++ b/core/trino-main/src/test/java/io/trino/spiller/TestFileSingleStreamSpillerFactory.java
@@ -76,6 +76,7 @@ public class TestFileSingleStreamSpillerFactory
             throws Exception
     {
         closer.close();
+        closer = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -6959,6 +6959,11 @@ public class TestAnalyzer
             throws Exception
     {
         closer.close();
+        transactionManager = null;
+        accessControl = null;
+        plannerContext = null;
+        tablePropertyManager = null;
+        analyzePropertyManager = null;
     }
 
     private void inSetupTransaction(Consumer<Session> consumer)

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -224,7 +224,7 @@ public class TestAnalyzer
 
     private static final SqlParser SQL_PARSER = new SqlParser();
 
-    private final Closer closer = Closer.create();
+    private Closer closer;
     private TransactionManager transactionManager;
     private AccessControl accessControl;
     private PlannerContext plannerContext;
@@ -6625,6 +6625,7 @@ public class TestAnalyzer
     @BeforeClass
     public void setup()
     {
+        closer = Closer.create();
         LocalQueryRunner queryRunner = LocalQueryRunner.create(TEST_SESSION);
         closer.register(queryRunner);
         transactionManager = queryRunner.getTransactionManager();
@@ -6959,6 +6960,7 @@ public class TestAnalyzer
             throws Exception
     {
         closer.close();
+        closer = null;
         transactionManager = null;
         accessControl = null;
         plannerContext = null;

--- a/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestAnonymizeJsonRepresentation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestAnonymizeJsonRepresentation.java
@@ -86,7 +86,7 @@ public class TestAnonymizeJsonRepresentation
         queryRunner.createCatalog(TEST_SESSION.getCatalog().get(), new TpchConnectorFactory(1), ImmutableMap.of());
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void tearDown()
     {
         queryRunner.close();

--- a/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestAnonymizeJsonRepresentation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestAnonymizeJsonRepresentation.java
@@ -34,6 +34,7 @@ import io.trino.sql.planner.plan.DynamicFilterId;
 import io.trino.sql.planner.plan.JoinNode;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.testing.LocalQueryRunner;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -83,6 +84,13 @@ public class TestAnonymizeJsonRepresentation
     {
         queryRunner = LocalQueryRunner.create(TEST_SESSION);
         queryRunner.createCatalog(TEST_SESSION.getCatalog().get(), new TpchConnectorFactory(1), ImmutableMap.of());
+    }
+
+    @AfterClass
+    public void tearDown()
+    {
+        queryRunner.close();
+        queryRunner = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
@@ -30,6 +30,7 @@ import io.trino.sql.planner.plan.PlanFragmentId;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.testing.LocalQueryRunner;
 import io.trino.testing.MaterializedResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -71,6 +72,13 @@ public class TestJsonRepresentation
     {
         queryRunner = LocalQueryRunner.create(TEST_SESSION);
         queryRunner.createCatalog(TEST_SESSION.getCatalog().get(), new TpchConnectorFactory(1), ImmutableMap.of());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        queryRunner.close();
+        queryRunner = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/sanity/TestValidateScaledWritersUsage.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/sanity/TestValidateScaledWritersUsage.java
@@ -37,6 +37,7 @@ import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.testing.LocalQueryRunner;
 import io.trino.testing.TestingTransactionHandle;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -55,13 +56,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestValidateScaledWritersUsage
         extends BasePlanTest
 {
+    private LocalQueryRunner queryRunner;
     private PlannerContext plannerContext;
     private PlanBuilder planBuilder;
     private Symbol symbol;
     private TableScanNode tableScanNode;
     private CatalogHandle catalogSupportingScaledWriters;
     private CatalogHandle catalogNotSupportingScaledWriters;
-    private LocalQueryRunner queryRunner;
     private SchemaTableName schemaTableName;
 
     @BeforeClass
@@ -82,6 +83,18 @@ public class TestValidateScaledWritersUsage
         TpchColumnHandle nationkeyColumnHandle = new TpchColumnHandle("nationkey", BIGINT);
         symbol = new Symbol("nationkey");
         tableScanNode = planBuilder.tableScan(nationTableHandle, ImmutableList.of(symbol), ImmutableMap.of(symbol, nationkeyColumnHandle));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        queryRunner.close();
+        queryRunner = null;
+        plannerContext = null;
+        planBuilder = null;
+        tableScanNode = null;
+        catalogSupportingScaledWriters = null;
+        catalogNotSupportingScaledWriters = null;
     }
 
     private MockConnectorFactory createConnectorFactorySupportingReportingBytesWritten(boolean supportsWrittenBytes, String name)

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
@@ -158,6 +158,7 @@ public class TestColumnMask
     @AfterAll
     public void teardown()
     {
+        accessControl = null;
         assertions.close();
         assertions = null;
     }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestRowFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestRowFilter.java
@@ -144,6 +144,7 @@ public class TestRowFilter
     @AfterAll
     public void teardown()
     {
+        accessControl = null;
         assertions.close();
         assertions = null;
     }

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestCachingOrcDataSource.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestCachingOrcDataSource.java
@@ -90,6 +90,7 @@ public class TestCachingOrcDataSource
             throws Exception
     {
         tempFile.close();
+        tempFile = null;
     }
 
     @Test

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestStructColumnReader.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestStructColumnReader.java
@@ -75,6 +75,7 @@ public class TestStructColumnReader
             throws IOException
     {
         tempFile.close();
+        tempFile = null;
     }
 
     /**

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectionCreationTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectionCreationTest.java
@@ -16,6 +16,7 @@ package io.trino.plugin.jdbc;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.testing.AbstractTestQueryFramework;
 import org.intellij.lang.annotations.Language;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -43,6 +44,14 @@ public abstract class BaseJdbcConnectionCreationTest
         // Test expects connectionFactory to be provided with AbstractTestQueryFramework.createQueryRunner implementation
         requireNonNull(connectionFactory, "connectionFactory is null");
         connectionFactory.assertThatNoConnectionHasLeaked();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy()
+            throws Exception
+    {
+        connectionFactory.close();
+        connectionFactory = null;
     }
 
     protected void assertJdbcConnections(@Language("SQL") String query, int expectedJdbcConnectionsCount, Optional<String> errorMessage)

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestCachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestCachingJdbcClient.java
@@ -127,7 +127,9 @@ public class TestCachingJdbcClient
             throws Exception
     {
         executor.shutdownNow();
+        executor = null;
         database.close();
+        database = null;
     }
 
     @Test

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcMetadata.java
@@ -112,6 +112,7 @@ public class TestDefaultJdbcMetadata
             throws Exception
     {
         database.close();
+        database = null;
     }
 
     @Test

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
@@ -181,6 +181,7 @@ public class TestDefaultJdbcQueryBuilder
             throws Exception
     {
         database.close();
+        database = null;
     }
 
     @Test

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcClient.java
@@ -66,6 +66,7 @@ public class TestJdbcClient
             throws Exception
     {
         database.close();
+        database = null;
     }
 
     @Test

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcRecordSet.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcRecordSet.java
@@ -67,6 +67,8 @@ public class TestJdbcRecordSet
         closeAll(
                 database,
                 () -> executor.shutdownNow());
+        database = null;
+        executor = null;
     }
 
     @Test

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcRecordSetProvider.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcRecordSetProvider.java
@@ -90,6 +90,8 @@ public class TestJdbcRecordSetProvider
         closeAll(
                 database,
                 () -> executor.shutdownNow());
+        database = null;
+        executor = null;
     }
 
     @Test

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraServer.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraServer.java
@@ -196,9 +196,7 @@ public class CassandraServer
     @Override
     public void close()
     {
-        if (session != null) {
-            session.close();
-        }
+        session.close();
         dockerContainer.close();
     }
 }

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraServer.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraServer.java
@@ -25,6 +25,7 @@ import com.google.common.io.Resources;
 import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
+import io.trino.testing.ResourcePresence;
 import org.testcontainers.containers.GenericContainer;
 
 import java.io.Closeable;
@@ -198,5 +199,11 @@ public class CassandraServer
     {
         session.close();
         dockerContainer.close();
+    }
+
+    @ResourcePresence
+    public boolean isRunning()
+    {
+        return dockerContainer.getContainerId() != null;
     }
 }

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
@@ -27,6 +27,7 @@ import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.assertions.Assert;
 import io.trino.testing.sql.TestTable;
 import org.testng.SkipException;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
@@ -133,6 +134,13 @@ public class TestCassandraConnectorTest
         session = server.getSession();
         session.execute("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE + " WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor': 1}");
         return createCassandraQueryRunner(server, ImmutableMap.of(), ImmutableMap.of(), REQUIRED_TPCH_TABLES);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanUp()
+    {
+        session.close();
+        session = null;
     }
 
     @Override

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraTokenSplitManager.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraTokenSplitManager.java
@@ -50,6 +50,9 @@ public class TestCassandraTokenSplitManager
     public void tearDown()
     {
         server.close();
+        server = null;
+        session.close();
+        session = null;
     }
 
     @Test

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraTypeMapping.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraTypeMapping.java
@@ -28,6 +28,7 @@ import io.trino.testing.datatype.DataSetup;
 import io.trino.testing.datatype.SqlDataTypeTest;
 import io.trino.testing.sql.TrinoSqlExecutor;
 import org.intellij.lang.annotations.Language;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -142,6 +143,13 @@ public class TestCassandraTypeMapping
                 ImmutableMap.of(),
                 ImmutableMap.of(),
                 ImmutableList.of());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanUp()
+    {
+        session.close();
+        session = null;
     }
 
     @Test

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestingClickHouseServer.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestingClickHouseServer.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.clickhouse;
 
 import com.clickhouse.client.ClickHouseVersion;
+import io.trino.testing.ResourcePresence;
 import org.testcontainers.containers.ClickHouseContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -101,5 +102,11 @@ public class TestingClickHouseServer
     public void close()
     {
         dockerContainer.stop();
+    }
+
+    @ResourcePresence
+    public boolean isRunning()
+    {
+        return dockerContainer.getContainerId() != null;
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -119,6 +119,8 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     protected HiveMinioDataLake hiveMinioDataLake;
     private HiveMetastore metastore;
 
+    protected void environmentSetup() {}
+
     protected abstract HiveMinioDataLake createHiveMinioDataLake()
             throws Exception;
 
@@ -137,6 +139,8 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
+        environmentSetup();
+
         this.hiveMinioDataLake = closeAfterClass(createHiveMinioDataLake());
         this.metastore = new BridgingHiveMetastore(
                 testingThriftHiveMetastoreBuilder()

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeGcsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeGcsConnectorSmokeTest.java
@@ -71,15 +71,21 @@ public class TestDeltaLakeGcsConnectorSmokeTest
     private static final FileAttribute<?> READ_ONLY_PERMISSIONS = PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-r--r--"));
 
     private final String gcpStorageBucket;
-    private final Path gcpCredentialsFile;
-    private final FileSystem fileSystem;
+    private final String gcpCredentialKey;
+
+    private Path gcpCredentialsFile;
+    private FileSystem fileSystem;
 
     @Parameters({"testing.gcp-storage-bucket", "testing.gcp-credentials-key"})
     public TestDeltaLakeGcsConnectorSmokeTest(String gcpStorageBucket, String gcpCredentialKey)
     {
         this.gcpStorageBucket = requireNonNull(gcpStorageBucket, "gcpStorageBucket is null");
+        this.gcpCredentialKey = requireNonNull(gcpCredentialKey, "gcpCredentialKey is null");
+    }
 
-        requireNonNull(gcpCredentialKey, "gcpCredentialKey is null");
+    @Override
+    protected void environmentSetup()
+    {
         InputStream jsonKey = new ByteArrayInputStream(Base64.getDecoder().decode(gcpCredentialKey));
         try {
             this.gcpCredentialsFile = Files.createTempFile("gcp-credentials", ".json", READ_ONLY_PERMISSIONS);
@@ -111,6 +117,7 @@ public class TestDeltaLakeGcsConnectorSmokeTest
                 // The GCS bucket should be configured to expire objects automatically. Clean up issues do not need to fail the test.
                 LOG.warn(e, "Failed to clean up GCS test directory: %s", bucketUrl());
             }
+            fileSystem = null;
         }
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeRenameToWithGlueMetastore.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeRenameToWithGlueMetastore.java
@@ -98,7 +98,7 @@ public class TestDeltaLakeRenameToWithGlueMetastore
         }
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void cleanup()
     {
         assertUpdate("DROP SCHEMA IF EXISTS " + SCHEMA);

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/BaseDruidConnectorTest.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/BaseDruidConnectorTest.java
@@ -57,6 +57,7 @@ public abstract class BaseDruidConnectorTest
     {
         if (druidServer != null) {
             druidServer.close();
+            druidServer = null;
         }
     }
 

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidTypeMapping.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidTypeMapping.java
@@ -19,6 +19,7 @@ import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.datatype.DataSetup;
 import io.trino.testing.datatype.SqlDataTypeTest;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -41,6 +42,13 @@ public class TestDruidTypeMapping
     {
         this.druidServer = new TestingDruidServer(DRUID_DOCKER_IMAGE);
         return DruidQueryRunner.createDruidQueryRunnerTpch(druidServer, ImmutableMap.of(), ImmutableList.of());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        druidServer.close();
+        druidServer = null;
     }
 
     @Test

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -92,7 +92,9 @@ public abstract class BaseElasticsearchConnectorTest
             throws IOException
     {
         elasticsearch.stop();
+        elasticsearch = null;
         client.close();
+        client = null;
     }
 
     @SuppressWarnings("DuplicateBranchesInSwitch")

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -87,6 +87,14 @@ public abstract class BaseElasticsearchConnectorTest
                 catalogName);
     }
 
+    @AfterClass(alwaysRun = true)
+    public final void destroy()
+            throws IOException
+    {
+        elasticsearch.stop();
+        client.close();
+    }
+
     @SuppressWarnings("DuplicateBranchesInSwitch")
     @Override
     protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
@@ -138,14 +146,6 @@ public abstract class BaseElasticsearchConnectorTest
                 {500},
                 {1000}
         };
-    }
-
-    @AfterClass(alwaysRun = true)
-    public final void destroy()
-            throws IOException
-    {
-        elasticsearch.stop();
-        client.close();
     }
 
     @Test

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchServer.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchServer.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.elasticsearch;
 
 import com.google.common.net.HostAndPort;
+import io.trino.testing.ResourcePresence;
 import org.testcontainers.containers.Network;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.utility.DockerImageName;
@@ -69,6 +70,12 @@ public class ElasticsearchServer
     {
         container.close();
         deleteRecursively(configurationPath, ALLOW_INSECURE);
+    }
+
+    @ResourcePresence
+    public boolean isRunning()
+    {
+        return container.getContainerId() != null;
     }
 
     public HostAndPort getAddress()

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestDisabledLegacyPassThroughQuery.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestDisabledLegacyPassThroughQuery.java
@@ -54,6 +54,7 @@ public class TestDisabledLegacyPassThroughQuery
             throws IOException
     {
         elasticsearch.stop();
+        elasticsearch = null;
     }
 
     @Test

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchBackpressure.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchBackpressure.java
@@ -60,8 +60,11 @@ public class TestElasticsearchBackpressure
             throws IOException
     {
         elasticsearchNginxProxy.stop();
+        elasticsearchNginxProxy = null;
         elasticsearch.stop();
+        elasticsearch = null;
         network.close();
+        network = null;
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/containers/HiveMinioDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/containers/HiveMinioDataLake.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.hive.containers;
 
 import com.google.common.collect.ImmutableMap;
+import io.trino.testing.ResourcePresence;
 import io.trino.testing.containers.Minio;
 import io.trino.testing.minio.MinioClient;
 import io.trino.util.AutoCloseableCloser;
@@ -97,6 +98,12 @@ public class HiveMinioDataLake
     {
         closer.close();
         state = State.STOPPED;
+    }
+
+    @ResourcePresence
+    public boolean isNotStopped()
+    {
+        return state != State.STOPPED;
     }
 
     public MinioClient getMinioClient()

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.plugin.hive.acid.AcidOperation;
+import io.trino.testng.services.ManageTestResources;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsData;
@@ -50,6 +51,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.apache.hadoop.hive.metastore.api.PrincipalType.ROLE;
 import static org.apache.hadoop.hive.metastore.api.PrincipalType.USER;
 
+@ManageTestResources.Suppress(because = "close() is no-op and instance's resources are negligible")
 public class MockThriftMetastoreClient
         implements ThriftMetastoreClient
 {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/rubix/TestRubixCaching.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/rubix/TestRubixCaching.java
@@ -101,8 +101,8 @@ public class TestRubixCaching
 {
     private static final DataSize SMALL_FILE_SIZE = DataSize.of(1, MEGABYTE);
     private static final DataSize LARGE_FILE_SIZE = DataSize.of(100, MEGABYTE);
-    private static final MBeanServer BEAN_SERVER = ManagementFactory.getPlatformMBeanServer();
 
+    private MBeanServer mBeanServer;
     private java.nio.file.Path tempDirectory;
     private Path cacheStoragePath;
     private HdfsConfig config;
@@ -116,6 +116,8 @@ public class TestRubixCaching
     public void setup()
             throws IOException
     {
+        mBeanServer = ManagementFactory.getPlatformMBeanServer();
+
         cacheStoragePath = getStoragePath("/");
         config = new HdfsConfig();
         List<PropertyMetadata<?>> hiveSessionProperties = getHiveSessionProperties(
@@ -237,6 +239,8 @@ public class TestRubixCaching
             throws IOException
     {
         closeFileSystem(nonCachingFileSystem);
+        nonCachingFileSystem = null;
+        mBeanServer = null;
     }
 
     @AfterMethod(alwaysRun = true)
@@ -557,8 +561,8 @@ public class TestRubixCaching
     private long getRemoteReadsCount()
     {
         try {
-            long directRemoteReads = (long) BEAN_SERVER.getAttribute(new ObjectName("rubix:name=stats,type=detailed,catalog=catalog"), "Direct_rrc_requests");
-            long remoteReads = (long) BEAN_SERVER.getAttribute(new ObjectName("rubix:name=stats,type=detailed,catalog=catalog"), "Remote_rrc_requests");
+            long directRemoteReads = (long) mBeanServer.getAttribute(new ObjectName("rubix:name=stats,type=detailed,catalog=catalog"), "Direct_rrc_requests");
+            long remoteReads = (long) mBeanServer.getAttribute(new ObjectName("rubix:name=stats,type=detailed,catalog=catalog"), "Remote_rrc_requests");
             return directRemoteReads + remoteReads;
         }
         catch (Exception exception) {
@@ -569,7 +573,7 @@ public class TestRubixCaching
     private long getCachedReadsCount()
     {
         try {
-            return (long) BEAN_SERVER.getAttribute(new ObjectName("rubix:name=stats,type=detailed,catalog=catalog"), "Cached_rrc_requests");
+            return (long) mBeanServer.getAttribute(new ObjectName("rubix:name=stats,type=detailed,catalog=catalog"), "Cached_rrc_requests");
         }
         catch (Exception exception) {
             throw new RuntimeException(exception);
@@ -583,7 +587,7 @@ public class TestRubixCaching
         }
 
         try {
-            return (long) BEAN_SERVER.getAttribute(new ObjectName("metrics:name=rubix.bookkeeper.count.async_downloaded_mb"), "Count");
+            return (long) mBeanServer.getAttribute(new ObjectName("metrics:name=rubix.bookkeeper.count.async_downloaded_mb"), "Count");
         }
         catch (Exception exception) {
             throw new RuntimeException(exception);

--- a/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpEventListener.java
+++ b/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpEventListener.java
@@ -234,6 +234,7 @@ public class TestHttpEventListener
         catch (IOException ignored) {
             // MockWebServer.close() method sometimes throws 'Gave up waiting for executor to shut down'
         }
+        server = null;
     }
 
     /**

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGcsConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGcsConnectorSmokeTest.java
@@ -57,23 +57,30 @@ public class TestIcebergGcsConnectorSmokeTest
     private static final Logger LOG = Logger.get(TestIcebergGcsConnectorSmokeTest.class);
 
     private static final FileAttribute<?> READ_ONLY_PERMISSIONS = PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-r--r--"));
-    private final String schema;
     private final String gcpStorageBucket;
-    private final Path gcpCredentialsFile;
-    private final HiveHadoop hiveHadoop;
-    private final FileSystem fileSystem;
+    private final String gcpCredentialKey;
+    private final String schema;
+
+    private HiveHadoop hiveHadoop;
+    private FileSystem fileSystem;
 
     @Parameters({"testing.gcp-storage-bucket", "testing.gcp-credentials-key"})
     public TestIcebergGcsConnectorSmokeTest(String gcpStorageBucket, String gcpCredentialKey)
     {
         super(ORC);
-        this.schema = "test_iceberg_gcs_connector_smoke_test_" + randomNameSuffix();
         this.gcpStorageBucket = requireNonNull(gcpStorageBucket, "gcpStorageBucket is null");
+        this.gcpCredentialKey = requireNonNull(gcpCredentialKey, "gcpCredentialKey is null");
+        this.schema = "test_iceberg_gcs_connector_smoke_test_" + randomNameSuffix();
+    }
 
-        requireNonNull(gcpCredentialKey, "gcpCredentialKey is null");
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
         InputStream jsonKey = new ByteArrayInputStream(Base64.getDecoder().decode(gcpCredentialKey));
+        Path gcpCredentialsFile;
         try {
-            this.gcpCredentialsFile = Files.createTempFile("gcp-credentials", ".json", READ_ONLY_PERMISSIONS);
+            gcpCredentialsFile = Files.createTempFile("gcp-credentials", ".json", READ_ONLY_PERMISSIONS);
             gcpCredentialsFile.toFile().deleteOnExit();
             Files.write(gcpCredentialsFile, jsonKey.readAllBytes());
 
@@ -104,39 +111,7 @@ public class TestIcebergGcsConnectorSmokeTest
         catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
-    }
 
-    @AfterClass(alwaysRun = true)
-    public void removeTestData()
-    {
-        if (fileSystem != null) {
-            try {
-                fileSystem.delete(new org.apache.hadoop.fs.Path(schemaUrl()), true);
-            }
-            catch (IOException e) {
-                // The GCS bucket should be configured to expire objects automatically. Clean up issues do not need to fail the test.
-                LOG.warn(e, "Failed to clean up GCS test directory: %s", schemaUrl());
-            }
-        }
-    }
-
-    @Override
-    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
-    {
-        switch (connectorBehavior) {
-            case SUPPORTS_RENAME_SCHEMA:
-                // GCS tests use the Hive Metastore catalog which does not support renaming schemas
-                return false;
-
-            default:
-                return super.hasBehavior(connectorBehavior);
-        }
-    }
-
-    @Override
-    protected QueryRunner createQueryRunner()
-            throws Exception
-    {
         return IcebergQueryRunner.builder()
                 .setIcebergProperties(ImmutableMap.<String, String>builder()
                         .put("iceberg.catalog.type", "hive_metastore")
@@ -152,6 +127,34 @@ public class TestIcebergGcsConnectorSmokeTest
                                 .withSchemaProperties(ImmutableMap.of("location", "'" + schemaUrl() + "'"))
                                 .build())
                 .build();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void removeTestData()
+    {
+        if (fileSystem != null) {
+            try {
+                fileSystem.delete(new org.apache.hadoop.fs.Path(schemaUrl()), true);
+            }
+            catch (IOException e) {
+                // The GCS bucket should be configured to expire objects automatically. Clean up issues do not need to fail the test.
+                LOG.warn(e, "Failed to clean up GCS test directory: %s", schemaUrl());
+            }
+            fileSystem = null;
+        }
+    }
+
+    @Override
+    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
+    {
+        switch (connectorBehavior) {
+            case SUPPORTS_RENAME_SCHEMA:
+                // GCS tests use the Hive Metastore catalog which does not support renaming schemas
+                return false;
+
+            default:
+                return super.hasBehavior(connectorBehavior);
+        }
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGetTableStatisticsOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGetTableStatisticsOperations.java
@@ -92,6 +92,9 @@ public class TestIcebergGetTableStatisticsOperations
             throws IOException
     {
         deleteRecursively(metastoreDir.toPath(), ALLOW_INSECURE);
+        localQueryRunner.close();
+        localQueryRunner = null;
+        metadata = null;
     }
 
     @BeforeMethod

--- a/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/TestMinimalFunctionality.java
+++ b/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/TestMinimalFunctionality.java
@@ -86,7 +86,7 @@ public class TestMinimalFunctionality
         embeddedKinesisStream = new EmbeddedKinesisStream(TestUtils.noneToBlank(accessKey), TestUtils.noneToBlank(secretKey));
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void stop()
     {
         embeddedKinesisStream.close();

--- a/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/TestMinimalFunctionality.java
+++ b/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/TestMinimalFunctionality.java
@@ -175,5 +175,6 @@ public class TestMinimalFunctionality
     {
         embeddedKinesisStream.deleteStream(streamName);
         queryRunner.close();
+        queryRunner = null;
     }
 }

--- a/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/TestMinimalFunctionality.java
+++ b/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/TestMinimalFunctionality.java
@@ -90,6 +90,7 @@ public class TestMinimalFunctionality
     public void stop()
     {
         embeddedKinesisStream.close();
+        embeddedKinesisStream = null;
     }
 
     @Parameters({

--- a/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/TestRecordAccess.java
+++ b/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/TestRecordAccess.java
@@ -83,7 +83,7 @@ public class TestRecordAccess
         mockClient = TestUtils.installKinesisPlugin(queryRunner);
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void stop()
     {
         queryRunner.close();

--- a/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/TestRecordAccess.java
+++ b/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/TestRecordAccess.java
@@ -79,7 +79,7 @@ public class TestRecordAccess
         jsonStreamName = "sampleTable";
         jsonGzipCompressStreamName = "sampleGzipCompressTable";
         jsonAutomaticCompressStreamName = "sampleAutomaticCompressTable";
-        this.queryRunner = new StandaloneQueryRunner(SESSION);
+        queryRunner = new StandaloneQueryRunner(SESSION);
         mockClient = TestUtils.installKinesisPlugin(queryRunner);
     }
 
@@ -87,6 +87,7 @@ public class TestRecordAccess
     public void stop()
     {
         queryRunner.close();
+        queryRunner = null;
     }
 
     private void createDummyMessages(String streamName, int count)

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/BaseKuduConnectorSmokeTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/BaseKuduConnectorSmokeTest.java
@@ -16,6 +16,7 @@ package io.trino.plugin.kudu;
 import io.trino.testing.BaseConnectorSmokeTest;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
@@ -41,6 +42,13 @@ public abstract class BaseKuduConnectorSmokeTest
     {
         kuduServer = new TestingKuduServer(getKuduServerVersion());
         return createKuduQueryRunnerTpch(kuduServer, getKuduSchemaEmulationPrefix(), REQUIRED_TPCH_TABLES);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        kuduServer.close();
+        kuduServer = null;
     }
 
     @SuppressWarnings("DuplicateBranchesInSwitch")

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestingKuduServer.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestingKuduServer.java
@@ -16,6 +16,7 @@ package io.trino.plugin.kudu;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Closer;
 import com.google.common.net.HostAndPort;
+import io.trino.testing.ResourcePresence;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
@@ -49,6 +50,8 @@ public class TestingKuduServer
     private final ToxiproxyContainer toxiProxy;
     private final GenericContainer<?> master;
     private final List<GenericContainer<?>> tServers;
+
+    private boolean stopped;
 
     public TestingKuduServer()
     {
@@ -120,6 +123,13 @@ public class TestingKuduServer
         catch (IOException e) {
             throw new RuntimeException(e);
         }
+        stopped = true;
+    }
+
+    @ResourcePresence
+    public boolean isNotStopped()
+    {
+        return !stopped;
     }
 
     private static String getHostIPAddress()

--- a/plugin/trino-mariadb/pom.xml
+++ b/plugin/trino-mariadb/pom.xml
@@ -125,6 +125,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-tpch</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestingMariaDbServer.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestingMariaDbServer.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.mariadb;
 
+import io.trino.testing.ResourcePresence;
 import org.testcontainers.containers.MariaDBContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -83,5 +84,11 @@ public class TestingMariaDbServer
     public void close()
     {
         container.close();
+    }
+
+    @ResourcePresence
+    public boolean isRunning()
+    {
+        return container.getContainerId() != null;
     }
 }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
@@ -63,7 +63,9 @@ public abstract class BaseMongoConnectorTest
     public final void destroy()
     {
         server.close();
+        server = null;
         client.close();
+        client = null;
     }
 
     @SuppressWarnings("DuplicateBranchesInSwitch")

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoServer.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoServer.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.mongodb;
 
 import com.mongodb.ConnectionString;
+import io.trino.testing.ResourcePresence;
 import org.testcontainers.containers.MongoDBContainer;
 
 import java.io.Closeable;
@@ -46,5 +47,11 @@ public class MongoServer
     public void close()
     {
         dockerContainer.close();
+    }
+
+    @ResourcePresence
+    public boolean isRunning()
+    {
+        return dockerContainer.getContainerId() != null;
     }
 }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
@@ -26,7 +26,7 @@ public class TestMongoConnectorTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        server = closeAfterClass(new MongoServer());
+        server = new MongoServer();
         client = createMongoClient(server);
         return createMongoQueryRunner(server, ImmutableMap.of(), REQUIRED_TPCH_TABLES);
     }

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestingMySqlServer.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestingMySqlServer.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.mysql;
 
+import io.trino.testing.ResourcePresence;
 import org.testcontainers.containers.MySQLContainer;
 
 import java.io.Closeable;
@@ -116,5 +117,11 @@ public class TestingMySqlServer
         catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    @ResourcePresence
+    public boolean isRunning()
+    {
+        return container.getContainerId() != null;
     }
 }

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleServer.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleServer.java
@@ -21,6 +21,7 @@ import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.DriverConnectionFactory;
 import io.trino.plugin.jdbc.RetryingConnectionFactory;
 import io.trino.plugin.jdbc.credential.StaticCredentialProvider;
+import io.trino.testing.ResourcePresence;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
 import oracle.jdbc.OracleDriver;
@@ -131,5 +132,11 @@ public class TestingOracleServer
     public void close()
     {
         container.stop();
+    }
+
+    @ResourcePresence
+    public boolean isRunning()
+    {
+        return container.getContainerId() != null;
     }
 }

--- a/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapAuthenticator.java
+++ b/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapAuthenticator.java
@@ -31,7 +31,7 @@ import static org.testng.Assert.assertEquals;
 
 public class TestLdapAuthenticator
 {
-    private final Closer closer = Closer.create();
+    private Closer closer;
 
     private TestingOpenLdapServer openLdapServer;
     private LdapAuthenticatorClient client;
@@ -40,6 +40,7 @@ public class TestLdapAuthenticator
     public void setup()
             throws Exception
     {
+        closer = Closer.create();
         Network network = Network.newNetwork();
         closer.register(network::close);
 
@@ -56,6 +57,7 @@ public class TestLdapAuthenticator
             throws Exception
     {
         closer.close();
+        closer = null;
         openLdapServer = null;
         client = null;
     }

--- a/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapAuthenticator.java
+++ b/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapAuthenticator.java
@@ -43,8 +43,7 @@ public class TestLdapAuthenticator
         Network network = Network.newNetwork();
         closer.register(network::close);
 
-        openLdapServer = new TestingOpenLdapServer(network);
-        closer.register(openLdapServer);
+        openLdapServer = closer.register(new TestingOpenLdapServer(network));
         openLdapServer.start();
 
         client = new LdapAuthenticatorClient(
@@ -57,6 +56,8 @@ public class TestLdapAuthenticator
             throws Exception
     {
         closer.close();
+        openLdapServer = null;
+        client = null;
     }
 
     @Test

--- a/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapAuthenticatorWithTimeouts.java
+++ b/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapAuthenticatorWithTimeouts.java
@@ -52,8 +52,7 @@ public class TestLdapAuthenticatorWithTimeouts
         closer.register(proxyServer::close);
         proxyServer.start();
 
-        openLdapServer = new TestingOpenLdapServer(network);
-        closer.register(openLdapServer);
+        openLdapServer = closer.register(new TestingOpenLdapServer(network));
         openLdapServer.start();
 
         ContainerProxy proxy = proxyServer.getProxy(openLdapServer.getNetworkAlias(), LDAP_PORT);
@@ -67,6 +66,8 @@ public class TestLdapAuthenticatorWithTimeouts
             throws Exception
     {
         closer.close();
+        openLdapServer = null;
+        proxyLdapUrl = null;
     }
 
     @Test

--- a/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapAuthenticatorWithTimeouts.java
+++ b/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapAuthenticatorWithTimeouts.java
@@ -35,7 +35,7 @@ import static org.testng.Assert.assertEquals;
 
 public class TestLdapAuthenticatorWithTimeouts
 {
-    private final Closer closer = Closer.create();
+    private Closer closer;
 
     private TestingOpenLdapServer openLdapServer;
     private String proxyLdapUrl;
@@ -44,6 +44,7 @@ public class TestLdapAuthenticatorWithTimeouts
     public void setup()
             throws Exception
     {
+        closer = Closer.create();
         Network network = Network.newNetwork();
         closer.register(network::close);
 
@@ -66,6 +67,7 @@ public class TestLdapAuthenticatorWithTimeouts
             throws Exception
     {
         closer.close();
+        closer = null;
         openLdapServer = null;
         proxyLdapUrl = null;
     }

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestingPhoenixServer.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestingPhoenixServer.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.phoenix5;
 
 import io.airlift.log.Logger;
+import io.trino.testng.services.ManageTestResources;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
@@ -31,6 +32,7 @@ import static org.apache.hadoop.hbase.HConstants.HBASE_CLIENT_RETRIES_NUMBER;
 import static org.apache.hadoop.hbase.HConstants.MASTER_INFO_PORT;
 import static org.apache.hadoop.hbase.HConstants.REGIONSERVER_INFO_PORT;
 
+@ManageTestResources.Suppress(because = "The actual server is kept on a static field and instance of this class is used for reference counting only")
 public final class TestingPhoenixServer
 {
     private static final Logger LOG = Logger.get(TestingPhoenixServer.class);

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlServer.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlServer.java
@@ -15,6 +15,7 @@ package io.trino.plugin.postgresql;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.plugin.jdbc.RemoteDatabaseEvent;
+import io.trino.testing.ResourcePresence;
 import org.intellij.lang.annotations.Language;
 import org.testcontainers.containers.PostgreSQLContainer;
 
@@ -162,6 +163,12 @@ public class TestingPostgreSqlServer
     public void close()
     {
         dockerContainer.close();
+    }
+
+    @ResourcePresence
+    public boolean isRunning()
+    {
+        return dockerContainer.getContainerId() != null;
     }
 
     public static class DatabaseEventsRecorder

--- a/plugin/trino-prometheus/pom.xml
+++ b/plugin/trino-prometheus/pom.xml
@@ -182,6 +182,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>http-server</artifactId>
             <scope>test</scope>

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/PrometheusServer.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/PrometheusServer.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.prometheus;
 
+import io.trino.testing.ResourcePresence;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
@@ -66,5 +67,11 @@ public class PrometheusServer
     public void close()
     {
         dockerContainer.close();
+    }
+
+    @ResourcePresence
+    public boolean isRunning()
+    {
+        return dockerContainer.getContainerId() != null;
     }
 }

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusCaseInsensitiveNameMatching.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusCaseInsensitiveNameMatching.java
@@ -48,6 +48,7 @@ public class TestPrometheusCaseInsensitiveNameMatching
     {
         if (prometheusHttpServer != null) {
             prometheusHttpServer.stop();
+            prometheusHttpServer = null;
         }
     }
 

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusQueryMatrixResponseParse.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusQueryMatrixResponseParse.java
@@ -15,6 +15,7 @@ package io.trino.plugin.prometheus;
 
 import com.google.common.io.Resources;
 import io.trino.spi.TrinoException;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -85,5 +86,15 @@ public class TestPrometheusQueryMatrixResponseParse
         URL promErrorResponse = Resources.getResource(getClass(), "/prometheus-data/prom_error_response.json");
         assertNotNull(promMatrixResponse, "metadataUrl is null");
         this.promErrorResponse = promErrorResponse.openStream();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown()
+            throws Exception
+    {
+        promMatrixResponse.close();
+        promMatrixResponse = null;
+        promErrorResponse.close();
+        promErrorResponse = null;
     }
 }

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusQueryScalarResponseParse.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusQueryScalarResponseParse.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.prometheus;
 
 import com.google.common.io.Resources;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -70,5 +71,13 @@ public class TestPrometheusQueryScalarResponseParse
         URL promMatrixResponse = Resources.getResource(getClass(), "/prometheus-data/up_scalar_response.json");
         assertNotNull(promMatrixResponse, "metadataUrl is null");
         this.promVectorResponse = promMatrixResponse.openStream();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown()
+            throws Exception
+    {
+        promVectorResponse.close();
+        promVectorResponse = null;
     }
 }

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusQueryVectorResponseParse.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusQueryVectorResponseParse.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.prometheus;
 
 import com.google.common.io.Resources;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -70,5 +71,13 @@ public class TestPrometheusQueryVectorResponseParse
         URL promMatrixResponse = Resources.getResource(getClass(), "/prometheus-data/up_vector_response.json");
         assertNotNull(promMatrixResponse, "metadataUrl is null");
         this.promVectorResponse = promMatrixResponse.openStream();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown()
+            throws Exception
+    {
+        promVectorResponse.close();
+        promVectorResponse = null;
     }
 }

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusRecordSet.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusRecordSet.java
@@ -105,6 +105,7 @@ public class TestPrometheusRecordSet
     {
         if (prometheusHttpServer != null) {
             prometheusHttpServer.stop();
+            prometheusHttpServer = null;
         }
     }
 }

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusRecordSetProvider.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusRecordSetProvider.java
@@ -57,6 +57,7 @@ public class TestPrometheusRecordSetProvider
     {
         if (prometheusHttpServer != null) {
             prometheusHttpServer.stop();
+            prometheusHttpServer = null;
         }
     }
 

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusSplit.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusSplit.java
@@ -28,6 +28,7 @@ import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
 import org.apache.http.NameValuePair;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -74,6 +75,13 @@ public class TestPrometheusSplit
     public void setUp()
     {
         prometheusHttpServer = new PrometheusHttpServer();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        prometheusHttpServer.stop();
+        prometheusHttpServer = null;
     }
 
     @Test

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorConnector.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorConnector.java
@@ -120,6 +120,7 @@ public class TestRaptorConnector
             throws Exception
     {
         dummyHandle.close();
+        dummyHandle = null;
         deleteRecursively(dataDir.toPath(), ALLOW_INSECURE);
     }
 

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorMySqlConnectorTest.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorMySqlConnectorTest.java
@@ -45,6 +45,7 @@ public class TestRaptorMySqlConnectorTest
     public final void destroy()
     {
         mysqlContainer.close();
+        mysqlContainer = null;
     }
 
     private static String getJdbcUrl(MySQLContainer<?> container)

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestDatabaseShardManager.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestDatabaseShardManager.java
@@ -117,6 +117,7 @@ public class TestDatabaseShardManager
             throws IOException
     {
         dummyHandle.close();
+        dummyHandle = null;
         deleteRecursively(dataDir.toPath(), ALLOW_INSECURE);
     }
 

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestMetadataDao.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestMetadataDao.java
@@ -48,6 +48,7 @@ public class TestMetadataDao
     public void tearDown()
     {
         dummyHandle.close();
+        dummyHandle = null;
     }
 
     @Test

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestRaptorMetadata.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestRaptorMetadata.java
@@ -112,6 +112,7 @@ public class TestRaptorMetadata
     public void cleanupDatabase()
     {
         dummyHandle.close();
+        dummyHandle = null;
     }
 
     @Test

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestRaptorSplitManager.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestRaptorSplitManager.java
@@ -133,6 +133,7 @@ public class TestRaptorSplitManager
             throws IOException
     {
         dummyHandle.close();
+        dummyHandle = null;
         deleteRecursively(temporary, ALLOW_INSECURE);
     }
 

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestShardCleaner.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestShardCleaner.java
@@ -111,6 +111,7 @@ public class TestShardCleaner
     {
         if (dummyHandle != null) {
             dummyHandle.close();
+            dummyHandle = null;
         }
         deleteRecursively(temporary, ALLOW_INSECURE);
     }

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestShardDao.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestShardDao.java
@@ -57,6 +57,7 @@ public class TestShardDao
     public void teardown()
     {
         dummyHandle.close();
+        dummyHandle = null;
     }
 
     @Test

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/TestBucketBalancer.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/TestBucketBalancer.java
@@ -86,6 +86,7 @@ public class TestBucketBalancer
     {
         if (dummyHandle != null) {
             dummyHandle.close();
+            dummyHandle = null;
         }
     }
 

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/TestRaptorStorageManager.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/TestRaptorStorageManager.java
@@ -165,6 +165,7 @@ public class TestRaptorStorageManager
     {
         if (dummyHandle != null) {
             dummyHandle.close();
+            dummyHandle = null;
         }
         deleteRecursively(temporary, ALLOW_INSECURE);
     }

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/TestShardEjector.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/TestShardEjector.java
@@ -88,6 +88,7 @@ public class TestShardEjector
     {
         if (dummyHandle != null) {
             dummyHandle.close();
+            dummyHandle = null;
         }
         if (dataDir != null) {
             deleteRecursively(dataDir, ALLOW_INSECURE);

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/TestShardRecovery.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/TestShardRecovery.java
@@ -88,6 +88,7 @@ public class TestShardRecovery
     {
         if (dummyHandle != null) {
             dummyHandle.close();
+            dummyHandle = null;
         }
         deleteRecursively(temporary, ALLOW_INSECURE);
     }

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/organization/TestShardCompactor.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/organization/TestShardCompactor.java
@@ -101,6 +101,7 @@ public class TestShardCompactor
     {
         if (dummyHandle != null) {
             dummyHandle.close();
+            dummyHandle = null;
         }
         deleteRecursively(temporary, ALLOW_INSECURE);
     }

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/organization/TestShardOrganizationManager.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/organization/TestShardOrganizationManager.java
@@ -77,6 +77,7 @@ public class TestShardOrganizationManager
     public void teardown()
     {
         dummyHandle.close();
+        dummyHandle = null;
     }
 
     @Test

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/organization/TestShardOrganizerUtil.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/organization/TestShardOrganizerUtil.java
@@ -94,6 +94,7 @@ public class TestShardOrganizerUtil
             throws Exception
     {
         dummyHandle.close();
+        dummyHandle = null;
         deleteRecursively(dataDir.toPath(), ALLOW_INSECURE);
     }
 

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/systemtables/TestShardMetadataRecordCursor.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/systemtables/TestShardMetadataRecordCursor.java
@@ -92,6 +92,7 @@ public class TestShardMetadataRecordCursor
     public void teardown()
     {
         dummyHandle.close();
+        dummyHandle = null;
     }
 
     @Test

--- a/plugin/trino-session-property-managers/src/test/java/io/trino/plugin/session/db/TestDbSessionPropertyManager.java
+++ b/plugin/trino-session-property-managers/src/test/java/io/trino/plugin/session/db/TestDbSessionPropertyManager.java
@@ -80,6 +80,7 @@ public class TestDbSessionPropertyManager
     {
         specsProvider.destroy();
         mysqlContainer.close();
+        mysqlContainer = null;
     }
 
     @Override

--- a/plugin/trino-session-property-managers/src/test/java/io/trino/plugin/session/db/TestDbSessionPropertyManagerIntegration.java
+++ b/plugin/trino-session-property-managers/src/test/java/io/trino/plugin/session/db/TestDbSessionPropertyManagerIntegration.java
@@ -102,6 +102,8 @@ public class TestDbSessionPropertyManagerIntegration
             closer.register(queryRunner);
             closer.register(mysqlContainer::close);
         }
+        queryRunner = null;
+        mysqlContainer = null;
     }
 
     @BeforeMethod

--- a/plugin/trino-singlestore/pom.xml
+++ b/plugin/trino-singlestore/pom.xml
@@ -136,6 +136,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-tpch</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestingSingleStoreServer.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestingSingleStoreServer.java
@@ -46,11 +46,11 @@ public class TestingSingleStoreServer
         addEnv("ROOT_PASSWORD", "memsql_root_password");
         withCommand("sh", "-xeuc",
                 "/startup && " +
-                // Lower the size of pre-allocated log files to 1MB (minimum allowed) to reduce disk footprint
-                "memsql-admin update-config --yes --all --set-global --key \"log_file_size_partitions\" --value \"1048576\" && " +
-                "memsql-admin update-config --yes --all --set-global --key \"log_file_size_ref_dbs\" --value \"1048576\" && " +
-                // re-execute startup to actually start the nodes (first run performs setup but doesn't start the nodes)
-                "exec /startup");
+                        // Lower the size of pre-allocated log files to 1MB (minimum allowed) to reduce disk footprint
+                        "memsql-admin update-config --yes --all --set-global --key \"log_file_size_partitions\" --value \"1048576\" && " +
+                        "memsql-admin update-config --yes --all --set-global --key \"log_file_size_ref_dbs\" --value \"1048576\" && " +
+                        // re-execute startup to actually start the nodes (first run performs setup but doesn't start the nodes)
+                        "exec /startup");
         start();
     }
 

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestingSingleStoreServer.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestingSingleStoreServer.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.singlestore;
 
 import com.google.common.collect.ImmutableSet;
+import io.trino.testing.ResourcePresence;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -101,6 +102,12 @@ public class TestingSingleStoreServer
     public void execute(String sql)
     {
         execute(sql, getUsername(), getPassword());
+    }
+
+    @ResourcePresence
+    public boolean isResourcePresent()
+    {
+        return isRunning() || getContainerId() != null;
     }
 
     public void execute(String sql, String user, String password)

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestingSqlServer.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestingSqlServer.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.sqlserver;
 
 import io.airlift.log.Logger;
+import io.trino.testing.ResourcePresence;
 import io.trino.testing.sql.SqlExecutor;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
@@ -211,6 +212,12 @@ public final class TestingSqlServer
         catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    @ResourcePresence
+    public boolean isRunning()
+    {
+        return container.getContainerId() != null;
     }
 
     private static class InitializedState

--- a/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/TestThriftProjectionPushdown.java
+++ b/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/TestThriftProjectionPushdown.java
@@ -107,7 +107,7 @@ public class TestThriftProjectionPushdown
         return Optional.of(runner);
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void cleanup()
     {
         if (servers != null) {

--- a/service/trino-proxy/src/test/java/io/trino/proxy/TestProxyServer.java
+++ b/service/trino-proxy/src/test/java/io/trino/proxy/TestProxyServer.java
@@ -113,8 +113,10 @@ public class TestProxyServer
             throws IOException
     {
         server.close();
+        server = null;
         lifeCycleManager.stop();
         executorService.shutdownNow();
+        executorService = null;
         Files.delete(sharedSecretFile);
     }
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestImpersonation.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestImpersonation.java
@@ -15,6 +15,7 @@ package io.trino.tests.product;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+import io.trino.tempto.AfterTestWithContext;
 import io.trino.tempto.BeforeTestWithContext;
 import io.trino.tempto.ProductTest;
 import io.trino.tempto.hadoop.hdfs.HdfsClient;
@@ -55,6 +56,13 @@ public class TestImpersonation
     public void setup()
     {
         aliceExecutor = connectToTrino("alice@presto");
+    }
+
+    @AfterTestWithContext
+    public void cleanup()
+    {
+        // should not be closed, this would close a shared, global QueryExecutor
+        aliceExecutor = null;
     }
 
     @Test(groups = {HDFS_NO_IMPERSONATION, PROFILE_SPECIFIC_TESTS})

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestSqlCancel.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestSqlCancel.java
@@ -79,7 +79,10 @@ public class TestSqlCancel
     public void cleanUp()
             throws IOException
     {
+        queryCanceller = null; // closed via closer
+        executor = null; // closed via closer
         closer.close();
+        closer = null;
     }
 
     @Test(groups = CANCEL_QUERY, timeOut = 60_000L)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/BaseTestDeltaLakeMinioReads.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/BaseTestDeltaLakeMinioReads.java
@@ -67,6 +67,7 @@ public abstract class BaseTestDeltaLakeMinioReads
     {
         deleteNotificationsTable(NOTIFICATIONS_TABLE);
         client.close();
+        client = null;
     }
 
     @Test(groups = {DELTA_LAKE_MINIO, PROFILE_SPECIFIC_TESTS})

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestGrantRevoke.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestGrantRevoke.java
@@ -88,6 +88,11 @@ public class TestGrantRevoke
         aliceExecutor.executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
         aliceExecutor.executeQuery(format("DROP VIEW IF EXISTS %s", viewName));
         cleanupRoles();
+
+        // should not be closed, this would close a shared, global QueryExecutor
+        aliceExecutor = null;
+        bobExecutor = null;
+        charlieExecutor = null;
     }
 
     @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
@@ -1831,8 +1831,7 @@ public class TestHiveTransactionalTable
                 "STORED AS ORC " +
                 "TBLPROPERTIES ('transactional'='true')");
 
-        ThriftMetastoreClient client = testHiveMetastoreClientFactory.createMetastoreClient();
-        try {
+        try (ThriftMetastoreClient client = testHiveMetastoreClientFactory.createMetastoreClient()) {
             String selectFromOnePartitionsSql = "SELECT col FROM " + tableName + " ORDER BY COL";
 
             // Create `delta-A` file
@@ -1873,7 +1872,6 @@ public class TestHiveTransactionalTable
             assertThat(onePartitionQueryResult).containsOnly(row(1), row(1), row(2), row(2));
         }
         finally {
-            client.close();
             onHive().executeQuery("DROP TABLE " + tableName);
         }
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestSqlStandardAccessControlChecks.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestSqlStandardAccessControlChecks.java
@@ -13,6 +13,7 @@
  */
 package io.trino.tests.product.hive;
 
+import io.trino.tempto.AfterTestWithContext;
 import io.trino.tempto.BeforeTestWithContext;
 import io.trino.tempto.ProductTest;
 import io.trino.tempto.query.QueryExecutor;
@@ -50,6 +51,16 @@ public class TestSqlStandardAccessControlChecks
 
         aliceExecutor.executeQuery(format("DROP VIEW IF EXISTS %s", viewName));
         aliceExecutor.executeQuery(format("CREATE VIEW %s AS SELECT month, day FROM %s", viewName, tableName));
+    }
+
+    @AfterTestWithContext
+    public void cleanup()
+    {
+        // should not be closed, this would close a shared, global QueryExecutor
+        aliceExecutor = null;
+        bobExecutor = null;
+        charlieExecutor = null;
+        caseSensitiveUserNameExecutor = null;
     }
 
     @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
 import io.airlift.concurrent.MoreFutures;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreClient;
+import io.trino.tempto.AfterTestWithContext;
 import io.trino.tempto.BeforeTestWithContext;
 import io.trino.tempto.ProductTest;
 import io.trino.tempto.hadoop.hdfs.HdfsClient;
@@ -96,6 +97,13 @@ public class TestIcebergSparkCompatibility
             throws TException
     {
         metastoreClient = testHiveMetastoreClientFactory.createMetastoreClient();
+    }
+
+    @AfterTestWithContext
+    public void tearDown()
+    {
+        metastoreClient.close();
+        metastoreClient = null;
     }
 
     // see spark-defaults.conf

--- a/testing/trino-test-jdbc-compatibility-old-driver/src/test/java/io/trino/TestJdbcCompatibility.java
+++ b/testing/trino-test-jdbc-compatibility-old-driver/src/test/java/io/trino/TestJdbcCompatibility.java
@@ -105,6 +105,7 @@ public class TestJdbcCompatibility
             throws IOException
     {
         server.close();
+        server = null;
     }
 
     @Test

--- a/testing/trino-testing-containers/pom.xml
+++ b/testing/trino-testing-containers/pom.xml
@@ -18,6 +18,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>log</artifactId>
         </dependency>

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/BaseTestContainer.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/BaseTestContainer.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
 import io.airlift.log.Logger;
+import io.trino.testing.ResourcePresence;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
 import org.testcontainers.containers.Container;
@@ -161,6 +162,12 @@ public abstract class BaseTestContainer
     public void close()
     {
         stop();
+    }
+
+    @ResourcePresence
+    public boolean isPresent()
+    {
+        return container.isRunning() || container.getContainerId() != null;
     }
 
     protected abstract static class Builder<SELF extends BaseTestContainer.Builder<SELF, BUILD>, BUILD extends BaseTestContainer>

--- a/testing/trino-testing-kafka/pom.xml
+++ b/testing/trino-testing-kafka/pom.xml
@@ -18,6 +18,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>log</artifactId>
         </dependency>

--- a/testing/trino-testing-kafka/src/main/java/io/trino/testing/kafka/TestingKafka.java
+++ b/testing/trino-testing-kafka/src/main/java/io/trino/testing/kafka/TestingKafka.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Closer;
 import com.google.common.util.concurrent.Futures;
 import io.airlift.log.Logger;
+import io.trino.testing.ResourcePresence;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -46,6 +47,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.stream.Stream;
 
+import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
 import static java.time.temporal.ChronoUnit.MILLIS;
 import static org.testcontainers.containers.KafkaContainer.KAFKA_PORT;
@@ -67,6 +69,7 @@ public final class TestingKafka
     private final GenericContainer<?> schemaRegistry;
     private final boolean withSchemaRegistry;
     private final Closer closer = Closer.create();
+    private boolean stopped;
 
     public static TestingKafka create()
     {
@@ -130,6 +133,7 @@ public final class TestingKafka
 
     public void start()
     {
+        checkState(!stopped, "Cannot start again");
         kafka.start();
         if (withSchemaRegistry) {
             schemaRegistry.start();
@@ -141,6 +145,13 @@ public final class TestingKafka
             throws IOException
     {
         closer.close();
+        stopped = true;
+    }
+
+    @ResourcePresence
+    public boolean isNotStopped()
+    {
+        return !stopped;
     }
 
     public void createTopic(String topic)

--- a/testing/trino-testing-services/pom.xml
+++ b/testing/trino-testing-services/pom.xml
@@ -38,6 +38,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/testing/trino-testing-services/src/main/java/io/trino/testing/ResourcePresence.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testing/ResourcePresence.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Specifies a method that determines whether given resource-like class currently holds on to resources.
+ * The annotated method must not take parameters and must return a boolean, {@code true} indicating
+ * that a resource is present.
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface ResourcePresence {}

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/Listeners.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/Listeners.java
@@ -13,6 +13,7 @@
  */
 package io.trino.testng.services;
 
+import com.google.errorprone.annotations.FormatMethod;
 import org.testng.ITestNGListener;
 
 import static java.lang.String.format;
@@ -26,6 +27,7 @@ final class Listeners
      *
      * @apiNote A TestNG listener cannot throw an exception, as this are not currently properly handled by TestNG.
      */
+    @FormatMethod
     public static void reportListenerFailure(Class<? extends ITestNGListener> listenerClass, String format, Object... args)
     {
         System.err.println(format("FATAL: %s: ", listenerClass.getName()) + format(format, args));

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/ManageTestResources.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/ManageTestResources.java
@@ -1,0 +1,369 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testng.services;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.log.Logger;
+import io.trino.testing.ResourcePresence;
+import org.intellij.lang.annotations.Language;
+import org.testng.ITestClass;
+import org.testng.ITestContext;
+import org.testng.ITestListener;
+import org.testng.ITestNGMethod;
+import org.testng.ITestResult;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Throwables.getStackTraceAsString;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.MoreCollectors.toOptional;
+import static io.trino.testng.services.Listeners.reportListenerFailure;
+import static io.trino.testng.services.ManageTestResources.Stage.AFTER_CLASS;
+import static io.trino.testng.services.ManageTestResources.Stage.BEFORE_CLASS;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static java.lang.reflect.Modifier.isStatic;
+
+public class ManageTestResources
+        implements ITestListener
+{
+    private static final Logger log = Logger.get(ManageTestResources.class);
+
+    private final boolean enabled;
+    private final List<Rule> rules;
+
+    public ManageTestResources()
+    {
+        enabled = isEnabled();
+        if (!enabled) {
+            log.info("ManageTestResources is disabled!");
+            rules = List.of();
+            return;
+        }
+
+        ImmutableList.Builder<Rule> rules = ImmutableList.builder();
+
+        // E.g. io.trino.testing.QueryRunner, io.trino.sql.query.QueryAssertions
+        rules.add(isAutoCloseable());
+
+        isInstanceTransactionManagerField().ifPresent(rules::add);
+
+        // any testcontainers resources
+        rules.add(declaredClassPattern("org\\.testcontainers\\..*"));
+
+        // any docker-java API's resources
+        rules.add(declaredClassPattern("com\\.github\\.dockerjava\\..*"));
+
+        rules.add(isSomeServer());
+
+        rules.add(isLeftoverExecutorService());
+
+        this.rules = rules.build();
+    }
+
+    private static boolean isEnabled()
+    {
+        if (System.getProperty("ManageTestResources.enabled") != null) {
+            return Boolean.getBoolean("ManageTestResources.enabled");
+        }
+        if (System.getenv("DISABLE_REPORT_RESOURCE_HUNGRY_TESTS_CHECK") != null) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void onStart(ITestContext context)
+    {
+        try {
+            if (!enabled) {
+                log.debug("ManageTestResources.onStart ignored, check is disabled");
+                return;
+            }
+
+            log.info("ManageTestResources.onStart: running checks");
+            manageResources(context, BEFORE_CLASS);
+        }
+        catch (ReflectiveOperationException | Error e) {
+            reportListenerFailure(
+                    ManageTestResources.class,
+                    "Failed to process %s: \n%s",
+                    context,
+                    getStackTraceAsString(e));
+        }
+    }
+
+    @Override
+    public void onTestStart(ITestResult result) {}
+
+    @Override
+    public void onTestSuccess(ITestResult result) {}
+
+    @Override
+    public void onTestFailure(ITestResult result) {}
+
+    @Override
+    public void onTestSkipped(ITestResult result) {}
+
+    @Override
+    public void onTestFailedButWithinSuccessPercentage(ITestResult result) {}
+
+    @Override
+    public void onFinish(ITestContext context)
+    {
+        try {
+            if (!enabled) {
+                log.debug("ManageTestResources.onFinish ignored, check is disabled");
+                return;
+            }
+
+            log.info("ManageTestResources.onFinish: running checks");
+            manageResources(context, AFTER_CLASS);
+        }
+        catch (ReflectiveOperationException | Error e) {
+            reportListenerFailure(
+                    ManageTestResources.class,
+                    "Failed to process %s: \n%s",
+                    context,
+                    getStackTraceAsString(e));
+        }
+    }
+
+    private void manageResources(ITestContext context, Stage stage)
+            throws ReflectiveOperationException
+    {
+        Set<ITestClass> testClasses = Stream.of(context.getAllTestMethods())
+                .map(ITestNGMethod::getTestClass)
+                .collect(toImmutableSet());
+        for (ITestClass testClass : testClasses) {
+            manageResources(testClass, stage);
+        }
+    }
+
+    private void manageResources(ITestClass testClass, Stage stage)
+            throws ReflectiveOperationException
+    {
+        // This method should not be called when check not enabled.
+        checkState(enabled, "Not enabled");
+
+        for (Object instance : testClass.getInstances(false)) {
+            for (Class<?> clazz = instance.getClass(); clazz != null; clazz = clazz.getSuperclass()) {
+                for (Field field : clazz.getDeclaredFields()) {
+                    if (field.isAnnotationPresent(Suppress.class)) {
+                        log.debug("Skipping audit of field due to field-level suppression %s: %s", field.getAnnotation(Suppress.class), field);
+                        continue;
+                    }
+
+                    field.setAccessible(true);
+                    Object value = field.get(instance);
+                    if (value == null) {
+                        continue;
+                    }
+                    if (value.getClass().isAnnotationPresent(Suppress.class)) {
+                        log.debug(
+                                "Skipping audit of field due to suppression %s on the field actual type (%s): %s",
+                                value.getClass().getAnnotation(Suppress.class),
+                                value.getClass(),
+                                field);
+                        continue;
+                    }
+                    for (Rule rule : rules) {
+                        if (rule.isExpensiveResource(field, value, stage)) {
+                            reportListenerFailure(
+                                    ManageTestResources.class,
+                                    """
+
+                                            \tTest instance field has value that looks like a resource
+                                            \t    Test class: %s
+                                            \t    Instance: %s
+                                            \t    Field: %s
+                                            \t    Value: %s
+                                            \t    Test execution stage: %s
+                                            \t    Matching rule: %s
+
+                                            \tResources must not be allocated in a field initializer or a test constructor,
+                                            \tand must be freed when test class is completed.
+                                            \tDepending which rule has been violated, if the reported class holds on
+                                            \tto resources only conditionally, you can add @ResourcePresence to declare that.
+                                            """,
+                                    testClass.getRealClass(),
+                                    instance,
+                                    field,
+                                    value,
+                                    stage,
+                                    rule);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    enum Stage
+    {
+        BEFORE_CLASS,
+        AFTER_CLASS,
+    }
+
+    @FunctionalInterface
+    private interface Rule
+    {
+        boolean isExpensiveResource(Field field, Object value, Stage stage);
+    }
+
+    private static Rule declaredClassPattern(@Language("RegExp") String classNamePattern)
+    {
+        Pattern pattern = Pattern.compile(classNamePattern);
+        return named(
+                "declaredClassPattern(%s)".formatted(classNamePattern),
+                (field, value, stage) -> pattern.matcher(field.getType().getName()).matches());
+    }
+
+    /**
+     * Report {@link AutoCloseable} instances.
+     */
+    private static Rule isAutoCloseable()
+    {
+        return named("isAutoCloseable", (field, value, stage) -> {
+            if (!(value instanceof AutoCloseable)) {
+                return false;
+            }
+
+            // Disallow AutoCloseable instances, even if not started, before class is run.
+            // Allocation of such resources generally correlates with too eager initialization.
+            // Allow stopped instances after class to work nicely with
+            // `AbstractTestQueryFramework.closeAfterClass` usages.
+            return !(stage == AFTER_CLASS && isResourceStopped(value));
+        });
+    }
+
+    /**
+     * Report anything that looks like a "Server" and does not appear to be stopped after class is finished.
+     */
+    private static Rule isSomeServer()
+    {
+        return named("isSomeServer", (field, value, stage) -> {
+            Class<?> type = field.getType();
+            if (!type.getName().endsWith("Server")) {
+                return false;
+            }
+
+            // Disallow "*Server" instances, even if not started, before class is run.
+            // Allow stopped instances to work nicely with `AbstractTestQueryFramework.closeAfterClass` usages.
+            return !(stage == AFTER_CLASS && isResourceStopped(value));
+        });
+    }
+
+    // see https://github.com/trinodb/trino/commit/9e3b45b743e1cc350e759c1bed3cfb336b1cf610
+    private static Optional<Rule> isInstanceTransactionManagerField()
+    {
+        return tryLoadClass("io.trino.transaction.TransactionManager").map(transactionManagerClass ->
+                named(
+                        "is-instance-TransactionManager-field",
+                        (field, value, stage) -> {
+                            // Exclude static fields to allow usages of the form: `static final TransactionManager TRANSACTION_MANAGER = createTestTransactionManager()`
+                            if (isStatic(field.getModifiers())) {
+                                return false;
+                            }
+                            return transactionManagerClass.isInstance(value);
+                        }));
+    }
+
+    private static boolean isResourceStopped(Object resource)
+    {
+        return Stream.of(resource.getClass().getMethods())
+                .filter(method -> method.isAnnotationPresent(ResourcePresence.class))
+                .collect(toOptional())
+                .map(resourcePresence -> {
+                    try {
+                        return !(boolean) resourcePresence.invoke(resource);
+                    }
+                    catch (ReflectiveOperationException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .orElse(false); // assume not stopped
+    }
+
+    /**
+     * Report {@link java.util.concurrent.ExecutorService} instances that are left behind.
+     * Does not report prematurely initialized instances since typical execuctor service creates
+     * threads lazily.
+     */
+    private static Rule isLeftoverExecutorService()
+    {
+        return named("isLeftoverExecutorService", (field, value, stage) -> {
+            if (!(value instanceof ExecutorService executorService)) {
+                return false;
+            }
+
+            // TODO we should check for executorService.isTerminated(), i.e. require tests to wait for completion of any background tasks
+            return stage == AFTER_CLASS && !executorService.isShutdown();
+        });
+    }
+
+    private static Rule named(String name, Rule delegate)
+    {
+        return new Rule()
+        {
+            @Override
+            public boolean isExpensiveResource(Field field, Object value, Stage stage)
+            {
+                return delegate.isExpensiveResource(field, value, stage);
+            }
+
+            @Override
+            public String toString()
+            {
+                return name;
+            }
+        };
+    }
+
+    private static Optional<Class<?>> tryLoadClass(String className)
+    {
+        try {
+            return Optional.of(Thread.currentThread().getContextClassLoader().loadClass(className));
+        }
+        catch (ClassNotFoundException e) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Suppresses checks when
+     * <ul>
+     *     <li>field is annotated
+     *     <li>field actual type is annotated (note that the annotation *IS* inherited)
+     * </ul>
+     */
+    @Retention(RUNTIME)
+    @Target({TYPE, FIELD})
+    @Inherited
+    public @interface Suppress
+    {
+        String because();
+    }
+}

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/ProgressLoggingListener.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/ProgressLoggingListener.java
@@ -16,6 +16,8 @@ package io.trino.testng.services;
 import com.google.common.base.Joiner;
 import io.airlift.log.Logger;
 import org.testng.IClassListener;
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
 import org.testng.ITestClass;
 import org.testng.ITestContext;
 import org.testng.ITestListener;
@@ -27,7 +29,7 @@ import java.math.RoundingMode;
 import static java.lang.String.format;
 
 public class ProgressLoggingListener
-        implements IClassListener, ITestListener
+        implements IClassListener, ITestListener, IInvokedMethodListener
 {
     private static final Logger LOGGER = Logger.get(ProgressLoggingListener.class);
     private final boolean enabled;
@@ -53,18 +55,32 @@ public class ProgressLoggingListener
     }
 
     @Override
-    public void onStart(ITestContext context)
-    {
-    }
+    public void onStart(ITestContext context) {}
 
     @Override
-    public void onTestStart(ITestResult testCase)
+    public void beforeInvocation(IInvokedMethod method, ITestResult testResult)
     {
         if (!enabled) {
             return;
         }
-        LOGGER.info("[TEST START] %s", formatTestName(testCase));
+        boolean testMethod = method.isTestMethod();
+        boolean configurationMethod = method.isConfigurationMethod();
+        if (testMethod) {
+            LOGGER.info("[TEST START] %s", formatTestName(testResult));
+        }
+        if (configurationMethod) {
+            LOGGER.info("[CONFIGURATION] %s for %s", method, formatTestName(testResult));
+        }
+        if (!testMethod && !configurationMethod) {
+            LOGGER.info("[UNKNOWN THING] %s for %s", method, formatTestName(testResult));
+        }
     }
+
+    @Override
+    public void afterInvocation(IInvokedMethod method, ITestResult testResult) {}
+
+    @Override
+    public void onTestStart(ITestResult testCase) {}
 
     @Override
     public void onTestSuccess(ITestResult testCase)
@@ -99,14 +115,10 @@ public class ProgressLoggingListener
     }
 
     @Override
-    public void onTestFailedButWithinSuccessPercentage(ITestResult testCase)
-    {
-    }
+    public void onTestFailedButWithinSuccessPercentage(ITestResult testCase) {}
 
     @Override
-    public void onFinish(ITestContext context)
-    {
-    }
+    public void onFinish(ITestContext context) {}
 
     @Override
     public void onBeforeClass(ITestClass testClass)

--- a/testing/trino-testing-services/src/main/resources/META-INF/services/org.testng.ITestNGListener
+++ b/testing/trino-testing-services/src/main/resources/META-INF/services/org.testng.ITestNGListener
@@ -1,3 +1,4 @@
+io.trino.testng.services.ManageTestResources
 io.trino.testng.services.ReportOrphanedExecutors
 io.trino.testng.services.ReportPrivateMethods
 io.trino.testng.services.ReportUnannotatedMethods

--- a/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
@@ -86,19 +86,21 @@ public class DistributedQueryRunner
     private static final Logger log = Logger.get(DistributedQueryRunner.class);
     private static final String ENVIRONMENT = "testing";
 
-    private final TestingDiscoveryServer discoveryServer;
-    private final TestingTrinoServer coordinator;
-    private final Optional<TestingTrinoServer> backupCoordinator;
-    private final Runnable registerNewWorker;
+    private TestingDiscoveryServer discoveryServer;
+    private TestingTrinoServer coordinator;
+    private Optional<TestingTrinoServer> backupCoordinator;
+    private Runnable registerNewWorker;
     private final List<TestingTrinoServer> servers = new CopyOnWriteArrayList<>();
     private final List<FunctionBundle> functionBundles = new CopyOnWriteArrayList<>(ImmutableList.of(AbstractTestQueries.CUSTOM_FUNCTIONS));
     private final List<Plugin> plugins = new CopyOnWriteArrayList<>();
 
     private final Closer closer = Closer.create();
 
-    private final TestingTrinoClient trinoClient;
+    private TestingTrinoClient trinoClient;
 
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
+
+    private boolean closed;
 
     public static Builder<?> builder(Session defaultSession)
     {
@@ -566,6 +568,9 @@ public class DistributedQueryRunner
     @Override
     public final void close()
     {
+        if (closed) {
+            return;
+        }
         cancelAllQueries();
         try {
             closer.close();
@@ -573,6 +578,17 @@ public class DistributedQueryRunner
         catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+        discoveryServer = null;
+        coordinator = null;
+        backupCoordinator = Optional.empty();
+        registerNewWorker = () -> {
+            throw new IllegalStateException("Already closed");
+        };
+        servers.clear();
+        functionBundles.clear();
+        plugins.clear();
+        trinoClient = null;
+        closed = true;
     }
 
     private void cancelAllQueries()

--- a/testing/trino-testing/src/test/java/io/trino/testing/TestTestingTrinoClient.java
+++ b/testing/trino-testing/src/test/java/io/trino/testing/TestTestingTrinoClient.java
@@ -83,6 +83,7 @@ public class TestTestingTrinoClient
             throws Exception
     {
         server.close();
+        server = null;
     }
 
     @Test

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestDenyOnSchema.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestDenyOnSchema.java
@@ -102,6 +102,7 @@ public class TestDenyOnSchema
     {
         assertions.close();
         assertions = null;
+        queryRunner = null; // closed by assertions.close
     }
 
     @Test(dataProvider = "privileges")

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestDenyOnTable.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestDenyOnTable.java
@@ -99,6 +99,7 @@ public class TestDenyOnTable
     {
         assertions.close();
         assertions = null;
+        queryRunner = null; // closed by assertions.close
     }
 
     @Test(dataProvider = "privileges")

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestDeprecatedFunctionWarning.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestDeprecatedFunctionWarning.java
@@ -77,6 +77,7 @@ public class TestDeprecatedFunctionWarning
     public void tearDown()
     {
         queryRunner.close();
+        queryRunner = null;
     }
 
     @Test

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestGrantOnSchema.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestGrantOnSchema.java
@@ -68,6 +68,7 @@ public class TestGrantOnSchema
     {
         assertions.close();
         assertions = null;
+        queryRunner = null; // closed by assertions.close
     }
 
     @Test(dataProviderClass = DataProviders.class, dataProvider = "trueFalse")

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestGrantOnTable.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestGrantOnTable.java
@@ -75,6 +75,7 @@ public class TestGrantOnTable
     {
         assertions.close();
         assertions = null;
+        queryRunner = null; // closed by assertions.close
     }
 
     @Test(dataProviderClass = DataProviders.class, dataProvider = "trueFalse")

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestPendingStageState.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestPendingStageState.java
@@ -72,6 +72,7 @@ public class TestPendingStageState
     {
         if (queryRunner != null) {
             queryRunner.close();
+            queryRunner = null;
         }
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestQueryTracker.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestQueryTracker.java
@@ -41,7 +41,7 @@ public class TestQueryTracker
     private final CountDownLatch freeze = new CountDownLatch(1);
     private final CountDownLatch interrupted = new CountDownLatch(1);
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void unfreeze()
     {
         freeze.countDown();

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestRevokeOnSchema.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestRevokeOnSchema.java
@@ -70,6 +70,7 @@ public class TestRevokeOnSchema
     {
         assertions.close();
         assertions = null;
+        queryRunner = null; // closed by assertions.close
     }
 
     @Test(dataProvider = "privilegesAndUsers")

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestRevokeOnTable.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestRevokeOnTable.java
@@ -84,6 +84,7 @@ public class TestRevokeOnTable
     {
         assertions.close();
         assertions = null;
+        queryRunner = null; // closed by assertions.close
     }
 
     @Test(dataProvider = "privilegesAndUsers")

--- a/testing/trino-tests/src/test/java/io/trino/sql/planner/BaseIcebergCostBasedPlanTest.java
+++ b/testing/trino-tests/src/test/java/io/trino/sql/planner/BaseIcebergCostBasedPlanTest.java
@@ -34,6 +34,7 @@ import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
 import io.trino.testing.containers.Minio;
 import io.trino.testing.minio.MinioClient;
+import io.trino.testng.services.ManageTestResources;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterSuite;
@@ -79,6 +80,7 @@ public abstract class BaseIcebergCostBasedPlanTest
     // The container needs to be shared, since bucket name cannot be reused between tests.
     // The bucket name is used as a key in TrinoFileSystemCache which is managed in static manner.
     @GuardedBy("sharedMinioLock")
+    @ManageTestResources.Suppress(because = "This resource is leaked, but consciously -- there is no known way to avoid that")
     private static Minio sharedMinio;
     private static final Object sharedMinioLock = new Object();
 

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestGetTableStatisticsOperations.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestGetTableStatisticsOperations.java
@@ -23,6 +23,7 @@ import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.LocalQueryRunner;
 import io.trino.testing.QueryRunner;
 import org.intellij.lang.annotations.Language;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -50,6 +51,14 @@ public class TestGetTableStatisticsOperations
         localQueryRunner.installPlugin(new TpchPlugin());
         localQueryRunner.createCatalog("tpch", "tpch", ImmutableMap.of());
         return localQueryRunner;
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        localQueryRunner.close();
+        localQueryRunner = null;
+        metadata = null;
     }
 
     @BeforeMethod

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestServer.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestServer.java
@@ -106,6 +106,8 @@ public class TestServer
             throws Exception
     {
         closeAll(server, client);
+        server = null;
+        client = null;
     }
 
     @Test


### PR DESCRIPTION
When running TestNG tests with surefire, the test class instance
initialization (class initializer, test instance construction) happens
before tests are run, for all instances. Allocating resources during
this phase is bad for these reasons:

- resources are allocated long before they are needed, so tests may
  exhaust available memory even if every single test is not memory-hungry
- failure reporting during this phase is imperfect (it was observed that
  actual failure stacktrace may not be reported in the logs), so
  diagnosing failures is hard.

This commit adds a runtime verification attempting to ensure that test
instances do not hold on to any "resourceful" classes before the test is
started. Of course, we don't want to prohibit any field initialization
in test instances (that would affect readability and would be
frustrating), so "resourceful" classes are some known ones. The list can
be extended in the future.

Besides checking test instances before test is run, it also checks
instances after test class is completed, to catch any resources that
were left behind and not closed.

Adds test coverage for https://github.com/trinodb/trino/pull/15133

Already approved at https://github.com/trinodb/trino/pull/15151 