### PR TITLE
Change substring start value 0 to the same as value 1

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
@@ -277,8 +277,12 @@ public final class StringFunctions
     @SqlType("varchar(x)")
     public static Slice substring(@SqlType("varchar(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start)
     {
-        if ((start == 0) || utf8.length() == 0) {
+        if (utf8.length() == 0) {
             return Slices.EMPTY_SLICE;
+        }
+
+        if (start == 0) {
+            start = 1;
         }
 
         int startCodePoint = Ints.saturatedCast(start);
@@ -324,8 +328,12 @@ public final class StringFunctions
     @SqlType("varchar(x)")
     public static Slice substring(@SqlType("varchar(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start, @SqlType(StandardTypes.BIGINT) long length)
     {
-        if (start == 0 || (length <= 0) || (utf8.length() == 0)) {
+        if ((length <= 0) || (utf8.length() == 0)) {
             return Slices.EMPTY_SLICE;
+        }
+
+        if (start == 0) {
+            start = 1;
         }
 
         int startCodePoint = Ints.saturatedCast(start);

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
@@ -357,7 +357,7 @@ public class TestStringFunctions
         assertFunction("SUBSTR('Quadratically', 50)", createVarcharType(13), "");
         assertFunction("SUBSTR('Quadratically', -5)", createVarcharType(13), "cally");
         assertFunction("SUBSTR('Quadratically', -50)", createVarcharType(13), "");
-        assertFunction("SUBSTR('Quadratically', 0)", createVarcharType(13), "");
+        assertFunction("SUBSTR('Quadratically', 0)", createVarcharType(13), "Quadratically");
 
         assertFunction("SUBSTR('Quadratically', 5, 6)", createVarcharType(13), "ratica");
         assertFunction("SUBSTR('Quadratically', 5, 10)", createVarcharType(13), "ratically");
@@ -394,7 +394,7 @@ public class TestStringFunctions
         assertFunction("SUBSTR(CAST('Quadratically' AS CHAR(13)), 50)", createVarcharType(13), "");
         assertFunction("SUBSTR(CAST('Quadratically' AS CHAR(13)), -5)", createVarcharType(13), "cally");
         assertFunction("SUBSTR(CAST('Quadratically' AS CHAR(13)), -50)", createVarcharType(13), "");
-        assertFunction("SUBSTR(CAST('Quadratically' AS CHAR(13)), 0)", createVarcharType(13), "");
+        assertFunction("SUBSTR(CAST('Quadratically' AS CHAR(13)), 0)", createVarcharType(13), "Quadratically");
 
         assertFunction("SUBSTR(CAST('Quadratically' AS CHAR(13)), 5, 6)", createVarcharType(13), "ratica");
         assertFunction("SUBSTR(CAST('Quadratically' AS CHAR(13)), 5, 10)", createVarcharType(13), "ratically");


### PR DESCRIPTION
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
I run some SQLs in hive and trino, then I find the substring function is different between hive and trino when the start parameter is 0. 
In hive: the start parameter 0 is the same as 1
hive> select substr('20191125',0,4);
OK
_c0
2019
Time taken: 0.134 seconds, Fetched: 1 row(s)

hive> select substr('20191125',1,4);
OK
_c0
2019

But in trino, when the start is 0, the substring return empty string.
before pr:
trino:tpcds_bin_partitioned_orc_2> select substr('20191125',0,4);
 _col0 
       
(1 row)

trino:tpcds_bin_partitioned_orc_2> select substr('20191125',1,4);
 _col0 
 2019  
(1 row)

So I change the substring function.
after pr:
trino:tpcds_bin_partitioned_orc_2> select substr('20191125',0,4);
 _col0 
 2019  
(1 row)

trino:tpcds_bin_partitioned_orc_2> select substr('20191125',1,4);
 _col0 
 2019  
(1 row)

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

