### PR TITLE
Improve performance of parquet dictionary to domain conversion

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
@@ -981,6 +981,44 @@ public final class SortedRangeSet
                 .collect(joining(", ", "{", "}"));
     }
 
+    public static Builder builder(Type type, int expectedSize)
+    {
+        return new SortedRangeSet.Builder(type, expectedSize);
+    }
+
+    public static class Builder
+    {
+        private final Type type;
+        private final MethodHandle rangeComparisonOperator;
+        private final List<Range> ranges;
+
+        private Builder(Type type, int expectedSize)
+        {
+            this.type = requireNonNull(type, "type is null");
+            // Calculating the comparison operator once instead of per range to avoid hitting TypeOperators cache
+            this.rangeComparisonOperator = Range.getComparisonOperator(type);
+            this.ranges = new ArrayList<>(expectedSize);
+        }
+
+        public Builder addRangeInclusive(Object lowValue, Object highValue)
+        {
+            ranges.add(new Range(type, true, Optional.of(lowValue), true, Optional.of(highValue), rangeComparisonOperator));
+            return this;
+        }
+
+        public Builder addValue(Object value)
+        {
+            Optional<Object> valueAsOptional = Optional.of(value);
+            ranges.add(new Range(type, true, valueAsOptional, true, valueAsOptional, rangeComparisonOperator));
+            return this;
+        }
+
+        public SortedRangeSet build()
+        {
+            return SortedRangeSet.of(ranges);
+        }
+    }
+
     static SortedRangeSet buildFromUnsortedRanges(Type type, Collection<Range> unsortedRanges)
     {
         requireNonNull(type, "type is null");


### PR DESCRIPTION
## Description

Improved logic for constructing domain from dictionary values in TupleDomainParquetPredicate by using the faster code path for constructing ValueSet from singleton values rather than Ranges.

Benchmark                                                  Mode  Cnt  Score Before      Score After     Units
BenchmarkTupleDomainParquetPredicate.domainFromDictionary  avgt   10  354.194 ± 29.631  211.831 ± 8.793 ms/op

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Hudi, Iceberg, Delta
* Improve performance of reading parquet filter for queries with filters. ({issue}`issuenumber`)
```
