### PR TITLE
Multiply on disk column sizes of iceberg data files by 4 for column stats

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -846,8 +846,8 @@ public abstract class BaseIcebergConnectorTest
                                 "  ('a_double', NULL, NULL, 0.5e0, NULL, '1.0', '1.0'), " +
                                 "  ('a_short_decimal', NULL, NULL, 0.5e0, NULL, '1.0', '1.0'), " +
                                 "  ('a_long_decimal', NULL, NULL, 0.5e0, NULL, '11.0', '11.0'), " +
-                                "  ('a_varchar', 87e0, NULL, 0.5e0, NULL, NULL, NULL), " +
-                                "  ('a_varbinary', 82e0, NULL, 0.5e0, NULL, NULL, NULL), " +
+                                "  ('a_varchar', 234e0, NULL, 0.5e0, NULL, NULL, NULL), " +
+                                "  ('a_varbinary', 114e0, NULL, 0.5e0, NULL, NULL, NULL), " +
                                 "  ('a_date', NULL, NULL, 0.5e0, NULL, '2021-07-24', '2021-07-24'), " +
                                 "  ('a_time', NULL, NULL, 0.5e0, NULL, NULL, NULL), " +
                                 "  ('a_timestamp', NULL, NULL, 0.5e0, NULL, '2021-07-24 03:43:57.987654', '2021-07-24 03:43:57.987654'), " +
@@ -856,7 +856,7 @@ public abstract class BaseIcebergConnectorTest
                                 "  ('a_row', NULL, NULL, NULL, NULL, NULL, NULL), " +
                                 "  ('an_array', NULL, NULL, NULL, NULL, NULL, NULL), " +
                                 "  ('a_map', NULL, NULL, NULL, NULL, NULL, NULL), " +
-                                "  ('a quoted, field', 83e0, NULL, 0.5e0, NULL, NULL, NULL), " +
+                                "  ('a quoted, field', 224e0, NULL, 0.5e0, NULL, NULL, NULL), " +
                                 "  (NULL, NULL, NULL, NULL, 2e0, NULL, NULL)");
             }
             case AVRO -> {
@@ -2620,7 +2620,7 @@ public abstract class BaseIcebergConnectorTest
         assertThat(query("SHOW STATS FOR test_truncate_text_transform"))
                 .skippingTypesCheck()
                 .matches("VALUES " +
-                        "  ('d', " + (format == PARQUET ? "205e0" : "NULL") + ", NULL, " + (format == AVRO ? "NULL" : "0.125e0") + ", NULL, NULL, NULL), " +
+                        "  ('d', " + (format == PARQUET ? "553e0" : "NULL") + ", NULL, " + (format == AVRO ? "NULL" : "0.125e0") + ", NULL, NULL, NULL), " +
                         (format == AVRO ? "  ('b', NULL, NULL, NULL, NULL, NULL, NULL), " : "  ('b', NULL, NULL, 0e0, NULL, '1', '101'), ") +
                         "  (NULL, NULL, NULL, NULL, 8e0, NULL, NULL)");
 
@@ -2912,7 +2912,7 @@ public abstract class BaseIcebergConnectorTest
         }
         if (format == PARQUET) {
             expected = "VALUES " +
-                    "  ('d', 136e0, NULL, 0e0, NULL, NULL, NULL), " +
+                    "  ('d', 367e0, NULL, 0e0, NULL, NULL, NULL), " +
                     "  ('b', NULL, NULL, 0e0, NULL, '1', '7'), " +
                     "  (NULL, NULL, NULL, NULL, 7e0, NULL, NULL)";
         }
@@ -2971,7 +2971,7 @@ public abstract class BaseIcebergConnectorTest
             assertThat(query("SHOW STATS FOR test_void_transform"))
                     .skippingTypesCheck()
                     .matches("VALUES " +
-                            "  ('d', " + (format == PARQUET ? "76e0" : "NULL") + ", NULL, 0.2857142857142857, NULL, NULL, NULL), " +
+                            "  ('d', " + (format == PARQUET ? "205e0" : "NULL") + ", NULL, 0.2857142857142857, NULL, NULL, NULL), " +
                             "  ('b', NULL, NULL, 0e0, NULL, '1', '7'), " +
                             "  (NULL, NULL, NULL, NULL, 7e0, NULL, NULL)");
         }
@@ -3136,8 +3136,8 @@ public abstract class BaseIcebergConnectorTest
                 "  (NULL, NULL, NULL, NULL, 5e0, NULL, NULL)")
                 : ("VALUES " +
                 "  ('regionkey', NULL, NULL, 0e0, NULL, '0', '4'), " +
-                "  ('name', " + (format == PARQUET ? "87e0" : "NULL") + ", NULL, 0e0, NULL, NULL, NULL), " +
-                "  ('comment', " + (format == PARQUET ? "237e0" : "NULL") + ", NULL, 0e0, NULL, NULL, NULL), " +
+                "  ('name', " + (format == PARQUET ? "234e0" : "NULL") + ", NULL, 0e0, NULL, NULL, NULL), " +
+                "  ('comment', " + (format == PARQUET ? "639e0" : "NULL") + ", NULL, 0e0, NULL, NULL, NULL), " +
                 "  (NULL, NULL, NULL, NULL, 5e0, NULL, NULL)");
 
         String statsWithNdv = format == AVRO
@@ -3148,8 +3148,8 @@ public abstract class BaseIcebergConnectorTest
                 "  (NULL, NULL, NULL, NULL, 5e0, NULL, NULL)")
                 : ("VALUES " +
                 "  ('regionkey', NULL, 5e0, 0e0, NULL, '0', '4'), " +
-                "  ('name', " + (format == PARQUET ? "87e0" : "NULL") + ", 5e0, 0e0, NULL, NULL, NULL), " +
-                "  ('comment', " + (format == PARQUET ? "237e0" : "NULL") + ", 5e0, 0e0, NULL, NULL, NULL), " +
+                "  ('name', " + (format == PARQUET ? "234e0" : "NULL") + ", 5e0, 0e0, NULL, NULL, NULL), " +
+                "  ('comment', " + (format == PARQUET ? "639e0" : "NULL") + ", 5e0, 0e0, NULL, NULL, NULL), " +
                 "  (NULL, NULL, NULL, NULL, 5e0, NULL, NULL)");
 
         // initially, no NDV information
@@ -3588,8 +3588,8 @@ public abstract class BaseIcebergConnectorTest
                             "  ('dbl', NULL, NULL, 0e0, NULL, '1.0', '1.0'), " +
                             "  ('mp', NULL, NULL, " + (format == ORC ? "0e0" : "NULL") + ", NULL, NULL, NULL), " +
                             "  ('dec', NULL, NULL, 0e0, NULL, '1.0', '1.0'), " +
-                            "  ('vc', " + (format == PARQUET ? "43e0" : "NULL") + ", NULL, 0e0, NULL, NULL, NULL), " +
-                            "  ('vb', " + (format == PARQUET ? "55e0" : "NULL") + ", NULL, 0e0, NULL, NULL, NULL), " +
+                            "  ('vc', " + (format == PARQUET ? "116e0" : "NULL") + ", NULL, 0e0, NULL, NULL, NULL), " +
+                            "  ('vb', " + (format == PARQUET ? "77e0" : "NULL") + ", NULL, 0e0, NULL, NULL, NULL), " +
                             "  ('ts', NULL, NULL, 0e0, NULL, '2021-07-24 02:43:57.348000', " + (format == ORC ? "'2021-07-24 02:43:57.348999'" : "'2021-07-24 02:43:57.348000'") + "), " +
                             "  ('tstz', NULL, NULL, 0e0, NULL, '2021-07-24 02:43:57.348 UTC', '2021-07-24 02:43:57.348 UTC'), " +
                             "  ('str', NULL, NULL, " + (format == ORC ? "0e0" : "NULL") + ", NULL, NULL, NULL), " +
@@ -3651,7 +3651,7 @@ public abstract class BaseIcebergConnectorTest
                             "  ('dbl', NULL, NULL, 0e0, NULL, '1.0', '1.0'), " +
                             "  ('mp', NULL, NULL, " + (format == ORC ? "0e0" : "NULL") + ", NULL, NULL, NULL), " +
                             "  ('dec', NULL, NULL, 0e0, NULL, '1.0', '1.0'), " +
-                            "  ('vc', " + (format == PARQUET ? "43e0" : "NULL") + ", NULL, 0e0, NULL, NULL, NULL), " +
+                            "  ('vc', " + (format == PARQUET ? "116e0" : "NULL") + ", NULL, 0e0, NULL, NULL, NULL), " +
                             "  ('str', NULL, NULL, " + (format == ORC ? "0e0" : "NULL") + ", NULL, NULL, NULL), " +
                             "  (NULL, NULL, NULL, NULL, 1e0, NULL, NULL)");
         }
@@ -3963,8 +3963,8 @@ public abstract class BaseIcebergConnectorTest
                             "  ('a_double', NULL, NULL, 0.5e0, NULL, '1.0', '1.0'), " +
                             "  ('a_short_decimal', NULL, NULL, 0.5e0, NULL, '1.0', '1.0'), " +
                             "  ('a_long_decimal', NULL, NULL, 0.5e0, NULL, '11.0', '11.0'), " +
-                            "  ('a_varchar', " + (format == PARQUET ? "87e0" : "NULL") + ", NULL, 0.5e0, NULL, NULL, NULL), " +
-                            "  ('a_varbinary', " + (format == PARQUET ? "82e0" : "NULL") + ", NULL, 0.5e0, NULL, NULL, NULL), " +
+                            "  ('a_varchar', " + (format == PARQUET ? "234e0" : "NULL") + ", NULL, 0.5e0, NULL, NULL, NULL), " +
+                            "  ('a_varbinary', " + (format == PARQUET ? "114e0" : "NULL") + ", NULL, 0.5e0, NULL, NULL, NULL), " +
                             "  ('a_date', NULL, NULL, 0.5e0, NULL, '2021-07-24', '2021-07-24'), " +
                             "  ('a_time', NULL, NULL, 0.5e0, NULL, NULL, NULL), " +
                             "  ('a_timestamp', NULL, NULL, 0.5e0, NULL, " + (format == ORC ? "'2021-07-24 03:43:57.987000', '2021-07-24 03:43:57.987999'" : "'2021-07-24 03:43:57.987654', '2021-07-24 03:43:57.987654'") + "), " +
@@ -4017,8 +4017,8 @@ public abstract class BaseIcebergConnectorTest
                             "  ('a_double', NULL, 1e0, 0.5e0, NULL, '1.0', '1.0'), " +
                             "  ('a_short_decimal', NULL, 1e0, 0.5e0, NULL, '1.0', '1.0'), " +
                             "  ('a_long_decimal', NULL, 1e0, 0.5e0, NULL, '11.0', '11.0'), " +
-                            "  ('a_varchar', " + (format == PARQUET ? "87e0" : "NULL") + ", 1e0, 0.5e0, NULL, NULL, NULL), " +
-                            "  ('a_varbinary', " + (format == PARQUET ? "82e0" : "NULL") + ", 1e0, 0.5e0, NULL, NULL, NULL), " +
+                            "  ('a_varchar', " + (format == PARQUET ? "234e0" : "NULL") + ", 1e0, 0.5e0, NULL, NULL, NULL), " +
+                            "  ('a_varbinary', " + (format == PARQUET ? "114e0" : "NULL") + ", 1e0, 0.5e0, NULL, NULL, NULL), " +
                             "  ('a_date', NULL, 1e0, 0.5e0, NULL, '2021-07-24', '2021-07-24'), " +
                             "  ('a_time', NULL, 1e0, 0.5e0, NULL, NULL, NULL), " +
                             "  ('a_timestamp', NULL, 1e0, 0.5e0, NULL, " + (format == ORC ? "'2021-07-24 03:43:57.987000', '2021-07-24 03:43:57.987999'" : "'2021-07-24 03:43:57.987654', '2021-07-24 03:43:57.987654'") + "), " +

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -1496,15 +1496,25 @@ public class TestIcebergSparkCompatibility
         String sparkTableName = sparkTableName(tableName);
         String trinoTableName = trinoTableName(tableName);
 
-        onSpark().executeQuery("CREATE TABLE " + sparkTableName + "(col0 INT, col1 INT)");
-        onSpark().executeQuery("INSERT INTO " + sparkTableName + " VALUES (1, 2)");
+        onSpark().executeQuery("CREATE TABLE " + sparkTableName + "(col0 INT, col1 INT, col2 STRING, col3 BINARY)");
+        onSpark().executeQuery("INSERT INTO " + sparkTableName + " VALUES (1, 2, 'col2Value0', X'000102f0feff')");
         assertThat(onTrino().executeQuery("SHOW STATS FOR " + trinoTableName))
-                .containsOnly(row("col0", null, null, 0.0, null, "1", "1"), row("col1", null, null, 0.0, null, "2", "2"), row(null, null, null, null, 1.0, null, null));
+                .containsOnly(
+                        row("col0", null, null, 0.0, null, "1", "1"),
+                        row("col1", null, null, 0.0, null, "2", "2"),
+                        row("col2", 151.0, null, 0.0, null, null, null),
+                        row("col3", 72.0, null, 0.0, null, null, null),
+                        row(null, null, null, null, 1.0, null, null));
 
         onSpark().executeQuery("ALTER TABLE " + sparkTableName + " SET TBLPROPERTIES (write.metadata.metrics.column.col1='none')");
-        onSpark().executeQuery("INSERT INTO " + sparkTableName + " VALUES (3, 4)");
+        onSpark().executeQuery("INSERT INTO " + sparkTableName + " VALUES (3, 4, 'col2Value1', X'000102f0feee')");
         assertThat(onTrino().executeQuery("SHOW STATS FOR " + trinoTableName))
-                .containsOnly(row("col0", null, null, 0.0, null, "1", "3"), row("col1", null, null, null, null, null, null), row(null, null, null, null, 2.0, null, null));
+                .containsOnly(
+                        row("col0", null, null, 0.0, null, "1", "3"),
+                        row("col1", null, null, null, null, null, null),
+                        row("col2", 305.0, null, 0.0, null, null, null),
+                        row("col3", 145.0, null, 0.0, null, null, null),
+                        row(null, null, null, null, 2.0, null, null));
 
         onSpark().executeQuery("DROP TABLE " + sparkTableName);
     }

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q19.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q19.plan.txt
@@ -10,14 +10,14 @@ local exchange (GATHER, SINGLE, [])
                                     scan customer_address
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                            local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                scan customer
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                    join (INNER, REPLICATED):
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                                                 local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                    join (INNER, REPLICATED):
+                                                    scan customer
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
                                                                 scan store_sales
@@ -27,6 +27,6 @@ local exchange (GATHER, SINGLE, [])
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                                     scan date_dim
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan store
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan store

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q24.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q24.plan.txt
@@ -10,18 +10,18 @@ remote exchange (GATHER, SINGLE, [])
                                     final aggregation over (c_first_name, c_last_name, ca_state, i_color, i_current_price, i_manager_id, i_size, i_units, s_state, s_store_name)
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["c_first_name", "c_last_name", "ca_state", "i_color", "i_current_price", "i_manager_id", "i_size", "i_units", "s_state", "s_store_name"])
-                                                local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                    partial aggregation over (c_first_name, c_last_name, ca_state, i_color, i_current_price, i_manager_id, i_size, i_units, s_state, s_store_name)
-                                                        join (INNER, REPLICATED):
-                                                            scan customer_address
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    join (INNER, PARTITIONED):
-                                                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                                            local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                                                scan customer
+                                                partial aggregation over (c_first_name, c_last_name, ca_state, i_color, i_current_price, i_manager_id, i_size, i_units, s_state, s_store_name)
+                                                    join (INNER, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, ["ca_zip", "upper"])
+                                                            local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                scan customer_address
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPARTITION, HASH, ["c_birth_country", "s_zip"])
+                                                                local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                    join (INNER, REPLICATED):
+                                                                        scan customer
                                                                         local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                                                            remote exchange (REPLICATE, BROADCAST, [])
                                                                                 join (INNER, PARTITIONED):
                                                                                     remote exchange (REPARTITION, HASH, ["sr_item_sk", "sr_ticket_number"])
                                                                                         local exchange (REPARTITION, ROUND_ROBIN, [])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q27.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q27.plan.txt
@@ -3,22 +3,24 @@ local exchange (GATHER, SINGLE, [])
         final aggregation over (groupid, i_item_id$gid, s_state$gid)
             local exchange (REPARTITION, HASH, ["groupid", "i_item_id$gid", "s_state$gid"])
                 remote exchange (REPARTITION, HASH, ["groupid", "i_item_id$gid", "s_state$gid"])
-                    local exchange (REPARTITION, ROUND_ROBIN, [])
-                        partial aggregation over (groupid, i_item_id$gid, s_state$gid)
-                            join (INNER, REPLICATED):
-                                join (INNER, REPLICATED):
+                    partial aggregation over (groupid, i_item_id$gid, s_state$gid)
+                        join (INNER, PARTITIONED):
+                            remote exchange (REPARTITION, HASH, ["ss_item_sk"])
+                                local exchange (REPARTITION, ROUND_ROBIN, [])
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            scan store_sales
+                                            join (INNER, REPLICATED):
+                                                scan store_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan customer_demographics
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan customer_demographics
+                                                    scan store
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan store
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
-                                            scan date_dim
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["i_item_sk"])
+                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                         scan item

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q29.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q29.plan.txt
@@ -13,10 +13,10 @@ local exchange (GATHER, SINGLE, [])
                                     local exchange (REPARTITION, ROUND_ROBIN, [])
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
-                                                scan catalog_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        join (INNER, REPLICATED):
+                                                join (INNER, REPLICATED):
+                                                    scan catalog_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
                                                             join (INNER, PARTITIONED):
                                                                 remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_item_sk", "ss_ticket_number"])
                                                                     local exchange (REPARTITION, ROUND_ROBIN, [])
@@ -33,9 +33,9 @@ local exchange (GATHER, SINGLE, [])
                                                                                 local exchange (GATHER, SINGLE, [])
                                                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                                                         scan date_dim
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan store
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
+                                                    scan store

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q30.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q30.plan.txt
@@ -2,30 +2,33 @@ local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         cross join:
             join (LEFT, REPLICATED):
-                join (INNER, REPLICATED):
-                    final aggregation over (ca_state, wr_returning_customer_sk)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ca_state", "wr_returning_customer_sk"])
-                                partial aggregation over (ca_state, wr_returning_customer_sk)
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["wr_returning_addr_sk"])
-                                            local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                join (INNER, REPLICATED):
-                                                    scan web_returns
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                    scan customer_address
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPLICATE, BROADCAST, [])
-                            join (INNER, REPLICATED):
-                                scan customer
+                join (INNER, PARTITIONED):
+                    remote exchange (REPARTITION, HASH, ["wr_returning_customer_sk"])
+                        local exchange (REPARTITION, ROUND_ROBIN, [])
+                            final aggregation over (ca_state, wr_returning_customer_sk)
                                 local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        scan customer_address
+                                    remote exchange (REPARTITION, HASH, ["ca_state", "wr_returning_customer_sk"])
+                                        partial aggregation over (ca_state, wr_returning_customer_sk)
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, ["wr_returning_addr_sk"])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                        join (INNER, REPLICATED):
+                                                            scan web_returns
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan date_dim
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                        local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                            scan customer_address
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                            local exchange (REPARTITION, ROUND_ROBIN, [])
+                                join (INNER, REPLICATED):
+                                    scan customer
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            scan customer_address
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPLICATE, BROADCAST, [])
                         final aggregation over (ca_state_85)

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q31.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q31.plan.txt
@@ -7,16 +7,18 @@ remote exchange (GATHER, SINGLE, [])
                         final aggregation over (ca_county_66, d_qoy_39, d_year_35)
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["ca_county_66", "d_qoy_39", "d_year_35"])
-                                    local exchange (REPARTITION, ROUND_ROBIN, [])
-                                        partial aggregation over (ca_county_66, d_qoy_39, d_year_35)
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                    partial aggregation over (ca_county_66, d_qoy_39, d_year_35)
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["ss_addr_sk_9"])
+                                                local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["ca_address_sk_59"])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         scan customer_address
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["ca_county_140", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
@@ -24,31 +26,35 @@ remote exchange (GATHER, SINGLE, [])
                                     final aggregation over (ca_county_140, d_qoy_113, d_year_109)
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["ca_county_140", "d_qoy_113", "d_year_109"])
-                                                local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                    partial aggregation over (ca_county_140, d_qoy_113, d_year_109)
-                                                        join (INNER, REPLICATED):
-                                                            join (INNER, REPLICATED):
-                                                                scan store_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan date_dim
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                partial aggregation over (ca_county_140, d_qoy_113, d_year_109)
+                                                    join (INNER, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, ["ss_addr_sk_83"])
+                                                            local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                join (INNER, REPLICATED):
+                                                                    scan store_sales
+                                                                    local exchange (GATHER, SINGLE, [])
+                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                            scan date_dim
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPARTITION, HASH, ["ca_address_sk_133"])
+                                                                local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                     scan customer_address
                     join (INNER, PARTITIONED):
                         final aggregation over (ca_county_276, d_qoy_249, d_year_245)
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["ca_county_276", "d_qoy_249", "d_year_245"])
-                                    local exchange (REPARTITION, ROUND_ROBIN, [])
-                                        partial aggregation over (ca_county_276, d_qoy_249, d_year_245)
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan web_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                    partial aggregation over (ca_county_276, d_qoy_249, d_year_245)
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk_209"])
+                                                local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    join (INNER, REPLICATED):
+                                                        scan web_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["ca_address_sk_269"])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         scan customer_address
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["ca_county_361", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
@@ -56,16 +62,18 @@ remote exchange (GATHER, SINGLE, [])
                                     final aggregation over (ca_county_361, d_qoy_334, d_year_330)
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["ca_county_361", "d_qoy_334", "d_year_330"])
-                                                local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                    partial aggregation over (ca_county_361, d_qoy_334, d_year_330)
-                                                        join (INNER, REPLICATED):
-                                                            join (INNER, REPLICATED):
-                                                                scan web_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan date_dim
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                partial aggregation over (ca_county_361, d_qoy_334, d_year_330)
+                                                    join (INNER, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk_294"])
+                                                            local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                join (INNER, REPLICATED):
+                                                                    scan web_sales
+                                                                    local exchange (GATHER, SINGLE, [])
+                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                            scan date_dim
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPARTITION, HASH, ["ca_address_sk_354"])
+                                                                local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                     scan customer_address
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["ca_county", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
@@ -74,28 +82,32 @@ remote exchange (GATHER, SINGLE, [])
                                 final aggregation over (ca_county, d_qoy, d_year)
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["ca_county", "d_qoy", "d_year"])
-                                            local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                partial aggregation over (ca_county, d_qoy, d_year)
-                                                    join (INNER, REPLICATED):
-                                                        join (INNER, REPLICATED):
-                                                            scan store_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                            partial aggregation over (ca_county, d_qoy, d_year)
+                                                join (INNER, PARTITIONED):
+                                                    remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
+                                                        local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                            join (INNER, REPLICATED):
+                                                                scan store_sales
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                        scan date_dim
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                            local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                 scan customer_address
                                 final aggregation over (ca_county_191, d_qoy_164, d_year_160)
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["ca_county_191", "d_qoy_164", "d_year_160"])
-                                            local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                partial aggregation over (ca_county_191, d_qoy_164, d_year_160)
-                                                    join (INNER, REPLICATED):
-                                                        join (INNER, REPLICATED):
-                                                            scan web_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                            partial aggregation over (ca_county_191, d_qoy_164, d_year_160)
+                                                join (INNER, PARTITIONED):
+                                                    remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk"])
+                                                        local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                            join (INNER, REPLICATED):
+                                                                scan web_sales
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                        scan date_dim
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPARTITION, HASH, ["ca_address_sk_184"])
+                                                            local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                 scan customer_address

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q57.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q57.plan.txt
@@ -19,10 +19,10 @@ local exchange (GATHER, SINGLE, [])
                                                                     scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan call_center
+                                                                scan item
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan item
+                                                            scan call_center
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["cc_name_102", "i_brand_14", "i_category_18"])
                         local exchange (REPARTITION, ROUND_ROBIN, [])
@@ -40,10 +40,10 @@ local exchange (GATHER, SINGLE, [])
                                                                     scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan call_center
+                                                                scan item
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan item
+                                                            scan call_center
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["cc_name_232", "i_brand_144", "i_category_148"])
                     local exchange (REPARTITION, ROUND_ROBIN, [])
@@ -61,7 +61,7 @@ local exchange (GATHER, SINGLE, [])
                                                                 scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan call_center
+                                                            scan item
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan item
+                                                        scan call_center

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q72.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q72.plan.txt
@@ -1,52 +1,52 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
-        final aggregation over (d_week_seq, i_item_desc, w_warehouse_name)
+        final aggregation over (d_week_seq_16, i_item_desc, w_warehouse_name)
             local exchange (GATHER, SINGLE, [])
-                remote exchange (REPARTITION, HASH, ["d_week_seq", "i_item_desc", "w_warehouse_name"])
-                    partial aggregation over (d_week_seq, i_item_desc, w_warehouse_name)
+                remote exchange (REPARTITION, HASH, ["d_week_seq_16", "i_item_desc", "w_warehouse_name"])
+                    partial aggregation over (d_week_seq_16, i_item_desc, w_warehouse_name)
                         join (LEFT, PARTITIONED):
-                            remote exchange (REPARTITION, HASH, ["cs_order_number", "inv_item_sk"])
-                                join (LEFT, REPLICATED):
-                                    join (INNER, REPLICATED):
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["inv_date_sk", "inv_item_sk"])
-                                                local exchange (REPARTITION, ROUND_ROBIN, [])
+                            join (LEFT, REPLICATED):
+                                join (INNER, REPLICATED):
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["inv_item_sk"])
+                                            local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                join (INNER, REPLICATED):
                                                     scan inventory
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["cs_item_sk", "d_date_sk_12"])
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, ["cs_item_sk"])
                                                     local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
                                                                 join (INNER, REPLICATED):
                                                                     join (INNER, REPLICATED):
-                                                                        join (INNER, REPLICATED):
-                                                                            join (INNER, REPLICATED):
-                                                                                scan catalog_sales
-                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                        scan household_demographics
-                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan customer_demographics
+                                                                        scan catalog_sales
                                                                         local exchange (GATHER, SINGLE, [])
                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan date_dim
+                                                                                scan household_demographics
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
+                                                                            scan customer_demographics
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan item
+                                                                        scan date_dim
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                                     scan date_dim
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                scan warehouse
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPARTITION, HASH, ["i_item_sk"])
+                                                        local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                            scan item
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan promotion
+                                            scan warehouse
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPLICATE, BROADCAST, [])
+                                        scan promotion
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["cr_item_sk", "cr_order_number"])
+                                remote exchange (REPARTITION, HASH, ["cr_item_sk"])
                                     local exchange (REPARTITION, ROUND_ROBIN, [])
                                         scan catalog_returns

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q83.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q83.plan.txt
@@ -1,73 +1,73 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
-            final aggregation over (i_item_id_74)
+            final aggregation over (i_item_id)
                 local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["i_item_id_74"])
-                        partial aggregation over (i_item_id_74)
+                    remote exchange (REPARTITION, HASH, ["i_item_id"])
+                        partial aggregation over (i_item_id)
                             join (INNER, PARTITIONED):
-                                remote exchange (REPARTITION, HASH, ["cr_item_sk"])
+                                remote exchange (REPARTITION, HASH, ["sr_item_sk"])
                                     local exchange (REPARTITION, ROUND_ROBIN, [])
                                         join (INNER, REPLICATED):
-                                            scan catalog_returns
+                                            scan store_returns
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     join (INNER, REPLICATED):
                                                         scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                final aggregation over (d_date_131)
+                                                                final aggregation over (d_date_6)
                                                                     local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPARTITION, HASH, ["d_date_131"])
+                                                                        remote exchange (REPARTITION, HASH, ["d_date_6"])
                                                                             local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                                                partial aggregation over (d_date_131)
+                                                                                partial aggregation over (d_date_6)
                                                                                     join (INNER, REPLICATED, can skip output duplicates):
                                                                                         scan date_dim
                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                final aggregation over (d_week_seq_165)
+                                                                                                final aggregation over (d_week_seq_40)
                                                                                                     local exchange (GATHER, SINGLE, [])
-                                                                                                        remote exchange (REPARTITION, HASH, ["d_week_seq_165"])
+                                                                                                        remote exchange (REPARTITION, HASH, ["d_week_seq_40"])
                                                                                                             local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                                                                                partial aggregation over (d_week_seq_165)
+                                                                                                                partial aggregation over (d_week_seq_40)
                                                                                                                     scan date_dim
                                 local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["i_item_sk_73"])
+                                    remote exchange (REPARTITION, HASH, ["i_item_sk"])
                                         local exchange (REPARTITION, ROUND_ROBIN, [])
                                             scan item
             join (INNER, PARTITIONED):
-                final aggregation over (i_item_id)
+                final aggregation over (i_item_id_74)
                     local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["i_item_id"])
-                            partial aggregation over (i_item_id)
+                        remote exchange (REPARTITION, HASH, ["i_item_id_74"])
+                            partial aggregation over (i_item_id_74)
                                 join (INNER, PARTITIONED):
-                                    remote exchange (REPARTITION, HASH, ["sr_item_sk"])
+                                    remote exchange (REPARTITION, HASH, ["cr_item_sk"])
                                         local exchange (REPARTITION, ROUND_ROBIN, [])
                                             join (INNER, REPLICATED):
-                                                scan store_returns
+                                                scan catalog_returns
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         join (INNER, REPLICATED):
                                                             scan date_dim
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    final aggregation over (d_date_6)
+                                                                    final aggregation over (d_date_131)
                                                                         local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPARTITION, HASH, ["d_date_6"])
+                                                                            remote exchange (REPARTITION, HASH, ["d_date_131"])
                                                                                 local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                                                    partial aggregation over (d_date_6)
+                                                                                    partial aggregation over (d_date_131)
                                                                                         join (INNER, REPLICATED, can skip output duplicates):
                                                                                             scan date_dim
                                                                                             local exchange (GATHER, SINGLE, [])
                                                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                    final aggregation over (d_week_seq_40)
+                                                                                                    final aggregation over (d_week_seq_165)
                                                                                                         local exchange (GATHER, SINGLE, [])
-                                                                                                            remote exchange (REPARTITION, HASH, ["d_week_seq_40"])
+                                                                                                            remote exchange (REPARTITION, HASH, ["d_week_seq_165"])
                                                                                                                 local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                                                                                    partial aggregation over (d_week_seq_40)
+                                                                                                                    partial aggregation over (d_week_seq_165)
                                                                                                                         scan date_dim
                                     local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["i_item_sk"])
+                                        remote exchange (REPARTITION, HASH, ["i_item_sk_73"])
                                             local exchange (REPARTITION, ROUND_ROBIN, [])
                                                 scan item
                 final aggregation over (i_item_id_201)

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q19.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q19.plan.txt
@@ -10,14 +10,14 @@ local exchange (GATHER, SINGLE, [])
                                     scan customer_address
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                            local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                scan customer
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                    join (INNER, REPLICATED):
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                                                 local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                    join (INNER, REPLICATED):
+                                                    scan customer
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
                                                                 scan store_sales
@@ -27,6 +27,6 @@ local exchange (GATHER, SINGLE, [])
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                                     scan date_dim
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan store
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan store

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q24.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q24.plan.txt
@@ -10,18 +10,18 @@ remote exchange (GATHER, SINGLE, [])
                                     final aggregation over (c_first_name, c_last_name, ca_state, i_color, i_current_price, i_manager_id, i_size, i_units, s_state, s_store_name)
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["c_first_name", "c_last_name", "ca_state", "i_color", "i_current_price", "i_manager_id", "i_size", "i_units", "s_state", "s_store_name"])
-                                                local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                    partial aggregation over (c_first_name, c_last_name, ca_state, i_color, i_current_price, i_manager_id, i_size, i_units, s_state, s_store_name)
-                                                        join (INNER, REPLICATED):
-                                                            scan customer_address
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    join (INNER, PARTITIONED):
-                                                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                                            local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                                                scan customer
+                                                partial aggregation over (c_first_name, c_last_name, ca_state, i_color, i_current_price, i_manager_id, i_size, i_units, s_state, s_store_name)
+                                                    join (INNER, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, ["ca_zip", "upper"])
+                                                            local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                scan customer_address
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPARTITION, HASH, ["c_birth_country", "s_zip"])
+                                                                local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                    join (INNER, REPLICATED):
+                                                                        scan customer
                                                                         local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                                                            remote exchange (REPLICATE, BROADCAST, [])
                                                                                 join (INNER, PARTITIONED):
                                                                                     remote exchange (REPARTITION, HASH, ["sr_item_sk", "sr_ticket_number"])
                                                                                         local exchange (REPARTITION, ROUND_ROBIN, [])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q27.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q27.plan.txt
@@ -3,22 +3,24 @@ local exchange (GATHER, SINGLE, [])
         final aggregation over (groupid, i_item_id$gid, s_state$gid)
             local exchange (REPARTITION, HASH, ["groupid", "i_item_id$gid", "s_state$gid"])
                 remote exchange (REPARTITION, HASH, ["groupid", "i_item_id$gid", "s_state$gid"])
-                    local exchange (REPARTITION, ROUND_ROBIN, [])
-                        partial aggregation over (groupid, i_item_id$gid, s_state$gid)
-                            join (INNER, REPLICATED):
-                                join (INNER, REPLICATED):
+                    partial aggregation over (groupid, i_item_id$gid, s_state$gid)
+                        join (INNER, PARTITIONED):
+                            remote exchange (REPARTITION, HASH, ["ss_item_sk"])
+                                local exchange (REPARTITION, ROUND_ROBIN, [])
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            scan store_sales
+                                            join (INNER, REPLICATED):
+                                                scan store_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan customer_demographics
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan customer_demographics
+                                                    scan store
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan store
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
-                                            scan date_dim
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["i_item_sk"])
+                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                         scan item

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q29.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q29.plan.txt
@@ -13,10 +13,10 @@ local exchange (GATHER, SINGLE, [])
                                     local exchange (REPARTITION, ROUND_ROBIN, [])
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
-                                                scan catalog_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        join (INNER, REPLICATED):
+                                                join (INNER, REPLICATED):
+                                                    scan catalog_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
                                                             join (INNER, PARTITIONED):
                                                                 remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_item_sk", "ss_ticket_number"])
                                                                     local exchange (REPARTITION, ROUND_ROBIN, [])
@@ -33,9 +33,9 @@ local exchange (GATHER, SINGLE, [])
                                                                                 local exchange (GATHER, SINGLE, [])
                                                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                                                         scan date_dim
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan store
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
+                                                    scan store

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q30.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q30.plan.txt
@@ -2,30 +2,33 @@ local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         cross join:
             join (LEFT, REPLICATED):
-                join (INNER, REPLICATED):
-                    final aggregation over (ca_state, wr_returning_customer_sk)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ca_state", "wr_returning_customer_sk"])
-                                partial aggregation over (ca_state, wr_returning_customer_sk)
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["wr_returning_addr_sk"])
-                                            local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                join (INNER, REPLICATED):
-                                                    scan web_returns
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                    scan customer_address
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPLICATE, BROADCAST, [])
-                            join (INNER, REPLICATED):
-                                scan customer
+                join (INNER, PARTITIONED):
+                    remote exchange (REPARTITION, HASH, ["wr_returning_customer_sk"])
+                        local exchange (REPARTITION, ROUND_ROBIN, [])
+                            final aggregation over (ca_state, wr_returning_customer_sk)
                                 local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        scan customer_address
+                                    remote exchange (REPARTITION, HASH, ["ca_state", "wr_returning_customer_sk"])
+                                        partial aggregation over (ca_state, wr_returning_customer_sk)
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, ["wr_returning_addr_sk"])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                        join (INNER, REPLICATED):
+                                                            scan web_returns
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan date_dim
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                        local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                            scan customer_address
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                            local exchange (REPARTITION, ROUND_ROBIN, [])
+                                join (INNER, REPLICATED):
+                                    scan customer
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            scan customer_address
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPLICATE, BROADCAST, [])
                         final aggregation over (ca_state_85)

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q31.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q31.plan.txt
@@ -7,16 +7,18 @@ remote exchange (GATHER, SINGLE, [])
                         final aggregation over (ca_county_66, d_qoy_39, d_year_35)
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["ca_county_66", "d_qoy_39", "d_year_35"])
-                                    local exchange (REPARTITION, ROUND_ROBIN, [])
-                                        partial aggregation over (ca_county_66, d_qoy_39, d_year_35)
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                    partial aggregation over (ca_county_66, d_qoy_39, d_year_35)
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["ss_addr_sk_10"])
+                                                local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["ca_address_sk_59"])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         scan customer_address
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["ca_county_140", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
@@ -24,31 +26,35 @@ remote exchange (GATHER, SINGLE, [])
                                     final aggregation over (ca_county_140, d_qoy_113, d_year_109)
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["ca_county_140", "d_qoy_113", "d_year_109"])
-                                                local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                    partial aggregation over (ca_county_140, d_qoy_113, d_year_109)
-                                                        join (INNER, REPLICATED):
-                                                            join (INNER, REPLICATED):
-                                                                scan store_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan date_dim
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                partial aggregation over (ca_county_140, d_qoy_113, d_year_109)
+                                                    join (INNER, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, ["ss_addr_sk_84"])
+                                                            local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                join (INNER, REPLICATED):
+                                                                    scan store_sales
+                                                                    local exchange (GATHER, SINGLE, [])
+                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                            scan date_dim
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPARTITION, HASH, ["ca_address_sk_133"])
+                                                                local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                     scan customer_address
                     join (INNER, PARTITIONED):
                         final aggregation over (ca_county_276, d_qoy_249, d_year_245)
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["ca_county_276", "d_qoy_249", "d_year_245"])
-                                    local exchange (REPARTITION, ROUND_ROBIN, [])
-                                        partial aggregation over (ca_county_276, d_qoy_249, d_year_245)
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan web_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                    partial aggregation over (ca_county_276, d_qoy_249, d_year_245)
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk_210"])
+                                                local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    join (INNER, REPLICATED):
+                                                        scan web_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["ca_address_sk_269"])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         scan customer_address
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["ca_county_361", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
@@ -56,16 +62,18 @@ remote exchange (GATHER, SINGLE, [])
                                     final aggregation over (ca_county_361, d_qoy_334, d_year_330)
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["ca_county_361", "d_qoy_334", "d_year_330"])
-                                                local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                    partial aggregation over (ca_county_361, d_qoy_334, d_year_330)
-                                                        join (INNER, REPLICATED):
-                                                            join (INNER, REPLICATED):
-                                                                scan web_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan date_dim
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                partial aggregation over (ca_county_361, d_qoy_334, d_year_330)
+                                                    join (INNER, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk_295"])
+                                                            local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                join (INNER, REPLICATED):
+                                                                    scan web_sales
+                                                                    local exchange (GATHER, SINGLE, [])
+                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                            scan date_dim
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPARTITION, HASH, ["ca_address_sk_354"])
+                                                                local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                     scan customer_address
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["ca_county", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
@@ -74,28 +82,32 @@ remote exchange (GATHER, SINGLE, [])
                                 final aggregation over (ca_county, d_qoy, d_year)
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["ca_county", "d_qoy", "d_year"])
-                                            local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                partial aggregation over (ca_county, d_qoy, d_year)
-                                                    join (INNER, REPLICATED):
-                                                        join (INNER, REPLICATED):
-                                                            scan store_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                            partial aggregation over (ca_county, d_qoy, d_year)
+                                                join (INNER, PARTITIONED):
+                                                    remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
+                                                        local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                            join (INNER, REPLICATED):
+                                                                scan store_sales
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                        scan date_dim
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                            local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                 scan customer_address
                                 final aggregation over (ca_county_191, d_qoy_164, d_year_160)
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["ca_county_191", "d_qoy_164", "d_year_160"])
-                                            local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                partial aggregation over (ca_county_191, d_qoy_164, d_year_160)
-                                                    join (INNER, REPLICATED):
-                                                        join (INNER, REPLICATED):
-                                                            scan web_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                            partial aggregation over (ca_county_191, d_qoy_164, d_year_160)
+                                                join (INNER, PARTITIONED):
+                                                    remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk"])
+                                                        local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                            join (INNER, REPLICATED):
+                                                                scan web_sales
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                        scan date_dim
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPARTITION, HASH, ["ca_address_sk_184"])
+                                                            local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                 scan customer_address

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q57.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q57.plan.txt
@@ -19,10 +19,10 @@ local exchange (GATHER, SINGLE, [])
                                                                     scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan call_center
+                                                                scan item
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan item
+                                                            scan call_center
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["cc_name_102", "i_brand_14", "i_category_18"])
                         local exchange (REPARTITION, ROUND_ROBIN, [])
@@ -40,10 +40,10 @@ local exchange (GATHER, SINGLE, [])
                                                                     scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan call_center
+                                                                scan item
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan item
+                                                            scan call_center
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["cc_name_232", "i_brand_144", "i_category_148"])
                     local exchange (REPARTITION, ROUND_ROBIN, [])
@@ -61,7 +61,7 @@ local exchange (GATHER, SINGLE, [])
                                                                 scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan call_center
+                                                            scan item
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan item
+                                                        scan call_center

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q72.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q72.plan.txt
@@ -1,52 +1,52 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
-        final aggregation over (d_week_seq, i_item_desc, w_warehouse_name)
+        final aggregation over (d_week_seq_16, i_item_desc, w_warehouse_name)
             local exchange (GATHER, SINGLE, [])
-                remote exchange (REPARTITION, HASH, ["d_week_seq", "i_item_desc", "w_warehouse_name"])
-                    partial aggregation over (d_week_seq, i_item_desc, w_warehouse_name)
+                remote exchange (REPARTITION, HASH, ["d_week_seq_16", "i_item_desc", "w_warehouse_name"])
+                    partial aggregation over (d_week_seq_16, i_item_desc, w_warehouse_name)
                         join (LEFT, PARTITIONED):
-                            remote exchange (REPARTITION, HASH, ["cs_order_number", "inv_item_sk"])
-                                join (LEFT, REPLICATED):
-                                    join (INNER, REPLICATED):
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["inv_date_sk", "inv_item_sk"])
-                                                local exchange (REPARTITION, ROUND_ROBIN, [])
+                            join (LEFT, REPLICATED):
+                                join (INNER, REPLICATED):
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["inv_item_sk"])
+                                            local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                join (INNER, REPLICATED):
                                                     scan inventory
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["cs_item_sk", "d_date_sk_12"])
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, ["cs_item_sk"])
                                                     local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
                                                                 join (INNER, REPLICATED):
                                                                     join (INNER, REPLICATED):
-                                                                        join (INNER, REPLICATED):
-                                                                            join (INNER, REPLICATED):
-                                                                                scan catalog_sales
-                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                        scan household_demographics
-                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan customer_demographics
+                                                                        scan catalog_sales
                                                                         local exchange (GATHER, SINGLE, [])
                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan date_dim
+                                                                                scan household_demographics
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
+                                                                            scan customer_demographics
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan item
+                                                                        scan date_dim
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                                     scan date_dim
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                scan warehouse
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPARTITION, HASH, ["i_item_sk"])
+                                                        local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                            scan item
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan promotion
+                                            scan warehouse
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPLICATE, BROADCAST, [])
+                                        scan promotion
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["cr_item_sk", "cr_order_number"])
+                                remote exchange (REPARTITION, HASH, ["cr_item_sk"])
                                     local exchange (REPARTITION, ROUND_ROBIN, [])
                                         scan catalog_returns

--- a/testing/trino-tests/src/test/resources/sql/presto/tpch/iceberg/parquet/partitioned/q05.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpch/iceberg/parquet/partitioned/q05.plan.txt
@@ -6,28 +6,30 @@ remote exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["name_18"])
                         partial aggregation over (name_18)
                             join (INNER, PARTITIONED):
-                                remote exchange (REPARTITION, HASH, ["nationkey_11", "orderkey_4"])
-                                    local exchange (REPARTITION, ROUND_ROBIN, [])
-                                        join (INNER, REPLICATED):
-                                            scan lineitem
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    join (INNER, REPLICATED):
-                                                        scan supplier
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                remote exchange (REPARTITION, HASH, ["nationkey", "suppkey"])
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["orderkey_4"])
+                                            local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                scan lineitem
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["orderkey"])
+                                                join (INNER, PARTITIONED):
+                                                    remote exchange (REPARTITION, HASH, ["custkey_0"])
+                                                        local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                            scan orders
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPARTITION, HASH, ["custkey"])
+                                                            local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                 join (INNER, REPLICATED):
-                                                                    scan nation
+                                                                    scan customer
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan region
+                                                                            join (INNER, REPLICATED):
+                                                                                scan nation
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                                        scan region
                                 local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["nationkey", "orderkey"])
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["custkey_0"])
-                                                local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                    scan orders
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["custkey"])
-                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                        scan customer
+                                    remote exchange (REPARTITION, HASH, ["nationkey_11", "suppkey_8"])
+                                        local exchange (REPARTITION, ROUND_ROBIN, [])
+                                            scan supplier

--- a/testing/trino-tests/src/test/resources/sql/presto/tpch/iceberg/parquet/partitioned/q07.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpch/iceberg/parquet/partitioned/q07.plan.txt
@@ -6,28 +6,28 @@ remote exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["expr$gid", "name_18", "name_23"])
                         partial aggregation over (expr$gid, name_18, name_23)
                             join (INNER, PARTITIONED):
-                                remote exchange (REPARTITION, HASH, ["orderkey"])
-                                    local exchange (REPARTITION, ROUND_ROBIN, [])
-                                        join (INNER, REPLICATED):
-                                            scan lineitem
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
+                                remote exchange (REPARTITION, HASH, ["custkey"])
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["orderkey_4"])
+                                            local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                scan orders
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["orderkey"])
+                                                local exchange (REPARTITION, ROUND_ROBIN, [])
                                                     join (INNER, REPLICATED):
-                                                        scan supplier
+                                                        scan lineitem
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan nation
+                                                                join (INNER, REPLICATED):
+                                                                    scan supplier
+                                                                    local exchange (GATHER, SINGLE, [])
+                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                            scan nation
                                 local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["orderkey_4"])
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["custkey"])
-                                                local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                    scan orders
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["custkey_8"])
-                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                        join (INNER, REPLICATED):
-                                                            scan customer
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan nation
+                                    remote exchange (REPARTITION, HASH, ["custkey_8"])
+                                        local exchange (REPARTITION, ROUND_ROBIN, [])
+                                            join (INNER, REPLICATED):
+                                                scan customer
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan nation

--- a/testing/trino-tests/src/test/resources/sql/presto/tpch/iceberg/parquet/partitioned/q08.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpch/iceberg/parquet/partitioned/q08.plan.txt
@@ -5,39 +5,39 @@ remote exchange (GATHER, SINGLE, [])
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["expr$gid"])
                         partial aggregation over (expr$gid)
-                            join (INNER, PARTITIONED):
-                                remote exchange (REPARTITION, HASH, ["suppkey_5"])
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["custkey"])
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["orderkey_9"])
-                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                        scan orders
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["orderkey"])
+                            join (INNER, REPLICATED):
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["suppkey_5"])
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["custkey"])
+                                                join (INNER, PARTITIONED):
+                                                    remote exchange (REPARTITION, HASH, ["orderkey_9"])
                                                         local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                            join (INNER, REPLICATED):
-                                                                scan lineitem
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan part
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["custkey_13"])
-                                                local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                    join (INNER, REPLICATED):
-                                                        scan customer
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan orders
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPARTITION, HASH, ["orderkey"])
+                                                            local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                 join (INNER, REPLICATED):
-                                                                    scan nation
+                                                                    scan lineitem
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan region
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["suppkey"])
-                                        local exchange (REPARTITION, ROUND_ROBIN, [])
-                                            join (INNER, REPLICATED):
+                                                                            scan part
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["custkey_13"])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                        join (INNER, REPLICATED):
+                                                            scan customer
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    join (INNER, REPLICATED):
+                                                                        scan nation
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                scan region
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["suppkey"])
+                                            local exchange (REPARTITION, ROUND_ROBIN, [])
                                                 scan supplier
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan nation
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPLICATE, BROADCAST, [])
+                                        scan nation

--- a/testing/trino-tests/src/test/resources/sql/presto/tpch/iceberg/parquet/unpartitioned/q05.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpch/iceberg/parquet/unpartitioned/q05.plan.txt
@@ -6,28 +6,30 @@ remote exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["name_18"])
                         partial aggregation over (name_18)
                             join (INNER, PARTITIONED):
-                                remote exchange (REPARTITION, HASH, ["nationkey_11", "orderkey_4"])
-                                    local exchange (REPARTITION, ROUND_ROBIN, [])
-                                        join (INNER, REPLICATED):
-                                            scan lineitem
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    join (INNER, REPLICATED):
-                                                        scan supplier
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                remote exchange (REPARTITION, HASH, ["nationkey", "suppkey"])
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["orderkey_4"])
+                                            local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                scan lineitem
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["orderkey"])
+                                                join (INNER, PARTITIONED):
+                                                    remote exchange (REPARTITION, HASH, ["custkey_0"])
+                                                        local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                            scan orders
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPARTITION, HASH, ["custkey"])
+                                                            local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                 join (INNER, REPLICATED):
-                                                                    scan nation
+                                                                    scan customer
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan region
+                                                                            join (INNER, REPLICATED):
+                                                                                scan nation
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                                        scan region
                                 local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["nationkey", "orderkey"])
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["custkey_0"])
-                                                local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                    scan orders
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["custkey"])
-                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                        scan customer
+                                    remote exchange (REPARTITION, HASH, ["nationkey_11", "suppkey_8"])
+                                        local exchange (REPARTITION, ROUND_ROBIN, [])
+                                            scan supplier

--- a/testing/trino-tests/src/test/resources/sql/presto/tpch/iceberg/parquet/unpartitioned/q07.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpch/iceberg/parquet/unpartitioned/q07.plan.txt
@@ -6,28 +6,28 @@ remote exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["expr$gid", "name_18", "name_23"])
                         partial aggregation over (expr$gid, name_18, name_23)
                             join (INNER, PARTITIONED):
-                                remote exchange (REPARTITION, HASH, ["orderkey"])
-                                    local exchange (REPARTITION, ROUND_ROBIN, [])
-                                        join (INNER, REPLICATED):
-                                            scan lineitem
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
+                                remote exchange (REPARTITION, HASH, ["custkey"])
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["orderkey_4"])
+                                            local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                scan orders
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["orderkey"])
+                                                local exchange (REPARTITION, ROUND_ROBIN, [])
                                                     join (INNER, REPLICATED):
-                                                        scan supplier
+                                                        scan lineitem
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan nation
+                                                                join (INNER, REPLICATED):
+                                                                    scan supplier
+                                                                    local exchange (GATHER, SINGLE, [])
+                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                            scan nation
                                 local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["orderkey_4"])
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["custkey"])
-                                                local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                    scan orders
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["custkey_8"])
-                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                        join (INNER, REPLICATED):
-                                                            scan customer
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan nation
+                                    remote exchange (REPARTITION, HASH, ["custkey_8"])
+                                        local exchange (REPARTITION, ROUND_ROBIN, [])
+                                            join (INNER, REPLICATED):
+                                                scan customer
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan nation

--- a/testing/trino-tests/src/test/resources/sql/presto/tpch/iceberg/parquet/unpartitioned/q08.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpch/iceberg/parquet/unpartitioned/q08.plan.txt
@@ -5,39 +5,39 @@ remote exchange (GATHER, SINGLE, [])
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["expr$gid"])
                         partial aggregation over (expr$gid)
-                            join (INNER, PARTITIONED):
-                                remote exchange (REPARTITION, HASH, ["suppkey_5"])
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["custkey"])
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["orderkey_9"])
-                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                        scan orders
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["orderkey"])
+                            join (INNER, REPLICATED):
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["suppkey_5"])
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["custkey"])
+                                                join (INNER, PARTITIONED):
+                                                    remote exchange (REPARTITION, HASH, ["orderkey_9"])
                                                         local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                            join (INNER, REPLICATED):
-                                                                scan lineitem
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan part
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["custkey_13"])
-                                                local exchange (REPARTITION, ROUND_ROBIN, [])
-                                                    join (INNER, REPLICATED):
-                                                        scan customer
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan orders
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPARTITION, HASH, ["orderkey"])
+                                                            local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                 join (INNER, REPLICATED):
-                                                                    scan nation
+                                                                    scan lineitem
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan region
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["suppkey"])
-                                        local exchange (REPARTITION, ROUND_ROBIN, [])
-                                            join (INNER, REPLICATED):
+                                                                            scan part
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["custkey_13"])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
+                                                        join (INNER, REPLICATED):
+                                                            scan customer
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    join (INNER, REPLICATED):
+                                                                        scan nation
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                scan region
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["suppkey"])
+                                            local exchange (REPARTITION, ROUND_ROBIN, [])
                                                 scan supplier
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan nation
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPLICATE, BROADCAST, [])
+                                        scan nation


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
These stats are used by CBO that expects sizes of data while it resides in memory.
The idea is to use column-sizes from Iceberg metadata stored there by parquet writer. From some tests I ran it looks like multiplying by 10 looks like a good heuristic. 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
