### PR TITLE
Read parquet column chunks in small steps

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/AbstractParquetDataSource.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/AbstractParquetDataSource.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static java.lang.Math.toIntExact;
@@ -299,6 +300,15 @@ public abstract class AbstractParquetDataSource
             if (referenceCount == 0) {
                 data = null;
             }
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("range", range)
+                    .add("referenceCount", referenceCount)
+                    .toString();
         }
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/DiskRange.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/DiskRange.java
@@ -17,16 +17,15 @@ import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 // same as io.trino.orc.DiskRange
 public final class DiskRange
 {
     private final long offset;
-    private final int length;
+    private final long length;
 
-    public DiskRange(long offset, int length)
+    public DiskRange(long offset, long length)
     {
         checkArgument(offset >= 0, "offset is negative");
         checkArgument(length > 0, "length must be at least 1");
@@ -40,7 +39,7 @@ public final class DiskRange
         return offset;
     }
 
-    public int getLength()
+    public long getLength()
     {
         return length;
     }
@@ -65,7 +64,7 @@ public final class DiskRange
         requireNonNull(otherDiskRange, "otherDiskRange is null");
         long start = Math.min(this.offset, otherDiskRange.getOffset());
         long end = Math.max(getEnd(), otherDiskRange.getEnd());
-        return new DiskRange(start, toIntExact(end - start));
+        return new DiskRange(start, end - start);
     }
 
     @Override

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetDataSource.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetDataSource.java
@@ -15,6 +15,7 @@ package io.trino.parquet;
 
 import com.google.common.collect.ListMultimap;
 import io.airlift.slice.Slice;
+import io.trino.memory.context.AggregatedMemoryContext;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -36,7 +37,7 @@ public interface ParquetDataSource
     Slice readFully(long position, int length)
             throws IOException;
 
-    <K> ListMultimap<K, ChunkReader> planRead(ListMultimap<K, DiskRange> diskRanges);
+    <K> ListMultimap<K, ChunkReader> planRead(ListMultimap<K, DiskRange> diskRanges, AggregatedMemoryContext memoryContext);
 
     @Override
     default void close()

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ChunkedInputStream.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ChunkedInputStream.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.airlift.slice.BasicSliceInput;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.parquet.ChunkReader;
+import io.trino.parquet.ParquetReaderOptions;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Iterator;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkPositionIndexes;
+import static com.google.common.io.ByteStreams.readFully;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A single continuous {@link InputStream} over multiple {@link Slice}s read on demand using given collection of {@link ChunkReader}s.
+ * It is used to read parquet column chunk in limited (small) byte chunks (8MB by default, controlled by {@link ParquetReaderOptions#getMaxReadBlockSize()}).
+ * Column chunks consists of multiple pages.
+ * This abstraction is used because the page size is unknown until the page header is read
+ * and page header and page data can be split between two or more byte chunks.
+ */
+public final class ChunkedInputStream
+        extends InputStream
+{
+    private final Iterator<? extends ChunkReader> chunks;
+    private ChunkReader currentChunkReader;
+    private BasicSliceInput current;
+
+    public ChunkedInputStream(Collection<? extends ChunkReader> chunks)
+    {
+        requireNonNull(chunks, "chunks is null");
+        checkArgument(!chunks.isEmpty(), "At least one chunk is expected but got none");
+        this.chunks = chunks.iterator();
+        readNextChunk();
+    }
+
+    public Slice getSlice(int length)
+            throws IOException
+    {
+        if (length == 0) {
+            return Slices.EMPTY_SLICE;
+        }
+        ensureOpen();
+        while (!current.isReadable()) {
+            checkArgument(chunks.hasNext(), "Requested %s bytes but 0 was available", length);
+            readNextChunk();
+        }
+        if (current.available() >= length) {
+            return current.readSlice(length);
+        }
+        // requested length crosses the slice boundary
+        byte[] bytes = new byte[length];
+        try {
+            readFully(this, bytes, 0, bytes.length);
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to read " + length + " bytes", e);
+        }
+        return Slices.wrappedBuffer(bytes);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len)
+            throws IOException
+    {
+        checkPositionIndexes(off, off + len, b.length);
+        if (len == 0) {
+            return 0;
+        }
+        ensureOpen();
+        while (!current.isReadable()) {
+            if (!chunks.hasNext()) {
+                return -1;
+            }
+            readNextChunk();
+        }
+
+        return current.read(b, off, len);
+    }
+
+    @Override
+    public int read()
+            throws IOException
+    {
+        ensureOpen();
+        while (!current.isReadable() && chunks.hasNext()) {
+            readNextChunk();
+        }
+
+        return current.read();
+    }
+
+    @Override
+    public int available()
+            throws IOException
+    {
+        ensureOpen();
+        return current.available();
+    }
+
+    @Override
+    public void close()
+    {
+        if (current == null) {
+            // already closed
+            return;
+        }
+        currentChunkReader.free();
+
+        while (chunks.hasNext()) {
+            chunks.next().free();
+        }
+        current = null;
+    }
+
+    private void ensureOpen()
+            throws IOException
+    {
+        if (current == null) {
+            throw new IOException("Stream closed");
+        }
+    }
+
+    private void readNextChunk()
+    {
+        if (currentChunkReader != null) {
+            currentChunkReader.free();
+        }
+        currentChunkReader = chunks.next();
+        Slice slice = currentChunkReader.readUnchecked();
+        checkArgument(slice.length() > 0, "all chunks have to be not empty");
+        current = slice.getInput();
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetColumnChunkIterator.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetColumnChunkIterator.java
@@ -13,15 +13,12 @@
  */
 package io.trino.parquet.reader;
 
-import io.airlift.slice.BasicSliceInput;
-import io.airlift.slice.Slice;
-import io.trino.parquet.DataPage;
 import io.trino.parquet.DataPageV1;
 import io.trino.parquet.DataPageV2;
 import io.trino.parquet.DictionaryPage;
+import io.trino.parquet.Page;
 import io.trino.parquet.ParquetCorruptionException;
 import org.apache.parquet.column.Encoding;
-import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.format.DataPageHeader;
 import org.apache.parquet.format.DataPageHeaderV2;
 import org.apache.parquet.format.DictionaryPageHeader;
@@ -29,96 +26,93 @@ import org.apache.parquet.format.PageHeader;
 import org.apache.parquet.format.Util;
 import org.apache.parquet.internal.column.columnindex.OffsetIndex;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.Iterator;
 import java.util.Optional;
 import java.util.OptionalLong;
 
-import static com.google.common.base.Verify.verify;
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.parquet.ParquetTypeUtils.getParquetEncoding;
 import static java.util.Objects.requireNonNull;
 
-public class ParquetColumnChunk
+public final class ParquetColumnChunkIterator
+        implements Iterator<Page>
 {
     private final Optional<String> fileCreatedBy;
     private final ColumnChunkDescriptor descriptor;
-    private final List<Slice> slices;
-    private int sliceIndex;
-    private BasicSliceInput input;
+    private final ChunkedInputStream input;
     private final OffsetIndex offsetIndex;
 
-    public ParquetColumnChunk(
+    private long valueCount;
+    private int dataPageCount;
+    private boolean dictionaryWasRead;
+
+    public ParquetColumnChunkIterator(
             Optional<String> fileCreatedBy,
             ColumnChunkDescriptor descriptor,
-            List<Slice> slices,
-            OffsetIndex offsetIndex)
+            ChunkedInputStream input,
+            @Nullable OffsetIndex offsetIndex)
     {
         this.fileCreatedBy = requireNonNull(fileCreatedBy, "fileCreatedBy is null");
-        this.descriptor = descriptor;
-        this.slices = slices;
-        this.sliceIndex = 0;
-        this.input = slices.get(0).getInput();
+        this.descriptor = requireNonNull(descriptor, "descriptor is null");
+        this.input = requireNonNull(input, "input is null");
         this.offsetIndex = offsetIndex;
     }
 
-    private void advanceIfNecessary()
+    public boolean hasDictionaryPage()
     {
-        if (input.available() == 0) {
-            sliceIndex++;
-            if (sliceIndex < slices.size()) {
-                input = slices.get(sliceIndex).getInput();
-            }
-        }
+        return descriptor.getColumnChunkMetaData().hasDictionaryPage();
     }
 
-    protected PageHeader readPageHeader()
-            throws IOException
+    @Override
+    public boolean hasNext()
     {
-        verify(input.available() > 0, "Reached end of input unexpectedly");
-        PageHeader pageHeader = Util.readPageHeader(input);
-        advanceIfNecessary();
-        return pageHeader;
+        return hasMorePages(valueCount, dataPageCount) || (hasDictionaryPage() && !dictionaryWasRead);
     }
 
-    public PageReader readAllPages()
-            throws IOException
+    @Override
+    public Page next()
     {
-        LinkedList<DataPage> pages = new LinkedList<>();
-        DictionaryPage dictionaryPage = null;
-        long valueCount = 0;
-        int dataPageCount = 0;
-        while (hasMorePages(valueCount, dataPageCount)) {
+        checkArgument(hasNext());
+
+        try {
             PageHeader pageHeader = readPageHeader();
             int uncompressedPageSize = pageHeader.getUncompressed_page_size();
             int compressedPageSize = pageHeader.getCompressed_page_size();
+            Page result = null;
             switch (pageHeader.type) {
                 case DICTIONARY_PAGE:
-                    if (dictionaryPage != null) {
-                        throw new ParquetCorruptionException("%s has more than one dictionary page in column chunk", descriptor.getColumnDescriptor());
+                    if (dataPageCount != 0) {
+                        throw new ParquetCorruptionException("%s has dictionary page at not first position in column chunk", descriptor.getColumnDescriptor());
                     }
-                    dictionaryPage = readDictionaryPage(pageHeader, uncompressedPageSize, compressedPageSize);
+                    result = readDictionaryPage(pageHeader, pageHeader.getUncompressed_page_size(), pageHeader.getCompressed_page_size());
+                    dictionaryWasRead = true;
                     break;
                 case DATA_PAGE:
-                    valueCount += readDataPageV1(pageHeader, uncompressedPageSize, compressedPageSize, pages, getFirstRowIndex(dataPageCount, offsetIndex));
+                    result = readDataPageV1(pageHeader, uncompressedPageSize, compressedPageSize, getFirstRowIndex(dataPageCount, offsetIndex));
                     ++dataPageCount;
                     break;
                 case DATA_PAGE_V2:
-                    valueCount += readDataPageV2(pageHeader, uncompressedPageSize, compressedPageSize, pages, getFirstRowIndex(dataPageCount, offsetIndex));
+                    result = readDataPageV2(pageHeader, uncompressedPageSize, compressedPageSize, getFirstRowIndex(dataPageCount, offsetIndex));
                     ++dataPageCount;
                     break;
                 default:
                     input.skip(compressedPageSize);
-                    advanceIfNecessary();
                     break;
             }
+            return result;
         }
-        // Parquet schema may specify a column definition as OPTIONAL even though there are no nulls in the actual data.
-        // Row-group column statistics can be used to identify such cases and switch to faster non-nullable read
-        // paths in FlatColumnReader.
-        Statistics<?> columnStatistics = descriptor.getColumnChunkMetaData().getStatistics();
-        boolean hasNoNulls = columnStatistics != null && columnStatistics.getNumNulls() == 0;
-        return new PageReader(descriptor.getColumnChunkMetaData().getCodec(), pages, dictionaryPage, valueCount, hasNoNulls);
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private PageHeader readPageHeader()
+            throws IOException
+    {
+        return Util.readPageHeader(input);
     }
 
     private boolean hasMorePages(long valuesCountReadSoFar, int dataPageCountReadSoFar)
@@ -129,67 +123,61 @@ public class ParquetColumnChunk
         return dataPageCountReadSoFar < offsetIndex.getPageCount();
     }
 
-    private Slice getSlice(int size)
-    {
-        Slice slice = input.readSlice(size);
-        advanceIfNecessary();
-        return slice;
-    }
-
     private DictionaryPage readDictionaryPage(PageHeader pageHeader, int uncompressedPageSize, int compressedPageSize)
+            throws IOException
     {
         DictionaryPageHeader dicHeader = pageHeader.getDictionary_page_header();
         return new DictionaryPage(
-                getSlice(compressedPageSize),
+                input.getSlice(compressedPageSize),
                 uncompressedPageSize,
                 dicHeader.getNum_values(),
                 getParquetEncoding(Encoding.valueOf(dicHeader.getEncoding().name())));
     }
 
-    private long readDataPageV1(
+    private DataPageV1 readDataPageV1(
             PageHeader pageHeader,
             int uncompressedPageSize,
             int compressedPageSize,
-            List<DataPage> pages,
             OptionalLong firstRowIndex)
+            throws IOException
     {
         DataPageHeader dataHeaderV1 = pageHeader.getData_page_header();
-        pages.add(new DataPageV1(
-                getSlice(compressedPageSize),
+        valueCount += dataHeaderV1.getNum_values();
+        return new DataPageV1(
+                input.getSlice(compressedPageSize),
                 dataHeaderV1.getNum_values(),
                 uncompressedPageSize,
                 firstRowIndex,
                 getParquetEncoding(Encoding.valueOf(dataHeaderV1.getRepetition_level_encoding().name())),
                 getParquetEncoding(Encoding.valueOf(dataHeaderV1.getDefinition_level_encoding().name())),
-                getParquetEncoding(Encoding.valueOf(dataHeaderV1.getEncoding().name()))));
-        return dataHeaderV1.getNum_values();
+                getParquetEncoding(Encoding.valueOf(dataHeaderV1.getEncoding().name())));
     }
 
-    private long readDataPageV2(
+    private DataPageV2 readDataPageV2(
             PageHeader pageHeader,
             int uncompressedPageSize,
             int compressedPageSize,
-            List<DataPage> pages,
             OptionalLong firstRowIndex)
+            throws IOException
     {
         DataPageHeaderV2 dataHeaderV2 = pageHeader.getData_page_header_v2();
         int dataSize = compressedPageSize - dataHeaderV2.getRepetition_levels_byte_length() - dataHeaderV2.getDefinition_levels_byte_length();
-        pages.add(new DataPageV2(
+        valueCount += dataHeaderV2.getNum_values();
+        return new DataPageV2(
                 dataHeaderV2.getNum_rows(),
                 dataHeaderV2.getNum_nulls(),
                 dataHeaderV2.getNum_values(),
-                getSlice(dataHeaderV2.getRepetition_levels_byte_length()),
-                getSlice(dataHeaderV2.getDefinition_levels_byte_length()),
+                input.getSlice(dataHeaderV2.getRepetition_levels_byte_length()),
+                input.getSlice(dataHeaderV2.getDefinition_levels_byte_length()),
                 getParquetEncoding(Encoding.valueOf(dataHeaderV2.getEncoding().name())),
-                getSlice(dataSize),
+                input.getSlice(dataSize),
                 uncompressedPageSize,
                 firstRowIndex,
                 MetadataReader.readStats(
                         fileCreatedBy,
                         Optional.ofNullable(dataHeaderV2.getStatistics()),
                         descriptor.getColumnDescriptor().getPrimitiveType()),
-                dataHeaderV2.isIs_compressed()));
-        return dataHeaderV2.getNum_values();
+                dataHeaderV2.isIs_compressed());
     }
 
     private static OptionalLong getFirstRowIndex(int pageIndex, OffsetIndex offsetIndex)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
@@ -214,14 +214,14 @@ public class ParquetReader
                     filteredOffsetIndex = getFilteredOffsetIndex(blockRowRanges[rowGroup], rowGroup, rowGroupRowCount, columnPath);
                 }
                 if (filteredOffsetIndex == null) {
-                    DiskRange range = new DiskRange(startingPosition, toIntExact(totalLength));
+                    DiskRange range = new DiskRange(startingPosition, totalLength);
                     totalDataSize = range.getLength();
                     ranges.put(new ChunkKey(columnId, rowGroup), range);
                 }
                 else {
                     List<OffsetRange> offsetRanges = filteredOffsetIndex.calculateOffsetRanges(startingPosition);
                     for (OffsetRange offsetRange : offsetRanges) {
-                        DiskRange range = new DiskRange(offsetRange.getOffset(), toIntExact(offsetRange.getLength()));
+                        DiskRange range = new DiskRange(offsetRange.getOffset(), offsetRange.getLength());
                         totalDataSize += range.getLength();
                         ranges.put(new ChunkKey(columnId, rowGroup), range);
                     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PrimitiveColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PrimitiveColumnReader.java
@@ -60,10 +60,8 @@ public abstract class PrimitiveColumnReader
     private int nextBatchSize;
     private LevelReader repetitionReader;
     private LevelReader definitionReader;
-    private long totalValueCount;
     private PageReader pageReader;
     private Dictionary dictionary;
-    private int currentValueCount;
     private DataPage page;
     private int remainingValueCountInPage;
     private int readOffset;
@@ -117,8 +115,6 @@ public abstract class PrimitiveColumnReader
         else {
             dictionary = null;
         }
-        checkArgument(pageReader.getTotalValueCount() > 0, "page is empty");
-        totalValueCount = pageReader.getTotalValueCount();
         if (rowRanges.isPresent()) {
             indexIterator = rowRanges.get().getParquetRowRanges().iterator();
             // If rowRanges is empty for a row-group, then no page needs to be read, and we should not reach here
@@ -255,7 +251,6 @@ public abstract class PrimitiveColumnReader
 
     private void seek()
     {
-        checkArgument(currentValueCount <= totalValueCount, "Already read all values in column chunk");
         if (readOffset == 0) {
             return;
         }
@@ -300,7 +295,6 @@ public abstract class PrimitiveColumnReader
             valuesReader = null;
         }
         remainingValueCountInPage -= totalCount;
-        currentValueCount += valuesRead;
     }
 
     private ValuesReader readPageV1(DataPageV1 page)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PrimitiveColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PrimitiveColumnReader.java
@@ -204,7 +204,7 @@ public abstract class PrimitiveColumnReader
      * 100  │  p5  │      │      │
      *      └──────┴──────┴──────┘
      * </pre>
-     *
+     * <p>
      * The pages 1, 2, 3 in col1 are skipped so we have to skip the rows [20, 79]. Because page 1 in col2 contains values
      * only for the rows [40, 79] we skip this entire page as well. To synchronize the row reading we have to skip the
      * values (and the related rl and dl) for the rows [20, 39] in the end of the page 0 for col2. Similarly, we have to

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/TrinoColumnIndexStore.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/TrinoColumnIndexStore.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
-import io.airlift.slice.Slice;
 import io.trino.parquet.ChunkReader;
 import io.trino.parquet.DiskRange;
 import io.trino.parquet.ParquetDataSource;
@@ -35,13 +34,14 @@ import org.apache.parquet.schema.PrimitiveType;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -102,9 +102,9 @@ public class TrinoColumnIndexStore
     public ColumnIndex getColumnIndex(ColumnPath column)
     {
         if (columnIndexStore == null) {
-            columnIndexStore = loadIndexes(dataSource, columnIndexReferences, (buffer, columnMetadata) -> {
+            columnIndexStore = loadIndexes(dataSource, columnIndexReferences, (inputStream, columnMetadata) -> {
                 try {
-                    return ParquetMetadataConverter.fromParquetColumnIndex(columnMetadata.getPrimitiveType(), Util.readColumnIndex(buffer.getInput()));
+                    return ParquetMetadataConverter.fromParquetColumnIndex(columnMetadata.getPrimitiveType(), Util.readColumnIndex(inputStream));
                 }
                 catch (IOException e) {
                     throw new RuntimeException(e);
@@ -119,9 +119,9 @@ public class TrinoColumnIndexStore
     public OffsetIndex getOffsetIndex(ColumnPath column)
     {
         if (offsetIndexStore == null) {
-            offsetIndexStore = loadIndexes(dataSource, offsetIndexReferences, (buffer, columnMetadata) -> {
+            offsetIndexStore = loadIndexes(dataSource, offsetIndexReferences, (inputStream, columnMetadata) -> {
                 try {
-                    return ParquetMetadataConverter.fromParquetOffsetIndex(Util.readOffsetIndex(buffer.getInput()));
+                    return ParquetMetadataConverter.fromParquetOffsetIndex(Util.readOffsetIndex(inputStream));
                 }
                 catch (IOException e) {
                     throw new RuntimeException(e);
@@ -135,7 +135,7 @@ public class TrinoColumnIndexStore
     private static <T> Map<ColumnPath, T> loadIndexes(
             ParquetDataSource dataSource,
             List<ColumnIndexMetadata> indexMetadata,
-            BiFunction<Slice, ColumnIndexMetadata, T> deserializer)
+            BiFunction<InputStream, ColumnIndexMetadata, T> deserializer)
     {
         // Merge multiple small reads of the file for indexes stored close to each other
         ListMultimap<ColumnPath, DiskRange> ranges = ArrayListMultimap.create(indexMetadata.size(), 1);
@@ -143,15 +143,17 @@ public class TrinoColumnIndexStore
             ranges.put(column.getPath(), column.getDiskRange());
         }
 
-        Multimap<ColumnPath, ChunkReader> chunkReaders = dataSource.planRead(ranges);
+        Multimap<ColumnPath, ChunkReader> chunkReaders = dataSource.planRead(ranges, newSimpleAggregatedMemoryContext());
+        Map<ColumnPath, ChunkedInputStream> columnInputStreams = chunkReaders.asMap().entrySet().stream()
+                .collect(toImmutableMap(Map.Entry::getKey, entry -> new ChunkedInputStream(entry.getValue())));
         try {
             return indexMetadata.stream()
                     .collect(toImmutableMap(
                             ColumnIndexMetadata::getPath,
-                            column -> deserializer.apply(getOnlyElement(chunkReaders.get(column.getPath())).readUnchecked(), column)));
+                            column -> deserializer.apply(columnInputStreams.get(column.getPath()), column)));
         }
         finally {
-            chunkReaders.values().forEach(ChunkReader::free);
+            columnInputStreams.values().forEach(ChunkedInputStream::close);
         }
     }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/FlatColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/FlatColumnReader.java
@@ -340,7 +340,6 @@ public class FlatColumnReader<BufferType>
             plainValuesDecoder.read(dictionary, 0, size);
             dictionaryDecoder = new DictionaryDecoder<>(dictionary, columnAdapter);
         }
-        checkArgument(pageReader.getTotalValueCount() > 0, "page is empty");
         this.rowRanges = createRowRangesIterator(rowRanges);
     }
 

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/AbstractColumnReaderBenchmark.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/AbstractColumnReaderBenchmark.java
@@ -102,7 +102,7 @@ public abstract class AbstractColumnReaderBenchmark<VALUES>
             throws IOException
     {
         ColumnReader columnReader = ColumnReaderFactory.create(field, UTC, true);
-        columnReader.setPageReader(new PageReader(UNCOMPRESSED, new LinkedList<>(dataPages), null, dataPositions, false), Optional.empty());
+        columnReader.setPageReader(new PageReader(UNCOMPRESSED, new LinkedList<>(dataPages).iterator(), false, false), Optional.empty());
         int rowsRead = 0;
         while (rowsRead < dataPositions) {
             int remaining = dataPositions - rowsRead;

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestChunkedInputStream.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestChunkedInputStream.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.ByteStreams;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.Slices.EMPTY_SLICE;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestChunkedInputStream
+{
+    @Test
+    public void empty()
+            throws IOException
+    {
+        assertThatThrownBy(() -> input(ImmutableList.of())).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test(dataProvider = "chunks")
+    public void testInput(List<byte[]> chunks)
+            throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        for (byte[] chunk : chunks) {
+            out.write(chunk);
+        }
+        byte[] expectedBytes = out.toByteArray();
+        byte[] buffer = new byte[expectedBytes.length + 1];
+
+        List<Slice> slices = chunks.stream().map(Slices::wrappedBuffer).collect(toImmutableList());
+        assertEquals(input(slices).readAllBytes(), expectedBytes);
+        assertEquals(input(slices).getSlice(expectedBytes.length).getBytes(), expectedBytes);
+        assertEquals(readAll(input(slices)), expectedBytes);
+
+        assertEquals(input(slices).readNBytes(expectedBytes.length), expectedBytes);
+
+        assertEquals(input(slices).read(buffer, 0, 0), 0);
+        assertEquals(input(slices).getSlice(0), EMPTY_SLICE);
+
+        if (expectedBytes.length > 0) {
+            // read from one chunk only
+            assertEquals(input(slices).read(buffer, 0, 1), 1);
+            assertEquals(buffer[0], expectedBytes[0]);
+        }
+
+        // rad more than total length
+        ChunkedInputStream input = input(slices);
+        int bytesRead = ByteStreams.read(input, buffer, 0, buffer.length);
+        assertEquals(bytesRead, expectedBytes.length > 0 ? expectedBytes.length : -1);
+
+        // read after input is done returns -1
+        assertEquals(input.read(), -1);
+        // getSlice(0) after input is done returns empty slice
+        assertEquals(input.getSlice(0), EMPTY_SLICE);
+        assertThatThrownBy(() -> input.getSlice(1)).isInstanceOf(IllegalArgumentException.class);
+
+        assertEquals(input.read(buffer, 0, 1), -1);
+
+        // verify available
+        ChunkedInputStream availableInput = input(slices);
+        assertEquals(availableInput.available(), chunks.get(0).length);
+        availableInput.skipNBytes(chunks.get(0).length);
+        assertEquals(availableInput.available(), 0);
+        if (chunks.size() > 1) {
+            availableInput.read();
+            assertEquals(availableInput.available(), chunks.get(1).length - 1);
+            availableInput.skipNBytes(chunks.get(1).length - 1);
+            assertEquals(availableInput.available(), 0);
+        }
+    }
+
+    @Test(dataProvider = "chunks")
+    public void testClose(List<byte[]> chunks)
+            throws IOException
+    {
+        List<Slice> slices = chunks.stream().map(Slices::wrappedBuffer).collect(toImmutableList());
+
+        // close fresh input, not read
+        List<TestingChunkReader> chunksReaders = slices.stream().map(TestingChunkReader::new).collect(toImmutableList());
+        ChunkedInputStream input = new ChunkedInputStream(chunksReaders);
+        input.close();
+        for (TestingChunkReader chunksReader : chunksReaders) {
+            assertTrue(chunksReader.isFreed());
+        }
+
+        // close partially read input
+        chunksReaders = slices.stream().map(TestingChunkReader::new).collect(toImmutableList());
+        input = new ChunkedInputStream(chunksReaders);
+        input.readNBytes(chunks.get(0).length);
+        input.close();
+        for (TestingChunkReader chunksReader : chunksReaders) {
+            assertTrue(chunksReader.isFreed());
+        }
+
+        // close fully read input
+        chunksReaders = slices.stream().map(TestingChunkReader::new).collect(toImmutableList());
+        input = new ChunkedInputStream(chunksReaders);
+        input.readNBytes(chunks.stream().mapToInt(chunk -> chunk.length).sum());
+        input.close();
+        for (TestingChunkReader chunksReader : chunksReaders) {
+            assertTrue(chunksReader.isFreed());
+        }
+    }
+
+    @DataProvider
+    public Object[][] chunks()
+    {
+        return new Object[][] {
+                {ImmutableList.of(new byte[] {1, 2, 3})},
+                {ImmutableList.of(new byte[] {1, 2, 3}, new byte[] {1, 2})},
+                {ImmutableList.of(new byte[] {1, 2, 3}, new byte[] {1}, new byte[] {1, 2})},
+        };
+    }
+
+    private static byte[] readAll(ChunkedInputStream input)
+            throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int read;
+        while ((read = input.read()) != -1) {
+            out.write(read);
+        }
+        return out.toByteArray();
+    }
+
+    private static ChunkedInputStream input(List<Slice> slices)
+    {
+        return new ChunkedInputStream(slices.stream().map(TestingChunkReader::new).collect(toImmutableList()));
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestInt96Timestamp.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestInt96Timestamp.java
@@ -33,7 +33,6 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -108,7 +107,7 @@ public class TestInt96Timestamp
         // Read and assert
         ColumnReader reader = ColumnReaderFactory.create(field, DateTimeZone.UTC, true);
         reader.setPageReader(
-                new PageReader(UNCOMPRESSED, new LinkedList<>(List.of(dataPage)), null, dataPage.getValueCount(), false),
+                new PageReader(UNCOMPRESSED, List.of(dataPage).iterator(), false, false),
                 Optional.empty());
         reader.prepareNextRead(valueCount);
         Block block = reader.readPrimitive().getBlock();

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestPageReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestPageReader.java
@@ -1,0 +1,431 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.compress.snappy.SnappyCompressor;
+import io.airlift.compress.snappy.SnappyRawCompressor;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.parquet.DataPage;
+import io.trino.parquet.DataPageV1;
+import io.trino.parquet.DataPageV2;
+import io.trino.parquet.DictionaryPage;
+import io.trino.parquet.ParquetCorruptionException;
+import io.trino.parquet.ParquetEncoding;
+import io.trino.parquet.ParquetTypeUtils;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.EncodingStats;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.format.DataPageHeader;
+import org.apache.parquet.format.DataPageHeaderV2;
+import org.apache.parquet.format.DictionaryPageHeader;
+import org.apache.parquet.format.Encoding;
+import org.apache.parquet.format.PageHeader;
+import org.apache.parquet.format.PageType;
+import org.apache.parquet.format.Util;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.parquet.reader.TestPageReader.DataPageType.V1;
+import static io.trino.parquet.reader.TestPageReader.DataPageType.V2;
+import static java.util.Objects.requireNonNull;
+import static org.apache.parquet.column.Encoding.PLAIN;
+import static org.apache.parquet.column.Encoding.RLE_DICTIONARY;
+import static org.apache.parquet.format.PageType.DATA_PAGE_V2;
+import static org.apache.parquet.format.PageType.DICTIONARY_PAGE;
+import static org.apache.parquet.hadoop.metadata.CompressionCodecName.SNAPPY;
+import static org.apache.parquet.hadoop.metadata.CompressionCodecName.UNCOMPRESSED;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestPageReader
+{
+    private static final byte[] DATA_PAGE = new byte[] {1, 2, 3};
+
+    @Test(dataProvider = "pageParameters")
+    public void singlePage(CompressionCodecName compressionCodec, DataPageType dataPageType)
+            throws Exception
+    {
+        int valueCount = 10;
+        byte[] compressedDataPage = dataPageType.compress(compressionCodec, DATA_PAGE);
+
+        PageHeader pageHeader = new PageHeader(dataPageType.pageType(), DATA_PAGE.length, compressedDataPage.length);
+        dataPageType.setDataPageHeader(pageHeader, valueCount);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream(20);
+        Util.writePageHeader(pageHeader, out);
+        int headerSize = out.size();
+        out.write(compressedDataPage);
+        byte[] bytes = out.toByteArray();
+
+        // single slice
+        assertSinglePage(compressionCodec, valueCount, pageHeader, compressedDataPage, ImmutableList.of(
+                Slices.wrappedBuffer(bytes)));
+
+        // pageHeader split across two slices
+        assertSinglePage(compressionCodec, valueCount, pageHeader, compressedDataPage, ImmutableList.of(
+                Slices.wrappedBuffer(Arrays.copyOf(bytes, 8)),
+                Slices.wrappedBuffer(Arrays.copyOfRange(bytes, 8, bytes.length))));
+
+        // pageHeader split across many slices
+        int secondHeaderChunkOffset = 5;
+        int thirdHeaderChunkOffset = 11;
+        assertSinglePage(compressionCodec, valueCount, pageHeader, compressedDataPage, ImmutableList.of(
+                Slices.wrappedBuffer(Arrays.copyOf(bytes, secondHeaderChunkOffset)),
+                Slices.wrappedBuffer(Arrays.copyOfRange(bytes, secondHeaderChunkOffset, thirdHeaderChunkOffset)),
+                Slices.wrappedBuffer(Arrays.copyOfRange(bytes, thirdHeaderChunkOffset, bytes.length))));
+
+        // page data split across two slices
+        assertSinglePage(compressionCodec, valueCount, pageHeader, compressedDataPage, ImmutableList.of(
+                Slices.wrappedBuffer(Arrays.copyOf(bytes, headerSize + 1)),
+                Slices.wrappedBuffer(Arrays.copyOfRange(bytes, headerSize + 1, bytes.length))));
+
+        // page data split across many slices
+        assertSinglePage(compressionCodec, valueCount, pageHeader, compressedDataPage, ImmutableList.of(
+                Slices.wrappedBuffer(Arrays.copyOf(bytes, headerSize + 1)),
+                Slices.wrappedBuffer(Arrays.copyOfRange(bytes, headerSize + 1, headerSize + 2)),
+                Slices.wrappedBuffer(Arrays.copyOfRange(bytes, headerSize + 2, bytes.length))));
+    }
+
+    @Test(dataProvider = "pageParameters")
+    public void manyPages(CompressionCodecName compressionCodec, DataPageType dataPageType)
+            throws Exception
+    {
+        int totalValueCount = 30;
+        byte[] compressedDataPage = dataPageType.compress(compressionCodec, DATA_PAGE);
+
+        PageHeader pageHeader = new PageHeader(dataPageType.pageType(), DATA_PAGE.length, compressedDataPage.length);
+        dataPageType.setDataPageHeader(pageHeader, 10);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream(100);
+        Util.writePageHeader(pageHeader, out);
+        int headerSize = out.size();
+        out.write(compressedDataPage);
+        // second page
+        Util.writePageHeader(pageHeader, out);
+        out.write(compressedDataPage);
+        // third page
+        Util.writePageHeader(pageHeader, out);
+        out.write(compressedDataPage);
+        byte[] bytes = out.toByteArray();
+
+        // single slice
+        assertPages(compressionCodec, totalValueCount, 3, pageHeader, compressedDataPage, ImmutableList.of(
+                Slices.wrappedBuffer(bytes)));
+
+        // each page in its own split
+        int pageSize = headerSize + compressedDataPage.length;
+        assertPages(compressionCodec, totalValueCount, 3, pageHeader, compressedDataPage, ImmutableList.of(
+                Slices.wrappedBuffer(Arrays.copyOf(bytes, pageSize)),
+                Slices.wrappedBuffer(Arrays.copyOfRange(bytes, pageSize, pageSize * 2)),
+                Slices.wrappedBuffer(Arrays.copyOfRange(bytes, pageSize * 2, bytes.length))));
+
+        // page start in the middle of the slice
+        assertPages(compressionCodec, totalValueCount, 3, pageHeader, compressedDataPage, ImmutableList.of(
+                Slices.wrappedBuffer(Arrays.copyOf(bytes, pageSize - 2)),
+                Slices.wrappedBuffer(Arrays.copyOfRange(bytes, pageSize - 2, pageSize * 2)),
+                Slices.wrappedBuffer(Arrays.copyOfRange(bytes, pageSize * 2, bytes.length))));
+    }
+
+    @Test(dataProvider = "pageParameters")
+    public void dictionaryPage(CompressionCodecName compressionCodec, DataPageType dataPageType)
+            throws Exception
+    {
+        byte[] dictionaryPage = {4};
+        byte[] compressedDictionaryPage = TestPageReader.compress(compressionCodec, dictionaryPage, 0, dictionaryPage.length);
+        PageHeader dictionaryPageHeader = new PageHeader(DICTIONARY_PAGE, dictionaryPage.length, compressedDictionaryPage.length);
+        dictionaryPageHeader.setDictionary_page_header(new DictionaryPageHeader(3, Encoding.PLAIN));
+        int totalValueCount = 30;
+        byte[] compressedDataPage = dataPageType.compress(compressionCodec, DATA_PAGE);
+
+        PageHeader pageHeader = new PageHeader(dataPageType.pageType(), DATA_PAGE.length, compressedDataPage.length);
+        dataPageType.setDataPageHeader(pageHeader, 10);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream(100);
+        Util.writePageHeader(dictionaryPageHeader, out);
+        int dictionaryHeaderSize = out.size();
+        out.write(compressedDictionaryPage);
+        int dictionaryPageSize = out.size();
+
+        Util.writePageHeader(pageHeader, out);
+        out.write(compressedDataPage);
+        // second page
+        Util.writePageHeader(pageHeader, out);
+        out.write(compressedDataPage);
+        // third page
+        Util.writePageHeader(pageHeader, out);
+        out.write(compressedDataPage);
+        byte[] bytes = out.toByteArray();
+
+        PageReader pageReader = createPageReader(totalValueCount, compressionCodec, true, ImmutableList.of(Slices.wrappedBuffer(bytes)));
+        DictionaryPage uncompressedDictionaryPage = pageReader.readDictionaryPage();
+        assertThat(uncompressedDictionaryPage.getDictionarySize()).isEqualTo(dictionaryPageHeader.getDictionary_page_header().getNum_values());
+        assertEncodingEquals(uncompressedDictionaryPage.getEncoding(), dictionaryPageHeader.getDictionary_page_header().getEncoding());
+        assertThat(uncompressedDictionaryPage.getSlice()).isEqualTo(Slices.wrappedBuffer(dictionaryPage));
+
+        // single slice
+        assertPages(compressionCodec, totalValueCount, 3, pageHeader, compressedDataPage, true, ImmutableList.of(Slices.wrappedBuffer(bytes)));
+
+        // only dictionary
+        assertPages(compressionCodec, 0, 0, pageHeader, compressedDataPage, true, ImmutableList.of(
+                Slices.wrappedBuffer(Arrays.copyOf(bytes, dictionaryPageSize))));
+
+        // multiple slices dictionary
+        assertPages(compressionCodec, totalValueCount, 3, pageHeader, compressedDataPage, true, ImmutableList.of(
+                Slices.wrappedBuffer(Arrays.copyOfRange(bytes, 0, dictionaryHeaderSize - 1)),
+                Slices.wrappedBuffer(Arrays.copyOfRange(bytes, dictionaryHeaderSize - 1, dictionaryPageSize - 1)),
+                Slices.wrappedBuffer(Arrays.copyOfRange(bytes, dictionaryPageSize - 1, dictionaryPageSize + 1)),
+                Slices.wrappedBuffer(Arrays.copyOfRange(bytes, dictionaryPageSize + 1, bytes.length))));
+    }
+
+    @Test
+    public void dictionaryPageNotFirst()
+            throws Exception
+    {
+        byte[] dictionaryPage = {4};
+        CompressionCodecName compressionCodec = UNCOMPRESSED;
+        byte[] compressedDictionaryPage = TestPageReader.compress(compressionCodec, dictionaryPage, 0, dictionaryPage.length);
+        PageHeader dictionaryPageHeader = new PageHeader(DICTIONARY_PAGE, dictionaryPage.length, compressedDictionaryPage.length);
+        dictionaryPageHeader.setDictionary_page_header(new DictionaryPageHeader(3, Encoding.PLAIN));
+        DataPageType dataPageType = V2;
+        byte[] compressedDataPage = DATA_PAGE;
+
+        PageHeader pageHeader = new PageHeader(dataPageType.pageType(), DATA_PAGE.length, compressedDataPage.length);
+        int valueCount = 10;
+        dataPageType.setDataPageHeader(pageHeader, valueCount);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream(100);
+        Util.writePageHeader(pageHeader, out);
+        out.write(compressedDataPage);
+
+        Util.writePageHeader(dictionaryPageHeader, out);
+        out.write(compressedDictionaryPage);
+        // write another page so that we have something to read after the first
+        Util.writePageHeader(pageHeader, out);
+        out.write(compressedDataPage);
+        byte[] bytes = out.toByteArray();
+
+        int totalValueCount = valueCount * 2;
+
+        // metadata says there is a dictionary but it's not the first page
+        assertThatThrownBy(() -> createPageReader(totalValueCount, compressionCodec, true, ImmutableList.of(Slices.wrappedBuffer(bytes))).readDictionaryPage())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageStartingWith("DictionaryPage has to be the first page in the column chunk");
+
+        // metadata says there is no dictionary, but it's there as second page
+        PageReader pageReader = createPageReader(totalValueCount, compressionCodec, false, ImmutableList.of(Slices.wrappedBuffer(bytes)));
+        assertTrue(pageReader.hasNext());
+        pageReader.skipNextPage();
+        assertThatThrownBy(pageReader::readPage).isInstanceOf(RuntimeException.class).hasCauseInstanceOf(ParquetCorruptionException.class);
+    }
+
+    private static void assertSinglePage(CompressionCodecName compressionCodec, int valueCount, PageHeader pageHeader, byte[] compressedDataPage, List<Slice> slices)
+            throws IOException
+    {
+        assertPages(compressionCodec, valueCount, 1, pageHeader, compressedDataPage, slices);
+    }
+
+    private static void assertPages(CompressionCodecName compressionCodec, int valueCount, int pageCount, PageHeader pageHeader, byte[] compressedDataPage, List<Slice> slices)
+            throws IOException
+    {
+        assertPages(compressionCodec, valueCount, pageCount, pageHeader, compressedDataPage, false, slices);
+    }
+
+    private static void assertPages(
+            CompressionCodecName compressionCodec,
+            int valueCount,
+            int pageCount,
+            PageHeader pageHeader,
+            byte[] compressedDataPage,
+            boolean hasDictionary,
+            List<Slice> slices)
+            throws IOException
+    {
+        PageReader pageReader = createPageReader(valueCount, compressionCodec, hasDictionary, slices);
+        DictionaryPage dictionaryPage = pageReader.readDictionaryPage();
+        assertEquals(dictionaryPage != null, hasDictionary);
+
+        for (int i = 0; i < pageCount; i++) {
+            assertTrue(pageReader.hasNext());
+            DataPage decompressedPage = pageReader.readPage();
+            assertNotNull(decompressedPage);
+            assertDataPageEquals(pageHeader, DATA_PAGE, compressedDataPage, decompressedPage);
+        }
+        assertFalse(pageReader.hasNext());
+        assertNull(pageReader.readPage());
+    }
+
+    @DataProvider
+    public Object[][] pageParameters()
+    {
+        return new Object[][] {{UNCOMPRESSED, V1}, {SNAPPY, V1}, {UNCOMPRESSED, V2}, {SNAPPY, V2}};
+    }
+
+    public enum DataPageType
+    {
+        V1(PageType.DATA_PAGE) {
+            @Override
+            public void setDataPageHeader(PageHeader pageHeader, int valueCount)
+            {
+                pageHeader.setData_page_header(new DataPageHeader(valueCount, Encoding.PLAIN, Encoding.PLAIN, Encoding.PLAIN));
+            }
+
+            @Override
+            public byte[] compress(CompressionCodecName compressionCodec, byte[] dataPage)
+            {
+                return TestPageReader.compress(compressionCodec, dataPage, 0, dataPage.length);
+            }
+        },
+        V2(DATA_PAGE_V2) {
+            @Override
+            public void setDataPageHeader(PageHeader pageHeader, int valueCount)
+            {
+                pageHeader.setData_page_header_v2(new DataPageHeaderV2(valueCount, 0, valueCount, Encoding.PLAIN, 1, 1));
+            }
+
+            @Override
+            public byte[] compress(CompressionCodecName compressionCodec, byte[] dataPage)
+            {
+                // compress only the date, copy definition and repetition levels uncompressed
+                byte[] compressedData = TestPageReader.compress(compressionCodec, dataPage, 2, dataPage.length - 2);
+                Slice slice = Slices.allocate(2 + compressedData.length);
+                slice.setBytes(0, dataPage, 0, 2);
+                slice.setBytes(2, compressedData);
+                return slice.byteArray();
+            }
+        };
+
+        private final PageType pageType;
+
+        DataPageType(PageType pageType)
+        {
+            this.pageType = requireNonNull(pageType, "pageType is null");
+        }
+
+        public abstract void setDataPageHeader(PageHeader pageHeader, int valueCount);
+
+        public PageType pageType()
+        {
+            return pageType;
+        }
+
+        public abstract byte[] compress(CompressionCodecName compressionCodec, byte[] dataPage);
+    }
+
+    private static byte[] compress(CompressionCodecName compressionCodec, byte[] bytes, int offset, int length)
+    {
+        if (compressionCodec == UNCOMPRESSED) {
+            return Arrays.copyOfRange(bytes, offset, offset + length);
+        }
+        if (compressionCodec == SNAPPY) {
+            byte[] out = new byte[SnappyRawCompressor.maxCompressedLength(length)];
+            int compressedSize = new SnappyCompressor().compress(bytes, offset, length, out, 0, out.length);
+            return Arrays.copyOf(out, compressedSize);
+        }
+        throw new IllegalArgumentException("unsupported compression code " + compressionCodec);
+    }
+
+    private static PageReader createPageReader(int valueCount, CompressionCodecName compressionCodec, boolean hasDictionary, List<Slice> slices)
+            throws IOException
+    {
+        EncodingStats.Builder encodingStats = new EncodingStats.Builder();
+        if (hasDictionary) {
+            encodingStats.addDictEncoding(PLAIN);
+            encodingStats.addDataEncoding(RLE_DICTIONARY);
+        }
+        ColumnChunkMetaData columnChunkMetaData = ColumnChunkMetaData.get(
+                ColumnPath.get(""),
+                INT32,
+                compressionCodec,
+                encodingStats.build(),
+                ImmutableSet.of(),
+                Statistics.createStats(Types.optional(INT32).named("fake_type")),
+                0,
+                0,
+                valueCount,
+                0,
+                0);
+        return PageReader.createPageReader(
+                new ChunkedInputStream(slices.stream().map(TestingChunkReader::new).collect(toImmutableList())),
+                columnChunkMetaData,
+                new ColumnDescriptor(new String[] {}, new PrimitiveType(REQUIRED, INT32, ""), 0, 0),
+                null,
+                Optional.empty());
+    }
+
+    private static void assertDataPageEquals(PageHeader pageHeader, byte[] dataPage, byte[] compressedDataPage, DataPage decompressedPage)
+    {
+        assertThat(decompressedPage.getUncompressedSize()).isEqualTo(pageHeader.getUncompressed_page_size());
+        assertThat(pageHeader.getCompressed_page_size()).isEqualTo(compressedDataPage.length);
+        assertThat(decompressedPage.getFirstRowIndex()).isEmpty();
+        if (PageType.DATA_PAGE.equals(pageHeader.getType())) {
+            assertDataPageV1(dataPage, pageHeader, decompressedPage);
+        }
+        if (DATA_PAGE_V2.equals(pageHeader.getType())) {
+            assertDataPageV2(dataPage, pageHeader, decompressedPage);
+        }
+    }
+
+    private static void assertDataPageV1(byte[] dataPage, PageHeader pageHeader, DataPage decompressedPage)
+    {
+        DataPageHeader dataPageHeader = pageHeader.getData_page_header();
+        assertThat(decompressedPage.getValueCount()).isEqualTo(dataPageHeader.getNum_values());
+        assertThat(decompressedPage).isInstanceOf(DataPageV1.class);
+        DataPageV1 decompressedV1Page = (DataPageV1) decompressedPage;
+        assertThat(decompressedV1Page.getSlice()).isEqualTo(Slices.wrappedBuffer(dataPage));
+        assertEncodingEquals(decompressedV1Page.getValueEncoding(), dataPageHeader.getEncoding());
+        assertEncodingEquals(decompressedV1Page.getDefinitionLevelEncoding(), dataPageHeader.getDefinition_level_encoding());
+        assertEncodingEquals(decompressedV1Page.getRepetitionLevelEncoding(), dataPageHeader.getRepetition_level_encoding());
+    }
+
+    private static void assertDataPageV2(byte[] dataPage, PageHeader pageHeader, DataPage decompressedPage)
+    {
+        DataPageHeaderV2 dataPageHeader = pageHeader.getData_page_header_v2();
+        assertThat(decompressedPage.getValueCount()).isEqualTo(dataPageHeader.getNum_values());
+        assertThat(decompressedPage).isInstanceOf(DataPageV2.class);
+        DataPageV2 decompressedV2Page = (DataPageV2) decompressedPage;
+        int dataOffset = dataPageHeader.getDefinition_levels_byte_length() + dataPageHeader.getRepetition_levels_byte_length();
+        assertThat(decompressedV2Page.getSlice()).isEqualTo(Slices.wrappedBuffer(dataPage).slice(dataOffset, dataPage.length - dataOffset));
+        assertEncodingEquals(decompressedV2Page.getDataEncoding(), dataPageHeader.getEncoding());
+
+        assertThat(decompressedV2Page.getRepetitionLevels()).isEqualTo(Slices.wrappedBuffer(dataPage).slice(0, 1));
+        assertThat(decompressedV2Page.getDefinitionLevels()).isEqualTo(Slices.wrappedBuffer(dataPage).slice(1, 1));
+    }
+
+    private static void assertEncodingEquals(ParquetEncoding parquetEncoding, Encoding encoding)
+    {
+        assertThat(parquetEncoding).isEqualTo(ParquetTypeUtils.getParquetEncoding(org.apache.parquet.column.Encoding.valueOf(encoding.name())));
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestingChunkReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestingChunkReader.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.airlift.slice.Slice;
+import io.trino.parquet.ChunkReader;
+
+import javax.annotation.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+public class TestingChunkReader
+        implements ChunkReader
+{
+    @Nullable
+    private Slice slice;
+
+    public TestingChunkReader(Slice slice)
+    {
+        this.slice = requireNonNull(slice, "slice is null");
+    }
+
+    @Override
+    public Slice read()
+    {
+        return requireNonNull(slice, "slice is null");
+    }
+
+    @Override
+    public long getDiskOffset()
+    {
+        return 0;
+    }
+
+    @Override
+    public void free()
+    {
+        slice = null;
+    }
+
+    public boolean isFreed()
+    {
+        return slice == null;
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestingParquetDataSource.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestingParquetDataSource.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.airlift.slice.Slice;
+import io.trino.parquet.AbstractParquetDataSource;
+import io.trino.parquet.ParquetDataSourceId;
+import io.trino.parquet.ParquetReaderOptions;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static java.lang.Math.toIntExact;
+
+public class TestingParquetDataSource
+        extends AbstractParquetDataSource
+{
+    private final Slice input;
+
+    public TestingParquetDataSource(Slice slice, ParquetReaderOptions options)
+            throws IOException
+    {
+        super(new ParquetDataSourceId(UUID.randomUUID().toString()), slice.length(), options);
+        this.input = slice;
+    }
+
+    @Override
+    protected void readInternal(long position, byte[] buffer, int bufferOffset, int bufferLength)
+            throws IOException
+    {
+        input.getBytes(toIntExact(position), buffer, bufferOffset, bufferLength);
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetReaderConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetReaderConfig.java
@@ -18,6 +18,7 @@ import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.DataSize;
+import io.airlift.units.MinDataSize;
 import io.trino.parquet.ParquetReaderOptions;
 
 import javax.validation.constraints.NotNull;
@@ -73,6 +74,7 @@ public class ParquetReaderConfig
     }
 
     @NotNull
+    @MinDataSize("1MB")
     public DataSize getMaxBufferSize()
     {
         return options.getMaxBufferSize();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestParquetPageSkipping.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestParquetPageSkipping.java
@@ -27,8 +27,7 @@ public class TestParquetPageSkipping
                 .setHiveProperties(
                         ImmutableMap.of(
                                 "parquet.use-column-index", "true",
-                                // Small max-buffer-size allows testing mix of small and large ranges in HdfsParquetDataSource#planRead
-                                "parquet.max-buffer-size", "400B",
+                                "parquet.max-buffer-size", "1MB",
                                 "parquet.optimized-reader.enabled", "false"))
                 .build();
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestParquetPageSkippingWithOptimizedReader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestParquetPageSkippingWithOptimizedReader.java
@@ -27,8 +27,7 @@ public class TestParquetPageSkippingWithOptimizedReader
                 .setHiveProperties(
                         ImmutableMap.of(
                                 "parquet.use-column-index", "true",
-                                // Small max-buffer-size allows testing mix of small and large ranges in HdfsParquetDataSource#planRead
-                                "parquet.max-buffer-size", "400B",
+                                "parquet.max-buffer-size", "1MB",
                                 "parquet.optimized-reader.enabled", "true"))
                 .build();
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetDataSource.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetDataSource.java
@@ -37,7 +37,7 @@ import static io.trino.plugin.hive.HiveTestUtils.HDFS_FILE_SYSTEM_FACTORY;
 import static io.trino.plugin.hive.HiveTestUtils.SESSION;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TestHdfsParquetDataSource
+public class TestParquetDataSource
 {
     @Test(dataProvider = "testPlanReadOrderingProvider")
     public void testPlanReadOrdering(DataSize maxBufferSize)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Currently, `ParquetReader` will read the entire row group at once. This means that:

* `limit N` queries will take longer time than needed because the reader might read hundreds of megabytes before returning a few rows.

* Reader might allocate and read hundreds of megabytes at once. This is problematic because:
  * memory accounting for the reader happens after data is already read and arrays are created. This can lead to OOM and general system instability (e.g. GC) because such allocations will not be accounted for
  * peak memory usage is higher than needed (e.g. GBs vs MBs)

The issue can especially be seen when Parquet row group size is large.

This PR fixes this by reading parquet column chunks in small (8MB by default) pieces.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

* fixes https://github.com/trinodb/trino/issues/5729

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( X) Release notes are required, with the following suggested text:

```markdown
# Hive, Delta, Hudi, Iceberg
* Avoid large memory allocations in parquet reader by limiting the maximum size of reads from file. This improves stability and reduces peak memory requirements. The catalog configuration property `parquet.max-buffer-size` can be used to change the maximum size of reads performed by the parquet reader from the default value of 8MB. ({issue}`15374`)
```
