### PR TITLE
Improve heuristic of using dictionary in project and filter

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/project/DictionaryAwarePageFilter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/DictionaryAwarePageFilter.java
@@ -60,7 +60,7 @@ public class DictionaryAwarePageFilter
 
         if (block instanceof RunLengthEncodedBlock) {
             Block value = ((RunLengthEncodedBlock) block).getValue();
-            Optional<boolean[]> selectedPosition = processDictionary(session, value);
+            Optional<boolean[]> selectedPosition = processDictionary(session, value, block.getPositionCount());
             // single value block is always considered effective, but the processing could have thrown
             // in that case we fallback and process again so the correct error message sent
             if (selectedPosition.isPresent()) {
@@ -71,7 +71,7 @@ public class DictionaryAwarePageFilter
         if (block instanceof DictionaryBlock) {
             DictionaryBlock dictionaryBlock = (DictionaryBlock) block;
             // Attempt to process the dictionary.  If dictionary is processing has not been considered effective, an empty response will be returned
-            Optional<boolean[]> selectedDictionaryPositions = processDictionary(session, dictionaryBlock.getDictionary());
+            Optional<boolean[]> selectedDictionaryPositions = processDictionary(session, dictionaryBlock.getDictionary(), block.getPositionCount());
             // record the usage count regardless of dictionary processing choice, so we have stats for next time
             lastDictionaryUsageCount += page.getPositionCount();
             // if dictionary was processed, produce a dictionary block; otherwise do normal processing
@@ -83,7 +83,7 @@ public class DictionaryAwarePageFilter
         return filter.filter(session, new Page(block));
     }
 
-    private Optional<boolean[]> processDictionary(ConnectorSession session, Block dictionary)
+    private Optional<boolean[]> processDictionary(ConnectorSession session, Block dictionary, int blockPositionsCount)
     {
         if (lastInputDictionary == dictionary) {
             return lastOutputDictionary;
@@ -91,9 +91,9 @@ public class DictionaryAwarePageFilter
 
         // Process dictionary if:
         //   this is the first block
-        //   there is only entry in the dictionary
+        //   dictionary positions count is not greater than block positions count
         //   the last dictionary was used for more positions than were in the dictionary
-        boolean shouldProcessDictionary = lastInputDictionary == null || dictionary.getPositionCount() == 1 || lastDictionaryUsageCount >= lastInputDictionary.getPositionCount();
+        boolean shouldProcessDictionary = lastInputDictionary == null || dictionary.getPositionCount() <= blockPositionsCount || lastDictionaryUsageCount >= lastInputDictionary.getPositionCount();
 
         lastDictionaryUsageCount = 0;
         lastInputDictionary = dictionary;

--- a/core/trino-main/src/main/java/io/trino/operator/project/DictionaryAwarePageProjection.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/DictionaryAwarePageProjection.java
@@ -216,10 +216,10 @@ public class DictionaryAwarePageProjection
             }
 
             // Try use dictionary processing first; if it fails, fall back to the generic case
-            dictionaryProcessingProjectionWork = createDictionaryBlockProjection(dictionary);
+            dictionaryProcessingProjectionWork = createDictionaryBlockProjection(dictionary, block.getPositionCount());
         }
 
-        private Work<Block> createDictionaryBlockProjection(Optional<Block> dictionary)
+        private Work<Block> createDictionaryBlockProjection(Optional<Block> dictionary, int blockPositionsCount)
         {
             if (dictionary.isEmpty()) {
                 lastOutputDictionary = Optional.empty();
@@ -232,10 +232,10 @@ public class DictionaryAwarePageProjection
             }
 
             // Process dictionary if:
-            //   there is only one entry in the dictionary
+            //   dictionary positions count is not greater than block positions count
             //   this is the first block
             //   the last dictionary was used for more positions than were in the dictionary
-            boolean shouldProcessDictionary = dictionary.get().getPositionCount() == 1 || lastInputDictionary == null || lastDictionaryUsageCount >= lastInputDictionary.getPositionCount();
+            boolean shouldProcessDictionary = dictionary.get().getPositionCount() <= blockPositionsCount || lastInputDictionary == null || lastDictionaryUsageCount >= lastInputDictionary.getPositionCount();
 
             // record the usage count regardless of dictionary processing choice, so we have stats for next time
             lastDictionaryUsageCount = 0;


### PR DESCRIPTION
## Description

When last dictionary was not effective but incoming dictionary size is not bigger than the block size, enable dictionary processing. Earlier this logic would apply only to the next dictionary through the existing `lastDictionaryUsageCount >= lastInputDictionary.getPositionCount()` condition. This change makes the heuristic more consistent by applying the same logic to the incoming dictionary page as well.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Minor improvement, not significant enough to RN.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

