### PR TITLE
Avoid Optional.orElse(expression)

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/OkHttpUtil.java
+++ b/client/trino-client/src/main/java/io/trino/client/OkHttpUtil.java
@@ -195,7 +195,7 @@ public final class OkHttpUtil
                 catch (IOException | GeneralSecurityException ignored) {
                     keyManagerPassword = keyStorePassword.map(String::toCharArray).orElse(null);
 
-                    keyStore = KeyStore.getInstance(keyStoreType.orElse(KeyStore.getDefaultType()));
+                    keyStore = KeyStore.getInstance(keyStoreType.orElseGet(KeyStore::getDefaultType));
                     try (InputStream in = new FileInputStream(keyStorePath.get())) {
                         keyStore.load(in, keyManagerPassword);
                     }
@@ -265,7 +265,7 @@ public final class OkHttpUtil
     private static KeyStore loadTrustStore(File trustStorePath, Optional<String> trustStorePassword, Optional<String> trustStoreType)
             throws IOException, GeneralSecurityException
     {
-        KeyStore trustStore = KeyStore.getInstance(trustStoreType.orElse(KeyStore.getDefaultType()));
+        KeyStore trustStore = KeyStore.getInstance(trustStoreType.orElseGet(KeyStore::getDefaultType));
         try {
             // attempt to read the trust store as a PEM file
             List<X509Certificate> certificateChain = PemReader.readCertificateChain(trustStorePath);
@@ -301,7 +301,7 @@ public final class OkHttpUtil
             }
         }
 
-        KeyStore trustStore = KeyStore.getInstance(systemTrustStoreType.orElse(KeyStore.getDefaultType()));
+        KeyStore trustStore = KeyStore.getInstance(systemTrustStoreType.orElseGet(KeyStore::getDefaultType));
         trustStore.load(null, null);
         return trustStore;
     }

--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -551,7 +551,6 @@
                             <executable>${java.home}/bin/java</executable>
                             <arguments>
                                 <argument>-DoutputDirectory=benchmark_outputs</argument>
-                                <argument>-Dmyproperty=myvalue</argument>
                                 <argument>-classpath</argument>
                                 <classpath />
                                 <argument>io.trino.benchmark.BenchmarkSuite</argument>

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -994,7 +994,7 @@ public class EventDrivenFaultTolerantQueryScheduler
                 ExecutionFailureInfo failureInfo = taskStatus.getFailures().stream()
                         .findFirst()
                         .map(this::rewriteTransportFailure)
-                        .orElse(toFailure(new TrinoException(GENERIC_INTERNAL_ERROR, "A task failed for an unknown reason")));
+                        .orElseGet(() -> toFailure(new TrinoException(GENERIC_INTERNAL_ERROR, "A task failed for an unknown reason")));
 
                 List<ScheduledTask> replacementTasks = stageExecution.taskFailed(taskId, failureInfo, taskStatus);
                 replacementTasks.forEach(task -> schedulingQueue.addOrUpdate(task, task.priority()));

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantStageScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantStageScheduler.java
@@ -660,7 +660,7 @@ public class FaultTolerantStageScheduler
                             ExecutionFailureInfo failureInfo = taskStatus.getFailures().stream()
                                     .findFirst()
                                     .map(this::rewriteTransportFailure)
-                                    .orElse(toFailure(new TrinoException(GENERIC_INTERNAL_ERROR, "A task failed for an unknown reason")));
+                                    .orElseGet(() -> toFailure(new TrinoException(GENERIC_INTERNAL_ERROR, "A task failed for an unknown reason")));
                             log.warn(failureInfo.toException(), "Task failed: %s", taskId);
                             ErrorCode errorCode = failureInfo.getErrorCode();
                             partitionMemoryEstimator.registerPartitionFinished(session, memoryLimits, taskStatus.getPeakMemoryReservation(), false, Optional.ofNullable(errorCode));

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedStageExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedStageExecution.java
@@ -346,7 +346,7 @@ public class PipelinedStageExecution
                         .findFirst()
                         .map(this::rewriteTransportFailure)
                         .map(ExecutionFailureInfo::toException)
-                        .orElse(new TrinoException(GENERIC_INTERNAL_ERROR, "A task failed for an unknown reason"));
+                        .orElseGet(() -> new TrinoException(GENERIC_INTERNAL_ERROR, "A task failed for an unknown reason"));
                 fail(failure);
                 break;
             case CANCELED:

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/TaskExecutionStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/TaskExecutionStats.java
@@ -157,7 +157,7 @@ public class TaskExecutionStats
         {
             ExecutionFailureInfo failureInfo = info.getTaskStatus().getFailures().stream()
                     .findFirst()
-                    .orElse(toFailure(new TrinoException(GENERIC_INTERNAL_ERROR, "A task failed for an unknown reason")));
+                    .orElseGet(() -> toFailure(new TrinoException(GENERIC_INTERNAL_ERROR, "A task failed for an unknown reason")));
             ErrorType errorType = Optional.ofNullable(failureInfo.getErrorCode()).map(ErrorCode::getType).orElse(INTERNAL_ERROR);
             TaskStats stats = info.getStats();
             switch (errorType) {

--- a/core/trino-main/src/main/java/io/trino/metadata/PolymorphicScalarFunctionBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/PolymorphicScalarFunctionBuilder.java
@@ -61,7 +61,7 @@ public final class PolymorphicScalarFunctionBuilder
     public PolymorphicScalarFunctionBuilder signature(Signature signature)
     {
         this.signature = requireNonNull(signature, "signature is null");
-        this.hidden = Optional.of(hidden.orElse(isOperator(signature)));
+        this.hidden = Optional.of(hidden.orElseGet(() -> isOperator(signature)));
         return this;
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/PagesIndex.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesIndex.java
@@ -466,7 +466,7 @@ public class PagesIndex
         // if compilation fails, use interpreter
         return new SimplePagesHashStrategy(
                 types,
-                outputChannels.orElse(rangeList(types.size())),
+                outputChannels.orElseGet(() -> rangeList(types.size())),
                 ImmutableList.copyOf(channels),
                 joinChannels,
                 hashChannel,
@@ -536,7 +536,7 @@ public class PagesIndex
 
         PagesHashStrategy hashStrategy = new SimplePagesHashStrategy(
                 types,
-                outputChannels.orElse(rangeList(types.size())),
+                outputChannels.orElseGet(() -> rangeList(types.size())),
                 channels,
                 joinChannels,
                 hashChannel,

--- a/core/trino-main/src/main/java/io/trino/operator/TrinoOperatorFactories.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TrinoOperatorFactories.java
@@ -47,7 +47,7 @@ public class TrinoOperatorFactories
             Optional<List<Integer>> probeOutputChannelsOptional,
             BlockTypeOperators blockTypeOperators)
     {
-        List<Integer> probeOutputChannels = probeOutputChannelsOptional.orElse(rangeList(probeTypes.size()));
+        List<Integer> probeOutputChannels = probeOutputChannelsOptional.orElseGet(() -> rangeList(probeTypes.size()));
         List<Type> probeOutputChannelTypes = probeOutputChannels.stream()
                 .map(probeTypes::get)
                 .collect(toImmutableList());
@@ -81,7 +81,7 @@ public class TrinoOperatorFactories
             PartitioningSpillerFactory partitioningSpillerFactory,
             BlockTypeOperators blockTypeOperators)
     {
-        List<Integer> probeOutputChannels = probeOutputChannelsOptional.orElse(rangeList(probeTypes.size()));
+        List<Integer> probeOutputChannels = probeOutputChannelsOptional.orElseGet(() -> rangeList(probeTypes.size()));
         List<Type> probeOutputChannelTypes = probeOutputChannels.stream()
                 .map(probeTypes::get)
                 .collect(toImmutableList());

--- a/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
@@ -1338,8 +1338,11 @@ public class AccessControlManager
 
     private List<SystemAccessControl> getSystemAccessControls()
     {
-        return Optional.ofNullable(systemAccessControls.get())
-                .orElse(ImmutableList.of(new InitializingSystemAccessControl()));
+        List<SystemAccessControl> accessControls = systemAccessControls.get();
+        if (accessControls != null) {
+            return accessControls;
+        }
+        return ImmutableList.of(new InitializingSystemAccessControl());
     }
 
     private ConnectorSecurityContext toConnectorSecurityContext(String catalogName, SecurityContext securityContext)

--- a/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
@@ -150,7 +150,7 @@ public class JoinCompiler
     {
         return lookupSourceFactories.getUnchecked(new CacheKey(
                 types,
-                outputChannels.orElse(rangeList(types.size())),
+                outputChannels.orElseGet(() -> rangeList(types.size())),
                 joinChannels,
                 sortChannel));
     }
@@ -168,7 +168,7 @@ public class JoinCompiler
 
         return new PagesHashStrategyFactory(hashStrategies.getUnchecked(new CacheKey(
                 types,
-                outputChannels.orElse(rangeList(types.size())),
+                outputChannels.orElseGet(() -> rangeList(types.size())),
                 joinChannels,
                 Optional.empty())));
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -3220,7 +3220,7 @@ public class LocalExecutionPlanner
                         // Disabling partial pre-aggregation memory limit effectively
                         // turns PARTIAL aggregation into INTERMEDIATE.
                         Optional.empty());
-            }).orElse(new DevNullOperatorFactory(context.getNextOperatorId(), node.getId()));
+            }).orElseGet(() -> new DevNullOperatorFactory(context.getNextOperatorId(), node.getId()));
 
             List<Integer> inputChannels = node.getColumns().stream()
                     .map(source::symbolToChannel)
@@ -3293,12 +3293,12 @@ public class LocalExecutionPlanner
                         200,
                         // final aggregation ignores partial pre-aggregation memory limit
                         Optional.empty());
-            }).orElse(new DevNullOperatorFactory(context.getNextOperatorId(), node.getId()));
+            }).orElseGet(() -> new DevNullOperatorFactory(context.getNextOperatorId(), node.getId()));
 
             Map<Symbol, Integer> aggregationOutput = outputMapping.buildOrThrow();
             StatisticAggregationsDescriptor<Integer> descriptor = node.getStatisticsAggregationDescriptor()
                     .map(desc -> desc.map(aggregationOutput::get))
-                    .orElse(StatisticAggregationsDescriptor.empty());
+                    .orElseGet(StatisticAggregationsDescriptor::empty);
 
             OperatorFactory operatorFactory = new TableFinishOperatorFactory(
                     context.getNextOperatorId(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
@@ -266,7 +266,7 @@ class TranslationMap
 
                 return getSymbolForColumn(node)
                         .map(symbol -> coerceIfNecessary(node, symbol.toSymbolReference()))
-                        .orElse(coerceIfNecessary(node, node));
+                        .orElseGet(() -> coerceIfNecessary(node, node));
             }
 
             @Override
@@ -844,9 +844,9 @@ class TranslationMap
                         .add(pathExpression)
                         .add(orderedParameters.getParametersRow())
                         .add(new GenericLiteral("tinyint", String.valueOf(rewritten.getEmptyBehavior().ordinal())))
-                        .add(rewritten.getEmptyDefault().orElse(new Cast(new NullLiteral(), toSqlType(resolvedFunction.getSignature().getReturnType()))))
+                        .add(rewritten.getEmptyDefault().orElseGet(() -> new Cast(new NullLiteral(), toSqlType(resolvedFunction.getSignature().getReturnType()))))
                         .add(new GenericLiteral("tinyint", String.valueOf(rewritten.getErrorBehavior().ordinal())))
-                        .add(rewritten.getErrorDefault().orElse(new Cast(new NullLiteral(), toSqlType(resolvedFunction.getSignature().getReturnType()))));
+                        .add(rewritten.getErrorDefault().orElseGet(() -> new Cast(new NullLiteral(), toSqlType(resolvedFunction.getSignature().getReturnType()))));
 
                 Expression result = new FunctionCall(resolvedFunction.toQualifiedName(), arguments.build());
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/Rule.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/Rule.java
@@ -62,9 +62,11 @@ public interface Rule<T>
 
     final class Result
     {
+        private static final Result EMPTY = new Result(Optional.empty());
+
         public static Result empty()
         {
-            return new Result(Optional.empty());
+            return EMPTY;
         }
 
         public static Result ofPlanNode(PlanNode transformedPlan)

--- a/core/trino-main/src/main/java/io/trino/testing/TestingConnectorSession.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingConnectorSession.java
@@ -211,7 +211,7 @@ public class TestingConnectorSession
                     traceToken,
                     timeZoneKey,
                     locale,
-                    start.orElse(Instant.now()),
+                    start.orElseGet(Instant::now),
                     propertyMetadatas,
                     propertyValues);
         }

--- a/core/trino-main/src/test/java/io/trino/cost/StatsCalculatorAssertion.java
+++ b/core/trino-main/src/test/java/io/trino/cost/StatsCalculatorAssertion.java
@@ -101,7 +101,7 @@ public class StatsCalculatorAssertion
                             noLookup(),
                             transactionSession,
                             types,
-                            tableStatsProvider.orElse(new CachingTableStatsProvider(metadata, session)));
+                            tableStatsProvider.orElseGet(() -> new CachingTableStatsProvider(metadata, session)));
                 });
         statisticsAssertionConsumer.accept(PlanNodeStatsAssertion.assertThat(statsEstimate));
         return this;
@@ -116,7 +116,7 @@ public class StatsCalculatorAssertion
                 noLookup(),
                 session,
                 types,
-                tableStatsProvider.orElse(new CachingTableStatsProvider(metadata, session)));
+                tableStatsProvider.orElseGet(() -> new CachingTableStatsProvider(metadata, session)));
         checkState(statsEstimate.isPresent(), "Expected stats estimates to be present");
         statisticsAssertionConsumer.accept(PlanNodeStatsAssertion.assertThat(statsEstimate.get()));
         return this;

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestEventDrivenTaskSource.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestEventDrivenTaskSource.java
@@ -395,7 +395,7 @@ public class TestEventDrivenTaskSource
         Multimaps.asMap(splits).forEach(((planNodeId, connectorSplits) -> splitSources.put(planNodeId, new TestingSplitSource(executor, connectorSplits))));
         splitSources.putAll(failingSplitSources);
 
-        EventDrivenTaskSource.Callback taskSourceCallback = failingCallback.orElse(new TestingTaskSourceCallback());
+        EventDrivenTaskSource.Callback taskSourceCallback = failingCallback.orElseGet(TestingTaskSourceCallback::new);
         int partitionCount = getPartitionCount(sourceHandles.values(), splits.values());
         FaultTolerantPartitioningScheme partitioningScheme = createPartitioningScheme(partitionCount);
         AtomicLong getSplitInvocations = new AtomicLong();

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -499,7 +499,7 @@ public class PlanBuilder
         {
             checkState(groupingSets != null, "No grouping sets defined; use globalGrouping/groupingKeys method");
             return new AggregationNode(
-                    nodeId.orElse(idAllocator.getNextId()),
+                    nodeId.orElseGet(idAllocator::getNextId),
                     source,
                     assignments,
                     groupingSets,

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DescriptorField.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DescriptorField.java
@@ -80,7 +80,8 @@ public class DescriptorField
     @Override
     public String toString()
     {
-        return type.map(dataType -> name + " " + dataType).orElse(name.toString());
+        return type.map(dataType -> name + " " + dataType)
+                .orElseGet(name::toString);
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/Constraint.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/Constraint.java
@@ -28,6 +28,9 @@ import static java.util.Objects.requireNonNull;
 
 public class Constraint
 {
+    private static final Constraint ALWAYS_TRUE = new Constraint(TupleDomain.all());
+    private static final Constraint ALWAYS_FALSE = new Constraint(TupleDomain.none(), bindings -> false, Set.of());
+
     private final TupleDomain<ColumnHandle> summary;
     private final ConnectorExpression expression;
     private final Map<String, ColumnHandle> assignments;
@@ -36,12 +39,12 @@ public class Constraint
 
     public static Constraint alwaysTrue()
     {
-        return new Constraint(TupleDomain.all());
+        return ALWAYS_TRUE;
     }
 
     public static Constraint alwaysFalse()
     {
-        return new Constraint(TupleDomain.none(), bindings -> false, Set.of());
+        return ALWAYS_FALSE;
     }
 
     public Constraint(TupleDomain<ColumnHandle> summary)

--- a/lib/trino-matching/src/main/java/io/trino/matching/pattern/WithPattern.java
+++ b/lib/trino-matching/src/main/java/io/trino/matching/pattern/WithPattern.java
@@ -54,7 +54,7 @@ public class WithPattern<T>
         BiFunction<? super T, C, Optional<?>> property = (BiFunction<? super T, C, Optional<?>>) propertyPattern.getProperty().getFunction();
         Optional<?> propertyValue = property.apply((T) object, context);
         return propertyValue.map(value -> propertyPattern.getPattern().match(value, captures, context))
-                .orElse(Stream.of());
+                .orElseGet(Stream::of);
     }
 
     @Override

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloClient.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloClient.java
@@ -304,13 +304,14 @@ public class AccumuloClient
     private static String getRowIdColumn(ConnectorTableMetadata meta)
     {
         Optional<String> rowIdColumn = AccumuloTableProperties.getRowId(meta.getProperties());
-        return rowIdColumn.orElse(meta.getColumns().get(0).getName()).toLowerCase(Locale.ENGLISH);
+        return rowIdColumn.orElseGet(() -> meta.getColumns().get(0).getName()).toLowerCase(Locale.ENGLISH);
     }
 
     private static List<AccumuloColumnHandle> getColumnHandles(ConnectorTableMetadata meta, String rowIdColumn)
     {
         // Get the column mappings from the table property or auto-generate columns if not defined
-        Map<String, Pair<String, String>> mapping = AccumuloTableProperties.getColumnMapping(meta.getProperties()).orElse(autoGenerateMapping(meta.getColumns(), AccumuloTableProperties.getLocalityGroups(meta.getProperties())));
+        Map<String, Pair<String, String>> mapping = AccumuloTableProperties.getColumnMapping(meta.getProperties())
+                .orElseGet(() -> autoGenerateMapping(meta.getColumns(), AccumuloTableProperties.getLocalityGroups(meta.getProperties())));
 
         // The list of indexed columns
         Optional<List<String>> indexedColumns = AccumuloTableProperties.getIndexColumns(meta.getProperties());

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -189,7 +189,7 @@ public class BigQueryClient
 
     public String getProjectId()
     {
-        String projectId = configProjectId.orElse(bigQuery.getOptions().getProjectId());
+        String projectId = configProjectId.orElseGet(() -> bigQuery.getOptions().getProjectId());
         checkState(projectId.toLowerCase(ENGLISH).equals(projectId), "projectId must be lowercase but it's " + projectId);
         return projectId;
     }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
@@ -98,7 +98,7 @@ public class BigQuerySplitManager
         log.debug("getSplits(transaction=%s, session=%s, table=%s)", transaction, session, table);
         BigQueryTableHandle bigQueryTableHandle = (BigQueryTableHandle) table;
 
-        int actualParallelism = parallelism.orElse(nodeManager.getRequiredWorkerNodes().size());
+        int actualParallelism = parallelism.orElseGet(() -> nodeManager.getRequiredWorkerNodes().size());
         TupleDomain<ColumnHandle> tableConstraint = bigQueryTableHandle.getConstraint();
         Optional<String> filter = BigQueryFilterQueryBuilder.buildFilter(tableConstraint);
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ViewMaterializationCache.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ViewMaterializationCache.java
@@ -68,8 +68,8 @@ public class ViewMaterializationCache
 
     private TableId createDestinationTable(TableId remoteTableId)
     {
-        String project = viewMaterializationProject.orElse(remoteTableId.getProject());
-        String dataset = viewMaterializationDataset.orElse(remoteTableId.getDataset());
+        String project = viewMaterializationProject.orElseGet(remoteTableId::getProject);
+        String dataset = viewMaterializationDataset.orElseGet(remoteTableId::getDataset);
 
         String name = format("_pbc_%s", randomUUID().toString().toLowerCase(ENGLISH).replace("-", ""));
         return TableId.of(project, dataset, name);

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPartitionManager.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPartitionManager.java
@@ -82,7 +82,7 @@ public class CassandraPartitionManager
                                 .flatMap(partitionTupleDomain -> partitionTupleDomain.getDomains()
                                         .map(Map::keySet)
                                         .map(Set::stream))
-                                .orElse(Stream.empty()))
+                                .orElseGet(Stream::empty))
                         .collect(toImmutableSet());
                 remainingTupleDomain = tupleDomain.filter((column, domain) -> !usedPartitionColumns.contains(column));
             }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -230,6 +230,7 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.TypeUtils.isFloatingPointNaN;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.String.format;
+import static java.time.Instant.EPOCH;
 import static java.util.Collections.emptyIterator;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableMap;
@@ -2286,8 +2287,8 @@ public class DeltaLakeMetadata
         Optional<Instant> filesModifiedAfter = Optional.empty();
         if (filesModifiedAfterFromProperties.isPresent() || alreadyAnalyzedModifiedTimeMax.isPresent()) {
             filesModifiedAfter = Optional.of(Comparators.max(
-                    filesModifiedAfterFromProperties.orElse(Instant.ofEpochMilli(0)),
-                    alreadyAnalyzedModifiedTimeMax.orElse(Instant.ofEpochMilli(0))));
+                    filesModifiedAfterFromProperties.orElse(EPOCH),
+                    alreadyAnalyzedModifiedTimeMax.orElse(EPOCH)));
         }
 
         Optional<Set<String>> analyzeColumnNames = DeltaLakeAnalyzeProperties.getColumnNames(analyzeProperties);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
@@ -226,7 +226,7 @@ public class DeltaLakeSplitManager
     {
         return effectivePredicate.getDomains()
                 .flatMap(domains -> Optional.ofNullable(domains.get(pathColumnHandle())))
-                .orElse(Domain.all(pathColumnHandle().getType()));
+                .orElseGet(() -> Domain.all(pathColumnHandle().getType()));
     }
 
     private static boolean pathMatchesPredicate(Domain pathDomain, String path)

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/s3/S3AsyncClientWrapper.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/s3/S3AsyncClientWrapper.java
@@ -148,7 +148,7 @@ public abstract class S3AsyncClientWrapper
                 .version(VersionInfo.SDK_VERSION).name("PAGINATED").build());
         AwsRequestOverrideConfiguration overrideConfiguration = request.overrideConfiguration()
                 .map(c -> c.toBuilder().applyMutation(userAgentApplier).build())
-                .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(userAgentApplier).build()));
+                .orElseGet(() -> AwsRequestOverrideConfiguration.builder().applyMutation(userAgentApplier).build());
         return (T) request.toBuilder().overrideConfiguration(overrideConfiguration).build();
     }
 

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsMetadata.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsMetadata.java
@@ -131,7 +131,7 @@ public class SheetsMetadata
     @Override
     public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
     {
-        String schema = schemaName.orElse(getOnlyElement(SCHEMAS));
+        String schema = schemaName.orElseGet(() -> getOnlyElement(SCHEMAS));
 
         if (listSchemaNames().contains(schema)) {
             return sheetsClient.getTableNames().stream()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCompressionCodecs.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCompressionCodecs.java
@@ -26,7 +26,7 @@ public final class HiveCompressionCodecs
         HiveCompressionOption compressionOption = HiveSessionProperties.getCompressionCodec(session);
         return HiveStorageFormat.getHiveStorageFormat(storageFormat)
                 .map(format -> selectCompressionCodec(compressionOption, format))
-                .orElse(selectCompressionCodecForUnknownStorageFormat(compressionOption));
+                .orElseGet(() -> selectCompressionCodecForUnknownStorageFormat(compressionOption));
     }
 
     public static HiveCompressionCodec selectCompressionCodec(ConnectorSession session, HiveStorageFormat storageFormat)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/aws/athena/PartitionProjection.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/aws/athena/PartitionProjection.java
@@ -111,7 +111,7 @@ public final class PartitionProjection
                                         table.getPartitionColumns().stream()
                                                 .map(column -> column.getName()).collect(Collectors.toList()),
                                         partitionValues))
-                                .orElse(format("%s/%s/", table.getStorage().getLocation(), partitionName)))
+                                .orElseGet(() -> format("%s/%s/", table.getStorage().getLocation(), partitionName)))
                         .setBucketProperty(table.getStorage().getBucketProperty())
                         .setSerdeParameters(table.getStorage().getSerdeParameters()))
                 .build();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/aws/athena/projection/IntegerProjection.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/aws/athena/projection/IntegerProjection.java
@@ -54,7 +54,7 @@ public class IntegerProjection
             int currentValue = current;
             String currentValueFormatted = digits
                     .map(digits -> String.format("%0" + digits + "d", currentValue))
-                    .orElse(Integer.toString(current));
+                    .orElseGet(() -> Integer.toString(currentValue));
             if (isValueInDomain(partitionValueFilter, current, currentValueFormatted)) {
                 builder.add(currentValueFormatted);
             }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3select/S3SelectRecordCursorProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3select/S3SelectRecordCursorProvider.java
@@ -93,7 +93,7 @@ public class S3SelectRecordCursorProvider
 
         List<HiveColumnHandle> readerColumns = projectedReaderColumns
                 .map(readColumns -> readColumns.get().stream().map(HiveColumnHandle.class::cast).collect(toImmutableList()))
-                .orElse(ImmutableList.copyOf(columns));
+                .orElseGet(() -> ImmutableList.copyOf(columns));
         // Query is not going to filter any data, no need to use S3 Select
         if (!hasFilters(schema, effectivePredicate, readerColumns)) {
             return Optional.empty();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
@@ -126,7 +126,7 @@ public final class IcebergQueryRunner
                 }
 
                 queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", icebergProperties);
-                schemaInitializer.orElse(SchemaInitializer.builder().build()).accept(queryRunner);
+                schemaInitializer.orElseGet(() -> SchemaInitializer.builder().build()).accept(queryRunner);
 
                 return queryRunner;
             }

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchMetadata.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchMetadata.java
@@ -539,7 +539,7 @@ public class TpchMetadata
                     return entry.getValue().stream()
                             .map(nullableValue -> Domain.singleValue(type, nullableValue.getValue()))
                             .reduce((Domain::union))
-                            .orElse(Domain.none(type));
+                            .orElseGet(() -> Domain.none(type));
                 })));
     }
 

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/configs/ConfigEnvBased.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/configs/ConfigEnvBased.java
@@ -74,7 +74,7 @@ public class ConfigEnvBased
                         .omitEmptyStrings()
                         .trimResults()
                         .splitToList(value))
-                .orElse(super.getExcludedGroups());
+                .orElseGet(super::getExcludedGroups);
     }
 
     @Override
@@ -86,7 +86,7 @@ public class ConfigEnvBased
                         .omitEmptyStrings()
                         .trimResults()
                         .splitToList(value))
-                .orElse(super.getExcludedTests());
+                .orElseGet(super::getExcludedTests);
     }
 
     @Override

--- a/testing/trino-testing-kafka/src/main/java/io/trino/testing/kafka/TestingKafka.java
+++ b/testing/trino-testing-kafka/src/main/java/io/trino/testing/kafka/TestingKafka.java
@@ -214,7 +214,7 @@ public final class TestingKafka
         try (KafkaProducer<K, V> producer = createProducer(extraProducerProperties)) {
             Future<RecordMetadata> future = recordStream.map(record -> send(producer, record))
                     .reduce((first, second) -> second)
-                    .orElse(Futures.immediateFuture(null));
+                    .orElseGet(() -> Futures.immediateFuture(null));
             producer.flush();
             return future.get();
         }

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/FlakyTestRetryAnalyzer.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/FlakyTestRetryAnalyzer.java
@@ -55,7 +55,7 @@ public class FlakyTestRetryAnalyzer
 
         Optional<String> enabledSystemPropertyValue = Optional.ofNullable(System.getProperty(ENABLED_SYSTEM_PROPERTY));
         if (!enabledSystemPropertyValue.map(Boolean::parseBoolean)
-                .orElse(System.getenv("CONTINUOUS_INTEGRATION") != null)) {
+                .orElseGet(() -> System.getenv("CONTINUOUS_INTEGRATION") != null)) {
             log.info(
                     "FlakyTestRetryAnalyzer not enabled: " +
                             "CONTINUOUS_INTEGRATION environment is not detected or " +


### PR DESCRIPTION
Evaluate option's alternative with `orElseGet` rather than eagerly with `orElse(expression)`, when expression is expensive to evaluate. Here "expensive" means anything that can run a validation, i.e. is NOT constant NOR assessor, NOR a factory method of a simple type (like `Optional`, `ImmutableList`, and similar).
