### PR TITLE
Fix test for invalid rate in FormatUtils.formatDataRate()

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/FormatUtils.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/FormatUtils.java
@@ -134,7 +134,7 @@ public final class FormatUtils
     public static String formatDataRate(DataSize dataSize, Duration duration, boolean longForm, boolean decimalDataSize)
     {
         long rate = Math.round(dataSize.toBytes() / duration.getValue(SECONDS));
-        if (Double.isNaN(rate) || Double.isInfinite(rate)) {
+        if (rate == Long.MAX_VALUE) {
             rate = 0;
         }
 

--- a/client/trino-cli/src/test/java/io/trino/cli/TestFormatUtils.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestFormatUtils.java
@@ -13,6 +13,7 @@
  */
 package io.trino.cli;
 
+import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import org.junit.jupiter.api.Test;
 
@@ -418,9 +419,8 @@ public class TestFormatUtils
         assertThat(formatDataRate(ofBytes(8640000), Duration.valueOf("10d"), false, true)).isEqualTo("10B");
         assertThat(formatDataRate(ofBytes(8640000), Duration.valueOf("10d"), true, true)).isEqualTo("10B/s");
 
-        // Currently, these tests fail due to https://github.com/trinodb/trino/issues/13093
-        // assertThat(FormatUtils.formatDataRate(DataSize.ofBytes(1), Duration.valueOf("0s"), false)).isEqualTo("0B");
-        // assertThat(FormatUtils.formatDataRate(DataSize.ofBytes(1), Duration.valueOf("0s"), true)).isEqualTo("0B/s");
+        assertThat(FormatUtils.formatDataRate(DataSize.ofBytes(1), Duration.valueOf("0s"), false, true)).isEqualTo("0B");
+        assertThat(FormatUtils.formatDataRate(DataSize.ofBytes(1), Duration.valueOf("0s"), true, true)).isEqualTo("0B/s");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

`FormatUtils.formatDataRate()` contains the following code:

```java
long rate = Math.round(dataSize.toBytes() / duration.getValue(SECONDS));
if (Double.isNaN(rate) || Double.isInfinite(rate)) {
    rate = 0;
}
```

The test can never evaluate as `true`, since both functions will return false for any `long`.

The correct test is:

```java
if (rate == Long.MAX_VALUE) {
    rate = 0;
}
```

It's not necessary to test for `Long.MIN_VALUE`, since neither `dataSize` nor `duration` can be negative.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Unit Test

I added a new class, `TestFormatUtils` to test both this fix and the rest of `FormatUtils`. The tests for this change are:

```java
assertEquals(FormatUtils.formatDataRate(DataSize.ofBytes(1), Duration.valueOf("0s"), false), "0B");
assertEquals(FormatUtils.formatDataRate(DataSize.ofBytes(1), Duration.valueOf("0s"), true), "0B/s");
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

## Related Issue

Fixes #13093