### PR TITLE
Add note about escaping quotes properly to query table function docs

### DIFF
--- a/docs/src/main/sphinx/connector/bigquery.rst
+++ b/docs/src/main/sphinx/connector/bigquery.rst
@@ -343,6 +343,8 @@ For example, group and concatenate all employee IDs by manager ID::
         )
       );
 
+.. include:: query-function-escaping-quotes.fragment
+
 FAQ
 ---
 

--- a/docs/src/main/sphinx/connector/druid.rst
+++ b/docs/src/main/sphinx/connector/druid.rst
@@ -153,3 +153,4 @@ to split and then count the number of comma-separated values in a column::
         )
       );
 
+.. include:: query-function-escaping-quotes.fragment

--- a/docs/src/main/sphinx/connector/mariadb.rst
+++ b/docs/src/main/sphinx/connector/mariadb.rst
@@ -310,6 +310,8 @@ As an example, select the age of employees by using ``TIMESTAMPDIFF`` and
         )
       );
 
+.. include:: query-function-escaping-quotes.fragment
+
 Performance
 -----------
 

--- a/docs/src/main/sphinx/connector/mongodb.rst
+++ b/docs/src/main/sphinx/connector/mongodb.rst
@@ -532,3 +532,5 @@ For example, get all rows where ``regionkey`` field is 0::
           filter => '{ regionkey: 0 }'
         )
       );
+
+.. include:: query-function-escaping-quotes.fragment

--- a/docs/src/main/sphinx/connector/mysql.rst
+++ b/docs/src/main/sphinx/connector/mysql.rst
@@ -344,6 +344,12 @@ For example, group and concatenate all employee IDs by manager ID::
         )
       );
 
+.. note::
+
+  If your query statement includes characters in quotes, you must escape the
+  quote with two single quotes ``''`` instead of a double quote ``"`` to prevent
+  the parser from ending the string.
+
 Performance
 -----------
 

--- a/docs/src/main/sphinx/connector/oracle.rst
+++ b/docs/src/main/sphinx/connector/oracle.rst
@@ -476,6 +476,8 @@ As a practical example, you can use the
         )
       );
 
+.. include:: query-function-escaping-quotes.fragment
+
 Performance
 -----------
 

--- a/docs/src/main/sphinx/connector/postgresql.rst
+++ b/docs/src/main/sphinx/connector/postgresql.rst
@@ -392,6 +392,7 @@ when using window functions::
         )
       );
 
+.. include:: query-function-escaping-quotes.fragment
 
 Performance
 -----------

--- a/docs/src/main/sphinx/connector/query-function-escaping-quotes.fragment
+++ b/docs/src/main/sphinx/connector/query-function-escaping-quotes.fragment
@@ -1,0 +1,5 @@
+.. note::
+
+  If your query statement includes characters in quotes, you must escape the
+  quote with two single quotes ``''`` instead of a double quote ``"`` to prevent
+  the parser from ending the string.

--- a/docs/src/main/sphinx/connector/redshift.rst
+++ b/docs/src/main/sphinx/connector/redshift.rst
@@ -177,3 +177,4 @@ For example, select the top 10 nations by population::
         )
       );
 
+.. include:: query-function-escaping-quotes.fragment

--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -365,6 +365,7 @@ For example, select the top 10 percent of nations by population::
         )
       );
 
+.. include:: query-function-escaping-quotes.fragment
 
 Performance
 -----------


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Documents a requirement for escaping quotes in the contents of query table functions.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

As I understand it, this is a limitation of the parser for the query table function, may apply to raw_query in Elasticsearch connector as well (which is not yet documented). Please correct me if I'm wrong.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
