### PR TITLE
Elasticsearch passthrough query support split to multiple tasks

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConfig.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConfig.java
@@ -76,6 +76,7 @@ public class ElasticsearchConfig
     private String truststorePassword;
     private boolean ignorePublishAddress;
     private boolean verifyHostnames = true;
+    private boolean isPassthroughQuerySplitEnable;
 
     private Security security;
 
@@ -356,6 +357,18 @@ public class ElasticsearchConfig
     public ElasticsearchConfig setSecurity(Security security)
     {
         this.security = security;
+        return this;
+    }
+
+    public boolean isPassthroughQuerySplit()
+    {
+        return isPassthroughQuerySplitEnable;
+    }
+
+    @Config("elasticsearch.passthrough-query-split")
+    public ElasticsearchConfig setPassthroughQuerySplit(boolean isPassthroughQuerySplitEnable)
+    {
+        this.isPassthroughQuerySplitEnable = isPassthroughQuerySplitEnable;
         return this;
     }
 }

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchPageSourceProvider.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchPageSourceProvider.java
@@ -60,7 +60,7 @@ public class ElasticsearchPageSourceProvider
         ElasticsearchSplit elasticsearchSplit = (ElasticsearchSplit) split;
 
         if (elasticsearchTable.getType().equals(QUERY)) {
-            return new PassthroughQueryPageSource(client, elasticsearchTable);
+            return new PassthroughQueryPageSource(client, session, elasticsearchTable, elasticsearchSplit.getShard());
         }
 
         if (columns.isEmpty()) {

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchSplitManager.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchSplitManager.java
@@ -52,7 +52,7 @@ public class ElasticsearchSplitManager
     {
         ElasticsearchTableHandle tableHandle = (ElasticsearchTableHandle) table;
 
-        if (tableHandle.getType().equals(QUERY)) {
+        if (tableHandle.getType().equals(QUERY) && !ElasticsearchUtils.isSplit(client.isPassthroughQuerySplitEnable(), tableHandle.getQuery().get())) {
             return new FixedSplitSource(new ElasticsearchSplit(tableHandle.getIndex(), 0, Optional.empty()));
         }
         List<ElasticsearchSplit> splits = client.getSearchShards(tableHandle.getIndex()).stream()

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchUtils.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.elasticsearch;
+
+public class ElasticsearchUtils
+{
+    private ElasticsearchUtils()
+    {
+    }
+
+    private static boolean isAggregations(String query)
+    {
+        if (query.contains("\"aggs\"") || query.contains("\"aggregations\"")) {
+            return true;
+        }
+        return false;
+    }
+
+    public static boolean isSplit(boolean isPassthroughQuerySplitEnable, String query)
+    {
+        return isPassthroughQuerySplitEnable && !isAggregations(query);
+    }
+}

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchConfig.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchConfig.java
@@ -57,7 +57,8 @@ public class TestElasticsearchConfig
                 .setTruststorePassword(null)
                 .setVerifyHostnames(true)
                 .setIgnorePublishAddress(false)
-                .setSecurity(null));
+                .setSecurity(null)
+                .setPassthroughQuerySplit(false));
     }
 
     @Test
@@ -89,6 +90,7 @@ public class TestElasticsearchConfig
                 .put("elasticsearch.tls.verify-hostnames", "false")
                 .put("elasticsearch.ignore-publish-address", "true")
                 .put("elasticsearch.security", "AWS")
+                .put("elasticsearch.passthrough-query-split", "true")
                 .buildOrThrow();
 
         ElasticsearchConfig expected = new ElasticsearchConfig()
@@ -112,7 +114,8 @@ public class TestElasticsearchConfig
                 .setTruststorePassword("truststore-password")
                 .setVerifyHostnames(false)
                 .setIgnorePublishAddress(true)
-                .setSecurity(AWS);
+                .setSecurity(AWS)
+                .setPassthroughQuerySplit(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

Release notes are required, with the following suggested text:

```markdown
# Section
* the query from trino to elasticsearch is always only one task，and all split are concentrated in this task. after fix, The query time is reduced by one order of magnitude. 

({issue}`15171`)

```
