### PR TITLE
Deterministically get only element from the stream

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/policy/PhasedExecutionSchedule.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/policy/PhasedExecutionSchedule.java
@@ -57,6 +57,7 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.trino.execution.scheduler.StageExecution.State.FLUSHING;
 import static io.trino.execution.scheduler.StageExecution.State.RUNNING;
 import static io.trino.execution.scheduler.StageExecution.State.SCHEDULED;
@@ -290,7 +291,8 @@ public class PhasedExecutionSchedule
 
         QueryId queryId = stages.stream()
                 .map(stage -> stage.getStageId().getQueryId())
-                .findAny().orElseThrow();
+                .distinct()
+                .collect(onlyElement());
         List<PlanFragment> fragments = stages.stream()
                 .map(StageExecution::getFragment)
                 .collect(toImmutableList());

--- a/core/trino-main/src/test/java/io/trino/TestSystemSessionProperties.java
+++ b/core/trino-main/src/test/java/io/trino/TestSystemSessionProperties.java
@@ -38,6 +38,7 @@ import io.trino.spi.session.PropertyMetadata;
 import io.trino.sql.planner.OptimizerConfig;
 import org.testng.annotations.Test;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.trino.SystemSessionProperties.QUERY_MAX_RUN_TIME;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -88,7 +89,6 @@ public class TestSystemSessionProperties
     {
         return properties.getSessionProperties().stream()
                 .filter(p -> p.getName().equals(propertyName))
-                .findFirst()
-                .orElseThrow();
+                .collect(onlyElement());
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestCommentTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCommentTask.java
@@ -26,6 +26,7 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.trino.spi.StandardErrorCode.COLUMN_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
@@ -118,7 +119,7 @@ public class TestCommentTask
         getFutureValue(setComment(COLUMN, columnName, Optional.of("new test column comment")));
         TableHandle tableHandle = metadata.getTableHandle(testSession, tableName).get();
         ConnectorTableMetadata connectorTableMetadata = metadata.getTableMetadata(testSession, tableHandle).getMetadata();
-        assertThat(Optional.ofNullable(connectorTableMetadata.getColumns().stream().filter(column -> "test".equals(column.getName())).findFirst().get().getComment()))
+        assertThat(Optional.ofNullable(connectorTableMetadata.getColumns().stream().filter(column -> "test".equals(column.getName())).collect(onlyElement()).getComment()))
                 .isEqualTo(Optional.of("new test column comment"));
     }
 
@@ -132,7 +133,7 @@ public class TestCommentTask
         assertThat(metadata.isView(testSession, viewName)).isTrue();
 
         getFutureValue(setComment(COLUMN, columnName, Optional.of("new test column comment")));
-        assertThat(metadata.getView(testSession, viewName).get().getColumns().stream().filter(column -> "test".equals(column.getName())).findAny().get().getComment())
+        assertThat(metadata.getView(testSession, viewName).get().getColumns().stream().filter(column -> "test".equals(column.getName())).collect(onlyElement()).getComment())
                 .isEqualTo(Optional.of("new test column comment"));
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(setComment(COLUMN, missingColumnName, Optional.of("comment for missing column"))))

--- a/core/trino-spi/src/main/java/io/trino/spi/metrics/Metrics.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/metrics/Metrics.java
@@ -21,6 +21,7 @@ import io.trino.spi.Unstable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.StringJoiner;
 
 import static java.util.Objects.requireNonNull;
 
@@ -72,6 +73,14 @@ public class Metrics
     public int hashCode()
     {
         return Objects.hash(metrics);
+    }
+
+    @Override
+    public String toString()
+    {
+        return new StringJoiner(", ", Metrics.class.getSimpleName() + "[", "]")
+                .add(metrics.toString())
+                .toString();
     }
 
     public static class Accumulator

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestingColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestingColumnReader.java
@@ -71,6 +71,7 @@ import java.util.Map.Entry;
 import java.util.function.IntFunction;
 import java.util.stream.Stream;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.trino.parquet.ParquetTypeUtils.getParquetEncoding;
 import static io.trino.parquet.ParquetTypeUtils.paddingBigInteger;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -847,8 +848,7 @@ public class TestingColumnReader
             Class<? extends Block> blockClass = BLOCK_CLASSES.entrySet().stream()
                     .filter(entry -> entry.getKey().getClass().isAssignableFrom(trinoType.getClass()))
                     .map(Entry::getValue)
-                    .findFirst()
-                    .orElseThrow();
+                    .collect(onlyElement());
             if (block.getClass() != RunLengthEncodedBlock.class && block.getClass() != DictionaryBlock.class) {
                 assertThat(block).isInstanceOf(blockClass);
             }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestCachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestCachingJdbcClient.java
@@ -52,6 +52,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.plugin.jdbc.TestCachingJdbcClient.CachingJdbcCache.STATISTICS_CACHE;
 import static io.trino.plugin.jdbc.TestCachingJdbcClient.CachingJdbcCache.TABLE_HANDLES_BY_NAME_CACHE;
@@ -863,8 +864,7 @@ public class TestCachingJdbcClient
         return client.getColumns(SESSION, tableHandle)
                 .stream()
                 .filter(jdbcColumnHandle -> jdbcColumnHandle.getColumnMetadata().equals(columnMetadata))
-                .findAny()
-                .orElseThrow();
+                .collect(onlyElement());
     }
 
     private static ConnectorSession createSession(String sessionName)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -150,6 +150,7 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.trino.plugin.deltalake.DeltaLakeColumnHandle.FILE_MODIFIED_TIME_COLUMN_NAME;
 import static io.trino.plugin.deltalake.DeltaLakeColumnHandle.MERGE_ROW_ID_TYPE;
 import static io.trino.plugin.deltalake.DeltaLakeColumnHandle.ROW_ID_COLUMN_NAME;
@@ -2610,8 +2611,7 @@ public class DeltaLakeMetadata
                     }
                     return Optional.of(Instant.ofEpochMilli(unpackMillisUtc(TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS.getLong(entry.getValue(), 0))));
                 })
-                .findFirst()
-                .orElseThrow();
+                .collect(onlyElement());
     }
 
     public DeltaLakeMetastore getMetastore()

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
@@ -56,6 +56,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.collect.Sets.union;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.testing.Assertions.assertEqualsIgnoreOrder;
@@ -198,8 +199,7 @@ public class TestTransactionLogAccess
         AddFileEntry addFileEntry = addFileEntries
                 .stream()
                 .filter(entry -> entry.getPath().equals("age=42/part-00000-b26c891a-7288-4d96-9d3b-bef648f12a34.c000.snappy.parquet"))
-                .findFirst()
-                .get();
+                .collect(onlyElement());
 
         assertThat(addFileEntry.getPartitionValues())
                 .hasSize(1)
@@ -223,8 +223,7 @@ public class TestTransactionLogAccess
         AddFileEntry addFileEntry = addFileEntries
                 .stream()
                 .filter(entry -> entry.getPath().equals("ALA=1/part-00000-20a863e0-890d-4776-8825-f9dccc8973ba.c000.snappy.parquet"))
-                .findFirst()
-                .get();
+                .collect(onlyElement());
 
         assertThat(addFileEntry.getPartitionValues())
                 .hasSize(1)
@@ -666,8 +665,7 @@ public class TestTransactionLogAccess
 
         AddFileEntry addFileEntry = addFileEntries.stream()
                 .filter(entry -> entry.getPath().equalsIgnoreCase("part-00000-0e22455f-5650-442f-a094-e1a8b7ed2271-c000.snappy.parquet"))
-                .findFirst()
-                .get();
+                .collect(onlyElement());
 
         assertThat(addFileEntry.getStats()).isPresent();
         DeltaLakeFileStatistics fileStats = addFileEntry.getStats().get();

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestBingTileFunctions.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestBingTileFunctions.java
@@ -30,6 +30,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.io.Resources.getResource;
 import static io.trino.operator.scalar.ApplyFunction.APPLY_FUNCTION;
 import static io.trino.plugin.geospatial.BingTile.fromCoordinates;
@@ -645,7 +646,7 @@ public class TestBingTileFunctions
         String filePath = new File(getResource("too_large_polygon.txt").toURI()).getPath();
         String largeWkt;
         try (Stream<String> lines = Files.lines(Paths.get(filePath))) {
-            largeWkt = lines.findFirst().get();
+            largeWkt = lines.collect(onlyElement());
         }
         assertTrinoExceptionThrownBy(() -> assertions.expression("geometry_to_bing_tiles(ST_GeometryFromText('" + largeWkt + "'), 16)").evaluate())
                 .hasMessage("The zoom level is too high or the geometry is too complex to compute a set of covering Bing tiles. Please use a lower zoom level or convert the geometry to its bounding box using the ST_Envelope function.");

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHivePlugin.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHivePlugin.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.collect.MoreCollectors.toOptional;
 import static com.google.common.collect.Streams.stream;
 import static com.google.common.io.MoreFiles.deleteRecursively;
@@ -249,8 +250,7 @@ public class TestHivePlugin
     {
         return connector.getSessionProperties().stream()
                 .filter(propertyMetadata -> "insert_existing_partitions_behavior".equals(propertyMetadata.getName()))
-                .findAny()
-                .orElseThrow()
+                .collect(onlyElement())
                 .getDefaultValue();
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriterFactory.java
@@ -79,6 +79,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Maps.immutableEntry;
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.trino.hdfs.ConfigurationUtils.toJobConf;
 import static io.trino.plugin.hive.HiveCompressionCodecs.selectCompressionCodec;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
@@ -503,8 +504,7 @@ public class HiveWriterFactory
         if (transaction.isMerge()) {
             OrcFileWriterFactory orcFileWriterFactory = (OrcFileWriterFactory) fileWriterFactories.stream()
                     .filter(factory -> factory instanceof OrcFileWriterFactory)
-                    .findFirst()
-                    .get();
+                    .collect(onlyElement());
             checkArgument(hiveRowtype.isPresent(), "rowTypes not present");
             RowIdSortingFileWriterMaker fileWriterMaker = (deleteWriter, deletePath) -> makeRowIdSortingWriter(deleteWriter, deletePath);
             hiveFileWriter = new MergeFileWriter(transaction, 0, bucketNumber, fileWriterMaker, path, orcFileWriterFactory, inputColumns, conf, session, typeManager, hiveRowtype.get());

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/rubix/RubixInitializer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/rubix/RubixInitializer.java
@@ -47,6 +47,7 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.propagateIfPossible;
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.qubole.rubix.spi.CacheConfig.enableHeartbeat;
 import static com.qubole.rubix.spi.CacheConfig.setBookKeeperServerPort;
 import static com.qubole.rubix.spi.CacheConfig.setCacheDataDirPrefix;
@@ -277,7 +278,9 @@ public class RubixInitializer
 
     private Configuration getRubixServerConfiguration()
     {
-        Node master = nodeManager.getAllNodes().stream().filter(Node::isCoordinator).findFirst().get();
+        Node master = nodeManager.getAllNodes().stream()
+                .filter(Node::isCoordinator)
+                .collect(onlyElement());
         masterAddress = master.getHostAndPort();
 
         Configuration configuration = getInitialConfiguration();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -96,6 +96,7 @@ import static com.google.common.base.Throwables.getStackTraceAsString;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.collect.Sets.intersection;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
@@ -8422,7 +8423,7 @@ public abstract class BaseHiveConnectorTest
         MaterializedResult result = computeActual("EXPLAIN (TYPE IO, FORMAT JSON) " + query);
         Set<ColumnConstraint> constraints = getIoPlanCodec().fromJson((String) getOnlyElement(result.getOnlyColumnAsSet()))
                 .getInputTableColumnInfos().stream()
-                .findFirst().get()
+                .collect(onlyElement())
                 .getConstraint()
                 .getColumnConstraints();
 

--- a/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpEventListener.java
+++ b/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpEventListener.java
@@ -63,7 +63,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.trino.testing.assertions.Assert.assertEquals;
 import static java.lang.String.format;
@@ -467,8 +469,9 @@ public class TestHttpEventListener
         TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         trustManagerFactory.init(keyStore);
 
-        X509TrustManager x509TrustManager = (X509TrustManager) List.of(trustManagerFactory.getTrustManagers()).stream().filter(tm -> tm instanceof X509TrustManager)
-                .findFirst().get();
+        X509TrustManager x509TrustManager = (X509TrustManager) Stream.of(trustManagerFactory.getTrustManagers())
+                .filter(tm -> tm instanceof X509TrustManager)
+                .collect(onlyElement());
 
         KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         keyManagerFactory.init(keyStore, "testing-ssl".toCharArray());

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/TableInfo.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/TableInfo.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 
@@ -88,8 +89,7 @@ public class TableInfo
     {
         return columns.stream()
                 .filter(column -> column.getHandle().equals(handle))
-                .findFirst()
-                .get();
+                .collect(onlyElement());
     }
 
     public Map<HostAddress, MemoryDataFragment> getDataFragments()

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
@@ -205,7 +205,7 @@ public class TestMemoryConnectorTest
         assertEquals(result.getResult().getRowCount(), 615);
 
         OperatorStats probeStats = getScanOperatorStats(getDistributedQueryRunner(), result.getQueryId()).stream()
-                .findFirst().orElseThrow();
+                .findFirst().orElseThrow(); // there should be two: one for lineitem and one for supplier
         assertEquals(probeStats.getInputPositions(), 615);
         assertEquals(probeStats.getPhysicalInputPositions(), LINEITEM_COUNT);
     }

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/organization/TestShardOrganizerUtil.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/organization/TestShardOrganizerUtil.java
@@ -43,6 +43,7 @@ import java.util.OptionalInt;
 import java.util.Set;
 import java.util.UUID;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
@@ -187,8 +188,7 @@ public class TestShardOrganizerUtil
         for (ShardInfo shard : shards) {
             ColumnStats temporalColumnStats = shard.getColumnStats().stream()
                     .filter(columnStats -> columnStats.getColumnId() == temporalColumn.getColumnId())
-                    .findFirst()
-                    .get();
+                    .collect(onlyElement());
 
             if (temporalColumnStats.getMin() == null || temporalColumnStats.getMax() == null) {
                 continue;

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/DeltaLakeTestUtils.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/DeltaLakeTestUtils.java
@@ -18,6 +18,7 @@ import org.intellij.lang.annotations.Language;
 
 import java.util.Optional;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.trino.tests.product.utils.QueryExecutors.onDelta;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
@@ -60,6 +61,6 @@ public final class DeltaLakeTestUtils
         return (String) result.rows().stream()
                 .filter(row -> row.get(0).equals("Comment"))
                 .map(row -> row.get(1))
-                .findFirst().orElseThrow();
+                .collect(onlyElement());
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestGracefulShutdown.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestGracefulShutdown.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.trino.execution.QueryState.FINISHED;
 import static io.trino.memory.TestMemoryManager.createQueryRunner;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -121,8 +122,7 @@ public class TestGracefulShutdown
             TestingTrinoServer coordinator = queryRunner.getServers()
                     .stream()
                     .filter(TestingTrinoServer::isCoordinator)
-                    .findFirst()
-                    .get();
+                    .collect(onlyElement());
 
             assertThatThrownBy(coordinator.getGracefulShutdownHandler()::requestShutdown)
                     .isInstanceOf(UnsupportedOperationException.class)

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestGracefulShutdown.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestGracefulShutdown.java
@@ -37,6 +37,7 @@ import static io.trino.memory.TestMemoryManager.createQueryRunner;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -110,7 +111,7 @@ public class TestGracefulShutdown
         }
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
+    @Test
     public void testCoordinatorShutdown()
             throws Exception
     {
@@ -121,7 +122,9 @@ public class TestGracefulShutdown
                     .findFirst()
                     .get();
 
-            coordinator.getGracefulShutdownHandler().requestShutdown();
+            assertThatThrownBy(coordinator.getGracefulShutdownHandler()::requestShutdown)
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessage("Cannot shutdown coordinator");
         }
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestGracefulShutdown.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestGracefulShutdown.java
@@ -83,11 +83,12 @@ public class TestGracefulShutdown
                         executor));
             }
 
+            @SuppressWarnings("resource")
             TestingTrinoServer worker = queryRunner.getServers()
                     .stream()
                     .filter(server -> !server.isCoordinator())
                     .findFirst()
-                    .get();
+                    .orElseThrow();
 
             SqlTaskManager taskManager = worker.getTaskManager();
 
@@ -116,6 +117,7 @@ public class TestGracefulShutdown
             throws Exception
     {
         try (DistributedQueryRunner queryRunner = createQueryRunner(TINY_SESSION, ImmutableMap.of())) {
+            @SuppressWarnings("resource")
             TestingTrinoServer coordinator = queryRunner.getServers()
                     .stream()
                     .filter(TestingTrinoServer::isCoordinator)


### PR DESCRIPTION
Use `.collect(onlyElement())` to get the only element from the stream instead of `findAny` or `findFirst`. Use the latter only when it's expected that the stream can contain multiple elements and it is not important which one is chosen.
