### PR TITLE
Add time stats for ORC file open time

### DIFF
--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoInput.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoInput.java
@@ -31,6 +31,8 @@ public interface TrinoInput
     int readTail(byte[] buffer, int bufferOffset, int bufferLength)
             throws IOException;
 
+    long getFileOpenTime();
+
     default Slice readFully(long position, int length)
             throws IOException
     {

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/hdfs/HdfsInput.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/hdfs/HdfsInput.java
@@ -59,6 +59,12 @@ class HdfsInput
     }
 
     @Override
+    public long getFileOpenTime()
+    {
+        return ((HdfsInputFile) inputFile).fileOpenTime();
+    }
+
+    @Override
     public void close()
             throws IOException
     {

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/hdfs/HdfsInputFile.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/hdfs/HdfsInputFile.java
@@ -36,6 +36,7 @@ class HdfsInputFile
     private final HdfsContext context;
     private final Path file;
     private Long length;
+    private Long fileOpenTime;
     private FileStatus status;
 
     public HdfsInputFile(String path, Long length, HdfsEnvironment environment, HdfsContext context)
@@ -53,7 +54,9 @@ class HdfsInputFile
             throws IOException
     {
         FileSystem fileSystem = environment.getFileSystem(context, file);
+        long fileOpenStart = System.nanoTime();
         FSDataInputStream input = environment.doAs(context.getIdentity(), () -> fileSystem.open(file));
+        fileOpenTime = System.nanoTime() - fileOpenStart;
         return new HdfsInput(input, this);
     }
 
@@ -86,6 +89,11 @@ class HdfsInputFile
     public String location()
     {
         return path;
+    }
+
+    long fileOpenTime()
+    {
+        return fileOpenTime;
     }
 
     private FileStatus lazyStatus()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
@@ -107,6 +107,9 @@ public class HiveModule
         binder.bind(FileFormatDataSourceStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(FileFormatDataSourceStats.class).withGeneratedName();
 
+        binder.bind(OrcFileOperationStats.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(OrcFileOperationStats.class).withGeneratedName();
+
         binder.bind(TrinoFileSystemCacheStats.class).toInstance(TrinoFileSystemCache.INSTANCE.getFileSystemCacheStats());
         newExporter(binder).export(TrinoFileSystemCacheStats.class)
                 .as(generator -> generator.generatedNameOf(io.trino.plugin.hive.fs.TrinoFileSystemCache.class));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/OrcFileOperationStats.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/OrcFileOperationStats.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import io.airlift.stats.TimeStat;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class OrcFileOperationStats
+{
+    private final TimeStat openStats = new TimeStat(MILLISECONDS);
+
+    @Managed
+    @Nested
+    public TimeStat getOpenStats()
+    {
+        return openStats;
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/HdfsOrcDataSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/HdfsOrcDataSource.java
@@ -50,6 +50,11 @@ public class HdfsOrcDataSource
         this.stats = requireNonNull(stats, "stats is null");
     }
 
+    public long getFileOpenTime()
+    {
+        return input.getFileOpenTime();
+    }
+
     @Override
     public void close()
             throws IOException

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcDeleteDeltaPageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcDeleteDeltaPageSource.java
@@ -26,6 +26,7 @@ import io.trino.orc.OrcReader;
 import io.trino.orc.OrcReaderOptions;
 import io.trino.orc.OrcRecordReader;
 import io.trino.plugin.hive.FileFormatDataSourceStats;
+import io.trino.plugin.hive.OrcFileOperationStats;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorPageSource;
@@ -74,7 +75,8 @@ public class OrcDeleteDeltaPageSource
     public static Optional<ConnectorPageSource> createOrcDeleteDeltaPageSource(
             TrinoInputFile inputFile,
             OrcReaderOptions options,
-            FileFormatDataSourceStats stats)
+            FileFormatDataSourceStats stats,
+            OrcFileOperationStats orcFileOperationStats)
     {
         OrcDataSource orcDataSource;
         String path = inputFile.location();
@@ -85,6 +87,7 @@ public class OrcDeleteDeltaPageSource
                     options,
                     inputFile,
                     stats);
+            orcFileOperationStats.getOpenStats().addNanos(((HdfsOrcDataSource) orcDataSource).getFileOpenTime());
         }
         catch (Exception e) {
             if (nullToEmpty(e.getMessage()).trim().equals("Filesystem closed") ||

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcDeleteDeltaPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcDeleteDeltaPageSourceFactory.java
@@ -16,6 +16,7 @@ package io.trino.plugin.hive.orc;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.orc.OrcReaderOptions;
 import io.trino.plugin.hive.FileFormatDataSourceStats;
+import io.trino.plugin.hive.OrcFileOperationStats;
 import io.trino.spi.connector.ConnectorPageSource;
 
 import java.util.Optional;
@@ -27,13 +28,16 @@ public class OrcDeleteDeltaPageSourceFactory
 {
     private final OrcReaderOptions options;
     private final FileFormatDataSourceStats stats;
+    private final OrcFileOperationStats orcFileOperationStats;
 
     public OrcDeleteDeltaPageSourceFactory(
             OrcReaderOptions options,
-            FileFormatDataSourceStats stats)
+            FileFormatDataSourceStats stats,
+            OrcFileOperationStats orcFileOperationStats)
     {
         this.options = requireNonNull(options, "options is null");
         this.stats = requireNonNull(stats, "stats is null");
+        this.orcFileOperationStats = requireNonNull(orcFileOperationStats, "orcFileOperationStats is null");
     }
 
     public Optional<ConnectorPageSource> createPageSource(TrinoInputFile inputFile)
@@ -41,6 +45,7 @@ public class OrcDeleteDeltaPageSourceFactory
         return createOrcDeleteDeltaPageSource(
                 inputFile,
                 options,
-                stats);
+                stats,
+                orcFileOperationStats);
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveTestUtils.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveTestUtils.java
@@ -169,9 +169,10 @@ public final class HiveTestUtils
     {
         TrinoFileSystemFactory fileSystemFactory = new HdfsFileSystemFactory(hdfsEnvironment);
         FileFormatDataSourceStats stats = new FileFormatDataSourceStats();
+        OrcFileOperationStats orcFileOperationStats = new OrcFileOperationStats();
         return ImmutableSet.<HivePageSourceFactory>builder()
                 .add(new RcFilePageSourceFactory(TESTING_TYPE_MANAGER, hdfsEnvironment, stats, hiveConfig))
-                .add(new OrcPageSourceFactory(new OrcReaderConfig(), fileSystemFactory, stats, hiveConfig))
+                .add(new OrcPageSourceFactory(new OrcReaderConfig(), fileSystemFactory, stats, orcFileOperationStats, hiveConfig))
                 .add(new ParquetPageSourceFactory(fileSystemFactory, stats, new ParquetReaderConfig(), hiveConfig))
                 .build();
     }
@@ -196,6 +197,7 @@ public final class HiveTestUtils
                 TESTING_TYPE_MANAGER,
                 new NodeVersion("test_version"),
                 new FileFormatDataSourceStats(),
+                new OrcFileOperationStats(),
                 new OrcWriterConfig());
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
@@ -109,6 +109,7 @@ public class TestHiveFileFormats
         extends AbstractTestHiveFileFormats
 {
     private static final FileFormatDataSourceStats STATS = new FileFormatDataSourceStats();
+    private static final OrcFileOperationStats ORC_FILE_OPERATION_STATS = new OrcFileOperationStats();
     private static final ConnectorSession PARQUET_SESSION = getHiveSession(createParquetHiveConfig(false));
     private static final ConnectorSession PARQUET_SESSION_USE_NAME = getHiveSession(createParquetHiveConfig(true));
 
@@ -303,7 +304,7 @@ public class TestHiveFileFormats
                 .withColumns(TEST_COLUMNS)
                 .withRowsCount(rowCount)
                 .withFileSizePadding(fileSizePadding)
-                .isReadableByPageSource(new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, STATS, UTC));
+                .isReadableByPageSource(new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, STATS, ORC_FILE_OPERATION_STATS, UTC));
     }
 
     @Test(dataProvider = "validRowAndFileSizePadding")
@@ -331,9 +332,9 @@ public class TestHiveFileFormats
                 .withRowsCount(rowCount)
                 .withSession(session)
                 .withFileSizePadding(fileSizePadding)
-                .withFileWriterFactory(new OrcFileWriterFactory(TESTING_TYPE_MANAGER, new NodeVersion("test"), STATS, new OrcWriterOptions(), HDFS_FILE_SYSTEM_FACTORY))
+                .withFileWriterFactory(new OrcFileWriterFactory(TESTING_TYPE_MANAGER, new NodeVersion("test"), STATS, ORC_FILE_OPERATION_STATS, new OrcWriterOptions(), HDFS_FILE_SYSTEM_FACTORY))
                 .isReadableByRecordCursor(createGenericHiveRecordCursorProvider(HDFS_ENVIRONMENT))
-                .isReadableByPageSource(new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, STATS, UTC));
+                .isReadableByPageSource(new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, STATS, ORC_FILE_OPERATION_STATS, UTC));
     }
 
     @Test(dataProvider = "rowCount")
@@ -352,7 +353,7 @@ public class TestHiveFileFormats
                 .withRowsCount(rowCount)
                 .withReadColumns(Lists.reverse(testColumns))
                 .withSession(session)
-                .isReadableByPageSource(new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, STATS, UTC));
+                .isReadableByPageSource(new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, STATS, ORC_FILE_OPERATION_STATS, UTC));
     }
 
     @Test(dataProvider = "rowCount")
@@ -369,7 +370,7 @@ public class TestHiveFileFormats
                 .withRowsCount(rowCount)
                 .withReadColumns(TEST_COLUMNS)
                 .withSession(session)
-                .isReadableByPageSource(new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, STATS, UTC));
+                .isReadableByPageSource(new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, STATS, ORC_FILE_OPERATION_STATS, UTC));
     }
 
     @Test(dataProvider = "validRowAndFileSizePadding")
@@ -531,7 +532,7 @@ public class TestHiveFileFormats
         assertThatFileFormat(ORC)
                 .withWriteColumns(ImmutableList.of(writeColumn))
                 .withReadColumns(ImmutableList.of(readColumn))
-                .isReadableByPageSource(new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, STATS, UTC));
+                .isReadableByPageSource(new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, STATS, ORC_FILE_OPERATION_STATS, UTC));
 
         assertThatFileFormat(PARQUET)
                 .withWriteColumns(ImmutableList.of(writeColumn))
@@ -631,13 +632,13 @@ public class TestHiveFileFormats
                 .withReadColumns(readColumns)
                 .withRowsCount(rowCount)
                 .withSession(session)
-                .isReadableByPageSource(new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, STATS, UTC));
+                .isReadableByPageSource(new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, STATS, ORC_FILE_OPERATION_STATS, UTC));
 
         assertThatFileFormat(ORC)
                 .withWriteColumns(writeColumns)
                 .withReadColumns(readColumns)
                 .withRowsCount(rowCount)
-                .isReadableByPageSource(new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, STATS, UTC));
+                .isReadableByPageSource(new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, STATS, ORC_FILE_OPERATION_STATS, UTC));
     }
 
     @Test(dataProvider = "rowCount")
@@ -829,7 +830,7 @@ public class TestHiveFileFormats
 
         assertThatFileFormat(ORC)
                 .withColumns(columns)
-                .isFailingForPageSource(new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, STATS, UTC), expectedErrorCode, expectedMessage);
+                .isFailingForPageSource(new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, STATS, ORC_FILE_OPERATION_STATS, UTC), expectedErrorCode, expectedMessage);
 
         assertThatFileFormat(PARQUET)
                 .withColumns(columns)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -194,7 +194,8 @@ public class TestOrcPageSourceMemoryTracking
         // feel free to change them if they break in the future
 
         FileFormatDataSourceStats stats = new FileFormatDataSourceStats();
-        ConnectorPageSource pageSource = testPreparer.newPageSource(stats, useCache ? CACHED_SESSION : UNCACHED_SESSION);
+        OrcFileOperationStats orcFileOperationStats = new OrcFileOperationStats();
+        ConnectorPageSource pageSource = testPreparer.newPageSource(stats, orcFileOperationStats, useCache ? CACHED_SESSION : UNCACHED_SESSION);
 
         if (useCache) {
             // file is fully cached
@@ -333,6 +334,7 @@ public class TestOrcPageSourceMemoryTracking
                 .setPropertyMetadata(hiveSessionProperties.getSessionProperties())
                 .build();
         FileFormatDataSourceStats stats = new FileFormatDataSourceStats();
+        OrcFileOperationStats orcFileOperationStats = new OrcFileOperationStats();
 
         // Build a table where every row gets larger, so we can test that the "batchSize" reduces
         int numColumns = 5;
@@ -349,7 +351,7 @@ public class TestOrcPageSourceMemoryTracking
         tempFile.delete();
 
         TestPreparer testPreparer = new TestPreparer(tempFile.getAbsolutePath(), testColumns, rowCount, rowCount);
-        ConnectorPageSource pageSource = testPreparer.newPageSource(stats, session);
+        ConnectorPageSource pageSource = testPreparer.newPageSource(stats, orcFileOperationStats, session);
 
         try {
             int positionCount = 0;
@@ -546,12 +548,12 @@ public class TestOrcPageSourceMemoryTracking
 
         public ConnectorPageSource newPageSource()
         {
-            return newPageSource(new FileFormatDataSourceStats(), UNCACHED_SESSION);
+            return newPageSource(new FileFormatDataSourceStats(), new OrcFileOperationStats(), UNCACHED_SESSION);
         }
 
-        public ConnectorPageSource newPageSource(FileFormatDataSourceStats stats, ConnectorSession session)
+        public ConnectorPageSource newPageSource(FileFormatDataSourceStats stats, OrcFileOperationStats orcFileOperationStats, ConnectorSession session)
         {
-            OrcPageSourceFactory orcPageSourceFactory = new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, stats, UTC);
+            OrcPageSourceFactory orcPageSourceFactory = new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, stats, orcFileOperationStats, UTC);
 
             List<HivePageSourceProvider.ColumnMapping> columnMappings = buildColumnMappings(
                     partitionName,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/StandardFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/StandardFileFormats.java
@@ -32,6 +32,7 @@ import io.trino.plugin.hive.HiveConfig;
 import io.trino.plugin.hive.HivePageSourceFactory;
 import io.trino.plugin.hive.HiveRecordCursorProvider;
 import io.trino.plugin.hive.HiveStorageFormat;
+import io.trino.plugin.hive.OrcFileOperationStats;
 import io.trino.plugin.hive.RecordFileWriter;
 import io.trino.plugin.hive.orc.OrcPageSourceFactory;
 import io.trino.plugin.hive.parquet.ParquetPageSourceFactory;
@@ -144,7 +145,7 @@ public final class StandardFileFormats
         @Override
         public Optional<HivePageSourceFactory> getHivePageSourceFactory(HdfsEnvironment hdfsEnvironment)
         {
-            return Optional.of(new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, new FileFormatDataSourceStats(), UTC));
+            return Optional.of(new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, new FileFormatDataSourceStats(), new OrcFileOperationStats(), UTC));
         }
 
         @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcDeleteDeltaPageSource.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcDeleteDeltaPageSource.java
@@ -18,6 +18,7 @@ import com.google.common.io.Resources;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.orc.OrcReaderOptions;
 import io.trino.plugin.hive.FileFormatDataSourceStats;
+import io.trino.plugin.hive.OrcFileOperationStats;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.security.ConnectorIdentity;
 import io.trino.testing.MaterializedResult;
@@ -45,7 +46,8 @@ public class TestOrcDeleteDeltaPageSource
         TrinoInputFile inputFile = HDFS_FILE_SYSTEM_FACTORY.create(ConnectorIdentity.ofUser("test")).newInputFile(deleteDeltaFile.toURI().toString());
         OrcDeleteDeltaPageSourceFactory pageSourceFactory = new OrcDeleteDeltaPageSourceFactory(
                 new OrcReaderOptions(),
-                new FileFormatDataSourceStats());
+                new FileFormatDataSourceStats(),
+                new OrcFileOperationStats());
 
         ConnectorPageSource pageSource = pageSourceFactory.createPageSource(inputFile).orElseThrow();
         MaterializedResult materializedRows = MaterializedResult.materializeSourceDataStream(SESSION, pageSource, ImmutableList.of(BIGINT, INTEGER, BIGINT));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcDeletedRows.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcDeletedRows.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableSet;
 import io.trino.orc.OrcReaderOptions;
 import io.trino.plugin.hive.AcidInfo;
 import io.trino.plugin.hive.FileFormatDataSourceStats;
+import io.trino.plugin.hive.OrcFileOperationStats;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
@@ -153,7 +154,8 @@ public class TestOrcDeletedRows
     {
         OrcDeleteDeltaPageSourceFactory pageSourceFactory = new OrcDeleteDeltaPageSourceFactory(
                 new OrcReaderOptions(),
-                new FileFormatDataSourceStats());
+                new FileFormatDataSourceStats(),
+                new OrcFileOperationStats());
 
         OrcDeletedRows deletedRows = new OrcDeletedRows(
                 sourceFileName,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPageSourceFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPageSourceFactory.java
@@ -21,6 +21,7 @@ import io.trino.plugin.hive.FileFormatDataSourceStats;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HiveConfig;
 import io.trino.plugin.hive.HivePageSourceFactory;
+import io.trino.plugin.hive.OrcFileOperationStats;
 import io.trino.plugin.hive.ReaderPageSource;
 import io.trino.spi.Page;
 import io.trino.spi.connector.ConnectorPageSource;
@@ -80,6 +81,7 @@ public class TestOrcPageSourceFactory
             new OrcReaderConfig(),
             new HdfsFileSystemFactory(HDFS_ENVIRONMENT),
             new FileFormatDataSourceStats(),
+            new OrcFileOperationStats(),
             new HiveConfig());
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPredicates.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPredicates.java
@@ -26,6 +26,7 @@ import io.trino.plugin.hive.HiveConfig;
 import io.trino.plugin.hive.HivePageSourceProvider;
 import io.trino.plugin.hive.HivePartitionKey;
 import io.trino.plugin.hive.NodeVersion;
+import io.trino.plugin.hive.OrcFileOperationStats;
 import io.trino.plugin.hive.TableToPartitionMapping;
 import io.trino.spi.Page;
 import io.trino.spi.connector.ConnectorPageSource;
@@ -72,6 +73,7 @@ public class TestOrcPredicates
 {
     private static final int NUM_ROWS = 50000;
     private static final FileFormatDataSourceStats STATS = new FileFormatDataSourceStats();
+    private static final OrcFileOperationStats ORC_FILE_OPERATION_STATS = new OrcFileOperationStats();
 
     // Prepare test columns
     private static final TestColumn columnPrimitiveInteger = new TestColumn("column_primitive_integer", javaIntObjectInspector, 3, 3);
@@ -99,7 +101,7 @@ public class TestOrcPredicates
         file.delete();
         try {
             // Write data
-            OrcFileWriterFactory writerFactory = new OrcFileWriterFactory(TESTING_TYPE_MANAGER, new NodeVersion("test"), STATS, new OrcWriterOptions(), HDFS_FILE_SYSTEM_FACTORY);
+            OrcFileWriterFactory writerFactory = new OrcFileWriterFactory(TESTING_TYPE_MANAGER, new NodeVersion("test"), STATS, ORC_FILE_OPERATION_STATS, new OrcWriterOptions(), HDFS_FILE_SYSTEM_FACTORY);
             FileSplit split = createTestFileTrino(file.getAbsolutePath(), ORC, HiveCompressionCodec.NONE, columnsToWrite, session, NUM_ROWS, writerFactory);
 
             TupleDomain<TestColumn> testingPredicate;
@@ -163,7 +165,7 @@ public class TestOrcPredicates
             ConnectorSession session,
             FileSplit split)
     {
-        OrcPageSourceFactory readerFactory = new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, STATS, UTC);
+        OrcPageSourceFactory readerFactory = new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_FILE_SYSTEM_FACTORY, STATS, ORC_FILE_OPERATION_STATS, UTC);
 
         Properties splitProperties = new Properties();
         splitProperties.setProperty(FILE_INPUT_FORMAT, ORC.getInputFormat());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Internally we have a time stat exposed through JMX that keeps track of the elapsed time for opening ORC file in the Hive connector. I decided to add `TrinoInput#getFileOpenTime` to expose this metric since that is the public interface accessible from the Hive connector to `trino-filesystem` library and the only implementation is `HdfsInput` so the impacted scope is restricted.



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: