### PR TITLE
Add safe expressions evaluator for EqualityInference

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/EqualityInference.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/EqualityInference.java
@@ -44,6 +44,7 @@ import static io.trino.sql.ExpressionUtils.extractConjuncts;
 import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
 import static io.trino.sql.planner.ExpressionNodeInliner.replaceExpression;
 import static io.trino.sql.planner.NullabilityAnalyzer.mayReturnNullOnNonNullInput;
+import static io.trino.sql.planner.SafeExpressionEvaluator.isSafeExpression;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -184,7 +185,10 @@ public class EqualityInference
             ComparisonExpression comparison = (ComparisonExpression) expression;
             if (comparison.getOperator() == ComparisonExpression.Operator.EQUAL) {
                 // We should only consider equalities that have distinct left and right components
-                return !comparison.getLeft().equals(comparison.getRight());
+                if (comparison.getLeft().equals(comparison.getRight())) {
+                    return false;
+                }
+                return isSafeExpression(comparison.getLeft()) && isSafeExpression(comparison.getRight());
             }
         }
         return false;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/SafeExpressionEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SafeExpressionEvaluator.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import io.trino.sql.tree.ArithmeticBinaryExpression;
+import io.trino.sql.tree.ArithmeticUnaryExpression;
+import io.trino.sql.tree.Cast;
+import io.trino.sql.tree.DefaultExpressionTraversalVisitor;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.FunctionCall;
+import io.trino.sql.tree.LambdaExpression;
+import io.trino.sql.tree.TryExpression;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Determines whether a given Expression is safe (aka. exception-free)
+ */
+public final class SafeExpressionEvaluator
+{
+    private SafeExpressionEvaluator() {}
+
+    public static boolean isSafeExpression(Expression expression)
+    {
+        requireNonNull(expression, "expression is null");
+
+        AtomicBoolean result = new AtomicBoolean(true);
+        new Visitor().process(expression, result);
+        return result.get();
+    }
+
+    private static class Visitor
+            extends DefaultExpressionTraversalVisitor<AtomicBoolean>
+    {
+        public Visitor() {}
+
+        @Override
+        protected Void visitCast(Cast node, AtomicBoolean result)
+        {
+            result.set(false);
+            return null;
+        }
+
+        @Override
+        protected Void visitArithmeticBinary(ArithmeticBinaryExpression node, AtomicBoolean result)
+        {
+            // May cause overflow, underflow or division by zero
+            result.set(false);
+            return null;
+        }
+
+        @Override
+        protected Void visitArithmeticUnary(ArithmeticUnaryExpression node, AtomicBoolean result)
+        {
+            result.set(false);
+            return null;
+        }
+
+        @Override
+        protected Void visitTryExpression(TryExpression node, AtomicBoolean result)
+        {
+            result.set(false);
+            return null;
+        }
+
+        @Override
+        protected Void visitLambdaExpression(LambdaExpression node, AtomicBoolean result)
+        {
+            result.set(false);
+            return null;
+        }
+
+        @Override
+        protected Void visitFunctionCall(FunctionCall node, AtomicBoolean result)
+        {
+            // By default all functions are not safe
+            result.set(false);
+            return null;
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestSafeExpressionEvaluator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestSafeExpressionEvaluator.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.spi.type.Type;
+import io.trino.sql.tree.ArithmeticBinaryExpression;
+import io.trino.sql.tree.ArithmeticUnaryExpression;
+import io.trino.sql.tree.Cast;
+import io.trino.sql.tree.ComparisonExpression;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.FunctionCall;
+import io.trino.sql.tree.GenericLiteral;
+import io.trino.sql.tree.Identifier;
+import io.trino.sql.tree.InPredicate;
+import io.trino.sql.tree.LambdaExpression;
+import io.trino.sql.tree.LongLiteral;
+import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.SymbolReference;
+import io.trino.sql.tree.TryExpression;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.sql.analyzer.TypeSignatureTranslator.toSqlType;
+import static io.trino.sql.planner.SafeExpressionEvaluator.isSafeExpression;
+import static io.trino.sql.tree.ArithmeticUnaryExpression.Sign.MINUS;
+import static io.trino.sql.tree.ComparisonExpression.Operator.EQUAL;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestSafeExpressionEvaluator
+{
+    private static final TestingFunctionResolution functionResolution = new TestingFunctionResolution();
+
+    @Test
+    public void testSanity()
+    {
+        assertTrue(isSafeExpression(new ComparisonExpression(EQUAL, new LongLiteral("1"), new LongLiteral("2"))));
+        assertTrue(isSafeExpression(new InPredicate(new SymbolReference("value"), new SymbolReference("element"))));
+
+        assertFalse(isSafeExpression(new Cast(new GenericLiteral("CHAR", "a"), toSqlType(REAL))));
+        assertFalse(isSafeExpression(new ArithmeticUnaryExpression(MINUS, new SymbolReference("c1"))));
+        assertFalse(isSafeExpression(new ArithmeticBinaryExpression(ArithmeticBinaryExpression.Operator.ADD, new LongLiteral("1"), new LongLiteral("2"))));
+        assertFalse(isSafeExpression(new TryExpression(new LongLiteral("1"))));
+        assertFalse(isSafeExpression(new LambdaExpression(ImmutableList.of(), new Identifier("x"))));
+        assertFalse(isSafeExpression(function("typeof", ImmutableList.of(REAL), ImmutableList.of(function("rand")))));
+
+        assertFalse(isSafeExpression(new ComparisonExpression(EQUAL, new ArithmeticUnaryExpression(MINUS, new SymbolReference("c1")), new LongLiteral("2"))));
+    }
+
+    private FunctionCall function(String name)
+    {
+        return function(name, ImmutableList.of(), ImmutableList.of());
+    }
+
+    private FunctionCall function(String name, List<Type> types, List<Expression> arguments)
+    {
+        return functionResolution
+                .functionCallBuilder(QualifiedName.of(name))
+                .setArguments(types, arguments)
+                .build();
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
There is a query correctness issue when a predicate from outer query is improperly handled in PredicatePushDown, specifically in EqualityInference. For example, below query will cause Division by zero exception, while it shouldn't based on the SQL semantic.
```
SELECT * FROM
   (SELECT n.nationkey, r.regionkey FROM nation n, region r WHERE least(n.regionkey, r.regionkey) > 0) T
WHERE nationkey/regionkey = 1;
```
The solution is to introduce a "SafeExpressionEvaluator". Here "safe" means that the predicate is free from failure or exception, so that it won't bring any side-effect to the query and can be safely rearranged.

Plan before fix
```
 Output[columnNames = [nationkey, regionkey]]
 │   Layout: [nationkey:bigint, regionkey_1:bigint]
 │   Estimates: {rows: 0 (0B), cpu: 0, memory: 0B, network: 0B}
 │   regionkey := regionkey_1
 └─ FilterProject[filterPredicate = ((("nationkey" / "regionkey_1") = BIGINT '1') AND (least("regionkey", "regionkey_1") > BIGINT '0'))]
    │   Layout: [nationkey:bigint, regionkey_1:bigint]
    │   Estimates: {rows: 0 (0B), cpu: 3.30k, memory: 0B, network: 0B}/{rows: 0 (0B), cpu: 0, memory: 0B, network: 0B}
    └─ CrossJoin[]
       │   Layout: [nationkey:bigint, regionkey:bigint, regionkey_1:bigint]
       │   Estimates: {rows: 125 (3.30kB), cpu: 3.78k, memory: 45B, network: 0B}
       │   Distribution: REPLICATED
       ├─ TableScan[table = tpch:sf1:nation]
       │      Layout: [nationkey:bigint, regionkey:bigint]
       │      Estimates: {rows: 25 (450B), cpu: 450, memory: 0B, network: 0B}
       │      nationkey := tpch:nationkey
       │      regionkey := tpch:regionkey
       └─ LocalExchange[partitioning = SINGLE]
          │   Layout: [regionkey_1:bigint]
          │   Estimates: {rows: 5 (45B), cpu: 0, memory: 0B, network: 0B}
          └─ RemoteExchange[type = REPLICATE]
             │   Layout: [regionkey_1:bigint]
             │   Estimates: {rows: 5 (45B), cpu: 0, memory: 0B, network: 45B}
             └─ TableScan[table = tpch:sf1:region]
                    Layout: [regionkey_1:bigint]
                    Estimates: {rows: 5 (45B), cpu: 45, memory: 0B, network: 0B}
                    regionkey_1 := tpch:regionkey
```

Plan after fix
```
 Output[columnNames = [nationkey, regionkey]]
 │   Layout: [nationkey:bigint, regionkey_1:bigint]
 │   Estimates: {rows: 0 (0B), cpu: 0, memory: 0B, network: 0B}
 │   regionkey := regionkey_1
 └─ FilterProject[filterPredicate = ((least("regionkey", "regionkey_1") > BIGINT '0') AND (("nationkey" / "regionkey_1") = BIGINT '1'))]
    │   Layout: [nationkey:bigint, regionkey_1:bigint]
    │   Estimates: {rows: 0 (0B), cpu: 3.30k, memory: 0B, network: 0B}/{rows: 0 (0B), cpu: 0, memory: 0B, network: 0B}
    └─ CrossJoin[]
       │   Layout: [nationkey:bigint, regionkey:bigint, regionkey_1:bigint]
       │   Estimates: {rows: 125 (3.30kB), cpu: 3.78k, memory: 45B, network: 0B}
       │   Distribution: REPLICATED
       ├─ TableScan[table = tpch:sf1:nation]
       │      Layout: [nationkey:bigint, regionkey:bigint]
       │      Estimates: {rows: 25 (450B), cpu: 450, memory: 0B, network: 0B}
       │      nationkey := tpch:nationkey
       │      regionkey := tpch:regionkey
       └─ LocalExchange[partitioning = SINGLE]
          │   Layout: [regionkey_1:bigint]
          │   Estimates: {rows: 5 (45B), cpu: 0, memory: 0B, network: 0B}
          └─ RemoteExchange[type = REPLICATE]
             │   Layout: [regionkey_1:bigint]
             │   Estimates: {rows: 5 (45B), cpu: 0, memory: 0B, network: 45B}
             └─ TableScan[table = tpch:sf1:region]
                    Layout: [regionkey_1:bigint]
                    Estimates: {rows: 5 (45B), cpu: 45, memory: 0B, network: 0B}
                    regionkey_1 := tpch:regionkey
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# General
* Fix an incorrect result issue when certain predicate is rearranged. ({issue}`issuenumber`)
```
