### PR TITLE
Speed up `QualifiedName` constructor

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/tree/QualifiedName.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/QualifiedName.java
@@ -13,7 +13,6 @@
  */
 package io.trino.sql.tree;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
@@ -63,7 +62,7 @@ public class QualifiedName
         this.parts = originalParts.stream()
                 .map(QualifiedName::mapIdentifier)
                 .collect(toImmutableList());
-        this.name = Joiner.on(".").join(parts);
+        this.name = String.join(".", parts);
 
         if (originalParts.size() == 1) {
             this.prefix = Optional.empty();

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/QualifiedName.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/QualifiedName.java
@@ -59,9 +59,12 @@ public class QualifiedName
     private QualifiedName(List<Identifier> originalParts)
     {
         this.originalParts = originalParts;
-        this.parts = originalParts.stream()
-                .map(QualifiedName::mapIdentifier)
-                .collect(toImmutableList());
+        // Iteration instead of stream for performance reasons
+        ImmutableList.Builder partsBuilder = ImmutableList.builderWithExpectedSize(originalParts.size());
+        for (Identifier identifier : originalParts) {
+            partsBuilder.add(mapIdentifier(identifier));
+        }
+        this.parts = partsBuilder.build();
         this.name = String.join(".", parts);
 
         if (originalParts.size() == 1) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

A small performance tweak.
I noticed that about 1% of analysis time in some of my huge queries was spent in the constructor of `QualifiedName` in stream logic.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
