### PR TITLE
Close mongo cursor in MongoSession#getTableMetadataNames

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -665,13 +665,12 @@ public class MongoSession
     private Set<String> getTableMetadataNames(String schemaName)
             throws TableNotFoundException
     {
-        MongoDatabase db = client.getDatabase(schemaName);
-        MongoCursor<Document> cursor = db.getCollection(schemaCollection)
-                .find().projection(new Document(TABLE_NAME_KEY, true)).iterator();
-
         HashSet<String> names = new HashSet<>();
-        while (cursor.hasNext()) {
-            names.add((cursor.next()).getString(TABLE_NAME_KEY));
+        try (MongoCursor<Document> cursor = client.getDatabase(schemaName).getCollection(schemaCollection)
+                .find().projection(new Document(TABLE_NAME_KEY, true)).iterator()) {
+            while (cursor.hasNext()) {
+                names.add((cursor.next()).getString(TABLE_NAME_KEY));
+            }
         }
 
         return names;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

MongoCursor implement Closeable and should be closed in MongoSession#getTableMetadataNames

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

N/A

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
