### PR TITLE
Fix recording of projection metrics

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
@@ -342,13 +342,15 @@ public class PageProcessor
                 }
                 else {
                     if (pageProjectWork == null) {
-                        Page inputPage = projection.getInputChannels().getInputChannels(page);
-                        expressionProfiler.start();
-                        pageProjectWork = projection.project(session, yieldSignal, inputPage, positionsBatch);
-                        long projectionTimeNanos = expressionProfiler.stop(positionsBatch.size());
-                        metrics.recordProjectionTime(projectionTimeNanos);
+                        pageProjectWork = projection.project(session, yieldSignal, projection.getInputChannels().getInputChannels(page), positionsBatch);
                     }
-                    if (!pageProjectWork.process()) {
+
+                    expressionProfiler.start();
+                    boolean finished = pageProjectWork.process();
+                    long projectionTimeNanos = expressionProfiler.stop(positionsBatch.size());
+                    metrics.recordProjectionTime(projectionTimeNanos);
+
+                    if (!finished) {
                         return ProcessBatchResult.processBatchYield();
                     }
                     previouslyComputedResults[i] = pageProjectWork.getResult();


### PR DESCRIPTION
## Description

Actual work is done in `pageProjectWork.process()` call while `projection.project` only performs setup of projection. 
So both `expressionProfiler` and `metrics.recordProjectionTime` needed to be around that method.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix recording of `Projection CPU time` in EXPLAIN ANALYZE VERBOSE. ({issue}`15364`)
```
