### PR TITLE
Optimize reading dictionary encoded parquet columns

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
@@ -142,12 +142,12 @@ public final class ColumnReaderFactory
                 if (timestampType.isShort()) {
                     return new FlatColumnReader<>(
                             field,
-                            (encoding, primitiveField, dictionary) -> getInt96ToShortTimestampDecoder(encoding, primitiveField, dictionary, timeZone),
+                            (encoding, primitiveField) -> getInt96ToShortTimestampDecoder(encoding, primitiveField, timeZone),
                             LONG_ADAPTER);
                 }
                 return new FlatColumnReader<>(
                         field,
-                        (encoding, primitiveField, dictionary) -> getInt96ToLongTimestampDecoder(encoding, primitiveField, dictionary, timeZone),
+                        (encoding, primitiveField) -> getInt96ToLongTimestampDecoder(encoding, primitiveField, timeZone),
                         INT96_ADAPTER);
             }
             if (type instanceof TimestampWithTimeZoneType timestampWithTimeZoneType && primitiveType == INT96) {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/TransformingValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/TransformingValueDecoders.java
@@ -15,13 +15,10 @@ package io.trino.parquet.reader.decoders;
 
 import io.trino.parquet.ParquetEncoding;
 import io.trino.parquet.PrimitiveField;
-import io.trino.parquet.dictionary.Dictionary;
 import io.trino.parquet.reader.SimpleSliceInputStream;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import org.joda.time.DateTimeZone;
-
-import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.parquet.reader.decoders.ValueDecoders.getInt96Decoder;
@@ -50,10 +47,10 @@ public class TransformingValueDecoders
 {
     private TransformingValueDecoders() {}
 
-    public static ValueDecoder<long[]> getTimeMicrosDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<long[]> getTimeMicrosDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         return new InlineTransformDecoder<>(
-                getLongDecoder(encoding, field, dictionary),
+                getLongDecoder(encoding, field),
                 (values, offset, length) -> {
                     for (int i = offset; i < offset + length; i++) {
                         values[i] = values[i] * PICOSECONDS_PER_MICROSECOND;
@@ -61,14 +58,14 @@ public class TransformingValueDecoders
                 });
     }
 
-    public static ValueDecoder<long[]> getInt96ToShortTimestampDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary, DateTimeZone timeZone)
+    public static ValueDecoder<long[]> getInt96ToShortTimestampDecoder(ParquetEncoding encoding, PrimitiveField field, DateTimeZone timeZone)
     {
         checkArgument(
                 field.getType() instanceof TimestampType timestampType && timestampType.isShort(),
                 "Trino type %s is not a short timestamp",
                 field.getType());
         int precision = ((TimestampType) field.getType()).getPrecision();
-        ValueDecoder<Int96Buffer> delegate = getInt96Decoder(encoding, field, dictionary);
+        ValueDecoder<Int96Buffer> delegate = getInt96Decoder(encoding, field);
         return new ValueDecoder<>()
         {
             @Override
@@ -104,7 +101,7 @@ public class TransformingValueDecoders
         };
     }
 
-    public static ValueDecoder<Int96Buffer> getInt96ToLongTimestampDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary, DateTimeZone timeZone)
+    public static ValueDecoder<Int96Buffer> getInt96ToLongTimestampDecoder(ParquetEncoding encoding, PrimitiveField field, DateTimeZone timeZone)
     {
         checkArgument(
                 field.getType() instanceof TimestampType timestampType && !timestampType.isShort(),
@@ -112,7 +109,7 @@ public class TransformingValueDecoders
                 field.getType());
         int precision = ((TimestampType) field.getType()).getPrecision();
         return new InlineTransformDecoder<>(
-                getInt96Decoder(encoding, field, dictionary),
+                getInt96Decoder(encoding, field),
                 (values, offset, length) -> {
                     for (int i = offset; i < offset + length; i++) {
                         long epochSeconds = values.longs[i];
@@ -131,13 +128,13 @@ public class TransformingValueDecoders
                 });
     }
 
-    public static ValueDecoder<long[]> getInt96ToShortTimestampWithTimeZoneDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<long[]> getInt96ToShortTimestampWithTimeZoneDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         checkArgument(
                 field.getType() instanceof TimestampWithTimeZoneType timestampWithTimeZoneType && timestampWithTimeZoneType.isShort(),
                 "Trino type %s is not a short timestamp with timezone",
                 field.getType());
-        ValueDecoder<Int96Buffer> delegate = getInt96Decoder(encoding, field, dictionary);
+        ValueDecoder<Int96Buffer> delegate = getInt96Decoder(encoding, field);
         return new ValueDecoder<>() {
             @Override
             public void init(SimpleSliceInputStream input)
@@ -166,14 +163,14 @@ public class TransformingValueDecoders
         };
     }
 
-    public static ValueDecoder<long[]> getInt64TimestampMillsToShortTimestampDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<long[]> getInt64TimestampMillsToShortTimestampDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         checkArgument(
                 field.getType() instanceof TimestampType timestampType && timestampType.isShort(),
                 "Trino type %s is not a short timestamp",
                 field.getType());
         int precision = ((TimestampType) field.getType()).getPrecision();
-        ValueDecoder<long[]> valueDecoder = getLongDecoder(encoding, field, dictionary);
+        ValueDecoder<long[]> valueDecoder = getLongDecoder(encoding, field);
         if (precision < 3) {
             return new InlineTransformDecoder<>(
                     valueDecoder,
@@ -194,14 +191,14 @@ public class TransformingValueDecoders
                 });
     }
 
-    public static ValueDecoder<long[]> getInt64TimestampMillsToShortTimestampWithTimeZoneDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<long[]> getInt64TimestampMillsToShortTimestampWithTimeZoneDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         checkArgument(
                 field.getType() instanceof TimestampWithTimeZoneType timestampWithTimeZoneType && timestampWithTimeZoneType.isShort(),
                 "Trino type %s is not a short timestamp",
                 field.getType());
         int precision = ((TimestampWithTimeZoneType) field.getType()).getPrecision();
-        ValueDecoder<long[]> valueDecoder = getLongDecoder(encoding, field, dictionary);
+        ValueDecoder<long[]> valueDecoder = getLongDecoder(encoding, field);
         if (precision < 3) {
             return new InlineTransformDecoder<>(
                     valueDecoder,
@@ -222,14 +219,14 @@ public class TransformingValueDecoders
                 });
     }
 
-    public static ValueDecoder<long[]> getInt64TimestampMicrosToShortTimestampDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<long[]> getInt64TimestampMicrosToShortTimestampDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         checkArgument(
                 field.getType() instanceof TimestampType timestampType && timestampType.isShort(),
                 "Trino type %s is not a short timestamp",
                 field.getType());
         int precision = ((TimestampType) field.getType()).getPrecision();
-        ValueDecoder<long[]> valueDecoder = getLongDecoder(encoding, field, dictionary);
+        ValueDecoder<long[]> valueDecoder = getLongDecoder(encoding, field);
         if (precision == 6) {
             return valueDecoder;
         }
@@ -243,7 +240,7 @@ public class TransformingValueDecoders
                 });
     }
 
-    public static ValueDecoder<long[]> getInt64TimestampMicrosToShortTimestampWithTimeZoneDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<long[]> getInt64TimestampMicrosToShortTimestampWithTimeZoneDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         checkArgument(
                 field.getType() instanceof TimestampWithTimeZoneType timestampWithTimeZoneType && timestampWithTimeZoneType.isShort(),
@@ -251,7 +248,7 @@ public class TransformingValueDecoders
                 field.getType());
         int precision = ((TimestampWithTimeZoneType) field.getType()).getPrecision();
         return new InlineTransformDecoder<>(
-                getLongDecoder(encoding, field, dictionary),
+                getLongDecoder(encoding, field),
                 (values, offset, length) -> {
                     // decoded values are epochMicros, round to lower precision and convert to packed millis utc value
                     for (int i = offset; i < offset + length; i++) {
@@ -260,7 +257,7 @@ public class TransformingValueDecoders
                 });
     }
 
-    public static ValueDecoder<long[]> getInt64TimestampNanosToShortTimestampDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<long[]> getInt64TimestampNanosToShortTimestampDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         checkArgument(
                 field.getType() instanceof TimestampType timestampType && timestampType.isShort(),
@@ -268,7 +265,7 @@ public class TransformingValueDecoders
                 field.getType());
         int precision = ((TimestampType) field.getType()).getPrecision();
         return new InlineTransformDecoder<>(
-                getLongDecoder(encoding, field, dictionary),
+                getLongDecoder(encoding, field),
                 (values, offset, length) -> {
                     // decoded values are epochNanos, round to lower precision and convert to epochMicros
                     for (int i = offset; i < offset + length; i++) {
@@ -277,9 +274,9 @@ public class TransformingValueDecoders
                 });
     }
 
-    public static ValueDecoder<Int96Buffer> getInt64TimestampMillisToLongTimestampDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<Int96Buffer> getInt64TimestampMillisToLongTimestampDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
-        ValueDecoder<long[]> delegate = getLongDecoder(encoding, field, dictionary);
+        ValueDecoder<long[]> delegate = getLongDecoder(encoding, field);
         return new ValueDecoder<>()
         {
             @Override
@@ -306,9 +303,9 @@ public class TransformingValueDecoders
         };
     }
 
-    public static ValueDecoder<Int96Buffer> getInt64TimestampMicrosToLongTimestampDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<Int96Buffer> getInt64TimestampMicrosToLongTimestampDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
-        ValueDecoder<long[]> delegate = getLongDecoder(encoding, field, dictionary);
+        ValueDecoder<long[]> delegate = getLongDecoder(encoding, field);
         return new ValueDecoder<>()
         {
             @Override
@@ -332,9 +329,9 @@ public class TransformingValueDecoders
         };
     }
 
-    public static ValueDecoder<Int96Buffer> getInt64TimestampMicrosToLongTimestampWithTimeZoneDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<Int96Buffer> getInt64TimestampMicrosToLongTimestampWithTimeZoneDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
-        ValueDecoder<long[]> delegate = getLongDecoder(encoding, field, dictionary);
+        ValueDecoder<long[]> delegate = getLongDecoder(encoding, field);
         return new ValueDecoder<>()
         {
             @Override
@@ -363,9 +360,9 @@ public class TransformingValueDecoders
         };
     }
 
-    public static ValueDecoder<Int96Buffer> getInt64TimestampNanosToLongTimestampDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<Int96Buffer> getInt64TimestampNanosToLongTimestampDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
-        ValueDecoder<long[]> delegate = getLongDecoder(encoding, field, dictionary);
+        ValueDecoder<long[]> delegate = getLongDecoder(encoding, field);
         return new ValueDecoder<>()
         {
             @Override

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoder.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoder.java
@@ -15,10 +15,7 @@ package io.trino.parquet.reader.decoders;
 
 import io.trino.parquet.ParquetEncoding;
 import io.trino.parquet.PrimitiveField;
-import io.trino.parquet.dictionary.Dictionary;
 import io.trino.parquet.reader.SimpleSliceInputStream;
-
-import javax.annotation.Nullable;
 
 public interface ValueDecoder<T>
 {
@@ -30,6 +27,6 @@ public interface ValueDecoder<T>
 
     interface ValueDecodersProvider<T>
     {
-        ValueDecoder<T> create(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary);
+        ValueDecoder<T> create(ParquetEncoding encoding, PrimitiveField field);
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
@@ -15,7 +15,6 @@ package io.trino.parquet.reader.decoders;
 
 import io.trino.parquet.ParquetEncoding;
 import io.trino.parquet.PrimitiveField;
-import io.trino.parquet.dictionary.Dictionary;
 import io.trino.parquet.reader.flat.BinaryBuffer;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
@@ -23,11 +22,8 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 import org.apache.parquet.column.values.ValuesReader;
 
-import javax.annotation.Nullable;
-
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.trino.parquet.ParquetEncoding.PLAIN_DICTIONARY;
-import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
+import static io.trino.parquet.ParquetEncoding.PLAIN;
 import static io.trino.parquet.ValuesType.VALUES;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.BinaryApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.BooleanApacheParquetValueDecoder;
@@ -45,7 +41,6 @@ import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortA
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortDecimalApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.UuidApacheParquetValueDecoder;
 import static io.trino.parquet.reader.flat.Int96ColumnAdapter.Int96Buffer;
-import static java.util.Objects.requireNonNull;
 
 /**
  * This class provides static API for creating value decoders for given fields and encodings.
@@ -58,143 +53,143 @@ public final class ValueDecoders
 {
     private ValueDecoders() {}
 
-    public static ValueDecoder<long[]> getDoubleDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<long[]> getDoubleDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
-        return switch (encoding) {
-            case PLAIN, PLAIN_DICTIONARY, RLE_DICTIONARY -> new DoubleApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
-            default -> throw wrongEncoding(encoding, field);
-        };
+        if (PLAIN.equals(encoding)) {
+            return new DoubleApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
+        }
+        throw wrongEncoding(encoding, field);
     }
 
-    public static ValueDecoder<int[]> getRealDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<int[]> getRealDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
-        return switch (encoding) {
-            case PLAIN, PLAIN_DICTIONARY, RLE_DICTIONARY -> new FloatApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
-            default -> throw wrongEncoding(encoding, field);
-        };
+        if (PLAIN.equals(encoding)) {
+            return new FloatApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
+        }
+        throw wrongEncoding(encoding, field);
     }
 
-    public static ValueDecoder<long[]> getShortDecimalDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<long[]> getShortDecimalDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         checkArgument(field.getType() instanceof DecimalType, "Trino type %s is not a decimal", field.getType());
         return switch (field.getDescriptor().getPrimitiveType().getPrimitiveTypeName()) {
-            case INT64 -> getLongDecoder(encoding, field, dictionary);
-            case INT32 -> getIntToLongDecoder(encoding, field, dictionary);
-            case FIXED_LEN_BYTE_ARRAY -> getFixedWidthShortDecimalDecoder(encoding, field, dictionary, (DecimalType) field.getType());
+            case INT64 -> getLongDecoder(encoding, field);
+            case INT32 -> getIntToLongDecoder(encoding, field);
+            case FIXED_LEN_BYTE_ARRAY -> getFixedWidthShortDecimalDecoder(encoding, field, (DecimalType) field.getType());
             default -> throw wrongEncoding(encoding, field);
         };
     }
 
-    public static ValueDecoder<long[]> getLongDecimalDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<long[]> getLongDecimalDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         return switch (field.getDescriptor().getPrimitiveType().getPrimitiveTypeName()) {
-            case FIXED_LEN_BYTE_ARRAY -> getFixedWidthLongDecimalDecoder(encoding, field, dictionary);
-            case BINARY -> getBinaryLongDecimalDecoder(encoding, field, dictionary);
+            case FIXED_LEN_BYTE_ARRAY -> getFixedWidthLongDecimalDecoder(encoding, field);
+            case BINARY -> getBinaryLongDecimalDecoder(encoding, field);
             default -> throw wrongEncoding(encoding, field);
         };
     }
 
-    public static ValueDecoder<long[]> getUuidDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<long[]> getUuidDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         return switch (encoding) {
-            case PLAIN, DELTA_BYTE_ARRAY, PLAIN_DICTIONARY, RLE_DICTIONARY ->
-                    new UuidApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
+            case PLAIN, DELTA_BYTE_ARRAY ->
+                    new UuidApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
             default -> throw wrongEncoding(encoding, field);
         };
     }
 
-    public static ValueDecoder<long[]> getLongDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<long[]> getLongDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         return switch (encoding) {
-            case PLAIN, DELTA_BINARY_PACKED, RLE, BIT_PACKED, PLAIN_DICTIONARY, RLE_DICTIONARY ->
-                    new LongApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
+            case PLAIN, DELTA_BINARY_PACKED, RLE, BIT_PACKED ->
+                    new LongApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
             default -> throw wrongEncoding(encoding, field);
         };
     }
 
-    public static ValueDecoder<long[]> getIntToLongDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<long[]> getIntToLongDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         // We need to produce LongArrayBlock from the decoded integers for INT32 backed decimals and bigints
         return switch (encoding) {
-            case PLAIN, DELTA_BINARY_PACKED, RLE, BIT_PACKED, PLAIN_DICTIONARY, RLE_DICTIONARY ->
-                    new IntToLongApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
+            case PLAIN, DELTA_BINARY_PACKED, RLE, BIT_PACKED ->
+                    new IntToLongApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
             default -> throw wrongEncoding(encoding, field);
         };
     }
 
-    public static ValueDecoder<int[]> getIntDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<int[]> getIntDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         return switch (encoding) {
-            case PLAIN, DELTA_BINARY_PACKED, RLE, BIT_PACKED, PLAIN_DICTIONARY, RLE_DICTIONARY ->
-                    new IntApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
+            case PLAIN, DELTA_BINARY_PACKED, RLE, BIT_PACKED ->
+                    new IntApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
             default -> throw wrongEncoding(encoding, field);
         };
     }
 
-    public static ValueDecoder<byte[]> getByteDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<byte[]> getByteDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         return switch (encoding) {
-            case PLAIN, DELTA_BINARY_PACKED, RLE, BIT_PACKED, PLAIN_DICTIONARY, RLE_DICTIONARY ->
-                    new ByteApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
+            case PLAIN, DELTA_BINARY_PACKED, RLE, BIT_PACKED ->
+                    new ByteApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
             default -> throw wrongEncoding(encoding, field);
         };
     }
 
-    public static ValueDecoder<short[]> getShortDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<short[]> getShortDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         return switch (encoding) {
-            case PLAIN, DELTA_BINARY_PACKED, RLE, BIT_PACKED, PLAIN_DICTIONARY, RLE_DICTIONARY ->
-                    new ShortApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
+            case PLAIN, DELTA_BINARY_PACKED, RLE, BIT_PACKED ->
+                    new ShortApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
             default -> throw wrongEncoding(encoding, field);
         };
     }
 
-    public static ValueDecoder<byte[]> getBooleanDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<byte[]> getBooleanDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         return switch (encoding) {
-            case PLAIN, RLE, BIT_PACKED -> new BooleanApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
+            case PLAIN, RLE, BIT_PACKED -> new BooleanApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
             default -> throw wrongEncoding(encoding, field);
         };
     }
 
-    public static ValueDecoder<Int96Buffer> getInt96Decoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<Int96Buffer> getInt96Decoder(ParquetEncoding encoding, PrimitiveField field)
     {
-        return switch (encoding) {
-            case PLAIN, PLAIN_DICTIONARY, RLE_DICTIONARY -> new Int96ApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
-            default -> throw wrongEncoding(encoding, field);
-        };
+        if (PLAIN.equals(encoding)) {
+            return new Int96ApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
+        }
+        throw wrongEncoding(encoding, field);
     }
 
-    private static ValueDecoder<long[]> getFixedWidthShortDecimalDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary, DecimalType decimalType)
+    private static ValueDecoder<long[]> getFixedWidthShortDecimalDecoder(ParquetEncoding encoding, PrimitiveField field, DecimalType decimalType)
     {
         return switch (encoding) {
-            case PLAIN, DELTA_BYTE_ARRAY, PLAIN_DICTIONARY, RLE_DICTIONARY -> new ShortDecimalApacheParquetValueDecoder(
-                    getApacheParquetReader(encoding, field, dictionary),
+            case PLAIN, DELTA_BYTE_ARRAY -> new ShortDecimalApacheParquetValueDecoder(
+                    getApacheParquetReader(encoding, field),
                     decimalType,
                     field.getDescriptor());
             default -> throw wrongEncoding(encoding, field);
         };
     }
 
-    private static ValueDecoder<long[]> getFixedWidthLongDecimalDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    private static ValueDecoder<long[]> getFixedWidthLongDecimalDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         return switch (encoding) {
-            case PLAIN, DELTA_BYTE_ARRAY, PLAIN_DICTIONARY, RLE_DICTIONARY ->
-                    new LongDecimalApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
+            case PLAIN, DELTA_BYTE_ARRAY ->
+                    new LongDecimalApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
             default -> throw wrongEncoding(encoding, field);
         };
     }
 
-    private static ValueDecoder<long[]> getBinaryLongDecimalDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    private static ValueDecoder<long[]> getBinaryLongDecimalDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         return switch (encoding) {
-            case PLAIN, DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY, PLAIN_DICTIONARY, RLE_DICTIONARY ->
-                    new LongDecimalApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
+            case PLAIN, DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY ->
+                    new LongDecimalApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
             default -> throw wrongEncoding(encoding, field);
         };
     }
 
-    public static ValueDecoder<BinaryBuffer> getBoundedVarcharBinaryDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<BinaryBuffer> getBoundedVarcharBinaryDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         Type trinoType = field.getType();
         checkArgument(
@@ -202,13 +197,13 @@ public final class ValueDecoders
                 "Trino type %s is not a bounded varchar",
                 trinoType);
         return switch (encoding) {
-            case PLAIN, DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY, PLAIN_DICTIONARY, RLE_DICTIONARY ->
-                    new BoundedVarcharApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary), (VarcharType) trinoType);
+            case PLAIN, DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY ->
+                    new BoundedVarcharApacheParquetValueDecoder(getApacheParquetReader(encoding, field), (VarcharType) trinoType);
             default -> throw wrongEncoding(encoding, field);
         };
     }
 
-    public static ValueDecoder<BinaryBuffer> getCharBinaryDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<BinaryBuffer> getCharBinaryDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         Type trinoType = field.getType();
         checkArgument(
@@ -216,26 +211,23 @@ public final class ValueDecoders
                 "Trino type %s is not a char",
                 trinoType);
         return switch (encoding) {
-            case PLAIN, DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY, PLAIN_DICTIONARY, RLE_DICTIONARY ->
-                    new CharApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary), (CharType) trinoType);
+            case PLAIN, DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY ->
+                    new CharApacheParquetValueDecoder(getApacheParquetReader(encoding, field), (CharType) trinoType);
             default -> throw wrongEncoding(encoding, field);
         };
     }
 
-    public static ValueDecoder<BinaryBuffer> getBinaryDecoder(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    public static ValueDecoder<BinaryBuffer> getBinaryDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         return switch (encoding) {
-            case PLAIN, DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY, PLAIN_DICTIONARY, RLE_DICTIONARY ->
-                    new BinaryApacheParquetValueDecoder(getApacheParquetReader(encoding, field, dictionary));
+            case PLAIN, DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY ->
+                    new BinaryApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
             default -> throw wrongEncoding(encoding, field);
         };
     }
 
-    private static ValuesReader getApacheParquetReader(ParquetEncoding encoding, PrimitiveField field, @Nullable Dictionary dictionary)
+    private static ValuesReader getApacheParquetReader(ParquetEncoding encoding, PrimitiveField field)
     {
-        if (encoding == RLE_DICTIONARY || encoding == PLAIN_DICTIONARY) {
-            return encoding.getDictionaryBasedValuesReader(field.getDescriptor(), VALUES, requireNonNull(dictionary, "dictionary is null"));
-        }
         return encoding.getValuesReader(field.getDescriptor(), VALUES);
     }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/BinaryBuffer.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/BinaryBuffer.java
@@ -73,6 +73,11 @@ public class BinaryBuffer
         offsets[offset + 1] = offsets[offset] + slice.length();
     }
 
+    public void addChunk(Slice slice)
+    {
+        chunks.add(slice);
+    }
+
     public Slice asSlice()
     {
         if (chunks.size() == 1) {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/BooleanColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/BooleanColumnAdapter.java
@@ -46,4 +46,12 @@ public class BooleanColumnAdapter
     {
         destination[destinationIndex] = source[sourceIndex];
     }
+
+    @Override
+    public void decodeDictionaryIds(byte[] values, int offset, int length, int[] ids, byte[] dictionary)
+    {
+        for (int i = 0; i < length; i++) {
+            values[offset + i] = dictionary[ids[i]];
+        }
+    }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ByteColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ByteColumnAdapter.java
@@ -46,4 +46,12 @@ public class ByteColumnAdapter
     {
         destination[destinationIndex] = source[sourceIndex];
     }
+
+    @Override
+    public void decodeDictionaryIds(byte[] values, int offset, int length, int[] ids, byte[] dictionary)
+    {
+        for (int i = 0; i < length; i++) {
+            values[offset + i] = dictionary[ids[i]];
+        }
+    }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ColumnAdapter.java
@@ -45,4 +45,6 @@ public interface ColumnAdapter<BufferType>
             destOffset++;
         }
     }
+
+    void decodeDictionaryIds(BufferType values, int offset, int length, int[] ids, BufferType dictionary);
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/DictionaryDecoder.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/DictionaryDecoder.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.flat;
+
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import io.trino.parquet.reader.decoders.ValueDecoder;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
+import org.apache.parquet.io.ParquetDecodingException;
+
+import java.io.IOException;
+
+import static java.util.Objects.requireNonNull;
+
+public final class DictionaryDecoder<T>
+        implements ValueDecoder<T>
+{
+    private final T dictionary;
+    private final ColumnAdapter<T> columnAdapter;
+
+    private RunLengthBitPackingHybridDecoder dictionaryIdsReader;
+
+    public DictionaryDecoder(T dictionary, ColumnAdapter<T> columnAdapter)
+    {
+        this.columnAdapter = requireNonNull(columnAdapter, "columnAdapter is null");
+        this.dictionary = requireNonNull(dictionary, "dictionary is null");
+    }
+
+    @Override
+    public void init(SimpleSliceInputStream input)
+    {
+        int bitWidth = input.readByte();
+        this.dictionaryIdsReader = new RunLengthBitPackingHybridDecoder(bitWidth, ByteBufferInputStream.wrap(input.asSlice().toByteBuffer()));
+    }
+
+    @Override
+    public void read(T values, int offset, int length)
+    {
+        int[] ids = new int[length];
+        try {
+            for (int i = 0; i < length; i++) {
+                ids[i] = dictionaryIdsReader.readInt();
+            }
+        }
+        catch (IOException e) {
+            throw new ParquetDecodingException(e);
+        }
+        columnAdapter.decodeDictionaryIds(values, offset, length, ids, dictionary);
+    }
+
+    @Override
+    public void skip(int n)
+    {
+        try {
+            for (int i = 0; i < n; i++) {
+                dictionaryIdsReader.readInt();
+            }
+        }
+        catch (IOException e) {
+            throw new ParquetDecodingException(e);
+        }
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/Int128ColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/Int128ColumnAdapter.java
@@ -47,4 +47,15 @@ public class Int128ColumnAdapter
         destination[destinationIndex * 2] = source[sourceIndex * 2];
         destination[(destinationIndex * 2) + 1] = source[(sourceIndex * 2) + 1];
     }
+
+    @Override
+    public void decodeDictionaryIds(long[] values, int offset, int length, int[] ids, long[] dictionary)
+    {
+        for (int i = 0; i < length; i++) {
+            int id = 2 * ids[i];
+            int destinationIndex = 2 * (offset + i);
+            values[destinationIndex] = dictionary[id];
+            values[destinationIndex + 1] = dictionary[id + 1];
+        }
+    }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/Int96ColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/Int96ColumnAdapter.java
@@ -48,6 +48,15 @@ public class Int96ColumnAdapter
         return new Int96ArrayBlock(values.size(), Optional.empty(), values.longs, values.ints);
     }
 
+    @Override
+    public void decodeDictionaryIds(Int96Buffer values, int offset, int length, int[] ids, Int96Buffer dictionary)
+    {
+        for (int i = 0; i < length; i++) {
+            values.longs[offset + i] = dictionary.longs[ids[i]];
+            values.ints[offset + i] = dictionary.ints[ids[i]];
+        }
+    }
+
     public static class Int96Buffer
     {
         public final long[] longs;

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/IntColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/IntColumnAdapter.java
@@ -46,4 +46,12 @@ public class IntColumnAdapter
     {
         destination[destinationIndex] = source[sourceIndex];
     }
+
+    @Override
+    public void decodeDictionaryIds(int[] values, int offset, int length, int[] ids, int[] dictionary)
+    {
+        for (int i = 0; i < length; i++) {
+            values[offset + i] = dictionary[ids[i]];
+        }
+    }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/LongColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/LongColumnAdapter.java
@@ -46,4 +46,12 @@ public class LongColumnAdapter
     {
         destination[destinationIndex] = source[sourceIndex];
     }
+
+    @Override
+    public void decodeDictionaryIds(long[] values, int offset, int length, int[] ids, long[] dictionary)
+    {
+        for (int i = 0; i < length; i++) {
+            values[offset + i] = dictionary[ids[i]];
+        }
+    }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ShortColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ShortColumnAdapter.java
@@ -46,4 +46,12 @@ public class ShortColumnAdapter
     {
         destination[destinationIndex] = source[sourceIndex];
     }
+
+    @Override
+    public void decodeDictionaryIds(short[] values, int offset, int length, int[] ids, short[] dictionary)
+    {
+        for (int i = 0; i < length; i++) {
+            values[offset + i] = dictionary[ids[i]];
+        }
+    }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestTimestamp.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestTimestamp.java
@@ -40,7 +40,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.cycle;
+import static com.google.common.collect.Iterables.limit;
+import static com.google.common.collect.Iterables.transform;
 import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.plugin.hive.HiveTestUtils.getHiveSession;
@@ -51,6 +53,7 @@ import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
 import static io.trino.testing.DataProviders.toDataProvider;
 import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardStructObjectInspector;
 import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaLongObjectInspector;
@@ -79,18 +82,33 @@ public class TestTimestamp
             case NANOSECONDS -> "TIMESTAMP(NANOS,true)";
         };
         MessageType parquetSchema = parseMessageType("message hive_timestamp { optional int64 test (" + logicalAnnotation + "); }");
-        List<Long> writeValues = ContiguousSet.create(Range.closedOpen((long) -1_000, (long) 1_000), DiscreteDomain.longs()).stream()
-                .collect(toImmutableList());
-        List<SqlTimestamp> timestampReadValues = writeValues.stream()
-                .map(value -> switch (timestamp) {
-                    case MILLISECONDS -> SqlTimestamp.fromMillis(timestamp.getPrecision(), value);
-                    case MICROSECONDS -> SqlTimestamp.newInstance(timestamp.getPrecision(), value, 0);
-                    case NANOSECONDS -> SqlTimestamp.newInstance(
-                            timestamp.getPrecision(),
-                            floorDiv(value, NANOSECONDS_PER_MICROSECOND),
-                            floorMod(value, NANOSECONDS_PER_MICROSECOND) * PICOSECONDS_PER_NANOSECOND);
-                })
-                .collect(toImmutableList());
+
+        Iterable<Long> writeNullableDictionaryValues = limit(cycle(asList(1L, null, 3L, 5L, null, null, null, 7L, 11L, null, 13L, 17L)), 30_000);
+        testRoundTrip(parquetSchema, writeNullableDictionaryValues, timestamp);
+
+        Iterable<Long> writeDictionaryValues = limit(cycle(asList(1L, 3L, 5L, 7L, 11L, 13L, 17L)), 30_000);
+        testRoundTrip(parquetSchema, writeDictionaryValues, timestamp);
+
+        Iterable<Long> writeValues = ContiguousSet.create(Range.closedOpen((long) -1_000, (long) 1_000), DiscreteDomain.longs());
+        testRoundTrip(parquetSchema, writeValues, timestamp);
+    }
+
+    private static void testRoundTrip(MessageType parquetSchema, Iterable<Long> writeValues, HiveTimestampPrecision timestamp)
+            throws Exception
+    {
+        Iterable<SqlTimestamp> timestampReadValues = transform(writeValues, value -> {
+            if (value == null) {
+                return null;
+            }
+            return switch (timestamp) {
+                case MILLISECONDS -> SqlTimestamp.fromMillis(timestamp.getPrecision(), value);
+                case MICROSECONDS -> SqlTimestamp.newInstance(timestamp.getPrecision(), value, 0);
+                case NANOSECONDS -> SqlTimestamp.newInstance(
+                        timestamp.getPrecision(),
+                        floorDiv(value, NANOSECONDS_PER_MICROSECOND),
+                        floorMod(value, NANOSECONDS_PER_MICROSECOND) * PICOSECONDS_PER_NANOSECOND);
+            };
+        });
 
         List<ObjectInspector> objectInspectors = singletonList(javaLongObjectInspector);
         List<String> columnNames = ImmutableList.of("test");
@@ -120,7 +138,7 @@ public class TestTimestamp
         }
     }
 
-    private static void testReadingAs(Type type, ConnectorSession session, ParquetTester.TempFile tempFile, List<String> columnNames, List<?> expectedValues)
+    private static void testReadingAs(Type type, ConnectorSession session, ParquetTester.TempFile tempFile, List<String> columnNames, Iterable<?> expectedValues)
              throws IOException
     {
         Iterator<?> expected = expectedValues.iterator();


### PR DESCRIPTION
## Description

Uses batched decoders to resolve dictionary ids into actual values instead of going through `Dictionary#decodeXXX` methods

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
