### PR TITLE
Apply RetryingConnectionFactory to JDBC plugins

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForRetryJdbc.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForRetryJdbc.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForRetryJdbc
+{
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcDiagnosticModule.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcDiagnosticModule.java
@@ -73,7 +73,7 @@ public class JdbcDiagnosticModule
     @Provides
     @Singleton
     @StatsCollecting
-    public static ConnectionFactory createConnectionFactoryWithStats(@ForBaseJdbc ConnectionFactory connectionFactory)
+    public static ConnectionFactory createConnectionFactoryWithStats(@ForRetryJdbc ConnectionFactory connectionFactory)
     {
         return new StatisticsAwareConnectionFactory(connectionFactory);
     }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcModule.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcModule.java
@@ -94,7 +94,7 @@ public class JdbcModule
                 QueryConfig::isRetryOpeningConnection,
                 innerBinder -> {
                     innerBinder.bind(ConnectionFactory.class).annotatedWith(ForRetryJdbc.class).to(RetryingConnectionFactory.class);
-                    innerBinder.bind(RetryingConnectionCondition.class).toInstance(RetryingConnectionFactory::isRetryableException);
+                    newOptionalBinder(innerBinder, RetryingConnectionCondition.class);
                 },
                 innerBinder -> innerBinder.bind(ConnectionFactory.class).annotatedWith(ForRetryJdbc.class).to(Key.get(ConnectionFactory.class, ForBaseJdbc.class)).in(Scopes.SINGLETON)));
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryConfig.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryConfig.java
@@ -19,10 +19,16 @@ import io.airlift.configuration.ConfigDescription;
 public class QueryConfig
 {
     private boolean reuseConnection = true;
+    private boolean retryOpeningConnection;
 
     public boolean isReuseConnection()
     {
         return reuseConnection;
+    }
+
+    public boolean isRetryOpeningConnection()
+    {
+        return retryOpeningConnection;
     }
 
     @Config("query.reuse-connection")
@@ -30,6 +36,14 @@ public class QueryConfig
     public QueryConfig setReuseConnection(boolean reuseConnection)
     {
         this.reuseConnection = reuseConnection;
+        return this;
+    }
+
+    @Config("query.retry-opening-connection")
+    @ConfigDescription("Enables retrying opening JDBC connection")
+    public QueryConfig setRetryOpeningConnection(boolean retryOpeningConnection)
+    {
+        this.retryOpeningConnection = retryOpeningConnection;
         return this;
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryConfig.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryConfig.java
@@ -19,7 +19,7 @@ import io.airlift.configuration.ConfigDescription;
 public class QueryConfig
 {
     private boolean reuseConnection = true;
-    private boolean retryOpeningConnection;
+    private boolean retryOpeningConnection = true;
 
     public boolean isReuseConnection()
     {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/RetryingConnectionCondition.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/RetryingConnectionCondition.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.jdbc;
+
+public interface RetryingConnectionCondition
+{
+    boolean isRetryable(Throwable exception);
+}

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestQueryConfig.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestQueryConfig.java
@@ -28,7 +28,8 @@ public class TestQueryConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(QueryConfig.class)
-                .setReuseConnection(true));
+                .setReuseConnection(true)
+                .setRetryOpeningConnection(false));
     }
 
     @Test
@@ -36,10 +37,12 @@ public class TestQueryConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("query.reuse-connection", "false")
+                .put("query.retry-opening-connection", "true")
                 .buildOrThrow();
 
         QueryConfig expected = new QueryConfig()
-                .setReuseConnection(false);
+                .setReuseConnection(false)
+                .setRetryOpeningConnection(true);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestQueryConfig.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestQueryConfig.java
@@ -29,7 +29,7 @@ public class TestQueryConfig
     {
         assertRecordedDefaults(recordDefaults(QueryConfig.class)
                 .setReuseConnection(true)
-                .setRetryOpeningConnection(false));
+                .setRetryOpeningConnection(true));
     }
 
     @Test
@@ -37,12 +37,12 @@ public class TestQueryConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("query.reuse-connection", "false")
-                .put("query.retry-opening-connection", "true")
+                .put("query.retry-opening-connection", "false")
                 .buildOrThrow();
 
         QueryConfig expected = new QueryConfig()
                 .setReuseConnection(false)
-                .setRetryOpeningConnection(true);
+                .setRetryOpeningConnection(false);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestRetryingConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestRetryingConnectionFactory.java
@@ -23,6 +23,7 @@ import java.sql.SQLException;
 import java.sql.SQLTransientException;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static com.google.common.reflect.Reflection.newProxy;
@@ -52,7 +53,7 @@ public class TestRetryingConnectionFactory
             throws Exception
     {
         MockConnectorFactory mock = new MockConnectorFactory(RETURN);
-        ConnectionFactory factory = new RetryingConnectionFactory(mock, RetryingConnectionFactory::isRetryableException);
+        ConnectionFactory factory = new RetryingConnectionFactory(mock, Optional.of(RetryingConnectionFactory::isRetryableException));
         assertNotNull(factory.openConnection(SESSION));
         assertEquals(mock.getCallCount(), 1);
     }
@@ -61,7 +62,7 @@ public class TestRetryingConnectionFactory
     public void testRetryAndStopOnTrinoException()
     {
         MockConnectorFactory mock = new MockConnectorFactory(THROW_SQL_TRANSIENT_EXCEPTION, THROW_TRINO_EXCEPTION);
-        ConnectionFactory factory = new RetryingConnectionFactory(mock, RetryingConnectionFactory::isRetryableException);
+        ConnectionFactory factory = new RetryingConnectionFactory(mock, Optional.of(RetryingConnectionFactory::isRetryableException));
         assertThatThrownBy(() -> factory.openConnection(SESSION))
                 .isInstanceOf(TrinoException.class)
                 .hasMessage("Testing Trino exception");
@@ -72,7 +73,7 @@ public class TestRetryingConnectionFactory
     public void testRetryAndStopOnSqlException()
     {
         MockConnectorFactory mock = new MockConnectorFactory(THROW_SQL_TRANSIENT_EXCEPTION, THROW_SQL_EXCEPTION);
-        ConnectionFactory factory = new RetryingConnectionFactory(mock, RetryingConnectionFactory::isRetryableException);
+        ConnectionFactory factory = new RetryingConnectionFactory(mock, Optional.of(RetryingConnectionFactory::isRetryableException));
         assertThatThrownBy(() -> factory.openConnection(SESSION))
                 .isInstanceOf(SQLException.class)
                 .hasMessage("Testing sql exception");
@@ -83,7 +84,7 @@ public class TestRetryingConnectionFactory
     public void testNullPointerException()
     {
         MockConnectorFactory mock = new MockConnectorFactory(THROW_NPE);
-        ConnectionFactory factory = new RetryingConnectionFactory(mock, RetryingConnectionFactory::isRetryableException);
+        ConnectionFactory factory = new RetryingConnectionFactory(mock, Optional.of(RetryingConnectionFactory::isRetryableException));
         assertThatThrownBy(() -> factory.openConnection(SESSION))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessage("Testing NPE");
@@ -95,7 +96,7 @@ public class TestRetryingConnectionFactory
             throws Exception
     {
         MockConnectorFactory mock = new MockConnectorFactory(THROW_SQL_TRANSIENT_EXCEPTION, RETURN);
-        ConnectionFactory factory = new RetryingConnectionFactory(mock, RetryingConnectionFactory::isRetryableException);
+        ConnectionFactory factory = new RetryingConnectionFactory(mock, Optional.of(RetryingConnectionFactory::isRetryableException));
         assertNotNull(factory.openConnection(SESSION));
         assertEquals(mock.getCallCount(), 2);
     }
@@ -105,7 +106,7 @@ public class TestRetryingConnectionFactory
             throws Exception
     {
         MockConnectorFactory mock = new MockConnectorFactory(THROW_WRAPPED_SQL_TRANSIENT_EXCEPTION, RETURN);
-        ConnectionFactory factory = new RetryingConnectionFactory(mock, RetryingConnectionFactory::isRetryableException);
+        ConnectionFactory factory = new RetryingConnectionFactory(mock, Optional.of(RetryingConnectionFactory::isRetryableException));
         assertNotNull(factory.openConnection(SESSION));
         assertEquals(mock.getCallCount(), 2);
     }

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleServer.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleServer.java
@@ -37,6 +37,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.temporal.ChronoUnit;
+import java.util.Optional;
 
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static java.lang.String.format;
@@ -124,7 +125,7 @@ public class TestingOracleServer
                 new OracleDriver(),
                 new BaseJdbcConfig().setConnectionUrl(connectionUrl),
                 StaticCredentialProvider.of(username, password));
-        return new RetryingConnectionFactory(connectionFactory, OracleClientModule::isRetryableException);
+        return new RetryingConnectionFactory(connectionFactory, Optional.of(OracleClientModule::isRetryableException));
     }
 
     @Override

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleServer.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleServer.java
@@ -124,7 +124,7 @@ public class TestingOracleServer
                 new OracleDriver(),
                 new BaseJdbcConfig().setConnectionUrl(connectionUrl),
                 StaticCredentialProvider.of(username, password));
-        return new RetryingConnectionFactory(connectionFactory);
+        return new RetryingConnectionFactory(connectionFactory, OracleClientModule::isRetryableException);
     }
 
     @Override

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClientModule.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClientModule.java
@@ -140,7 +140,7 @@ public class PhoenixClientModule
                 QueryConfig::isRetryOpeningConnection,
                 innerBinder -> {
                     innerBinder.bind(ConnectionFactory.class).annotatedWith(ForRetryJdbc.class).to(RetryingConnectionFactory.class);
-                    innerBinder.bind(RetryingConnectionCondition.class).toInstance(RetryingConnectionFactory::isRetryableException);
+                    newOptionalBinder(innerBinder, RetryingConnectionCondition.class);
                 },
                 innerBinder -> innerBinder.bind(ConnectionFactory.class).annotatedWith(ForRetryJdbc.class).to(Key.get(ConnectionFactory.class, ForBaseJdbc.class)).in(Scopes.SINGLETON)));
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

JDBC connectors consume one JDBC connection per table scan. So, if a single query contains tens or hundreds of table scans, it can hit the max connection limit on the database side. In this case, the connection pooling usually can be a solution, however, in Trino, one cluster can have a large number of workers, so simply introducing the connection pooling doesn't work.

Retrying opening JDBC connection can make JDBC connectors more robust. It would work as an alternative to the connection pooling.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This is a fresh version of #3125 leveraging #4947

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
