### PR TITLE
Fix isEffectivelySingleStream for multi-stream partitionings

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -163,6 +163,7 @@ import static io.trino.spi.StandardErrorCode.SYNTAX_ERROR;
 import static io.trino.spi.StandardErrorCode.TABLE_REDIRECTION_ERROR;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypeSignatures;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.trino.sql.planner.PartitioningHandle.createPartitioning;
 import static io.trino.transaction.InMemoryTransactionManager.createTestTransactionManager;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static java.lang.String.format;
@@ -417,7 +418,7 @@ public final class MetadataManager
         CatalogMetadata catalogMetadata = getCatalogMetadata(session, catalogHandle);
         ConnectorMetadata metadata = catalogMetadata.getMetadataFor(session, catalogHandle);
         Optional<ConnectorPartitioningHandle> commonHandle = metadata.getCommonPartitioningHandle(session.toConnectorSession(catalogHandle), left.getConnectorHandle(), right.getConnectorHandle());
-        return commonHandle.map(handle -> new PartitioningHandle(Optional.of(catalogHandle), left.getTransactionHandle(), handle));
+        return commonHandle.map(handle -> createPartitioning(Optional.of(catalogHandle), left.getTransactionHandle(), handle));
     }
 
     @Override
@@ -1001,7 +1002,7 @@ public final class MetadataManager
         ConnectorTransactionHandle transactionHandle = catalogMetadata.getTransactionHandleFor(catalogHandle);
 
         return metadata.getUpdateLayout(session.toConnectorSession(catalogHandle), tableHandle.getConnectorHandle())
-                .map(partitioning -> new PartitioningHandle(Optional.of(catalogHandle), Optional.of(transactionHandle), partitioning));
+                .map(partitioning -> createPartitioning(Optional.of(catalogHandle), Optional.of(transactionHandle), partitioning));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/metadata/TableLayout.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TableLayout.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.trino.sql.planner.PartitioningHandle.createPartitioning;
 import static java.util.Objects.requireNonNull;
 
 public class TableLayout
@@ -59,7 +60,7 @@ public class TableLayout
     public Optional<PartitioningHandle> getPartitioning()
     {
         return layout.getPartitioning()
-                .map(partitioning -> new PartitioningHandle(Optional.of(catalogHandle), Optional.of(transactionHandle), partitioning));
+                .map(partitioning -> createPartitioning(Optional.of(catalogHandle), Optional.of(transactionHandle), partitioning));
     }
 
     public List<String> getPartitionColumns()

--- a/core/trino-main/src/main/java/io/trino/metadata/TableProperties.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TableProperties.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import static io.trino.sql.planner.PartitioningHandle.createPartitioning;
 import static java.util.Objects.requireNonNull;
 
 public class TableProperties
@@ -61,7 +62,7 @@ public class TableProperties
     {
         return tableProperties.getTablePartitioning()
                 .map(nodePartitioning -> new TablePartitioning(
-                        new PartitioningHandle(
+                        createPartitioning(
                                 Optional.of(catalogHandle),
                                 Optional.of(transaction),
                                 nodePartitioning.getPartitioningHandle()),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/Partitioning.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/Partitioning.java
@@ -197,7 +197,7 @@ public final class Partitioning
 
     public boolean isEffectivelySinglePartition(Set<Symbol> knownConstants)
     {
-        return isPartitionedOn(ImmutableSet.of(), knownConstants);
+        return handle.isDeterministic() && isPartitionedOn(ImmutableSet.of(), knownConstants);
     }
 
     public boolean isRepartitionEffective(Collection<Symbol> keys, Set<Symbol> knownConstants)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PartitioningHandle.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PartitioningHandle.java
@@ -39,14 +39,27 @@ public class PartitioningHandle
                 && (partitioning.equals(SCALED_WRITER_HASH_DISTRIBUTION) || partitioning.getCatalogHandle().isPresent());
     }
 
-    public PartitioningHandle(
+    public static PartitioningHandle createPartitioning(
             Optional<CatalogHandle> catalogHandle,
             Optional<ConnectorTransactionHandle> transactionHandle,
             ConnectorPartitioningHandle connectorHandle)
     {
-        this(catalogHandle, transactionHandle, connectorHandle, false);
+        return new PartitioningHandle(catalogHandle, transactionHandle, connectorHandle, false);
     }
 
+    public static PartitioningHandle createScaledWriterPartitioning(
+            Optional<CatalogHandle> catalogHandle,
+            Optional<ConnectorTransactionHandle> transactionHandle,
+            ConnectorPartitioningHandle connectorHandle)
+    {
+        return new PartitioningHandle(catalogHandle, transactionHandle, connectorHandle, true);
+    }
+
+    /*
+     * This constructor is for JSON deserialization only. Do not use.
+     * It's marked as @Deprecated to help avoid usage, and not because we plan to remove it.
+     */
+    @Deprecated
     @JsonCreator
     public PartitioningHandle(
             @JsonProperty("catalogHandle") Optional<CatalogHandle> catalogHandle,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -162,6 +162,7 @@ import static io.trino.sql.analyzer.TypeSignatureTranslator.toSqlType;
 import static io.trino.sql.planner.GroupingOperationRewriter.rewriteGroupingOperation;
 import static io.trino.sql.planner.LogicalPlanner.failFunction;
 import static io.trino.sql.planner.OrderingScheme.sortItemToSortOrder;
+import static io.trino.sql.planner.PartitioningHandle.createPartitioning;
 import static io.trino.sql.planner.PlanBuilder.newPlanBuilder;
 import static io.trino.sql.planner.ScopeAware.scopeAwareKey;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
@@ -1128,7 +1129,7 @@ class QueryPlanner
         Optional<PartitioningScheme> updatePartitioning = updateLayout.map(handle ->
                 new PartitioningScheme(Partitioning.create(handle, ImmutableList.of(rowIdSymbol)), ImmutableList.of(rowIdSymbol)));
 
-        PartitioningHandle partitioningHandle = new PartitioningHandle(
+        PartitioningHandle partitioningHandle = createPartitioning(
                 Optional.empty(),
                 Optional.empty(),
                 new MergePartitioningHandle(insertPartitioning, updatePartitioning));

--- a/core/trino-main/src/main/java/io/trino/sql/planner/SystemPartitioningHandle.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SystemPartitioningHandle.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.sql.planner.PartitioningHandle.createNonDeterministicPartitioning;
 import static io.trino.sql.planner.PartitioningHandle.createPartitioning;
 import static io.trino.sql.planner.PartitioningHandle.createScaledWriterPartitioning;
 import static java.util.Objects.requireNonNull;
@@ -50,17 +51,22 @@ public final class SystemPartitioningHandle
     public static final PartitioningHandle SINGLE_DISTRIBUTION = createSystemPartitioning(SystemPartitioning.SINGLE, SystemPartitionFunction.SINGLE);
     public static final PartitioningHandle COORDINATOR_DISTRIBUTION = createSystemPartitioning(SystemPartitioning.COORDINATOR_ONLY, SystemPartitionFunction.SINGLE);
     public static final PartitioningHandle FIXED_HASH_DISTRIBUTION = createSystemPartitioning(SystemPartitioning.FIXED, SystemPartitionFunction.HASH);
-    public static final PartitioningHandle FIXED_ARBITRARY_DISTRIBUTION = createSystemPartitioning(SystemPartitioning.FIXED, SystemPartitionFunction.ROUND_ROBIN);
-    public static final PartitioningHandle FIXED_BROADCAST_DISTRIBUTION = createSystemPartitioning(SystemPartitioning.FIXED, SystemPartitionFunction.BROADCAST);
+    public static final PartitioningHandle FIXED_ARBITRARY_DISTRIBUTION = createNonDeterministicSystemPartitioning(SystemPartitioning.FIXED, SystemPartitionFunction.ROUND_ROBIN);
+    public static final PartitioningHandle FIXED_BROADCAST_DISTRIBUTION = createNonDeterministicSystemPartitioning(SystemPartitioning.FIXED, SystemPartitionFunction.BROADCAST);
     public static final PartitioningHandle SCALED_WRITER_ROUND_ROBIN_DISTRIBUTION = createScaledWriterSystemPartitioning(SystemPartitionFunction.ROUND_ROBIN);
     public static final PartitioningHandle SCALED_WRITER_HASH_DISTRIBUTION = createScaledWriterSystemPartitioning(SystemPartitionFunction.HASH);
-    public static final PartitioningHandle SOURCE_DISTRIBUTION = createSystemPartitioning(SystemPartitioning.SOURCE, SystemPartitionFunction.UNKNOWN);
-    public static final PartitioningHandle ARBITRARY_DISTRIBUTION = createSystemPartitioning(SystemPartitioning.ARBITRARY, SystemPartitionFunction.UNKNOWN);
-    public static final PartitioningHandle FIXED_PASSTHROUGH_DISTRIBUTION = createSystemPartitioning(SystemPartitioning.FIXED, SystemPartitionFunction.UNKNOWN);
+    public static final PartitioningHandle SOURCE_DISTRIBUTION = createNonDeterministicSystemPartitioning(SystemPartitioning.SOURCE, SystemPartitionFunction.UNKNOWN);
+    public static final PartitioningHandle ARBITRARY_DISTRIBUTION = createNonDeterministicSystemPartitioning(SystemPartitioning.ARBITRARY, SystemPartitionFunction.UNKNOWN);
+    public static final PartitioningHandle FIXED_PASSTHROUGH_DISTRIBUTION = createNonDeterministicSystemPartitioning(SystemPartitioning.FIXED, SystemPartitionFunction.UNKNOWN);
 
     private static PartitioningHandle createSystemPartitioning(SystemPartitioning partitioning, SystemPartitionFunction function)
     {
         return createPartitioning(Optional.empty(), Optional.empty(), new SystemPartitioningHandle(partitioning, function));
+    }
+
+    private static PartitioningHandle createNonDeterministicSystemPartitioning(SystemPartitioning partitioning, SystemPartitionFunction function)
+    {
+        return createNonDeterministicPartitioning(Optional.empty(), Optional.empty(), new SystemPartitioningHandle(partitioning, function));
     }
 
     private static PartitioningHandle createScaledWriterSystemPartitioning(SystemPartitionFunction function)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/SystemPartitioningHandle.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SystemPartitioningHandle.java
@@ -31,6 +31,8 @@ import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.sql.planner.PartitioningHandle.createPartitioning;
+import static io.trino.sql.planner.PartitioningHandle.createScaledWriterPartitioning;
 import static java.util.Objects.requireNonNull;
 
 public final class SystemPartitioningHandle
@@ -58,12 +60,12 @@ public final class SystemPartitioningHandle
 
     private static PartitioningHandle createSystemPartitioning(SystemPartitioning partitioning, SystemPartitionFunction function)
     {
-        return new PartitioningHandle(Optional.empty(), Optional.empty(), new SystemPartitioningHandle(partitioning, function));
+        return createPartitioning(Optional.empty(), Optional.empty(), new SystemPartitioningHandle(partitioning, function));
     }
 
     private static PartitioningHandle createScaledWriterSystemPartitioning(SystemPartitionFunction function)
     {
-        return new PartitioningHandle(Optional.empty(), Optional.empty(), new SystemPartitioningHandle(SystemPartitioning.ARBITRARY, function), true);
+        return createScaledWriterPartitioning(Optional.empty(), Optional.empty(), new SystemPartitioningHandle(SystemPartitioning.ARBITRARY, function));
     }
 
     private final SystemPartitioning partitioning;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/ActualProperties.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/ActualProperties.java
@@ -338,18 +338,18 @@ public class ActualProperties
 
         public static Global coordinatorSingleStreamPartition()
         {
-            return partitionedOn(
-                    COORDINATOR_DISTRIBUTION,
-                    ImmutableList.of(),
-                    Optional.of(ImmutableList.of()));
+            return new Global(
+                    Optional.of(Partitioning.create(COORDINATOR_DISTRIBUTION, ImmutableList.of())),
+                    Optional.of(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of())),
+                    false);
         }
 
         public static Global singleStreamPartition()
         {
-            return partitionedOn(
-                    SINGLE_DISTRIBUTION,
-                    ImmutableList.of(),
-                    Optional.of(ImmutableList.of()));
+            return new Global(
+                    Optional.of(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of())),
+                    Optional.of(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of())),
+                    false);
         }
 
         public static Global arbitraryPartition()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
@@ -84,6 +84,7 @@ import static io.trino.SystemSessionProperties.isForceFixedDistributionForPartit
 import static io.trino.SystemSessionProperties.isSpillEnabled;
 import static io.trino.SystemSessionProperties.isTaskScaleWritersEnabled;
 import static io.trino.sql.ExpressionUtils.isEffectivelyLiteral;
+import static io.trino.sql.planner.PartitioningHandle.createScaledWriterPartitioning;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.SCALED_WRITER_HASH_DISTRIBUTION;
@@ -707,11 +708,10 @@ public class AddLocalExchanges
                             newSource.getNode(),
                             partitioningScheme
                                     .withPartitioningHandle(
-                                            new PartitioningHandle(
+                                            createScaledWriterPartitioning(
                                                     partitioningHandle.getCatalogHandle(),
                                                     partitioningHandle.getTransactionHandle(),
-                                                    partitioningHandle.getConnectorHandle(),
-                                                    true))),
+                                                    partitioningHandle.getConnectorHandle()))),
                     newSource.getProperties());
 
             return rebaseAndDeriveProperties(node, ImmutableList.of(exchange));

--- a/core/trino-main/src/test/java/io/trino/operator/exchange/TestLocalExchange.java
+++ b/core/trino-main/src/test/java/io/trino/operator/exchange/TestLocalExchange.java
@@ -60,6 +60,8 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.spi.connector.ConnectorBucketNodeMap.createBucketNodeMap;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.planner.PartitioningHandle.createPartitioning;
+import static io.trino.sql.planner.PartitioningHandle.createScaledWriterPartitioning;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_PASSTHROUGH_DISTRIBUTION;
@@ -843,7 +845,7 @@ public class TestLocalExchange
         partitionManagers.put(
                 TEST_CATALOG_HANDLE,
                 connectorNodePartitioningProvider);
-        PartitioningHandle partitioningHandle = new PartitioningHandle(
+        PartitioningHandle partitioningHandle = createPartitioning(
                 Optional.of(TEST_CATALOG_HANDLE),
                 Optional.of(TestingTransactionHandle.create()),
                 connectorPartitioningHandle);
@@ -1047,11 +1049,10 @@ public class TestLocalExchange
         partitionManagers.put(
                 TEST_CATALOG_HANDLE,
                 connectorNodePartitioningProvider);
-        return new PartitioningHandle(
+        return createScaledWriterPartitioning(
                 Optional.of(TEST_CATALOG_HANDLE),
                 Optional.of(TestingTransactionHandle.create()),
-                connectorPartitioningHandle,
-                true);
+                connectorPartitioningHandle);
     }
 
     private void run(LocalExchange localExchange, Consumer<LocalExchange> test)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestAddLocalExchangesForPartitionedInsertAndMerge.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestAddLocalExchangesForPartitionedInsertAndMerge.java
@@ -40,6 +40,7 @@ import static io.trino.SystemSessionProperties.TASK_PARTITIONED_WRITER_COUNT;
 import static io.trino.SystemSessionProperties.TASK_SCALE_WRITERS_ENABLED;
 import static io.trino.SystemSessionProperties.TASK_WRITER_COUNT;
 import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.sql.planner.PartitioningHandle.createPartitioning;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
@@ -63,7 +64,7 @@ public class TestAddLocalExchangesForPartitionedInsertAndMerge
                     FIXED_HASH_DISTRIBUTION,
                     ImmutableList.of(new Symbol("year"))),
             ImmutableList.of(new Symbol("customer"), new Symbol("year")));
-    private static final PartitioningHandle MERGE_PARTITIONING_HANDLE = new PartitioningHandle(
+    private static final PartitioningHandle MERGE_PARTITIONING_HANDLE = createPartitioning(
             Optional.empty(),
             Optional.empty(),
             new MergePartitioningHandle(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestAddLocalExchangesForTaskScaleWriters.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestAddLocalExchangesForTaskScaleWriters.java
@@ -34,6 +34,8 @@ import java.util.Optional;
 import static io.trino.SystemSessionProperties.SCALE_WRITERS;
 import static io.trino.SystemSessionProperties.TASK_SCALE_WRITERS_ENABLED;
 import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.sql.planner.PartitioningHandle.createPartitioning;
+import static io.trino.sql.planner.PartitioningHandle.createScaledWriterPartitioning;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.SCALED_WRITER_HASH_DISTRIBUTION;
@@ -149,7 +151,7 @@ public class TestAddLocalExchangesForTaskScaleWriters
     public void testLocalScaledPartitionedWriterWithoutSupportForMultipleWritersPerPartition(boolean taskScaleWritersEnabled)
     {
         String catalogName = "mock_report_written_bytes_without_multiple_writer_per_partition";
-        PartitioningHandle partitioningHandle = new PartitioningHandle(
+        PartitioningHandle partitioningHandle = createPartitioning(
                 Optional.of(CatalogHandle.fromId(catalogName)),
                 Optional.of(MockConnectorTransactionHandle.INSTANCE),
                 CONNECTOR_PARTITIONING_HANDLE);
@@ -196,7 +198,7 @@ public class TestAddLocalExchangesForTaskScaleWriters
     public void testLocalScaledPartitionedWriterWithoutSupportsForReportingWrittenBytes(boolean taskScaleWritersEnabled)
     {
         String catalogName = "mock_dont_report_written_bytes";
-        PartitioningHandle partitioningHandle = new PartitioningHandle(
+        PartitioningHandle partitioningHandle = createPartitioning(
                 Optional.of(CatalogHandle.fromId(catalogName)),
                 Optional.of(MockConnectorTransactionHandle.INSTANCE),
                 CONNECTOR_PARTITIONING_HANDLE);
@@ -290,15 +292,14 @@ public class TestAddLocalExchangesForTaskScaleWriters
     public void testLocalScaledPartitionedWriterForConnectorPartitioning()
     {
         String catalogName = "mock_report_written_bytes_with_multiple_writer_per_partition";
-        PartitioningHandle partitioningHandle = new PartitioningHandle(
+        PartitioningHandle partitioningHandle = createPartitioning(
                 Optional.of(CatalogHandle.fromId(catalogName)),
                 Optional.of(MockConnectorTransactionHandle.INSTANCE),
                 CONNECTOR_PARTITIONING_HANDLE);
-        PartitioningHandle scaledPartitioningHandle = new PartitioningHandle(
+        PartitioningHandle scaledPartitioningHandle = createScaledWriterPartitioning(
                 Optional.of(CatalogHandle.fromId(catalogName)),
                 Optional.of(MockConnectorTransactionHandle.INSTANCE),
-                CONNECTOR_PARTITIONING_HANDLE,
-                true);
+                CONNECTOR_PARTITIONING_HANDLE);
 
         assertDistributedPlan(
                 "INSERT INTO connector_partitioned_table SELECT * FROM source_table",

--- a/core/trino-main/src/test/java/io/trino/sql/planner/sanity/TestValidateScaledWritersUsage.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/sanity/TestValidateScaledWritersUsage.java
@@ -45,6 +45,7 @@ import java.util.Optional;
 
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.planner.PartitioningHandle.createScaledWriterPartitioning;
 import static io.trino.sql.planner.SystemPartitioningHandle.SCALED_WRITER_HASH_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.SCALED_WRITER_ROUND_ROBIN_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
@@ -322,11 +323,10 @@ public class TestValidateScaledWritersUsage
         return new Object[][] {
                 {SCALED_WRITER_ROUND_ROBIN_DISTRIBUTION},
                 {SCALED_WRITER_HASH_DISTRIBUTION},
-                {new PartitioningHandle(
+                {createScaledWriterPartitioning(
                         Optional.of(CatalogHandle.fromId("test")),
                         Optional.of(new ConnectorTransactionHandle() {}),
-                        new ConnectorPartitioningHandle() {},
-                        true)}
+                        new ConnectorPartitioningHandle() {})}
         };
     }
 


### PR DESCRIPTION
## Description

    isEffectivelySingleStream should return false for partitionings that
    can effectively have multiple streams. Certain system partitionings
    like FIXED_ARBITRARY_DISTRIBUTION or SOURCE_DISTRIBUTION will
    have multiple streams even if there are no partitioning columns.
    Previously due to lack of partitioning columns isEffectivelySingleStream
    returned true (it assumed constant partition value).
    This PR adds PartitioningHandle#deterministic which will be false
    if partitioning doesn't provide any guarantees about distribution
    of rows for a given partition.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix a correctness bug for queries with certain complex window operators used in sequence 
```
