### PR TITLE
Fix SET TIME ZONE LOCAL works appropriate

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SetTimeZoneTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetTimeZoneTask.java
@@ -35,7 +35,7 @@ import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Map;
-import java.util.TimeZone;
+import java.util.Optional;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.SystemSessionProperties.TIME_ZONE_ID;
@@ -76,11 +76,14 @@ public class SetTimeZoneTask
             List<Expression> parameters,
             WarningCollector warningCollector)
     {
-        String timeZoneId = statement.getTimeZone()
-                .map(timeZone -> getTimeZoneId(timeZone, statement, stateMachine, parameters, warningCollector))
-                .orElse(TimeZone.getDefault().getID());
-        stateMachine.addSetSessionProperties(TIME_ZONE_ID, timeZoneId);
-
+        Optional<String> timeZoneId = statement.getTimeZone()
+                .map(timeZone -> getTimeZoneId(timeZone, statement, stateMachine, parameters, warningCollector));
+        if (timeZoneId.isPresent()) {
+            stateMachine.addSetSessionProperties(TIME_ZONE_ID, timeZoneId.get());
+        }
+        else {
+            stateMachine.addResetSessionProperties(TIME_ZONE_ID);
+        }
         return immediateVoidFuture();
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetTimeZoneTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetTimeZoneTask.java
@@ -79,9 +79,8 @@ public class TestSetTimeZoneTask
                 Optional.empty());
         executeSetTimeZone(setTimeZone, stateMachine);
 
-        Map<String, String> setSessionProperties = stateMachine.getSetSessionProperties();
-        assertThat(setSessionProperties).hasSize(1);
-        assertEquals(setSessionProperties.get(TIME_ZONE_ID), "America/Bahia_Banderas");
+        assertThat(stateMachine.getResetSessionProperties()).hasSize(1);
+        assertThat(stateMachine.getResetSessionProperties()).contains(TIME_ZONE_ID);
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This is a PR to solve the #15314 issue.

`SET TIME ZONE LOCAL` statement means to reflect the TimeZone initially set on the client. Currently, if TimeZone information is not checked in the syntax (LOCAL), the default TimeZone of the server is reflected.

In the case of LOCAL, rather than setting the client TimeZone in `SessionProperties`, the code was modified to invalidate the TIME_ZONE_ID set in `SessionProperties` and use the client's TimeZoneKey.

Based on the changed code, it works as follows.

* Server's timezone: `America/Los_Angeles`
* Client's timezone: `Europe/Warsaw`

```

trino> select current_timestamp;
                 _col0                 
---------------------------------------
 2022-12-08 07:47:48.873 Europe/Warsaw 
(1 row)

Query 20221208_064748_00005_yxge6, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
0.14 [0 rows, 0B] [0 rows/s, 0B/s]

trino> SET TIME ZONE 'Asia/Seoul';
SET TIME ZONE
trino> select current_timestamp;
               _col0                
------------------------------------
 2022-12-08 15:48:04.399 Asia/Seoul 
(1 row)

Query 20221208_064804_00007_yxge6, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
0.08 [0 rows, 0B] [0 rows/s, 0B/s]

trino> SET TIME ZONE LOCAL;
SET TIME ZONE
trino> select current_timestamp;
                 _col0                 
---------------------------------------
 2022-12-08 07:48:12.829 Europe/Warsaw 
(1 row)

Query 20221208_064812_00009_yxge6, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
0.16 [0 rows, 0B] [0 rows/s, 0B/s]
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes #15314

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, please propose a release note for me.
