### PR TITLE
Provide injection mechanism for the metastore in the Delta Lake connector

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConnectorFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConnectorFactory.java
@@ -20,6 +20,7 @@ import io.trino.spi.connector.ConnectorFactory;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static io.trino.plugin.base.Versions.checkSpiVersion;
@@ -53,8 +54,8 @@ public class DeltaLakeConnectorFactory
             Class<?> moduleClass = classLoader.loadClass(Module.class.getName());
             Object moduleInstance = classLoader.loadClass(module.getName()).getConstructor().newInstance();
             return (Connector) classLoader.loadClass(InternalDeltaLakeConnectorFactory.class.getName())
-                    .getMethod("createConnector", String.class, Map.class, ConnectorContext.class, moduleClass)
-                    .invoke(null, catalogName, config, context, moduleInstance);
+                    .getMethod("createConnector", String.class, Map.class, ConnectorContext.class, Optional.class, moduleClass)
+                    .invoke(null, catalogName, config, context, Optional.empty(), moduleInstance);
         }
         catch (InvocationTargetException e) {
             Throwable targetException = e.getTargetException();

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/InternalDeltaLakeConnectorFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/InternalDeltaLakeConnectorFactory.java
@@ -72,6 +72,7 @@ public final class InternalDeltaLakeConnectorFactory
             String catalogName,
             Map<String, String> config,
             ConnectorContext context,
+            Optional<Module> metastoreModule,
             Module module)
     {
         ClassLoader classLoader = InternalDeltaLakeConnectorFactory.class.getClassLoader();
@@ -92,7 +93,7 @@ public final class InternalDeltaLakeConnectorFactory
                     new HdfsAuthenticationModule(),
                     new HdfsFileSystemModule(),
                     new CatalogNameModule(catalogName),
-                    new DeltaLakeMetastoreModule(),
+                    metastoreModule.orElse(new DeltaLakeMetastoreModule()),
                     new DeltaLakeModule(),
                     new DeltaLakeSecurityModule(),
                     binder -> {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeRegisterTableProcedureTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeRegisterTableProcedureTest.java
@@ -15,6 +15,7 @@ package io.trino.plugin.deltalake;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
+import io.trino.plugin.deltalake.metastore.TestingDeltaLakeMetastoreModule;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
@@ -24,8 +25,10 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -33,6 +36,7 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.io.MoreFiles.deleteDirectoryContents;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static com.google.inject.util.Modules.EMPTY_MODULE;
 import static io.trino.plugin.deltalake.DeltaLakeConnectorFactory.CONNECTOR_NAME;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.getTransactionLogDir;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.getTransactionLogJsonEntryPath;
@@ -64,10 +68,9 @@ public abstract class BaseDeltaLakeRegisterTableProcedureTest
         this.dataDirectory = queryRunner.getCoordinator().getBaseDataDir().resolve("delta_lake_data").toString();
         this.metastore = createTestMetastore(dataDirectory);
 
-        queryRunner.installPlugin(new TestingDeltaLakePlugin());
+        queryRunner.installPlugin(new TestingDeltaLakePlugin(Optional.of(new TestingDeltaLakeMetastoreModule(metastore)), EMPTY_MODULE));
 
         Map<String, String> connectorProperties = ImmutableMap.<String, String>builder()
-                .putAll(getConnectorProperties(dataDirectory))
                 .put("delta.unique-table-location", "true")
                 .put("delta.register-table-procedure.enabled", "true")
                 .buildOrThrow();
@@ -77,8 +80,6 @@ public abstract class BaseDeltaLakeRegisterTableProcedureTest
 
         return queryRunner;
     }
-
-    protected abstract Map<String, String> getConnectorProperties(String dataDirectory);
 
     protected abstract HiveMetastore createTestMetastore(String dataDirectory);
 
@@ -185,14 +186,14 @@ public abstract class BaseDeltaLakeRegisterTableProcedureTest
         String tableNameNew = "test_register_table_with_no_transaction_log_new_" + randomNameSuffix();
 
         // Delete files under transaction log directory and put an invalid log file to verify register_table call fails
-        String transactionLogDir = getTransactionLogDir(new org.apache.hadoop.fs.Path(tableLocation)).toString();
+        String transactionLogDir = new URI(getTransactionLogDir(new org.apache.hadoop.fs.Path(tableLocation)).toString()).getPath();
         deleteDirectoryContents(Path.of(transactionLogDir), ALLOW_INSECURE);
         new File(getTransactionLogJsonEntryPath(new org.apache.hadoop.fs.Path(transactionLogDir), 0).toString()).createNewFile();
 
         assertQueryFails(format("CALL system.register_table('%s', '%s', '%s')", SCHEMA, tableNameNew, tableLocation),
                 ".*Failed to access table location: (.*)");
 
-        deleteRecursively(Path.of(tableLocation), ALLOW_INSECURE);
+        deleteRecursively(Path.of(new URI(tableLocation).getPath()), ALLOW_INSECURE);
         metastore.dropTable(SCHEMA, tableName, false);
     }
 
@@ -209,12 +210,12 @@ public abstract class BaseDeltaLakeRegisterTableProcedureTest
         String tableNameNew = "test_register_table_with_no_transaction_log_new_" + randomNameSuffix();
 
         // Delete files under transaction log directory to verify register_table call fails
-        deleteDirectoryContents(Path.of(getTransactionLogDir(new org.apache.hadoop.fs.Path(tableLocation)).toString()), ALLOW_INSECURE);
+        deleteDirectoryContents(Path.of(new URI(getTransactionLogDir(new org.apache.hadoop.fs.Path(tableLocation)).toString()).getPath()), ALLOW_INSECURE);
 
         assertQueryFails(format("CALL system.register_table('%s', '%s', '%s')", SCHEMA, tableNameNew, tableLocation),
                 ".*No transaction log found in location (.*)");
 
-        deleteRecursively(Path.of(tableLocation), ALLOW_INSECURE);
+        deleteRecursively(Path.of(new URI(tableLocation).getPath()), ALLOW_INSECURE);
         metastore.dropTable(SCHEMA, tableName, false);
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePerTransactionMetastoreCache.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePerTransactionMetastoreCache.java
@@ -91,6 +91,7 @@ public class TestDeltaLakePerTransactionMetastoreCache
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
 
         queryRunner.installPlugin(new TestingDeltaLakePlugin(
+                Optional.empty(),
                 new AbstractConfigurationAwareModule()
                 {
                     @Override

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeRegisterTableProcedureWithFileMetastore.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeRegisterTableProcedureWithFileMetastore.java
@@ -13,25 +13,15 @@
  */
 package io.trino.plugin.deltalake;
 
-import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 
 import java.io.File;
-import java.util.Map;
 
 import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
 
 public class TestDeltaLakeRegisterTableProcedureWithFileMetastore
         extends BaseDeltaLakeRegisterTableProcedureTest
 {
-    @Override
-    protected Map<String, String> getConnectorProperties(String dataDirectory)
-    {
-        return ImmutableMap.of(
-                "hive.metastore", "file",
-                "hive.metastore.catalog.dir", dataDirectory);
-    }
-
     @Override
     protected HiveMetastore createTestMetastore(String dataDirectory)
     {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestingDeltaLakePlugin.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestingDeltaLakePlugin.java
@@ -22,6 +22,7 @@ import io.trino.spi.connector.ConnectorFactory;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.inject.util.Modules.EMPTY_MODULE;
 import static java.util.Objects.requireNonNull;
@@ -29,15 +30,17 @@ import static java.util.Objects.requireNonNull;
 public class TestingDeltaLakePlugin
         extends DeltaLakePlugin
 {
+    private final Optional<Module> metastoreModule;
     private final Module additionalModule;
 
     public TestingDeltaLakePlugin()
     {
-        this(EMPTY_MODULE);
+        this(Optional.empty(), EMPTY_MODULE);
     }
 
-    public TestingDeltaLakePlugin(Module additionalModule)
+    public TestingDeltaLakePlugin(Optional<Module> metastoreModule, Module additionalModule)
     {
+        this.metastoreModule = requireNonNull(metastoreModule, "metastoreModule is null");
         this.additionalModule = requireNonNull(additionalModule, "additionalModule is null");
     }
 
@@ -59,6 +62,7 @@ public class TestingDeltaLakePlugin
                         catalogName,
                         config,
                         context,
+                        metastoreModule,
                         new AbstractConfigurationAwareModule()
                         {
                             @Override

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreAccessOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreAccessOperations.java
@@ -37,6 +37,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -77,7 +78,7 @@ public class TestDeltaLakeMetastoreAccessOperations
                         .setMetastoreUser("test"));
         metastore = new CountingAccessHiveMetastore(hiveMetastore);
 
-        queryRunner.installPlugin(new TestingDeltaLakePlugin(new CountingAccessMetastoreModule(metastore)));
+        queryRunner.installPlugin(new TestingDeltaLakePlugin(Optional.empty(), new CountingAccessMetastoreModule(metastore)));
         ImmutableMap.Builder<String, String> deltaLakeProperties = ImmutableMap.builder();
         deltaLakeProperties.put("hive.metastore", "test"); // use test value so we do not get clash with default bindings)
         queryRunner.createCatalog("delta_lake", "delta-lake", deltaLakeProperties.buildOrThrow());

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestingDeltaLakeMetastoreModule.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestingDeltaLakeMetastoreModule.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.metastore;
+
+import com.google.inject.Binder;
+import com.google.inject.Key;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.plugin.deltalake.AllowDeltaLakeManagedTableRename;
+import io.trino.plugin.hive.HideDeltaLakeTables;
+import io.trino.plugin.hive.metastore.DecoratedHiveMetastoreModule;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
+import io.trino.plugin.hive.metastore.RawHiveMetastoreFactory;
+
+import static java.util.Objects.requireNonNull;
+
+public class TestingDeltaLakeMetastoreModule
+        extends AbstractConfigurationAwareModule
+{
+    private final HiveMetastore metastore;
+
+    public TestingDeltaLakeMetastoreModule(HiveMetastore metastore)
+    {
+        this.metastore = requireNonNull(metastore, "metastore is null");
+    }
+
+    @Override
+    public void setup(Binder binder)
+    {
+        binder.bind(HiveMetastoreFactory.class).annotatedWith(RawHiveMetastoreFactory.class).toInstance(HiveMetastoreFactory.ofInstance(metastore));
+        install(new DecoratedHiveMetastoreModule());
+
+        binder.bind(Key.get(boolean.class, HideDeltaLakeTables.class)).toInstance(false);
+        binder.bind(Key.get(boolean.class, AllowDeltaLakeManagedTableRename.class)).toInstance(true);
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeRegisterTableProcedureWithGlue.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeRegisterTableProcedureWithGlue.java
@@ -14,14 +14,12 @@
 package io.trino.plugin.deltalake.metastore.glue;
 
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.deltalake.BaseDeltaLakeRegisterTableProcedureTest;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.glue.DefaultGlueColumnStatisticsProviderFactory;
 import io.trino.plugin.hive.metastore.glue.GlueHiveMetastore;
 import io.trino.plugin.hive.metastore.glue.GlueHiveMetastoreConfig;
 
-import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
@@ -31,19 +29,12 @@ public class TestDeltaLakeRegisterTableProcedureWithGlue
         extends BaseDeltaLakeRegisterTableProcedureTest
 {
     @Override
-    protected Map<String, String> getConnectorProperties(String dataDirectory)
-    {
-        return ImmutableMap.of(
-                "hive.metastore", "glue",
-                "hive.metastore.glue.default-warehouse-dir", dataDirectory);
-    }
-
-    @Override
     protected HiveMetastore createTestMetastore(String dataDirectory)
     {
         return new GlueHiveMetastore(
                 HDFS_ENVIRONMENT,
-                new GlueHiveMetastoreConfig(),
+                new GlueHiveMetastoreConfig()
+                        .setDefaultWarehouseDir(dataDirectory),
                 DefaultAWSCredentialsProviderChain.getInstance(),
                 directExecutor(),
                 new DefaultGlueColumnStatisticsProviderFactory(directExecutor(), directExecutor()),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Testing infrastructure change.

Add the ability to inject the metastore into the Delta Lake connector. This change is mainly done to enable more testing scenarios:

-  reuse within the test scope the metastore used by the Delta Lake connector.
- change the functionality of the underlying metastore of the connector simulate a specific failure scenario.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
