### PR TITLE
Remove stream partitioning

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
@@ -164,7 +164,6 @@ public class InformationSchemaMetadata
                 tableHandle.getPrefixes().isEmpty() ? TupleDomain.none() : TupleDomain.all(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty(),
                 emptyList());
     }
 

--- a/core/trino-main/src/main/java/io/trino/metadata/TableProperties.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TableProperties.java
@@ -26,7 +26,6 @@ import io.trino.sql.planner.PartitioningHandle;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
@@ -65,12 +64,8 @@ public class TableProperties
                                 Optional.of(catalogHandle),
                                 Optional.of(transaction),
                                 nodePartitioning.getPartitioningHandle()),
-                        nodePartitioning.getPartitioningColumns()));
-    }
-
-    public Optional<Set<ColumnHandle>> getStreamPartitioningColumns()
-    {
-        return tableProperties.getStreamPartitioningColumns();
+                        nodePartitioning.getPartitioningColumns(),
+                        nodePartitioning.isSingleSplitPerPartition()));
     }
 
     public Optional<DiscretePredicates> getDiscretePredicates()
@@ -82,11 +77,13 @@ public class TableProperties
     {
         private final PartitioningHandle partitioningHandle;
         private final List<ColumnHandle> partitioningColumns;
+        private final boolean singleSplitPerPartition;
 
-        public TablePartitioning(PartitioningHandle partitioningHandle, List<ColumnHandle> partitioningColumns)
+        public TablePartitioning(PartitioningHandle partitioningHandle, List<ColumnHandle> partitioningColumns, boolean singleSplitPerPartition)
         {
             this.partitioningHandle = requireNonNull(partitioningHandle, "partitioningHandle is null");
             this.partitioningColumns = ImmutableList.copyOf(requireNonNull(partitioningColumns, "partitioningColumns is null"));
+            this.singleSplitPerPartition = singleSplitPerPartition;
         }
 
         public PartitioningHandle getPartitioningHandle()
@@ -99,6 +96,11 @@ public class TableProperties
             return partitioningColumns;
         }
 
+        public boolean isSingleSplitPerPartition()
+        {
+            return singleSplitPerPartition;
+        }
+
         @Override
         public boolean equals(Object o)
         {
@@ -109,14 +111,15 @@ public class TableProperties
                 return false;
             }
             TablePartitioning that = (TablePartitioning) o;
-            return Objects.equals(partitioningHandle, that.partitioningHandle) &&
+            return singleSplitPerPartition == that.singleSplitPerPartition &&
+                    Objects.equals(partitioningHandle, that.partitioningHandle) &&
                     Objects.equals(partitioningColumns, that.partitioningColumns);
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(partitioningHandle, partitioningColumns);
+            return Objects.hash(partitioningHandle, partitioningColumns, singleSplitPerPartition);
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/Partitioning.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/Partitioning.java
@@ -200,19 +200,6 @@ public final class Partitioning
         return isPartitionedOn(ImmutableSet.of(), knownConstants);
     }
 
-    public boolean isRepartitionEffective(Collection<Symbol> keys, Set<Symbol> knownConstants)
-    {
-        Set<Symbol> keysWithoutConstants = keys.stream()
-                .filter(symbol -> !knownConstants.contains(symbol))
-                .collect(toImmutableSet());
-        Set<Symbol> nonConstantArgs = arguments.stream()
-                .filter(ArgumentBinding::isVariable)
-                .map(ArgumentBinding::getColumn)
-                .filter(symbol -> !knownConstants.contains(symbol))
-                .collect(toImmutableSet());
-        return !nonConstantArgs.equals(keysWithoutConstants);
-    }
-
     public Partitioning translate(Function<Symbol, Symbol> translator)
     {
         return new Partitioning(handle, arguments.stream()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/ActualProperties.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/ActualProperties.java
@@ -149,14 +149,6 @@ public class ActualProperties
         return global.isEffectivelySingleStream(constants.keySet());
     }
 
-    /**
-     * @return true if repartitioning on the keys will yield some difference
-     */
-    public boolean isStreamRepartitionEffective(Collection<Symbol> keys)
-    {
-        return global.isStreamRepartitionEffective(keys, constants.keySet());
-    }
-
     public ActualProperties translate(Function<Symbol, Optional<Symbol>> translator)
     {
         return builder()
@@ -468,14 +460,6 @@ public class ActualProperties
         private boolean isEffectivelySingleStream(Set<Symbol> constants)
         {
             return streamPartitioning.isPresent() && streamPartitioning.get().isEffectivelySinglePartition(constants) && !nullsAndAnyReplicated;
-        }
-
-        /**
-         * @return true if repartitioning on the keys will yield some difference
-         */
-        private boolean isStreamRepartitionEffective(Collection<Symbol> keys, Set<Symbol> constants)
-        {
-            return (streamPartitioning.isEmpty() || streamPartitioning.get().isRepartitionEffective(keys, constants)) && !nullsAndAnyReplicated;
         }
 
         private Global translate(Partitioning.Translator translator)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/ActualProperties.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/ActualProperties.java
@@ -141,12 +141,9 @@ public class ActualProperties
                 session);
     }
 
-    /**
-     * @return true if all the data will effectively land in a single stream
-     */
-    public boolean isEffectivelySingleStream()
+    public boolean isEffectivelySinglePartition()
     {
-        return global.isEffectivelySingleStream(constants.keySet());
+        return global.isEffectivelySinglePartition(constants.keySet());
     }
 
     public ActualProperties translate(Function<Symbol, Optional<Symbol>> translator)
@@ -454,12 +451,9 @@ public class ActualProperties
             return streamPartitioning.isPresent() && streamPartitioning.get().isPartitionedOnExactly(columns, constants) && this.nullsAndAnyReplicated == nullsAndAnyReplicated;
         }
 
-        /**
-         * @return true if all the data will effectively land in a single stream
-         */
-        private boolean isEffectivelySingleStream(Set<Symbol> constants)
+        private boolean isEffectivelySinglePartition(Set<Symbol> constants)
         {
-            return streamPartitioning.isPresent() && streamPartitioning.get().isEffectivelySinglePartition(constants) && !nullsAndAnyReplicated;
+            return nodePartitioning.isPresent() && nodePartitioning.get().isEffectivelySinglePartition(constants) && !nullsAndAnyReplicated;
         }
 
         private Global translate(Partitioning.Translator translator)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
@@ -361,8 +361,7 @@ public class AddExchanges
 
             PlanWithProperties child = node.getSource().accept(this, preferredChildProperties);
 
-            if (child.getProperties().isSingleNode() ||
-                    !isStreamPartitionedOn(child.getProperties(), node.getDistinctSymbols())) {
+            if (child.getProperties().isSingleNode() || !isNodePartitionedOn(child.getProperties(), node.getDistinctSymbols())) {
                 child = withDerivedProperties(
                         partitionedExchange(
                                 idAllocator.getNextId(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PreferredProperties.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PreferredProperties.java
@@ -104,14 +104,6 @@ class PreferredProperties
                 .build();
     }
 
-    public static PreferredProperties undistributedWithLocal(List<? extends LocalProperty<Symbol>> localProperties)
-    {
-        return builder()
-                .global(Global.undistributed())
-                .local(localProperties)
-                .build();
-    }
-
     public static PreferredProperties local(List<? extends LocalProperty<Symbol>> localProperties)
     {
         return builder()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
@@ -99,19 +99,14 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.spi.predicate.TupleDomain.extractFixedValues;
 import static io.trino.sql.planner.SystemPartitioningHandle.ARBITRARY_DISTRIBUTION;
-import static io.trino.sql.planner.SystemPartitioningHandle.COORDINATOR_DISTRIBUTION;
-import static io.trino.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static io.trino.sql.planner.optimizations.ActualProperties.Global.arbitraryPartition;
-import static io.trino.sql.planner.optimizations.ActualProperties.Global.coordinatorSingleStreamPartition;
+import static io.trino.sql.planner.optimizations.ActualProperties.Global.coordinatorSinglePartition;
 import static io.trino.sql.planner.optimizations.ActualProperties.Global.partitionedOn;
-import static io.trino.sql.planner.optimizations.ActualProperties.Global.singleStreamPartition;
-import static io.trino.sql.planner.optimizations.ActualProperties.Global.streamPartitionedOn;
+import static io.trino.sql.planner.optimizations.ActualProperties.Global.singlePartition;
 import static io.trino.sql.planner.plan.ExchangeNode.Scope.LOCAL;
 import static io.trino.sql.planner.plan.ExchangeNode.Scope.REMOTE;
-import static io.trino.sql.planner.plan.ExchangeNode.Type.GATHER;
 import static io.trino.sql.tree.PatternRecognitionRelation.RowsPerMatch.ONE;
 import static io.trino.sql.tree.PatternRecognitionRelation.RowsPerMatch.WINDOW;
 import static io.trino.sql.tree.SkipTo.Position.PAST_LAST;
@@ -196,7 +191,7 @@ public final class PropertyDerivations
         public ActualProperties visitExplainAnalyze(ExplainAnalyzeNode node, List<ActualProperties> inputProperties)
         {
             return ActualProperties.builder()
-                    .global(coordinatorSingleStreamPartition())
+                    .global(coordinatorSinglePartition())
                     .build();
         }
 
@@ -232,7 +227,7 @@ public final class PropertyDerivations
             }
 
             return ActualProperties.builderFrom(properties)
-                    .global(partitionedOn(ARBITRARY_DISTRIBUTION, ImmutableList.of(node.getIdColumn()), Optional.of(ImmutableList.of(node.getIdColumn()))))
+                    .global(partitionedOn(ARBITRARY_DISTRIBUTION, ImmutableList.of(node.getIdColumn())))
                     .local(newLocalProperties.build())
                     .build();
         }
@@ -484,7 +479,7 @@ public final class PropertyDerivations
         public ActualProperties visitStatisticsWriterNode(StatisticsWriterNode node, List<ActualProperties> context)
         {
             return ActualProperties.builder()
-                    .global(coordinatorSingleStreamPartition())
+                    .global(coordinatorSinglePartition())
                     .build();
         }
 
@@ -492,7 +487,7 @@ public final class PropertyDerivations
         public ActualProperties visitTableFinish(TableFinishNode node, List<ActualProperties> inputProperties)
         {
             return ActualProperties.builder()
-                    .global(coordinatorSingleStreamPartition())
+                    .global(coordinatorSinglePartition())
                     .build();
         }
 
@@ -500,7 +495,7 @@ public final class PropertyDerivations
         public ActualProperties visitTableDelete(TableDeleteNode node, List<ActualProperties> context)
         {
             return ActualProperties.builder()
-                    .global(coordinatorSingleStreamPartition())
+                    .global(coordinatorSinglePartition())
                     .build();
         }
 
@@ -511,11 +506,11 @@ public final class PropertyDerivations
 
             if (properties.isCoordinatorOnly()) {
                 return ActualProperties.builder()
-                        .global(coordinatorSingleStreamPartition())
+                        .global(coordinatorSinglePartition())
                         .build();
             }
             return ActualProperties.builder()
-                    .global(properties.isSingleNode() ? singleStreamPartition() : arbitraryPartition())
+                    .global(properties.isSingleNode() ? singlePartition() : arbitraryPartition())
                     .build();
         }
 
@@ -524,7 +519,7 @@ public final class PropertyDerivations
         {
             // metadata operations always run on the coordinator
             return ActualProperties.builder()
-                    .global(coordinatorSingleStreamPartition())
+                    .global(coordinatorSinglePartition())
                     .build();
         }
 
@@ -583,7 +578,7 @@ public final class PropertyDerivations
                         // We can't say anything about the partitioning scheme because any partition of
                         // a hash-partitioned join can produce nulls in case of a lack of matches
                         ActualProperties.builder()
-                                .global(probeProperties.isSingleNode() ? singleStreamPartition() : arbitraryPartition())
+                                .global(probeProperties.isSingleNode() ? singlePartition() : arbitraryPartition())
                                 .build();
             };
         }
@@ -648,7 +643,7 @@ public final class PropertyDerivations
         public ActualProperties visitIndexSource(IndexSourceNode node, List<ActualProperties> context)
         {
             return ActualProperties.builder()
-                    .global(singleStreamPartition())
+                    .global(singlePartition())
                     .build();
         }
 
@@ -713,18 +708,10 @@ public final class PropertyDerivations
                 builder.constants(constants);
 
                 if (inputProperties.stream().anyMatch(ActualProperties::isCoordinatorOnly)) {
-                    builder.global(partitionedOn(
-                            COORDINATOR_DISTRIBUTION,
-                            ImmutableList.of(),
-                            // only gathering local exchange preserves single stream property
-                            node.getType() == GATHER ? Optional.of(ImmutableList.of()) : Optional.empty()));
+                    builder.global(coordinatorSinglePartition());
                 }
                 else if (inputProperties.stream().anyMatch(ActualProperties::isSingleNode)) {
-                    builder.global(partitionedOn(
-                            SINGLE_DISTRIBUTION,
-                            ImmutableList.of(),
-                            // only gathering local exchange preserves single stream property
-                            node.getType() == GATHER ? Optional.of(ImmutableList.of()) : Optional.empty()));
+                    builder.global(singlePartition());
                 }
 
                 return builder.build();
@@ -732,14 +719,12 @@ public final class PropertyDerivations
 
             return switch (node.getType()) {
                 case GATHER -> ActualProperties.builder()
-                        .global(node.getPartitioningScheme().getPartitioning().getHandle().isCoordinatorOnly() ? coordinatorSingleStreamPartition() : singleStreamPartition())
+                        .global(node.getPartitioningScheme().getPartitioning().getHandle().isCoordinatorOnly() ? coordinatorSinglePartition() : singlePartition())
                         .local(localProperties.build())
                         .constants(constants)
                         .build();
                 case REPARTITION -> ActualProperties.builder()
-                        .global(partitionedOn(
-                                node.getPartitioningScheme().getPartitioning(),
-                                Optional.of(node.getPartitioningScheme().getPartitioning()))
+                        .global(partitionedOn(node.getPartitioningScheme().getPartitioning())
                                 .withReplicatedNulls(node.getPartitioningScheme().isReplicateNullsAndAny()))
                         .constants(constants)
                         .build();
@@ -817,7 +802,7 @@ public final class PropertyDerivations
         public ActualProperties visitRefreshMaterializedView(RefreshMaterializedViewNode node, List<ActualProperties> inputProperties)
         {
             return ActualProperties.builder()
-                    .global(coordinatorSingleStreamPartition())
+                    .global(coordinatorSinglePartition())
                     .build();
         }
 
@@ -833,11 +818,11 @@ public final class PropertyDerivations
 
             if (properties.isCoordinatorOnly()) {
                 return ActualProperties.builder()
-                        .global(coordinatorSingleStreamPartition())
+                        .global(coordinatorSinglePartition())
                         .build();
             }
             return ActualProperties.builder()
-                    .global(properties.isSingleNode() ? singleStreamPartition() : arbitraryPartition())
+                    .global(properties.isSingleNode() ? singlePartition() : arbitraryPartition())
                     .build();
         }
 
@@ -871,7 +856,7 @@ public final class PropertyDerivations
         public ActualProperties visitValues(ValuesNode node, List<ActualProperties> context)
         {
             return ActualProperties.builder()
-                    .global(singleStreamPartition())
+                    .global(singlePartition())
                     .build();
         }
 
@@ -898,7 +883,7 @@ public final class PropertyDerivations
             properties.constants(symbolConstants);
 
             // Partitioning properties
-            properties.global(deriveGlobalProperties(node, layout, assignments, globalConstants));
+            properties.global(deriveGlobalProperties(node, layout, assignments));
 
             // Append the global constants onto the local properties to maximize their translation potential
             List<LocalProperty<ColumnHandle>> constantAppendedLocalProperties = ImmutableList.<LocalProperty<ColumnHandle>>builder()
@@ -910,13 +895,8 @@ public final class PropertyDerivations
             return properties.build();
         }
 
-        private Global deriveGlobalProperties(TableScanNode node, TableProperties layout, Map<ColumnHandle, Symbol> assignments, Map<ColumnHandle, NullableValue> constants)
+        private Global deriveGlobalProperties(TableScanNode node, TableProperties layout, Map<ColumnHandle, Symbol> assignments)
         {
-            Optional<List<Symbol>> streamPartitioning = layout.getTablePartitioning()
-                    .filter(TablePartitioning::isSingleSplitPerPartition)
-                    .map(TablePartitioning::getPartitioningColumns)
-                    .flatMap(columns -> translateToNonConstantSymbols(columns, assignments, constants));
-
             if (layout.getTablePartitioning().isPresent() && node.isUseConnectorNodePartitioning()) {
                 TablePartitioning tablePartitioning = layout.getTablePartitioning().get();
                 if (assignments.keySet().containsAll(tablePartitioning.getPartitioningColumns())) {
@@ -924,36 +904,10 @@ public final class PropertyDerivations
                             .map(assignments::get)
                             .collect(toImmutableList());
 
-                    return partitionedOn(tablePartitioning.getPartitioningHandle(), arguments, streamPartitioning);
+                    return partitionedOn(tablePartitioning.getPartitioningHandle(), arguments);
                 }
-            }
-
-            if (streamPartitioning.isPresent()) {
-                return streamPartitionedOn(streamPartitioning.get());
             }
             return arbitraryPartition();
-        }
-
-        private static Optional<List<Symbol>> translateToNonConstantSymbols(
-                List<ColumnHandle> columnHandles,
-                Map<ColumnHandle, Symbol> assignments,
-                Map<ColumnHandle, NullableValue> globalConstants)
-        {
-            // Strip off the constants from the partitioning columns (since those are not required for translation)
-            Set<ColumnHandle> constantsStrippedColumns = columnHandles.stream()
-                    .filter(column -> !globalConstants.containsKey(column))
-                    .collect(toImmutableSet());
-
-            ImmutableSet.Builder<Symbol> builder = ImmutableSet.builder();
-            for (ColumnHandle column : constantsStrippedColumns) {
-                Symbol translated = assignments.get(column);
-                if (translated == null) {
-                    return Optional.empty();
-                }
-                builder.add(translated);
-            }
-
-            return Optional.of(ImmutableList.copyOf(builder.build()));
         }
 
         private static Map<Symbol, Symbol> computeIdentityTranslations(Map<Symbol, Expression> assignments)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
@@ -907,7 +907,9 @@ public final class PropertyDerivations
 
         private Global deriveGlobalProperties(TableScanNode node, TableProperties layout, Map<ColumnHandle, Symbol> assignments, Map<ColumnHandle, NullableValue> constants)
         {
-            Optional<List<Symbol>> streamPartitioning = layout.getStreamPartitioningColumns()
+            Optional<List<Symbol>> streamPartitioning = layout.getTablePartitioning()
+                    .filter(TablePartitioning::isSingleSplitPerPartition)
+                    .map(TablePartitioning::getPartitioningColumns)
                     .flatMap(columns -> translateToNonConstantSymbols(columns, assignments, constants));
 
             if (layout.getTablePartitioning().isPresent() && node.isUseConnectorNodePartitioning()) {
@@ -928,7 +930,7 @@ public final class PropertyDerivations
         }
 
         private static Optional<List<Symbol>> translateToNonConstantSymbols(
-                Set<ColumnHandle> columnHandles,
+                List<ColumnHandle> columnHandles,
                 Map<ColumnHandle, Symbol> assignments,
                 Map<ColumnHandle, NullableValue> globalConstants)
         {

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestEffectivePredicateExtractor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestEffectivePredicateExtractor.java
@@ -171,7 +171,6 @@ public class TestEffectivePredicateExtractor
                             ((PredicatedTableHandle) handle.getConnectorHandle()).getPredicate(),
                             Optional.empty(),
                             Optional.empty(),
-                            Optional.empty(),
                             ImmutableList.of()));
         }
     };

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestTableScanNodePartitioning.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestTableScanNodePartitioning.java
@@ -190,7 +190,6 @@ public class TestTableScanNodePartitioning
                                 TupleDomain.all(),
                                 Optional.of(new ConnectorTablePartitioning(PARTITIONING_HANDLE, ImmutableList.of(COLUMN_HANDLE_A))),
                                 Optional.empty(),
-                                Optional.empty(),
                                 ImmutableList.of());
                     }
                     if (tableName.equals(SINGLE_BUCKET_TABLE)) {
@@ -198,14 +197,12 @@ public class TestTableScanNodePartitioning
                                 TupleDomain.all(),
                                 Optional.of(new ConnectorTablePartitioning(SINGLE_BUCKET_HANDLE, ImmutableList.of(COLUMN_HANDLE_A))),
                                 Optional.empty(),
-                                Optional.empty(),
                                 ImmutableList.of());
                     }
                     if (tableName.equals(FIXED_PARTITIONED_TABLE)) {
                         return new ConnectorTableProperties(
                                 TupleDomain.all(),
                                 Optional.of(new ConnectorTablePartitioning(FIXED_PARTITIONING_HANDLE, ImmutableList.of(COLUMN_HANDLE_A))),
-                                Optional.empty(),
                                 Optional.empty(),
                                 ImmutableList.of());
                     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateIntoTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateIntoTableScan.java
@@ -396,7 +396,6 @@ public class TestPushPredicateIntoTableScan
                                 TupleDomain.all(),
                                 Optional.of(new ConnectorTablePartitioning(PARTITIONING_HANDLE, ImmutableList.of(MOCK_COLUMN_HANDLE))),
                                 Optional.empty(),
-                                Optional.empty(),
                                 ImmutableList.of());
                     }
                     return new ConnectorTableProperties();

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushProjectionIntoTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushProjectionIntoTableScan.java
@@ -259,7 +259,6 @@ public class TestPushProjectionIntoTableScan
                                 TupleDomain.all(),
                                 Optional.of(new ConnectorTablePartitioning(PARTITIONING_HANDLE, ImmutableList.of(column("col", VARCHAR)))),
                                 Optional.empty(),
-                                Optional.empty(),
                                 ImmutableList.of());
                     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestColocatedJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestColocatedJoin.java
@@ -90,7 +90,6 @@ public class TestColocatedJoin
                                 PARTITIONING_HANDLE,
                                 ImmutableList.of(new MockConnectorColumnHandle(COLUMN_A, BIGINT)))),
                         Optional.empty(),
-                        Optional.empty(),
                         ImmutableList.of()))
                 .build();
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestPartialTopNWithPresortedInput.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestPartialTopNWithPresortedInput.java
@@ -93,7 +93,6 @@ public class TestPartialTopNWithPresortedInput
                                 TupleDomain.all(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                Optional.empty(),
                                 ImmutableList.of(new SortingProperty<>(columnHandleA, ASC_NULLS_FIRST)));
                     }
                     else if (tableHandle.getTableName().equals(nestedField)) {

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveEmptyUnionBranches.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveEmptyUnionBranches.java
@@ -121,7 +121,7 @@ public class TestRemoveEmptyUnionBranches
                         .collect(toImmutableList()))
                 .withGetTableProperties((session, handle) -> {
                     MockConnectorTableHandle table = (MockConnectorTableHandle) handle;
-                    return new ConnectorTableProperties(table.getConstraint(), Optional.empty(), Optional.empty(), Optional.empty(), emptyList());
+                    return new ConnectorTableProperties(table.getConstraint(), Optional.empty(), Optional.empty(), emptyList());
                 })
                 .withApplyFilter(applyFilter())
                 .withName(catalogHandle)

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -254,6 +254,18 @@
                                     <old>method void io.trino.spi.connector.MaterializedViewFreshness::&lt;init&gt;(boolean)</old>
                                     <new>method void io.trino.spi.connector.MaterializedViewFreshness::&lt;init&gt;(io.trino.spi.connector.MaterializedViewFreshness.Freshness, java.util.Optional&lt;java.time.Instant&gt;)</new>
                                 </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method java.util.Optional&lt;java.util.Set&lt;io.trino.spi.connector.ColumnHandle&gt;&gt; io.trino.spi.connector.ConnectorTableProperties::getStreamPartitioningColumns()</old>
+                                    <justification>Replaced with the ConnectorTablePartitioning#singleSplitPerPartition. Soft migration is not straightforward.</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method void io.trino.spi.connector.ConnectorTableProperties::&lt;init&gt;(io.trino.spi.predicate.TupleDomain&lt;io.trino.spi.connector.ColumnHandle&gt;, java.util.Optional&lt;io.trino.spi.connector.ConnectorTablePartitioning&gt;, java.util.Optional&lt;java.util.Set&lt;io.trino.spi.connector.ColumnHandle&gt;&gt;, java.util.Optional&lt;io.trino.spi.connector.DiscretePredicates&gt;, java.util.List&lt;io.trino.spi.connector.LocalProperty&lt;io.trino.spi.connector.ColumnHandle&gt;&gt;)</old>
+                                    <new>method void io.trino.spi.connector.ConnectorTableProperties::&lt;init&gt;(io.trino.spi.predicate.TupleDomain&lt;io.trino.spi.connector.ColumnHandle&gt;, java.util.Optional&lt;io.trino.spi.connector.ConnectorTablePartitioning&gt;, java.util.Optional&lt;io.trino.spi.connector.DiscretePredicates&gt;, java.util.List&lt;io.trino.spi.connector.LocalProperty&lt;io.trino.spi.connector.ColumnHandle&gt;&gt;)</new>
+                                    <justification>Replaced with the ConnectorTablePartitioning#singleSplitPerPartition. Soft migration is not straightforward.</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTablePartitioning.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTablePartitioning.java
@@ -49,11 +49,18 @@ public class ConnectorTablePartitioning
 {
     private final ConnectorPartitioningHandle partitioningHandle;
     private final List<ColumnHandle> partitioningColumns;
+    private final boolean singleSplitPerPartition;
 
     public ConnectorTablePartitioning(ConnectorPartitioningHandle partitioningHandle, List<ColumnHandle> partitioningColumns)
     {
+        this(partitioningHandle, partitioningColumns, false);
+    }
+
+    public ConnectorTablePartitioning(ConnectorPartitioningHandle partitioningHandle, List<ColumnHandle> partitioningColumns, boolean singleSplitPerPartition)
+    {
         this.partitioningHandle = requireNonNull(partitioningHandle, "partitioningHandle is null");
         this.partitioningColumns = List.copyOf(requireNonNull(partitioningColumns, "partitioningColumns is null"));
+        this.singleSplitPerPartition = singleSplitPerPartition;
     }
 
     /**
@@ -76,6 +83,11 @@ public class ConnectorTablePartitioning
         return partitioningColumns;
     }
 
+    public boolean isSingleSplitPerPartition()
+    {
+        return singleSplitPerPartition;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -86,13 +98,14 @@ public class ConnectorTablePartitioning
             return false;
         }
         ConnectorTablePartitioning that = (ConnectorTablePartitioning) o;
-        return Objects.equals(partitioningHandle, that.partitioningHandle) &&
+        return singleSplitPerPartition == that.singleSplitPerPartition &&
+                Objects.equals(partitioningHandle, that.partitioningHandle) &&
                 Objects.equals(partitioningColumns, that.partitioningColumns);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(partitioningHandle, partitioningColumns);
+        return Objects.hash(partitioningHandle, partitioningColumns, singleSplitPerPartition);
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableProperties.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableProperties.java
@@ -18,7 +18,6 @@ import io.trino.spi.predicate.TupleDomain;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
@@ -27,30 +26,26 @@ public class ConnectorTableProperties
 {
     private final TupleDomain<ColumnHandle> predicate;
     private final Optional<ConnectorTablePartitioning> tablePartitioning;
-    private final Optional<Set<ColumnHandle>> streamPartitioningColumns;
     private final Optional<DiscretePredicates> discretePredicates;
     private final List<LocalProperty<ColumnHandle>> localProperties;
 
     public ConnectorTableProperties()
     {
-        this(TupleDomain.all(), Optional.empty(), Optional.empty(), Optional.empty(), emptyList());
+        this(TupleDomain.all(), Optional.empty(), Optional.empty(), emptyList());
     }
 
     public ConnectorTableProperties(
             TupleDomain<ColumnHandle> predicate,
             Optional<ConnectorTablePartitioning> tablePartitioning,
-            Optional<Set<ColumnHandle>> streamPartitioningColumns,
             Optional<DiscretePredicates> discretePredicates,
             List<LocalProperty<ColumnHandle>> localProperties)
     {
-        requireNonNull(streamPartitioningColumns, "streamPartitioningColumns is null");
         requireNonNull(tablePartitioning, "tablePartitioning is null");
         requireNonNull(predicate, "predicate is null");
         requireNonNull(discretePredicates, "discretePredicates is null");
         requireNonNull(localProperties, "localProperties is null");
 
         this.tablePartitioning = tablePartitioning;
-        this.streamPartitioningColumns = streamPartitioningColumns;
         this.predicate = predicate;
         this.discretePredicates = discretePredicates;
         this.localProperties = localProperties;
@@ -79,20 +74,6 @@ public class ConnectorTableProperties
     }
 
     /**
-     * The partitioning for the table streams.
-     * If empty, the table layout is partitioned arbitrarily.
-     * Otherwise, table steams are partitioned on the given set of columns (or unpartitioned, if the set is empty)
-     * <p>
-     * If the table is partitioned, the connector guarantees that each combination of values for
-     * the partition columns will be contained within a single split (i.e., partitions cannot
-     * straddle multiple splits)
-     */
-    public Optional<Set<ColumnHandle>> getStreamPartitioningColumns()
-    {
-        return streamPartitioningColumns;
-    }
-
-    /**
      * A collection of discrete predicates describing the data in this layout. The union of
      * these predicates is expected to be equivalent to the overall predicate returned
      * by {@link #getPredicate()}. They may be used by the engine for further optimizations.
@@ -113,7 +94,7 @@ public class ConnectorTableProperties
     @Override
     public int hashCode()
     {
-        return Objects.hash(predicate, discretePredicates, streamPartitioningColumns, tablePartitioning, localProperties);
+        return Objects.hash(predicate, discretePredicates, tablePartitioning, localProperties);
     }
 
     @Override
@@ -128,7 +109,6 @@ public class ConnectorTableProperties
         ConnectorTableProperties other = (ConnectorTableProperties) obj;
         return Objects.equals(this.predicate, other.predicate)
                 && Objects.equals(this.discretePredicates, other.discretePredicates)
-                && Objects.equals(this.streamPartitioningColumns, other.streamPartitioningColumns)
                 && Objects.equals(this.tablePartitioning, other.tablePartitioning)
                 && Objects.equals(this.localProperties, other.localProperties);
     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -450,7 +450,6 @@ public class DeltaLakeMetadata
                         .transformKeys(ColumnHandle.class::cast),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty(),
                 ImmutableList.of());
     }
 

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
@@ -460,7 +460,6 @@ public class ElasticsearchMetadata
                 handle.getConstraint(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty(),
                 ImmutableList.of());
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -2877,7 +2877,6 @@ public class HiveMetadata
         return new ConnectorTableProperties(
                 predicate,
                 tablePartitioning,
-                Optional.empty(),
                 discretePredicates,
                 sortingProperties);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -765,7 +765,6 @@ public abstract class AbstractTestHive
                         fileFormatColumn, Domain.create(ValueSet.ofRanges(Range.equal(createUnboundedVarcharType(), utf8Slice("textfile")), Range.equal(createUnboundedVarcharType(), utf8Slice("sequencefile")), Range.equal(createUnboundedVarcharType(), utf8Slice("rctext")), Range.equal(createUnboundedVarcharType(), utf8Slice("rcbinary"))), false),
                         dummyColumn, Domain.create(ValueSet.ofRanges(Range.equal(INTEGER, 1L), Range.equal(INTEGER, 2L), Range.equal(INTEGER, 3L), Range.equal(INTEGER, 4L)), false))),
                 Optional.empty(),
-                Optional.empty(),
                 Optional.of(new DiscretePredicates(partitionColumns, ImmutableList.of(
                         TupleDomain.withColumnDomains(ImmutableMap.of(
                                 dsColumn, Domain.create(ValueSet.ofRanges(Range.equal(createUnboundedVarcharType(), utf8Slice("2012-12-29"))), false),
@@ -1356,7 +1355,6 @@ public abstract class AbstractTestHive
             assertEquals(actual.getColumns(), expected.getColumns());
             assertEqualsIgnoreOrder(actual.getPredicates(), expected.getPredicates());
         });
-        assertEquals(actualProperties.getStreamPartitioningColumns(), expectedProperties.getStreamPartitioningColumns());
         assertEquals(actualProperties.getLocalProperties(), expectedProperties.getLocalProperties());
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -495,7 +495,7 @@ public class IcebergMetadata
         if (table.getSnapshotId().isEmpty()) {
             // A table with missing snapshot id produces no splits, so we optimize here by returning
             // TupleDomain.none() as the predicate
-            return new ConnectorTableProperties(TupleDomain.none(), Optional.empty(), Optional.empty(), Optional.empty(), ImmutableList.of());
+            return new ConnectorTableProperties(TupleDomain.none(), Optional.empty(), Optional.empty(), ImmutableList.of());
         }
 
         Table icebergTable = catalog.loadTable(session, table.getSchemaTableName());
@@ -561,7 +561,6 @@ public class IcebergMetadata
                 // over all tableScan.planFiles() and caching partition values in table handle.
                 enforcedPredicate.transformKeys(ColumnHandle.class::cast),
                 // TODO: implement table partitioning
-                Optional.empty(),
                 Optional.empty(),
                 Optional.ofNullable(discretePredicates),
                 ImmutableList.of());

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
@@ -66,7 +66,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
-import java.util.Set;
 import java.util.function.Consumer;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -438,13 +437,11 @@ public class KuduMetadata
         KuduTableHandle handle = (KuduTableHandle) table;
 
         Optional<ConnectorTablePartitioning> tablePartitioning = Optional.empty();
-        Optional<Set<ColumnHandle>> partitioningColumns = Optional.empty();
         List<LocalProperty<ColumnHandle>> localProperties = ImmutableList.of();
 
         return new ConnectorTableProperties(
                 handle.getConstraint(),
                 tablePartitioning,
-                partitioningColumns,
                 Optional.empty(),
                 localProperties);
     }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
@@ -511,7 +511,6 @@ public class MongoMetadata
     {
         MongoTableHandle tableHandle = (MongoTableHandle) table;
 
-        Optional<Set<ColumnHandle>> partitioningColumns = Optional.empty(); //TODO: sharding key
         ImmutableList.Builder<LocalProperty<ColumnHandle>> localProperties = ImmutableList.builder();
 
         MongoTable tableInfo = mongoSession.getTable(tableHandle.getSchemaTableName());
@@ -531,7 +530,6 @@ public class MongoMetadata
         return new ConnectorTableProperties(
                 TupleDomain.all(),
                 Optional.empty(),
-                partitioningColumns,
                 Optional.empty(),
                 localProperties.build());
     }

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
@@ -118,7 +118,7 @@ public class PhoenixMetadata
                         .collect(toImmutableList()))
                 .orElse(ImmutableList.of());
 
-        return new ConnectorTableProperties(TupleDomain.all(), Optional.empty(), Optional.empty(), Optional.empty(), sortingProperties);
+        return new ConnectorTableProperties(TupleDomain.all(), Optional.empty(), Optional.empty(), sortingProperties);
     }
 
     @Override

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorMetadata.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorMetadata.java
@@ -349,8 +349,8 @@ public class RaptorMetadata
                 TupleDomain.all(),
                 Optional.of(new ConnectorTablePartitioning(
                         partitioning,
-                        ImmutableList.copyOf(bucketColumnHandles))),
-                oneSplitPerBucket ? Optional.of(ImmutableSet.copyOf(bucketColumnHandles)) : Optional.empty(),
+                        ImmutableList.copyOf(bucketColumnHandles),
+                        oneSplitPerBucket)),
                 Optional.empty(),
                 ImmutableList.of());
     }

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchMetadata.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchMetadata.java
@@ -422,7 +422,6 @@ public class TpchMetadata
         TpchTableHandle tableHandle = (TpchTableHandle) table;
 
         Optional<ConnectorTablePartitioning> tablePartitioning = Optional.empty();
-        Optional<Set<ColumnHandle>> partitioningColumns = Optional.empty();
         List<LocalProperty<ColumnHandle>> localProperties = ImmutableList.of();
 
         Map<String, ColumnHandle> columns = getColumnHandles(session, tableHandle);
@@ -432,8 +431,8 @@ public class TpchMetadata
                     new TpchPartitioningHandle(
                             TpchTable.ORDERS.getTableName(),
                             calculateTotalRows(OrderGenerator.SCALE_BASE, tableHandle.getScaleFactor())),
-                    ImmutableList.of(orderKeyColumn)));
-            partitioningColumns = Optional.of(ImmutableSet.of(orderKeyColumn));
+                    ImmutableList.of(orderKeyColumn),
+                    true));
             localProperties = ImmutableList.of(new SortingProperty<>(orderKeyColumn, SortOrder.ASC_NULLS_FIRST));
         }
         else if (partitioningEnabled && tableHandle.getTableName().equals(TpchTable.LINE_ITEM.getTableName())) {
@@ -442,8 +441,8 @@ public class TpchMetadata
                     new TpchPartitioningHandle(
                             TpchTable.ORDERS.getTableName(),
                             calculateTotalRows(OrderGenerator.SCALE_BASE, tableHandle.getScaleFactor())),
-                    ImmutableList.of(orderKeyColumn)));
-            partitioningColumns = Optional.of(ImmutableSet.of(orderKeyColumn));
+                    ImmutableList.of(orderKeyColumn),
+                    true));
             localProperties = ImmutableList.of(
                     new SortingProperty<>(orderKeyColumn, SortOrder.ASC_NULLS_FIRST),
                     new SortingProperty<>(columns.get(columnNaming.getName(LineItemColumn.LINE_NUMBER)), SortOrder.ASC_NULLS_FIRST));
@@ -466,7 +465,6 @@ public class TpchMetadata
         return new ConnectorTableProperties(
                 constraint,
                 tablePartitioning,
-                partitioningColumns,
                 Optional.empty(),
                 localProperties);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Remove stream partitioning in favor of `StreamPropertyDeriviations`. Further down the road the plan is to merge `PropertyDeriviations` and `StreamPropertyDeriviation` into a single thing that can do both and use it for both, `AddExchanges` and `AddLocalExchanges`.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
