### PR TITLE
Update MySQL JDBC driver to 8.0.29

### DIFF
--- a/docs/src/main/sphinx/connector/mysql.rst
+++ b/docs/src/main/sphinx/connector/mysql.rst
@@ -40,14 +40,12 @@ to the MySQL JDBC driver. The supported parameters for the URL are
 available in the `MySQL Developer Guide
 <https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html>`_.
 
-For example, the following ``connection-url`` allows you to
-configure the JDBC driver to interpret time values based on UTC as a timezone on
-the server, and serves as a `workaround for a known issue
-<https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-usagenotes-known-issues-limitations.html>`_.
+For example, the following ``connection-url`` allows you to require encrypted
+connections to the MySQL server:
 
 .. code-block:: text
 
-    connection-url=jdbc:mysql://example.net:3306?serverTimezone=UTC
+    connection-url=jdbc:mysql://example.net:3306?sslMode=REQUIRED
 
 The ``connection-user`` and ``connection-password`` are typically required and
 determine the user credentials for the connection, often a service user. You can

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -34,6 +34,8 @@ import io.trino.plugin.jdbc.JdbcSortItem;
 import io.trino.plugin.jdbc.JdbcStatisticsConfig;
 import io.trino.plugin.jdbc.JdbcTableHandle;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.LongReadFunction;
+import io.trino.plugin.jdbc.LongWriteFunction;
 import io.trino.plugin.jdbc.PreparedQuery;
 import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.RemoteTableName;
@@ -86,6 +88,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLSyntaxErrorException;
 import java.sql.Types;
+import java.time.LocalDate;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Collection;
 import java.util.List;
@@ -120,8 +123,7 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.bigintWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.booleanColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.booleanWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.charWriteFunction;
-import static io.trino.plugin.jdbc.StandardColumnMappings.dateColumnMappingUsingLocalDate;
-import static io.trino.plugin.jdbc.StandardColumnMappings.dateWriteFunctionUsingLocalDate;
+import static io.trino.plugin.jdbc.StandardColumnMappings.dateReadFunctionUsingLocalDate;
 import static io.trino.plugin.jdbc.StandardColumnMappings.decimalColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.defaultCharColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.defaultVarcharColumnMapping;
@@ -135,9 +137,9 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.realWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.shortDecimalWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.smallintColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.smallintWriteFunction;
-import static io.trino.plugin.jdbc.StandardColumnMappings.timeColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.timeReadFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.timeWriteFunction;
-import static io.trino.plugin.jdbc.StandardColumnMappings.timestampColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.timestampReadFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.timestampWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.tinyintColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.tinyintWriteFunction;
@@ -167,6 +169,7 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.String.format;
 import static java.lang.String.join;
+import static java.time.format.DateTimeFormatter.ISO_DATE;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
@@ -439,21 +442,95 @@ public class MySqlClient
                 return Optional.of(ColumnMapping.sliceMapping(VARBINARY, varbinaryReadFunction(), varbinaryWriteFunction(), FULL_PUSHDOWN));
 
             case Types.DATE:
-                return Optional.of(dateColumnMappingUsingLocalDate());
+                return Optional.of(ColumnMapping.longMapping(
+                        DATE,
+                        dateReadFunctionUsingLocalDate(),
+                        mySqlDateWriteFunctionUsingLocalDate()));
 
             case Types.TIME:
                 TimeType timeType = createTimeType(getTimePrecision(typeHandle.getRequiredColumnSize()));
-                return Optional.of(timeColumnMapping(timeType));
+                requireNonNull(timeType, "timeType is null");
+                checkArgument(timeType.getPrecision() <= 9, "Unsupported type precision: %s", timeType);
+                return Optional.of(ColumnMapping.longMapping(
+                        timeType,
+                        mySqlTimeReadFunction(timeType),
+                        timeWriteFunction(timeType.getPrecision())));
 
             case Types.TIMESTAMP:
                 TimestampType timestampType = createTimestampType(getTimestampPrecision(typeHandle.getRequiredColumnSize()));
-                return Optional.of(timestampColumnMapping(timestampType));
+                checkArgument(timestampType.getPrecision() <= TimestampType.MAX_SHORT_PRECISION, "Precision is out of range: %s", timestampType.getPrecision());
+                return Optional.of(ColumnMapping.longMapping(
+                        timestampType,
+                        mySqlTimestampReadFunction(timestampType),
+                        timestampWriteFunction(timestampType)));
         }
 
         if (getUnsupportedTypeHandling(session) == CONVERT_TO_VARCHAR) {
             return mapToUnboundedVarchar(typeHandle);
         }
         return Optional.empty();
+    }
+
+    private LongWriteFunction mySqlDateWriteFunctionUsingLocalDate()
+    {
+        return new LongWriteFunction() {
+            @Override
+            public String getBindExpression()
+            {
+                return "CAST(? AS DATE)";
+            }
+
+            @Override
+            public void set(PreparedStatement statement, int index, long epochDay)
+                    throws SQLException
+            {
+                statement.setString(index, LocalDate.ofEpochDay(epochDay).format(ISO_DATE));
+            }
+        };
+    }
+
+    private static LongReadFunction mySqlTimestampReadFunction(TimestampType timestampType)
+    {
+        return new LongReadFunction()
+        {
+            @Override
+            public boolean isNull(ResultSet resultSet, int columnIndex)
+                    throws SQLException
+            {
+                // super calls ResultSet#getObject(), which for TIMESTAMP type returns java.sql.Timestamp, for which the conversion can fail if the value isn't a valid instant in server's time zone.
+                resultSet.getObject(columnIndex, String.class);
+                return resultSet.wasNull();
+            }
+
+            @Override
+            public long readLong(ResultSet resultSet, int columnIndex)
+                    throws SQLException
+            {
+                return timestampReadFunction(timestampType).readLong(resultSet, columnIndex);
+            }
+        };
+    }
+
+    private static LongReadFunction mySqlTimeReadFunction(TimeType timeType)
+    {
+        return new LongReadFunction()
+        {
+            @Override
+            public boolean isNull(ResultSet resultSet, int columnIndex)
+                    throws SQLException
+            {
+                // super calls ResultSet#getObject(), which for TIME type returns java.sql.Time, for which the conversion can fail if the value isn't a valid instant in server's time zone.
+                resultSet.getObject(columnIndex, String.class);
+                return resultSet.wasNull();
+            }
+
+            @Override
+            public long readLong(ResultSet resultSet, int columnIndex)
+                    throws SQLException
+            {
+                return timeReadFunction(timeType).readLong(resultSet, columnIndex);
+            }
+        };
     }
 
     private static int getTimestampPrecision(int timestampColumnSize)
@@ -510,7 +587,7 @@ public class MySqlClient
         }
 
         if (type == DATE) {
-            return WriteMapping.longMapping("date", dateWriteFunctionUsingLocalDate());
+            return WriteMapping.longMapping("date", mySqlDateWriteFunctionUsingLocalDate());
         }
 
         if (type instanceof TimeType timeType) {

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClientModule.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClientModule.java
@@ -17,7 +17,7 @@ import com.google.inject.Binder;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
-import com.mysql.jdbc.Driver;
+import com.mysql.cj.jdbc.Driver;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.ConnectionFactory;
@@ -73,6 +73,11 @@ public class MySqlClientModule
         connectionProperties.setProperty("characterEncoding", "utf8");
         connectionProperties.setProperty("tinyInt1isBit", "false");
         connectionProperties.setProperty("rewriteBatchedStatements", "true");
+
+        // See "Solution 2a" at https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-time-instants.html - these properties are required to preserve point-in-time when operating with MySQL TIMESTAMP types
+        connectionProperties.setProperty("preserveInstants", "true");
+        connectionProperties.setProperty("connectionTimeZone", "SERVER");
+
         if (mySqlConfig.isAutoReconnect()) {
             connectionProperties.setProperty("autoReconnect", String.valueOf(mySqlConfig.isAutoReconnect()));
             connectionProperties.setProperty("maxReconnects", String.valueOf(mySqlConfig.getMaxReconnects()));

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlJdbcConfig.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlJdbcConfig.java
@@ -15,7 +15,7 @@ package io.trino.plugin.mysql;
 
 import com.mysql.cj.conf.ConnectionUrlParser;
 import com.mysql.cj.exceptions.CJException;
-import com.mysql.jdbc.Driver;
+import com.mysql.cj.jdbc.Driver;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 
 import javax.validation.constraints.AssertTrue;
@@ -32,8 +32,7 @@ public class MySqlJdbcConfig
     public boolean isUrlValid()
     {
         try {
-            Driver driver = new Driver();
-            return driver.acceptsURL(getConnectionUrl());
+            return new Driver().acceptsURL(getConnectionUrl());
         }
         catch (SQLException e) {
             throw new RuntimeException(e);

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlConnectorTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlConnectorTest.java
@@ -15,7 +15,6 @@ package io.trino.plugin.mysql;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
-import org.testng.annotations.Test;
 
 import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,17 +28,6 @@ public class TestMySqlConnectorTest
     {
         mySqlServer = closeAfterClass(new TestingMySqlServer(false));
         return createMySqlQueryRunner(mySqlServer, ImmutableMap.of(), ImmutableMap.of(), REQUIRED_TPCH_TABLES);
-    }
-
-    @Test
-    @Override
-    public void testDateYearOfEraPredicate()
-    {
-        // MySQL throws an exception instead of an empty result when the value is out of range
-        assertQuery("SELECT orderdate FROM orders WHERE orderdate = DATE '1997-09-14'", "VALUES DATE '1997-09-14'");
-        assertQueryFails(
-                "SELECT * FROM orders WHERE orderdate = DATE '-1996-09-14'",
-                "Incorrect DATE value: '-1996-09-14'");
     }
 
     @Override

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlLegacyConnectorTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlLegacyConnectorTest.java
@@ -104,7 +104,7 @@ public class TestMySqlLegacyConnectorTest
                 .map(value -> format("'%1$s', '%1$s'", value))
                 .collect(toImmutableList());
 
-        try (TestTable testTable = new TestTable(onRemoteDatabase(), "tpch.distinct_strings", "(t_char CHAR(5), t_varchar VARCHAR(5) CHARACTER SET utf8mb4)", rows)) {
+        try (TestTable testTable = new TestTable(onRemoteDatabase(), "tpch.distinct_strings", "(t_char CHAR(5) CHARACTER SET utf8mb4, t_varchar VARCHAR(5) CHARACTER SET utf8mb4)", rows)) {
             // disabling hash generation to prevent extra projections in the plan which make it hard to write matchers for isNotFullyPushedDown
             Session optimizeHashGenerationDisabled = Session.builder(getSession())
                     .setSystemProperty("optimize_hash_generation", "false")
@@ -166,5 +166,13 @@ public class TestMySqlLegacyConnectorTest
     protected void verifyColumnNameLengthFailurePermissible(Throwable e)
     {
         assertThat(e).hasMessageMatching("Identifier name .* is too long");
+    }
+
+    @Override
+    public void testNativeQueryWithClause()
+    {
+        // Override because MySQL 5.x doesn't support WITH clause
+        assertThatThrownBy(super::testNativeQueryWithClause)
+                .hasStackTraceContaining("Failed to get table handle for prepared query. You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1536,7 +1536,7 @@
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>8.0.22</version>
+                <version>8.0.29</version>
             </dependency>
 
             <dependency>

--- a/testing/trino-product-tests/src/main/resources/tempto-configuration.yaml
+++ b/testing/trino-product-tests/src/main/resources/tempto-configuration.yaml
@@ -110,7 +110,7 @@ databases:
     https_keystore_password: ${databases.presto.https_keystore_password}
 
   mysql:
-    jdbc_driver_class: com.mysql.jdbc.Driver
+    jdbc_driver_class: com.mysql.cj.jdbc.Driver
     jdbc_url: jdbc:mysql://mysql:13306/test
     jdbc_user: root
     jdbc_password: test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Update MySQL JDBC driver to 8.0.29

Fixes #15332 Closes #12692

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Update MySQL JDBC driver to 8.0.29

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# MySQL
* Update MySQL JDBC driver to 8.0.29. This fixes failure when `query` table function contains `WITH` clause. ({issue}`15332`)
```
