### PR TITLE
Decide number of clients basing on average request size of client

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/DirectExchangeClient.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DirectExchangeClient.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.http.client.HttpClient;
@@ -36,9 +37,9 @@ import java.net.URI;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.locks.Lock;
@@ -68,7 +69,7 @@ public class DirectExchangeClient
     @GuardedBy("this")
     private boolean noMoreLocations;
 
-    private final ConcurrentMap<URI, HttpPageBufferClient> allClients = new ConcurrentHashMap<>();
+    private final Map<URI, HttpPageBufferClient> allClients = new ConcurrentHashMap<>();
 
     @GuardedBy("this")
     private final Deque<HttpPageBufferClient> queuedClients = new LinkedList<>();
@@ -260,36 +261,54 @@ public class DirectExchangeClient
         }
     }
 
-    private synchronized void scheduleRequestIfNecessary()
+    @VisibleForTesting
+    synchronized int scheduleRequestIfNecessary()
     {
         if ((buffer.isFinished() || buffer.isFailed()) && completedClients.size() == allClients.size()) {
-            return;
+            return 0;
         }
 
         long neededBytes = buffer.getRemainingCapacityInBytes();
         if (neededBytes <= 0) {
-            return;
+            return 0;
         }
 
-        int clientCount = (int) ((1.0 * neededBytes / averageBytesPerRequest) * concurrentRequestMultiplier);
-        clientCount = Math.max(clientCount, 1);
+        long reservedBytesForScheduledClients = allClients.values().stream()
+                .filter(client -> !queuedClients.contains(client) && !completedClients.contains(client))
+                .mapToLong(HttpPageBufferClient::getAverageRequestSizeInBytes)
+                .sum();
+        long projectedBytesToBeRequested = 0;
+        int clientCount = 0;
 
-        int pendingClients = allClients.size() - queuedClients.size() - completedClients.size();
-        clientCount -= pendingClients;
-
+        for (HttpPageBufferClient client : queuedClients) {
+            if (projectedBytesToBeRequested >= neededBytes * concurrentRequestMultiplier - reservedBytesForScheduledClients) {
+                break;
+            }
+            projectedBytesToBeRequested += client.getAverageRequestSizeInBytes();
+            clientCount++;
+        }
         for (int i = 0; i < clientCount; i++) {
             HttpPageBufferClient client = queuedClients.poll();
-            if (client == null) {
-                // no more clients available
-                return;
-            }
             client.scheduleRequest();
         }
+        return clientCount;
     }
 
     public ListenableFuture<Void> isBlocked()
     {
         return buffer.isBlocked();
+    }
+
+    @VisibleForTesting
+    Deque<HttpPageBufferClient> getQueuedClients()
+    {
+        return queuedClients;
+    }
+
+    @VisibleForTesting
+    Map<URI, HttpPageBufferClient> getAllClients()
+    {
+        return allClients;
     }
 
     private boolean addPages(HttpPageBufferClient client, List<Slice> pages)

--- a/core/trino-main/src/main/java/io/trino/operator/PageBufferClientStatus.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PageBufferClientStatus.java
@@ -37,6 +37,7 @@ public class PageBufferClientStatus
     private final int requestsScheduled;
     private final int requestsCompleted;
     private final int requestsFailed;
+    private final int requestsSucceeded;
     private final String httpRequestState;
 
     @JsonCreator
@@ -50,6 +51,7 @@ public class PageBufferClientStatus
             @JsonProperty("requestsScheduled") int requestsScheduled,
             @JsonProperty("requestsCompleted") int requestsCompleted,
             @JsonProperty("requestsFailed") int requestsFailed,
+            @JsonProperty("requestsSucceeded") int requestsSucceeded,
             @JsonProperty("httpRequestState") String httpRequestState)
     {
         this.uri = uri;
@@ -62,6 +64,7 @@ public class PageBufferClientStatus
         this.requestsScheduled = requestsScheduled;
         this.requestsCompleted = requestsCompleted;
         this.requestsFailed = requestsFailed;
+        this.requestsSucceeded = requestsSucceeded;
         this.httpRequestState = httpRequestState;
     }
 
@@ -123,6 +126,12 @@ public class PageBufferClientStatus
     public int getRequestsFailed()
     {
         return requestsFailed;
+    }
+
+    @JsonProperty
+    public int getRequestsSucceeded()
+    {
+        return requestsSucceeded;
     }
 
     @JsonProperty

--- a/core/trino-main/src/test/java/io/trino/operator/TestHttpPageBufferClient.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestHttpPageBufferClient.java
@@ -439,6 +439,33 @@ public class TestHttpPageBufferClient
     }
 
     @Test
+    public void testAverageSizeOfRequest()
+    {
+        HttpPageBufferClient client = new HttpPageBufferClient(
+                "localhost",
+                new TestingHttpClient(new MockExchangeRequestProcessor(DataSize.of(10, MEGABYTE)), scheduler),
+                DataIntegrityVerification.ABORT,
+                DataSize.of(10, MEGABYTE),
+                new Duration(30, TimeUnit.SECONDS),
+                true,
+                TASK_ID,
+                URI.create("http://localhost:8080"),
+                new TestingClientCallback(new CyclicBarrier(1)),
+                scheduler,
+                new TestingTicker(),
+                pageBufferClientCallbackExecutor);
+
+        assertEquals(client.getAverageRequestSizeInBytes(), 0);
+
+        client.requestSucceeded(0);
+        assertEquals(client.getAverageRequestSizeInBytes(), 0);
+
+        client.requestSucceeded(1000);
+        client.requestSucceeded(800);
+        assertEquals(client.getAverageRequestSizeInBytes(), 600);
+    }
+
+    @Test
     public void testMemoryExceededInAddPages()
             throws Exception
     {


### PR DESCRIPTION
## Description

Let's define the class of queries that are run on skewed data and as a result on some downstream stage there is one (or few nodes) that gather data from empty or nearly empty nodes at upstream stage - i.e. at some upstream stage most nodes are empty (serving no data) or nearly empty (serving little data). We observed that such queries are executed very poorly on Trino.
This PR addresses that issue.

The query listed below is a representant of that class:

```
SELECT
    count(*),
    cc.cc_name,
    cc.cc_class,
    cc.cc_manager,
    cc.cc_mkt_desc,
    cc.cc_market_manager,
    cc.cc_division_name
FROM catalog_sales cs
    RIGHT JOIN call_center cc ON cc.cc_call_center_sk =  cs.cs_call_center_sk
    RIGHT JOIN store s ON cc.cc_closed_date_sk = s.s_closed_date_sk
GROUP BY 2, 3, 4, 5, 6, 7
ORDER BY 1, 2, 3, 4, 5, 6, 7
LIMIT 100;
```

**Before the change it takes 11,5 minutes to finish that query on 32 nodes r6g.4xlarge cluster. After the change it takes 4 minutes to finish on same cluster.** 
No regresion in serial and throughput benchmarks. 

## Release notes

( *) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

