### PR TITLE
Open Iceberg and Hive table handle classes for extension

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableHandle.java
@@ -86,7 +86,7 @@ public class HiveTableHandle
                 .build();
     }
 
-    private HiveTableHandle(
+    protected HiveTableHandle(
             String schemaName,
             String tableName,
             Optional<Map<String, String>> tableParameters,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableHandle.java
@@ -104,7 +104,7 @@ public class IcebergTableHandle
                 .build();
     }
 
-    private IcebergTableHandle(
+    protected IcebergTableHandle(
             String schemaName,
             String tableName,
             TableType tableType,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Constructor visibility level was recently changed to private in `IcebergTableHandle` and `HiveTableHandle` classes.

This changes the constructor visibility level in these classes to `protected` to allow for extension.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/trinodb/trino/pull/15217

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
