### PR TITLE
Add support for grants on new entity kinds

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/DenyTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DenyTask.java
@@ -22,18 +22,21 @@ import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.RedirectionAwareTableHandle;
 import io.trino.security.AccessControl;
 import io.trino.spi.connector.CatalogSchemaName;
+import io.trino.spi.connector.EntityKindAndName;
+import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.security.Privilege;
 import io.trino.sql.tree.Deny;
 import io.trino.sql.tree.Expression;
-import io.trino.sql.tree.GrantOnType;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
+import static io.trino.execution.PrivilegeUtilities.fetchEntityKindPrivileges;
 import static io.trino.execution.PrivilegeUtilities.parseStatementPrivileges;
 import static io.trino.metadata.MetadataUtil.createCatalogSchemaName;
+import static io.trino.metadata.MetadataUtil.createEntityKindAndName;
 import static io.trino.metadata.MetadataUtil.createPrincipal;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -64,18 +67,22 @@ public class DenyTask
     @Override
     public ListenableFuture<Void> execute(Deny statement, QueryStateMachine stateMachine, List<Expression> parameters, WarningCollector warningCollector)
     {
-        if (statement.getType().filter(GrantOnType.SCHEMA::equals).isPresent()) {
+        String entityKind = statement.getGrantObject().getEntityKind().orElse("TABLE");
+        if (entityKind.equalsIgnoreCase("TABLE")) {
+            executeDenyOnTable(stateMachine.getSession(), statement, metadata, accessControl);
+        }
+        else if (entityKind.equalsIgnoreCase("SCHEMA")) {
             executeDenyOnSchema(stateMachine.getSession(), statement, metadata, accessControl);
         }
         else {
-            executeDenyOnTable(stateMachine.getSession(), statement, metadata, accessControl);
+            executeDenyOnEntity(stateMachine.getSession(), statement, metadata, entityKind, accessControl);
         }
         return immediateVoidFuture();
     }
 
     private static void executeDenyOnSchema(Session session, Deny statement, Metadata metadata, AccessControl accessControl)
     {
-        CatalogSchemaName schemaName = createCatalogSchemaName(session, statement, Optional.of(statement.getName()));
+        CatalogSchemaName schemaName = createCatalogSchemaName(session, statement, Optional.of(statement.getGrantObject().getName()));
 
         if (!metadata.schemaExists(session, schemaName)) {
             throw semanticException(SCHEMA_NOT_FOUND, statement, "Schema '%s' does not exist", schemaName);
@@ -91,7 +98,7 @@ public class DenyTask
 
     private static void executeDenyOnTable(Session session, Deny statement, Metadata metadata, AccessControl accessControl)
     {
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getName());
+        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getGrantObject().getName());
         RedirectionAwareTableHandle redirection = metadata.getRedirectionAwareTableHandle(session, tableName);
         if (redirection.tableHandle().isEmpty()) {
             throw semanticException(TABLE_NOT_FOUND, statement, "Table '%s' does not exist", tableName);
@@ -107,5 +114,17 @@ public class DenyTask
         }
 
         metadata.denyTablePrivileges(session, tableName, privileges, createPrincipal(statement.getGrantee()));
+    }
+
+    private static void executeDenyOnEntity(Session session, Deny statement, Metadata metadata, String entityKind, AccessControl accessControl)
+    {
+        EntityKindAndName entity = createEntityKindAndName(entityKind, statement.getGrantObject().getName());
+        Set<EntityPrivilege> privileges = fetchEntityKindPrivileges(entityKind, metadata, statement.getPrivileges());
+
+        for (EntityPrivilege privilege : privileges) {
+            accessControl.checkCanDenyEntityPrivilege(session.toSecurityContext(), privilege, entity, createPrincipal(statement.getGrantee()));
+        }
+
+        metadata.denyEntityPrivileges(session, entity, privileges, createPrincipal(statement.getGrantee()));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/GrantTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/GrantTask.java
@@ -22,18 +22,21 @@ import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.RedirectionAwareTableHandle;
 import io.trino.security.AccessControl;
 import io.trino.spi.connector.CatalogSchemaName;
+import io.trino.spi.connector.EntityKindAndName;
+import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.security.Privilege;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.Grant;
-import io.trino.sql.tree.GrantOnType;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
+import static io.trino.execution.PrivilegeUtilities.fetchEntityKindPrivileges;
 import static io.trino.execution.PrivilegeUtilities.parseStatementPrivileges;
 import static io.trino.metadata.MetadataUtil.createCatalogSchemaName;
+import static io.trino.metadata.MetadataUtil.createEntityKindAndName;
 import static io.trino.metadata.MetadataUtil.createPrincipal;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -68,18 +71,22 @@ public class GrantTask
             List<Expression> parameters,
             WarningCollector warningCollector)
     {
-        if (statement.getType().filter(GrantOnType.SCHEMA::equals).isPresent()) {
+        String entityKind = statement.getGrantObject().getEntityKind().orElse("TABLE");
+        if (entityKind.equalsIgnoreCase("TABLE")) {
+            executeGrantOnTable(stateMachine.getSession(), statement);
+        }
+        else if (entityKind.equalsIgnoreCase("SCHEMA")) {
             executeGrantOnSchema(stateMachine.getSession(), statement);
         }
         else {
-            executeGrantOnTable(stateMachine.getSession(), statement);
+            executeGrantOnEntity(stateMachine.getSession(), entityKind, metadata, statement);
         }
         return immediateVoidFuture();
     }
 
     private void executeGrantOnSchema(Session session, Grant statement)
     {
-        CatalogSchemaName schemaName = createCatalogSchemaName(session, statement, Optional.of(statement.getName()));
+        CatalogSchemaName schemaName = createCatalogSchemaName(session, statement, Optional.of(statement.getGrantObject().getName()));
 
         if (!metadata.schemaExists(session, schemaName)) {
             throw semanticException(SCHEMA_NOT_FOUND, statement, "Schema '%s' does not exist", schemaName);
@@ -95,7 +102,7 @@ public class GrantTask
 
     private void executeGrantOnTable(Session session, Grant statement)
     {
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getName());
+        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getGrantObject().getName());
         RedirectionAwareTableHandle redirection = metadata.getRedirectionAwareTableHandle(session, tableName);
         if (redirection.tableHandle().isEmpty()) {
             throw semanticException(TABLE_NOT_FOUND, statement, "Table '%s' does not exist", tableName);
@@ -111,5 +118,17 @@ public class GrantTask
         }
 
         metadata.grantTablePrivileges(session, tableName, privileges, createPrincipal(statement.getGrantee()), statement.isWithGrantOption());
+    }
+
+    private void executeGrantOnEntity(Session session, String entityKind, Metadata metadata, Grant statement)
+    {
+        EntityKindAndName entity = createEntityKindAndName(entityKind, statement.getGrantObject().getName());
+        Set<EntityPrivilege> privileges = fetchEntityKindPrivileges(entityKind, metadata, statement.getPrivileges());
+
+        for (EntityPrivilege privilege : privileges) {
+            accessControl.checkCanGrantEntityPrivilege(session.toSecurityContext(), privilege, entity, createPrincipal(statement.getGrantee()), statement.isWithGrantOption());
+        }
+
+        metadata.grantEntityPrivileges(session, entity, privileges, createPrincipal(statement.getGrantee()), statement.isWithGrantOption());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/RevokeTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RevokeTask.java
@@ -22,9 +22,10 @@ import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.RedirectionAwareTableHandle;
 import io.trino.security.AccessControl;
 import io.trino.spi.connector.CatalogSchemaName;
+import io.trino.spi.connector.EntityKindAndName;
+import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.security.Privilege;
 import io.trino.sql.tree.Expression;
-import io.trino.sql.tree.GrantOnType;
 import io.trino.sql.tree.Revoke;
 
 import java.util.List;
@@ -32,8 +33,10 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
+import static io.trino.execution.PrivilegeUtilities.fetchEntityKindPrivileges;
 import static io.trino.execution.PrivilegeUtilities.parseStatementPrivileges;
 import static io.trino.metadata.MetadataUtil.createCatalogSchemaName;
+import static io.trino.metadata.MetadataUtil.createEntityKindAndName;
 import static io.trino.metadata.MetadataUtil.createPrincipal;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -68,18 +71,23 @@ public class RevokeTask
             List<Expression> parameters,
             WarningCollector warningCollector)
     {
-        if (statement.getType().filter(GrantOnType.SCHEMA::equals).isPresent()) {
+        String entityKind = statement.getGrantObject().getEntityKind().orElse("TABLE");
+        if (entityKind.equalsIgnoreCase("TABLE")) {
+            executeRevokeOnTable(stateMachine.getSession(), statement);
+        }
+        else if (entityKind.equalsIgnoreCase("SCHEMA")) {
             executeRevokeOnSchema(stateMachine.getSession(), statement);
         }
         else {
-            executeRevokeOnTable(stateMachine.getSession(), statement);
+            executeRevokeOnEntity(stateMachine.getSession(), entityKind, metadata, statement);
         }
+
         return immediateVoidFuture();
     }
 
     private void executeRevokeOnSchema(Session session, Revoke statement)
     {
-        CatalogSchemaName schemaName = createCatalogSchemaName(session, statement, Optional.of(statement.getName()));
+        CatalogSchemaName schemaName = createCatalogSchemaName(session, statement, Optional.of(statement.getGrantObject().getName()));
 
         if (!metadata.schemaExists(session, schemaName)) {
             throw semanticException(SCHEMA_NOT_FOUND, statement, "Schema '%s' does not exist", schemaName);
@@ -95,7 +103,7 @@ public class RevokeTask
 
     private void executeRevokeOnTable(Session session, Revoke statement)
     {
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getName());
+        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getGrantObject().getName());
         RedirectionAwareTableHandle redirection = metadata.getRedirectionAwareTableHandle(session, tableName);
         if (redirection.tableHandle().isEmpty()) {
             throw semanticException(TABLE_NOT_FOUND, statement, "Table '%s' does not exist", tableName);
@@ -110,5 +118,17 @@ public class RevokeTask
         }
 
         metadata.revokeTablePrivileges(session, tableName, privileges, createPrincipal(statement.getGrantee()), statement.isGrantOptionFor());
+    }
+
+    private void executeRevokeOnEntity(Session session, String entityKind, Metadata metadata, Revoke statement)
+    {
+        EntityKindAndName entity = createEntityKindAndName(entityKind, statement.getGrantObject().getName());
+        Set<EntityPrivilege> privileges = fetchEntityKindPrivileges(entityKind, metadata, statement.getPrivileges());
+
+        for (EntityPrivilege privilege : privileges) {
+            accessControl.checkCanRevokeEntityPrivilege(session.toSecurityContext(), privilege, entity, createPrincipal(statement.getGrantee()), statement.isGrantOptionFor());
+        }
+
+        metadata.revokeEntityPrivileges(session, entity, privileges, createPrincipal(statement.getGrantee()), statement.isGrantOptionFor());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/DisabledSystemSecurityMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/DisabledSystemSecurityMetadata.java
@@ -18,6 +18,8 @@ import io.trino.Session;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.EntityKindAndName;
+import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.function.CatalogSchemaFunctionName;
 import io.trino.spi.security.GrantInfo;
 import io.trino.spi.security.Identity;
@@ -25,8 +27,10 @@ import io.trino.spi.security.Privilege;
 import io.trino.spi.security.RoleGrant;
 import io.trino.spi.security.TrinoPrincipal;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 
@@ -138,6 +142,24 @@ public class DisabledSystemSecurityMetadata
     }
 
     @Override
+    public void grantEntityPrivileges(Session session, EntityKindAndName entity, Set<EntityPrivilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        throw notSupportedException(composeNameString(entity.name()));
+    }
+
+    @Override
+    public void denyEntityPrivileges(Session session, EntityKindAndName entity, Set<EntityPrivilege> privileges, TrinoPrincipal grantee)
+    {
+        throw notSupportedException(composeNameString(entity.name()));
+    }
+
+    @Override
+    public void revokeEntityPrivileges(Session session, EntityKindAndName entity, Set<EntityPrivilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        throw notSupportedException(composeNameString(entity.name()));
+    }
+
+    @Override
     public Optional<TrinoPrincipal> getSchemaOwner(Session session, CatalogSchemaName schema)
     {
         return Optional.empty();
@@ -206,5 +228,10 @@ public class DisabledSystemSecurityMetadata
     private static TrinoException notSupportedException(String catalogName)
     {
         return new TrinoException(NOT_SUPPORTED, "Catalog does not support permission management: " + catalogName);
+    }
+
+    private String composeNameString(List<String> parts)
+    {
+        return parts.stream().collect(Collectors.joining("."));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -30,6 +30,8 @@ import io.trino.spi.connector.ConnectorOutputMetadata;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
+import io.trino.spi.connector.EntityKindAndName;
+import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.connector.JoinApplicationResult;
 import io.trino.spi.connector.JoinStatistics;
 import io.trino.spi.connector.JoinType;
@@ -668,7 +670,7 @@ public interface Metadata
     void denyTablePrivileges(Session session, QualifiedObjectName tableName, Set<Privilege> privileges, TrinoPrincipal grantee);
 
     /**
-     * Revokes the specified privilege on the specified table from the specified user
+     * Revokes the specified privilege on the specified table from the specified user.
      */
     void revokeTablePrivileges(Session session, QualifiedObjectName tableName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption);
 
@@ -676,6 +678,42 @@ public interface Metadata
      * Gets the privileges for the specified table available to the given grantee considering the selected session role
      */
     List<GrantInfo> listTablePrivileges(Session session, QualifiedTablePrefix prefix);
+
+    /**
+     * Gets all the EntityPrivileges associated with an entityKind.  Defines ALL PRIVILEGES
+     * for the entityKind
+     */
+    default Set<EntityPrivilege> getAllEntityKindPrivileges(String entityKind)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Grants the specified privileges to the specified user on the specified grantee.
+     * If the set of privileges is empty, it is interpreted as all privileges for the entityKind.
+     */
+    default void grantEntityPrivileges(Session session, EntityKindAndName entity, Set<EntityPrivilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Deny the specified privileges to the specified principal on the specified entity.
+     * If the set of privileges is empty, it is interpreted as all privileges for the entityKind.
+     */
+    default void denyEntityPrivileges(Session session, EntityKindAndName entity, Set<EntityPrivilege> privileges, TrinoPrincipal grantee)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Revokes the specified privilege on the specified entity from the specified grantee.
+     * If the set of privileges is empty, it is interpreted as all privileges for the entityKind.
+     */
+    default void revokeEntityPrivileges(Session session, EntityKindAndName entity, Set<EntityPrivilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        throw new UnsupportedOperationException();
+    }
 
     //
     // Functions

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -61,6 +61,8 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
+import io.trino.spi.connector.EntityKindAndName;
+import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.connector.JoinApplicationResult;
 import io.trino.spi.connector.JoinStatistics;
 import io.trino.spi.connector.JoinType;
@@ -2390,6 +2392,31 @@ public final class MetadataManager
             }
         }
         return ImmutableList.copyOf(grantInfos.build());
+    }
+
+    @Override
+    public Set<EntityPrivilege> getAllEntityKindPrivileges(String entityKind)
+    {
+        requireNonNull(entityKind, "entityKind is null");
+        return systemSecurityMetadata.getAllEntityKindPrivileges(entityKind);
+    }
+
+    @Override
+    public void grantEntityPrivileges(Session session, EntityKindAndName entity, Set<EntityPrivilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        systemSecurityMetadata.grantEntityPrivileges(session, entity, privileges, grantee, grantOption);
+    }
+
+    @Override
+    public void denyEntityPrivileges(Session session, EntityKindAndName entity, Set<EntityPrivilege> privileges, TrinoPrincipal grantee)
+    {
+        systemSecurityMetadata.denyEntityPrivileges(session, entity, privileges, grantee);
+    }
+
+    @Override
+    public void revokeEntityPrivileges(Session session, EntityKindAndName entity, Set<EntityPrivilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        systemSecurityMetadata.revokeEntityPrivileges(session, entity, privileges, grantee, grantOption);
     }
 
     //

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataUtil.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataUtil.java
@@ -21,6 +21,7 @@ import io.trino.spi.connector.CatalogHandle;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.EntityKindAndName;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.PrincipalType;
 import io.trino.spi.security.TrinoPrincipal;
@@ -151,6 +152,11 @@ public final class MetadataUtil
                 semanticException(MISSING_CATALOG_NAME, node, "Catalog must be specified when session catalog is not set"));
 
         return new QualifiedObjectName(catalogName, schemaName, objectName);
+    }
+
+    public static EntityKindAndName createEntityKindAndName(String entityKind, QualifiedName name)
+    {
+        return new EntityKindAndName(entityKind, name.getParts());
     }
 
     public static TrinoPrincipal createPrincipal(Session session, GrantorSpecification specification)

--- a/core/trino-main/src/main/java/io/trino/metadata/SystemSecurityMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemSecurityMetadata.java
@@ -16,6 +16,8 @@ package io.trino.metadata;
 import io.trino.Session;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.EntityKindAndName;
+import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.function.CatalogSchemaFunctionName;
 import io.trino.spi.security.GrantInfo;
 import io.trino.spi.security.Identity;
@@ -113,6 +115,44 @@ public interface SystemSecurityMetadata
      * Gets the privileges for the specified table available to the given grantee considering the selected session role
      */
     Set<GrantInfo> listTablePrivileges(Session session, QualifiedTablePrefix prefix);
+
+    default Set<EntityPrivilege> getAllEntityKindPrivileges(String entityKind)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Grants the specified privilege to the specified user on the specified entity
+     */
+    default void grantEntityPrivileges(Session session, EntityKindAndName entity, Set<EntityPrivilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Deny the specified privilege to the specified principal on the specified entity
+     */
+    default void denyEntityPrivileges(Session session, EntityKindAndName entity, Set<EntityPrivilege> privileges, TrinoPrincipal grantee)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Revokes the specified privilege on the specified entity from the specified user
+     */
+    default void revokeEntityPrivileges(Session session, EntityKindAndName entity, Set<EntityPrivilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Throws an exception if the entityKind is not supported, or if the privileges
+     * are not supported for the entityKind
+     */
+    default void validateEntityKindAndPrivileges(Session session, String entityKind, Set<String> privileges)
+    {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Set the owner of the specified schema

--- a/core/trino-main/src/main/java/io/trino/security/AccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControl.java
@@ -17,6 +17,8 @@ import com.google.common.collect.ImmutableList;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.EntityKindAndName;
+import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.SchemaFunctionName;
 import io.trino.spi.security.AccessDeniedException;
@@ -434,6 +436,27 @@ public interface AccessControl
      * @throws AccessDeniedException if not allowed
      */
     void checkCanRevokeTablePrivilege(SecurityContext context, Privilege privilege, QualifiedObjectName tableName, TrinoPrincipal revokee, boolean grantOption);
+
+    /**
+     * Check if identity is allowed to grant the specified privilege to the grantee on the specified entity.
+     *
+     * @throws AccessDeniedException if not allowed
+     */
+    void checkCanGrantEntityPrivilege(SecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal grantee, boolean grantOption);
+
+    /**
+     * Check if identity is allowed to deny the specified privilege to the grantee on the specified entity.
+     *
+     * @throws AccessDeniedException if not allowed
+     */
+    void checkCanDenyEntityPrivilege(SecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal grantee);
+
+    /**
+     * Check if identity is allowed to revoke the specified privilege on the specified entity from the revokee.
+     *
+     * @throws AccessDeniedException if not allowed
+     */
+    void checkCanRevokeEntityPrivilege(SecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal revokee, boolean grantOption);
 
     /**
      * Check if identity is allowed to set the specified system property.

--- a/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
@@ -41,6 +41,8 @@ import io.trino.spi.connector.CatalogSchemaRoutineName;
 import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorSecurityContext;
+import io.trino.spi.connector.EntityKindAndName;
+import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.FunctionKind;
 import io.trino.spi.function.SchemaFunctionName;
@@ -1012,6 +1014,36 @@ public class AccessControlManager
         systemAuthorizationCheck(control -> control.checkCanRevokeTablePrivilege(securityContext.toSystemSecurityContext(), privilege, tableName.asCatalogSchemaTableName(), revokee, grantOption));
 
         catalogAuthorizationCheck(tableName.getCatalogName(), securityContext, (control, context) -> control.checkCanRevokeTablePrivilege(context, privilege, tableName.asSchemaTableName(), revokee, grantOption));
+    }
+
+    @Override
+    public void checkCanGrantEntityPrivilege(SecurityContext securityContext, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal grantee, boolean grantOption)
+    {
+        requireNonNull(securityContext, "securityContext is null");
+        requireNonNull(entity, "entity is null");
+        requireNonNull(privilege, "privilege is null");
+
+        systemAuthorizationCheck(control -> control.checkCanGrantEntityPrivilege(securityContext.toSystemSecurityContext(), privilege, entity, grantee, grantOption));
+    }
+
+    @Override
+    public void checkCanDenyEntityPrivilege(SecurityContext securityContext, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal grantee)
+    {
+        requireNonNull(securityContext, "securityContext is null");
+        requireNonNull(entity, "entity is null");
+        requireNonNull(privilege, "privilege is null");
+
+        systemAuthorizationCheck(control -> control.checkCanDenyEntityPrivilege(securityContext.toSystemSecurityContext(), privilege, entity, grantee));
+    }
+
+    @Override
+    public void checkCanRevokeEntityPrivilege(SecurityContext securityContext, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal revokee, boolean grantOption)
+    {
+        requireNonNull(securityContext, "securityContext is null");
+        requireNonNull(entity, "entity is null");
+        requireNonNull(privilege, "privilege is null");
+
+        systemAuthorizationCheck(control -> control.checkCanRevokeEntityPrivilege(securityContext.toSystemSecurityContext(), privilege, entity, revokee, grantOption));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/security/AllowAllAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/AllowAllAccessControl.java
@@ -16,6 +16,8 @@ package io.trino.security;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.EntityKindAndName;
+import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.SchemaFunctionName;
 import io.trino.spi.security.Identity;
@@ -320,6 +322,21 @@ public class AllowAllAccessControl
 
     @Override
     public void checkCanRevokeTablePrivilege(SecurityContext context, Privilege privilege, QualifiedObjectName tableName, TrinoPrincipal revokee, boolean grantOption)
+    {
+    }
+
+    @Override
+    public void checkCanGrantEntityPrivilege(SecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal grantee, boolean grantOption)
+    {
+    }
+
+    @Override
+    public void checkCanDenyEntityPrivilege(SecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal grantee)
+    {
+    }
+
+    @Override
+    public void checkCanRevokeEntityPrivilege(SecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal revokee, boolean grantOption)
     {
     }
 

--- a/core/trino-main/src/main/java/io/trino/security/DenyAllAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/DenyAllAccessControl.java
@@ -19,6 +19,8 @@ import com.google.common.collect.ImmutableSet;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.EntityKindAndName;
+import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.SchemaFunctionName;
 import io.trino.spi.security.Identity;
@@ -45,6 +47,7 @@ import static io.trino.spi.security.AccessDeniedException.denyCreateTable;
 import static io.trino.spi.security.AccessDeniedException.denyCreateView;
 import static io.trino.spi.security.AccessDeniedException.denyCreateViewWithSelect;
 import static io.trino.spi.security.AccessDeniedException.denyDeleteTable;
+import static io.trino.spi.security.AccessDeniedException.denyDenyEntityPrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyDenySchemaPrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyDenyTablePrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyDropCatalog;
@@ -58,6 +61,7 @@ import static io.trino.spi.security.AccessDeniedException.denyDropView;
 import static io.trino.spi.security.AccessDeniedException.denyExecuteProcedure;
 import static io.trino.spi.security.AccessDeniedException.denyExecuteQuery;
 import static io.trino.spi.security.AccessDeniedException.denyExecuteTableProcedure;
+import static io.trino.spi.security.AccessDeniedException.denyGrantEntityPrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyGrantRoles;
 import static io.trino.spi.security.AccessDeniedException.denyGrantSchemaPrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyGrantTablePrivilege;
@@ -71,6 +75,7 @@ import static io.trino.spi.security.AccessDeniedException.denyRenameMaterialized
 import static io.trino.spi.security.AccessDeniedException.denyRenameSchema;
 import static io.trino.spi.security.AccessDeniedException.denyRenameTable;
 import static io.trino.spi.security.AccessDeniedException.denyRenameView;
+import static io.trino.spi.security.AccessDeniedException.denyRevokeEntityPrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyRevokeRoles;
 import static io.trino.spi.security.AccessDeniedException.denyRevokeSchemaPrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyRevokeTablePrivilege;
@@ -429,6 +434,24 @@ public class DenyAllAccessControl
     public void checkCanRevokeTablePrivilege(SecurityContext context, Privilege privilege, QualifiedObjectName tableName, TrinoPrincipal revokee, boolean grantOption)
     {
         denyRevokeTablePrivilege(privilege.name(), tableName.toString());
+    }
+
+    @Override
+    public void checkCanGrantEntityPrivilege(SecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal grantee, boolean grantOption)
+    {
+        denyGrantEntityPrivilege(privilege.name(), entity);
+    }
+
+    @Override
+    public void checkCanDenyEntityPrivilege(SecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal grantee)
+    {
+        denyDenyEntityPrivilege(privilege.name(), entity);
+    }
+
+    @Override
+    public void checkCanRevokeEntityPrivilege(SecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal revokee, boolean grantOption)
+    {
+        denyRevokeEntityPrivilege(privilege.name(), entity);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/security/ForwardingAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/ForwardingAccessControl.java
@@ -16,6 +16,8 @@ package io.trino.security;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.EntityKindAndName;
+import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.SchemaFunctionName;
 import io.trino.spi.security.Identity;
@@ -381,6 +383,24 @@ public abstract class ForwardingAccessControl
     public void checkCanRevokeTablePrivilege(SecurityContext context, Privilege privilege, QualifiedObjectName tableName, TrinoPrincipal revokee, boolean grantOption)
     {
         delegate().checkCanRevokeTablePrivilege(context, privilege, tableName, revokee, grantOption);
+    }
+
+    @Override
+    public void checkCanGrantEntityPrivilege(SecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal grantee, boolean grantOption)
+    {
+        delegate().checkCanGrantEntityPrivilege(context, privilege, entity, grantee, grantOption);
+    }
+
+    @Override
+    public void checkCanDenyEntityPrivilege(SecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal grantee)
+    {
+        delegate().checkCanDenyEntityPrivilege(context, privilege, entity, grantee);
+    }
+
+    @Override
+    public void checkCanRevokeEntityPrivilege(SecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal revokee, boolean grantOption)
+    {
+        delegate().checkCanRevokeEntityPrivilege(context, privilege, entity, revokee, grantOption);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -71,6 +71,7 @@ import io.trino.sql.tree.DoubleLiteral;
 import io.trino.sql.tree.Explain;
 import io.trino.sql.tree.ExplainAnalyze;
 import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.GrantObject;
 import io.trino.sql.tree.Identifier;
 import io.trino.sql.tree.LikePredicate;
 import io.trino.sql.tree.LongLiteral;
@@ -313,7 +314,8 @@ public final class ShowQueriesRewrite
             String catalogName = session.getCatalog().orElse(null);
             Optional<Expression> predicate = Optional.empty();
 
-            Optional<QualifiedName> tableName = showGrants.getTableName();
+            // TODO: Should this handle any entityKind?
+            Optional<QualifiedName> tableName = showGrants.getGrantObject().map(GrantObject::getName);
             if (tableName.isPresent()) {
                 QualifiedObjectName qualifiedTableName = createQualifiedObjectName(session, showGrants, tableName.get());
                 if (!metadata.isView(session, qualifiedTableName)) {

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingAccessControl.java
@@ -22,6 +22,8 @@ import io.trino.security.AccessControl;
 import io.trino.security.SecurityContext;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.EntityKindAndName;
+import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.SchemaFunctionName;
 import io.trino.spi.security.Identity;
@@ -551,6 +553,33 @@ public class TracingAccessControl
         Span span = startSpan("checkCanRevokeTablePrivilege");
         try (var ignored = scopedSpan(span)) {
             delegate.checkCanRevokeTablePrivilege(context, privilege, tableName, revokee, grantOption);
+        }
+    }
+
+    @Override
+    public void checkCanGrantEntityPrivilege(SecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal grantee, boolean grantOption)
+    {
+        Span span = startSpan("checkCanGrantEntityPrivilege");
+        try (var ignored = scopedSpan(span)) {
+            delegate.checkCanGrantEntityPrivilege(context, privilege, entity, grantee, grantOption);
+        }
+    }
+
+    @Override
+    public void checkCanDenyEntityPrivilege(SecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal grantee)
+    {
+        Span span = startSpan("checkCanDenyEntityPrivilege");
+        try (var ignored = scopedSpan(span)) {
+            delegate.checkCanDenyEntityPrivilege(context, privilege, entity, grantee);
+        }
+    }
+
+    @Override
+    public void checkCanRevokeEntityPrivilege(SecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal revokee, boolean grantOption)
+    {
+        Span span = startSpan("checkCanRevokeEntityPrivilege");
+        try (var ignored = scopedSpan(span)) {
+            delegate.checkCanRevokeEntityPrivilege(context, privilege, entity, revokee, grantOption);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -58,6 +58,8 @@ import io.trino.spi.connector.ConnectorOutputMetadata;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
+import io.trino.spi.connector.EntityKindAndName;
+import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.connector.JoinApplicationResult;
 import io.trino.spi.connector.JoinStatistics;
 import io.trino.spi.connector.JoinType;
@@ -110,6 +112,7 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 
 import static io.trino.tracing.ScopedSpan.scopedSpan;
 import static java.util.Objects.requireNonNull;
@@ -1204,6 +1207,39 @@ public class TracingMetadata
     }
 
     @Override
+    public Set<EntityPrivilege> getAllEntityKindPrivileges(String entityKind)
+    {
+        return delegate.getAllEntityKindPrivileges(entityKind);
+    }
+
+    @Override
+    public void grantEntityPrivileges(Session session, EntityKindAndName entity, Set<EntityPrivilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        Span span = startSpan("grantEntityPrivileges", entity, privileges, grantee, grantOption);
+        try (var ignored = scopedSpan(span)) {
+            delegate.grantEntityPrivileges(session, entity, privileges, grantee, grantOption);
+        }
+    }
+
+    @Override
+    public void denyEntityPrivileges(Session session, EntityKindAndName entity, Set<EntityPrivilege> privileges, TrinoPrincipal grantee)
+    {
+        Span span = startSpan("denyEntityPrivileges", entity, privileges, grantee, false);
+        try (var ignored = scopedSpan(span)) {
+            delegate.denyEntityPrivileges(session, entity, privileges, grantee);
+        }
+    }
+
+    @Override
+    public void revokeEntityPrivileges(Session session, EntityKindAndName entity, Set<EntityPrivilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        Span span = startSpan("revokeEntityPrivileges", entity, privileges, grantee, grantOption);
+        try (var ignored = scopedSpan(span)) {
+            delegate.revokeEntityPrivileges(session, entity, privileges, grantee, grantOption);
+        }
+    }
+
+    @Override
     public Collection<FunctionMetadata> listGlobalFunctions(Session session)
     {
         Span span = startSpan("listGlobalFunctions");
@@ -1574,5 +1610,30 @@ public class TracingMetadata
                 .setAttribute(TrinoAttributes.CATALOG, table.getCatalogName())
                 .setAttribute(TrinoAttributes.SCHEMA, table.getSchemaName())
                 .setAttribute(TrinoAttributes.FUNCTION, table.getFunctionName());
+    }
+
+    private Span startSpan(String methodName, EntityKindAndName entity, Set<EntityPrivilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        Span span = startSpan(methodName);
+        if (span.isRecording()) {
+            String grant = String.format("%s-%s-%s-%s-%s%s",
+                    entity.entityKind(),
+                    entity.name(),
+                    grantee.getType(),
+                    grantee.getName(),
+                    privileges.stream().map(EntityPrivilege::name).collect(Collectors.joining("-")),
+                    grantOption ? "-grantOption" : "");
+            span.setAttribute(TrinoAttributes.PRIVILEGE_GRANT, grant);
+        }
+        return span;
+    }
+
+    private Span startSpan(String methodName, EntityKindAndName entity)
+    {
+        Span span = startSpan(methodName);
+        if (span.isRecording()) {
+            span.setAttribute(TrinoAttributes.ENTITY, String.format("%s-%s", entity.entityKind(), entity.name()));
+        }
+        return span;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/tracing/TrinoAttributes.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TrinoAttributes.java
@@ -62,4 +62,6 @@ public final class TrinoAttributes
     public static final AttributeKey<String> EVENT_STATE = stringKey("state");
 
     public static final AttributeKey<String> FAILURE_MESSAGE = stringKey("failure");
+    public static final AttributeKey<String> PRIVILEGE_GRANT = stringKey("grant");
+    public static final AttributeKey<String> ENTITY = stringKey("entity");
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Deny.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Deny.java
@@ -26,27 +26,25 @@ public class Deny
         extends Statement
 {
     private final Optional<List<String>> privileges; // missing means ALL PRIVILEGES
-    private final Optional<GrantOnType> type;
-    private final QualifiedName name;
+    private final GrantObject grantObject;
     private final PrincipalSpecification grantee;
 
-    public Deny(Optional<List<String>> privileges, Optional<GrantOnType> type, QualifiedName name, PrincipalSpecification grantee)
+    public Deny(Optional<List<String>> privileges, GrantObject grantObject, PrincipalSpecification grantee)
     {
-        this(Optional.empty(), privileges, type, name, grantee);
+        this(Optional.empty(), privileges, grantObject, grantee);
     }
 
-    public Deny(NodeLocation location, Optional<List<String>> privileges, Optional<GrantOnType> type, QualifiedName name, PrincipalSpecification grantee)
+    public Deny(NodeLocation location, Optional<List<String>> privileges, GrantObject grantObject, PrincipalSpecification grantee)
     {
-        this(Optional.of(location), privileges, type, name, grantee);
+        this(Optional.of(location), privileges, grantObject, grantee);
     }
 
-    private Deny(Optional<NodeLocation> location, Optional<List<String>> privileges, Optional<GrantOnType> type, QualifiedName name, PrincipalSpecification grantee)
+    private Deny(Optional<NodeLocation> location, Optional<List<String>> privileges, GrantObject grantObject, PrincipalSpecification grantee)
     {
         super(location);
         requireNonNull(privileges, "privileges is null");
         this.privileges = privileges.map(ImmutableList::copyOf);
-        this.type = requireNonNull(type, "type is null");
-        this.name = requireNonNull(name, "name is null");
+        this.grantObject = requireNonNull(grantObject, "grantScope is null");
         this.grantee = requireNonNull(grantee, "grantee is null");
     }
 
@@ -55,14 +53,9 @@ public class Deny
         return privileges;
     }
 
-    public Optional<GrantOnType> getType()
+    public GrantObject getGrantObject()
     {
-        return type;
-    }
-
-    public QualifiedName getName()
-    {
-        return name;
+        return grantObject;
     }
 
     public PrincipalSpecification getGrantee()
@@ -85,7 +78,7 @@ public class Deny
     @Override
     public int hashCode()
     {
-        return Objects.hash(privileges, type, name, grantee);
+        return Objects.hash(privileges, grantObject, grantee);
     }
 
     @Override
@@ -99,8 +92,7 @@ public class Deny
         }
         Deny o = (Deny) obj;
         return Objects.equals(privileges, o.privileges) &&
-                Objects.equals(type, o.type) &&
-                Objects.equals(name, o.name) &&
+                Objects.equals(grantObject, o.grantObject) &&
                 Objects.equals(grantee, o.grantee);
     }
 
@@ -109,8 +101,7 @@ public class Deny
     {
         return toStringHelper(this)
                 .add("privileges", privileges)
-                .add("type", type)
-                .add("name", name)
+                .add("grantScope", grantObject)
                 .add("grantee", grantee)
                 .toString();
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Grant.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Grant.java
@@ -26,28 +26,26 @@ public class Grant
         extends Statement
 {
     private final Optional<List<String>> privileges; // missing means ALL PRIVILEGES
-    private final Optional<GrantOnType> type;
-    private final QualifiedName name;
+    private final GrantObject grantObject;
     private final PrincipalSpecification grantee;
     private final boolean grantOption;
 
-    public Grant(Optional<List<String>> privileges, Optional<GrantOnType> type, QualifiedName name, PrincipalSpecification grantee, boolean grantOption)
+    public Grant(Optional<List<String>> privileges, GrantObject grantObject, PrincipalSpecification grantee, boolean grantOption)
     {
-        this(Optional.empty(), privileges, type, name, grantee, grantOption);
+        this(Optional.empty(), privileges, grantObject, grantee, grantOption);
     }
 
-    public Grant(NodeLocation location, Optional<List<String>> privileges, Optional<GrantOnType> type, QualifiedName name, PrincipalSpecification grantee, boolean grantOption)
+    public Grant(NodeLocation location, Optional<List<String>> privileges, GrantObject grantObject, PrincipalSpecification grantee, boolean grantOption)
     {
-        this(Optional.of(location), privileges, type, name, grantee, grantOption);
+        this(Optional.of(location), privileges, grantObject, grantee, grantOption);
     }
 
-    private Grant(Optional<NodeLocation> location, Optional<List<String>> privileges, Optional<GrantOnType> type, QualifiedName name, PrincipalSpecification grantee, boolean grantOption)
+    private Grant(Optional<NodeLocation> location, Optional<List<String>> privileges, GrantObject grantObject, PrincipalSpecification grantee, boolean grantOption)
     {
         super(location);
         requireNonNull(privileges, "privileges is null");
         this.privileges = privileges.map(ImmutableList::copyOf);
-        this.type = requireNonNull(type, "type is null");
-        this.name = requireNonNull(name, "name is null");
+        this.grantObject = requireNonNull(grantObject, "grantScope is null");
         this.grantee = requireNonNull(grantee, "grantee is null");
         this.grantOption = grantOption;
     }
@@ -57,14 +55,9 @@ public class Grant
         return privileges;
     }
 
-    public Optional<GrantOnType> getType()
+    public GrantObject getGrantObject()
     {
-        return type;
-    }
-
-    public QualifiedName getName()
-    {
-        return name;
+        return grantObject;
     }
 
     public PrincipalSpecification getGrantee()
@@ -92,7 +85,7 @@ public class Grant
     @Override
     public int hashCode()
     {
-        return Objects.hash(privileges, type, name, grantee, grantOption);
+        return Objects.hash(privileges, grantObject, grantee, grantOption);
     }
 
     @Override
@@ -106,8 +99,7 @@ public class Grant
         }
         Grant o = (Grant) obj;
         return Objects.equals(privileges, o.privileges) &&
-                Objects.equals(type, o.type) &&
-                Objects.equals(name, o.name) &&
+                Objects.equals(grantObject, o.grantObject) &&
                 Objects.equals(grantee, o.grantee) &&
                 Objects.equals(grantOption, o.grantOption);
     }
@@ -117,8 +109,7 @@ public class Grant
     {
         return toStringHelper(this)
                 .add("privileges", privileges)
-                .add("type", type)
-                .add("name", name)
+                .add("grantScope", grantObject)
                 .add("grantee", grantee)
                 .add("grantOption", grantOption)
                 .toString();

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/GrantObject.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/GrantObject.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class GrantObject
+        extends Node
+{
+    private final Optional<String> entityKind;
+    private final QualifiedName name;
+
+    public GrantObject(NodeLocation location, Optional<String> entityKind, QualifiedName name)
+    {
+        super(Optional.of(location));
+        this.entityKind = requireNonNull(entityKind, "entityKind is null");
+        this.name = requireNonNull(name, "name is null");
+    }
+
+    public Optional<String> getEntityKind()
+    {
+        return entityKind;
+    }
+
+    public QualifiedName getName()
+    {
+        return name;
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GrantObject that = (GrantObject) o;
+        return Objects.equals(entityKind, that.entityKind) && Objects.equals(name, that.name);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("entityKind", entityKind)
+                .add("qualifiedName", name)
+                .toString();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(entityKind, name);
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Revoke.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Revoke.java
@@ -27,28 +27,26 @@ public class Revoke
 {
     private final boolean grantOptionFor;
     private final Optional<List<String>> privileges; // missing means ALL PRIVILEGES
-    private final Optional<GrantOnType> type;
-    private final QualifiedName name;
+    private final GrantObject grantObject;
     private final PrincipalSpecification grantee;
 
-    public Revoke(boolean grantOptionFor, Optional<List<String>> privileges, Optional<GrantOnType> type, QualifiedName name, PrincipalSpecification grantee)
+    public Revoke(boolean grantOptionFor, Optional<List<String>> privileges, GrantObject grantObject, PrincipalSpecification grantee)
     {
-        this(Optional.empty(), grantOptionFor, privileges, type, name, grantee);
+        this(Optional.empty(), grantOptionFor, privileges, grantObject, grantee);
     }
 
-    public Revoke(NodeLocation location, boolean grantOptionFor, Optional<List<String>> privileges, Optional<GrantOnType> type, QualifiedName name, PrincipalSpecification grantee)
+    public Revoke(NodeLocation location, boolean grantOptionFor, Optional<List<String>> privileges, GrantObject grantObject, PrincipalSpecification grantee)
     {
-        this(Optional.of(location), grantOptionFor, privileges, type, name, grantee);
+        this(Optional.of(location), grantOptionFor, privileges, grantObject, grantee);
     }
 
-    private Revoke(Optional<NodeLocation> location, boolean grantOptionFor, Optional<List<String>> privileges, Optional<GrantOnType> type, QualifiedName name, PrincipalSpecification grantee)
+    private Revoke(Optional<NodeLocation> location, boolean grantOptionFor, Optional<List<String>> privileges, GrantObject grantObject, PrincipalSpecification grantee)
     {
         super(location);
         this.grantOptionFor = grantOptionFor;
         requireNonNull(privileges, "privileges is null");
         this.privileges = privileges.map(ImmutableList::copyOf);
-        this.type = requireNonNull(type, "type is null");
-        this.name = requireNonNull(name, "name is null");
+        this.grantObject = requireNonNull(grantObject, "grantScope is null");
         this.grantee = requireNonNull(grantee, "grantee is null");
     }
 
@@ -62,14 +60,9 @@ public class Revoke
         return privileges;
     }
 
-    public Optional<GrantOnType> getType()
+    public GrantObject getGrantObject()
     {
-        return type;
-    }
-
-    public QualifiedName getName()
-    {
-        return name;
+        return grantObject;
     }
 
     public PrincipalSpecification getGrantee()
@@ -92,7 +85,7 @@ public class Revoke
     @Override
     public int hashCode()
     {
-        return Objects.hash(grantOptionFor, privileges, type, name, grantee);
+        return Objects.hash(grantOptionFor, privileges, grantObject, grantee);
     }
 
     @Override
@@ -107,8 +100,7 @@ public class Revoke
         Revoke o = (Revoke) obj;
         return Objects.equals(grantOptionFor, o.grantOptionFor) &&
                 Objects.equals(privileges, o.privileges) &&
-                Objects.equals(type, o.type) &&
-                Objects.equals(name, o.name) &&
+                Objects.equals(grantObject, o.grantObject) &&
                 Objects.equals(grantee, o.grantee);
     }
 
@@ -118,8 +110,7 @@ public class Revoke
         return toStringHelper(this)
                 .add("grantOptionFor", grantOptionFor)
                 .add("privileges", privileges)
-                .add("type", type)
-                .add("name", name)
+                .add("grantScope", grantObject)
                 .add("grantee", grantee)
                 .toString();
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ShowGrants.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ShowGrants.java
@@ -20,41 +20,36 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static java.util.Objects.requireNonNull;
 
 public class ShowGrants
         extends Statement
 {
-    private final boolean table;
-    private final Optional<QualifiedName> tableName;
+    private final Optional<GrantObject> grantObject;
 
-    public ShowGrants(boolean table, Optional<QualifiedName> tableName)
+    public ShowGrants(Optional<GrantObject> grantObject)
     {
-        this(Optional.empty(), table, tableName);
+        this(Optional.empty(), grantObject);
     }
 
-    public ShowGrants(NodeLocation location, boolean table, Optional<QualifiedName> tableName)
+    public ShowGrants(NodeLocation location, Optional<GrantObject> grantObject)
     {
-        this(Optional.of(location), table, tableName);
+        this(Optional.of(location), grantObject);
     }
 
-    public ShowGrants(Optional<NodeLocation> location, boolean table, Optional<QualifiedName> tableName)
+    public ShowGrants(Optional<NodeLocation> location, Optional<GrantObject> grantObject)
     {
         super(location);
-        requireNonNull(tableName, "tableName is null");
-
-        this.table = table;
-        this.tableName = tableName;
+        this.grantObject = grantObject == null ? Optional.empty() : grantObject;
     }
 
-    public boolean getTable()
+    public Optional<String> getEntityKind()
     {
-        return table;
+        return grantObject.flatMap(scope -> scope.getEntityKind());
     }
 
-    public Optional<QualifiedName> getTableName()
+    public Optional<GrantObject> getGrantObject()
     {
-        return tableName;
+        return grantObject;
     }
 
     @Override
@@ -72,7 +67,7 @@ public class ShowGrants
     @Override
     public int hashCode()
     {
-        return Objects.hash(table, tableName);
+        return grantObject.hashCode();
     }
 
     @Override
@@ -85,16 +80,14 @@ public class ShowGrants
             return false;
         }
         ShowGrants o = (ShowGrants) obj;
-        return Objects.equals(table, o.table) &&
-                Objects.equals(tableName, o.tableName);
+        return Objects.equals(grantObject, o.grantObject);
     }
 
     @Override
     public String toString()
     {
         return toStringHelper(this)
-                .add("table", table)
-                .add("tableName", tableName)
+                .add("grantScope", grantObject)
                 .toString();
     }
 }

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -81,7 +81,7 @@ import io.trino.sql.tree.FunctionCall.NullTreatment;
 import io.trino.sql.tree.GenericDataType;
 import io.trino.sql.tree.GenericLiteral;
 import io.trino.sql.tree.Grant;
-import io.trino.sql.tree.GrantOnType;
+import io.trino.sql.tree.GrantObject;
 import io.trino.sql.tree.GrantRoles;
 import io.trino.sql.tree.GrantorSpecification;
 import io.trino.sql.tree.GroupBy;
@@ -3354,43 +3354,37 @@ public class TestSqlParser
         assertStatement("GRANT INSERT, DELETE ON t TO u",
                 new Grant(
                         Optional.of(ImmutableList.of("INSERT", "DELETE")),
-                        Optional.empty(),
-                        QualifiedName.of("t"),
+                        new GrantObject(location(1, 1), Optional.empty(), QualifiedName.of("t")),
                         new PrincipalSpecification(PrincipalSpecification.Type.UNSPECIFIED, new Identifier("u")),
                         false));
         assertStatement("GRANT UPDATE ON t TO u",
                 new Grant(
                         Optional.of(ImmutableList.of("UPDATE")),
-                        Optional.empty(),
-                        QualifiedName.of("t"),
+                        new GrantObject(location(1, 1), Optional.empty(), QualifiedName.of("t")),
                         new PrincipalSpecification(PrincipalSpecification.Type.UNSPECIFIED, new Identifier("u")),
                         false));
         assertStatement("GRANT SELECT ON t TO ROLE PUBLIC WITH GRANT OPTION",
                 new Grant(
                         Optional.of(ImmutableList.of("SELECT")),
-                        Optional.empty(),
-                        QualifiedName.of("t"),
+                        new GrantObject(location(1, 1), Optional.empty(), QualifiedName.of("t")),
                         new PrincipalSpecification(PrincipalSpecification.Type.ROLE, new Identifier("PUBLIC")),
                         true));
         assertStatement("GRANT ALL PRIVILEGES ON TABLE t TO USER u",
                 new Grant(
                         Optional.empty(),
-                        Optional.of(GrantOnType.TABLE),
-                        QualifiedName.of("t"),
+                        new GrantObject(location(1, 1), Optional.of("TABLE"), QualifiedName.of("t")),
                         new PrincipalSpecification(PrincipalSpecification.Type.USER, new Identifier("u")),
                         false));
         assertStatement("GRANT DELETE ON \"t\" TO ROLE \"public\" WITH GRANT OPTION",
                 new Grant(
                         Optional.of(ImmutableList.of("DELETE")),
-                        Optional.empty(),
-                        QualifiedName.of("t"),
+                        new GrantObject(location(1, 1), Optional.empty(), QualifiedName.of("t")),
                         new PrincipalSpecification(PrincipalSpecification.Type.ROLE, new Identifier("public")),
                         true));
         assertStatement("GRANT SELECT ON SCHEMA s TO USER u",
                 new Grant(
                         Optional.of(ImmutableList.of("SELECT")),
-                        Optional.of(GrantOnType.SCHEMA),
-                        QualifiedName.of("s"),
+                        new GrantObject(location(1, 1), Optional.of("SCHEMA"), QualifiedName.of("s")),
                         new PrincipalSpecification(PrincipalSpecification.Type.USER, new Identifier("u")),
                         false));
     }
@@ -3401,26 +3395,22 @@ public class TestSqlParser
         assertStatement("DENY INSERT, DELETE ON t TO u",
                 new Deny(
                         Optional.of(ImmutableList.of("INSERT", "DELETE")),
-                        Optional.empty(),
-                        QualifiedName.of("t"),
+                        new GrantObject(location(1, 1), Optional.empty(), QualifiedName.of("t")),
                         new PrincipalSpecification(PrincipalSpecification.Type.UNSPECIFIED, new Identifier("u"))));
         assertStatement("DENY UPDATE ON t TO u",
                 new Deny(
                         Optional.of(ImmutableList.of("UPDATE")),
-                        Optional.empty(),
-                        QualifiedName.of("t"),
+                        new GrantObject(location(1, 1), Optional.empty(), QualifiedName.of("t")),
                         new PrincipalSpecification(PrincipalSpecification.Type.UNSPECIFIED, new Identifier("u"))));
         assertStatement("DENY ALL PRIVILEGES ON TABLE t TO USER u",
                 new Deny(
                         Optional.empty(),
-                        Optional.of(GrantOnType.TABLE),
-                        QualifiedName.of("t"),
+                        new GrantObject(location(1, 1), Optional.of("TABLE"), QualifiedName.of("t")),
                         new PrincipalSpecification(PrincipalSpecification.Type.USER, new Identifier("u"))));
         assertStatement("DENY SELECT ON SCHEMA s TO USER u",
                 new Deny(
                         Optional.of(ImmutableList.of("SELECT")),
-                        Optional.of(GrantOnType.SCHEMA),
-                        QualifiedName.of("s"),
+                        new GrantObject(location(1, 1), Optional.of("SCHEMA"), QualifiedName.of("s")),
                         new PrincipalSpecification(PrincipalSpecification.Type.USER, new Identifier("u"))));
     }
 
@@ -3431,55 +3421,137 @@ public class TestSqlParser
                 new Revoke(
                         false,
                         Optional.of(ImmutableList.of("INSERT", "DELETE")),
-                        Optional.empty(),
-                        QualifiedName.of("t"),
+                        new GrantObject(location(1, 1), Optional.empty(), QualifiedName.of("t")),
                         new PrincipalSpecification(PrincipalSpecification.Type.UNSPECIFIED, new Identifier("u"))));
         assertStatement("REVOKE UPDATE ON t FROM u",
                 new Revoke(
                         false,
                         Optional.of(ImmutableList.of("UPDATE")),
-                        Optional.empty(),
-                        QualifiedName.of("t"),
+                        new GrantObject(location(1, 1), Optional.empty(), QualifiedName.of("t")),
                         new PrincipalSpecification(PrincipalSpecification.Type.UNSPECIFIED, new Identifier("u"))));
         assertStatement("REVOKE GRANT OPTION FOR SELECT ON t FROM ROLE PUBLIC",
                 new Revoke(
                         true,
                         Optional.of(ImmutableList.of("SELECT")),
-                        Optional.empty(),
-                        QualifiedName.of("t"),
+                        new GrantObject(location(1, 1), Optional.empty(), QualifiedName.of("t")),
                         new PrincipalSpecification(PrincipalSpecification.Type.ROLE, new Identifier("PUBLIC"))));
         assertStatement("REVOKE ALL PRIVILEGES ON TABLE t FROM USER u",
                 new Revoke(
                         false,
                         Optional.empty(),
-                        Optional.of(GrantOnType.TABLE),
-                        QualifiedName.of("t"),
+                        new GrantObject(location(1, 1), Optional.of("TABLE"), QualifiedName.of("t")),
                         new PrincipalSpecification(PrincipalSpecification.Type.USER, new Identifier("u"))));
         assertStatement("REVOKE DELETE ON TABLE \"t\" FROM \"u\"",
                 new Revoke(
                         false,
                         Optional.of(ImmutableList.of("DELETE")),
-                        Optional.of(GrantOnType.TABLE),
-                        QualifiedName.of("t"),
+                        new GrantObject(location(1, 1), Optional.of("TABLE"), QualifiedName.of("t")),
                         new PrincipalSpecification(PrincipalSpecification.Type.UNSPECIFIED, new Identifier("u"))));
         assertStatement("REVOKE SELECT ON SCHEMA s FROM USER u",
                 new Revoke(
                         false,
                         Optional.of(ImmutableList.of("SELECT")),
-                        Optional.of(GrantOnType.SCHEMA),
-                        QualifiedName.of("s"),
+                        new GrantObject(location(1, 1), Optional.of("SCHEMA"), QualifiedName.of("s")),
                         new PrincipalSpecification(PrincipalSpecification.Type.USER, new Identifier("u"))));
+    }
+
+    @Test
+    public void testExoticPrivilegesAndEntityKinds()
+    {
+        assertThat(statement("GRANT ALL PRIVILEGES ON FUNKY_ENTITY t TO u"))
+                .isEqualTo(new Grant(
+                        location(1, 1),
+                        Optional.empty(),
+                        new GrantObject(location(1, 1), Optional.of("FUNKY_ENTITY"), QualifiedName.of(ImmutableList.of(new Identifier(location(1, 38), "t", false)))),
+                        new PrincipalSpecification(Type.UNSPECIFIED, new Identifier(location(1, 43), "u", false)),
+                        false));
+        assertThat(statement("GRANT ALL PRIVILEGES ON FUNKY_ENTITY t TO u WITH GRANT OPTION"))
+                .isEqualTo(new Grant(
+                        location(1, 1),
+                        Optional.empty(),
+                        new GrantObject(location(1, 1), Optional.of("FUNKY_ENTITY"), QualifiedName.of(ImmutableList.of(new Identifier(location(1, 38), "t", false)))),
+                        new PrincipalSpecification(Type.UNSPECIFIED, new Identifier(location(1, 43), "u", false)),
+                        true));
+        assertThat(statement("GRANT AUTO_GYRATE ON FUNKY_ENTITY t TO u WITH GRANT OPTION"))
+                .isEqualTo(new Grant(
+                        location(1, 1),
+                        Optional.of(ImmutableList.of("AUTO_GYRATE")),
+                        new GrantObject(location(1, 1), Optional.of("FUNKY_ENTITY"), QualifiedName.of(ImmutableList.of(new Identifier(location(1, 35), "t", false)))),
+                        new PrincipalSpecification(Type.UNSPECIFIED, new Identifier(location(1, 40), "u", false)),
+                        true));
+        assertThat(statement("GRANT AUTO_GYRATE ON FUNKY_ENTITY t TO u"))
+                .isEqualTo(new Grant(
+                        location(1, 1),
+                        Optional.of(ImmutableList.of("AUTO_GYRATE")),
+                        new GrantObject(location(1, 1), Optional.of("FUNKY_ENTITY"), QualifiedName.of(ImmutableList.of(new Identifier(location(1, 35), "t", false)))),
+                        new PrincipalSpecification(Type.UNSPECIFIED, new Identifier(location(1, 40), "u", false)),
+                        false));
+        assertThat(statement("GRANT AUTO_GYRATE ON t TO u"))
+                .isEqualTo(new Grant(
+                        location(1, 1),
+                        Optional.of(ImmutableList.of("AUTO_GYRATE")),
+                        new GrantObject(location(1, 1), Optional.empty(), QualifiedName.of(ImmutableList.of(new Identifier(location(1, 22), "t", false)))),
+                        new PrincipalSpecification(Type.UNSPECIFIED, new Identifier(location(1, 27), "u", false)),
+                        false));
+
+        assertThat(statement("REVOKE ALL PRIVILEGES ON FUNKY_ENTITY t FROM u"))
+                .isEqualTo(new Revoke(
+                        location(1, 1),
+                        false,
+                        Optional.empty(),
+                        new GrantObject(location(1, 1), Optional.of("FUNKY_ENTITY"), QualifiedName.of(ImmutableList.of(new Identifier(location(1, 39), "t", false)))),
+                        new PrincipalSpecification(Type.UNSPECIFIED, new Identifier(location(1, 46), "u", false))));
+        assertThat(statement("REVOKE AUTO_GYRATE ON FUNKY_ENTITY t FROM u"))
+                .isEqualTo(new Revoke(
+                        location(1, 1),
+                        false,
+                        Optional.of(ImmutableList.of("AUTO_GYRATE")),
+                        new GrantObject(location(1, 1), Optional.of("FUNKY_ENTITY"), QualifiedName.of(ImmutableList.of(new Identifier(location(1, 36), "t", false)))),
+                        new PrincipalSpecification(Type.UNSPECIFIED, new Identifier(location(1, 43), "u", false))));
+        assertThat(statement("REVOKE GRANT OPTION FOR AUTO_GYRATE ON FUNKY_ENTITY t FROM u"))
+                .isEqualTo(new Revoke(
+                        location(1, 1),
+                        true,
+                        Optional.of(ImmutableList.of("AUTO_GYRATE")),
+                        new GrantObject(location(1, 1), Optional.of("FUNKY_ENTITY"), QualifiedName.of(ImmutableList.of(new Identifier(location(1, 53), "t", false)))),
+                        new PrincipalSpecification(Type.UNSPECIFIED, new Identifier(location(1, 60), "u", false))));
+        assertThat(statement("REVOKE AUTO_GYRATE ON t FROM u"))
+                .isEqualTo(new Revoke(
+                        location(1, 1),
+                        false,
+                        Optional.of(ImmutableList.of("AUTO_GYRATE")),
+                        new GrantObject(location(1, 1), Optional.empty(), QualifiedName.of(ImmutableList.of(new Identifier(location(1, 23), "t", false)))),
+                        new PrincipalSpecification(Type.UNSPECIFIED, new Identifier(location(1, 30), "u", false))));
+
+        assertThat(statement("DENY ALL PRIVILEGES ON FUNKY_ENTITY t TO u"))
+                .isEqualTo(new Deny(
+                        location(1, 1),
+                        Optional.empty(),
+                        new GrantObject(location(1, 1), Optional.of("FUNKY_ENTITY"), QualifiedName.of(ImmutableList.of(new Identifier(location(1, 37), "t", false)))),
+                        new PrincipalSpecification(Type.UNSPECIFIED, new Identifier(location(1, 42), "u", false))));
+        assertThat(statement("DENY AUTO_GYRATE ON FUNKY_ENTITY t TO u"))
+                .isEqualTo(new Deny(
+                        location(1, 1),
+                        Optional.of(ImmutableList.of("AUTO_GYRATE")),
+                        new GrantObject(location(1, 1), Optional.of("FUNKY_ENTITY"), QualifiedName.of(ImmutableList.of(new Identifier(location(1, 34), "t", false)))),
+                        new PrincipalSpecification(Type.UNSPECIFIED, new Identifier(location(1, 39), "u", false))));
+        assertThat(statement("DENY AUTO_GYRATE ON t TO u"))
+                .isEqualTo(new Deny(
+                        location(1, 1),
+                        Optional.of(ImmutableList.of("AUTO_GYRATE")),
+                        new GrantObject(location(1, 1), Optional.empty(), QualifiedName.of(ImmutableList.of(new Identifier(location(1, 21), "t", false)))),
+                        new PrincipalSpecification(Type.UNSPECIFIED, new Identifier(location(1, 26), "u", false))));
     }
 
     @Test
     public void testShowGrants()
     {
         assertStatement("SHOW GRANTS ON TABLE t",
-                new ShowGrants(true, Optional.of(QualifiedName.of("t"))));
+                new ShowGrants(Optional.of(new GrantObject(location(1, 1), Optional.of("TABLE"), QualifiedName.of("t")))));
         assertStatement("SHOW GRANTS ON t",
-                new ShowGrants(false, Optional.of(QualifiedName.of("t"))));
+                new ShowGrants(Optional.of(new GrantObject(location(1, 1), Optional.empty(), QualifiedName.of("t")))));
         assertStatement("SHOW GRANTS",
-                new ShowGrants(false, Optional.empty()));
+                new ShowGrants(Optional.empty()));
     }
 
     @Test

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/EntityKindAndName.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/EntityKindAndName.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.connector;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public record EntityKindAndName(String entityKind, @JsonProperty List<String> name)
+{
+    public EntityKindAndName
+    {
+        requireNonNull(entityKind, "entityKind is null");
+        name = List.copyOf(name);
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/EntityPrivilege.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/EntityPrivilege.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.connector;
+
+import static java.util.Objects.requireNonNull;
+
+public record EntityPrivilege(String name)
+{
+    public EntityPrivilege
+    {
+        requireNonNull(name, "name is null");
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/security/AccessDeniedException.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/AccessDeniedException.java
@@ -14,6 +14,7 @@
 package io.trino.spi.security;
 
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.EntityKindAndName;
 import io.trino.spi.function.FunctionKind;
 
 import java.security.Principal;
@@ -588,6 +589,46 @@ public class AccessDeniedException
     public static void denyRevokeTablePrivilege(String privilege, String tableName, String extraInfo)
     {
         throw new AccessDeniedException(format("Cannot revoke privilege %s on table %s%s", privilege, tableName, formatExtraInfo(extraInfo)));
+    }
+
+    public static void denyGrantEntityPrivilege(String privilege, EntityKindAndName entity)
+    {
+        denyGrantEntityPrivilege(privilege, entity, null);
+    }
+
+    public static void denyGrantEntityPrivilege(String privilege, EntityKindAndName entity, String extraInfo)
+    {
+        entityPrivilegeException("grant", privilege, entity, extraInfo);
+    }
+
+    public static void denyDenyEntityPrivilege(String privilege, EntityKindAndName entity)
+    {
+        denyDenyEntityPrivilege(privilege, entity, null);
+    }
+
+    public static void denyDenyEntityPrivilege(String privilege, EntityKindAndName entity, String extraInfo)
+    {
+        entityPrivilegeException("deny", privilege, entity, extraInfo);
+    }
+
+    public static void denyRevokeEntityPrivilege(String privilege, EntityKindAndName entity)
+    {
+        denyRevokeEntityPrivilege(privilege, entity, null);
+    }
+
+    public static void denyRevokeEntityPrivilege(String privilege, EntityKindAndName entity, String extraInfo)
+    {
+        entityPrivilegeException("revoke", privilege, entity, extraInfo);
+    }
+
+    private static void entityPrivilegeException(String operation, String privilege, EntityKindAndName entity, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot %s privilege %s on %s %s%s",
+                operation,
+                privilege,
+                entity.entityKind().toLowerCase(Locale.ROOT),
+                entity.name(),
+                formatExtraInfo(extraInfo)));
     }
 
     public static void denyShowRoles()

--- a/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
@@ -16,6 +16,8 @@ package io.trino.spi.security;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaRoutineName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.EntityKindAndName;
+import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.function.SchemaFunctionName;
@@ -43,6 +45,7 @@ import static io.trino.spi.security.AccessDeniedException.denyCreateTable;
 import static io.trino.spi.security.AccessDeniedException.denyCreateView;
 import static io.trino.spi.security.AccessDeniedException.denyCreateViewWithSelect;
 import static io.trino.spi.security.AccessDeniedException.denyDeleteTable;
+import static io.trino.spi.security.AccessDeniedException.denyDenyEntityPrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyDenySchemaPrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyDenyTablePrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyDropCatalog;
@@ -56,6 +59,7 @@ import static io.trino.spi.security.AccessDeniedException.denyDropView;
 import static io.trino.spi.security.AccessDeniedException.denyExecuteProcedure;
 import static io.trino.spi.security.AccessDeniedException.denyExecuteQuery;
 import static io.trino.spi.security.AccessDeniedException.denyExecuteTableProcedure;
+import static io.trino.spi.security.AccessDeniedException.denyGrantEntityPrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyGrantRoles;
 import static io.trino.spi.security.AccessDeniedException.denyGrantSchemaPrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyGrantTablePrivilege;
@@ -68,6 +72,7 @@ import static io.trino.spi.security.AccessDeniedException.denyRenameColumn;
 import static io.trino.spi.security.AccessDeniedException.denyRenameMaterializedView;
 import static io.trino.spi.security.AccessDeniedException.denyRenameSchema;
 import static io.trino.spi.security.AccessDeniedException.denyRenameTable;
+import static io.trino.spi.security.AccessDeniedException.denyRevokeEntityPrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyRevokeRoles;
 import static io.trino.spi.security.AccessDeniedException.denyRevokeSchemaPrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyRevokeTablePrivilege;
@@ -707,6 +712,36 @@ public interface SystemAccessControl
     default void checkCanRevokeTablePrivilege(SystemSecurityContext context, Privilege privilege, CatalogSchemaTableName table, TrinoPrincipal revokee, boolean grantOption)
     {
         denyRevokeTablePrivilege(privilege.toString(), table.toString());
+    }
+
+    /**
+     * Check if identity is allowed to grant the specified privilege to the grantee on the specified entity.
+     *
+     * @throws AccessDeniedException if not allowed
+     */
+    default void checkCanGrantEntityPrivilege(SystemSecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal grantee, boolean grantOption)
+    {
+        denyGrantEntityPrivilege(privilege.toString(), entity);
+    }
+
+    /**
+     * Check if identity is allowed to deny the specified privilege to the grantee on the specified entity.
+     *
+     * @throws AccessDeniedException if not allowed
+     */
+    default void checkCanDenyEntityPrivilege(SystemSecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal grantee)
+    {
+        denyDenyEntityPrivilege(privilege.toString(), entity);
+    }
+
+    /**
+     * Check if identity is allowed to revoke the specified privilege on the specified entity from the revokee.
+     *
+     * @throws AccessDeniedException if not allowed
+     */
+    default void checkCanRevokeEntityPrivilege(SystemSecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal revokee, boolean grantOption)
+    {
+        denyRevokeEntityPrivilege(privilege.toString(), entity);
     }
 
     /**

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllSystemAccessControl.java
@@ -17,6 +17,8 @@ import com.google.common.collect.ImmutableSet;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaRoutineName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.EntityKindAndName;
+import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.function.SchemaFunctionName;
@@ -367,6 +369,21 @@ public class AllowAllSystemAccessControl
 
     @Override
     public void checkCanRevokeTablePrivilege(SystemSecurityContext context, Privilege privilege, CatalogSchemaTableName table, TrinoPrincipal revokee, boolean grantOption)
+    {
+    }
+
+    @Override
+    public void checkCanGrantEntityPrivilege(SystemSecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal grantee, boolean grantOption)
+    {
+    }
+
+    @Override
+    public void checkCanDenyEntityPrivilege(SystemSecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal grantee)
+    {
+    }
+
+    @Override
+    public void checkCanRevokeEntityPrivilege(SystemSecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal revokee, boolean grantOption)
     {
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
@@ -23,6 +23,8 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaRoutineName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.EntityKindAndName;
+import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.function.SchemaFunctionName;
@@ -872,6 +874,24 @@ public class FileBasedSystemAccessControl
         if (!checkTablePermission(context, table, OWNERSHIP)) {
             denyRevokeTablePrivilege(privilege.name(), table.toString());
         }
+    }
+
+    @Override
+    public void checkCanGrantEntityPrivilege(SystemSecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal grantee, boolean grantOption)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void checkCanDenyEntityPrivilege(SystemSecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal grantee)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void checkCanRevokeEntityPrivilege(SystemSecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal revokee, boolean grantOption)
+    {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingSystemAccessControl.java
@@ -16,6 +16,8 @@ package io.trino.plugin.base.security;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaRoutineName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.EntityKindAndName;
+import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.function.SchemaFunctionName;
@@ -425,6 +427,24 @@ public abstract class ForwardingSystemAccessControl
     public void checkCanRevokeTablePrivilege(SystemSecurityContext context, Privilege privilege, CatalogSchemaTableName table, TrinoPrincipal revokee, boolean grantOption)
     {
         delegate().checkCanRevokeTablePrivilege(context, privilege, table, revokee, grantOption);
+    }
+
+    @Override
+    public void checkCanGrantEntityPrivilege(SystemSecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal grantee, boolean grantOption)
+    {
+        delegate().checkCanGrantEntityPrivilege(context, privilege, entity, grantee, grantOption);
+    }
+
+    @Override
+    public void checkCanDenyEntityPrivilege(SystemSecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal grantee)
+    {
+        delegate().checkCanDenyEntityPrivilege(context, privilege, entity, grantee);
+    }
+
+    @Override
+    public void checkCanRevokeEntityPrivilege(SystemSecurityContext context, EntityPrivilege privilege, EntityKindAndName entity, TrinoPrincipal revokee, boolean grantOption)
+    {
+        delegate().checkCanRevokeEntityPrivilege(context, privilege, entity, revokee, grantOption);
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This PR privides a first-cut at syntax generalizing
privilege grants so that the entity kinds to which
the grants apply and the privileges for those grants
can be extended.
    
The PR also adds APIs to grant, deny, revoke and list grants
on arbitrary entity kinds.  Entity kinds TABLE and SCHEMA
are processed as before, but new entity kinds can be
supported by implementing the new methods on SystemAccessControl
and SystemSecurityMetadata.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
