### PR TITLE
Add builders to Iceberg and Hive table handles

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionManager.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionManager.java
@@ -168,24 +168,16 @@ public class HivePartitionManager
             List<HiveColumnHandle> partitionColumns = partitions.getPartitionColumns();
             enforcedConstraint = partitions.getEffectivePredicate().filter((column, domain) -> partitionColumns.contains(column));
         }
-        return new HiveTableHandle(
-                handle.getSchemaName(),
-                handle.getTableName(),
-                handle.getTableParameters(),
-                ImmutableList.copyOf(partitions.getPartitionColumns()),
-                handle.getDataColumns(),
-                partitionNames,
-                partitionList,
-                partitions.getCompactEffectivePredicate(),
-                enforcedConstraint,
-                partitions.getBucketHandle(),
-                partitions.getBucketFilter(),
-                handle.getAnalyzePartitionValues(),
-                Sets.union(handle.getConstraintColumns(), constraint.getPredicateColumns().orElseGet(ImmutableSet::of)),
-                handle.getProjectedColumns(),
-                handle.getTransaction(),
-                handle.isRecordScannedFiles(),
-                handle.getMaxScannedFileSize());
+        return HiveTableHandle.buildFrom(handle)
+                .withPartitionColumns(ImmutableList.copyOf(partitions.getPartitionColumns()))
+                .withPartitionNames(partitionNames)
+                .withPartitions(partitionList)
+                .withCompactEffectivePredicate(partitions.getCompactEffectivePredicate())
+                .withEnforcedConstraint(enforcedConstraint)
+                .withBucketHandle(partitions.getBucketHandle())
+                .withBucketFilter(partitions.getBucketFilter())
+                .withConstraintColumns(Sets.union(handle.getConstraintColumns(), constraint.getPredicateColumns().orElseGet(ImmutableSet::of)))
+                .build();
     }
 
     public Iterator<HivePartition> getPartitions(SemiTransactionalHiveMetastore metastore, HiveTableHandle table)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionsSystemTableProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionsSystemTableProvider.java
@@ -86,13 +86,15 @@ public class PartitionsSystemTableProvider
             return Optional.empty();
         }
         verifyOnline(sourceTableName, Optional.empty(), getProtectMode(sourceTable), sourceTable.getParameters());
-        HiveTableHandle sourceTableHandle = new HiveTableHandle(
-                sourceTableName.getSchemaName(),
-                sourceTableName.getTableName(),
-                sourceTable.getParameters(),
-                getPartitionKeyColumnHandles(sourceTable, typeManager),
-                getRegularColumnHandles(sourceTable, typeManager, getTimestampPrecision(session)),
-                getHiveBucketHandle(session, sourceTable, typeManager));
+
+        HiveTableHandle sourceTableHandle = HiveTableHandle.builder()
+                .withSchemaName(sourceTableName.getSchemaName())
+                .withTableName(sourceTableName.getTableName())
+                .withTableParameters(Optional.of(sourceTable.getParameters()))
+                .withPartitionColumns(getPartitionKeyColumnHandles(sourceTable, typeManager))
+                .withDataColumns(getRegularColumnHandles(sourceTable, typeManager, getTimestampPrecision(session)))
+                .withBucketHandle(getHiveBucketHandle(session, sourceTable, typeManager))
+                .build();
 
         List<HiveColumnHandle> partitionColumns = sourceTableHandle.getPartitionColumns();
         if (partitionColumns.isEmpty()) {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -710,7 +710,10 @@ public abstract class AbstractTestHive
         tablePartitionSchemaChangeNonCanonical = new SchemaTableName(database, "trino_test_partition_schema_change_non_canonical");
         tableBucketEvolution = new SchemaTableName(database, "trino_test_bucket_evolution");
 
-        invalidTableHandle = new HiveTableHandle(database, INVALID_TABLE, ImmutableMap.of(), ImmutableList.of(), ImmutableList.of(), Optional.empty());
+        invalidTableHandle = HiveTableHandle.builder()
+                .withSchemaName(database)
+                .withTableName(INVALID_TABLE)
+                .build();
 
         dsColumn = createBaseColumn("ds", -1, HIVE_STRING, VARCHAR, PARTITION_KEY, Optional.empty());
         fileFormatColumn = createBaseColumn("file_format", -1, HIVE_STRING, VARCHAR, PARTITION_KEY, Optional.empty());
@@ -3716,7 +3719,9 @@ public abstract class AbstractTestHive
             // Extra columns handles in HiveTableHandle should get pruned
             projectionResult = metadata.applyProjection(
                     session,
-                    ((HiveTableHandle) tableHandle).withProjectedColumns(ImmutableSet.copyOf(columnHandles)),
+                    HiveTableHandle.buildFrom((HiveTableHandle) tableHandle)
+                            .withProjectedColumns(ImmutableSet.copyOf(columnHandles))
+                            .build(),
                     inputProjections,
                     inputAssignments);
             assertProjectionResult(projectionResult, false, inputProjections, expectedAssignments);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
@@ -265,7 +265,10 @@ public class TestHivePageSink
                 Optional.empty(),
                 0,
                 SplitWeight.standard());
-        ConnectorTableHandle table = new HiveTableHandle(SCHEMA_NAME, TABLE_NAME, ImmutableMap.of(), ImmutableList.of(), ImmutableList.of(), Optional.empty());
+        ConnectorTableHandle table = HiveTableHandle.builder()
+                .withSchemaName(SCHEMA_NAME)
+                .withTableName(TABLE_NAME)
+                .build();
         HivePageSourceProvider provider = new HivePageSourceProvider(
                 TESTING_TYPE_MANAGER,
                 HDFS_ENVIRONMENT,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveTableHandle.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveTableHandle.java
@@ -13,12 +13,8 @@
  */
 package io.trino.plugin.hive;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonCodec;
 import org.testng.annotations.Test;
-
-import java.util.Optional;
 
 import static org.testng.Assert.assertEquals;
 
@@ -29,7 +25,10 @@ public class TestHiveTableHandle
     @Test
     public void testRoundTrip()
     {
-        HiveTableHandle expected = new HiveTableHandle("schema", "table", ImmutableMap.of(), ImmutableList.of(), ImmutableList.of(), Optional.empty());
+        HiveTableHandle expected = HiveTableHandle.builder()
+                .withSchemaName("schema")
+                .withTableName("table")
+                .build();
 
         String json = codec.toJson(expected);
         HiveTableHandle actual = codec.fromJson(json);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestNodeLocalDynamicSplitPruning.java
@@ -141,18 +141,17 @@ public class TestNodeLocalDynamicSplitPruning
 
         TableHandle tableHandle = new TableHandle(
                 TEST_CATALOG_HANDLE,
-                new HiveTableHandle(
-                        SCHEMA_NAME,
-                        TABLE_NAME,
-                        ImmutableMap.of(),
-                        ImmutableList.of(),
-                        ImmutableList.of(BUCKET_HIVE_COLUMN_HANDLE),
-                        Optional.of(new HiveBucketHandle(
+                HiveTableHandle.builder()
+                        .withSchemaName(SCHEMA_NAME)
+                        .withTableName(TABLE_NAME)
+                        .withDataColumns(ImmutableList.of(BUCKET_HIVE_COLUMN_HANDLE))
+                        .withBucketHandle(Optional.of(new HiveBucketHandle(
                                 ImmutableList.of(BUCKET_HIVE_COLUMN_HANDLE),
                                 BUCKETING_V1,
                                 20,
                                 20,
-                                ImmutableList.of()))),
+                                ImmutableList.of())))
+                        .build(),
                 transaction);
 
         HivePageSourceProvider provider = new HivePageSourceProvider(

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/AbstractFileFormat.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/AbstractFileFormat.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.hive.benchmark;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.hdfs.HdfsEnvironment;
 import io.trino.plugin.hive.GenericHiveRecordCursorProvider;
@@ -160,8 +159,12 @@ public abstract class AbstractFileFormat
 
         return factory.createPageSource(
                 TestingConnectorTransactionHandle.INSTANCE,
-                session, split,
-                new HiveTableHandle("schema_name", "table_name", ImmutableMap.of(), ImmutableList.of(), ImmutableList.of(), Optional.empty()),
+                session,
+                split,
+                HiveTableHandle.builder()
+                        .withSchemaName("schema_name")
+                        .withTableName("table_name")
+                        .build(),
                 readColumns,
                 DynamicFilter.EMPTY);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
@@ -165,7 +165,10 @@ public class TestConnectorPushdownRulesWithHive
                 REGULAR,
                 Optional.empty());
 
-        HiveTableHandle hiveTable = new HiveTableHandle(SCHEMA_NAME, tableName, ImmutableMap.of(), ImmutableList.of(), ImmutableList.of(), Optional.empty());
+        HiveTableHandle hiveTable = HiveTableHandle.builder()
+                .withSchemaName(SCHEMA_NAME)
+                .withTableName(tableName)
+                .build();
         TableHandle table = new TableHandle(TEST_CATALOG_HANDLE, hiveTable, new HiveTransactionHandle(false));
 
         HiveColumnHandle fullColumn = partialColumn.getBaseColumn();
@@ -183,7 +186,9 @@ public class TestConnectorPushdownRulesWithHive
                         project(
                                 ImmutableMap.of("expr", expression("col")),
                                 tableScan(
-                                        hiveTable.withProjectedColumns(ImmutableSet.of(fullColumn))::equals,
+                                        HiveTableHandle.buildFrom(hiveTable)
+                                                .withProjectedColumns(ImmutableSet.of(fullColumn))
+                                                .build()::equals,
                                         TupleDomain.all(),
                                         ImmutableMap.of("col", fullColumn::equals))));
 
@@ -195,7 +200,9 @@ public class TestConnectorPushdownRulesWithHive
                                 p.tableScan(
                                         new TableHandle(
                                                 TEST_CATALOG_HANDLE,
-                                                hiveTable.withProjectedColumns(ImmutableSet.of(fullColumn)),
+                                                HiveTableHandle.buildFrom(hiveTable)
+                                                        .withProjectedColumns(ImmutableSet.of(fullColumn))
+                                                        .build(),
                                                 new HiveTransactionHandle(false)),
                                         ImmutableList.of(p.symbol("struct_of_int", baseType)),
                                         ImmutableMap.of(p.symbol("struct_of_int", baseType), fullColumn))))
@@ -214,7 +221,9 @@ public class TestConnectorPushdownRulesWithHive
                 .matches(project(
                         ImmutableMap.of("expr_deref", expression(new SymbolReference("struct_of_int#a"))),
                         tableScan(
-                                hiveTable.withProjectedColumns(ImmutableSet.of(partialColumn))::equals,
+                                HiveTableHandle.buildFrom(hiveTable)
+                                        .withProjectedColumns(ImmutableSet.of(partialColumn))
+                                        .build()::equals,
                                 TupleDomain.all(),
                                 ImmutableMap.of("struct_of_int#a", partialColumn::equals))));
 
@@ -229,7 +238,10 @@ public class TestConnectorPushdownRulesWithHive
 
         PushPredicateIntoTableScan pushPredicateIntoTableScan = new PushPredicateIntoTableScan(tester().getPlannerContext(), tester().getTypeAnalyzer());
 
-        HiveTableHandle hiveTable = new HiveTableHandle(SCHEMA_NAME, tableName, ImmutableMap.of(), ImmutableList.of(), ImmutableList.of(), Optional.empty());
+        HiveTableHandle hiveTable = HiveTableHandle.builder()
+                .withSchemaName(SCHEMA_NAME)
+                .withTableName(tableName)
+                .build();
         TableHandle table = new TableHandle(TEST_CATALOG_HANDLE, hiveTable, new HiveTransactionHandle(false));
 
         HiveColumnHandle column = createBaseColumn("a", 0, HIVE_INT, INTEGER, REGULAR, Optional.empty());
@@ -261,7 +273,10 @@ public class TestConnectorPushdownRulesWithHive
 
         PruneTableScanColumns pruneTableScanColumns = new PruneTableScanColumns(tester().getMetadata());
 
-        HiveTableHandle hiveTable = new HiveTableHandle(SCHEMA_NAME, tableName, ImmutableMap.of(), ImmutableList.of(), ImmutableList.of(), Optional.empty());
+        HiveTableHandle hiveTable = HiveTableHandle.builder()
+                .withSchemaName(SCHEMA_NAME)
+                .withTableName(tableName)
+                .build();
         TableHandle table = new TableHandle(TEST_CATALOG_HANDLE, hiveTable, new HiveTransactionHandle(false));
 
         HiveColumnHandle columnA = createBaseColumn("a", 0, HIVE_INT, INTEGER, REGULAR, Optional.empty());
@@ -284,7 +299,9 @@ public class TestConnectorPushdownRulesWithHive
                         strictProject(
                                 ImmutableMap.of("expr", expression("COLA")),
                                 tableScan(
-                                        hiveTable.withProjectedColumns(ImmutableSet.of(columnA))::equals,
+                                        HiveTableHandle.buildFrom(hiveTable)
+                                                .withProjectedColumns(ImmutableSet.of(columnA))
+                                                .build()::equals,
                                         TupleDomain.all(),
                                         ImmutableMap.of("COLA", columnA::equals))));
 
@@ -304,7 +321,10 @@ public class TestConnectorPushdownRulesWithHive
                 tester().getTypeAnalyzer(),
                 new ScalarStatsCalculator(tester().getPlannerContext(), tester().getTypeAnalyzer()));
 
-        HiveTableHandle hiveTable = new HiveTableHandle(SCHEMA_NAME, tableName, ImmutableMap.of(), ImmutableList.of(), ImmutableList.of(), Optional.empty());
+        HiveTableHandle hiveTable = HiveTableHandle.builder()
+                .withSchemaName(SCHEMA_NAME)
+                .withTableName(tableName)
+                .build();
         TableHandle table = new TableHandle(TEST_CATALOG_HANDLE, hiveTable, new HiveTransactionHandle(false));
 
         HiveColumnHandle bigintColumn = createBaseColumn("just_bigint", 1, toHiveType(BIGINT), BIGINT, REGULAR, Optional.empty());
@@ -341,7 +361,9 @@ public class TestConnectorPushdownRulesWithHive
                                 "column_ref", expression("just_bigint_0"),
                                 "negated_column_ref", expression("- just_bigint_0")),
                         tableScan(
-                                hiveTable.withProjectedColumns(ImmutableSet.of(bigintColumn))::equals,
+                                HiveTableHandle.buildFrom(hiveTable)
+                                        .withProjectedColumns(ImmutableSet.of(bigintColumn))
+                                        .build()::equals,
                                 TupleDomain.all(),
                                 ImmutableMap.of("just_bigint_0", bigintColumn::equals))));
 
@@ -365,7 +387,9 @@ public class TestConnectorPushdownRulesWithHive
                                 "expr_deref", expression(new SymbolReference("struct_of_bigint#a")),
                                 "expr_deref_2", expression(new ArithmeticBinaryExpression(ADD, new SymbolReference("struct_of_bigint#a"), new LongLiteral("2")))),
                         tableScan(
-                                hiveTable.withProjectedColumns(ImmutableSet.of(partialColumn))::equals,
+                                HiveTableHandle.buildFrom(hiveTable)
+                                        .withProjectedColumns(ImmutableSet.of(partialColumn))
+                                        .build()::equals,
                                 TupleDomain.all(),
                                 ImmutableMap.of("struct_of_bigint#a", partialColumn::equals))));
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHiveProjectionPushdownIntoTableScan.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHiveProjectionPushdownIntoTableScan.java
@@ -164,8 +164,9 @@ public class TestHiveProjectionPushdownIntoTableScan
         assertPlan(
                 "SELECT col0.x expr_x, col0.y expr_y FROM " + testTable,
                 any(tableScan(
-                        ((HiveTableHandle) tableHandle.get().getConnectorHandle())
-                                .withProjectedColumns(ImmutableSet.of(columnX, columnY))::equals,
+                        HiveTableHandle.buildFrom((HiveTableHandle) tableHandle.get().getConnectorHandle())
+                                .withProjectedColumns(ImmutableSet.of(columnX, columnY))
+                                .build()::equals,
                         TupleDomain.all(),
                         ImmutableMap.of("col0#x", columnX::equals, "col0#y", columnY::equals))));
 
@@ -226,8 +227,9 @@ public class TestHiveProjectionPushdownIntoTableScan
                                         .right(
                                                 anyTree(
                                                         tableScan(
-                                                                ((HiveTableHandle) tableHandle.get().getConnectorHandle())
-                                                                        .withProjectedColumns(ImmutableSet.of(column1Handle))::equals,
+                                                                HiveTableHandle.buildFrom((HiveTableHandle) tableHandle.get().getConnectorHandle())
+                                                                        .withProjectedColumns(ImmutableSet.of(column1Handle))
+                                                                        .build()::equals,
                                                                 TupleDomain.all(),
                                                                 ImmutableMap.of("s_expr_1", column1Handle::equals))))))));
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -369,24 +369,18 @@ public class IcebergMetadata
 
         Map<String, String> tableProperties = table.properties();
         String nameMappingJson = tableProperties.get(TableProperties.DEFAULT_NAME_MAPPING);
-        return new IcebergTableHandle(
-                tableName.getSchemaName(),
-                name.getTableName(),
-                name.getTableType(),
-                tableSnapshotId,
-                SchemaParser.toJson(tableSchema),
-                partitionSpec.map(PartitionSpecParser::toJson),
-                table.operations().current().formatVersion(),
-                TupleDomain.all(),
-                TupleDomain.all(),
-                ImmutableSet.of(),
-                Optional.ofNullable(nameMappingJson),
-                table.location(),
-                table.properties(),
-                NO_RETRIES,
-                ImmutableList.of(),
-                false,
-                Optional.empty());
+        return IcebergTableHandle.builder()
+                .withSchemaName(tableName.getSchemaName())
+                .withTableName(name.getTableName())
+                .withTableType(name.getTableType())
+                .withSnapshotId(tableSnapshotId)
+                .withTableSchemaJson(SchemaParser.toJson(tableSchema))
+                .withPartitionSpecJson(partitionSpec.map(PartitionSpecParser::toJson))
+                .withFormatVersion(table.operations().current().formatVersion())
+                .withNameMappingJson(Optional.ofNullable(nameMappingJson))
+                .withTableLocation(table.location())
+                .withStorageProperties(table.properties())
+                .build();
     }
 
     private static long getSnapshotIdFromVersion(Table table, ConnectorTableVersion version)
@@ -1082,7 +1076,10 @@ public class IcebergMetadata
 
         return new BeginTableExecuteResult<>(
                 executeHandle,
-                table.forOptimize(true, optimizeHandle.getMaxScannedFileSize()));
+                IcebergTableHandle.buildFrom(table)
+                        .withRecordScannedFiles(true)
+                        .withMaxScannedFileSize(Optional.of(optimizeHandle.getMaxScannedFileSize()))
+                        .build());
     }
 
     @Override
@@ -1693,7 +1690,9 @@ public class IcebergMetadata
         validateNotPartitionedByNestedField(icebergTable.schema(), icebergTable.spec());
 
         beginTransaction(icebergTable);
-        return table.withRetryMode(retryMode);
+        return IcebergTableHandle.buildFrom(table)
+                .withRetryMode(retryMode)
+                .build();
     }
 
     @Override
@@ -1719,10 +1718,12 @@ public class IcebergMetadata
         validateNotPartitionedByNestedField(icebergTable.schema(), icebergTable.spec());
 
         beginTransaction(icebergTable);
-        return table.withRetryMode(retryMode)
+        return IcebergTableHandle.buildFrom(table)
+                .withRetryMode(retryMode)
                 .withUpdatedColumns(updatedColumns.stream()
                         .map(IcebergColumnHandle.class::cast)
-                        .collect(toImmutableList()));
+                        .collect(toImmutableList()))
+                .build();
     }
 
     @Override
@@ -1792,7 +1793,9 @@ public class IcebergMetadata
 
         beginTransaction(icebergTable);
 
-        IcebergTableHandle newTableHandle = table.withRetryMode(retryMode);
+        IcebergTableHandle newTableHandle = IcebergTableHandle.buildFrom(table)
+                .withRetryMode(retryMode)
+                .build();
         IcebergWritableTableHandle insertHandle = newWritableTableHandle(table.getSchemaTableName(), icebergTable, retryMode);
 
         return new IcebergMergeTableHandle(newTableHandle, insertHandle);
@@ -2114,26 +2117,11 @@ public class IcebergMetadata
                 && newUnenforcedConstraint.equals(table.getUnenforcedPredicate())) {
             return Optional.empty();
         }
-
         return Optional.of(new ConstraintApplicationResult<>(
-                new IcebergTableHandle(
-                        table.getSchemaName(),
-                        table.getTableName(),
-                        table.getTableType(),
-                        table.getSnapshotId(),
-                        table.getTableSchemaJson(),
-                        table.getPartitionSpecJson(),
-                        table.getFormatVersion(),
-                        newUnenforcedConstraint,
-                        newEnforcedConstraint,
-                        table.getProjectedColumns(),
-                        table.getNameMappingJson(),
-                        table.getTableLocation(),
-                        table.getStorageProperties(),
-                        table.getRetryMode(),
-                        table.getUpdatedColumns(),
-                        table.isRecordScannedFiles(),
-                        table.getMaxScannedFileSize()),
+                IcebergTableHandle.buildFrom(table)
+                        .withUnenforcedPredicate(newUnenforcedConstraint)
+                        .withEnforcedPredicate(newEnforcedConstraint)
+                        .build(),
                 remainingConstraint.transformKeys(ColumnHandle.class::cast),
                 extractionResult.remainingExpression(),
                 false));
@@ -2187,7 +2175,9 @@ public class IcebergMetadata
                     .collect(toImmutableList());
 
             return Optional.of(new ProjectionApplicationResult<>(
-                    icebergTableHandle.withProjectedColumns(projectedColumns),
+                    IcebergTableHandle.buildFrom(icebergTableHandle)
+                            .withProjectedColumns(projectedColumns)
+                            .build(),
                     projections,
                     assignmentsList,
                     false));
@@ -2221,7 +2211,9 @@ public class IcebergMetadata
 
         List<Assignment> outputAssignments = ImmutableList.copyOf(newAssignments.values());
         return Optional.of(new ProjectionApplicationResult<>(
-                icebergTableHandle.withProjectedColumns(projectedColumnsBuilder.build()),
+                IcebergTableHandle.buildFrom(icebergTableHandle)
+                        .withProjectedColumns(projectedColumnsBuilder.build())
+                        .build(),
                 newProjections,
                 outputAssignments,
                 false));
@@ -2265,24 +2257,10 @@ public class IcebergMetadata
         checkArgument(originalHandle.getMaxScannedFileSize().isEmpty(), "Unexpected max scanned file size set");
 
         return tableStatisticsCache.computeIfAbsent(
-                new IcebergTableHandle(
-                        originalHandle.getSchemaName(),
-                        originalHandle.getTableName(),
-                        originalHandle.getTableType(),
-                        originalHandle.getSnapshotId(),
-                        originalHandle.getTableSchemaJson(),
-                        originalHandle.getPartitionSpecJson(),
-                        originalHandle.getFormatVersion(),
-                        originalHandle.getUnenforcedPredicate(),
-                        originalHandle.getEnforcedPredicate(),
-                        ImmutableSet.of(), // projectedColumns don't affect stats
-                        originalHandle.getNameMappingJson(),
-                        originalHandle.getTableLocation(),
-                        originalHandle.getStorageProperties(),
-                        NO_RETRIES, // retry mode doesn't affect stats
-                        originalHandle.getUpdatedColumns(),
-                        originalHandle.isRecordScannedFiles(),
-                        originalHandle.getMaxScannedFileSize()),
+                IcebergTableHandle.buildFrom(originalHandle)
+                        .withProjectedColumns(ImmutableSet.of()) // projectedColumns don't affect stats
+                        .withRetryMode(NO_RETRIES) // retry mode doesn't affect stats
+                        .build(),
                 handle -> {
                     Table icebergTable = catalog.loadTable(session, handle.getSchemaTableName());
                     return TableStatisticsMaker.getTableStatistics(typeManager, session, handle, icebergTable);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableHandle.java
@@ -32,6 +32,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
@@ -84,27 +85,26 @@ public class IcebergTableHandle
             @JsonProperty("retryMode") RetryMode retryMode,
             @JsonProperty("updatedColumns") List<IcebergColumnHandle> updatedColumns)
     {
-        return new IcebergTableHandle(
-                schemaName,
-                tableName,
-                tableType,
-                snapshotId,
-                tableSchemaJson,
-                partitionSpecJson,
-                formatVersion,
-                unenforcedPredicate,
-                enforcedPredicate,
-                projectedColumns,
-                nameMappingJson,
-                tableLocation,
-                storageProperties,
-                retryMode,
-                updatedColumns,
-                false,
-                Optional.empty());
+        return builder()
+                .withSchemaName(schemaName)
+                .withTableName(tableName)
+                .withTableType(tableType)
+                .withSnapshotId(snapshotId)
+                .withTableSchemaJson(tableSchemaJson)
+                .withPartitionSpecJson(partitionSpecJson)
+                .withFormatVersion(formatVersion)
+                .withUnenforcedPredicate(unenforcedPredicate)
+                .withEnforcedPredicate(enforcedPredicate)
+                .withProjectedColumns(projectedColumns)
+                .withNameMappingJson(nameMappingJson)
+                .withTableLocation(tableLocation)
+                .withStorageProperties(storageProperties)
+                .withRetryMode(retryMode)
+                .withUpdatedColumns(updatedColumns)
+                .build();
     }
 
-    public IcebergTableHandle(
+    private IcebergTableHandle(
             String schemaName,
             String tableName,
             TableType tableType,
@@ -254,94 +254,6 @@ public class IcebergTableHandle
         return new SchemaTableName(schemaName, tableName + "$" + tableType.name().toLowerCase(Locale.ROOT));
     }
 
-    public IcebergTableHandle withProjectedColumns(Set<IcebergColumnHandle> projectedColumns)
-    {
-        return new IcebergTableHandle(
-                schemaName,
-                tableName,
-                tableType,
-                snapshotId,
-                tableSchemaJson,
-                partitionSpecJson,
-                formatVersion,
-                unenforcedPredicate,
-                enforcedPredicate,
-                projectedColumns,
-                nameMappingJson,
-                tableLocation,
-                storageProperties,
-                retryMode,
-                updatedColumns,
-                recordScannedFiles,
-                maxScannedFileSize);
-    }
-
-    public IcebergTableHandle withRetryMode(RetryMode retryMode)
-    {
-        return new IcebergTableHandle(
-                schemaName,
-                tableName,
-                tableType,
-                snapshotId,
-                tableSchemaJson,
-                partitionSpecJson,
-                formatVersion,
-                unenforcedPredicate,
-                enforcedPredicate,
-                projectedColumns,
-                nameMappingJson,
-                tableLocation,
-                storageProperties,
-                retryMode,
-                updatedColumns,
-                recordScannedFiles,
-                maxScannedFileSize);
-    }
-
-    public IcebergTableHandle withUpdatedColumns(List<IcebergColumnHandle> updatedColumns)
-    {
-        return new IcebergTableHandle(
-                schemaName,
-                tableName,
-                tableType,
-                snapshotId,
-                tableSchemaJson,
-                partitionSpecJson,
-                formatVersion,
-                unenforcedPredicate,
-                enforcedPredicate,
-                projectedColumns,
-                nameMappingJson,
-                tableLocation,
-                storageProperties,
-                retryMode,
-                updatedColumns,
-                recordScannedFiles,
-                maxScannedFileSize);
-    }
-
-    public IcebergTableHandle forOptimize(boolean recordScannedFiles, DataSize maxScannedFileSize)
-    {
-        return new IcebergTableHandle(
-                schemaName,
-                tableName,
-                tableType,
-                snapshotId,
-                tableSchemaJson,
-                partitionSpecJson,
-                formatVersion,
-                unenforcedPredicate,
-                enforcedPredicate,
-                projectedColumns,
-                nameMappingJson,
-                tableLocation,
-                storageProperties,
-                retryMode,
-                updatedColumns,
-                recordScannedFiles,
-                Optional.of(maxScannedFileSize));
-    }
-
     @Override
     public boolean equals(Object o)
     {
@@ -394,5 +306,185 @@ public class IcebergTableHandle
                     .collect(joining(", ", "[", "]")));
         }
         return builder.toString();
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static Builder buildFrom(IcebergTableHandle table)
+    {
+        return new Builder(table);
+    }
+
+    public static class Builder
+    {
+        private String schemaName;
+        private String tableName;
+        private TableType tableType;
+        private Optional<Long> snapshotId = Optional.empty();
+        private String tableSchemaJson;
+        private Optional<String> partitionSpecJson = Optional.empty();
+        private int formatVersion;
+        private String tableLocation;
+        private Map<String, String> storageProperties = emptyMap();
+        private RetryMode retryMode = RetryMode.NO_RETRIES;
+        private List<IcebergColumnHandle> updatedColumns = ImmutableList.of();
+        private TupleDomain<IcebergColumnHandle> unenforcedPredicate = TupleDomain.all();
+        private TupleDomain<IcebergColumnHandle> enforcedPredicate = TupleDomain.all();
+        private Set<IcebergColumnHandle> projectedColumns = ImmutableSet.of();
+        private Optional<String> nameMappingJson = Optional.empty();
+        private boolean recordScannedFiles;
+        private Optional<DataSize> maxScannedFileSize = Optional.empty();
+
+        private Builder()
+        {
+        }
+
+        private Builder(IcebergTableHandle table)
+        {
+            this.schemaName = table.schemaName;
+            this.tableName = table.tableName;
+            this.tableType = table.tableType;
+            this.snapshotId = table.snapshotId;
+            this.tableSchemaJson = table.tableSchemaJson;
+            this.partitionSpecJson = table.partitionSpecJson;
+            this.formatVersion = table.formatVersion;
+            this.tableLocation = table.tableLocation;
+            this.storageProperties = table.storageProperties;
+            this.retryMode = table.retryMode;
+            this.updatedColumns = table.updatedColumns;
+            this.unenforcedPredicate = table.unenforcedPredicate;
+            this.enforcedPredicate = table.enforcedPredicate;
+            this.projectedColumns = table.projectedColumns;
+            this.nameMappingJson = table.nameMappingJson;
+            this.recordScannedFiles = table.recordScannedFiles;
+            this.maxScannedFileSize = table.maxScannedFileSize;
+        }
+
+        public Builder withSchemaName(String schemaName)
+        {
+            this.schemaName = schemaName;
+            return this;
+        }
+
+        public Builder withTableName(String tableName)
+        {
+            this.tableName = tableName;
+            return this;
+        }
+
+        public Builder withTableType(TableType tableType)
+        {
+            this.tableType = tableType;
+            return this;
+        }
+
+        public Builder withSnapshotId(Optional<Long> snapshotId)
+        {
+            this.snapshotId = snapshotId;
+            return this;
+        }
+
+        public Builder withTableSchemaJson(String tableSchemaJson)
+        {
+            this.tableSchemaJson = tableSchemaJson;
+            return this;
+        }
+
+        public Builder withPartitionSpecJson(Optional<String> partitionSpecJson)
+        {
+            this.partitionSpecJson = partitionSpecJson;
+            return this;
+        }
+
+        public Builder withFormatVersion(int formatVersion)
+        {
+            this.formatVersion = formatVersion;
+            return this;
+        }
+
+        public Builder withTableLocation(String tableLocation)
+        {
+            this.tableLocation = tableLocation;
+            return this;
+        }
+
+        public Builder withStorageProperties(Map<String, String> storageProperties)
+        {
+            this.storageProperties = storageProperties;
+            return this;
+        }
+
+        public Builder withRetryMode(RetryMode retryMode)
+        {
+            this.retryMode = retryMode;
+            return this;
+        }
+
+        public Builder withUpdatedColumns(List<IcebergColumnHandle> updatedColumns)
+        {
+            this.updatedColumns = updatedColumns;
+            return this;
+        }
+
+        public Builder withUnenforcedPredicate(TupleDomain<IcebergColumnHandle> unenforcedPredicate)
+        {
+            this.unenforcedPredicate = unenforcedPredicate;
+            return this;
+        }
+
+        public Builder withEnforcedPredicate(TupleDomain<IcebergColumnHandle> enforcedPredicate)
+        {
+            this.enforcedPredicate = enforcedPredicate;
+            return this;
+        }
+
+        public Builder withProjectedColumns(Set<IcebergColumnHandle> projectedColumns)
+        {
+            this.projectedColumns = projectedColumns;
+            return this;
+        }
+
+        public Builder withNameMappingJson(Optional<String> nameMappingJson)
+        {
+            this.nameMappingJson = nameMappingJson;
+            return this;
+        }
+
+        public Builder withRecordScannedFiles(boolean recordScannedFiles)
+        {
+            this.recordScannedFiles = recordScannedFiles;
+            return this;
+        }
+
+        public Builder withMaxScannedFileSize(Optional<DataSize> maxScannedFileSize)
+        {
+            this.maxScannedFileSize = maxScannedFileSize;
+            return this;
+        }
+
+        public IcebergTableHandle build()
+        {
+            return new IcebergTableHandle(
+                    schemaName,
+                    tableName,
+                    tableType,
+                    snapshotId,
+                    tableSchemaJson,
+                    partitionSpecJson,
+                    formatVersion,
+                    unenforcedPredicate,
+                    enforcedPredicate,
+                    projectedColumns,
+                    nameMappingJson,
+                    tableLocation,
+                    storageProperties,
+                    retryMode,
+                    updatedColumns,
+                    recordScannedFiles,
+                    maxScannedFileSize);
+        }
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -42,7 +42,6 @@ import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.DynamicFilter;
-import io.trino.spi.connector.RetryMode;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.Type;
@@ -179,24 +178,17 @@ public class TestIcebergNodeLocalDynamicSplitPruning
         String tablePath = filePath.substring(0, filePath.lastIndexOf("/"));
         TableHandle tableHandle = new TableHandle(
                 TEST_CATALOG_HANDLE,
-                new IcebergTableHandle(
-                        SCHEMA_NAME,
-                        TABLE_NAME,
-                        TableType.DATA,
-                        Optional.empty(),
-                        SchemaParser.toJson(TABLE_SCHEMA),
-                        Optional.of(PartitionSpecParser.toJson(PartitionSpec.unpartitioned())),
-                        2,
-                        TupleDomain.withColumnDomains(ImmutableMap.of(KEY_ICEBERG_COLUMN_HANDLE, Domain.singleValue(INTEGER, (long) KEY_COLUMN_VALUE))),
-                        TupleDomain.all(),
-                        ImmutableSet.of(KEY_ICEBERG_COLUMN_HANDLE),
-                        Optional.empty(),
-                        tablePath,
-                        ImmutableMap.of(),
-                        RetryMode.NO_RETRIES,
-                        ImmutableList.of(),
-                        false,
-                        Optional.empty()),
+                IcebergTableHandle.builder()
+                        .withSchemaName(SCHEMA_NAME)
+                        .withTableName(TABLE_NAME)
+                        .withTableType(TableType.DATA)
+                        .withTableSchemaJson(SchemaParser.toJson(TABLE_SCHEMA))
+                        .withPartitionSpecJson(Optional.of(PartitionSpecParser.toJson(PartitionSpec.unpartitioned())))
+                        .withFormatVersion(2)
+                        .withUnenforcedPredicate(TupleDomain.withColumnDomains(ImmutableMap.of(KEY_ICEBERG_COLUMN_HANDLE, Domain.singleValue(INTEGER, (long) KEY_COLUMN_VALUE))))
+                        .withProjectedColumns(ImmutableSet.of(KEY_ICEBERG_COLUMN_HANDLE))
+                        .withTableLocation(tablePath)
+                        .build(),
                 transaction);
 
         FileFormatDataSourceStats stats = new FileFormatDataSourceStats();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergProjectionPushdownPlans.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergProjectionPushdownPlans.java
@@ -166,7 +166,9 @@ public class TestIcebergProjectionPushdownPlans
         assertPlan(
                 "SELECT col0.x expr_x, col0.y expr_y FROM " + testTable,
                 any(tableScan(
-                        equalTo(((IcebergTableHandle) tableHandle.get().getConnectorHandle()).withProjectedColumns(Set.of(columnX, columnY))),
+                        equalTo(IcebergTableHandle.buildFrom((IcebergTableHandle) tableHandle.get().getConnectorHandle())
+                                .withProjectedColumns(Set.of(columnX, columnY))
+                                .build()),
                         TupleDomain.all(),
                         ImmutableMap.of("col0#x", equalTo(columnX), "col0#y", equalTo(columnY)))));
 
@@ -232,7 +234,9 @@ public class TestIcebergProjectionPushdownPlans
                                         .right(
                                                 anyTree(
                                                         tableScan(
-                                                                equalTo(((IcebergTableHandle) tableHandle.get().getConnectorHandle()).withProjectedColumns(Set.of(column1Handle))),
+                                                                equalTo(IcebergTableHandle.buildFrom((IcebergTableHandle) tableHandle.get().getConnectorHandle())
+                                                                        .withProjectedColumns(Set.of(column1Handle))
+                                                                        .build()),
                                                                 TupleDomain.all(),
                                                                 ImmutableMap.of("s_expr_1", equalTo(column1Handle)))))))));
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
@@ -60,8 +60,8 @@ import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.memoizeMetastore;
 import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
+import static io.trino.plugin.iceberg.TableType.DATA;
 import static io.trino.spi.connector.Constraint.alwaysTrue;
-import static io.trino.spi.connector.RetryMode.NO_RETRIES;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.tpch.TpchTable.NATION;
@@ -115,24 +115,16 @@ public class TestIcebergSplitSource
         long startMillis = System.currentTimeMillis();
         SchemaTableName schemaTableName = new SchemaTableName("tpch", "nation");
         Table nationTable = catalog.loadTable(SESSION, schemaTableName);
-        IcebergTableHandle tableHandle = new IcebergTableHandle(
-                schemaTableName.getSchemaName(),
-                schemaTableName.getTableName(),
-                TableType.DATA,
-                Optional.empty(),
-                SchemaParser.toJson(nationTable.schema()),
-                Optional.of(PartitionSpecParser.toJson(nationTable.spec())),
-                1,
-                TupleDomain.all(),
-                TupleDomain.all(),
-                ImmutableSet.of(),
-                Optional.empty(),
-                nationTable.location(),
-                nationTable.properties(),
-                NO_RETRIES,
-                ImmutableList.of(),
-                false,
-                Optional.empty());
+        IcebergTableHandle tableHandle = IcebergTableHandle.builder()
+                .withSchemaName(schemaTableName.getSchemaName())
+                .withTableName(schemaTableName.getTableName())
+                .withTableType(DATA)
+                .withTableSchemaJson(SchemaParser.toJson(nationTable.schema()))
+                .withPartitionSpecJson(Optional.of(PartitionSpecParser.toJson(nationTable.spec())))
+                .withFormatVersion(1)
+                .withTableLocation(nationTable.location())
+                .withStorageProperties(nationTable.properties())
+                .build();
 
         try (IcebergSplitSource splitSource = new IcebergSplitSource(
                 HDFS_ENVIRONMENT,


### PR DESCRIPTION
## Description

Add builders to Iceberg and Hive table handles.
Those will also be used outside of Trino.

## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: