### PR TITLE
Remove bogus checks

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/BasicRelationStatistics.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/BasicRelationStatistics.java
@@ -27,12 +27,6 @@ public class BasicRelationStatistics
 
     public BasicRelationStatistics(long rowCount, long dataSize)
     {
-        if (Double.isNaN(rowCount)) {
-            throw new IllegalArgumentException("NaN not allowed as rowCount");
-        }
-        if (Double.isNaN(dataSize)) {
-            throw new IllegalArgumentException("NaN not allowed as dataSize");
-        }
         this.rowCount = rowCount;
         this.dataSize = dataSize;
     }


### PR DESCRIPTION
The input is `long`, so `Double.isNan` was never true here.
