### PR TITLE
Fix dereference operations for union type in Hive Connector

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveType.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveType.java
@@ -32,10 +32,14 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.lenientFormat;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.hive.HiveStorageFormat.AVRO;
 import static io.trino.plugin.hive.HiveStorageFormat.ORC;
 import static io.trino.plugin.hive.HiveTimestampPrecision.DEFAULT_PRECISION;
+import static io.trino.plugin.hive.util.HiveTypeTranslator.UNION_FIELD_FIELD_PREFIX;
+import static io.trino.plugin.hive.util.HiveTypeTranslator.UNION_FIELD_TAG_NAME;
+import static io.trino.plugin.hive.util.HiveTypeTranslator.UNION_FIELD_TAG_TYPE;
 import static io.trino.plugin.hive.util.HiveTypeTranslator.fromPrimitiveType;
 import static io.trino.plugin.hive.util.HiveTypeTranslator.toTypeInfo;
 import static io.trino.plugin.hive.util.HiveTypeTranslator.toTypeSignature;
@@ -219,13 +223,32 @@ public final class HiveType
     {
         TypeInfo typeInfo = getTypeInfo();
         for (int fieldIndex : dereferences) {
-            checkArgument(typeInfo instanceof StructTypeInfo, "typeInfo should be struct type", typeInfo);
-            StructTypeInfo structTypeInfo = (StructTypeInfo) typeInfo;
-            try {
-                typeInfo = structTypeInfo.getAllStructFieldTypeInfos().get(fieldIndex);
+            if (typeInfo instanceof StructTypeInfo structTypeInfo) {
+                try {
+                    typeInfo = structTypeInfo.getAllStructFieldTypeInfos().get(fieldIndex);
+                }
+                catch (RuntimeException e) {
+                    // return empty when failed to dereference, this could happen when partition and table schema mismatch
+                    return Optional.empty();
+                }
             }
-            catch (RuntimeException e) {
-                return Optional.empty();
+            else if (typeInfo instanceof UnionTypeInfo unionTypeInfo) {
+                try {
+                    if (fieldIndex == 0) {
+                        //  union's tag field, defined in {@link io.trino.plugin.hive.util.HiveTypeTranslator#toTypeSignature}
+                        return Optional.of(HiveType.toHiveType(UNION_FIELD_TAG_TYPE));
+                    }
+                    else {
+                        typeInfo = unionTypeInfo.getAllUnionObjectTypeInfos().get(fieldIndex - 1);
+                    }
+                }
+                catch (RuntimeException e) {
+                    // return empty when failed to dereference, this could happen when partition and table schema mismatch
+                    return Optional.empty();
+                }
+            }
+            else {
+                throw new IllegalArgumentException(lenientFormat("typeInfo: %s should be struct or union type", typeInfo));
             }
         }
         return Optional.of(toHiveType(typeInfo));
@@ -235,16 +258,35 @@ public final class HiveType
     {
         ImmutableList.Builder<String> dereferenceNames = ImmutableList.builder();
         TypeInfo typeInfo = getTypeInfo();
-        for (int fieldIndex : dereferences) {
-            checkArgument(typeInfo instanceof StructTypeInfo, "typeInfo should be struct type", typeInfo);
-            StructTypeInfo structTypeInfo = (StructTypeInfo) typeInfo;
-
+        for (int i = 0; i < dereferences.size(); i++) {
+            int fieldIndex = dereferences.get(i);
             checkArgument(fieldIndex >= 0, "fieldIndex cannot be negative");
-            checkArgument(fieldIndex < structTypeInfo.getAllStructFieldNames().size(),
-                    "fieldIndex should be less than the number of fields in the struct");
-            String fieldName = structTypeInfo.getAllStructFieldNames().get(fieldIndex);
-            dereferenceNames.add(fieldName);
-            typeInfo = structTypeInfo.getAllStructFieldTypeInfos().get(fieldIndex);
+
+            if (typeInfo instanceof StructTypeInfo structTypeInfo) {
+                checkArgument(fieldIndex < structTypeInfo.getAllStructFieldNames().size(),
+                        "fieldIndex should be less than the number of fields in the struct");
+
+                String fieldName = structTypeInfo.getAllStructFieldNames().get(fieldIndex);
+                dereferenceNames.add(fieldName);
+                typeInfo = structTypeInfo.getAllStructFieldTypeInfos().get(fieldIndex);
+            }
+            else if (typeInfo instanceof UnionTypeInfo unionTypeInfo) {
+                checkArgument((fieldIndex - 1) < unionTypeInfo.getAllUnionObjectTypeInfos().size(),
+                        "fieldIndex should be less than the number of fields in the union plus tag field");
+
+                if (fieldIndex == 0) {
+                    checkArgument(i == (dereferences.size() - 1), "Union's tag field should not have more subfields");
+                    dereferenceNames.add(UNION_FIELD_TAG_NAME);
+                    break;
+                }
+                else {
+                    typeInfo = unionTypeInfo.getAllUnionObjectTypeInfos().get(fieldIndex - 1);
+                    dereferenceNames.add(UNION_FIELD_FIELD_PREFIX + (fieldIndex - 1));
+                }
+            }
+            else {
+                throw new IllegalArgumentException(lenientFormat("typeInfo: %s should be struct or union type", typeInfo));
+            }
         }
 
         return dereferenceNames.build();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveTypeTranslator.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveTypeTranslator.java
@@ -91,6 +91,10 @@ public final class HiveTypeTranslator
 {
     private HiveTypeTranslator() {}
 
+    public static final String UNION_FIELD_TAG_NAME = "tag";
+    public static final String UNION_FIELD_FIELD_PREFIX = "field";
+    public static final Type UNION_FIELD_TAG_TYPE = TINYINT;
+
     public static TypeInfo toTypeInfo(Type type)
     {
         requireNonNull(type, "type is null");
@@ -213,10 +217,10 @@ public final class HiveTypeTranslator
                 UnionTypeInfo unionTypeInfo = (UnionTypeInfo) typeInfo;
                 List<TypeInfo> unionObjectTypes = unionTypeInfo.getAllUnionObjectTypeInfos();
                 ImmutableList.Builder<TypeSignatureParameter> typeSignatures = ImmutableList.builder();
-                typeSignatures.add(namedField("tag", TINYINT.getTypeSignature()));
+                typeSignatures.add(namedField(UNION_FIELD_TAG_NAME, UNION_FIELD_TAG_TYPE.getTypeSignature()));
                 for (int i = 0; i < unionObjectTypes.size(); i++) {
                     TypeInfo unionObjectType = unionObjectTypes.get(i);
-                    typeSignatures.add(namedField("field" + i, toTypeSignature(unionObjectType, timestampPrecision)));
+                    typeSignatures.add(namedField(UNION_FIELD_FIELD_PREFIX + i, toTypeSignature(unionObjectType, timestampPrecision)));
                 }
                 return rowType(typeSignatures.build());
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Support dereferencing  using field names such as "field0", "field1", "tag" for Hive's Union Type. 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/trinodb/trino/pull/15017,
https://github.com/trinodb/trino/pull/3483,
https://github.com/trinodb/trino/commit/e071da402efb4b95f6c8b13b2a241e86e446e2a8

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive Connector
*  Fix queries referencing nested fields in union typed columns. ({issue}`15278`)
```
