### PR TITLE
Cleanup PartitioningExchanger

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/exchange/PartitioningExchanger.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/PartitioningExchanger.java
@@ -19,7 +19,6 @@ import io.trino.operator.PartitionFunction;
 import io.trino.spi.Page;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import java.util.List;
@@ -58,18 +57,7 @@ class PartitioningExchanger
     @Override
     public void accept(Page page)
     {
-        Consumer<Page> wholePagePartition = partitionPageOrFindWholePagePartition(page, partitionedPagePreparer.apply(page));
-        if (wholePagePartition != null) {
-            // whole input page will go to this partition, compact the input page avoid over-retaining memory and to
-            // match the behavior of sub-partitioned pages that copy positions out
-            page.compact();
-            sendPageToPartition(wholePagePartition, page);
-        }
-    }
-
-    @Nullable
-    private Consumer<Page> partitionPageOrFindWholePagePartition(Page page, Page partitionPage)
-    {
+        Page partitionPage = partitionedPagePreparer.apply(page);
         // assign each row to a partition. The assignments lists are all expected to cleared by the previous iterations
         for (int position = 0; position < partitionPage.getPositionCount(); position++) {
             int partition = partitionFunction.getPartition(partitionPage, position);
@@ -89,22 +77,19 @@ class PartitioningExchanger
             int[] positions = positionsList.elements();
             positionsList.clear();
 
+            Page pageSplit;
             if (partitionSize == page.getPositionCount()) {
-                // entire page will be sent to this partition, compact and send the page after releasing the lock
-                return buffers.get(partition);
+                // whole input page will go to this partition, compact the input page avoid over-retaining memory and to
+                // match the behavior of sub-partitioned pages that copy positions out
+                page.compact();
+                pageSplit = page;
             }
-            Page pageSplit = page.copyPositions(positions, 0, partitionSize);
-            sendPageToPartition(buffers.get(partition), pageSplit);
+            else {
+                pageSplit = page.copyPositions(positions, 0, partitionSize);
+            }
+            memoryManager.updateMemoryUsage(pageSplit.getRetainedSizeInBytes());
+            buffers.get(partition).accept(pageSplit);
         }
-        // No single partition receives the entire input page
-        return null;
-    }
-
-    // This is safe to call without synchronizing because the partition buffers are themselves threadsafe
-    private void sendPageToPartition(Consumer<Page> buffer, Page pageSplit)
-    {
-        memoryManager.updateMemoryUsage(pageSplit.getRetainedSizeInBytes());
-        buffer.accept(pageSplit);
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Removes outdated comments and unnecessary methods in local exchange PartitioningExchanger since the operator is no longer implemented in a way that attempts to be thread-safe after https://github.com/trinodb/trino/pull/13834



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
