### PR TITLE
Run check-commits dispatcher only if PR branch has `compile-commit` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,9 +101,15 @@ jobs:
           # The output from rev-list ends with a newline, so we have to filter out index -1 in jq since it's an empty string
           export JQ_PIPELINE='split("\n") | .[0:-1] | map({base_ref: "${{ github.event.pull_request.base.ref }}", commit: .}) | select(length > 0) | {include: .}'
           
-          # The HEAD commit of the PR can be safely ignored since it's already compiled in other jobs
-          # This is achieved by adding a tilde (~) after the HEAD sha
-          git rev-list refs/remotes/origin/${{ github.event.pull_request.base.ref }}..${{ github.event.pull_request.head.sha }}~ | jq --raw-input --slurp "$JQ_PIPELINE" > commit-matrix.json
+          # Make sure the PR branch contains the compile-commit composite job
+          if git merge-base --is-ancestor $( git rev-list HEAD -- .github/actions/compile-commit/action.yml | tail -n 1 ) ${{ github.event.pull_request.head.sha }}
+          then
+            # The HEAD commit of the PR can be safely ignored since it's already compiled in other jobs
+            # This is achieved by adding a tilde (~) after the HEAD sha
+            git rev-list refs/remotes/origin/${{ github.event.pull_request.base.ref }}..${{ github.event.pull_request.head.sha }}~ | jq --raw-input --slurp "$JQ_PIPELINE" > commit-matrix.json
+          else
+            echo -n '' > commit-matrix.json
+          fi
           
           echo "Commit matrix: $(jq '.' commit-matrix.json)"
           echo "matrix=$(jq -c '.' commit-matrix.json)" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # checkout all commits to be able to determine merge base
-          ref: ${{ github.event.pull_request.head.sha }} # checkout PR HEAD commit instead of merge commit
       - name: Check Commits
         uses: trinodb/github-actions/block-commits@c2991972560c5219d9ae5fb68c0c9d687ffcdd10
         with:
@@ -98,11 +97,14 @@ jobs:
           action-fixup: none
       - name: Set matrix
         id: set-matrix
-        # The output from rev-list ends with a newline, so we have to filter out index -1 in jq since it's an empty string
-        # The HEAD commit of the PR (index -2) can be safely ignored since it's already compiled in other jobs
         run: |
-          export JQ_PIPELINE='split("\n") | .[0:-2] | map({base_ref: "${{ github.event.pull_request.base.ref }}", commit: .}) | select(length > 0) | {include: .}'
-          git rev-list refs/remotes/origin/${{ github.event.pull_request.base.ref }}..HEAD | jq --raw-input --slurp "$JQ_PIPELINE" > commit-matrix.json
+          # The output from rev-list ends with a newline, so we have to filter out index -1 in jq since it's an empty string
+          export JQ_PIPELINE='split("\n") | .[0:-1] | map({base_ref: "${{ github.event.pull_request.base.ref }}", commit: .}) | select(length > 0) | {include: .}'
+          
+          # The HEAD commit of the PR can be safely ignored since it's already compiled in other jobs
+          # This is achieved by adding a tilde (~) after the HEAD sha
+          git rev-list refs/remotes/origin/${{ github.event.pull_request.base.ref }}..${{ github.event.pull_request.head.sha }}~ | jq --raw-input --slurp "$JQ_PIPELINE" > commit-matrix.json
+          
           echo "Commit matrix: $(jq '.' commit-matrix.json)"
           echo "matrix=$(jq -c '.' commit-matrix.json)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

#15157 introduced a composite job for compiling every commit of a PR.

Before running check-commits dispatcher it's important to check that the PR branch contains the definition of the `compile-commit` composite job.

A bug was also discovered in the job responsible for selecting commits to be compiled. 
The `rev-list` query by default returns the list of commit hashes in **reverse** chronological order.
The last `rev-list` entry removed by the `jq` pipeline expression was the oldest PR commit, not the newest one.

This commit fixes the problem by using the `rev-list` expression instead of `jq` pipeline to filter out PR HEAD.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
