### PR TITLE
Fix derivation of LocalExchange single stream property

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
@@ -546,8 +546,8 @@ public final class PropertyDerivations
                         .unordered(true)
                         .build();
                 case FULL ->
-                    // We can't say anything about the partitioning scheme because any partition of
-                    // a hash-partitioned join can produce nulls in case of a lack of matches
+                        // We can't say anything about the partitioning scheme because any partition of
+                        // a hash-partitioned join can produce nulls in case of a lack of matches
                         ActualProperties.builder()
                                 .global(probeProperties.isSingleNode() ? singleStreamPartition() : arbitraryPartition())
                                 .build();
@@ -704,7 +704,7 @@ public final class PropertyDerivations
                         .constants(constants)
                         .build();
                 case REPLICATE ->
-                    // TODO: this should have the same global properties as the stream taking the replicated data
+                        // TODO: this should have the same global properties as the stream taking the replicated data
                         ActualProperties.builder()
                                 .global(arbitraryPartition())
                                 .constants(constants)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

LocalExchange will preserve single stream property only if:
1. global partitioning is either on coordinator or single-node
2. LocalExchange is gathering

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix a correctness bug for queries with certain complex window operators used in sequence 
```
