### PR TITLE
Report buffer overutilization in EXPLAIN ANALYZE VERBOSE

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -495,20 +495,26 @@ public class PlanPrinter
                             stageStats.getOutputDataSize()));
             Optional<TDigestHistogram> outputBufferUtilization = stageInfo.get().getStageStats().getOutputBufferUtilization();
             if (verbose && outputBufferUtilization.isPresent()) {
+                TDigestHistogram utilization = outputBufferUtilization.get();
                 builder.append(indentString(1))
                         .append(format("Output buffer active time: %s, buffer utilization distribution (%%): {p01=%s, p05=%s, p10=%s, p25=%s, p50=%s, p75=%s, p90=%s, p95=%s, p99=%s, max=%s}\n",
-                                succinctNanos(outputBufferUtilization.get().getTotal()),
+                                succinctNanos(utilization.getTotal()),
                                 // scale ratio to percentages
-                                formatDouble(outputBufferUtilization.get().getP01() * 100),
-                                formatDouble(outputBufferUtilization.get().getP05() * 100),
-                                formatDouble(outputBufferUtilization.get().getP10() * 100),
-                                formatDouble(outputBufferUtilization.get().getP25() * 100),
-                                formatDouble(outputBufferUtilization.get().getP50() * 100),
-                                formatDouble(outputBufferUtilization.get().getP75() * 100),
-                                formatDouble(outputBufferUtilization.get().getP90() * 100),
-                                formatDouble(outputBufferUtilization.get().getP95() * 100),
-                                formatDouble(outputBufferUtilization.get().getP99() * 100),
-                                formatDouble(outputBufferUtilization.get().getMax() * 100)));
+                                formatDouble(utilization.getP01() * 100),
+                                formatDouble(utilization.getP05() * 100),
+                                formatDouble(utilization.getP10() * 100),
+                                formatDouble(utilization.getP25() * 100),
+                                formatDouble(utilization.getP50() * 100),
+                                formatDouble(utilization.getP75() * 100),
+                                formatDouble(utilization.getP90() * 100),
+                                formatDouble(utilization.getP95() * 100),
+                                formatDouble(utilization.getP99() * 100),
+                                formatDouble(utilization.getMax() * 100)));
+                if (utilization.getP50() > 1.0) {
+                    // Output buffer overutilization suggests that downstream task does not consume data fast enough
+                    builder.append(indentString(1))
+                            .append("Output buffer overutilized\n");
+                }
             }
         }
 


### PR DESCRIPTION
```
Example:
 Fragment 2 [SOURCE]
     CPU: 3.01s, Scheduled: 7.09s, Blocked 7.22s (Input: 0.00ns, Output: 7.22s), Input: 6001215 rows (769.89MB); per task: avg.: 6001215.00 std.dev.: 0.00, Output: 6001215
     Output buffer active time: 5.63s, buffer utilization distribution (%): {p01=0.00, p05=0.55, p10=4.81, p25=67.80, p50=100.58, p75=105.08, p90=107.06, p95=107.85, p99=10
     Output buffer overutilized
     Output layout: [orderkey, partkey, suppkey, linenumber, quantity, extendedprice, discount, tax, returnflag, linestatus, shipdate, commitdate, receiptdate, shipinstruct
     Output partitioning: ROUND_ROBIN []
```

NO RELEASE NOTES NEEDED