### PR TITLE
Fix DatabaseMetaData.getColumns nullability inconsistency

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
@@ -671,6 +671,7 @@ public class TestTrinoDatabaseMetaData
                 assertEquals(rs.getString("TABLE_SCHEM"), "information_schema");
                 assertEquals(rs.getString("TABLE_NAME"), "tables");
                 assertEquals(rs.getString("COLUMN_NAME"), "table_name");
+                assertEquals(rs.getLong("NULLABLE"), DatabaseMetaData.columnNullable);
                 assertEquals(rs.getString("IS_NULLABLE"), "YES");
                 assertEquals(rs.getInt("DATA_TYPE"), Types.VARCHAR);
                 assertTrue(rs.next());
@@ -742,6 +743,7 @@ public class TestTrinoDatabaseMetaData
             try (ResultSet rs = connection.getMetaData().getColumns(TEST_CATALOG, "tiny", "supplier", "suppkey")) {
                 assertColumnMetadata(rs);
                 assertTrue(rs.next());
+                assertEquals(rs.getLong("NULLABLE"), DatabaseMetaData.columnNoNulls);
                 assertEquals(rs.getString("IS_NULLABLE"), "NO");
             }
         }

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ColumnJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ColumnJdbcTable.java
@@ -330,7 +330,7 @@ public class ColumnJdbcTable
                     // num_prec_radix
                     numPrecRadix(column.getType()),
                     // nullable
-                    DatabaseMetaData.columnNullableUnknown,
+                    column.isNullable() ? DatabaseMetaData.columnNullable : DatabaseMetaData.columnNoNulls,
                     // remarks
                     column.getComment(),
                     // column_def

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ColumnJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ColumnJdbcTable.java
@@ -309,29 +309,53 @@ public class ColumnJdbcTable
                 continue;
             }
             builder.addRow(
+                    // table_cat
                     catalog,
+                    // table_schem
                     tableName.getSchemaName(),
+                    // table_name
                     tableName.getTableName(),
+                    // column_name
                     column.getName(),
+                    // data_type
                     jdbcDataType(column.getType()),
+                    // type_name
                     getDisplayLabel(column.getType(), isOmitTimestampPrecision),
+                    // column_size
                     columnSize(column.getType()),
+                    // buffer_length
                     0,
+                    // decimal_digits
                     decimalDigits(column.getType()),
+                    // num_prec_radix
                     numPrecRadix(column.getType()),
+                    // nullable
                     DatabaseMetaData.columnNullableUnknown,
+                    // remarks
                     column.getComment(),
+                    // column_def
                     null,
+                    // sql_data_type
                     null,
+                    // sql_datetime_sub
                     null,
+                    // char_octet_length
                     charOctetLength(column.getType()),
+                    // ordinal_position
                     ordinalPosition,
+                    // is_nullable
                     column.isNullable() ? "YES" : "NO",
+                    // scope_catalog
                     null,
+                    // scope_schema
                     null,
+                    // scope_table
                     null,
+                    // source_data_type
                     null,
+                    // is_autoincrement
                     null,
+                    // is_generatedcolumn
                     null);
             ordinalPosition++;
         }

--- a/testing/trino-product-tests/src/main/resources/io/trino/tests/product/jdbc/get_nation_columns.result
+++ b/testing/trino-product-tests/src/main/resources/io/trino/tests/product/jdbc/get_nation_columns.result
@@ -1,5 +1,5 @@
 -- delimiter: |; ignoreOrder: false; ignoreExcessRows: false;
-hive|default|nation|n_nationkey|-5|bigint|19|0|null|10|2|null|null|null|null|null|1|YES|null|null|null|null|null|null|
-hive|default|nation|n_name|12|varchar(25)|25|0|null|null|2|null|null|null|null|25|2|YES|null|null|null|null|null|null|
-hive|default|nation|n_regionkey|-5|bigint|19|0|null|10|2|null|null|null|null|null|3|YES|null|null|null|null|null|null|
-hive|default|nation|n_comment|12|varchar(152)|152|0|null|null|2|null|null|null|null|152|4|YES|null|null|null|null|null|null|
+hive|default|nation|n_nationkey|-5|bigint|19|0|null|10|1|null|null|null|null|null|1|YES|null|null|null|null|null|null|
+hive|default|nation|n_name|12|varchar(25)|25|0|null|null|1|null|null|null|null|25|2|YES|null|null|null|null|null|null|
+hive|default|nation|n_regionkey|-5|bigint|19|0|null|10|1|null|null|null|null|null|3|YES|null|null|null|null|null|null|
+hive|default|nation|n_comment|12|varchar(152)|152|0|null|null|1|null|null|null|null|152|4|YES|null|null|null|null|null|null|


### PR DESCRIPTION
`DatabaseMetaData.getColumns` reports nullability in two result columns

- NULLABLE, a number (0, 1, 2)
- IS_NULLABLE, a varchar column ("YES", "NO", "")

This fixes the `TrinoDatabaseMetaData` so that information returned in
those two ways is consistent.