### PR TITLE
Mark testUnionDistinctViews as `@Flaky`

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/AbstractTestHiveViews.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/AbstractTestHiveViews.java
@@ -44,6 +44,8 @@ import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.tests.product.TestGroups.HIVE_ICEBERG_REDIRECTIONS;
 import static io.trino.tests.product.TestGroups.HIVE_VIEWS;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.utils.HadoopTestUtils.ERROR_READING_FROM_HIVE_ISSUE;
+import static io.trino.tests.product.utils.HadoopTestUtils.ERROR_READING_FROM_HIVE_MATCH;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
@@ -312,7 +314,7 @@ public abstract class AbstractTestHiveViews
      * Test view containing IF, IN, LIKE, BETWEEN, CASE, COALESCE, operators, delimited and non-delimited columns, an inline comment
      */
     @Test(groups = HIVE_VIEWS)
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/7535", match = "FAILED: Execution Error, return code 2 from org.apache.hadoop.hive.ql.exec.mr.MapRedTask")
+    @Flaky(issue = ERROR_READING_FROM_HIVE_ISSUE, match = ERROR_READING_FROM_HIVE_MATCH)
     public void testRichSqlSyntax()
     {
         onHive().executeQuery("DROP VIEW IF EXISTS view_with_rich_syntax");
@@ -506,6 +508,7 @@ public abstract class AbstractTestHiveViews
     }
 
     @Test(groups = HIVE_VIEWS)
+    @Flaky(issue = ERROR_READING_FROM_HIVE_ISSUE, match = ERROR_READING_FROM_HIVE_MATCH)
     public void testUnionAllViews()
     {
         onHive().executeQuery("DROP TABLE IF EXISTS union_helper");
@@ -541,6 +544,7 @@ public abstract class AbstractTestHiveViews
     }
 
     @Test(groups = HIVE_VIEWS)
+    @Flaky(issue = ERROR_READING_FROM_HIVE_ISSUE, match = ERROR_READING_FROM_HIVE_MATCH)
     public void testUnionDistinctViews()
     {
         if (getHiveVersionMajor() < 1 || (getHiveVersionMajor() == 1 && getHiveVersionMinor() < 2)) {

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/utils/HadoopTestUtils.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/utils/HadoopTestUtils.java
@@ -29,6 +29,10 @@ public final class HadoopTestUtils
 
     private static final Logger log = Logger.get(HiveProductTest.class);
 
+    public static final String ERROR_READING_FROM_HIVE_ISSUE = "https://github.com/trinodb/trino/issues/7535";
+    @Language("RegExp")
+    public static final String ERROR_READING_FROM_HIVE_MATCH = "FAILED: Execution Error, return code 2 from org.apache.hadoop.hive.ql.exec.mr.MapRedTask";
+
     public static final String ERROR_COMMITTING_WRITE_TO_HIVE_ISSUE = "https://github.com/trinodb/trino/issues/4936";
     @Language("RegExp")
     public static final String ERROR_COMMITTING_WRITE_TO_HIVE_MATCH =


### PR DESCRIPTION
Should alleviate failure like this

    2022-12-05 19:03:57 INFO: Test io.trino.tests.product.hive.TestHiveViews.testUnionDistinctViews took 38.65s
    2022-12-05 19:03:57 INFO: FAILURE     /    io.trino.tests.product.hive.TestHiveViews.testUnionDistinctViews (Groups: hive_views) took 39.2 seconds
    2022-12-05 19:03:57 SEVERE: Failure cause:
    io.trino.tempto.query.QueryExecutionException: java.sql.SQLException: Error while processing statement: FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.exec.mr.MapRedTask. Error caching map.xml: java.nio.channels.ClosedByInterruptException
            at io.trino.tempto.query.JdbcQueryExecutor.execute(JdbcQueryExecutor.java:119)
            at io.trino.tempto.query.JdbcQueryExecutor.executeQuery(JdbcQueryExecutor.java:84)
            at io.trino.tests.product.hive.AbstractTestHiveViews.assertViewQuery(AbstractTestHiveViews.java:729)
            at io.trino.tests.product.hive.AbstractTestHiveViews.testUnionDistinctViews(AbstractTestHiveViews.java:571)
            at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
            at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.base/java.lang.reflect.Method.invoke(Method.java:568)
            at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:104)
            at org.testng.internal.Invoker.invokeMethod(Invoker.java:645)
            at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:851)
            at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1177)
            at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:129)
            at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:112)
            at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
            at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
            at java.base/java.lang.Thread.run(Thread.java:833)
    Caused by: java.sql.SQLException: Error while processing statement: FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.exec.mr.MapRedTask. Error caching map.xml: java.nio.channels.ClosedByInterruptException
            at org.apache.hive.jdbc.HiveStatement.execute(HiveStatement.java:275)
            at io.trino.tempto.query.JdbcQueryExecutor.executeQueryNoParams(JdbcQueryExecutor.java:128)
            at io.trino.tempto.query.JdbcQueryExecutor.execute(JdbcQueryExecutor.java:112)
            ... 16 more
            Suppressed: java.lang.Exception: Query: SELECT r_regionkey FROM UNION_DISTINCT_view
                    at io.trino.tempto.query.JdbcQueryExecutor.executeQueryNoParams(JdbcQueryExecutor.java:136)
                    ... 17 more

Also, opportunistically mark testUnionAllViews as well.
