### PR TITLE
Set output buffer overutilized when new pages are allowed

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/buffer/ArbitraryOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/ArbitraryOutputBuffer.java
@@ -116,7 +116,7 @@ public class ArbitraryOutputBuffer
     {
         // do not grab lock to acquire outputBuffers to avoid delaying TaskStatus response
         return OutputBufferStatus.builder(outputBuffers.getVersion())
-                .setOverutilized(memoryManager.getUtilization() >= 0.5 || !stateMachine.getState().canAddPages())
+                .setOverutilized(memoryManager.getUtilization() >= 0.5 && stateMachine.getState().canAddPages())
                 .build();
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Set output buffer overutilized when new pages are allowed. When a task is completed, its output buffer state is changed to FLUSHING and even if there is 0 output rows, it is considered as overutilized. This PR makes ArbitraryOutputBuffer's overutilized setting to be the same as BroadcastOutputBuffer.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
