### PR TITLE
Display operator CPU time in Stage Performance tab

### DIFF
--- a/core/trino-main/src/main/resources/webapp/src/components/StageDetail.jsx
+++ b/core/trino-main/src/main/resources/webapp/src/components/StageDetail.jsx
@@ -38,11 +38,16 @@ function getTotalWallTime(operator) {
     return parseDuration(operator.addInputWall) + parseDuration(operator.getOutputWall) + parseDuration(operator.finishWall) + parseDuration(operator.blockedWall)
 }
 
+function getTotalCpuTime(operator) {
+    return parseDuration(operator.addInputCpu) + parseDuration(operator.getOutputCpu) + parseDuration(operator.finishCpu)
+}
+
 class OperatorSummary extends React.Component {
     render() {
         const operator = this.props.operator;
 
-        const totalWallTime = parseDuration(operator.addInputWall) + parseDuration(operator.getOutputWall) + parseDuration(operator.finishWall) + parseDuration(operator.blockedWall);
+        const totalWallTime = getTotalWallTime(operator);
+        const totalCpuTime = getTotalCpuTime(operator);
 
         const rowInputRate = totalWallTime === 0 ? 0 : (1.0 * operator.inputPositions) / (totalWallTime / 1000.0);
         const byteInputRate = totalWallTime === 0 ? 0 : (1.0 * parseDataSize(operator.inputDataSize)) / (totalWallTime / 1000.0);
@@ -73,6 +78,14 @@ class OperatorSummary extends React.Component {
                         </td>
                         <td>
                             {operator.totalDrivers}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            CPU Time
+                        </td>
+                        <td>
+                            {formatDuration(totalCpuTime)}
                         </td>
                     </tr>
                     <tr>
@@ -157,6 +170,12 @@ class OperatorDetail extends React.Component {
     getInitialStatistics() {
         return [
             {
+                name: "Total CPU Time",
+                id: "totalCpuTime",
+                supplier: getTotalCpuTime,
+                renderer: formatDuration
+            },
+            {
                 name: "Total Wall Time",
                 id: "totalWallTime",
                 supplier: getTotalWallTime,
@@ -217,6 +236,7 @@ class OperatorDetail extends React.Component {
         const operator = this.props.operator;
         const operatorTasks = this.getOperatorTasks();
         const totalWallTime = getTotalWallTime(operator);
+        const totalCpuTime = getTotalCpuTime(operator);
 
         const rowInputRate = totalWallTime === 0 ? 0 : (1.0 * operator.inputPositions) / totalWallTime;
         const byteInputRate = totalWallTime === 0 ? 0 : (1.0 * parseDataSize(operator.inputDataSize)) / (totalWallTime / 1000.0);
@@ -277,6 +297,14 @@ class OperatorDetail extends React.Component {
                         <div className="col-xs-6">
                             <table className="table">
                                 <tbody>
+                                <tr>
+                                    <td>
+                                        CPU Time
+                                    </td>
+                                    <td>
+                                        {formatDuration(totalCpuTime)}
+                                    </td>
+                                </tr>
                                 <tr>
                                     <td>
                                         Wall Time


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In addition to Wall Time and Blocked Time

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

![image](https://user-images.githubusercontent.com/5570988/206293101-a638da76-7252-4662-ba0c-b8805d091920.png)
![image](https://user-images.githubusercontent.com/5570988/206293208-d3b7c0ea-9ba5-4c30-93f5-6139c8a698ec.png)


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# UI
* Display operator CPU time in Stage Performance tab
```
