### PR TITLE
Optimize PLAIN values decoders in parquet reader

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderUtils.java
@@ -74,6 +74,22 @@ public final class ParquetReaderUtils
     }
 
     /**
+     * Propagate the sign bit in values that are shorter than 8 bytes.
+     * <p>
+     * When the value of less than 8 bytes in put into a long variable, the padding bytes on the
+     * left side of the number should be all zeros for a positive number or all ones for negatives.
+     * This method does this padding using signed bit shift operator without branches.
+     *
+     * @param value Value to trim
+     * @param bitsToPad Number of bits to pad
+     * @return Value with correct padding
+     */
+    public static long propagateSignBit(long value, int bitsToPad)
+    {
+        return value << bitsToPad >> bitsToPad;
+    }
+
+    /**
      * Method simulates a cast from boolean to byte value. Despite using
      * a ternary (?) operator, the just-in-time compiler usually figures out
      * that this is a cast and turns that into a no-op.

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
@@ -297,7 +297,7 @@ public final class ParquetTypeUtils
             if (bytes[i] != expectedValue) {
                 throw new TrinoException(NOT_SUPPORTED, format(
                         "Could not read unscaled value %s into %s from column %s",
-                        new BigInteger(bytes),
+                        new BigInteger(bytes, offset, length + Long.BYTES),
                         trinoType,
                         descriptor));
             }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/dictionary/IntegerDictionary.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/dictionary/IntegerDictionary.java
@@ -14,12 +14,11 @@
 package io.trino.parquet.dictionary;
 
 import io.trino.parquet.DictionaryPage;
-import org.apache.parquet.column.values.plain.PlainValuesReader.IntegerPlainValuesReader;
-
-import java.io.IOException;
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import io.trino.parquet.reader.decoders.ValueDecoder;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static io.trino.parquet.ParquetReaderUtils.toInputStream;
+import static io.trino.parquet.reader.decoders.PlainValueDecoders.IntPlainValueDecoder;
 
 public class IntegerDictionary
         implements Dictionary
@@ -27,14 +26,11 @@ public class IntegerDictionary
     private final int[] content;
 
     public IntegerDictionary(DictionaryPage dictionaryPage)
-            throws IOException
     {
         content = new int[dictionaryPage.getDictionarySize()];
-        IntegerPlainValuesReader intReader = new IntegerPlainValuesReader();
-        intReader.initFromPage(dictionaryPage.getDictionarySize(), toInputStream(dictionaryPage));
-        for (int i = 0; i < content.length; i++) {
-            content[i] = intReader.readInteger();
-        }
+        ValueDecoder<int[]> intReader = new IntPlainValueDecoder();
+        intReader.init(new SimpleSliceInputStream(dictionaryPage.getSlice()));
+        intReader.read(content, 0, dictionaryPage.getDictionarySize());
     }
 
     @Override

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/dictionary/LongDictionary.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/dictionary/LongDictionary.java
@@ -14,12 +14,11 @@
 package io.trino.parquet.dictionary;
 
 import io.trino.parquet.DictionaryPage;
-import org.apache.parquet.column.values.plain.PlainValuesReader.LongPlainValuesReader;
-
-import java.io.IOException;
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import io.trino.parquet.reader.decoders.ValueDecoder;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static io.trino.parquet.ParquetReaderUtils.toInputStream;
+import static io.trino.parquet.reader.decoders.PlainValueDecoders.LongPlainValueDecoder;
 
 public class LongDictionary
         implements Dictionary
@@ -27,14 +26,11 @@ public class LongDictionary
     private final long[] content;
 
     public LongDictionary(DictionaryPage dictionaryPage)
-            throws IOException
     {
         content = new long[dictionaryPage.getDictionarySize()];
-        LongPlainValuesReader longReader = new LongPlainValuesReader();
-        longReader.initFromPage(dictionaryPage.getDictionarySize(), toInputStream(dictionaryPage));
-        for (int i = 0; i < content.length; i++) {
-            content[i] = longReader.readLong();
-        }
+        ValueDecoder<long[]> longReader = new LongPlainValueDecoder();
+        longReader.init(new SimpleSliceInputStream(dictionaryPage.getSlice()));
+        longReader.read(content, 0, dictionaryPage.getDictionarySize());
     }
 
     @Override

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/SimpleSliceInputStream.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/SimpleSliceInputStream.java
@@ -49,6 +49,13 @@ public final class SimpleSliceInputStream
         return slice.getByte(offset++);
     }
 
+    public short readShort()
+    {
+        short value = slice.getShort(offset);
+        offset += Short.BYTES;
+        return value;
+    }
+
     public long readLong()
     {
         long value = slice.getLong(offset);
@@ -111,5 +118,43 @@ public final class SimpleSliceInputStream
         int value = UnsafeSlice.getIntUnchecked(slice, offset);
         offset += Integer.BYTES;
         return value;
+    }
+
+    /**
+     * Always check if needed data is available with ensureBytesAvailable method.
+     * Failing to do so may result in instant JVM crash.
+     */
+    public long readLongUnsafe()
+    {
+        long value = UnsafeSlice.getLongUnchecked(slice, offset);
+        offset += Long.BYTES;
+        return value;
+    }
+
+    /**
+     * Always check if needed data is available with ensureBytesAvailable method.
+     * Failing to do so may result in instant JVM crash.
+     */
+    public byte getByteUnsafe(int index)
+    {
+        return UnsafeSlice.getByteUnchecked(slice, offset + index);
+    }
+
+    /**
+     * Always check if needed data is available with ensureBytesAvailable method.
+     * Failing to do so may result in instant JVM crash.
+     */
+    public int getIntUnsafe(int index)
+    {
+        return UnsafeSlice.getIntUnchecked(slice, offset + index);
+    }
+
+    /**
+     * Always check if needed data is available with ensureBytesAvailable method.
+     * Failing to do so may result in instant JVM crash.
+     */
+    public long getLongUnsafe(int index)
+    {
+        return UnsafeSlice.getLongUnchecked(slice, offset + index);
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/SimpleSliceInputStream.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/SimpleSliceInputStream.java
@@ -56,6 +56,13 @@ public final class SimpleSliceInputStream
         return value;
     }
 
+    public int readInt()
+    {
+        int value = slice.getInt(offset);
+        offset += Integer.BYTES;
+        return value;
+    }
+
     public long readLong()
     {
         long value = slice.getLong(offset);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/SimpleSliceInputStream.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/SimpleSliceInputStream.java
@@ -14,8 +14,10 @@
 package io.trino.parquet.reader;
 
 import io.airlift.slice.Slice;
+import io.airlift.slice.UnsafeSlice;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkPositionIndexes;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -61,6 +63,12 @@ public final class SimpleSliceInputStream
         return bytes;
     }
 
+    public void readBytes(Slice destination, int destinationIndex, int length)
+    {
+        slice.getBytes(offset, destination, destinationIndex, length);
+        offset += length;
+    }
+
     public void skip(int n)
     {
         offset += n;
@@ -87,5 +95,21 @@ public final class SimpleSliceInputStream
     public int getByteArrayOffset()
     {
         return offset + slice.byteArrayOffset();
+    }
+
+    public void ensureBytesAvailable(int bytes)
+    {
+        checkPositionIndexes(offset, offset + bytes, slice.length());
+    }
+
+    /**
+     * Always check if needed data is available with ensureBytesAvailable method.
+     * Failing to do so may result in instant JVM crash.
+     */
+    public int readIntUnsafe()
+    {
+        int value = UnsafeSlice.getIntUnchecked(slice, offset);
+        offset += Integer.BYTES;
+        return value;
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ApacheParquetValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ApacheParquetValueDecoders.java
@@ -208,68 +208,6 @@ public class ApacheParquetValueDecoders
         }
     }
 
-    public static final class DoubleApacheParquetValueDecoder
-            implements ValueDecoder<long[]>
-    {
-        private final ValuesReader delegate;
-
-        public DoubleApacheParquetValueDecoder(ValuesReader delegate)
-        {
-            this.delegate = requireNonNull(delegate, "delegate is null");
-        }
-
-        @Override
-        public void init(SimpleSliceInputStream input)
-        {
-            initialize(input, delegate);
-        }
-
-        @Override
-        public void read(long[] values, int offset, int length)
-        {
-            for (int i = offset; i < offset + length; i++) {
-                values[i] = Double.doubleToLongBits(delegate.readDouble());
-            }
-        }
-
-        @Override
-        public void skip(int n)
-        {
-            delegate.skip(n);
-        }
-    }
-
-    public static final class FloatApacheParquetValueDecoder
-            implements ValueDecoder<int[]>
-    {
-        private final ValuesReader delegate;
-
-        public FloatApacheParquetValueDecoder(ValuesReader delegate)
-        {
-            this.delegate = requireNonNull(delegate, "delegate is null");
-        }
-
-        @Override
-        public void init(SimpleSliceInputStream input)
-        {
-            initialize(input, delegate);
-        }
-
-        @Override
-        public void read(int[] values, int offset, int length)
-        {
-            for (int i = offset; i < offset + length; i++) {
-                values[i] = Float.floatToIntBits(delegate.readFloat());
-            }
-        }
-
-        @Override
-        public void skip(int n)
-        {
-            delegate.skip(n);
-        }
-    }
-
     public static final class BooleanApacheParquetValueDecoder
             implements ValueDecoder<byte[]>
     {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/PlainByteArrayDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/PlainByteArrayDecoders.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import io.trino.parquet.reader.flat.BinaryBuffer;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.VarcharType;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.spi.type.Chars.byteCountWithoutTrailingSpace;
+import static io.trino.spi.type.Varchars.byteCount;
+import static java.lang.System.arraycopy;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * read methods in this class calculate offsets and lengths of positions and then
+ * create a single byte array that is pushed to the output buffer
+ */
+public class PlainByteArrayDecoders
+{
+    private PlainByteArrayDecoders() {}
+
+    public static final class BoundedVarcharPlainValueDecoder
+            implements ValueDecoder<BinaryBuffer>
+    {
+        private final int boundedLength;
+
+        private SimpleSliceInputStream input;
+
+        public BoundedVarcharPlainValueDecoder(VarcharType varcharType)
+        {
+            checkArgument(
+                    !varcharType.isUnbounded(),
+                    "Trino type %s is not a bounded varchar",
+                    varcharType);
+            this.boundedLength = varcharType.getBoundedLength();
+        }
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            this.input = requireNonNull(input, "input is null");
+        }
+
+        @Override
+        public void read(BinaryBuffer values, int offset, int length)
+        {
+            Slice inputSlice = input.asSlice();
+            // Output offsets array is used as a temporary space for position lengths
+            int[] offsets = values.getOffsets();
+            int currentInputOffset = 0;
+            int outputBufferSize = 0;
+
+            for (int i = offset; i < offset + length; i++) {
+                int positionLength = inputSlice.getInt(currentInputOffset);
+                currentInputOffset += Integer.BYTES;
+                int outputLength = byteCount(inputSlice, currentInputOffset, positionLength, boundedLength);
+                offsets[i + 1] = outputLength;
+                outputBufferSize += outputLength;
+                currentInputOffset += positionLength;
+            }
+
+            createOutputBuffer(values, offset, length, inputSlice, outputBufferSize);
+            input.skip(currentInputOffset);
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            skipPlainValues(input, n);
+        }
+    }
+
+    public static final class CharPlainValueDecoder
+            implements ValueDecoder<BinaryBuffer>
+    {
+        private final int maxLength;
+
+        private SimpleSliceInputStream input;
+
+        public CharPlainValueDecoder(CharType charType)
+        {
+            this.maxLength = charType.getLength();
+        }
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            this.input = requireNonNull(input, "input is null");
+        }
+
+        @Override
+        public void read(BinaryBuffer values, int offset, int length)
+        {
+            Slice inputSlice = input.asSlice();
+            // Output offsets array is used as a temporary space for position lengths
+            int[] offsets = values.getOffsets();
+            int currentInputOffset = 0;
+            int outputBufferSize = 0;
+
+            for (int i = offset; i < offset + length; i++) {
+                int positionLength = inputSlice.getInt(currentInputOffset);
+                currentInputOffset += Integer.BYTES;
+                int outputLength = byteCountWithoutTrailingSpace(inputSlice, currentInputOffset, positionLength, maxLength);
+                offsets[i + 1] = outputLength;
+                outputBufferSize += outputLength;
+                currentInputOffset += positionLength;
+            }
+
+            createOutputBuffer(values, offset, length, inputSlice, outputBufferSize);
+            input.skip(currentInputOffset);
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            skipPlainValues(input, n);
+        }
+    }
+
+    public static final class BinaryPlainValueDecoder
+            implements ValueDecoder<BinaryBuffer>
+    {
+        private SimpleSliceInputStream input;
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            this.input = requireNonNull(input, "input is null");
+        }
+
+        @Override
+        public void read(BinaryBuffer values, int offset, int length)
+        {
+            Slice inputSlice = input.asSlice();
+            // Output offsets array is used as a temporary space for position lengths
+            int[] offsets = values.getOffsets();
+            int currentInputOffset = 0;
+            int outputBufferSize = 0;
+
+            for (int i = 0; i < length; i++) {
+                int positionLength = inputSlice.getInt(currentInputOffset);
+                offsets[offset + i + 1] = positionLength;
+                outputBufferSize += positionLength;
+                currentInputOffset += positionLength + Integer.BYTES;
+            }
+
+            createOutputBuffer(values, offset, length, inputSlice, outputBufferSize);
+            input.skip(currentInputOffset);
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            skipPlainValues(input, n);
+        }
+    }
+
+    private static void skipPlainValues(SimpleSliceInputStream input, int n)
+    {
+        for (int i = 0; i < n; i++) {
+            int positionLength = input.readInt();
+            input.skip(positionLength);
+        }
+    }
+
+    /**
+     * Create one big slice of data and add it to the output buffer since buffer size is known
+     */
+    private static void createOutputBuffer(BinaryBuffer values, int offset, int length, Slice inputSlice, int outputBufferSize)
+    {
+        int[] offsets = values.getOffsets();
+        byte[] outputBuffer = new byte[outputBufferSize];
+        int currentInputOffset = 0;
+        int currentOutputOffset = 0;
+
+        byte[] inputArray;
+        int inputArrayOffset;
+        if (length != 0) {
+            inputArray = inputSlice.byteArray();
+            inputArrayOffset = inputSlice.byteArrayOffset();
+        }
+        else {
+            inputArray = new byte[0];
+            inputArrayOffset = 0;
+        }
+        for (int i = 0; i < length; i++) {
+            int inputPositionLength = inputSlice.getInt(currentInputOffset);
+            int outputPositionLength = offsets[offset + i + 1];
+            arraycopy(inputArray, inputArrayOffset + currentInputOffset + Integer.BYTES, outputBuffer, currentOutputOffset, outputPositionLength);
+            offsets[offset + i + 1] = offsets[offset + i] + outputPositionLength;
+            currentInputOffset += inputPositionLength + Integer.BYTES;
+            currentOutputOffset += outputPositionLength;
+        }
+        values.addChunk(Slices.wrappedBuffer(outputBuffer));
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/PlainValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/PlainValueDecoders.java
@@ -1,0 +1,361 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.airlift.slice.Slices;
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import io.trino.parquet.reader.flat.BitPackingUtils;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Int128;
+import org.apache.parquet.column.ColumnDescriptor;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.parquet.ParquetReaderUtils.toByteExact;
+import static io.trino.parquet.ParquetReaderUtils.toShortExact;
+import static io.trino.parquet.ParquetTypeUtils.checkBytesFitInShortDecimal;
+import static io.trino.parquet.ParquetTypeUtils.getShortDecimalValue;
+import static io.trino.parquet.reader.flat.BitPackingUtils.unpack;
+import static java.lang.Math.min;
+import static java.util.Objects.requireNonNull;
+
+public final class PlainValueDecoders
+{
+    private PlainValueDecoders() {}
+
+    public static final class LongPlainValueDecoder
+            implements ValueDecoder<long[]>
+    {
+        private SimpleSliceInputStream input;
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            this.input = requireNonNull(input, "input is null");
+        }
+
+        @Override
+        public void read(long[] values, int offset, int length)
+        {
+            input.readBytes(Slices.wrappedLongArray(values), offset * Long.BYTES, length * Long.BYTES);
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            input.skip(n * Long.BYTES);
+        }
+    }
+
+    public static final class IntPlainValueDecoder
+            implements ValueDecoder<int[]>
+    {
+        private SimpleSliceInputStream input;
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            this.input = requireNonNull(input, "input is null");
+        }
+
+        @Override
+        public void read(int[] values, int offset, int length)
+        {
+            input.readBytes(Slices.wrappedIntArray(values), offset * Integer.BYTES, length * Integer.BYTES);
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            input.skip(n * Integer.BYTES);
+        }
+    }
+
+    public static final class IntToLongPlainValueDecoder
+            implements ValueDecoder<long[]>
+    {
+        private SimpleSliceInputStream input;
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            this.input = requireNonNull(input, "input is null");
+        }
+
+        @Override
+        public void read(long[] values, int offset, int length)
+        {
+            input.ensureBytesAvailable(Integer.BYTES * length);
+            int endOffset = offset + length;
+            for (int i = offset; i < endOffset; i++) {
+                values[i] = input.readIntUnsafe();
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            input.skip(n * Integer.BYTES);
+        }
+    }
+
+    public static final class IntToShortPlainValueDecoder
+            implements ValueDecoder<short[]>
+    {
+        private SimpleSliceInputStream input;
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            this.input = requireNonNull(input, "input is null");
+        }
+
+        @Override
+        public void read(short[] values, int offset, int length)
+        {
+            input.ensureBytesAvailable(Integer.BYTES * length);
+            int endOffset = offset + length;
+            for (int i = offset; i < endOffset; i++) {
+                values[i] = toShortExact(input.readIntUnsafe());
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            input.skip(n * Integer.BYTES);
+        }
+    }
+
+    public static final class IntToBytePlainValueDecoder
+            implements ValueDecoder<byte[]>
+    {
+        private SimpleSliceInputStream input;
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            this.input = requireNonNull(input, "input is null");
+        }
+
+        @Override
+        public void read(byte[] values, int offset, int length)
+        {
+            input.ensureBytesAvailable(Integer.BYTES * length);
+            int endOffset = offset + length;
+            for (int i = offset; i < endOffset; i++) {
+                values[i] = toByteExact(input.readIntUnsafe());
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            input.skip(n * Integer.BYTES);
+        }
+    }
+
+    public static final class BooleanPlainValueDecoder
+            implements ValueDecoder<byte[]>
+    {
+        private SimpleSliceInputStream input;
+        // Number of unread bits in the current byte
+        private int alreadyReadBits;
+        // Partly read byte
+        private byte partiallyReadByte;
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            this.input = requireNonNull(input, "input is null");
+            alreadyReadBits = 0;
+        }
+
+        @Override
+        public void read(byte[] values, int offset, int length)
+        {
+            if (alreadyReadBits != 0) { // Use partially unpacked byte
+                int bitsRemaining = Byte.SIZE - alreadyReadBits;
+                int chunkSize = min(bitsRemaining, length);
+                unpack(values, offset, partiallyReadByte, alreadyReadBits, alreadyReadBits + chunkSize);
+                alreadyReadBits = (alreadyReadBits + chunkSize) % Byte.SIZE; // Set to 0 when full byte reached
+                if (length == chunkSize) {
+                    return;
+                }
+                offset += chunkSize;
+                length -= chunkSize;
+            }
+
+            // Read full bytes
+            int bytesToRead = length / Byte.SIZE;
+            while (bytesToRead >= Long.BYTES) {
+                long packedLong = input.readLong();
+                BitPackingUtils.unpack64FromLong(values, offset, packedLong);
+                bytesToRead -= Long.BYTES;
+                offset += Long.SIZE;
+            }
+            while (bytesToRead >= Byte.BYTES) {
+                byte packedByte = input.readByte();
+                BitPackingUtils.unpack8FromByte(values, offset, packedByte);
+                bytesToRead -= Byte.BYTES;
+                offset += Byte.SIZE;
+            }
+
+            // Partially read the last byte
+            alreadyReadBits = length % Byte.SIZE;
+            if (alreadyReadBits != 0) {
+                partiallyReadByte = input.readByte();
+                unpack(values, offset, partiallyReadByte, 0, alreadyReadBits);
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            if (alreadyReadBits != 0) { // Skip the partially read byte
+                int chunkSize = min(Byte.SIZE - alreadyReadBits, n);
+                n -= chunkSize;
+                alreadyReadBits = (alreadyReadBits + chunkSize) % Byte.SIZE; // Set to 0 when full byte reached
+            }
+
+            // Skip full bytes
+            input.skip(n / Byte.SIZE);
+
+            if (n % Byte.SIZE != 0) { // Partially skip the last byte
+                alreadyReadBits = n % Byte.SIZE;
+                partiallyReadByte = input.readByte();
+            }
+        }
+    }
+
+    public static final class ShortDecimalFixedLengthByteArrayDecoder
+            implements ValueDecoder<long[]>
+    {
+        private final int typeLength;
+        private final DecimalType decimalType;
+        private final ColumnDescriptor descriptor;
+
+        private SimpleSliceInputStream input;
+
+        public ShortDecimalFixedLengthByteArrayDecoder(DecimalType decimalType, ColumnDescriptor descriptor)
+        {
+            checkArgument(decimalType.isShort(), "Decimal type %s is not a short decimal", decimalType);
+            this.decimalType = decimalType;
+            this.descriptor = requireNonNull(descriptor, "descriptor is null");
+            this.typeLength = descriptor.getPrimitiveType().getTypeLength();
+            checkArgument(typeLength > 0 && typeLength <= 16, "Expected column %s to have type length in range (1-16)", descriptor);
+        }
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            this.input = requireNonNull(input, "input is null");
+        }
+
+        @Override
+        public void read(long[] values, int offset, int length)
+        {
+            input.ensureBytesAvailable(typeLength * length);
+            int extraBytesLength = 0;
+            int bytesLength = typeLength;
+            if (typeLength > Long.BYTES) {
+                extraBytesLength = typeLength - Long.BYTES;
+                bytesLength = Long.BYTES;
+            }
+            byte[] inputBytes = input.getByteArray();
+            int inputBytesOffset = input.getByteArrayOffset();
+            for (int i = offset; i < offset + length; i++) {
+                checkBytesFitInShortDecimal(inputBytes, inputBytesOffset, extraBytesLength, decimalType, descriptor);
+                values[i] = getShortDecimalValue(inputBytes, inputBytesOffset + extraBytesLength, bytesLength);
+                inputBytesOffset += typeLength;
+            }
+            input.skip(length * typeLength);
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            input.skip(n * typeLength);
+        }
+    }
+
+    public static final class LongDecimalPlainValueDecoder
+            implements ValueDecoder<long[]>
+    {
+        private final int typeLength;
+        private final byte[] inputBytes;
+
+        private SimpleSliceInputStream input;
+
+        public LongDecimalPlainValueDecoder(int typeLength)
+        {
+            checkArgument(typeLength > 0 && typeLength <= 16, "typeLength %s should be in range (1-16) for a long decimal", typeLength);
+            this.typeLength = typeLength;
+            this.inputBytes = new byte[typeLength];
+        }
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            this.input = requireNonNull(input, "input is null");
+        }
+
+        @Override
+        public void read(long[] values, int offset, int length)
+        {
+            int endOffset = (offset + length) * 2;
+            for (int currentOutputOffset = offset * 2; currentOutputOffset < endOffset; currentOutputOffset += 2) {
+                input.readBytes(Slices.wrappedBuffer(inputBytes), 0, typeLength);
+                Int128 value = Int128.fromBigEndian(inputBytes);
+                values[currentOutputOffset] = value.getHigh();
+                values[currentOutputOffset + 1] = value.getLow();
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            input.skip(n * typeLength);
+        }
+    }
+
+    public static final class UuidPlainValueDecoder
+            implements ValueDecoder<long[]>
+    {
+        private static final int UUID_SIZE = 16;
+
+        private SimpleSliceInputStream input;
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            this.input = requireNonNull(input, "input is null");
+        }
+
+        @Override
+        public void read(long[] values, int offset, int length)
+        {
+            int endOffset = (offset + length) * 2;
+            for (int currentOutputOffset = offset * 2; currentOutputOffset < endOffset; currentOutputOffset += 2) {
+                values[currentOutputOffset] = input.readLong();
+                values[currentOutputOffset + 1] = input.readLong();
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            input.skip(n * UUID_SIZE);
+        }
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ShortDecimalFixedWidthByteArrayBatchDecoder.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ShortDecimalFixedWidthByteArrayBatchDecoder.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.trino.parquet.reader.SimpleSliceInputStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.parquet.ParquetReaderUtils.propagateSignBit;
+
+public class ShortDecimalFixedWidthByteArrayBatchDecoder
+{
+    private static final ShortDecimalDecoder[] VALUE_DECODERS = new ShortDecimalDecoder[] {
+            new BigEndianReader1(),
+            new BigEndianReader2(),
+            new BigEndianReader3(),
+            new BigEndianReader4(),
+            new BigEndianReader5(),
+            new BigEndianReader6(),
+            new BigEndianReader7(),
+            new BigEndianReader8()
+    };
+
+    public interface ShortDecimalDecoder
+    {
+        void decode(SimpleSliceInputStream input, long[] values, int offset, int length);
+    }
+
+    private final ShortDecimalDecoder decoder;
+
+    public ShortDecimalFixedWidthByteArrayBatchDecoder(int length)
+    {
+        checkArgument(
+                length > 0 && length <= 8,
+                "Short decimal length %s must be in range 1-8",
+                length);
+        decoder = VALUE_DECODERS[length - 1];
+        // Unscaled number is encoded as two's complement using big-endian byte order
+        // (the most significant byte is the zeroth element)
+    }
+
+    /**
+     * This method uses Unsafe operations on Slice.
+     * Always check if needed data is available with ensureBytesAvailable method.
+     * Failing to do so may result in instant JVM crash.
+     */
+    public void getShortDecimalValues(SimpleSliceInputStream input, long[] values, int offset, int length)
+    {
+        decoder.decode(input, values, offset, length);
+    }
+
+    private static final class BigEndianReader8
+            implements ShortDecimalDecoder
+    {
+        @Override
+        public void decode(SimpleSliceInputStream input, long[] values, int offset, int length)
+        {
+            int endOffset = offset + length;
+            for (int i = offset; i < endOffset; i++) {
+                values[i] = Long.reverseBytes(input.readLongUnsafe());
+            }
+        }
+    }
+
+    private static final class BigEndianReader7
+            implements ShortDecimalDecoder
+    {
+        @Override
+        public void decode(SimpleSliceInputStream input, long[] values, int offset, int length)
+        {
+            int bytesOffSet = 0;
+            int endOffset = offset + length;
+            for (int i = offset; i < endOffset - 1; i++) {
+                // We read redundant bytes and then ignore them. Sign bit is propagated by `>>` operator
+                values[i] = Long.reverseBytes(input.getLongUnsafe(bytesOffSet)) >> 8;
+                bytesOffSet += 7;
+            }
+            // Decode the last one "normally" as it would read data out of bounds
+            values[endOffset - 1] = decode(input, bytesOffSet);
+            input.skip(bytesOffSet + 7);
+        }
+
+        private long decode(SimpleSliceInputStream input, int index)
+        {
+            long value = (input.getByteUnsafe(index + 6) & 0xFFL)
+                    | (input.getByteUnsafe(index + 5) & 0xFFL) << 8
+                    | (input.getByteUnsafe(index + 4) & 0xFFL) << 16
+                    | (Integer.reverseBytes(input.getIntUnsafe(index)) & 0xFFFFFFFFL) << 24;
+            return propagateSignBit(value, 8);
+        }
+    }
+
+    private static final class BigEndianReader6
+            implements ShortDecimalDecoder
+    {
+        @Override
+        public void decode(SimpleSliceInputStream input, long[] values, int offset, int length)
+        {
+            int bytesOffSet = 0;
+            int endOffset = offset + length;
+            for (int i = offset; i < endOffset - 1; i++) {
+                // We read redundant bytes and then ignore them. Sign bit is propagated by `>>` operator
+                values[i] = Long.reverseBytes(input.getLongUnsafe(bytesOffSet)) >> 16;
+                bytesOffSet += 6;
+            }
+            // Decode the last one "normally" as it would read data out of bounds
+            values[endOffset - 1] = decode(input, bytesOffSet);
+            input.skip(bytesOffSet + 6);
+        }
+
+        private long decode(SimpleSliceInputStream input, int index)
+        {
+            long value = (input.getByteUnsafe(index + 5) & 0xFFL)
+                    | (input.getByteUnsafe(index + 4) & 0xFFL) << 8
+                    | (Integer.reverseBytes(input.getIntUnsafe(index)) & 0xFFFFFFFFL) << 16;
+            return propagateSignBit(value, 16);
+        }
+    }
+
+    private static final class BigEndianReader5
+            implements ShortDecimalDecoder
+    {
+        @Override
+        public void decode(SimpleSliceInputStream input, long[] values, int offset, int length)
+        {
+            int bytesOffSet = 0;
+            int endOffset = offset + length;
+            for (int i = offset; i < endOffset - 1; i++) {
+                // We read redundant bytes and then ignore them. Sign bit is propagated by `>>` operator
+                values[i] = Long.reverseBytes(input.getLongUnsafe(bytesOffSet)) >> 24;
+                bytesOffSet += 5;
+            }
+            // Decode the last one "normally" as it would read data out of bounds
+            values[endOffset - 1] = decode(input, bytesOffSet);
+            input.skip(bytesOffSet + 5);
+        }
+
+        private long decode(SimpleSliceInputStream input, int index)
+        {
+            long value = (input.getByteUnsafe(index + 4) & 0xFFL)
+                    | (Integer.reverseBytes(input.getIntUnsafe(index)) & 0xFFFFFFFFL) << 8;
+            return propagateSignBit(value, 24);
+        }
+    }
+
+    private static final class BigEndianReader4
+            implements ShortDecimalDecoder
+    {
+        @Override
+        public void decode(SimpleSliceInputStream input, long[] values, int offset, int length)
+        {
+            while (length > 1) {
+                long value = Long.reverseBytes(input.readLongUnsafe());
+
+                // Implicit cast will propagate the sign bit correctly, as it is performed after the byte reversal.
+                values[offset] = (int) (value >> 32);
+                values[offset + 1] = (int) value;
+
+                offset += 2;
+                length -= 2;
+            }
+
+            if (length > 0) {
+                int value = input.readIntUnsafe();
+                values[offset] = Integer.reverseBytes(value);
+            }
+        }
+    }
+
+    private static final class BigEndianReader3
+            implements ShortDecimalDecoder
+    {
+        @Override
+        public void decode(SimpleSliceInputStream input, long[] values, int offset, int length)
+        {
+            int bytesOffSet = 0;
+            int endOffset = offset + length;
+            int i = offset;
+            for (; i < endOffset - 2; i += 2) {
+                // We read redundant bytes and then ignore them. Sign bit is propagated by `>>` operator
+                long value = Long.reverseBytes(input.getLongUnsafe(bytesOffSet));
+                values[i] = value >> 40;
+                values[i + 1] = value << 24 >> 40;
+                bytesOffSet += 6;
+            }
+            // Decode the last values "normally" as it would read data out of bounds
+            while (i < endOffset) {
+                values[i++] = decode(input, bytesOffSet);
+                bytesOffSet += 3;
+            }
+            input.skip(bytesOffSet);
+        }
+
+        private long decode(SimpleSliceInputStream input, int index)
+        {
+            long value = (input.getByteUnsafe(index + 2) & 0xFFL)
+                    | (input.getByteUnsafe(index + 1) & 0xFFL) << 8
+                    | (input.getByteUnsafe(index) & 0xFFL) << 16;
+            return propagateSignBit(value, 40);
+        }
+    }
+
+    private static final class BigEndianReader2
+            implements ShortDecimalDecoder
+    {
+        @Override
+        public void decode(SimpleSliceInputStream input, long[] values, int offset, int length)
+        {
+            while (length > 3) {
+                long value = input.readLongUnsafe();
+                // Reverse all bytes at once
+                value = Long.reverseBytes(value);
+
+                // We first shift the byte as left as possible. Then, when shifting back right,
+                // the sign bit will get propagated
+                values[offset] = value >> 48;
+                values[offset + 1] = value << 16 >> 48;
+                values[offset + 2] = value << 32 >> 48;
+                values[offset + 3] = value << 48 >> 48;
+
+                offset += 4;
+                length -= 4;
+            }
+
+            while (length > 0) {
+                // Implicit cast will propagate the sign bit correctly, as it is performed after the byte reversal.
+                values[offset++] = Short.reverseBytes(input.readShort());
+                length--;
+            }
+        }
+    }
+
+    private static final class BigEndianReader1
+            implements ShortDecimalDecoder
+    {
+        @Override
+        public void decode(SimpleSliceInputStream input, long[] values, int offset, int length)
+        {
+            while (length > 7) {
+                long value = input.readLongUnsafe();
+
+                // We first shift the byte as left as possible. Then, when shifting back right,
+                // the sign bit will get propagated
+                values[offset] = value << 56 >> 56;
+                values[offset + 1] = value << 48 >> 56;
+                values[offset + 2] = value << 40 >> 56;
+                values[offset + 3] = value << 32 >> 56;
+                values[offset + 4] = value << 24 >> 56;
+                values[offset + 5] = value << 16 >> 56;
+                values[offset + 6] = value << 8 >> 56;
+                values[offset + 7] = value >> 56;
+
+                offset += 8;
+                length -= 8;
+            }
+
+            while (length > 0) {
+                // Implicit cast will propagate the sign bit correctly
+                values[offset++] = input.readByte();
+                length--;
+            }
+        }
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
@@ -13,9 +13,13 @@
  */
 package io.trino.parquet.reader.decoders;
 
+import io.trino.parquet.DictionaryPage;
 import io.trino.parquet.ParquetEncoding;
 import io.trino.parquet.PrimitiveField;
+import io.trino.parquet.reader.SimpleSliceInputStream;
 import io.trino.parquet.reader.flat.BinaryBuffer;
+import io.trino.parquet.reader.flat.ColumnAdapter;
+import io.trino.parquet.reader.flat.DictionaryDecoder;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Type;
@@ -30,8 +34,6 @@ import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.Boolea
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.BoundedVarcharApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ByteApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.CharApacheParquetValueDecoder;
-import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.DoubleApacheParquetValueDecoder;
-import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.FloatApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.Int96ApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.IntApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.IntToLongApacheParquetValueDecoder;
@@ -40,6 +42,15 @@ import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.LongDe
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortDecimalApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.UuidApacheParquetValueDecoder;
+import static io.trino.parquet.reader.decoders.PlainValueDecoders.BooleanPlainValueDecoder;
+import static io.trino.parquet.reader.decoders.PlainValueDecoders.IntPlainValueDecoder;
+import static io.trino.parquet.reader.decoders.PlainValueDecoders.IntToBytePlainValueDecoder;
+import static io.trino.parquet.reader.decoders.PlainValueDecoders.IntToLongPlainValueDecoder;
+import static io.trino.parquet.reader.decoders.PlainValueDecoders.IntToShortPlainValueDecoder;
+import static io.trino.parquet.reader.decoders.PlainValueDecoders.LongDecimalPlainValueDecoder;
+import static io.trino.parquet.reader.decoders.PlainValueDecoders.LongPlainValueDecoder;
+import static io.trino.parquet.reader.decoders.PlainValueDecoders.ShortDecimalFixedLengthByteArrayDecoder;
+import static io.trino.parquet.reader.decoders.PlainValueDecoders.UuidPlainValueDecoder;
 import static io.trino.parquet.reader.flat.Int96ColumnAdapter.Int96Buffer;
 
 /**
@@ -56,7 +67,7 @@ public final class ValueDecoders
     public static ValueDecoder<long[]> getDoubleDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         if (PLAIN.equals(encoding)) {
-            return new DoubleApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
+            return new LongPlainValueDecoder();
         }
         throw wrongEncoding(encoding, field);
     }
@@ -64,7 +75,7 @@ public final class ValueDecoders
     public static ValueDecoder<int[]> getRealDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         if (PLAIN.equals(encoding)) {
-            return new FloatApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
+            return new IntPlainValueDecoder();
         }
         throw wrongEncoding(encoding, field);
     }
@@ -92,7 +103,8 @@ public final class ValueDecoders
     public static ValueDecoder<long[]> getUuidDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         return switch (encoding) {
-            case PLAIN, DELTA_BYTE_ARRAY ->
+            case PLAIN -> new UuidPlainValueDecoder();
+            case DELTA_BYTE_ARRAY ->
                     new UuidApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
             default -> throw wrongEncoding(encoding, field);
         };
@@ -101,7 +113,8 @@ public final class ValueDecoders
     public static ValueDecoder<long[]> getLongDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         return switch (encoding) {
-            case PLAIN, DELTA_BINARY_PACKED, RLE, BIT_PACKED ->
+            case PLAIN -> new LongPlainValueDecoder();
+            case DELTA_BINARY_PACKED, RLE, BIT_PACKED ->
                     new LongApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
             default -> throw wrongEncoding(encoding, field);
         };
@@ -111,7 +124,8 @@ public final class ValueDecoders
     {
         // We need to produce LongArrayBlock from the decoded integers for INT32 backed decimals and bigints
         return switch (encoding) {
-            case PLAIN, DELTA_BINARY_PACKED, RLE, BIT_PACKED ->
+            case PLAIN -> new IntToLongPlainValueDecoder();
+            case DELTA_BINARY_PACKED, RLE, BIT_PACKED ->
                     new IntToLongApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
             default -> throw wrongEncoding(encoding, field);
         };
@@ -120,7 +134,8 @@ public final class ValueDecoders
     public static ValueDecoder<int[]> getIntDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         return switch (encoding) {
-            case PLAIN, DELTA_BINARY_PACKED, RLE, BIT_PACKED ->
+            case PLAIN -> new IntPlainValueDecoder();
+            case DELTA_BINARY_PACKED, RLE, BIT_PACKED ->
                     new IntApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
             default -> throw wrongEncoding(encoding, field);
         };
@@ -129,7 +144,8 @@ public final class ValueDecoders
     public static ValueDecoder<byte[]> getByteDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         return switch (encoding) {
-            case PLAIN, DELTA_BINARY_PACKED, RLE, BIT_PACKED ->
+            case PLAIN -> new IntToBytePlainValueDecoder();
+            case DELTA_BINARY_PACKED, RLE, BIT_PACKED ->
                     new ByteApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
             default -> throw wrongEncoding(encoding, field);
         };
@@ -138,7 +154,8 @@ public final class ValueDecoders
     public static ValueDecoder<short[]> getShortDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         return switch (encoding) {
-            case PLAIN, DELTA_BINARY_PACKED, RLE, BIT_PACKED ->
+            case PLAIN -> new IntToShortPlainValueDecoder();
+            case DELTA_BINARY_PACKED, RLE, BIT_PACKED ->
                     new ShortApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
             default -> throw wrongEncoding(encoding, field);
         };
@@ -147,7 +164,8 @@ public final class ValueDecoders
     public static ValueDecoder<byte[]> getBooleanDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         return switch (encoding) {
-            case PLAIN, RLE, BIT_PACKED -> new BooleanApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
+            case PLAIN -> new BooleanPlainValueDecoder();
+            case RLE, BIT_PACKED -> new BooleanApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
             default -> throw wrongEncoding(encoding, field);
         };
     }
@@ -160,10 +178,11 @@ public final class ValueDecoders
         throw wrongEncoding(encoding, field);
     }
 
-    private static ValueDecoder<long[]> getFixedWidthShortDecimalDecoder(ParquetEncoding encoding, PrimitiveField field, DecimalType decimalType)
+    public static ValueDecoder<long[]> getFixedWidthShortDecimalDecoder(ParquetEncoding encoding, PrimitiveField field, DecimalType decimalType)
     {
         return switch (encoding) {
-            case PLAIN, DELTA_BYTE_ARRAY -> new ShortDecimalApacheParquetValueDecoder(
+            case PLAIN -> new ShortDecimalFixedLengthByteArrayDecoder(decimalType, field.getDescriptor());
+            case DELTA_BYTE_ARRAY -> new ShortDecimalApacheParquetValueDecoder(
                     getApacheParquetReader(encoding, field),
                     decimalType,
                     field.getDescriptor());
@@ -171,10 +190,11 @@ public final class ValueDecoders
         };
     }
 
-    private static ValueDecoder<long[]> getFixedWidthLongDecimalDecoder(ParquetEncoding encoding, PrimitiveField field)
+    public static ValueDecoder<long[]> getFixedWidthLongDecimalDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         return switch (encoding) {
-            case PLAIN, DELTA_BYTE_ARRAY ->
+            case PLAIN -> new LongDecimalPlainValueDecoder(field.getDescriptor().getPrimitiveType().getTypeLength());
+            case DELTA_BYTE_ARRAY ->
                     new LongDecimalApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
             default -> throw wrongEncoding(encoding, field);
         };
@@ -224,6 +244,18 @@ public final class ValueDecoders
                     new BinaryApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
             default -> throw wrongEncoding(encoding, field);
         };
+    }
+
+    public static <T> DictionaryDecoder<T> getDictionaryDecoder(
+            DictionaryPage dictionaryPage,
+            ColumnAdapter<T> columnAdapter,
+            ValueDecoder<T> plainValuesDecoder)
+    {
+        int size = dictionaryPage.getDictionarySize();
+        T dictionary = columnAdapter.createBuffer(size);
+        plainValuesDecoder.init(new SimpleSliceInputStream(dictionaryPage.getSlice()));
+        plainValuesDecoder.read(dictionary, 0, size);
+        return new DictionaryDecoder<>(dictionary, columnAdapter);
     }
 
     private static ValuesReader getApacheParquetReader(ParquetEncoding encoding, PrimitiveField field)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
@@ -42,6 +42,9 @@ import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.LongDe
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortDecimalApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.UuidApacheParquetValueDecoder;
+import static io.trino.parquet.reader.decoders.PlainByteArrayDecoders.BinaryPlainValueDecoder;
+import static io.trino.parquet.reader.decoders.PlainByteArrayDecoders.BoundedVarcharPlainValueDecoder;
+import static io.trino.parquet.reader.decoders.PlainByteArrayDecoders.CharPlainValueDecoder;
 import static io.trino.parquet.reader.decoders.PlainValueDecoders.BooleanPlainValueDecoder;
 import static io.trino.parquet.reader.decoders.PlainValueDecoders.IntPlainValueDecoder;
 import static io.trino.parquet.reader.decoders.PlainValueDecoders.IntToBytePlainValueDecoder;
@@ -217,7 +220,8 @@ public final class ValueDecoders
                 "Trino type %s is not a bounded varchar",
                 trinoType);
         return switch (encoding) {
-            case PLAIN, DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY ->
+            case PLAIN -> new BoundedVarcharPlainValueDecoder((VarcharType) trinoType);
+            case DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY ->
                     new BoundedVarcharApacheParquetValueDecoder(getApacheParquetReader(encoding, field), (VarcharType) trinoType);
             default -> throw wrongEncoding(encoding, field);
         };
@@ -231,7 +235,8 @@ public final class ValueDecoders
                 "Trino type %s is not a char",
                 trinoType);
         return switch (encoding) {
-            case PLAIN, DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY ->
+            case PLAIN -> new CharPlainValueDecoder((CharType) trinoType);
+            case DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY ->
                     new CharApacheParquetValueDecoder(getApacheParquetReader(encoding, field), (CharType) trinoType);
             default -> throw wrongEncoding(encoding, field);
         };
@@ -240,7 +245,8 @@ public final class ValueDecoders
     public static ValueDecoder<BinaryBuffer> getBinaryDecoder(ParquetEncoding encoding, PrimitiveField field)
     {
         return switch (encoding) {
-            case PLAIN, DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY ->
+            case PLAIN -> new BinaryPlainValueDecoder();
+            case DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY ->
                     new BinaryApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
             default -> throw wrongEncoding(encoding, field);
         };

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/BitPackingUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/BitPackingUtils.java
@@ -131,6 +131,99 @@ public class BitPackingUtils
         return Long.SIZE - Long.bitCount(packedValue);
     }
 
+    public static void unpack(byte[] values, int offset, byte packedByte, int startBit, int endBit)
+    {
+        for (int i = 0; i < endBit - startBit; i++) {
+            values[offset + i] = (byte) ((packedByte >>> (startBit + i)) & 1);
+        }
+    }
+
+    public static void unpack8FromByte(byte[] values, int offset, byte packedByte)
+    {
+        values[offset] = (byte) (packedByte & 1);
+        values[offset + 1] = (byte) ((packedByte >>> 1) & 1);
+        values[offset + 2] = (byte) ((packedByte >>> 2) & 1);
+        values[offset + 3] = (byte) ((packedByte >>> 3) & 1);
+        values[offset + 4] = (byte) ((packedByte >>> 4) & 1);
+        values[offset + 5] = (byte) ((packedByte >>> 5) & 1);
+        values[offset + 6] = (byte) ((packedByte >>> 6) & 1);
+        values[offset + 7] = (byte) ((packedByte >>> 7) & 1);
+    }
+
+    public static void unpack64FromLong(byte[] values, int offset, long packedValue)
+    {
+        values[offset] = (byte) (packedValue & 1);
+        values[offset + 1] = (byte) ((packedValue >>> 1) & 1);
+        values[offset + 2] = (byte) ((packedValue >>> 2) & 1);
+        values[offset + 3] = (byte) ((packedValue >>> 3) & 1);
+        values[offset + 4] = (byte) ((packedValue >>> 4) & 1);
+        values[offset + 5] = (byte) ((packedValue >>> 5) & 1);
+        values[offset + 6] = (byte) ((packedValue >>> 6) & 1);
+        values[offset + 7] = (byte) ((packedValue >>> 7) & 1);
+        values[offset + 8] = (byte) ((packedValue >>> 8) & 1);
+        values[offset + 9] = (byte) ((packedValue >>> 9) & 1);
+
+        values[offset + 10] = (byte) ((packedValue >>> 10) & 1);
+        values[offset + 11] = (byte) ((packedValue >>> 11) & 1);
+        values[offset + 12] = (byte) ((packedValue >>> 12) & 1);
+        values[offset + 13] = (byte) ((packedValue >>> 13) & 1);
+        values[offset + 14] = (byte) ((packedValue >>> 14) & 1);
+        values[offset + 15] = (byte) ((packedValue >>> 15) & 1);
+        values[offset + 16] = (byte) ((packedValue >>> 16) & 1);
+        values[offset + 17] = (byte) ((packedValue >>> 17) & 1);
+        values[offset + 18] = (byte) ((packedValue >>> 18) & 1);
+        values[offset + 19] = (byte) ((packedValue >>> 19) & 1);
+
+        values[offset + 20] = (byte) ((packedValue >>> 20) & 1);
+        values[offset + 21] = (byte) ((packedValue >>> 21) & 1);
+        values[offset + 22] = (byte) ((packedValue >>> 22) & 1);
+        values[offset + 23] = (byte) ((packedValue >>> 23) & 1);
+        values[offset + 24] = (byte) ((packedValue >>> 24) & 1);
+        values[offset + 25] = (byte) ((packedValue >>> 25) & 1);
+        values[offset + 26] = (byte) ((packedValue >>> 26) & 1);
+        values[offset + 27] = (byte) ((packedValue >>> 27) & 1);
+        values[offset + 28] = (byte) ((packedValue >>> 28) & 1);
+        values[offset + 29] = (byte) ((packedValue >>> 29) & 1);
+
+        values[offset + 30] = (byte) ((packedValue >>> 30) & 1);
+        values[offset + 31] = (byte) ((packedValue >>> 31) & 1);
+        values[offset + 32] = (byte) ((packedValue >>> 32) & 1);
+        values[offset + 33] = (byte) ((packedValue >>> 33) & 1);
+        values[offset + 34] = (byte) ((packedValue >>> 34) & 1);
+        values[offset + 35] = (byte) ((packedValue >>> 35) & 1);
+        values[offset + 36] = (byte) ((packedValue >>> 36) & 1);
+        values[offset + 37] = (byte) ((packedValue >>> 37) & 1);
+        values[offset + 38] = (byte) ((packedValue >>> 38) & 1);
+        values[offset + 39] = (byte) ((packedValue >>> 39) & 1);
+
+        values[offset + 40] = (byte) ((packedValue >>> 40) & 1);
+        values[offset + 41] = (byte) ((packedValue >>> 41) & 1);
+        values[offset + 42] = (byte) ((packedValue >>> 42) & 1);
+        values[offset + 43] = (byte) ((packedValue >>> 43) & 1);
+        values[offset + 44] = (byte) ((packedValue >>> 44) & 1);
+        values[offset + 45] = (byte) ((packedValue >>> 45) & 1);
+        values[offset + 46] = (byte) ((packedValue >>> 46) & 1);
+        values[offset + 47] = (byte) ((packedValue >>> 47) & 1);
+        values[offset + 48] = (byte) ((packedValue >>> 48) & 1);
+        values[offset + 49] = (byte) ((packedValue >>> 49) & 1);
+
+        values[offset + 50] = (byte) ((packedValue >>> 50) & 1);
+        values[offset + 51] = (byte) ((packedValue >>> 51) & 1);
+        values[offset + 52] = (byte) ((packedValue >>> 52) & 1);
+        values[offset + 53] = (byte) ((packedValue >>> 53) & 1);
+        values[offset + 54] = (byte) ((packedValue >>> 54) & 1);
+        values[offset + 55] = (byte) ((packedValue >>> 55) & 1);
+        values[offset + 56] = (byte) ((packedValue >>> 56) & 1);
+        values[offset + 57] = (byte) ((packedValue >>> 57) & 1);
+        values[offset + 58] = (byte) ((packedValue >>> 58) & 1);
+        values[offset + 59] = (byte) ((packedValue >>> 59) & 1);
+
+        values[offset + 60] = (byte) ((packedValue >>> 60) & 1);
+        values[offset + 61] = (byte) ((packedValue >>> 61) & 1);
+        values[offset + 62] = (byte) ((packedValue >>> 62) & 1);
+        values[offset + 63] = (byte) ((packedValue >>> 63) & 1);
+    }
+
     public static int bitCount(byte value)
     {
         return Integer.bitCount(value & 0xFF);

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkBinaryColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkBinaryColumnReader.java
@@ -33,6 +33,8 @@ import java.util.Random;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import static io.trino.parquet.reader.TestData.randomAsciiData;
+import static io.trino.parquet.reader.TestData.randomBinaryData;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.Math.max;
 import static java.util.Objects.requireNonNull;
@@ -100,9 +102,9 @@ public class BenchmarkBinaryColumnReader
 
     public enum FieldType
     {
-        UNBOUNDED(range -> VARBINARY, BenchmarkBinaryColumnReader::randomData),
-        VARCHAR_ASCII_BOUND_EXACT(range -> VarcharType.createVarcharType(max(1, range.to)), BenchmarkBinaryColumnReader::randomAsciiData),
-        CHAR_ASCII_BOUND_HALF(range -> CharType.createCharType(max(1, range.to / 2)), BenchmarkBinaryColumnReader::randomAsciiData),
+        UNBOUNDED(range -> VARBINARY, (size, range) -> randomBinaryData(size, range.from(), range.to())),
+        VARCHAR_ASCII_BOUND_EXACT(range -> VarcharType.createVarcharType(max(1, range.to)), (size, range) -> randomAsciiData(size, range.from(), range.to())),
+        CHAR_ASCII_BOUND_HALF(range -> CharType.createCharType(max(1, range.to / 2)), (size, range) -> randomAsciiData(size, range.from(), range.to())),
         CHAR_BOUND_HALF_PADDING_SOMETIMES(range -> CharType.createCharType(max(1, range.to / 2)), (length, range) -> randomAsciiDataWithPadding(length, range, .01)),
         /**/;
 
@@ -148,36 +150,6 @@ public class BenchmarkBinaryColumnReader
     }
 
     record Range(int from, int to) {}
-
-    private static byte[][] randomData(int size, Range positionLength)
-    {
-        Random random = new Random(Objects.hash(size, positionLength.from(), positionLength.to()));
-        byte[][] data = new byte[size][];
-        for (int i = 0; i < size; i++) {
-            int length = random.nextInt(positionLength.to() - positionLength.from() + 1) + positionLength.from();
-            byte[] value = new byte[length];
-            random.nextBytes(value);
-            data[i] = value;
-        }
-
-        return data;
-    }
-
-    private static byte[][] randomAsciiData(int size, Range positionLength)
-    {
-        Random random = new Random(Objects.hash(size, positionLength.from(), positionLength.to()));
-        byte[][] data = new byte[size][];
-        for (int i = 0; i < size; i++) {
-            int length = random.nextInt(positionLength.to() - positionLength.from() + 1) + positionLength.from();
-            byte[] value = new byte[length];
-            for (int j = 0; j < length; j++) {
-                value[j] = (byte) random.nextInt(128);
-            }
-            data[i] = value;
-        }
-
-        return data;
-    }
 
     private static byte[][] randomAsciiDataWithPadding(int size, Range positionLength, double paddingChance)
     {

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkShortDecimalColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkShortDecimalColumnReader.java
@@ -26,8 +26,8 @@ import org.apache.parquet.schema.Types;
 import org.openjdk.jmh.annotations.Param;
 
 import static io.trino.parquet.reader.TestData.longToBytes;
+import static io.trino.parquet.reader.TestData.maxPrecision;
 import static io.trino.parquet.reader.TestData.unscaledRandomShortDecimalSupplier;
-import static java.lang.Math.toIntExact;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
 
 public class BenchmarkShortDecimalColumnReader
@@ -71,16 +71,6 @@ public class BenchmarkShortDecimalColumnReader
     {
         Binary binary = Binary.fromConstantByteArray(longToBytes(batch[index], byteArrayLength));
         writer.writeBytes(binary);
-    }
-
-    private static int maxPrecision(int numBytes)
-    {
-        return toIntExact(
-                // convert double to long
-                Math.round(
-                        // number of base-10 digits
-                        Math.floor(Math.log10(
-                                Math.pow(2, 8 * numBytes - 1) - 1))));  // max value stored in numBytes
     }
 
     public static void main(String[] args)

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestData.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestData.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 
 import java.math.BigInteger;
+import java.util.Objects;
 import java.util.Random;
 import java.util.function.IntFunction;
 
@@ -142,6 +143,36 @@ public final class TestData
             return r.nextLong();
         }
         return ParquetReaderUtils.propagateSignBit(r.nextLong(), 64 - bitWidth);
+    }
+
+    public static byte[][] randomBinaryData(int size, int minLength, int maxLength)
+    {
+        Random random = new Random(Objects.hash(size, minLength, maxLength));
+        byte[][] data = new byte[size][];
+        for (int i = 0; i < size; i++) {
+            int length = random.nextInt(maxLength - minLength + 1) + minLength;
+            byte[] value = new byte[length];
+            random.nextBytes(value);
+            data[i] = value;
+        }
+
+        return data;
+    }
+
+    public static byte[][] randomAsciiData(int size, int minLength, int maxLength)
+    {
+        Random random = new Random(Objects.hash(size, minLength, maxLength));
+        byte[][] data = new byte[size][];
+        for (int i = 0; i < size; i++) {
+            int length = random.nextInt(maxLength - minLength + 1) + minLength;
+            byte[] value = new byte[length];
+            for (int j = 0; j < length; j++) {
+                value[j] = (byte) random.nextInt(128);
+            }
+            data[i] = value;
+        }
+
+        return data;
     }
 
     private static int propagateSignBit(int value, int bitsToPad)

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestData.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestData.java
@@ -16,6 +16,7 @@ package io.trino.parquet.reader;
 import com.google.common.primitives.Bytes;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.trino.parquet.ParquetReaderUtils;
 import io.trino.spi.type.Decimals;
 import it.unimi.dsi.fastutil.booleans.BooleanArrayList;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
@@ -140,23 +141,7 @@ public final class TestData
         if (bitWidth == 64) {
             return r.nextLong();
         }
-        return propagateSignBit(r.nextLong(), 64 - bitWidth);
-    }
-
-    /**
-     * Propagate the sign bit in values that are shorter than 8 bytes.
-     * <p>
-     * When the value of less than 8 bytes in put into a long variable, the padding bytes on the
-     * left side of the number should be all zeros for a positive number or all ones for negatives.
-     * This method does this padding using signed bit shift operator without branches.
-     *
-     * @param value Value to trim
-     * @param bitsToPad Number of bits to pad
-     * @return Value with correct padding
-     */
-    private static long propagateSignBit(long value, int bitsToPad)
-    {
-        return value << bitsToPad >> bitsToPad;
+        return ParquetReaderUtils.propagateSignBit(r.nextLong(), 64 - bitWidth);
     }
 
     private static int propagateSignBit(int value, int bitsToPad)

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestData.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestData.java
@@ -115,14 +115,11 @@ public final class TestData
 
     public static int randomInt(Random r, int bitWidth)
     {
-        checkArgument(bitWidth <= 32 && bitWidth >= 0, "bit width must be in range 0 - 32 inclusive");
+        checkArgument(bitWidth <= 32 && bitWidth > 0, "bit width must be in range 1 - 32 inclusive");
         if (bitWidth == 32) {
             return r.nextInt();
         }
-        else if (bitWidth == 31) {
-            return r.nextInt() & ((1 << 31) - 1);
-        }
-        return r.nextInt(1 << bitWidth);
+        return propagateSignBit(r.nextInt(), 32 - bitWidth);
     }
 
     private static long randomLong(Random r, int bitWidth)
@@ -146,6 +143,11 @@ public final class TestData
      * @return Value with correct padding
      */
     private static long propagateSignBit(long value, int bitsToPad)
+    {
+        return value << bitsToPad >> bitsToPad;
+    }
+
+    private static int propagateSignBit(int value, int bitsToPad)
     {
         return value << bitsToPad >> bitsToPad;
     }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestData.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestData.java
@@ -28,10 +28,22 @@ import java.util.function.IntFunction;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.trino.parquet.ParquetTypeUtils.paddingBigInteger;
+import static java.lang.Math.toIntExact;
 
 public final class TestData
 {
     private TestData() {}
+
+    // Based on org.apache.parquet.schema.Types.BasePrimitiveBuilder.maxPrecision to determine the max decimal precision supported by INT32/INT64
+    public static int maxPrecision(int numBytes)
+    {
+        return toIntExact(
+                // convert double to long
+                Math.round(
+                        // number of base-10 digits
+                        Math.floor(Math.log10(
+                                Math.pow(2, 8 * numBytes - 1) - 1))));  // max value stored in numBytes
+    }
 
     public static IntFunction<long[]> unscaledRandomShortDecimalSupplier(int bitWidth, int precision)
     {

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestData.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestData.java
@@ -134,7 +134,7 @@ public final class TestData
         return propagateSignBit(r.nextInt(), 32 - bitWidth);
     }
 
-    private static long randomLong(Random r, int bitWidth)
+    public static long randomLong(Random r, int bitWidth)
     {
         checkArgument(bitWidth <= 64 && bitWidth > 0, "bit width must be in range 1 - 64 inclusive");
         if (bitWidth == 64) {

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/AbstractValueDecodersTest.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/AbstractValueDecodersTest.java
@@ -70,6 +70,7 @@ import static java.lang.Math.min;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.apache.parquet.column.Encoding.RLE;
+import static org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainBinaryDictionaryValuesWriter;
 import static org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainDoubleDictionaryValuesWriter;
 import static org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainFixedLenArrayDictionaryValuesWriter;
 import static org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainFloatDictionaryValuesWriter;
@@ -346,12 +347,13 @@ public abstract class AbstractValueDecodersTest
             return switch (typeName) {
                 case BOOLEAN -> new BooleanPlainValuesWriter();
                 case FIXED_LEN_BYTE_ARRAY -> new FixedLenByteArrayPlainValuesWriter(typeLength.orElseThrow(), MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
-                case INT32, INT64, DOUBLE, FLOAT -> new PlainValuesWriter(MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
+                case BINARY, INT32, INT64, DOUBLE, FLOAT -> new PlainValuesWriter(MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
                 default -> throw new IllegalArgumentException("PLAIN encoding writer is not supported for type " + typeName);
             };
         }
         if (encoding.equals(RLE_DICTIONARY) || encoding.equals(PLAIN_DICTIONARY)) {
             return switch (typeName) {
+                case BINARY -> new PlainBinaryDictionaryValuesWriter(MAX_VALUE, RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
                 case FIXED_LEN_BYTE_ARRAY -> new PlainFixedLenArrayDictionaryValuesWriter(MAX_VALUE, typeLength.orElseThrow(), RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
                 case INT32 -> new PlainIntegerDictionaryValuesWriter(MAX_VALUE, RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
                 case INT64 -> new PlainLongDictionaryValuesWriter(MAX_VALUE, RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/AbstractValueDecodersTest.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/AbstractValueDecodersTest.java
@@ -1,0 +1,365 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.parquet.ParquetEncoding;
+import io.trino.parquet.PrimitiveField;
+import io.trino.parquet.dictionary.Dictionary;
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import io.trino.parquet.reader.TestingColumnReader;
+import io.trino.parquet.reader.flat.ColumnAdapter;
+import io.trino.spi.type.Type;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.page.DictionaryPage;
+import org.apache.parquet.column.values.ValuesReader;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.plain.BooleanPlainValuesWriter;
+import org.apache.parquet.column.values.plain.FixedLenByteArrayPlainValuesWriter;
+import org.apache.parquet.column.values.plain.PlainValuesWriter;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Random;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.parquet.ParquetEncoding.PLAIN;
+import static io.trino.parquet.ParquetEncoding.PLAIN_DICTIONARY;
+import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
+import static io.trino.parquet.ValuesType.VALUES;
+import static io.trino.parquet.reader.decoders.ValueDecoder.ValueDecodersProvider;
+import static io.trino.parquet.reader.decoders.ValueDecoders.getDictionaryDecoder;
+import static io.trino.testing.DataProviders.cartesianProduct;
+import static io.trino.testing.DataProviders.concat;
+import static io.trino.testing.DataProviders.toDataProvider;
+import static java.lang.Integer.MAX_VALUE;
+import static java.lang.Math.min;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.apache.parquet.column.Encoding.RLE;
+import static org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainDoubleDictionaryValuesWriter;
+import static org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainFixedLenArrayDictionaryValuesWriter;
+import static org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainFloatDictionaryValuesWriter;
+import static org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainIntegerDictionaryValuesWriter;
+import static org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainLongDictionaryValuesWriter;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+
+public abstract class AbstractValueDecodersTest
+{
+    private static final int MAX_DATA_SIZE = 1_000_000;
+
+    private static final Object[][] SMALL_SIZE_RUNNERS = Stream.of(
+                    ImmutableList.of(fullDecoder()),
+                    generateRunnerForBatchSize(AbstractValueDecodersTest::batchDecode, 1, 12),
+                    generateRunnerForBatchSize(AbstractValueDecodersTest::skippedBatchDecode, 0, 12))
+            .flatMap(List::stream)
+            .collect(toDataProvider());
+
+    private static final Object[][] LARGE_SIZE_RUNNERS = Stream.of(
+                    ImmutableList.of(fullDecoder()),
+                    generateRunnerForBatchSize(AbstractValueDecodersTest::batchDecode, 7, 8, 9, 31, 32, 33, 1024),
+                    generateRunnerForBatchSize(AbstractValueDecodersTest::skippedBatchDecode, 7, 8, 9, 31, 32, 33, 1024))
+            .flatMap(List::stream)
+            .collect(toDataProvider());
+
+    private static final Object[][] RUNNERS_AND_SIZES = concat(
+            cartesianProduct(SMALL_SIZE_RUNNERS, Stream.of(10).collect(toDataProvider())),
+            cartesianProduct(LARGE_SIZE_RUNNERS, Stream.of(10_000).collect(toDataProvider())));
+
+    abstract Object[][] tests();
+
+    @DataProvider(name = "decoders")
+    public Object[][] decoders()
+    {
+        return cartesianProduct(tests(), RUNNERS_AND_SIZES);
+    }
+
+    @Test(dataProvider = "decoders")
+    public <T> void testDecoder(
+            TestType<T> testType,
+            ParquetEncoding encoding,
+            InputDataProvider inputDataProvider,
+            Runner<T> runner,
+            int dataSize)
+    {
+        PrimitiveField field = testType.field();
+        PrimitiveType primitiveType = field.getDescriptor().getPrimitiveType();
+        ValuesWriter valuesWriter = getValuesWriter(encoding, primitiveType.getPrimitiveTypeName(), OptionalInt.of(primitiveType.getTypeLength()));
+        DataBuffer dataBuffer = inputDataProvider.write(valuesWriter, dataSize);
+
+        Optional<io.trino.parquet.DictionaryPage> dictionaryPage = Optional.ofNullable(dataBuffer.dictionaryPage())
+                .map(TestingColumnReader::toTrinoDictionaryPage);
+        Optional<Dictionary> dictionary = dictionaryPage.map(page -> {
+            try {
+                return encoding.initDictionary(field.getDescriptor(), page);
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+        ValuesReader valuesReader = getApacheParquetReader(encoding, field, dictionary);
+        ValueDecoder<T> apacheValuesDecoder = testType.apacheValuesDecoderProvider().apply(valuesReader);
+
+        Optional<ValueDecoder<T>> dictionaryDecoder = dictionaryPage.map(page -> getDictionaryDecoder(
+                page,
+                testType.columnAdapter(),
+                testType.optimizedValuesDecoderProvider().create(PLAIN, field)));
+        ValueDecoder<T> optimizedValuesDecoder = dictionaryDecoder.orElseGet(() -> testType.optimizedValuesDecoderProvider().create(encoding, field));
+
+        apacheValuesDecoder.init(new SimpleSliceInputStream(dataBuffer.dataPage()));
+        optimizedValuesDecoder.init(new SimpleSliceInputStream(dataBuffer.dataPage()));
+        ColumnAdapter<T> columnAdapter = testType.columnAdapter();
+        T apacheValuesDecoderResult = columnAdapter.createBuffer(dataSize);
+        T optimizedValuesDecoderResult = columnAdapter.createBuffer(dataSize);
+
+        runner.run(apacheValuesDecoder, apacheValuesDecoderResult, dataSize);
+        runner.run(optimizedValuesDecoder, optimizedValuesDecoderResult, dataSize);
+
+        testType.assertion().accept(optimizedValuesDecoderResult, apacheValuesDecoderResult);
+    }
+
+    interface Runner<T>
+    {
+        void run(ValueDecoder<T> decoder, T data, int size);
+    }
+
+    interface InputDataProvider
+    {
+        DataBuffer write(ValuesWriter valuesWriter, int dataSize);
+    }
+
+    static DataBuffer getWrittenBuffer(ValuesWriter valuesWriter)
+    {
+        try {
+            return new DataBuffer(
+                    Slices.wrappedBuffer(valuesWriter.getBytes().toByteArray()),
+                    valuesWriter.toDictPageAndClose());
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        finally {
+            valuesWriter.reset();
+        }
+    }
+
+    record DataBuffer(Slice dataPage, @Nullable DictionaryPage dictionaryPage)
+    {
+        DataBuffer(Slice dataPage, @Nullable DictionaryPage dictionaryPage)
+        {
+            this.dataPage = requireNonNull(dataPage, "dataPage is null");
+            this.dictionaryPage = dictionaryPage;
+        }
+    }
+
+    record TestType<T>(
+            PrimitiveField field,
+            ValueDecodersProvider<T> optimizedValuesDecoderProvider,
+            Function<ValuesReader, ValueDecoder<T>> apacheValuesDecoderProvider,
+            ColumnAdapter<T> columnAdapter,
+            BiConsumer<T, T> assertion)
+    {
+        TestType(PrimitiveField field, ValueDecodersProvider<T> optimizedValuesDecoderProvider, Function<ValuesReader, ValueDecoder<T>> apacheValuesDecoderProvider, ColumnAdapter<T> columnAdapter, BiConsumer<T, T> assertion)
+        {
+            this.field = requireNonNull(field, "field is null");
+            this.optimizedValuesDecoderProvider = requireNonNull(optimizedValuesDecoderProvider, "optimizedValuesDecoderProvider is null");
+            this.apacheValuesDecoderProvider = requireNonNull(apacheValuesDecoderProvider, "apacheValuesDecoderProvider is null");
+            this.columnAdapter = requireNonNull(columnAdapter, "columnAdapter is null");
+            this.assertion = requireNonNull(assertion, "assertion is null");
+        }
+
+        @Override
+        public String toString()
+        {
+            ColumnDescriptor descriptor = field.getDescriptor();
+            return toStringHelper(this)
+                    .add("primitiveType", descriptor.getPrimitiveType().getPrimitiveTypeName())
+                    .add("trinoType", field.getType())
+                    .add("typeLength", descriptor.getPrimitiveType().getTypeLength())
+                    .toString();
+        }
+    }
+
+    static <T> Object[][] testArgs(
+            TestType<T> testType,
+            List<ParquetEncoding> encodings,
+            InputDataProvider[] inputDataProviders)
+    {
+        return cartesianProduct(
+                Stream.of(testType).collect(toDataProvider()),
+                encodings.stream().collect(toDataProvider()),
+                Arrays.stream(inputDataProviders).collect(toDataProvider()));
+    }
+
+    static ValuesReader getApacheParquetReader(ParquetEncoding encoding, PrimitiveField field, Optional<Dictionary> dictionary)
+    {
+        if (encoding == RLE_DICTIONARY || encoding == PLAIN_DICTIONARY) {
+            return encoding.getDictionaryBasedValuesReader(field.getDescriptor(), VALUES, dictionary.orElseThrow());
+        }
+        checkArgument(dictionary.isEmpty(), "dictionary should be empty");
+        return encoding.getValuesReader(field.getDescriptor(), VALUES);
+    }
+
+    static void initialize(SimpleSliceInputStream input, ValuesReader reader)
+    {
+        byte[] buffer = input.readBytes();
+        try {
+            reader.initFromPage(0, ByteBufferInputStream.wrap(ByteBuffer.wrap(buffer, 0, buffer.length)));
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    static PrimitiveField createField(PrimitiveTypeName typeName, OptionalInt typeLength, Type trinoType)
+    {
+        Types.PrimitiveBuilder<PrimitiveType> builder = Types.required(typeName);
+        if (typeLength.isPresent()) {
+            builder = builder.length(typeLength.getAsInt());
+        }
+        return new PrimitiveField(
+                trinoType,
+                true,
+                new ColumnDescriptor(new String[] {}, builder.named("dummy"), 0, 0),
+                0);
+    }
+
+    private static <T> Runner<T> fullDecoder()
+    {
+        return new Runner<>()
+        {
+            @Override
+            public void run(ValueDecoder<T> decoder, T data, int size)
+            {
+                decoder.read(data, 0, size);
+            }
+
+            @Override
+            public String toString()
+            {
+                return "full";
+            }
+        };
+    }
+
+    private static <T> Runner<T> skippedBatchDecode(int batchSize)
+    {
+        return new Runner<>()
+        {
+            @Override
+            public void run(ValueDecoder<T> decoder, T data, int size)
+            {
+                // Small random seeds always produce true as first nextBoolean()
+                Random random = new Random(0xFFFFFFFFL * (size + batchSize));
+                int i = 0;
+                while (i < size) {
+                    if (random.nextBoolean()) {
+                        int readBatch = random.nextInt(1, batchSize + 2);
+                        decoder.read(data, i, min(readBatch, size - i));
+                        i += readBatch;
+                    }
+                    else {
+                        decoder.skip(min(batchSize, size - i));
+                        i += batchSize;
+                    }
+                }
+            }
+
+            @Override
+            public String toString()
+            {
+                return "skippedBatch(" + batchSize + ")";
+            }
+        };
+    }
+
+    private static <T> Runner<T> batchDecode(int batchSize)
+    {
+        return new Runner<>()
+        {
+            @Override
+            public void run(ValueDecoder<T> decoder, T data, int size)
+            {
+                for (int i = 0; i < size; i += batchSize) {
+                    decoder.read(data, i, min(batchSize, size - i));
+                }
+            }
+
+            @Override
+            public String toString()
+            {
+                return "batch(" + batchSize + ")";
+            }
+        };
+    }
+
+    private static <T> List<Runner<T>> generateRunnerForBatchSize(Function<Integer, Runner<T>> runnerProvider, int from, int to)
+    {
+        return IntStream.range(from, to)
+                .mapToObj(runnerProvider::apply)
+                .collect(toImmutableList());
+    }
+
+    private static <T> List<Runner<T>> generateRunnerForBatchSize(Function<Integer, Runner<T>> runnerProvider, Integer... batchSizes)
+    {
+        return Arrays.stream(batchSizes)
+                .map(runnerProvider)
+                .collect(toImmutableList());
+    }
+
+    private static ValuesWriter getValuesWriter(ParquetEncoding encoding, PrimitiveTypeName typeName, OptionalInt typeLength)
+    {
+        if (encoding.equals(PLAIN)) {
+            return switch (typeName) {
+                case BOOLEAN -> new BooleanPlainValuesWriter();
+                case FIXED_LEN_BYTE_ARRAY -> new FixedLenByteArrayPlainValuesWriter(typeLength.orElseThrow(), MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
+                case INT32, INT64, DOUBLE, FLOAT -> new PlainValuesWriter(MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
+                default -> throw new IllegalArgumentException("PLAIN encoding writer is not supported for type " + typeName);
+            };
+        }
+        if (encoding.equals(RLE_DICTIONARY) || encoding.equals(PLAIN_DICTIONARY)) {
+            return switch (typeName) {
+                case FIXED_LEN_BYTE_ARRAY -> new PlainFixedLenArrayDictionaryValuesWriter(MAX_VALUE, typeLength.orElseThrow(), RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
+                case INT32 -> new PlainIntegerDictionaryValuesWriter(MAX_VALUE, RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
+                case INT64 -> new PlainLongDictionaryValuesWriter(MAX_VALUE, RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
+                case FLOAT -> new PlainFloatDictionaryValuesWriter(MAX_VALUE, RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
+                case DOUBLE -> new PlainDoubleDictionaryValuesWriter(MAX_VALUE, RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
+                default -> throw new IllegalArgumentException("Dictionary encoding writer is not supported for type " + typeName);
+            };
+        }
+        throw new UnsupportedOperationException(format("Encoding %s is not supported", encoding));
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestBooleanValueDecoders.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestBooleanValueDecoders.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.type.BooleanType;
+import org.apache.parquet.column.values.ValuesWriter;
+
+import java.util.Arrays;
+import java.util.OptionalInt;
+import java.util.Random;
+
+import static io.trino.parquet.ParquetEncoding.PLAIN;
+import static io.trino.parquet.reader.TestData.generateMixedData;
+import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.BooleanApacheParquetValueDecoder;
+import static io.trino.parquet.reader.flat.BooleanColumnAdapter.BOOLEAN_ADAPTER;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class TestBooleanValueDecoders
+        extends AbstractValueDecodersTest
+{
+    @Override
+    protected Object[][] tests()
+    {
+        return testArgs(
+                new TestType<>(
+                        createField(BOOLEAN, OptionalInt.empty(), BooleanType.BOOLEAN),
+                        ValueDecoders::getBooleanDecoder,
+                        BooleanApacheParquetValueDecoder::new,
+                        BOOLEAN_ADAPTER,
+                        (actual, expected) -> assertThat(actual).isEqualTo(expected)),
+                ImmutableList.of(PLAIN),
+                BooleanInputProvider.values());
+    }
+
+    private enum BooleanInputProvider
+            implements InputDataProvider
+    {
+        BOOLEAN_ONLY_TRUE {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                boolean[] values = new boolean[dataSize];
+                Arrays.fill(values, true);
+                return writeBooleans(valuesWriter, values);
+            }
+        },
+        BOOLEAN_ONLY_FALSE {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                return writeBooleans(valuesWriter, new boolean[dataSize]);
+            }
+        },
+        BOOLEAN_RANDOM {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                Random random = new Random(dataSize);
+                boolean[] values = new boolean[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = random.nextBoolean();
+                }
+                return writeBooleans(valuesWriter, values);
+            }
+        },
+        BOOLEAN_MIXED_AND_GROUPS_SMALL {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                return writeMixedAndGroupedBooleans(valuesWriter, dataSize / 3, dataSize);
+            }
+        },
+        BOOLEAN_MIXED_AND_GROUPS_LARGE {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                return writeMixedAndGroupedBooleans(valuesWriter, 127, dataSize);
+            }
+        },
+        BOOLEAN_MIXED_AND_GROUPS_HUGE {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                return writeMixedAndGroupedBooleans(valuesWriter, 2111, dataSize);
+            }
+        }
+    }
+
+    private static DataBuffer writeMixedAndGroupedBooleans(ValuesWriter valuesWriter, int maxGroupSize, int dataSize)
+    {
+        Random random = new Random((long) maxGroupSize * dataSize);
+        boolean[] values = generateMixedData(random, dataSize, maxGroupSize);
+        return writeBooleans(valuesWriter, values);
+    }
+
+    private static DataBuffer writeBooleans(ValuesWriter valuesWriter, boolean[] input)
+    {
+        for (boolean value : input) {
+            valuesWriter.writeBoolean(value);
+        }
+
+        return getWrittenBuffer(valuesWriter);
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestByteArrayValueDecoders.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestByteArrayValueDecoders.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.parquet.reader.flat.BinaryBuffer;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.VarcharType;
+import io.trino.testing.DataProviders;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.io.api.Binary;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.OptionalInt;
+import java.util.Random;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static io.trino.parquet.ParquetEncoding.PLAIN;
+import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
+import static io.trino.parquet.reader.TestData.randomAsciiData;
+import static io.trino.parquet.reader.TestData.randomBinaryData;
+import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.BinaryApacheParquetValueDecoder;
+import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.BoundedVarcharApacheParquetValueDecoder;
+import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.CharApacheParquetValueDecoder;
+import static io.trino.parquet.reader.flat.BinaryColumnAdapter.BINARY_ADAPTER;
+import static io.trino.spi.type.CharType.createCharType;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class TestByteArrayValueDecoders
+        extends AbstractValueDecodersTest
+{
+    private static final BiConsumer<BinaryBuffer, BinaryBuffer> BINARY_ASSERT = (actual, expected) -> {
+        assertThat(actual.getOffsets()).containsExactly(expected.getOffsets());
+        assertThat(actual.asSlice()).isEqualTo(expected.asSlice());
+    };
+
+    @Override
+    protected Object[][] tests()
+    {
+        return DataProviders.concat(
+                testArgs(
+                        new TestType<>(
+                                createField(BINARY, OptionalInt.empty(), VARBINARY),
+                                ValueDecoders::getBinaryDecoder,
+                                BinaryApacheParquetValueDecoder::new,
+                                BINARY_ADAPTER,
+                                BINARY_ASSERT),
+                        ImmutableList.of(PLAIN, RLE_DICTIONARY),
+                        generateUnboundedBinaryInputs()),
+                testArgs(
+                        new TestType<>(
+                                createField(BINARY, OptionalInt.empty(), createUnboundedVarcharType()),
+                                ValueDecoders::getBinaryDecoder,
+                                BinaryApacheParquetValueDecoder::new,
+                                BINARY_ADAPTER,
+                                BINARY_ASSERT),
+                        ImmutableList.of(PLAIN, RLE_DICTIONARY),
+                        generateUnboundedBinaryInputs()),
+                testArgs(
+                        createBoundedVarcharTestType(),
+                        ImmutableList.of(PLAIN, RLE_DICTIONARY),
+                        generateBoundedVarcharInputs()),
+                testArgs(
+                        createCharTestType(),
+                        ImmutableList.of(PLAIN, RLE_DICTIONARY),
+                        generateCharInputs()));
+    }
+
+    private static TestType<BinaryBuffer> createBoundedVarcharTestType()
+    {
+        VarcharType varcharType = createVarcharType(5);
+        return new TestType<>(
+                createField(BINARY, OptionalInt.empty(), varcharType),
+                ValueDecoders::getBoundedVarcharBinaryDecoder,
+                valuesReader -> new BoundedVarcharApacheParquetValueDecoder(valuesReader, varcharType),
+                BINARY_ADAPTER,
+                BINARY_ASSERT);
+    }
+
+    private static TestType<BinaryBuffer> createCharTestType()
+    {
+        CharType charType = createCharType(5);
+        return new TestType<>(
+                createField(BINARY, OptionalInt.empty(), charType),
+                ValueDecoders::getCharBinaryDecoder,
+                valuesReader -> new CharApacheParquetValueDecoder(valuesReader, charType),
+                BINARY_ADAPTER,
+                BINARY_ASSERT);
+    }
+
+    private static InputDataProvider[] generateUnboundedBinaryInputs()
+    {
+        return ImmutableList.of(5, 10, 11, 13, 100, 1000).stream()
+                .map(length -> ImmutableList.of(
+                        createRandomBinaryInputProvider(length),
+                        createRepeatBinaryInputProvider(length)))
+                .flatMap(List::stream)
+                .toArray(InputDataProvider[]::new);
+    }
+
+    private static InputDataProvider[] generateBoundedVarcharInputs()
+    {
+        return ImmutableList.of(1, 3, 4, 5, 6).stream()
+                .map(length -> ImmutableList.of(
+                        createRandomUtf8BinaryInputProvider(length),
+                        createRandomAsciiBinaryInputProvider(length)))
+                .flatMap(List::stream)
+                .toArray(InputDataProvider[]::new);
+    }
+
+    private static InputDataProvider[] generateCharInputs()
+    {
+        return ImmutableList.of(1, 3, 4, 5, 6).stream()
+                .map(length -> ImmutableList.of(
+                        createRandomUtf8BinaryInputProvider(length),
+                        createRandomAsciiBinaryInputProvider(length),
+                        createRandomUtf8WithPaddingBinaryInputProvider(length),
+                        createRandomAsciiWithPaddingBinaryInputProvider(length)))
+                .flatMap(List::stream)
+                .toArray(InputDataProvider[]::new);
+    }
+
+    private static InputDataProvider createRandomBinaryInputProvider(int length)
+    {
+        return new InputDataProvider()
+        {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                return writeBytes(valuesWriter, randomBinaryData(dataSize, 0, length));
+            }
+
+            @Override
+            public String toString()
+            {
+                return "random(0-" + length + ")";
+            }
+        };
+    }
+
+    private static InputDataProvider createRepeatBinaryInputProvider(int length)
+    {
+        return new InputDataProvider()
+        {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                Random random = new Random(Objects.hash(dataSize, length));
+                byte[][] repeatedValues = randomBinaryData(23, 0, length);
+                byte[][] values = new byte[dataSize][];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = repeatedValues[random.nextInt(repeatedValues.length)];
+                }
+                return writeBytes(valuesWriter, values);
+            }
+
+            @Override
+            public String toString()
+            {
+                return "repeat(0-" + length + ")";
+            }
+        };
+    }
+
+    private static InputDataProvider createRandomUtf8BinaryInputProvider(int maxLength)
+    {
+        return createRandomBinaryInputProvider(
+                maxLength,
+                () -> "random utf8(0-" + maxLength + ")",
+                random -> randomUtf8(random, maxLength));
+    }
+
+    private static InputDataProvider createRandomUtf8WithPaddingBinaryInputProvider(int maxLength)
+    {
+        return createRandomBinaryInputProvider(
+                maxLength,
+                () -> "random utf8 with padding(0-" + maxLength + ")",
+                random -> randomUtf8WithPadding(random, maxLength));
+    }
+
+    private static InputDataProvider createRandomAsciiWithPaddingBinaryInputProvider(int maxLength)
+    {
+        return createRandomBinaryInputProvider(
+                maxLength,
+                () -> "random ascii with padding(0-" + maxLength + ")",
+                random -> randomAsciiWithPadding(random, maxLength));
+    }
+
+    private static InputDataProvider createRandomAsciiBinaryInputProvider(int length)
+    {
+        return new InputDataProvider() {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                return writeBytes(valuesWriter, randomAsciiData(dataSize, 0, length));
+            }
+
+            @Override
+            public String toString()
+            {
+                return "random ascii(0-" + length + ")";
+            }
+        };
+    }
+
+    private static InputDataProvider createRandomBinaryInputProvider(
+            int maxLength,
+            Supplier<String> descriptionProvider,
+            Function<Random, byte[]> dataProvider)
+    {
+        return new InputDataProvider() {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                Random random = new Random(Objects.hash(dataSize, maxLength));
+                byte[][] values = new byte[dataSize][];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = dataProvider.apply(random);
+                }
+                return writeBytes(valuesWriter, values);
+            }
+
+            @Override
+            public String toString()
+            {
+                return descriptionProvider.get();
+            }
+        };
+    }
+
+    private static byte[] randomUtf8(Random random, int maxLength)
+    {
+        StringBuilder builder = new StringBuilder();
+        int length = random.nextInt(maxLength + 1);
+        for (int i = 0; i < length; i++) {
+            builder.append((char) random.nextInt());
+        }
+        return builder.toString().getBytes(UTF_8);
+    }
+
+    private static byte[] randomUtf8WithPadding(Random random, int maxLength)
+    {
+        StringBuilder builder = new StringBuilder();
+        int length = random.nextInt(maxLength + 1);
+        for (int i = 0; i < length; i++) {
+            builder.append((char) random.nextInt());
+        }
+        int paddingLength = random.nextInt(maxLength + 1);
+        builder.append(" ".repeat(paddingLength));
+        return builder.toString().getBytes(UTF_8);
+    }
+
+    private static byte[] randomAsciiWithPadding(Random random, int maxLength)
+    {
+        int length = random.nextInt(maxLength + 1);
+        int paddingLength = random.nextInt(maxLength + 1);
+        byte[] value = new byte[length + paddingLength];
+        for (int i = 0; i < length; i++) {
+            value[i] = (byte) random.nextInt(128);
+        }
+        for (int i = length; i < length + paddingLength; i++) {
+            value[i] = ' ';
+        }
+        return value;
+    }
+
+    private static DataBuffer writeBytes(ValuesWriter valuesWriter, byte[][] input)
+    {
+        for (byte[] value : input) {
+            valuesWriter.writeBytes(Binary.fromConstantByteArray(value));
+        }
+
+        return getWrittenBuffer(valuesWriter);
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestByteValueDecoders.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestByteValueDecoders.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.parquet.column.values.ValuesWriter;
+
+import java.util.OptionalInt;
+import java.util.Random;
+
+import static io.trino.parquet.ParquetEncoding.PLAIN;
+import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
+import static io.trino.parquet.reader.TestData.randomInt;
+import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ByteApacheParquetValueDecoder;
+import static io.trino.parquet.reader.flat.ByteColumnAdapter.BYTE_ADAPTER;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class TestByteValueDecoders
+        extends AbstractValueDecodersTest
+{
+    @Override
+    protected Object[][] tests()
+    {
+        return testArgs(
+                new TestType<>(
+                        createField(INT32, OptionalInt.empty(), TINYINT),
+                        ValueDecoders::getByteDecoder,
+                        ByteApacheParquetValueDecoder::new,
+                        BYTE_ADAPTER,
+                        (actual, expected) -> assertThat(actual).isEqualTo(expected)),
+                ImmutableList.of(PLAIN, RLE_DICTIONARY),
+                ByteInputProvider.values());
+    }
+
+    private enum ByteInputProvider
+            implements InputDataProvider
+    {
+        BYTE_SEQUENCE {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                byte[] values = new byte[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = (byte) i;
+                }
+                return writeBytes(valuesWriter, values);
+            }
+        },
+        BYTE_REPEAT {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                Random random = new Random(dataSize);
+                byte[] constants = new byte[] {Byte.MIN_VALUE, -1, 0, 5, 17, Byte.MAX_VALUE};
+                byte[] values = new byte[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = constants[random.nextInt(constants.length)];
+                }
+                return writeBytes(valuesWriter, values);
+            }
+        },
+        BYTE_RANDOM {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                Random random = new Random(dataSize);
+                byte[] values = new byte[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = (byte) randomInt(random, 8);
+                }
+                return writeBytes(valuesWriter, values);
+            }
+        }
+    }
+
+    private static DataBuffer writeBytes(ValuesWriter valuesWriter, byte[] input)
+    {
+        for (byte value : input) {
+            valuesWriter.writeInteger(value);
+        }
+
+        return getWrittenBuffer(valuesWriter);
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestDoubleValueDecoders.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestDoubleValueDecoders.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import io.trino.spi.type.DoubleType;
+import org.apache.parquet.column.values.ValuesReader;
+import org.apache.parquet.column.values.ValuesWriter;
+
+import java.util.OptionalInt;
+import java.util.Random;
+
+import static io.trino.parquet.ParquetEncoding.PLAIN;
+import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
+import static io.trino.parquet.reader.flat.LongColumnAdapter.LONG_ADAPTER;
+import static java.util.Objects.requireNonNull;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class TestDoubleValueDecoders
+        extends AbstractValueDecodersTest
+{
+    @Override
+    protected Object[][] tests()
+    {
+        return testArgs(
+                new TestType<>(
+                        createField(DOUBLE, OptionalInt.empty(), DoubleType.DOUBLE),
+                        ValueDecoders::getDoubleDecoder,
+                        DoubleApacheParquetValueDecoder::new,
+                        LONG_ADAPTER,
+                        (actual, expected) -> assertThat(actual).isEqualTo(expected)),
+                ImmutableList.of(PLAIN, RLE_DICTIONARY),
+                DoubleInputProvider.values());
+    }
+
+    private enum DoubleInputProvider
+            implements InputDataProvider
+    {
+        DOUBLE_SEQUENCE {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                double[] values = new double[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = ((double) i) / 10;
+                }
+                return writeDoubles(valuesWriter, values);
+            }
+        },
+        DOUBLE_RANDOM_WITH_NAN_AND_INF {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                Random random = new Random(dataSize);
+                double[] values = new double[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = Double.longBitsToDouble(random.nextLong());
+                }
+                return writeDoubles(valuesWriter, values);
+            }
+        },
+        DOUBLE_RANDOM {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                Random random = new Random(dataSize);
+                double[] values = new double[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = random.nextDouble();
+                }
+                return writeDoubles(valuesWriter, values);
+            }
+        },
+        DOUBLE_REPEAT {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                double[] values = new double[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = ((double) (i % 101)) / 10;
+                }
+                return writeDoubles(valuesWriter, values);
+            }
+        }
+    }
+
+    private static DataBuffer writeDoubles(ValuesWriter valuesWriter, double[] input)
+    {
+        for (double value : input) {
+            valuesWriter.writeDouble(value);
+        }
+
+        return getWrittenBuffer(valuesWriter);
+    }
+
+    private static final class DoubleApacheParquetValueDecoder
+            implements ValueDecoder<long[]>
+    {
+        private final ValuesReader delegate;
+
+        public DoubleApacheParquetValueDecoder(ValuesReader delegate)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            initialize(input, delegate);
+        }
+
+        @Override
+        public void read(long[] values, int offset, int length)
+        {
+            for (int i = offset; i < offset + length; i++) {
+                values[i] = Double.doubleToLongBits(delegate.readDouble());
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            delegate.skip(n);
+        }
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestFixedWidthByteArrayValueDecoders.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestFixedWidthByteArrayValueDecoders.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.trino.parquet.ParquetEncoding;
+import io.trino.parquet.PrimitiveField;
+import io.trino.spi.type.DecimalType;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.io.api.Binary;
+
+import java.math.BigInteger;
+import java.util.OptionalInt;
+import java.util.Random;
+import java.util.stream.IntStream;
+
+import static io.trino.parquet.ParquetEncoding.PLAIN;
+import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
+import static io.trino.parquet.ParquetTypeUtils.paddingBigInteger;
+import static io.trino.parquet.reader.TestData.longToBytes;
+import static io.trino.parquet.reader.TestData.maxPrecision;
+import static io.trino.parquet.reader.TestData.unscaledRandomShortDecimalSupplier;
+import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.LongDecimalApacheParquetValueDecoder;
+import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortDecimalApacheParquetValueDecoder;
+import static io.trino.parquet.reader.decoders.ValueDecoders.getFixedWidthShortDecimalDecoder;
+import static io.trino.parquet.reader.flat.Int128ColumnAdapter.INT128_ADAPTER;
+import static io.trino.parquet.reader.flat.LongColumnAdapter.LONG_ADAPTER;
+import static io.trino.testing.DataProviders.concat;
+import static java.lang.Math.min;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class TestFixedWidthByteArrayValueDecoders
+        extends AbstractValueDecodersTest
+{
+    @Override
+    protected Object[][] tests()
+    {
+        return concat(
+                generateShortDecimalTests(PLAIN),
+                generateShortDecimalTests(RLE_DICTIONARY),
+                generateLongDecimalTests(PLAIN),
+                generateLongDecimalTests(RLE_DICTIONARY));
+    }
+
+    private static Object[][] generateShortDecimalTests(ParquetEncoding encoding)
+    {
+        return IntStream.range(1, 17)
+                .mapToObj(typeLength -> {
+                    int precision = maxPrecision(min(typeLength, 8));
+                    return new Object[] {
+                            createShortDecimalTestType(typeLength, precision),
+                            encoding,
+                            createShortDecimalInputDataProvider(typeLength, precision)};
+                })
+                .toArray(Object[][]::new);
+    }
+
+    private static Object[][] generateLongDecimalTests(ParquetEncoding encoding)
+    {
+        return IntStream.range(9, 17)
+                .mapToObj(typeLength -> new Object[] {
+                        createLongDecimalTestType(typeLength),
+                        encoding,
+                        createLongDecimalInputDataProvider(typeLength)})
+                .toArray(Object[][]::new);
+    }
+
+    private static TestType<long[]> createShortDecimalTestType(int typeLength, int precision)
+    {
+        DecimalType decimalType = DecimalType.createDecimalType(precision, 2);
+        PrimitiveField primitiveField = createField(FIXED_LEN_BYTE_ARRAY, OptionalInt.of(typeLength), decimalType);
+        return new TestType<>(
+                primitiveField,
+                (encoding, field) -> getFixedWidthShortDecimalDecoder(encoding, field, decimalType),
+                valuesReader -> new ShortDecimalApacheParquetValueDecoder(valuesReader, decimalType, primitiveField.getDescriptor()),
+                LONG_ADAPTER,
+                (actual, expected) -> assertThat(actual).isEqualTo(expected));
+    }
+
+    private static TestType<long[]> createLongDecimalTestType(int typeLength)
+    {
+        int precision = maxPrecision(typeLength);
+        DecimalType decimalType = DecimalType.createDecimalType(precision, 2);
+        return new TestType<>(
+                createField(FIXED_LEN_BYTE_ARRAY, OptionalInt.of(typeLength), decimalType),
+                ValueDecoders::getFixedWidthLongDecimalDecoder,
+                LongDecimalApacheParquetValueDecoder::new,
+                INT128_ADAPTER,
+                (actual, expected) -> assertThat(actual).isEqualTo(expected));
+    }
+
+    private static InputDataProvider createShortDecimalInputDataProvider(int typeLength, int precision)
+    {
+        return new InputDataProvider() {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                long[] values = unscaledRandomShortDecimalSupplier(min(typeLength * Byte.SIZE, 64), precision).apply(dataSize);
+                byte[][] bytes = new byte[dataSize][];
+                for (int i = 0; i < dataSize; i++) {
+                    bytes[i] = longToBytes(values[i], typeLength);
+                }
+                return writeBytes(valuesWriter, bytes);
+            }
+
+            @Override
+            public String toString()
+            {
+                return "fixed_len_byte_array(" + typeLength + ")";
+            }
+        };
+    }
+
+    private static InputDataProvider createLongDecimalInputDataProvider(int typeLength)
+    {
+        return new InputDataProvider() {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                Random random = new Random(dataSize);
+                byte[][] bytes = new byte[dataSize][];
+                for (int i = 0; i < dataSize; i++) {
+                    bytes[i] = paddingBigInteger(
+                            new BigInteger(Math.min(typeLength * Byte.SIZE - 1, 126), random),
+                            typeLength);
+                }
+                return writeBytes(valuesWriter, bytes);
+            }
+
+            @Override
+            public String toString()
+            {
+                return "fixed_len_byte_array(" + typeLength + ")";
+            }
+        };
+    }
+
+    private static DataBuffer writeBytes(ValuesWriter valuesWriter, byte[][] input)
+    {
+        for (byte[] value : input) {
+            valuesWriter.writeBytes(Binary.fromConstantByteArray(value));
+        }
+
+        return getWrittenBuffer(valuesWriter);
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestFloatValueDecoders.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestFloatValueDecoders.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import org.apache.parquet.column.values.ValuesReader;
+import org.apache.parquet.column.values.ValuesWriter;
+
+import java.util.OptionalInt;
+import java.util.Random;
+
+import static io.trino.parquet.ParquetEncoding.PLAIN;
+import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
+import static io.trino.parquet.reader.flat.IntColumnAdapter.INT_ADAPTER;
+import static io.trino.spi.type.RealType.REAL;
+import static java.util.Objects.requireNonNull;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class TestFloatValueDecoders
+        extends AbstractValueDecodersTest
+{
+    @Override
+    protected Object[][] tests()
+    {
+        return testArgs(
+                new TestType<>(
+                        createField(FLOAT, OptionalInt.empty(), REAL),
+                        ValueDecoders::getRealDecoder,
+                        FloatApacheParquetValueDecoder::new,
+                        INT_ADAPTER,
+                        (actual, expected) -> assertThat(actual).isEqualTo(expected)),
+                ImmutableList.of(PLAIN, RLE_DICTIONARY),
+                FloatInputProvider.values());
+    }
+
+    private enum FloatInputProvider
+            implements InputDataProvider
+    {
+        FLOAT_SEQUENCE {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                float[] values = new float[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = ((float) i) / 10;
+                }
+                return writeFloats(valuesWriter, values);
+            }
+        },
+        FLOAT_RANDOM_WITH_NAN_AND_INF {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                Random random = new Random(dataSize);
+                float[] values = new float[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = Float.intBitsToFloat(random.nextInt());
+                }
+                return writeFloats(valuesWriter, values);
+            }
+        },
+        FLOAT_RANDOM {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                Random random = new Random(dataSize);
+                float[] values = new float[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = random.nextFloat();
+                }
+                return writeFloats(valuesWriter, values);
+            }
+        },
+        FLOAT_REPEAT {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                float[] values = new float[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = ((float) (i % 101)) / 10;
+                }
+                return writeFloats(valuesWriter, values);
+            }
+        }
+    }
+
+    private static DataBuffer writeFloats(ValuesWriter valuesWriter, float[] input)
+    {
+        for (float value : input) {
+            valuesWriter.writeFloat(value);
+        }
+
+        return getWrittenBuffer(valuesWriter);
+    }
+
+    private static final class FloatApacheParquetValueDecoder
+            implements ValueDecoder<int[]>
+    {
+        private final ValuesReader delegate;
+
+        public FloatApacheParquetValueDecoder(ValuesReader delegate)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            initialize(input, delegate);
+        }
+
+        @Override
+        public void read(int[] values, int offset, int length)
+        {
+            for (int i = offset; i < offset + length; i++) {
+                values[i] = Float.floatToIntBits(delegate.readFloat());
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            delegate.skip(n);
+        }
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestIntValueDecoders.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestIntValueDecoders.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.parquet.column.values.ValuesWriter;
+
+import java.util.OptionalInt;
+import java.util.Random;
+
+import static io.trino.parquet.ParquetEncoding.PLAIN;
+import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
+import static io.trino.parquet.reader.TestData.randomInt;
+import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.IntApacheParquetValueDecoder;
+import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.IntToLongApacheParquetValueDecoder;
+import static io.trino.parquet.reader.flat.IntColumnAdapter.INT_ADAPTER;
+import static io.trino.parquet.reader.flat.LongColumnAdapter.LONG_ADAPTER;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.testing.DataProviders.concat;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class TestIntValueDecoders
+        extends AbstractValueDecodersTest
+{
+    @Override
+    protected Object[][] tests()
+    {
+        return concat(
+                testArgs(
+                        new TestType<>(
+                                createField(INT32, OptionalInt.empty(), INTEGER),
+                                ValueDecoders::getIntDecoder,
+                                IntApacheParquetValueDecoder::new,
+                                INT_ADAPTER,
+                                (actual, expected) -> assertThat(actual).isEqualTo(expected)),
+                        ImmutableList.of(PLAIN, RLE_DICTIONARY),
+                        IntInputProvider.values()),
+                testArgs(
+                        new TestType<>(
+                                createField(INT32, OptionalInt.empty(), BIGINT),
+                                ValueDecoders::getIntToLongDecoder,
+                                IntToLongApacheParquetValueDecoder::new,
+                                LONG_ADAPTER,
+                                (actual, expected) -> assertThat(actual).isEqualTo(expected)),
+                        ImmutableList.of(PLAIN, RLE_DICTIONARY),
+                        IntInputProvider.values()));
+    }
+
+    private enum IntInputProvider
+            implements InputDataProvider
+    {
+        INT_SEQUENCE {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                int[] values = new int[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = i;
+                }
+                return writeInts(valuesWriter, values);
+            }
+        },
+        INT_REPEAT {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                Random random = new Random(dataSize);
+                int[] constants = new int[] {Integer.MIN_VALUE, -1412341234, 0, 5, 4123, 1412341234, Integer.MAX_VALUE};
+                int[] values = new int[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = constants[random.nextInt(constants.length)];
+                }
+                return writeInts(valuesWriter, values);
+            }
+        },
+        INT_RANDOM {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                Random random = new Random(dataSize);
+                int[] values = new int[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = randomInt(random, 32);
+                }
+                return writeInts(valuesWriter, values);
+            }
+        }
+    }
+
+    private static DataBuffer writeInts(ValuesWriter valuesWriter, int[] input)
+    {
+        for (int value : input) {
+            valuesWriter.writeInteger(value);
+        }
+
+        return getWrittenBuffer(valuesWriter);
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestLongValueDecoders.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestLongValueDecoders.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.parquet.column.values.ValuesWriter;
+
+import java.util.OptionalInt;
+import java.util.Random;
+
+import static io.trino.parquet.ParquetEncoding.PLAIN;
+import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
+import static io.trino.parquet.reader.TestData.randomLong;
+import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.LongApacheParquetValueDecoder;
+import static io.trino.parquet.reader.flat.LongColumnAdapter.LONG_ADAPTER;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class TestLongValueDecoders
+        extends AbstractValueDecodersTest
+{
+    @Override
+    protected Object[][] tests()
+    {
+        return testArgs(
+                        new TestType<>(
+                                createField(INT64, OptionalInt.empty(), BIGINT),
+                                ValueDecoders::getLongDecoder,
+                                LongApacheParquetValueDecoder::new,
+                                LONG_ADAPTER,
+                                (actual, expected) -> assertThat(actual).isEqualTo(expected)),
+                        ImmutableList.of(PLAIN, RLE_DICTIONARY),
+                        LongInputProvider.values());
+    }
+
+    private enum LongInputProvider
+            implements InputDataProvider
+    {
+        LONG_SEQUENCE {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                long[] values = new long[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = i;
+                }
+                return writeLongs(valuesWriter, values);
+            }
+        },
+        LONG_REPEAT {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                Random random = new Random(dataSize);
+                long[] constants = new long[] {Long.MIN_VALUE, -111222333444555L, -1412341234L, 0, 4123, 1412341234L, 111222333444555L, Long.MAX_VALUE};
+                long[] values = new long[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = constants[random.nextInt(constants.length)];
+                }
+                return writeLongs(valuesWriter, values);
+            }
+        },
+        LONG_RANDOM {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                Random random = new Random(dataSize);
+                long[] values = new long[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = randomLong(random, 64);
+                }
+                return writeLongs(valuesWriter, values);
+            }
+        }
+    }
+
+    private static DataBuffer writeLongs(ValuesWriter valuesWriter, long[] input)
+    {
+        for (long value : input) {
+            valuesWriter.writeLong(value);
+        }
+
+        return getWrittenBuffer(valuesWriter);
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestShortValueDecoders.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestShortValueDecoders.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.parquet.column.values.ValuesWriter;
+
+import java.util.OptionalInt;
+import java.util.Random;
+
+import static io.trino.parquet.ParquetEncoding.PLAIN;
+import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
+import static io.trino.parquet.reader.TestData.randomInt;
+import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortApacheParquetValueDecoder;
+import static io.trino.parquet.reader.flat.ShortColumnAdapter.SHORT_ADAPTER;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class TestShortValueDecoders
+        extends AbstractValueDecodersTest
+{
+    @Override
+    protected Object[][] tests()
+    {
+        return testArgs(
+                new TestType<>(
+                        createField(INT32, OptionalInt.empty(), SMALLINT),
+                        ValueDecoders::getShortDecoder,
+                        ShortApacheParquetValueDecoder::new,
+                        SHORT_ADAPTER,
+                        (actual, expected) -> assertThat(actual).isEqualTo(expected)),
+                ImmutableList.of(PLAIN, RLE_DICTIONARY),
+                ShortInputProvider.values());
+    }
+
+    private enum ShortInputProvider
+            implements InputDataProvider
+    {
+        SHORT_SEQUENCE {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                short[] values = new short[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = (short) i;
+                }
+                return writeShorts(valuesWriter, values);
+            }
+        },
+        SHORT_REPEAT {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                Random random = new Random(dataSize);
+                short[] constants = new short[] {Short.MIN_VALUE, -4123, 0, 5, 4123, 8956, Short.MAX_VALUE};
+                short[] values = new short[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = constants[random.nextInt(constants.length)];
+                }
+                return writeShorts(valuesWriter, values);
+            }
+        },
+        SHORT_RANDOM {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                Random random = new Random(dataSize);
+                short[] values = new short[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = (short) randomInt(random, 16);
+                }
+                return writeShorts(valuesWriter, values);
+            }
+        }
+    }
+
+    private static DataBuffer writeShorts(ValuesWriter valuesWriter, short[] input)
+    {
+        for (short value : input) {
+            valuesWriter.writeInteger(value);
+        }
+
+        return getWrittenBuffer(valuesWriter);
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/TestBitPackingUtils.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/TestBitPackingUtils.java
@@ -53,6 +53,25 @@ public class TestBitPackingUtils
     }
 
     @Test
+    public void testUnpackByte()
+    {
+        Random random = new Random(0);
+        byte[] values = new byte[100 + 8];
+        for (int packedByte = 0; packedByte < 256; packedByte++) {
+            for (int start = 0; start < 8; start++) {
+                for (int end = start + 1; end <= 8; end++) {
+                    int offset = random.nextInt(100);
+                    unpack(values, offset, (byte) packedByte, start, end);
+
+                    for (int bit = start; bit < end; bit++) {
+                        assertThat(values[offset + bit - start]).isEqualTo((byte) ((packedByte >>> bit) & 1));
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
     public void testUnpack8()
     {
         Random random = new Random(0);
@@ -64,6 +83,21 @@ public class TestBitPackingUtils
 
             for (int bit = 0; bit < 8; bit++) {
                 assertThat(values[offset + bit]).isEqualTo(((packedByte >>> bit) & 1) == 1);
+            }
+        }
+    }
+
+    @Test
+    public void testUnpack8FromByte()
+    {
+        Random random = new Random(0);
+        byte[] values = new byte[100 + 8];
+        for (int packedByte = 0; packedByte < 256; packedByte++) {
+            int offset = random.nextInt(100);
+            BitPackingUtils.unpack8FromByte(values, offset, (byte) packedByte);
+
+            for (int bit = 0; bit < 8; bit++) {
+                assertThat(values[offset + bit]).isEqualTo((byte) ((packedByte >>> bit) & 1));
             }
         }
     }
@@ -81,6 +115,22 @@ public class TestBitPackingUtils
 
             for (int bit = 0; bit < 64; bit++) {
                 assertThat(values[offset + bit]).isEqualTo(((packedValue >>> bit) & 1) == 1);
+            }
+        }
+    }
+
+    @Test
+    public void testUnpack64FromLong()
+    {
+        Random random = new Random(1);
+        byte[] values = new byte[100 + 64];
+        for (int i = 0; i < 100_000; i++) {
+            int offset = random.nextInt(100);
+            long packedValue = random.nextLong();
+            BitPackingUtils.unpack64FromLong(values, offset, packedValue);
+
+            for (int bit = 0; bit < 64; bit++) {
+                assertThat(values[offset + bit]).isEqualTo((byte) ((packedValue >>> bit) & 1));
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Optimize PLAIN values decoders in parquet reader

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Hudi, Delta, Iceberg
* Improve performance of reading parquet files. ({issue}`15308`)
```
