### PR TITLE
Allow Hive connector to read files from public S3 buckets

### DIFF
--- a/docs/src/main/sphinx/connector/hive-s3.rst
+++ b/docs/src/main/sphinx/connector/hive-s3.rst
@@ -113,6 +113,8 @@ S3 configuration properties
     * - ``hive.s3.sts.region``
       - Optional override for the sts region given that IAM role based
         authentication via sts is used.
+    * - ``hive.s3.anonymous-requests.enabled``
+      - Access a public S3 bucket anonymously, rather than authenticating.
 
 .. _hive-s3-credentials:
 
@@ -146,6 +148,40 @@ as arguments. A custom credentials provider can be used to provide
 temporary credentials from STS (using ``STSSessionCredentialsProvider``),
 IAM role-based credentials (using ``STSAssumeRoleSessionCredentialsProvider``),
 or credentials for a specific use case (e.g., bucket/user specific credentials).
+
+Anonymous Access to Public S3 Buckets
+-------------------------------------
+
+You can configure the Hive connector to access a public S3 bucket by setting
+``hive.s3.anonymous-requests.enabled`` to ``true``. Note that the bucket
+policy must allow anonymous listing of the bucket contents and reading of
+objects within the bucket. For example:
+
+.. code-block:: json
+
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AllowPublicListObjectsInBucket",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "*"
+                },
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::abc"
+            },
+            {
+                "Sid": "AllowPublicGetObject",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "*"
+                },
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::abc/*"
+            }
+        ]
+    }
 
 
 .. _hive-s3-security-mapping:

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/HiveS3Config.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/HiveS3Config.java
@@ -81,6 +81,7 @@ public class HiveS3Config
     private boolean s3preemptiveBasicProxyAuth;
     private String s3StsEndpoint;
     private String s3StsRegion;
+    private boolean anonymousRequestsEnabled;
 
     public String getS3AwsAccessKey()
     {
@@ -624,6 +625,18 @@ public class HiveS3Config
     public HiveS3Config setS3StsRegion(String s3StsRegion)
     {
         this.s3StsRegion = s3StsRegion;
+        return this;
+    }
+
+    public boolean isAnonymousRequestsEnabled()
+    {
+        return anonymousRequestsEnabled;
+    }
+
+    @Config("hive.s3.anonymous-requests.enabled")
+    public HiveS3Config setAnonymousRequestsEnabled(boolean anonymousRequestsEnabled)
+    {
+        this.anonymousRequestsEnabled = anonymousRequestsEnabled;
         return this;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3ConfigurationInitializer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3ConfigurationInitializer.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_ACCESS_KEY;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_ACL_TYPE;
+import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_ANONYMOUS_REQUESTS_ENABLED;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_CONNECT_TIMEOUT;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_ENCRYPTION_MATERIALS_PROVIDER;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_ENDPOINT;
@@ -112,6 +113,7 @@ public class TrinoS3ConfigurationInitializer
     private final boolean s3preemptiveBasicProxyAuth;
     private final String s3StsEndpoint;
     private final String s3StsRegion;
+    private final boolean anonymousRequestsEnabled;
 
     @Inject
     public TrinoS3ConfigurationInitializer(HiveS3Config config)
@@ -158,6 +160,7 @@ public class TrinoS3ConfigurationInitializer
         this.s3preemptiveBasicProxyAuth = config.getS3PreemptiveBasicProxyAuth();
         this.s3StsEndpoint = config.getS3StsEndpoint();
         this.s3StsRegion = config.getS3StsRegion();
+        this.anonymousRequestsEnabled = config.isAnonymousRequestsEnabled();
     }
 
     @Override
@@ -248,5 +251,6 @@ public class TrinoS3ConfigurationInitializer
         if (s3StsRegion != null) {
             config.set(S3_STS_REGION, s3StsRegion);
         }
+        config.setBoolean(S3_ANONYMOUS_REQUESTS_ENABLED, anonymousRequestsEnabled);
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestHiveS3Config.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestHiveS3Config.java
@@ -79,7 +79,8 @@ public class TestHiveS3Config
                 .setS3ProxyPassword(null)
                 .setS3PreemptiveBasicProxyAuth(false)
                 .setS3StsEndpoint(null)
-                .setS3StsRegion(null));
+                .setS3StsRegion(null)
+                .setAnonymousRequestsEnabled(false));
     }
 
     @Test
@@ -131,6 +132,7 @@ public class TestHiveS3Config
                 .put("hive.s3.proxy.preemptive-basic-auth", "true")
                 .put("hive.s3.sts.endpoint", "http://minio:9000")
                 .put("hive.s3.sts.region", "eu-central-1")
+                .put("hive.s3.anonymous-requests.enabled", "true")
                 .buildOrThrow();
 
         HiveS3Config expected = new HiveS3Config()
@@ -175,7 +177,8 @@ public class TestHiveS3Config
                 .setS3ProxyPassword("test")
                 .setS3PreemptiveBasicProxyAuth(true)
                 .setS3StsEndpoint("http://minio:9000")
-                .setS3StsRegion("eu-central-1");
+                .setS3StsRegion("eu-central-1")
+                .setAnonymousRequestsEnabled(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description

Allow Hive connector to read files from public S3 buckets. Fixes #6127

Adds boolean connector property `hive.s3.anonymous-requests.enabled` to access a public bucket (no AWS access key or secret key is required).

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context

Before this change, attempts to access a public S3 bucket fail with `AccessDeniedException`. Now, when `hive.s3.anonymous-requests.enabled` is set to `true`, `TrinoS3FileSystem` creates the appropriate `AWSCredentialsProvider` to access the public bucket anonymously.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

Allow Hive connector to read data from public S3 buckets via a new `hive.s3.anonymous-requests.enabled` connector property. (#6127)

## Acknowledgements

Many thanks to @tooptoop4 for the bulk of the work. I just rebased their changes and added tests and docs.