### PR TITLE
Avoid String.format usages in hot paths

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timetz/TimeWithTimeZoneToTimestampWithTimeZoneCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timetz/TimeWithTimeZoneToTimestampWithTimeZoneCast.java
@@ -51,9 +51,10 @@ public final class TimeWithTimeZoneToTimestampWithTimeZoneCast
     {
         // source precision <= 9
         // target precision <= 3
-        long picos = normalizeAndRound(targetPrecision, rescale(unpackTimeNanos(packedTime), 9, 12), unpackOffsetMinutes(packedTime));
+        int offsetMinutes = unpackOffsetMinutes(packedTime);
+        long picos = normalizeAndRound(targetPrecision, rescale(unpackTimeNanos(packedTime), 9, 12), offsetMinutes);
 
-        return packDateTimeWithZone(calculateEpochMillis(session, picos), getTimeZoneKeyForOffset(unpackOffsetMinutes(packedTime)));
+        return packDateTimeWithZone(calculateEpochMillis(session, picos), getTimeZoneKeyForOffset(offsetMinutes));
     }
 
     @LiteralParameters({"sourcePrecision", "targetPrecision"})
@@ -79,12 +80,13 @@ public final class TimeWithTimeZoneToTimestampWithTimeZoneCast
     {
         // source precision <= 9
         // target precision > 3
-        long picos = normalizeAndRound(targetPrecision, rescale(unpackTimeNanos(packedTime), 9, 12), unpackOffsetMinutes(packedTime));
+        int offsetMinutes = unpackOffsetMinutes(packedTime);
+        long picos = normalizeAndRound(targetPrecision, rescale(unpackTimeNanos(packedTime), 9, 12), offsetMinutes);
 
         return LongTimestampWithTimeZone.fromEpochMillisAndFraction(
                 calculateEpochMillis(session, picos),
                 (int) (picos % PICOSECONDS_PER_MILLISECOND),
-                getTimeZoneKeyForOffset(unpackOffsetMinutes(packedTime)));
+                getTimeZoneKeyForOffset(offsetMinutes));
     }
 
     @LiteralParameters({"sourcePrecision", "targetPrecision"})

--- a/core/trino-main/src/main/java/io/trino/type/ColorType.java
+++ b/core/trino-main/src/main/java/io/trino/type/ColorType.java
@@ -19,11 +19,12 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.AbstractIntType;
 import io.trino.spi.type.TypeSignature;
 
-import static java.lang.String.format;
+import java.util.HexFormat;
 
 public class ColorType
         extends AbstractIntType
 {
+    private static final HexFormat HEX_FORMAT = HexFormat.of();
     public static final ColorType COLOR = new ColorType();
     public static final String NAME = "color";
 
@@ -50,10 +51,11 @@ public class ColorType
             return ColorFunctions.SystemColor.valueOf(-(color + 1)).getName();
         }
 
-        return format("#%02x%02x%02x",
-                (color >> 16) & 0xFF,
-                (color >> 8) & 0xFF,
-                color & 0xFF);
+        StringBuilder builder = new StringBuilder(7).append('#');
+        HEX_FORMAT.toHexDigits(builder, (byte) ((color >> 16) & 0xFF));
+        HEX_FORMAT.toHexDigits(builder, (byte) ((color >> 8) & 0xFF));
+        HEX_FORMAT.toHexDigits(builder, (byte) (color & 0xFF));
+        return builder.toString();
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/BenchmarkCastTimestampToVarchar.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/BenchmarkCastTimestampToVarchar.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar.timestamp;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.execution.buffer.BenchmarkDataGenerator;
+import io.trino.memory.context.LocalMemoryContext;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.DriverYieldSignal;
+import io.trino.operator.project.PageProcessor;
+import io.trino.operator.scalar.timestamptz.TimestampWithTimeZoneToTimestampWithTimeZoneCast;
+import io.trino.operator.scalar.timetz.TimeWithTimeZoneToTimeWithTimeZoneCast;
+import io.trino.spi.Page;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.LongTimeWithTimeZone;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.LongTimestampWithTimeZone;
+import io.trino.spi.type.SqlTime;
+import io.trino.spi.type.TimeType;
+import io.trino.spi.type.TimeWithTimeZoneType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+import io.trino.sql.relational.CallExpression;
+import io.trino.sql.relational.RowExpression;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_DAY;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
+import static io.trino.sql.relational.Expressions.field;
+import static io.trino.testing.TestingConnectorSession.SESSION;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.openjdk.jmh.annotations.Mode.Throughput;
+import static org.openjdk.jmh.annotations.Scope.Thread;
+
+@State(Thread)
+@OutputTimeUnit(SECONDS)
+@BenchmarkMode(Throughput)
+@Fork(1)
+@Warmup(iterations = 5, time = 1, timeUnit = SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = SECONDS)
+public class BenchmarkCastTimestampToVarchar
+{
+    private static final int POSITIONS_PER_PAGE = 1024;
+
+    @Benchmark
+    public List<Optional<Page>> benchmarkCastToVarchar(BenchmarkData data)
+    {
+        return ImmutableList.copyOf(data.pageProcessor.process(SESSION, data.yieldSignal, data.localMemoryContext, data.page));
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        @Param({"TIME", "TIME_WITH_TIME_ZONE", "TIMESTAMP", "TIMESTAMP_WITH_TIME_ZONE"})
+        private String type;
+        @Param({"0", "3", "12"})
+        private int precision;
+        private Random random;
+
+        private DriverYieldSignal yieldSignal;
+        private LocalMemoryContext localMemoryContext;
+        private PageProcessor pageProcessor;
+        private Page page;
+
+        @Setup
+        public void setup()
+        {
+            random = new Random(0);
+            yieldSignal = new DriverYieldSignal();
+            localMemoryContext = newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName());
+
+            Type sourceType;
+            switch (type) {
+                case "TIME":
+                    TimeType timeType = TimeType.createTimeType(precision);
+                    sourceType = timeType;
+                    page = createTimePage(random, timeType);
+                    break;
+                case "TIME_WITH_TIME_ZONE":
+                    TimeWithTimeZoneType timeTzType = TimeWithTimeZoneType.createTimeWithTimeZoneType(precision);
+                    sourceType = timeTzType;
+                    page = createTimeTzPage(random, timeTzType);
+                    break;
+                case "TIMESTAMP":
+                    TimestampType timestampType = TimestampType.createTimestampType(precision);
+                    sourceType = timestampType;
+                    page = createTimestampPage(random, timestampType);
+                    break;
+                case "TIMESTAMP_WITH_TIME_ZONE":
+                    TimestampWithTimeZoneType timestampTzType = TimestampWithTimeZoneType.createTimestampWithTimeZoneType(precision);
+                    sourceType = timestampTzType;
+                    page = createTimestampTzPage(random, timestampTzType);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unsupported type: " + type);
+            }
+
+            TestingFunctionResolution functionResolution = new TestingFunctionResolution();
+            List<RowExpression> timestampProjections = ImmutableList.of(new CallExpression(
+                    functionResolution.getCoercion(sourceType, VarcharType.createUnboundedVarcharType()),
+                    ImmutableList.of(field(0, sourceType))));
+            pageProcessor = functionResolution.getExpressionCompiler()
+                    .compilePageProcessor(Optional.empty(), timestampProjections)
+                    .get();
+        }
+
+        private static Page createTimePage(Random random, TimeType timeType)
+        {
+            BlockBuilder builder = timeType.createBlockBuilder(null, POSITIONS_PER_PAGE);
+            for (int i = 0; i < POSITIONS_PER_PAGE; i++) {
+                timeType.writeLong(builder, SqlTime.newInstance(12, random.nextLong(PICOSECONDS_PER_DAY)).roundTo(timeType.getPrecision()).getPicos());
+            }
+            return new Page(builder.build());
+        }
+
+        private static Page createTimeTzPage(Random random, TimeWithTimeZoneType timeTzType)
+        {
+            BlockBuilder builder = timeTzType.createBlockBuilder(null, POSITIONS_PER_PAGE);
+            for (int i = 0; i < POSITIONS_PER_PAGE; i++) {
+                LongTimeWithTimeZone value = new LongTimeWithTimeZone(random.nextLong(PICOSECONDS_PER_DAY), 0);
+                if (timeTzType.isShort()) {
+                    timeTzType.writeLong(builder, TimeWithTimeZoneToTimeWithTimeZoneCast.longToShort(timeTzType.getPrecision(), value));
+                }
+                else {
+                    timeTzType.writeObject(builder, TimeWithTimeZoneToTimeWithTimeZoneCast.longToLong(timeTzType.getPrecision(), value));
+                }
+            }
+            return new Page(builder.build());
+        }
+
+        private static Page createTimestampPage(Random random, TimestampType timestampType)
+        {
+            BlockBuilder builder = timestampType.createBlockBuilder(null, POSITIONS_PER_PAGE);
+            for (int i = 0; i < POSITIONS_PER_PAGE; i++) {
+                LongTimestamp value = BenchmarkDataGenerator.randomTimestamp(random);
+                if (timestampType.isShort()) {
+                    timestampType.writeLong(builder, TimestampToTimestampCast.longToShort(timestampType.getPrecision(), value));
+                }
+                else {
+                    timestampType.writeObject(builder, TimestampToTimestampCast.longToLong(timestampType.getPrecision(), value));
+                }
+            }
+            return new Page(builder.build());
+        }
+
+        private static Page createTimestampTzPage(Random random, TimestampWithTimeZoneType timestampTzType)
+        {
+            BlockBuilder builder = timestampTzType.createBlockBuilder(null, POSITIONS_PER_PAGE);
+            for (int i = 0; i < POSITIONS_PER_PAGE; i++) {
+                long epochMillis = random.nextLong(1L << 11); // must stay within bounds of what short timestamps with time zones can support
+                int picosFraction = random.nextInt(PICOSECONDS_PER_MILLISECOND);
+                LongTimestampWithTimeZone value = LongTimestampWithTimeZone.fromEpochMillisAndFraction(epochMillis, picosFraction, UTC_KEY);
+                if (timestampTzType.isShort()) {
+                    timestampTzType.writeLong(builder, TimestampWithTimeZoneToTimestampWithTimeZoneCast.longToShort(timestampTzType.getPrecision(), value));
+                }
+                else {
+                    timestampTzType.writeObject(builder, TimestampWithTimeZoneToTimestampWithTimeZoneCast.longToLong(timestampTzType.getPrecision(), value));
+                }
+            }
+            return new Page(builder.build());
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/type/TestColorType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestColorType.java
@@ -15,9 +15,12 @@ package io.trino.type;
 
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import org.testng.annotations.Test;
 
 import static io.trino.operator.scalar.ColorFunctions.rgb;
 import static io.trino.type.ColorType.COLOR;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
 
 public class TestColorType
         extends AbstractTestType
@@ -25,6 +28,28 @@ public class TestColorType
     public TestColorType()
     {
         super(COLOR, String.class, createTestBlock());
+    }
+
+    @Test
+    public void testGetObjectValue()
+    {
+        int[] valuesOfInterest = new int[]{0, 1, 15, 16, 127, 128, 255};
+        BlockBuilder builder = COLOR.createFixedSizeBlockBuilder(valuesOfInterest.length * valuesOfInterest.length * valuesOfInterest.length);
+        for (int r : valuesOfInterest) {
+            for (int g : valuesOfInterest) {
+                for (int b : valuesOfInterest) {
+                    COLOR.writeLong(builder, rgb(r, g, b));
+                }
+            }
+        }
+
+        Block block = builder.build();
+        for (int position = 0; position < block.getPositionCount(); position++) {
+            int value = block.getInt(position, 0);
+            assertEquals(
+                    COLOR.getObjectValue(null, block, position),
+                    format("#%02x%02x%02x", (value >> 16) & 0xFF, (value >> 8) & 0xFF, value & 0xFF));
+        }
     }
 
     public static Block createTestBlock()

--- a/core/trino-spi/src/main/java/io/trino/spi/type/SqlTime.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/SqlTime.java
@@ -89,18 +89,33 @@ public final class SqlTime
     @Override
     public String toString()
     {
-        StringBuilder builder = new StringBuilder();
-        builder.append(format(
-                "%02d:%02d:%02d",
-                picos / PICOSECONDS_PER_HOUR,
-                (picos / PICOSECONDS_PER_MINUTE) % MINUTES_PER_HOUR,
-                (picos / PICOSECONDS_PER_SECOND) % SECONDS_PER_MINUTE));
+        StringBuilder builder = new StringBuilder(8 + (precision == 0 ? 0 : 1 + precision));
+        appendTwoDigits((int) (picos / PICOSECONDS_PER_HOUR), builder);
+        builder.append(':');
+        appendTwoDigits((int) ((picos / PICOSECONDS_PER_MINUTE) % MINUTES_PER_HOUR), builder);
+        builder.append(':');
+        appendTwoDigits((int) ((picos / PICOSECONDS_PER_SECOND) % SECONDS_PER_MINUTE), builder);
 
         if (precision > 0) {
             long scaledFraction = (picos % PICOSECONDS_PER_SECOND) / POWERS_OF_TEN[MAX_PRECISION - precision];
-            builder.append(".");
-            builder.append(format("%0" + precision + "d", scaledFraction));
+            builder.append('.');
+            builder.setLength(builder.length() + precision);
+
+            for (int index = builder.length() - 1; index > 8; index--) {
+                long temp = scaledFraction / 10;
+                int digit = (int) (scaledFraction - (temp * 10));
+                scaledFraction = temp;
+                builder.setCharAt(index, (char) ('0' + digit));
+            }
         }
         return builder.toString();
+    }
+
+    private static void appendTwoDigits(int value, StringBuilder builder)
+    {
+        if (value < 10) {
+            builder.append('0');
+        }
+        builder.append(value);
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/SqlTimeWithTimeZone.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/SqlTimeWithTimeZone.java
@@ -103,20 +103,38 @@ public final class SqlTimeWithTimeZone
     @Override
     public String toString()
     {
-        StringBuilder builder = new StringBuilder();
-        builder.append(format(
-                "%02d:%02d:%02d",
-                picos / PICOSECONDS_PER_HOUR,
-                (picos / PICOSECONDS_PER_MINUTE) % MINUTES_PER_HOUR,
-                (picos / PICOSECONDS_PER_SECOND) % SECONDS_PER_MINUTE));
+        StringBuilder builder = new StringBuilder(14 + (precision == 0 ? 0 : 1 + precision));
+        appendTwoDigits((int) (picos / PICOSECONDS_PER_HOUR), builder);
+        builder.append(':');
+        appendTwoDigits((int) ((picos / PICOSECONDS_PER_MINUTE) % MINUTES_PER_HOUR), builder);
+        builder.append(':');
+        appendTwoDigits((int) ((picos / PICOSECONDS_PER_SECOND) % SECONDS_PER_MINUTE), builder);
 
         if (precision > 0) {
             long scaledFraction = (picos % PICOSECONDS_PER_SECOND) / POWERS_OF_TEN[MAX_PRECISION - precision];
-            builder.append(".");
-            builder.append(format("%0" + precision + "d", scaledFraction));
+            builder.append('.');
+            builder.setLength(builder.length() + precision);
+
+            for (int index = builder.length() - 1; index > 8; index--) {
+                long temp = scaledFraction / 10;
+                int digit = (int) (scaledFraction - (temp * 10));
+                scaledFraction = temp;
+                builder.setCharAt(index, (char) ('0' + digit));
+            }
         }
-        builder.append(format("%s%02d:%02d", offsetMinutes >= 0 ? '+' : '-', abs(offsetMinutes / 60), abs(offsetMinutes % 60)));
+        builder.append(offsetMinutes >= 0 ? '+' : '-');
+        appendTwoDigits(abs(offsetMinutes / 60), builder);
+        builder.append(':');
+        appendTwoDigits(abs(offsetMinutes % 60), builder);
 
         return builder.toString();
+    }
+
+    private static void appendTwoDigits(int value, StringBuilder builder)
+    {
+        if (value < 10) {
+            builder.append('0');
+        }
+        builder.append(value);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
@@ -242,7 +242,7 @@ public final class ViewReaderUtil
 
         // Calcite does not provide correct type strings for non-primitive types.
         // We add custom code here to make it work. Goal is for calcite/coral to handle this
-        private String getTypeString(RelDataType type)
+        private static String getTypeString(RelDataType type)
         {
             switch (type.getSqlTypeName()) {
                 case ROW: {
@@ -264,13 +264,13 @@ public final class ViewReaderUtil
                 case MAP: {
                     RelDataType keyType = type.getKeyType();
                     RelDataType valueType = type.getValueType();
-                    return format("map(%s,%s)", getTypeString(keyType), getTypeString(valueType));
+                    return "map(" + getTypeString(keyType) + "," + getTypeString(valueType) + ")";
                 }
                 case ARRAY: {
-                    return format("array(%s)", getTypeString(type.getComponentType()));
+                    return "array(" + getTypeString(type.getComponentType()) + ")";
                 }
                 case DECIMAL: {
-                    return format("decimal(%s,%s)", type.getPrecision(), type.getScale());
+                    return "decimal(" + type.getPrecision() + "," + type.getScale() + ")";
                 }
                 default:
                     return type.getSqlTypeName().toString();


### PR DESCRIPTION
## Description
Replaces usages of `String.format` in expected codepaths to improve performance. In particular `time` / `timestamp` related JSON serializers and casts to `varchar` improve dramatically with `timestamp(3)` casting throughput improving 2x, `time(3)` improving more than 30x, and `time with time zone(3)` improving ~40x (benchmark results: [jmh.morethan.io](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/pettyjamesm/706f34955e580d054606741ad41d3e3c/raw/2a905702d120ddb0a5b4ba58f28cfc60721b60fc/baseline-full.json,https://gist.githubusercontent.com/pettyjamesm/706f34955e580d054606741ad41d3e3c/raw/2a905702d120ddb0a5b4ba58f28cfc60721b60fc/improved-full.json)).

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

