### PR TITLE
Start benchmarks on PR comment command.

### DIFF
--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -34,3 +34,19 @@ jobs:
         issue-type: pull-request
         commands: test-with-secrets
         permission: write
+
+# If someone with write access comments "/start-benchmarks" on a pull request, emit a repository_dispatch event
+# for workflow: https://github.com/starburstdata/benchmarks-gha/actions/workflows/start-benchmarks-command.yaml
+# which runs requested benchmarks
+    - name: Slash Command Dispatch Benchmarks
+      # fork of peter-evans/slash-command-dispatch
+      uses: trinodb/github-actions/slash-command-dispatch@2c3f458fcad343199d0e92badaaa6e9dd7993b2e
+      env:
+        TOKEN: ${{ steps.generate_token.outputs.token }}
+      with:
+        token: ${{ env.TOKEN }} # GitHub App installation access token
+        reaction-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-type: pull-request
+        commands: start-benchmarks
+        repository: starburstdata/benchmarks-gha
+        permission: write


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Enable starting macro benchmarks directly from PR comment.

Typical workflow:
1. Contributor opens a PR
2. Maintainer (anyone with repo write access) reviews this PR and decides that:
    - safe to run benchmark on this branch
    - changes in this PR could affect performance, so it should be checked
3. Maintainer adds a comment like this: `/start-benchmarks sha=<commit-sha-to-be-tested>`
4. That command will invoke this [workflow](https://github.com/starburstdata/benchmarks-gha/actions/workflows/start-benchmarks-command.yaml)
5. After its finished results will be presented in added comment as this [example](https://github.com/trinodb/trino/pull/14124#issuecomment-1335123414), it contains:
    - Link to started workflow
    - Status of each run benchmark
    - Link to the zipped report
    - Summary with top 5 biggest duration differences beetwen this run, and found closest (in number of commits) run from master for each benchmark.

Benchmark configuration:
`/start-benchmarks sha=<commit-sha-to-be-tested>` this is minimal command to start benchmark as sha is the only required parameter, other parameters with possible and default values:
1. `BenchtoConfigDir` - choose what type of test to run
    default: `hive/sf1000_orc_part` - run hive test on ORC partitioned scale factor 1000 data set
    possible values:
          - "delta_lake/sf1_parquet_unpart"
          - "delta_lake/sf1000_parquet_part"
          - "delta_lake/sf1000_parquet_unpart"
          - "hive/sf1000_orc_part"
          - "hive/sf1000_orc_unpart"
          - "hive/sf1000_parquet_part"
          - "hive/sf1000_parquet_unpart"
          - "iceberg/sf1000_orc_part"
          - "iceberg/sf1000_orc_unpart"
          - "iceberg/sf1000_parquet_part"
          - "iceberg/sf1000_parquet_unpart"
          - "iceberg/sf1000_history_parquet_part"
          - "iceberg/sf1000_history_parquet_unpart"
          - "iceberg/sf1000_history_orc_part"
          - "iceberg/sf1000_history_orc_unpart"
          - "postgres/sf10_part"
          - "postgres/sf10_unpart"
2. `BenchtoTagPrefix` - prefix of a DB tag for this particular benchmark run
     default: PR branch name
     possible values: some `string`
3. `ActiveVariables` - variables passed to benchto during benchmark execution
     default: `ActiveVariables=join_distribution_type=AUTOMATIC,join_reordering_strategy=AUTOMATIC`
     possible values: 
       - `join_distribution_type` has 2 possible values: PARTITIONED, AUTOMATIC
       - `join_reordering_strategy` has 2 possible values: ELIMINATE_CROSS_JOINS, AUTOMATIC
       - If they are not set each query will be. executed for all possible values combination
       - `query=q12|q23` to run just few queries
 4. `RunTPCDSBenchmark` - whatever to run TPCDS Benchmark
     default: true
     possible values: true/false
 5. `RunTPCHBenchmark` - whatever to run TPCH Benchmark
     default: true
     possible values: true/false

This is current functionality/behaviour and. is subject to change if other features are requested.
As this PR is just about ability to invoke Benchmark workflow.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
