### PR TITLE
Remove obsolete comment from Hudi S3 query runner

### DIFF
--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/S3HudiQueryRunner.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/S3HudiQueryRunner.java
@@ -142,15 +142,6 @@ public final class S3HudiQueryRunner
         String bucketName = "test-bucket";
         HiveMinioDataLake hiveMinioDataLake = new HiveMinioDataLake(bucketName);
         hiveMinioDataLake.start();
-        /*
-         * Please set the below VM arguments for the main method to run:
-         *
-         * -ea --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
-         *
-         * TODO: We need to set above arguments due to Hudi's deep reflection based ObjectSizeEstimator.
-         *       Higher versions of jdk block illegal reflective access. This will not be needed after
-         *       https://issues.apache.org/jira/browse/HUDI-4687 is fixed.
-         */
         DistributedQueryRunner queryRunner = create(
                 ImmutableMap.of("http-server.http.port", "8080"),
                 ImmutableMap.of(),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This is a follow-up of https://github.com/trinodb/trino/pull/14737. I confirmed that the query runner starts correctly and TPCH tables are accessible without the VM arguments.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
