### PR TITLE
Disable preventive GC

### DIFF
--- a/core/docker/default/etc/jvm.config
+++ b/core/docker/default/etc/jvm.config
@@ -15,3 +15,5 @@
 # Improve AES performance for S3, etc. on ARM64 (JDK-8271567)
 -XX:+UnlockDiagnosticVMOptions
 -XX:+UseAESCTRIntrinsics
+# Disable Preventive GC for performance reasons (JDK-8293861)
+-XX:-G1UsePreventiveGC

--- a/core/trino-server-rpm/src/main/resources/dist/config/jvm.config
+++ b/core/trino-server-rpm/src/main/resources/dist/config/jvm.config
@@ -14,3 +14,5 @@
 # Improve AES performance for S3, etc. on ARM64 (JDK-8271567)
 -XX:+UnlockDiagnosticVMOptions
 -XX:+UseAESCTRIntrinsics
+# Disable Preventive GC for performance reasons (JDK-8293861)
+-XX:-G1UsePreventiveGC

--- a/docs/src/main/sphinx/installation/deployment.rst
+++ b/docs/src/main/sphinx/installation/deployment.rst
@@ -143,6 +143,8 @@ The following provides a good starting point for creating ``etc/jvm.config``:
     -Djdk.nio.maxCachedBufferSize=2000000
     -XX:+UnlockDiagnosticVMOptions
     -XX:+UseAESCTRIntrinsics
+    # Disable Preventive GC for performance reasons (JDK-8293861)
+    -XX:-G1UsePreventiveGC
 
 Because an ``OutOfMemoryError`` typically leaves the JVM in an
 inconsistent state, we write a heap dump, for debugging, and forcibly
@@ -156,6 +158,7 @@ temporary directory by adding ``-Djava.io.tmpdir=/path/to/other/tmpdir`` to the
 list of JVM options.
 
 We enable ``-XX:+UnlockDiagnosticVMOptions`` and ``-XX:+UseAESCTRIntrinsics`` to improve AES performance for S3, etc. on ARM64 (`JDK-8271567 <https://bugs.openjdk.java.net/browse/JDK-8271567>`_)
+We disable Preventive GC (``-XX:-G1UsePreventiveGC``) for performance reasons (see `JDK-8293861 <https://bugs.openjdk.org/browse/JDK-8293861>`_)
 
 .. _config_properties:
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Preventive GC was added in 17, but has issues so JDK 20 disables it by default (plans to [completely remove it in JDK 21](https://bugs.openjdk.org/browse/JDK-8297639))
Users should be aware that until Trino uses java 20+, they should not use preventive GC as it could lead to unexpected OOM
- close https://github.com/trinodb/trino/issues/15379

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

- https://trinodb.slack.com/archives/C01TEP0HJTH/p1670817191607989

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
