### PR TITLE
More string format removals

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/ClientTypeSignature.java
+++ b/client/trino-client/src/main/java/io/trino/client/ClientTypeSignature.java
@@ -31,7 +31,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.client.ClientStandardTypes.ROW;
 import static io.trino.client.ClientStandardTypes.VARCHAR;
-import static java.lang.String.format;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
@@ -104,20 +103,18 @@ public class ClientTypeSignature
     @Deprecated
     private String rowToString()
     {
-        String fields = arguments.stream()
+        if (arguments.isEmpty()) {
+            return "row";
+        }
+        return arguments.stream()
                 .map(ClientTypeSignatureParameter::getNamedTypeSignature)
                 .map(parameter -> {
                     if (parameter.getName().isPresent()) {
-                        return format("%s %s", parameter.getName().get(), parameter.getTypeSignature());
+                        return parameter.getName().get() + " " + parameter.getTypeSignature();
                     }
                     return parameter.getTypeSignature().toString();
                 })
-                .collect(joining(","));
-
-        if (fields.isEmpty()) {
-            return "row";
-        }
-        return format("row(%s)", fields);
+                .collect(joining(",", "row(", ")"));
     }
 
     @Override

--- a/client/trino-client/src/main/java/io/trino/client/NamedClientTypeSignature.java
+++ b/client/trino-client/src/main/java/io/trino/client/NamedClientTypeSignature.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import java.util.Optional;
 
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class NamedClientTypeSignature
@@ -73,7 +72,7 @@ public class NamedClientTypeSignature
     public String toString()
     {
         if (fieldName.isPresent()) {
-            return format("%s %s", fieldName.get(), typeSignature);
+            return fieldName.get() + " " + typeSignature;
         }
         return typeSignature.toString();
     }

--- a/client/trino-client/src/main/java/io/trino/client/Row.java
+++ b/client/trino-client/src/main/java/io/trino/client/Row.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
@@ -64,7 +63,7 @@ public final class Row
         return fields.stream()
                 .map(field -> {
                     if (field.getName().isPresent()) {
-                        return format("%s=%s", field.getName().get(), field.getValue());
+                        return field.getName().get() + "=" + field.getValue();
                     }
                     return String.valueOf(field.getValue());
                 })

--- a/client/trino-client/src/main/java/io/trino/client/Warning.java
+++ b/client/trino-client/src/main/java/io/trino/client/Warning.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public final class Warning
@@ -70,7 +69,7 @@ public final class Warning
     @Override
     public String toString()
     {
-        return format("%s, %s", warningCode, message);
+        return warningCode + ", " + message;
     }
 
     public static final class Code

--- a/client/trino-client/src/main/java/io/trino/client/auth/kerberos/SpnegoHandler.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/kerberos/SpnegoHandler.java
@@ -122,7 +122,7 @@ public class SpnegoHandler
         String principal = makeServicePrincipal(servicePrincipalPattern, remoteServiceName, hostName, useCanonicalHostname);
         byte[] token = generateToken(principal);
 
-        String credential = format("%s %s", NEGOTIATE, Base64.getEncoder().encodeToString(token));
+        String credential = NEGOTIATE + " " + Base64.getEncoder().encodeToString(token);
         return request.newBuilder()
                 .header(AUTHORIZATION, credential)
                 .build();

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -1293,7 +1293,9 @@ public class ExpressionAnalyzer
             for (int i = 0; i < argumentTypes.size(); i++) {
                 Expression expression = node.getArguments().get(i);
                 Type expectedType = signature.getArgumentTypes().get(i);
-                requireNonNull(expectedType, format("Type '%s' not found", signature.getArgumentTypes().get(i)));
+                if (expectedType == null) {
+                    throw new NullPointerException(format("Type '%s' not found", signature.getArgumentTypes().get(i)));
+                }
                 if (node.isDistinct() && !expectedType.isComparable()) {
                     throw semanticException(TYPE_MISMATCH, node, "DISTINCT can only be applied to comparable types (actual: %s)", expectedType);
                 }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/AndCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/AndCodeGenerator.java
@@ -25,7 +25,6 @@ import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantFalse;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class AndCodeGenerator
@@ -58,7 +57,7 @@ public class AndCodeGenerator
             RowExpression term = terms.get(i);
             block.append(generator.generate(term));
 
-            IfStatement ifWasNull = new IfStatement(format("if term %s wasNull...", i))
+            IfStatement ifWasNull = new IfStatement("if term " + i + " wasNull...")
                     .condition(wasNull);
 
             ifWasNull.ifTrue()

--- a/core/trino-main/src/main/java/io/trino/sql/gen/BytecodeUtils.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/BytecodeUtils.java
@@ -111,7 +111,7 @@ public final class BytecodeUtils
 
         isNull.pushJavaDefault(returnType);
         String loadDefaultComment;
-        loadDefaultComment = format("loadJavaDefault(%s)", returnType.getName());
+        loadDefaultComment = "loadJavaDefault(" + returnType.getName() + ")";
 
         isNull.gotoLabel(label);
 

--- a/core/trino-main/src/main/java/io/trino/sql/gen/OrCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/OrCodeGenerator.java
@@ -25,7 +25,6 @@ import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantFalse;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class OrCodeGenerator
@@ -57,7 +56,7 @@ public class OrCodeGenerator
             RowExpression term = terms.get(i);
             block.append(generator.generate(term));
 
-            IfStatement ifWasNull = new IfStatement(format("if term %s wasNull...", i))
+            IfStatement ifWasNull = new IfStatement("if term " + i + " wasNull...")
                     .condition(wasNull);
 
             ifWasNull.ifTrue()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
@@ -243,7 +243,9 @@ public class LogicalPlanner
         if (stage.ordinal() >= OPTIMIZED.ordinal()) {
             for (PlanOptimizer optimizer : planOptimizers) {
                 root = optimizer.optimize(root, session, symbolAllocator.getTypes(), symbolAllocator, idAllocator, warningCollector, tableStatsProvider);
-                requireNonNull(root, format("%s returned a null plan", optimizer.getClass().getName()));
+                if (root == null) {
+                    throw new NullPointerException(optimizer.getClass().getName() + " returned a null plan");
+                }
 
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("%s:\n%s", optimizer.getClass().getName(), PlanPrinter.textLogicalPlan(
@@ -542,9 +544,7 @@ public class LogicalPlanner
 
     private Expression createNullNotAllowedFailExpression(String columnName, Type type)
     {
-        return new Cast(failFunction(metadata, session, CONSTRAINT_VIOLATION, format(
-                "NULL value not allowed for NOT NULL column: %s",
-                columnName)), toSqlType(type));
+        return new Cast(failFunction(metadata, session, CONSTRAINT_VIOLATION, "NULL value not allowed for NOT NULL column: " + columnName), toSqlType(type));
     }
 
     private static Function<Expression, Expression> failIfPredicateIsNotMet(Metadata metadata, Session session, ErrorCodeSupplier errorCode, String errorMessage)

--- a/core/trino-main/src/main/java/io/trino/type/TypeUtils.java
+++ b/core/trino-main/src/main/java/io/trino/type/TypeUtils.java
@@ -13,7 +13,6 @@
  */
 package io.trino.type;
 
-import com.google.common.base.Joiner;
 import io.trino.spi.TrinoException;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.CharType;
@@ -28,14 +27,11 @@ import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 
-import java.util.List;
-
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.StandardTypes.ARRAY;
 import static io.trino.spi.type.StandardTypes.MAP;
 import static io.trino.spi.type.StandardTypes.ROW;
-import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
 
 public final class TypeUtils
 {
@@ -107,7 +103,7 @@ public final class TypeUtils
 
     private static String getRowDisplayLabelForLegacyClients(RowType type)
     {
-        List<String> fields = type.getFields().stream()
+        return type.getFields().stream()
                 .map(field -> {
                     String typeDisplayName = getDisplayLabelForLegacyClients(field.getType());
                     if (field.getName().isPresent()) {
@@ -115,8 +111,6 @@ public final class TypeUtils
                     }
                     return typeDisplayName;
                 })
-                .collect(toImmutableList());
-
-        return format("%s(%s)", ROW, Joiner.on(", ").join(fields));
+                .collect(joining(", ", ROW + "(", ")"));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/util/StatementUtils.java
+++ b/core/trino-main/src/main/java/io/trino/util/StatementUtils.java
@@ -283,7 +283,7 @@ public final class StatementUtils
             if (genericInterface instanceof ParameterizedType parameterizedInterface) {
                 if (parameterizedInterface.getRawType().equals(expectedInterfaceType)) {
                     Type actualStatementType = parameterizedInterface.getActualTypeArguments()[0];
-                    checkArgument(actualStatementType.equals(statementType), format("Expected %s statement type to be %s", statementType.getSimpleName(), taskType.getSimpleName()));
+                    checkArgument(actualStatementType.equals(statementType), "Expected %s statement type to be %s", statementType.getSimpleName(), taskType.getSimpleName());
                     return;
                 }
             }

--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -169,9 +169,9 @@ public final class ExpressionFormatter
         @Override
         protected String visitRow(Row node, Void context)
         {
-            return "ROW (" + Joiner.on(", ").join(node.getItems().stream()
+            return node.getItems().stream()
                     .map(child -> process(child, context))
-                    .collect(toList())) + ")";
+                    .collect(joining(", ", "ROW (", ")"));
         }
 
         @Override
@@ -298,11 +298,9 @@ public final class ExpressionFormatter
         @Override
         protected String visitArray(Array node, Void context)
         {
-            ImmutableList.Builder<String> valueStrings = ImmutableList.builder();
-            for (Expression value : node.getValues()) {
-                valueStrings.add(formatSql(value));
-            }
-            return "ARRAY[" + Joiner.on(",").join(valueStrings.build()) + "]";
+            return node.getValues().stream()
+                    .map(SqlFormatter::formatSql)
+                    .collect(joining(",", "ARRAY[", "]"));
         }
 
         @Override
@@ -993,9 +991,9 @@ public final class ExpressionFormatter
 
         private String joinExpressions(List<Expression> expressions)
         {
-            return Joiner.on(", ").join(expressions.stream()
-                    .map((e) -> process(e, null))
-                    .iterator());
+            return expressions.stream()
+                    .map(e -> process(e, null))
+                    .collect(joining(", "));
         }
 
         /**
@@ -1095,9 +1093,9 @@ public final class ExpressionFormatter
 
     public static String formatSortItems(List<SortItem> sortItems)
     {
-        return Joiner.on(", ").join(sortItems.stream()
+        return sortItems.stream()
                 .map(sortItemFormatterFunction())
-                .iterator());
+                .collect(joining(", "));
     }
 
     private static String formatWindow(Window window)
@@ -1220,9 +1218,7 @@ public final class ExpressionFormatter
 
     static String formatGroupBy(List<GroupingElement> groupingElements)
     {
-        ImmutableList.Builder<String> resultStrings = ImmutableList.builder();
-
-        for (GroupingElement groupingElement : groupingElements) {
+        return groupingElements.stream().map(groupingElement -> {
             String result = "";
             if (groupingElement instanceof SimpleGroupBy) {
                 List<Expression> columns = groupingElement.getExpressions();
@@ -1234,20 +1230,19 @@ public final class ExpressionFormatter
                 }
             }
             else if (groupingElement instanceof GroupingSets) {
-                result = format("GROUPING SETS (%s)", Joiner.on(", ").join(
-                        ((GroupingSets) groupingElement).getSets().stream()
-                                .map(ExpressionFormatter::formatGroupingSet)
-                                .iterator()));
+                result = ((GroupingSets) groupingElement).getSets().stream()
+                        .map(ExpressionFormatter::formatGroupingSet)
+                        .collect(joining(", ", "GROUPING SETS (", ")"));
             }
             else if (groupingElement instanceof Cube) {
-                result = format("CUBE %s", formatGroupingSet(groupingElement.getExpressions()));
+                result = "CUBE " + formatGroupingSet(groupingElement.getExpressions());
             }
             else if (groupingElement instanceof Rollup) {
-                result = format("ROLLUP %s", formatGroupingSet(groupingElement.getExpressions()));
+                result = "ROLLUP " + formatGroupingSet(groupingElement.getExpressions());
             }
-            resultStrings.add(result);
-        }
-        return Joiner.on(", ").join(resultStrings.build());
+            return result;
+        })
+        .collect(joining(", "));
     }
 
     private static boolean isAsciiPrintable(int codePoint)
@@ -1257,9 +1252,9 @@ public final class ExpressionFormatter
 
     private static String formatGroupingSet(List<Expression> groupingSet)
     {
-        return format("(%s)", Joiner.on(", ").join(groupingSet.stream()
+        return groupingSet.stream()
                 .map(ExpressionFormatter::formatExpression)
-                .iterator()));
+                .collect(joining(", ", "(", ")"));
     }
 
     private static Function<SortItem, String> sortItemFormatterFunction()

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -154,7 +154,6 @@ import static io.trino.sql.ExpressionFormatter.formatSkipTo;
 import static io.trino.sql.ExpressionFormatter.formatStringLiteral;
 import static io.trino.sql.ExpressionFormatter.formatWindowSpecification;
 import static io.trino.sql.RowPatternFormatter.formatPattern;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
@@ -1343,10 +1342,9 @@ public final class SqlFormatter
             builder.append(formatName(node.getName()));
 
             node.getColumnAliases().ifPresent(columnAliases -> {
-                String columnList = columnAliases.stream()
+                builder.append(columnAliases.stream()
                         .map(SqlFormatter::formatName)
-                        .collect(joining(", "));
-                builder.append(format("( %s )", columnList));
+                        .collect(joining(", ", "( ", " )")));
             });
 
             node.getComment().ifPresent(comment -> builder
@@ -1469,7 +1467,7 @@ public final class SqlFormatter
                     return principal.getName().toString();
                 case USER:
                 case ROLE:
-                    return format("%s %s", type.name(), principal.getName());
+                    return type.name() + " " + principal.getName();
             }
             throw new IllegalArgumentException("Unsupported principal type: " + type);
         }

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -3468,7 +3468,9 @@ class AstBuilder
                         }
                         else {
                             char currentCodePoint = (char) codePoint;
-                            check(!Character.isSurrogate(currentCodePoint), format("Invalid escaped character: %s. Escaped character is a surrogate. Use '\\+123456' instead.", currentEscapedCode), context);
+                            if (Character.isSurrogate(currentCodePoint)) {
+                                throw parseError(format("Invalid escaped character: %s. Escaped character is a surrogate. Use '\\+123456' instead.", currentEscapedCode), context);
+                            }
                             unicodeStringBuilder.append(currentCodePoint);
                         }
                         state = UnicodeDecodeState.EMPTY;

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/PathElement.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/PathElement.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public final class PathElement
@@ -98,7 +97,7 @@ public final class PathElement
     public String toString()
     {
         if (catalog.isPresent()) {
-            return format("%s.%s", catalog.get(), schema);
+            return catalog.get() + "." + schema;
         }
         return schema.toString();
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/UpdateAssignment.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/UpdateAssignment.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class UpdateAssignment
@@ -90,6 +89,6 @@ public class UpdateAssignment
     @Override
     public String toString()
     {
-        return format("%s = %s", name, value);
+        return name + " = " + value;
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Follow up from https://github.com/trinodb/trino/pull/15258 to replace other usages of `String.format` in non-exceptional code paths where simple string concatenations are equally clear (but more performant). These changes are not expected to be nearly as significant in terms of performance as the linked previous PR.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

No additional context should be necessary. 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

