### PR TITLE
Support setting read timeout in Google Sheets

### DIFF
--- a/docs/src/main/sphinx/connector/googlesheets.rst
+++ b/docs/src/main/sphinx/connector/googlesheets.rst
@@ -33,6 +33,7 @@ Property name                       Description
 ``gsheets.metadata-sheet-id``       Sheet ID of the spreadsheet, that contains the table mapping
 ``gsheets.max-data-cache-size``     Maximum number of spreadsheets to cache, defaults to ``1000``
 ``gsheets.data-cache-ttl``          How long to cache spreadsheet data or metadata, defaults to ``5m``
+``gsheets.read-timeout``            Timeout to read data from spreadsheet, defaults to ``20s``
 =================================== =====================================================================
 
 Credentials

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsConfig.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsConfig.java
@@ -31,6 +31,7 @@ public class SheetsConfig
     private String metadataSheetId;
     private int sheetsDataMaxCacheSize = 1000;
     private Duration sheetsDataExpireAfterWrite = new Duration(5, TimeUnit.MINUTES);
+    private Duration readTimeout = new Duration(20, TimeUnit.SECONDS); // 20s is the default timeout of com.google.api.client.http.HttpRequest
 
     @NotNull
     @FileExists
@@ -90,6 +91,19 @@ public class SheetsConfig
     public SheetsConfig setSheetsDataExpireAfterWrite(Duration sheetsDataExpireAfterWriteMinutes)
     {
         this.sheetsDataExpireAfterWrite = sheetsDataExpireAfterWriteMinutes;
+        return this;
+    }
+
+    @MinDuration("0ms")
+    public Duration getReadTimeout()
+    {
+        return readTimeout;
+    }
+
+    @Config("gsheets.read-timeout")
+    public SheetsConfig setReadTimeout(Duration readTimeout)
+    {
+        this.readTimeout = readTimeout;
         return this;
     }
 }

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestGoogleSheets.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestGoogleSheets.java
@@ -28,7 +28,7 @@ public class TestGoogleSheets
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createSheetsQueryRunner(ImmutableMap.of(), ImmutableMap.of());
+        return createSheetsQueryRunner(ImmutableMap.of(), ImmutableMap.of("gsheets.read-timeout", "1m"));
     }
 
     @Test

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestSheetsConfig.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestSheetsConfig.java
@@ -37,7 +37,8 @@ public class TestSheetsConfig
                 .setCredentialsFilePath(null)
                 .setMetadataSheetId(null)
                 .setSheetsDataMaxCacheSize(1000)
-                .setSheetsDataExpireAfterWrite(new Duration(5, TimeUnit.MINUTES)));
+                .setSheetsDataExpireAfterWrite(new Duration(5, TimeUnit.MINUTES))
+                .setReadTimeout(new Duration(20, TimeUnit.SECONDS)));
     }
 
     @Test
@@ -51,13 +52,15 @@ public class TestSheetsConfig
                 .put("gsheets.metadata-sheet-id", "foo_bar_sheet_id#Sheet1")
                 .put("gsheets.max-data-cache-size", "2000")
                 .put("gsheets.data-cache-ttl", "10m")
+                .put("gsheets.read-timeout", "1m")
                 .buildOrThrow();
 
         SheetsConfig expected = new SheetsConfig()
                 .setCredentialsFilePath(credentialsFile.toString())
                 .setMetadataSheetId("foo_bar_sheet_id#Sheet1")
                 .setSheetsDataMaxCacheSize(2000)
-                .setSheetsDataExpireAfterWrite(new Duration(10, TimeUnit.MINUTES));
+                .setSheetsDataExpireAfterWrite(new Duration(10, TimeUnit.MINUTES))
+                .setReadTimeout(new Duration(1, TimeUnit.MINUTES));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description

Hopefully, fixes #2941


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Google Sheets
* Add support for setting read timeout using the `gsheets.read-timeout` config property. ({issue}`15322`)
```
