### PR TITLE
Minor PipelineStats performance improvement

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/StageStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StageStateMachine.java
@@ -31,11 +31,12 @@ import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.util.Failures;
 import io.trino.util.Optionals;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import org.joda.time.DateTime;
 
 import javax.annotation.concurrent.ThreadSafe;
 
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +47,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongFunction;
 import java.util.function.Supplier;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -443,7 +445,7 @@ public class StageStateMachine
         boolean fullyBlocked = true;
         Set<BlockedReason> blockedReasons = new HashSet<>();
 
-        Map<String, OperatorStats> operatorToStats = new HashMap<>();
+        int maxTaskOperatorSummaries = 0;
         for (TaskInfo taskInfo : taskInfos) {
             TaskState taskState = taskInfo.getTaskStatus().getState();
             if (taskState.isDone()) {
@@ -538,13 +540,16 @@ public class StageStateMachine
             minFullGcSec = min(minFullGcSec, gcSec);
             maxFullGcSec = max(maxFullGcSec, gcSec);
 
+            // Count and record the maximum number of pipeline / operators across all task infos
+            int taskOperatorSummaries = 0;
             for (PipelineStats pipeline : taskStats.getPipelines()) {
-                for (OperatorStats operatorStats : pipeline.getOperatorSummaries()) {
-                    String id = pipeline.getPipelineId() + "." + operatorStats.getOperatorId();
-                    operatorToStats.compute(id, (k, v) -> v == null ? operatorStats : v.add(operatorStats));
-                }
+                taskOperatorSummaries += pipeline.getOperatorSummaries().size();
             }
+            maxTaskOperatorSummaries = max(taskOperatorSummaries, maxTaskOperatorSummaries);
         }
+
+        // Create merged operatorStats list if any operator summaries are present. Summarized task stats have empty operator summary lists
+        List<OperatorStats> operatorStats = maxTaskOperatorSummaries == 0 ? ImmutableList.of() : combineTaskOperatorSummaries(taskInfos, maxTaskOperatorSummaries);
 
         StageStats stageStats = new StageStats(
                 schedulingComplete.get(),
@@ -619,7 +624,7 @@ public class StageStateMachine
                         totalFullGcSec,
                         (int) (1.0 * totalFullGcSec / fullGcCount)),
 
-                ImmutableList.copyOf(operatorToStats.values()));
+                operatorStats);
 
         ExecutionFailureInfo failureInfo = null;
         if (state == FAILED) {
@@ -636,6 +641,36 @@ public class StageStateMachine
                 ImmutableList.of(),
                 tables,
                 failureInfo);
+    }
+
+    private static List<OperatorStats> combineTaskOperatorSummaries(List<TaskInfo> taskInfos, int maxTaskOperatorSummaries)
+    {
+        // Group each unique pipelineId + operatorId combination into lists
+        Long2ObjectOpenHashMap<List<OperatorStats>> pipelineAndOperatorToStats = new Long2ObjectOpenHashMap<>(maxTaskOperatorSummaries);
+        // Expect to have one operator stats entry for each taskInfo
+        int taskInfoCount = taskInfos.size();
+        LongFunction<List<OperatorStats>> statsListCreator = key -> new ArrayList<>(taskInfoCount);
+        for (TaskInfo taskInfo : taskInfos) {
+            for (PipelineStats pipeline : taskInfo.getStats().getPipelines()) {
+                // Place the pipelineId in the high bits of the combinedKey mask
+                long pipelineKeyMask = Integer.toUnsignedLong(pipeline.getPipelineId()) << 32;
+                for (OperatorStats operator : pipeline.getOperatorSummaries()) {
+                    // Place the operatorId into the low bits of the combined key
+                    long combinedKey = pipelineKeyMask | Integer.toUnsignedLong(operator.getOperatorId());
+                    pipelineAndOperatorToStats.computeIfAbsent(combinedKey, statsListCreator).add(operator);
+                }
+            }
+        }
+        // Merge the list of operator stats from each pipelineId + operatorId into a single entry
+        ImmutableList.Builder<OperatorStats> operatorStatsBuilder = ImmutableList.builderWithExpectedSize(pipelineAndOperatorToStats.size());
+        for (List<OperatorStats> operators : pipelineAndOperatorToStats.values()) {
+            OperatorStats stats = operators.get(0);
+            if (operators.size() > 1) {
+                stats = stats.add(operators.subList(1, operators.size()));
+            }
+            operatorStatsBuilder.add(stats);
+        }
+        return operatorStatsBuilder.build();
     }
 
     public void recordGetSplitTime(long startNanos)

--- a/core/trino-main/src/main/java/io/trino/operator/PipelineContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PipelineContext.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.units.DataSize.succinctBytes;
@@ -391,7 +392,8 @@ public class PipelineContext
         boolean unfinishedDriversFullyBlocked = true;
 
         TreeMap<Integer, OperatorStats> operatorSummaries = new TreeMap<>(this.operatorSummaries);
-        ListMultimap<Integer, OperatorStats> runningOperators = ArrayListMultimap.create();
+        // Expect the same number of operators as existing summaries, with one operator per driver context in the resulting multimap
+        ListMultimap<Integer, OperatorStats> runningOperators = ArrayListMultimap.create(operatorSummaries.size(), driverContexts.size());
         ImmutableList.Builder<DriverStats> drivers = ImmutableList.builderWithExpectedSize(driverContexts.size());
         for (DriverContext driverContext : driverContexts) {
             DriverStats driverStats = driverContext.getDriverStats();
@@ -438,24 +440,25 @@ public class PipelineContext
             physicalWrittenDataSize += driverStats.getPhysicalWrittenDataSize().toBytes();
         }
 
-        // merge the running operator stats into the operator summary
-        for (Integer operatorId : runningOperators.keySet()) {
+        // Computes the combined stats from existing completed operators and those still running
+        BiFunction<Integer, OperatorStats, OperatorStats> combineOperatorStats = (operatorId, current) -> {
             List<OperatorStats> runningStats = runningOperators.get(operatorId);
             if (runningStats.isEmpty()) {
-                continue;
+                return current;
             }
-            OperatorStats current = operatorSummaries.get(operatorId);
-            OperatorStats combined;
             if (current != null) {
-                combined = current.add(runningStats);
+                return current.add(runningStats);
             }
             else {
-                combined = runningStats.get(0);
+                OperatorStats combined = runningStats.get(0);
                 if (runningStats.size() > 1) {
                     combined = combined.add(runningStats.subList(1, runningStats.size()));
                 }
+                return combined;
             }
-            operatorSummaries.put(operatorId, combined);
+        };
+        for (Integer operatorId : runningOperators.keySet()) {
+            operatorSummaries.compute(operatorId, combineOperatorStats);
         }
 
         PipelineStatus pipelineStatus = pipelineStatusBuilder.build();


### PR DESCRIPTION
## Description

In `PipelineContext`, changes provide estimated keys and list sizes for the operator stats `ArrayListMultimap` when producing `PipelineStats`. Also avoids a per-key `TreeMap` traversal when combining existing operator stats with running operator stats by using `TreeMap#compute` instead of `get` / `put` pairs.

In `StageStateMachine`, merge `OperatorStats` in a single batch across all tasks instead of performing operator by operator merging when producing `StageStats`.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
