### PR TITLE
Set deterministic as false in MongoDB `ObjectId` function

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/ObjectIdFunctions.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/ObjectIdFunctions.java
@@ -40,7 +40,7 @@ public final class ObjectIdFunctions
     private ObjectIdFunctions() {}
 
     @Description("Mongodb ObjectId")
-    @ScalarFunction
+    @ScalarFunction(deterministic = false)
     @SqlType("ObjectId")
     public static Slice objectid()
     {


### PR DESCRIPTION
## Description

Set deterministic as false in MongoDB `ObjectId` function because 
the function may return different results in a query.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# MongoDB
* Fix potential incorrect results when `objectid` function is used more than once. ({issue}`15426`)
```
