### PR TITLE
Add support for setting TLS context in MongoDB

### DIFF
--- a/docs/src/main/sphinx/connector/mongodb.rst
+++ b/docs/src/main/sphinx/connector/mongodb.rst
@@ -61,6 +61,10 @@ Property name                              Description
 ``mongodb.connection-timeout``             The socket connect timeout
 ``mongodb.socket-timeout``                 The socket timeout
 ``mongodb.tls.enabled``                    Use TLS/SSL for connections to mongod/mongos
+``mongodb.tls.keystore-path``              Path to the PEM or JKS key store
+``mongodb.tls.truststore-path``            Path to the PEM or JKS trust store
+``mongodb.tls.keystore-password``          Password for the key store
+``mongodb.tls.truststore-password``        Password for the trust store
 ``mongodb.read-preference``                The read preference
 ``mongodb.write-concern``                  The write concern
 ``mongodb.required-replica-set``           The required replica set name
@@ -167,6 +171,34 @@ This property is optional; the default is ``0`` and means no timeout.
 This flag enables TLS connections to MongoDB servers.
 
 This property is optional; the default is ``false``.
+
+``mongodb.tls.keystore-path``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The path to the PEM or JKS key store. This file must be readable by the operating system user running Trino.
+
+This property is optional.
+
+``mongodb.tls.truststore-path``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The path to PEM or JKS trust store. This file must be readable by the operating system user running Trino.
+
+This property is optional.
+
+``mongodb.tls.keystore-password``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The key password for the key store specified by ``mongodb.tls.keystore-path``.
+
+This property is optional.
+
+``mongodb.tls.truststore-password``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The key password for the trust store specified by ``mongodb.tls.truststore-path``.
+
+This property is optional.
 
 ``mongodb.read-preference``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/src/main/sphinx/connector/mongodb.rst
+++ b/docs/src/main/sphinx/connector/mongodb.rst
@@ -60,7 +60,7 @@ Property name                              Description
 ``mongodb.max-connection-idle-time``       The maximum idle time of a pooled connection
 ``mongodb.connection-timeout``             The socket connect timeout
 ``mongodb.socket-timeout``                 The socket timeout
-``mongodb.ssl.enabled``                    Use TLS/SSL for connections to mongod/mongos
+``mongodb.tls.enabled``                    Use TLS/SSL for connections to mongod/mongos
 ``mongodb.read-preference``                The read preference
 ``mongodb.write-concern``                  The write concern
 ``mongodb.required-replica-set``           The required replica set name
@@ -161,10 +161,10 @@ The socket timeout in milliseconds. It is used for I/O socket read and write ope
 
 This property is optional; the default is ``0`` and means no timeout.
 
-``mongodb.ssl.enabled``
+``mongodb.tls.enabled``
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-This flag enables SSL connections to MongoDB servers.
+This flag enables TLS connections to MongoDB servers.
 
 This property is optional; the default is ``false``.
 

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
@@ -20,6 +20,7 @@ import com.mongodb.ServerAddress;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.configuration.DefunctConfig;
+import io.airlift.configuration.LegacyConfig;
 
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Min;
@@ -51,7 +52,7 @@ public class MongoClientConfig
     private int connectionTimeout = 10_000;
     private int socketTimeout;
     private int maxConnectionIdleTime;
-    private boolean sslEnabled;
+    private boolean tlsEnabled;
 
     // query configurations
     private int cursorBatchSize; // use driver default
@@ -310,15 +311,16 @@ public class MongoClientConfig
         return this;
     }
 
-    public boolean getSslEnabled()
+    public boolean getTlsEnabled()
     {
-        return this.sslEnabled;
+        return this.tlsEnabled;
     }
 
-    @Config("mongodb.ssl.enabled")
-    public MongoClientConfig setSslEnabled(boolean sslEnabled)
+    @Config("mongodb.tls.enabled")
+    @LegacyConfig("mongodb.ssl.enabled")
+    public MongoClientConfig setTlsEnabled(boolean tlsEnabled)
     {
-        this.sslEnabled = sslEnabled;
+        this.tlsEnabled = tlsEnabled;
         return this;
     }
 

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
@@ -21,12 +21,14 @@ import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.LegacyConfig;
+import io.airlift.configuration.validation.FileExists;
 
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -53,6 +55,10 @@ public class MongoClientConfig
     private int socketTimeout;
     private int maxConnectionIdleTime;
     private boolean tlsEnabled;
+    private File keystorePath;
+    private String keystorePassword;
+    private File truststorePath;
+    private String truststorePassword;
 
     // query configurations
     private int cursorBatchSize; // use driver default
@@ -70,6 +76,15 @@ public class MongoClientConfig
         }
 
         return seeds.isEmpty() || connectionUrl.isEmpty();
+    }
+
+    @AssertTrue(message = "'mongodb.tls.keystore-path', 'mongodb.tls.keystore-password', 'mongodb.tls.truststore-path' and 'mongodb.tls.truststore-password' must be empty when TLS is disabled")
+    public boolean isValidTlsConfig()
+    {
+        if (!tlsEnabled) {
+            return keystorePath == null && keystorePassword == null && truststorePath == null && truststorePassword == null;
+        }
+        return true;
     }
 
     @NotNull
@@ -321,6 +336,56 @@ public class MongoClientConfig
     public MongoClientConfig setTlsEnabled(boolean tlsEnabled)
     {
         this.tlsEnabled = tlsEnabled;
+        return this;
+    }
+
+    public Optional<@FileExists File> getKeystorePath()
+    {
+        return Optional.ofNullable(keystorePath);
+    }
+
+    @Config("mongodb.tls.keystore-path")
+    public MongoClientConfig setKeystorePath(File keystorePath)
+    {
+        this.keystorePath = keystorePath;
+        return this;
+    }
+
+    public Optional<String> getKeystorePassword()
+    {
+        return Optional.ofNullable(keystorePassword);
+    }
+
+    @Config("mongodb.tls.keystore-password")
+    @ConfigSecuritySensitive
+    public MongoClientConfig setKeystorePassword(String keystorePassword)
+    {
+        this.keystorePassword = keystorePassword;
+        return this;
+    }
+
+    public Optional<@FileExists File> getTruststorePath()
+    {
+        return Optional.ofNullable(truststorePath);
+    }
+
+    @Config("mongodb.tls.truststore-path")
+    public MongoClientConfig setTruststorePath(File truststorePath)
+    {
+        this.truststorePath = truststorePath;
+        return this;
+    }
+
+    public Optional<String> getTruststorePassword()
+    {
+        return Optional.ofNullable(truststorePassword);
+    }
+
+    @Config("mongodb.tls.truststore-password")
+    @ConfigSecuritySensitive
+    public MongoClientConfig setTruststorePassword(String truststorePassword)
+    {
+        this.truststorePassword = truststorePassword;
         return this;
     }
 

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientModule.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientModule.java
@@ -61,7 +61,7 @@ public class MongoClientModule
                 .applyToSocketSettings(builder -> builder
                         .connectTimeout(config.getConnectionTimeout(), MILLISECONDS)
                         .readTimeout(config.getSocketTimeout(), MILLISECONDS))
-                .applyToSslSettings(builder -> builder.enabled(config.getSslEnabled()));
+                .applyToSslSettings(builder -> builder.enabled(config.getTlsEnabled()));
 
         if (config.getRequiredReplicaSetName() != null) {
             options.applyToClusterSettings(builder -> builder.requiredReplicaSetName(config.getRequiredReplicaSetName()));

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientModule.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientModule.java
@@ -22,13 +22,22 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import io.trino.plugin.mongodb.ptf.Query;
+import io.trino.spi.TrinoException;
 import io.trino.spi.ptf.ConnectorTableFunction;
 import io.trino.spi.type.TypeManager;
 
 import javax.inject.Singleton;
+import javax.net.ssl.SSLContext;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Optional;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.trino.plugin.base.ssl.SslUtils.createSSLContext;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class MongoClientModule
@@ -60,11 +69,17 @@ public class MongoClientModule
                         .maxSize(config.getConnectionsPerHost()))
                 .applyToSocketSettings(builder -> builder
                         .connectTimeout(config.getConnectionTimeout(), MILLISECONDS)
-                        .readTimeout(config.getSocketTimeout(), MILLISECONDS))
-                .applyToSslSettings(builder -> builder.enabled(config.getTlsEnabled()));
+                        .readTimeout(config.getSocketTimeout(), MILLISECONDS));
 
         if (config.getRequiredReplicaSetName() != null) {
             options.applyToClusterSettings(builder -> builder.requiredReplicaSetName(config.getRequiredReplicaSetName()));
+        }
+        if (config.getTlsEnabled()) {
+            options.applyToSslSettings(builder -> {
+                builder.enabled(true);
+                buildSslContext(config.getKeystorePath(), config.getKeystorePassword(), config.getTruststorePath(), config.getTruststorePassword())
+                        .ifPresent(builder::context);
+            });
         }
 
         if (config.getConnectionUrl().isPresent()) {
@@ -83,5 +98,24 @@ public class MongoClientModule
                 typeManager,
                 client,
                 config);
+    }
+
+    // TODO https://github.com/trinodb/trino/issues/15247 Add test for x.509 certificates
+    private static Optional<SSLContext> buildSslContext(
+            Optional<File> keystorePath,
+            Optional<String> keystorePassword,
+            Optional<File> truststorePath,
+            Optional<String> truststorePassword)
+    {
+        if (keystorePath.isEmpty() && truststorePath.isEmpty()) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(createSSLContext(keystorePath, keystorePassword, truststorePath, truststorePassword));
+        }
+        catch (GeneralSecurityException | IOException e) {
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, e);
+        }
     }
 }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoClientConfig.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoClientConfig.java
@@ -40,7 +40,7 @@ public class TestMongoClientConfig
                 .setMaxWaitTime(120_000)
                 .setConnectionTimeout(10_000)
                 .setSocketTimeout(0)
-                .setSslEnabled(false)
+                .setTlsEnabled(false)
                 .setMaxConnectionIdleTime(0)
                 .setCursorBatchSize(0)
                 .setReadPreference(ReadPreferenceType.PRIMARY)
@@ -63,7 +63,7 @@ public class TestMongoClientConfig
                 .put("mongodb.max-wait-time", "120001")
                 .put("mongodb.connection-timeout", "9999")
                 .put("mongodb.socket-timeout", "1")
-                .put("mongodb.ssl.enabled", "true")
+                .put("mongodb.tls.enabled", "true")
                 .put("mongodb.max-connection-idle-time", "180000")
                 .put("mongodb.cursor-batch-size", "1")
                 .put("mongodb.read-preference", "NEAREST")
@@ -86,7 +86,7 @@ public class TestMongoClientConfig
                 .setMaxWaitTime(120_001)
                 .setConnectionTimeout(9_999)
                 .setSocketTimeout(1)
-                .setSslEnabled(true)
+                .setTlsEnabled(true)
                 .setMaxConnectionIdleTime(180_000)
                 .setCursorBatchSize(1)
                 .setReadPreference(ReadPreferenceType.NEAREST)
@@ -104,7 +104,7 @@ public class TestMongoClientConfig
         assertEquals(config.getMaxWaitTime(), expected.getMaxWaitTime());
         assertEquals(config.getConnectionTimeout(), expected.getConnectionTimeout());
         assertEquals(config.getSocketTimeout(), expected.getSocketTimeout());
-        assertEquals(config.getSslEnabled(), expected.getSslEnabled());
+        assertEquals(config.getTlsEnabled(), expected.getTlsEnabled());
         assertEquals(config.getMaxConnectionIdleTime(), expected.getMaxConnectionIdleTime());
         assertEquals(config.getCursorBatchSize(), expected.getCursorBatchSize());
         assertEquals(config.getReadPreference(), expected.getReadPreference());

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoPlugin.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoPlugin.java
@@ -18,8 +18,6 @@ import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorFactory;
 import io.trino.spi.type.Type;
 import io.trino.testing.TestingConnectorContext;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -28,33 +26,17 @@ import static org.testng.Assert.assertEquals;
 
 public class TestMongoPlugin
 {
-    private MongoServer server;
-    private String connectionString;
-
-    @BeforeClass
-    public void start()
-    {
-        server = new MongoServer();
-        connectionString = server.getConnectionString().toString();
-    }
-
     @Test
     public void testCreateConnector()
     {
         MongoPlugin plugin = new MongoPlugin();
 
         ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
-        Connector connector = factory.create("test", ImmutableMap.of("mongodb.connection-url", connectionString), new TestingConnectorContext());
+        Connector connector = factory.create("test", ImmutableMap.of("mongodb.connection-url", "mongodb://localhost:27017"), new TestingConnectorContext());
 
         Type type = getOnlyElement(plugin.getTypes());
         assertEquals(type, OBJECT_ID);
 
         connector.shutdown();
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void destroy()
-    {
-        server.close();
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# MongoDB
* Rename config properties from `mongodb.ssl.enabled` to `mongodb.tls.enabled`. ({issue}`15240`)
* Add support for setting file path and password for truststore and keystore. ({issue}`15240`)
```
