### PR TITLE
Make Compiler cache to soft value reference to reduce metaspace oom

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/gen/ExpressionCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/ExpressionCompiler.java
@@ -67,7 +67,8 @@ public class ExpressionCompiler
         this.pageFunctionCompiler = requireNonNull(pageFunctionCompiler, "pageFunctionCompiler is null");
         this.cursorProcessors = buildNonEvictableCache(CacheBuilder.newBuilder()
                         .recordStats()
-                        .maximumSize(1000),
+                        .maximumSize(1000)
+                        .softValues(),
                 CacheLoader.from(key -> compile(key.getFilter(), key.getProjections(), new CursorProcessorCompiler(functionManager), CursorProcessor.class)));
         this.cacheStatsMBean = new CacheStatsMBean(cursorProcessors);
     }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
@@ -108,14 +108,16 @@ public class JoinCompiler
     private final NonEvictableLoadingCache<CacheKey, LookupSourceSupplierFactory> lookupSourceFactories = buildNonEvictableCache(
             CacheBuilder.newBuilder()
                     .recordStats()
-                    .maximumSize(1000),
+                    .maximumSize(1000)
+                    .softValues(),
             CacheLoader.from(key ->
                     internalCompileLookupSourceFactory(key.getTypes(), key.getOutputChannels(), key.getJoinChannels(), key.getSortChannel())));
 
     private final NonEvictableLoadingCache<CacheKey, Class<? extends PagesHashStrategy>> hashStrategies = buildNonEvictableCache(
             CacheBuilder.newBuilder()
                     .recordStats()
-                    .maximumSize(1000),
+                    .maximumSize(1000)
+                    .softValues(),
             CacheLoader.from(key ->
                     internalCompileHashStrategy(key.getTypes(), key.getOutputChannels(), key.getJoinChannels(), key.getSortChannel())));
 

--- a/core/trino-main/src/main/java/io/trino/sql/gen/JoinFilterFunctionCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/JoinFilterFunctionCompiler.java
@@ -81,7 +81,8 @@ public class JoinFilterFunctionCompiler
         this.joinFilterFunctionFactories = buildNonEvictableCache(
                 CacheBuilder.newBuilder()
                         .recordStats()
-                        .maximumSize(1000),
+                        .maximumSize(1000)
+                        .softValues(),
                 CacheLoader.from(key -> internalCompileFilterFunctionFactory(key.getFilter(), key.getLeftBlocksSize())));
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/gen/OrderingCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/OrderingCompiler.java
@@ -75,13 +75,15 @@ public class OrderingCompiler
     private final NonEvictableLoadingCache<PagesIndexComparatorCacheKey, PagesIndexOrdering> pagesIndexOrderings = buildNonEvictableCache(
             CacheBuilder.newBuilder()
                     .recordStats()
-                    .maximumSize(1000),
+                    .maximumSize(1000)
+                    .softValues(),
             CacheLoader.from(key -> internalCompilePagesIndexOrdering(key.getSortTypes(), key.getSortChannels(), key.getSortOrders())));
 
     private final NonEvictableLoadingCache<PagesIndexComparatorCacheKey, PageWithPositionComparator> pageWithPositionComparators = buildNonEvictableCache(
             CacheBuilder.newBuilder()
                     .recordStats()
-                    .maximumSize(1000),
+                    .maximumSize(1000)
+                    .softValues(),
             CacheLoader.from(key -> internalCompilePageWithPositionComparator(key.getSortTypes(), key.getSortChannels(), key.getSortOrders())));
 
     private final TypeOperators typeOperators;

--- a/core/trino-main/src/main/java/io/trino/sql/gen/PageFunctionCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/PageFunctionCompiler.java
@@ -123,7 +123,8 @@ public class PageFunctionCompiler
             projectionCache = buildNonEvictableCache(
                     CacheBuilder.newBuilder()
                             .recordStats()
-                            .maximumSize(expressionCacheSize),
+                            .maximumSize(expressionCacheSize)
+                            .softValues(),
                     CacheLoader.from(projection -> compileProjectionInternal(projection, Optional.empty())));
             projectionCacheStats = new CacheStatsMBean(projectionCache);
         }
@@ -136,7 +137,8 @@ public class PageFunctionCompiler
             filterCache = buildNonEvictableCache(
                     CacheBuilder.newBuilder()
                             .recordStats()
-                            .maximumSize(expressionCacheSize),
+                            .maximumSize(expressionCacheSize)
+                            .softValues(),
                     CacheLoader.from(filter -> compileFilterInternal(filter, Optional.empty())));
             filterCacheStats = new CacheStatsMBean(filterCache);
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -426,10 +426,12 @@ public class LocalExecutionPlanner
 
     private final NonEvictableCache<FunctionKey, AccumulatorFactory> accumulatorFactoryCache = buildNonEvictableCache(CacheBuilder.newBuilder()
             .maximumSize(1000)
-            .expireAfterWrite(1, HOURS));
+            .expireAfterWrite(1, HOURS)
+            .softValues());
     private final NonEvictableCache<FunctionKey, AggregationWindowFunctionSupplier> aggregationWindowFunctionSupplierCache = buildNonEvictableCache(CacheBuilder.newBuilder()
             .maximumSize(1000)
-            .expireAfterWrite(1, HOURS));
+            .expireAfterWrite(1, HOURS)
+            .softValues());
 
     @Inject
     public LocalExecutionPlanner(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR can reduces metaspace oom issues, make some compiler that use guava cache value from strong reference to soft reference without obvious performance regression under 18,110 production queries.

Fixes #15232 

<img width="579" alt="image" src="https://user-images.githubusercontent.com/6520673/204534131-7521ab33-1bd9-4183-a5e2-c8b463a59565.png">


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
