### PR TITLE
Disable reduced index pushdown for IndexJoin

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -355,7 +355,7 @@ public class IndexJoinOptimizer
                     .map(Symbol::from)
                     .collect(toImmutableSet());
 
-            if (newLookupSymbols.isEmpty()) {
+            if (newLookupSymbols.size() != context.get().getLookupSymbols().size()) {
                 return node;
             }
 
@@ -397,15 +397,12 @@ public class IndexJoinOptimizer
             }
 
             // Lookup symbols can only be passed through if they are part of the partitioning
-            Set<Symbol> partitionByLookupSymbols = context.get().getLookupSymbols().stream()
-                    .filter(node.getPartitionBy()::contains)
-                    .collect(toImmutableSet());
 
-            if (partitionByLookupSymbols.isEmpty()) {
+            if (!node.getPartitionBy().containsAll(context.get().getLookupSymbols())) {
                 return node;
             }
 
-            return context.defaultRewrite(node, new Context(partitionByLookupSymbols, context.get().getSuccess()));
+            return context.defaultRewrite(node, new Context(context.get().getLookupSymbols(), context.get().getSuccess()));
         }
 
         @Override
@@ -418,15 +415,11 @@ public class IndexJoinOptimizer
         public PlanNode visitIndexJoin(IndexJoinNode node, RewriteContext<Context> context)
         {
             // Lookup symbols can only be passed through the probe side of an index join
-            Set<Symbol> probeLookupSymbols = context.get().getLookupSymbols().stream()
-                    .filter(node.getProbeSource().getOutputSymbols()::contains)
-                    .collect(toImmutableSet());
-
-            if (probeLookupSymbols.isEmpty()) {
+            if (!node.getProbeSource().getOutputSymbols().containsAll(context.get().getLookupSymbols())) {
                 return node;
             }
 
-            PlanNode rewrittenProbeSource = context.rewrite(node.getProbeSource(), new Context(probeLookupSymbols, context.get().getSuccess()));
+            PlanNode rewrittenProbeSource = context.rewrite(node.getProbeSource(), new Context(context.get().getLookupSymbols(), context.get().getSuccess()));
 
             PlanNode source = node;
             if (rewrittenProbeSource != node.getProbeSource()) {
@@ -440,15 +433,11 @@ public class IndexJoinOptimizer
         public PlanNode visitAggregation(AggregationNode node, RewriteContext<Context> context)
         {
             // Lookup symbols can only be passed through if they are part of the group by columns
-            Set<Symbol> groupByLookupSymbols = context.get().getLookupSymbols().stream()
-                    .filter(node.getGroupingKeys()::contains)
-                    .collect(toImmutableSet());
-
-            if (groupByLookupSymbols.isEmpty()) {
+            if (!node.getGroupingKeys().containsAll(context.get().getLookupSymbols())) {
                 return node;
             }
 
-            return context.defaultRewrite(node, new Context(groupByLookupSymbols, context.get().getSuccess()));
+            return context.defaultRewrite(node, new Context(context.get().getLookupSymbols(), context.get().getSuccess()));
         }
 
         @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Mitigates https://github.com/trinodb/trino/issues/15334

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/prestodb/presto/pull/1785

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
() Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# Core
* Disable reduced index push-down optimization that could result into some queries using index join occasionally return incorrect results
```
