### PR TITLE
bump azure core dependency to mitigate woodstox CVE

### DIFF
--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -335,7 +335,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-core</artifactId>
-            <version>1.25.0</version>
+            <version>1.34.0</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/plugin/trino-exchange-filesystem/pom.xml
+++ b/plugin/trino-exchange-filesystem/pom.xml
@@ -76,6 +76,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-core</artifactId>
+            <version>1.34.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Description

Bump azure-core dependency to address [woodstox CVE](https://github.com/trinodb/trino/issues/15249).

## Additional context and related issues

Two plugins rely on azure-core:

- trino-delta-lake
- trino-exchange-filesystem

Version 1.25 depends on Woodstox 6.2.6 which has a known CVE that showed up in our vulnerability scan. This CVE has been mitigated in azure-core 1.34 and its transitive dependenct woodstox 6.4.0

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: