### PR TITLE
Add metric that measures distribution of utilization of `DirectExchangeBuffer`

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
@@ -27,6 +27,7 @@ import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
+import io.airlift.stats.TDigest;
 import io.airlift.units.DataSize;
 import io.trino.exchange.ExchangeManagerRegistry;
 import io.trino.execution.StageId;
@@ -413,6 +414,13 @@ public class DeduplicatingDirectExchangeBuffer
     public int getSpilledPageCount()
     {
         return pageBuffer.getSpilledPageCount();
+    }
+
+    @Override
+    public TDigest getBufferUtilization()
+    {
+        // this buffer is always ready to accept more data therefore utilization of that buffer is always near to 0.
+        return new TDigest();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/DirectExchangeBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DirectExchangeBuffer.java
@@ -15,6 +15,7 @@ package io.trino.operator;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.slice.Slice;
+import io.airlift.stats.TDigest;
 import io.trino.execution.TaskId;
 
 import java.io.Closeable;
@@ -57,6 +58,8 @@ public interface DirectExchangeBuffer
     long getSpilledBytes();
 
     int getSpilledPageCount();
+
+    TDigest getBufferUtilization();
 
     @Override
     void close();

--- a/core/trino-main/src/main/java/io/trino/operator/DirectExchangeClient.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DirectExchangeClient.java
@@ -148,7 +148,8 @@ public class DirectExchangeClient
                     buffer.getSpilledBytes(),
                     noMoreLocations,
                     pageBufferClientStatus,
-                    new TDigestHistogram(TDigest.copyOf(requestDuration)));
+                    new TDigestHistogram(TDigest.copyOf(requestDuration)),
+                    new TDigestHistogram(TDigest.copyOf(buffer.getBufferUtilization())));
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/DirectExchangeClientStatus.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DirectExchangeClientStatus.java
@@ -37,6 +37,7 @@ public class DirectExchangeClientStatus
     private final boolean noMoreLocations;
     private final List<PageBufferClientStatus> pageBufferClientStatuses;
     private final TDigestHistogram requestDuration;
+    private final TDigestHistogram bufferUtilization;
 
     @JsonCreator
     public DirectExchangeClientStatus(
@@ -49,7 +50,8 @@ public class DirectExchangeClientStatus
             @JsonProperty("spilledBytes") long spilledBytes,
             @JsonProperty("noMoreLocations") boolean noMoreLocations,
             @JsonProperty("pageBufferClientStatuses") List<PageBufferClientStatus> pageBufferClientStatuses,
-            @JsonProperty("requestDuration") TDigestHistogram requestDuration)
+            @JsonProperty("requestDuration") TDigestHistogram requestDuration,
+            @JsonProperty("bufferUtilization") TDigestHistogram bufferUtilization)
     {
         this.bufferedBytes = bufferedBytes;
         this.maxBufferedBytes = maxBufferedBytes;
@@ -61,6 +63,7 @@ public class DirectExchangeClientStatus
         this.noMoreLocations = noMoreLocations;
         this.pageBufferClientStatuses = ImmutableList.copyOf(requireNonNull(pageBufferClientStatuses, "pageBufferClientStatuses is null"));
         this.requestDuration = requireNonNull(requestDuration, "requestsDuration is null");
+        this.bufferUtilization = requireNonNull(bufferUtilization, "bufferUtilization is null");
     }
 
     @JsonProperty
@@ -97,6 +100,12 @@ public class DirectExchangeClientStatus
     public int getSpilledPages()
     {
         return spilledPages;
+    }
+
+    @JsonProperty
+    public TDigestHistogram getBufferUtilization()
+    {
+        return bufferUtilization;
     }
 
     @JsonProperty
@@ -143,6 +152,7 @@ public class DirectExchangeClientStatus
                 .add("noMoreLocations", noMoreLocations)
                 .add("pageBufferClientStatuses", pageBufferClientStatuses)
                 .add("requestDuration", requestDuration)
+                .add("bufferUtilization", bufferUtilization)
                 .toString();
     }
 
@@ -159,7 +169,8 @@ public class DirectExchangeClientStatus
                 spilledBytes + other.spilledBytes,
                 noMoreLocations && other.noMoreLocations, // if at least one has some locations, mergee has some too
                 ImmutableList.of(), // pageBufferClientStatuses may be long, so we don't want to combine the lists
-                requestDuration.mergeWith(other.requestDuration)); // this is correct as long as all clients have the same shape of histogram
+                requestDuration.mergeWith(other.requestDuration), // this is correct as long as all clients have the same shape of histogram
+                bufferUtilization.mergeWith(other.bufferUtilization)); // this is correct as long as all clients have the same shape of histogram
     }
 
     private static long mergeAvgs(long value1, long count1, long value2, long count2)

--- a/core/trino-main/src/test/java/io/trino/operator/TestingDirectExchangeBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestingDirectExchangeBuffer.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.slice.Slice;
+import io.airlift.stats.TDigest;
 import io.airlift.units.DataSize;
 import io.trino.execution.TaskId;
 
@@ -192,6 +193,12 @@ public class TestingDirectExchangeBuffer
     public int getSpilledPageCount()
     {
         return 0;
+    }
+
+    @Override
+    public TDigest getBufferUtilization()
+    {
+        return new TDigest();
     }
 
     @Override


### PR DESCRIPTION
## Description
It adds the metric that measures distribution of utilization of the `DirectExchangeBuffer` buffer. It was found that it could be very useful during investigation.

There is no regression in throughtput benchmarks.

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

