### PR TITLE
graceful shutdown for containers

### DIFF
--- a/core/docker/bin/run-trino
+++ b/core/docker/bin/run-trino
@@ -5,7 +5,11 @@ set -xeuo pipefail
 function graceful_shutdown()
 {
     echo "Shutting down this worker gracefully"
-    curl -v -X PUT -d '"SHUTTING_DOWN"' -H "Content-type: application/json" http://localhost:8080/v1/info/state
+    curl -v -X PUT -d '"SHUTTING_DOWN"' \
+        -H "Content-type: application/json" \
+        --max-time 5 \
+        --retry 5 \
+        http://localhost:8080/v1/info/state
 }
 
 trap 'graceful_shutdown; wait $PID' SIGTERM

--- a/core/docker/bin/run-trino
+++ b/core/docker/bin/run-trino
@@ -2,9 +2,19 @@
 
 set -xeuo pipefail
 
+function graceful_shutdown()
+{
+    echo "Shutting down this worker gracefully"
+    curl -v -X PUT -d '"SHUTTING_DOWN"' -H "Content-type: application/json" http://localhost:8080/v1/info/state
+}
+
+trap 'graceful_shutdown; wait $PID' SIGTERM
+
 launcher_opts=(--etc-dir /etc/trino)
 if ! grep -s -q 'node.id' /etc/trino/node.properties; then
     launcher_opts+=("-Dnode.id=${HOSTNAME}")
 fi
 
-exec /usr/lib/trino/bin/launcher run "${launcher_opts[@]}" "$@"
+exec /usr/lib/trino/bin/launcher run "${launcher_opts[@]}" "$@" &
+PID=$!
+wait $PID


### PR DESCRIPTION
## Description

There is no mechanism to handle `SIGTERM` if your pods are being terminated in Kubernetes. 
This PR implements a simple graceful shutdown procedure which is documented in [here](https://trino.io/docs/current/admin/graceful-shutdown.html).

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

I know there is better proposals like #521 #9976 which try to solve this problem more elegantly and holistically but this is just a simpler change for benefiting from existing `/v1/info/state` API endpoint.

This implementation doesn't implement additional security aspects in case of having TLS/HTTPS enabled and shared-secret.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# Section
* Adding graceful shutdown procedure to docker image ({issue}`issuenumber`)
```
