### PR TITLE
Fix Iceberg DELETE with struct element partitioning

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -198,6 +198,17 @@ public abstract class BaseIcebergConnectorTest
         }
     }
 
+    @Test
+    public void testDeleteWithStructMemberPartitioning()
+    {
+        String tableName = "test_delete_all_" + randomNameSuffix();
+        assertUpdate(getSession(), "CREATE TABLE %s (parent row(child int))".formatted(tableName));
+        assertUpdate("INSERT INTO %s SELECT row(1)".formatted(tableName), 1);
+        assertUpdate(getSession(), "ALTER TABLE %s SET PROPERTIES partitioning = ARRAY['\"parent.child\"']".formatted(tableName));
+        assertUpdate("DELETE FROM " + tableName, 1);
+        assertUpdate(getSession(), "DROP TABLE " + tableName);
+    }
+
     @Override
     public void testAddAndDropColumnName(String columnName)
     {


### PR DESCRIPTION
This PR fixes a regression in Iceberg DELETE that results from calling IcebergMetadata.getInsertLayout() when creating the MergeAnalysis instance.  The bug is fixed by simply not creating an insert layout if the operation is a DELETE.

HOWEVER, I'm pretty sure that Iceberg still has a problem with UPDATE and MERGE operations with partition columns that are elements of a struct column.  Iceberg experts will need to help.

Fixes #15178 

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
