### PR TITLE
Filter out Iceberg Materialized view from Hive View Tables

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
@@ -157,7 +157,8 @@ public final class ViewReaderUtil
     public static boolean canDecodeView(Table table)
     {
         // we can decode Hive or Presto view
-        return table.getTableType().equals(VIRTUAL_VIEW.name());
+        return table.getTableType().equals(VIRTUAL_VIEW.name()) &&
+                !isTrinoMaterializedView(table.getTableType(), table.getParameters());
     }
 
     public static String encodeViewData(ConnectorViewDefinition definition)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
The Iceberg plugin uses the Hive Utils when using with Iceberg with a hive metastore backed TrinoIcebergCatalog. The implementation to allow IcebergMaterialized views to be used in this implementation requires the putting the flag `ICEBERG_MATERIALIZED_VIEW_COMMENT` into the table comment. Hive metastore tables with this flag cannot be decoded into `ConnectorViewDefinition`s. 


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
