### PR TITLE
Document examples for datetime functions

### DIFF
--- a/docs/src/main/sphinx/functions/datetime.rst
+++ b/docs/src/main/sphinx/functions/datetime.rst
@@ -228,7 +228,16 @@ The above examples use the timestamp ``2001-08-22 03:04:05.321`` as the input.
 
 .. function:: date_trunc(unit, x) -> [same as input]
 
-    Returns ``x`` truncated to ``unit``.
+    Returns ``x`` truncated to ``unit``::
+
+        SELECT date_trunc('day' , TIMESTAMP '2022-10-20 05:10:00');
+        -- 2022-10-20 00:00:00.000
+
+        SELECT date_trunc('month' , TIMESTAMP '2022-10-20 05:10:00');
+        -- 2022-10-01 00:00:00.000
+
+        SELECT date_trunc('year', TIMESTAMP '2022-10-20 05:10:00');
+        -- 2022-01-01 00:00:00.000
 
 .. _datetime-interval-functions:
 
@@ -383,11 +392,17 @@ Specifier Description
 
 .. function:: date_format(timestamp, format) -> varchar
 
-    Formats ``timestamp`` as a string using ``format``.
+    Formats ``timestamp`` as a string using ``format``::
+
+        SELECT date_format(TIMESTAMP '2022-10-20 05:10:00', '%m-%d-%Y %H');
+        -- 10-20-2022 05
 
 .. function:: date_parse(string, format) -> timestamp(3)
 
-    Parses ``string`` into a timestamp using ``format``.
+    Parses ``string`` into a timestamp using ``format``::
+
+        SELECT date_parse('2022/10/20/05', '%Y/%m/%d/%H');
+        -- 2022-10-20 05:00:00.000
 
 Java date functions
 -------------------
@@ -437,7 +452,10 @@ field to be extracted. Most fields support all date and time types.
 
 .. function:: extract(field FROM x) -> bigint
 
-    Returns ``field`` from ``x``.
+    Returns ``field`` from ``x``::
+
+        SELECT extract(YEAR FROM TIMESTAMP '2022-10-20 05:10:00');
+        -- 2022
 
     .. note:: This SQL-standard function uses special syntax for specifying the arguments.
 


### PR DESCRIPTION
## Description

This PR adds date_trunc, extract, date_parse, and date_format functions example so when someone looks at the docs, they know exactly how to use it. This also improves docs when using trinols (language server) in VsCode.

## Screen Shots

<img width="728" alt="Screenshot 2022-12-12 at 10 13 49 AM" src="https://user-images.githubusercontent.com/31558765/207096375-55e2bd73-351e-4cc7-a23f-cfda9d5944b9.png">
<img width="726" alt="Screenshot 2022-12-12 at 10 13 29 AM" src="https://user-images.githubusercontent.com/31558765/207096468-fec30fbe-10a3-492d-98b6-1f4b168c8c6b.png">
