### PR TITLE
Write Change Data Feed in Delta Lake

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/DeleteAndInsertMergeProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DeleteAndInsertMergeProcessor.java
@@ -29,6 +29,8 @@ import static com.google.common.base.Verify.verify;
 import static io.trino.spi.block.ColumnarRow.toColumnarRow;
 import static io.trino.spi.connector.ConnectorMergeSink.DELETE_OPERATION_NUMBER;
 import static io.trino.spi.connector.ConnectorMergeSink.INSERT_OPERATION_NUMBER;
+import static io.trino.spi.connector.ConnectorMergeSink.UPDATE_DELETE_OPERATION_NUMBER;
+import static io.trino.spi.connector.ConnectorMergeSink.UPDATE_INSERT_OPERATION_NUMBER;
 import static io.trino.spi.connector.ConnectorMergeSink.UPDATE_OPERATION_NUMBER;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static java.lang.Math.toIntExact;
@@ -112,6 +114,8 @@ public class DeleteAndInsertMergeProcessor
                 case INSERT_OPERATION_NUMBER -> insertPositions++;
                 case DELETE_OPERATION_NUMBER -> deletePositions++;
                 case UPDATE_OPERATION_NUMBER -> updatePositions++;
+                // This class will create such rows, they are not expected on input
+                case UPDATE_INSERT_OPERATION_NUMBER, UPDATE_DELETE_OPERATION_NUMBER -> throw new IllegalArgumentException("Unexpected operator number: " + operation);
                 default -> throw new IllegalArgumentException("Unknown operator number: " + operation);
             }
         }
@@ -130,11 +134,11 @@ public class DeleteAndInsertMergeProcessor
             if (operation != DEFAULT_CASE_OPERATION_NUMBER) {
                 // Delete and Update because both create a delete row
                 if (operation == DELETE_OPERATION_NUMBER || operation == UPDATE_OPERATION_NUMBER) {
-                    addDeleteRow(pageBuilder, inputPage, position);
+                    addDeleteRow(pageBuilder, inputPage, position, operation != DELETE_OPERATION_NUMBER);
                 }
                 // Insert and update because both create an insert row
                 if (operation == INSERT_OPERATION_NUMBER || operation == UPDATE_OPERATION_NUMBER) {
-                    addInsertRow(pageBuilder, mergeRow, position, operation == UPDATE_OPERATION_NUMBER);
+                    addInsertRow(pageBuilder, mergeRow, position, operation != INSERT_OPERATION_NUMBER);
                 }
             }
         }
@@ -144,7 +148,7 @@ public class DeleteAndInsertMergeProcessor
         return page;
     }
 
-    private void addDeleteRow(PageBuilder pageBuilder, Page originalPage, int position)
+    private void addDeleteRow(PageBuilder pageBuilder, Page originalPage, int position, boolean causedByUpdate)
     {
         // TODO: There is no need to copy the data columns themselves.  Instead, we could
         //  use a DictionaryBlock to omit columns.
@@ -165,7 +169,7 @@ public class DeleteAndInsertMergeProcessor
         }
 
         // Add the operation column == deleted
-        TINYINT.writeLong(pageBuilder.getBlockBuilder(dataColumnChannels.size()), DELETE_OPERATION_NUMBER);
+        TINYINT.writeLong(pageBuilder.getBlockBuilder(dataColumnChannels.size()), causedByUpdate ? UPDATE_DELETE_OPERATION_NUMBER : DELETE_OPERATION_NUMBER);
 
         // Copy row ID column
         rowIdType.appendTo(originalPage.getBlock(rowIdChannel), position, pageBuilder.getBlockBuilder(dataColumnChannels.size() + 1));
@@ -187,7 +191,7 @@ public class DeleteAndInsertMergeProcessor
         }
 
         // Add the operation column == insert
-        TINYINT.writeLong(pageBuilder.getBlockBuilder(dataColumnChannels.size()), INSERT_OPERATION_NUMBER);
+        TINYINT.writeLong(pageBuilder.getBlockBuilder(dataColumnChannels.size()), causedByUpdate ? UPDATE_INSERT_OPERATION_NUMBER : INSERT_OPERATION_NUMBER);
 
         // Add null row ID column
         pageBuilder.getBlockBuilder(dataColumnChannels.size() + 1).appendNull();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/MergePartitioningHandle.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/MergePartitioningHandle.java
@@ -39,6 +39,8 @@ import static com.google.common.collect.Iterables.getLast;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.connector.ConnectorMergeSink.DELETE_OPERATION_NUMBER;
 import static io.trino.spi.connector.ConnectorMergeSink.INSERT_OPERATION_NUMBER;
+import static io.trino.spi.connector.ConnectorMergeSink.UPDATE_DELETE_OPERATION_NUMBER;
+import static io.trino.spi.connector.ConnectorMergeSink.UPDATE_INSERT_OPERATION_NUMBER;
 import static io.trino.spi.connector.ConnectorMergeSink.UPDATE_OPERATION_NUMBER;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static java.lang.Math.toIntExact;
@@ -213,8 +215,8 @@ public final class MergePartitioningHandle
             Block operationBlock = page.getBlock(0);
             int operation = toIntExact(TINYINT.getLong(operationBlock, position));
             return switch (operation) {
-                case INSERT_OPERATION_NUMBER -> insertFunction.getPartition(page.getColumns(insertColumns), position);
-                case UPDATE_OPERATION_NUMBER, DELETE_OPERATION_NUMBER -> updateFunction.getPartition(page.getColumns(updateColumns), position);
+                case INSERT_OPERATION_NUMBER, UPDATE_INSERT_OPERATION_NUMBER -> insertFunction.getPartition(page.getColumns(insertColumns), position);
+                case UPDATE_OPERATION_NUMBER, DELETE_OPERATION_NUMBER, UPDATE_DELETE_OPERATION_NUMBER -> updateFunction.getPartition(page.getColumns(updateColumns), position);
                 default -> throw new VerifyException("Invalid merge operation number: " + operation);
             };
         }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMergeSink.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMergeSink.java
@@ -21,9 +21,32 @@ import java.util.concurrent.CompletableFuture;
 
 public interface ConnectorMergeSink
 {
+    /**
+     * Represents an inserted row.
+     */
     int INSERT_OPERATION_NUMBER = 1;
+
+    /**
+     * Represents a deleted row.
+     */
     int DELETE_OPERATION_NUMBER = 2;
+
+    /**
+     * Represents an updated row when using {@link RowChangeParadigm#CHANGE_ONLY_UPDATED_COLUMNS}.
+     */
     int UPDATE_OPERATION_NUMBER = 3;
+
+    /**
+     * Represents a new version of an updated row, to be inserted, when using
+     * {@link RowChangeParadigm#DELETE_ROW_AND_INSERT_ROW}.
+     */
+    int UPDATE_INSERT_OPERATION_NUMBER = 4;
+
+    /**
+     * Represents an old version of an updated row, to be deleted, when using
+     * {@link RowChangeParadigm#DELETE_ROW_AND_INSERT_ROW}.
+     */
+    int UPDATE_DELETE_OPERATION_NUMBER = 5;
 
     /**
      * Store the page resulting from a merge. The page consists of {@code n} channels, numbered {@code 0..n-1}:
@@ -34,6 +57,8 @@ public interface ConnectorMergeSink
      *         <li>{@link #INSERT_OPERATION_NUMBER}</li>
      *         <li>{@link #DELETE_OPERATION_NUMBER}</li>
      *         <li>{@link #UPDATE_OPERATION_NUMBER}</li>
+     *         <li>{@link #UPDATE_INSERT_OPERATION_NUMBER}</li>
+     *         <li>{@link #UPDATE_DELETE_OPERATION_NUMBER}</li>
      *     </ul>
      *     <li>Block {@code n-1} is a connector-specific rowId column, whose handle was previously returned by
      *         {@link ConnectorMetadata#getMergeRowIdColumnHandle(ConnectorSession, ConnectorTableHandle) getMergeRowIdColumnHandle()}

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/MergePage.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/MergePage.java
@@ -21,6 +21,8 @@ import java.util.stream.IntStream;
 
 import static io.trino.spi.connector.ConnectorMergeSink.DELETE_OPERATION_NUMBER;
 import static io.trino.spi.connector.ConnectorMergeSink.INSERT_OPERATION_NUMBER;
+import static io.trino.spi.connector.ConnectorMergeSink.UPDATE_DELETE_OPERATION_NUMBER;
+import static io.trino.spi.connector.ConnectorMergeSink.UPDATE_INSERT_OPERATION_NUMBER;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
@@ -79,11 +81,11 @@ public final class MergePage
         for (int position = 0; position < positionCount; position++) {
             int operation = toIntExact(TINYINT.getLong(operationBlock, position));
             switch (operation) {
-                case DELETE_OPERATION_NUMBER:
+                case DELETE_OPERATION_NUMBER, UPDATE_DELETE_OPERATION_NUMBER:
                     deletePositions[deletePositionCount] = position;
                     deletePositionCount++;
                     break;
-                case INSERT_OPERATION_NUMBER:
+                case INSERT_OPERATION_NUMBER, UPDATE_INSERT_OPERATION_NUMBER:
                     insertPositions[insertPositionCount] = position;
                     insertPositionCount++;
                     break;

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
@@ -1,0 +1,513 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
+import com.google.common.primitives.Ints;
+import com.google.common.util.concurrent.Futures;
+import io.airlift.concurrent.MoreFutures;
+import io.airlift.json.JsonCodec;
+import io.airlift.log.Logger;
+import io.airlift.slice.Slice;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.parquet.writer.ParquetSchemaConverter;
+import io.trino.parquet.writer.ParquetWriterOptions;
+import io.trino.plugin.hive.FileWriter;
+import io.trino.plugin.hive.HivePartitionKey;
+import io.trino.plugin.hive.parquet.ParquetFileWriter;
+import io.trino.plugin.hive.util.HiveUtil;
+import io.trino.plugin.hive.util.HiveWriteUtils;
+import io.trino.spi.Page;
+import io.trino.spi.PageIndexer;
+import io.trino.spi.PageIndexerFactory;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.ConnectorPageSink;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+import io.trino.spi.type.Type;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_BAD_WRITE;
+import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getCompressionCodec;
+import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterBlockSize;
+import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterPageSize;
+import static io.trino.plugin.deltalake.transactionlog.TransactionLogAccess.canonicalizeColumnName;
+import static io.trino.plugin.hive.util.HiveUtil.escapePathName;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
+import static java.util.stream.Collectors.toList;
+
+public abstract class AbstractDeltaLakePageSink
+        implements ConnectorPageSink
+{
+    private static final Logger LOG = Logger.get(AbstractDeltaLakePageSink.class);
+
+    private static final int MAX_PAGE_POSITIONS = 4096;
+
+    private final List<DeltaLakeColumnHandle> dataColumnHandles;
+    private final int[] dataColumnInputIndex;
+    private final List<String> dataColumnNames;
+    private final List<Type> dataColumnTypes;
+
+    private final int[] partitionColumnsInputIndex;
+    private final List<String> originalPartitionColumnNames;
+    private final List<Type> partitionColumnTypes;
+
+    private final PageIndexer pageIndexer;
+    private final TrinoFileSystem fileSystem;
+
+    private final int maxOpenWriters;
+
+    protected final JsonCodec<DataFileInfo> dataFileInfoCodec;
+
+    private final List<DeltaLakeWriter> writers = new ArrayList<>();
+
+    private final String tableLocation;
+    protected final String outputPathDirectory;
+    private final ConnectorSession session;
+    private final DeltaLakeWriterStats stats;
+    private final String trinoVersion;
+    private final long targetMaxFileSize;
+
+    private long writtenBytes;
+    private long memoryUsage;
+
+    private final List<Closeable> closedWriterRollbackActions = new ArrayList<>();
+    protected final ImmutableList.Builder<DataFileInfo> dataFileInfos = ImmutableList.builder();
+
+    public AbstractDeltaLakePageSink(
+            List<DeltaLakeColumnHandle> inputColumns,
+            List<String> originalPartitionColumns,
+            PageIndexerFactory pageIndexerFactory,
+            TrinoFileSystemFactory fileSystemFactory,
+            int maxOpenWriters,
+            JsonCodec<DataFileInfo> dataFileInfoCodec,
+            String tableLocation,
+            String outputPathDirectory,
+            ConnectorSession session,
+            DeltaLakeWriterStats stats,
+            String trinoVersion)
+    {
+        requireNonNull(inputColumns, "inputColumns is null");
+
+        requireNonNull(pageIndexerFactory, "pageIndexerFactory is null");
+
+        this.fileSystem = requireNonNull(fileSystemFactory, "fileSystemFactory is null").create(session);
+        this.maxOpenWriters = maxOpenWriters;
+        this.dataFileInfoCodec = requireNonNull(dataFileInfoCodec, "dataFileInfoCodec is null");
+
+        // determine the input index of the partition columns and data columns
+        int[] partitionColumnInputIndex = new int[originalPartitionColumns.size()];
+        ImmutableList.Builder<Integer> dataColumnsInputIndex = ImmutableList.builder();
+
+        Type[] partitionColumnTypes = new Type[originalPartitionColumns.size()];
+        String[] originalPartitionColumnNames = new String[originalPartitionColumns.size()];
+
+        ImmutableList.Builder<DeltaLakeColumnHandle> dataColumnHandles = ImmutableList.builder();
+        ImmutableList.Builder<Type> dataColumnTypes = ImmutableList.builder();
+        ImmutableList.Builder<String> dataColumnNames = ImmutableList.builder();
+
+        Map<String, String> canonicalToOriginalPartitionColumns = new HashMap<>();
+        Map<String, Integer> canonicalToOriginalPartitionPositions = new HashMap<>();
+        int partitionColumnPosition = 0;
+        for (String partitionColumnName : originalPartitionColumns) {
+            String canonicalizeColumnName = canonicalizeColumnName(partitionColumnName);
+            canonicalToOriginalPartitionColumns.put(canonicalizeColumnName, partitionColumnName);
+            canonicalToOriginalPartitionPositions.put(canonicalizeColumnName, partitionColumnPosition++);
+        }
+        for (int inputIndex = 0; inputIndex < inputColumns.size(); inputIndex++) {
+            DeltaLakeColumnHandle column = inputColumns.get(inputIndex);
+            switch (column.getColumnType()) {
+                case PARTITION_KEY:
+                    int partitionPosition = canonicalToOriginalPartitionPositions.get(column.getName());
+                    partitionColumnInputIndex[partitionPosition] = inputIndex;
+                    originalPartitionColumnNames[partitionPosition] = canonicalToOriginalPartitionColumns.get(column.getName());
+                    partitionColumnTypes[partitionPosition] = column.getType();
+                    break;
+                case REGULAR:
+                    dataColumnHandles.add(column);
+                    dataColumnsInputIndex.add(inputIndex);
+                    dataColumnNames.add(column.getName());
+                    dataColumnTypes.add(column.getType());
+                    break;
+                case SYNTHESIZED:
+                    processSynthesizedColumn(column);
+                    break;
+                default:
+                    throw new IllegalStateException("Unexpected column type: " + column.getColumnType());
+            }
+        }
+
+        addSpecialColumns(inputColumns, dataColumnHandles, dataColumnsInputIndex, dataColumnNames, dataColumnTypes);
+        this.partitionColumnsInputIndex = partitionColumnInputIndex;
+        this.dataColumnInputIndex = Ints.toArray(dataColumnsInputIndex.build());
+        this.originalPartitionColumnNames = ImmutableList.copyOf(originalPartitionColumnNames);
+        this.dataColumnHandles = dataColumnHandles.build();
+        this.partitionColumnTypes = ImmutableList.copyOf(partitionColumnTypes);
+        this.dataColumnNames = dataColumnNames.build();
+        this.dataColumnTypes = dataColumnTypes.build();
+
+        this.pageIndexer = pageIndexerFactory.createPageIndexer(this.partitionColumnTypes);
+
+        this.tableLocation = tableLocation;
+        this.outputPathDirectory = outputPathDirectory;
+        this.session = requireNonNull(session, "session is null");
+        this.stats = stats;
+
+        this.trinoVersion = requireNonNull(trinoVersion, "trinoVersion is null");
+        this.targetMaxFileSize = DeltaLakeSessionProperties.getTargetMaxFileSize(session);
+    }
+
+    protected abstract void processSynthesizedColumn(DeltaLakeColumnHandle column);
+
+    protected abstract void addSpecialColumns(
+            List<DeltaLakeColumnHandle> inputColumns,
+            ImmutableList.Builder<DeltaLakeColumnHandle> dataColumnHandles,
+            ImmutableList.Builder<Integer> dataColumnsInputIndex,
+            ImmutableList.Builder<String> dataColumnNames,
+            ImmutableList.Builder<Type> dataColumnTypes);
+
+    protected abstract String getPathPrefix();
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return writtenBytes;
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return memoryUsage;
+    }
+
+    @Override
+    public long getValidationCpuNanos()
+    {
+        return 0;
+    }
+
+    @Override
+    public CompletableFuture<Collection<Slice>> finish()
+    {
+        for (int writerIndex = 0; writerIndex < writers.size(); writerIndex++) {
+            closeWriter(writerIndex);
+        }
+        writers.clear();
+
+        List<DataFileInfo> dataFilesInfo = dataFileInfos.build();
+        Collection<Slice> result = dataFilesInfo.stream()
+                .map(dataFileInfo -> wrappedBuffer(dataFileInfoCodec.toJsonBytes(dataFileInfo)))
+                .collect(toImmutableList());
+        return MoreFutures.toCompletableFuture(Futures.immediateFuture(result));
+    }
+
+    @Override
+    public void abort()
+    {
+        List<Closeable> rollbackActions = Streams.concat(
+                        writers.stream()
+                                // writers can contain nulls if an exception is thrown when doAppend expands the writer list
+                                .filter(Objects::nonNull)
+                                .map(writer -> writer::rollback),
+                        closedWriterRollbackActions.stream())
+                .collect(toImmutableList());
+        RuntimeException rollbackException = null;
+        for (Closeable rollbackAction : rollbackActions) {
+            try {
+                rollbackAction.close();
+            }
+            catch (Throwable t) {
+                if (rollbackException == null) {
+                    rollbackException = new TrinoException(DELTA_LAKE_BAD_WRITE, "Error rolling back write to Delta Lake");
+                }
+                rollbackException.addSuppressed(t);
+            }
+        }
+        if (rollbackException != null) {
+            throw rollbackException;
+        }
+    }
+
+    @Override
+    public CompletableFuture<?> appendPage(Page page)
+    {
+        if (page.getPositionCount() == 0) {
+            return NOT_BLOCKED;
+        }
+
+        while (page.getPositionCount() > MAX_PAGE_POSITIONS) {
+            Page chunk = page.getRegion(0, MAX_PAGE_POSITIONS);
+            page = page.getRegion(MAX_PAGE_POSITIONS, page.getPositionCount() - MAX_PAGE_POSITIONS);
+            writePage(chunk);
+        }
+
+        writePage(page);
+        return NOT_BLOCKED;
+    }
+
+    private void writePage(Page page)
+    {
+        int[] writerIndexes = getWriterIndexes(page);
+
+        // position count for each writer
+        int[] sizes = new int[writers.size()];
+        for (int index : writerIndexes) {
+            sizes[index]++;
+        }
+
+        // record which positions are used by which writer
+        int[][] writerPositions = new int[writers.size()][];
+        int[] counts = new int[writers.size()];
+
+        for (int position = 0; position < page.getPositionCount(); position++) {
+            int index = writerIndexes[position];
+
+            int count = counts[index];
+            if (count == 0) {
+                writerPositions[index] = new int[sizes[index]];
+            }
+            writerPositions[index][count] = position;
+            counts[index] = count + 1;
+        }
+
+        // invoke the writers
+        Page dataPage = getDataPage(page);
+        for (int index = 0; index < writerPositions.length; index++) {
+            int[] positions = writerPositions[index];
+            if (positions == null) {
+                continue;
+            }
+
+            // If write is partitioned across multiple writers, filter page using dictionary blocks
+            Page pageForWriter = dataPage;
+            if (positions.length != dataPage.getPositionCount()) {
+                verify(positions.length == counts[index]);
+                pageForWriter = pageForWriter.getPositions(positions, 0, positions.length);
+            }
+
+            DeltaLakeWriter writer = writers.get(index);
+
+            long currentWritten = writer.getWrittenBytes();
+            long currentMemory = writer.getMemoryUsage();
+
+            writer.appendRows(pageForWriter);
+
+            writtenBytes += (writer.getWrittenBytes() - currentWritten);
+            memoryUsage += (writer.getMemoryUsage() - currentMemory);
+        }
+    }
+
+    private int[] getWriterIndexes(Page page)
+    {
+        Page partitionColumns = extractColumns(page, partitionColumnsInputIndex);
+        int[] writerIndexes = pageIndexer.indexPage(partitionColumns);
+        if (pageIndexer.getMaxIndex() >= maxOpenWriters) {
+            throw new TrinoException(DELTA_LAKE_BAD_WRITE, format("Exceeded limit of %s open writers for partitions", maxOpenWriters));
+        }
+
+        // expand writers list to new size
+        while (writers.size() <= pageIndexer.getMaxIndex()) {
+            writers.add(null);
+        }
+        // create missing writers
+        for (int position = 0; position < page.getPositionCount(); position++) {
+            int writerIndex = writerIndexes[position];
+            DeltaLakeWriter deltaLakeWriter = writers.get(writerIndex);
+            if (deltaLakeWriter != null) {
+                if (deltaLakeWriter.getWrittenBytes() <= targetMaxFileSize) {
+                    continue;
+                }
+                closeWriter(writerIndex);
+            }
+
+            Path filePath = new Path(outputPathDirectory);
+
+            List<String> partitionValues = createPartitionValues(partitionColumnTypes, partitionColumns, position);
+            Optional<String> partitionName = Optional.empty();
+            if (!originalPartitionColumnNames.isEmpty()) {
+                String partName = makePartName(originalPartitionColumnNames, partitionValues);
+                filePath = new Path(outputPathDirectory, partName);
+                partitionName = Optional.of(partName);
+            }
+
+            String fileName = session.getQueryId() + "-" + randomUUID();
+            filePath = new Path(filePath, fileName);
+
+            FileWriter fileWriter = createParquetFileWriter(filePath.toString());
+
+            Path rootTableLocationPath = new Path(tableLocation);
+            DeltaLakeWriter writer = new DeltaLakeWriter(
+                    fileSystem,
+                    fileWriter,
+                    rootTableLocationPath,
+                    getRelativeFilePath(partitionName, fileName),
+                    partitionValues,
+                    stats,
+                    dataColumnHandles);
+
+            writers.set(writerIndex, writer);
+            memoryUsage += writer.getMemoryUsage();
+        }
+        verify(writers.size() == pageIndexer.getMaxIndex() + 1);
+        verify(!writers.contains(null));
+
+        return writerIndexes;
+    }
+
+    private String getRelativeFilePath(Optional<String> partitionName, String fileName)
+    {
+        return getPathPrefix() + partitionName.map(partition -> new Path(partition, fileName).toString()).orElse(fileName);
+    }
+
+    protected void closeWriter(int writerIndex)
+    {
+        DeltaLakeWriter writer = writers.get(writerIndex);
+
+        long currentWritten = writer.getWrittenBytes();
+        long currentMemory = writer.getMemoryUsage();
+
+        closedWriterRollbackActions.add(writer.commit());
+
+        writtenBytes += writer.getWrittenBytes() - currentWritten;
+        memoryUsage -= currentMemory;
+
+        writers.set(writerIndex, null);
+
+        try {
+            DataFileInfo dataFileInfo = writer.getDataFileInfo();
+            dataFileInfos.add(dataFileInfo);
+        }
+        catch (IOException e) {
+            LOG.warn("exception '%s' while finishing write on %s", e, writer);
+            throw new TrinoException(DELTA_LAKE_BAD_WRITE, "Error committing Parquet file to Delta Lake", e);
+        }
+    }
+
+    /**
+     * Copy of {@link HiveUtil#makePartName} modified to preserve case of partition columns.
+     */
+    private static String makePartName(List<String> partitionColumns, List<String> partitionValues)
+    {
+        StringBuilder name = new StringBuilder();
+
+        for (int i = 0; i < partitionColumns.size(); ++i) {
+            if (i > 0) {
+                name.append("/");
+            }
+
+            name.append(escapePathName(partitionColumns.get(i)));
+            name.append('=');
+            name.append(escapePathName(partitionValues.get(i)));
+        }
+
+        return name.toString();
+    }
+
+    public static List<String> createPartitionValues(List<Type> partitionColumnTypes, Page partitionColumns, int position)
+    {
+        return HiveWriteUtils.createPartitionValues(partitionColumnTypes, partitionColumns, position).stream()
+                .map(value -> value.equals(HivePartitionKey.HIVE_DEFAULT_DYNAMIC_PARTITION) ? null : value)
+                .collect(toList());
+    }
+
+    private FileWriter createParquetFileWriter(String path)
+    {
+        ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
+                .setMaxBlockSize(getParquetWriterBlockSize(session))
+                .setMaxPageSize(getParquetWriterPageSize(session))
+                .build();
+        CompressionCodecName compressionCodecName = getCompressionCodec(session).getParquetCompressionCodec();
+
+        try {
+            Closeable rollbackAction = () -> fileSystem.deleteFile(path);
+
+            List<Type> parquetTypes = dataColumnTypes.stream()
+                    .map(type -> {
+                        if (type instanceof TimestampWithTimeZoneType) {
+                            verify(((TimestampWithTimeZoneType) type).getPrecision() == 3, "Unsupported type: %s", type);
+                            return TIMESTAMP_MILLIS;
+                        }
+                        return type;
+                    })
+                    .collect(toImmutableList());
+
+            // we use identity column mapping; input page already contains only data columns per
+            // DataLagePageSink.getDataPage()
+            int[] identityMapping = new int[dataColumnTypes.size()];
+            for (int i = 0; i < identityMapping.length; ++i) {
+                identityMapping[i] = i;
+            }
+
+            ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(parquetTypes, dataColumnNames, false, false);
+            return new ParquetFileWriter(
+                    fileSystem.newOutputFile(path),
+                    rollbackAction,
+                    parquetTypes,
+                    dataColumnNames,
+                    schemaConverter.getMessageType(),
+                    schemaConverter.getPrimitiveTypes(),
+                    parquetWriterOptions,
+                    identityMapping,
+                    compressionCodecName,
+                    trinoVersion,
+                    false,
+                    Optional.empty(),
+                    Optional.empty());
+        }
+        catch (IOException e) {
+            throw new TrinoException(DELTA_LAKE_BAD_WRITE, "Error creating Parquet file", e);
+        }
+    }
+
+    private Page getDataPage(Page page)
+    {
+        Block[] blocks = new Block[dataColumnInputIndex.length];
+        for (int i = 0; i < dataColumnInputIndex.length; i++) {
+            int dataColumn = dataColumnInputIndex[i];
+            blocks[i] = page.getBlock(dataColumn);
+        }
+        return new Page(page.getPositionCount(), blocks);
+    }
+
+    private static Page extractColumns(Page page, int[] columns)
+    {
+        Block[] blocks = new Block[columns.length];
+        for (int i = 0; i < columns.length; i++) {
+            int dataColumn = columns[i];
+            blocks[i] = page.getBlock(dataColumn);
+        }
+        return new Page(page.getPositionCount(), blocks);
+    }
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
@@ -25,6 +25,7 @@ import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.parquet.writer.ParquetSchemaConverter;
 import io.trino.parquet.writer.ParquetWriterOptions;
+import io.trino.plugin.deltalake.DataFileInfo.DataFileType;
 import io.trino.plugin.hive.FileWriter;
 import io.trino.plugin.hive.HivePartitionKey;
 import io.trino.plugin.hive.parquet.ParquetFileWriter;
@@ -199,6 +200,8 @@ public abstract class AbstractDeltaLakePageSink
             ImmutableList.Builder<Type> dataColumnTypes);
 
     protected abstract String getPathPrefix();
+
+    protected abstract DataFileType getDataFileType();
 
     @Override
     public long getCompletedBytes()
@@ -375,7 +378,8 @@ public abstract class AbstractDeltaLakePageSink
                     getRelativeFilePath(partitionName, fileName),
                     partitionValues,
                     stats,
-                    dataColumnHandles);
+                    dataColumnHandles,
+                    getDataFileType());
 
             writers.set(writerIndex, writer);
             memoryUsage += writer.getMemoryUsage();

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DataFileInfo.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DataFileInfo.java
@@ -23,9 +23,16 @@ import static java.util.Objects.requireNonNull;
 
 public class DataFileInfo
 {
+    public enum DataFileType
+    {
+        DATA,
+        CHANGE_DATA_FEED,
+    }
+
     private final String path;
     private final List<String> partitionValues;
     private final long size;
+    private final DataFileType dataFileType;
     private final long creationTime;
     private final DeltaLakeJsonFileStatistics statistics;
 
@@ -34,12 +41,14 @@ public class DataFileInfo
             @JsonProperty("path") String path,
             @JsonProperty("size") long size,
             @JsonProperty("creationTime") long creationTime,
+            @JsonProperty("fileType") DataFileType dataFileType,
             @JsonProperty("partitionValues") List<String> partitionValues,
             @JsonProperty("statistics") DeltaLakeJsonFileStatistics statistics)
     {
         this.path = path;
         this.size = size;
         this.creationTime = creationTime;
+        this.dataFileType = requireNonNull(dataFileType, "dataFileType is null");
         this.partitionValues = partitionValues;
         this.statistics = requireNonNull(statistics, "statistics is null");
     }
@@ -66,6 +75,12 @@ public class DataFileInfo
     public long getCreationTime()
     {
         return creationTime;
+    }
+
+    @JsonProperty
+    public DataFileType getDataFileType()
+    {
+        return dataFileType;
     }
 
     @JsonProperty

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeCdfPageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeCdfPageSink.java
@@ -21,19 +21,26 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.Type;
 
 import java.util.List;
+import java.util.OptionalInt;
 
-import static io.trino.plugin.deltalake.DataFileInfo.DataFileType.DATA;
+import static io.trino.plugin.deltalake.DataFileInfo.DataFileType.CHANGE_DATA_FEED;
+import static io.trino.plugin.deltalake.DeltaLakeColumnType.REGULAR;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 
-public class DeltaLakePageSink
+public class DeltaLakeCdfPageSink
         extends AbstractDeltaLakePageSink
 {
-    public DeltaLakePageSink(
+    public static final String CHANGE_TYPE_COLUMN_NAME = "_change_type";
+    public static final String CHANGE_DATA_FOLDER_NAME = "_change_data";
+
+    public DeltaLakeCdfPageSink(
             List<DeltaLakeColumnHandle> inputColumns,
             List<String> originalPartitionColumns,
             PageIndexerFactory pageIndexerFactory,
             TrinoFileSystemFactory fileSystemFactory,
             int maxOpenWriters,
             JsonCodec<DataFileInfo> dataFileInfoCodec,
+            String outputPath,
             String tableLocation,
             ConnectorSession session,
             DeltaLakeWriterStats stats,
@@ -47,36 +54,44 @@ public class DeltaLakePageSink
                 maxOpenWriters,
                 dataFileInfoCodec,
                 tableLocation,
-                tableLocation,
+                outputPath,
                 session,
                 stats,
                 trinoVersion);
     }
 
     @Override
-    protected void processSynthesizedColumn(DeltaLakeColumnHandle column)
-    {
-        throw new IllegalStateException("Unexpected column type: " + column.getColumnType());
-    }
+    protected void processSynthesizedColumn(DeltaLakeColumnHandle column) {}
 
     @Override
     protected void addSpecialColumns(
             List<DeltaLakeColumnHandle> inputColumns,
             ImmutableList.Builder<DeltaLakeColumnHandle> dataColumnHandles,
-            ImmutableList.Builder<Integer> dataColumnsInputIndex,
+            ImmutableList.Builder<Integer> dataColumnsInputIndices,
             ImmutableList.Builder<String> dataColumnNames,
             ImmutableList.Builder<Type> dataColumnTypes)
-    {}
+    {
+        dataColumnHandles.add(new DeltaLakeColumnHandle(
+                CHANGE_TYPE_COLUMN_NAME,
+                VARCHAR,
+                OptionalInt.empty(),
+                CHANGE_TYPE_COLUMN_NAME,
+                VARCHAR,
+                REGULAR));
+        dataColumnsInputIndices.add(inputColumns.size());
+        dataColumnNames.add(CHANGE_TYPE_COLUMN_NAME);
+        dataColumnTypes.add(VARCHAR);
+    }
 
     @Override
     protected String getPathPrefix()
     {
-        return "";
+        return CHANGE_DATA_FOLDER_NAME + "/";
     }
 
     @Override
     protected DataFileInfo.DataFileType getDataFileType()
     {
-        return DATA;
+        return CHANGE_DATA_FEED;
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.deltalake;
 
 import com.google.common.collect.ImmutableList;
+import io.airlift.concurrent.MoreFutures;
 import io.airlift.json.JsonCodec;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -30,21 +31,23 @@ import io.trino.plugin.hive.parquet.ParquetFileWriter;
 import io.trino.plugin.hive.parquet.ParquetPageSourceFactory;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
 import io.trino.spi.block.ColumnarRow;
+import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.connector.ConnectorMergeSink;
 import io.trino.spi.connector.ConnectorPageSink;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.connector.MergePage;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.joda.time.DateTimeZone;
-import org.roaringbitmap.longlong.ImmutableLongBitmapDataProvider;
 import org.roaringbitmap.longlong.LongBitmapDataProvider;
 import org.roaringbitmap.longlong.Roaring64Bitmap;
+
+import javax.annotation.Nullable;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -55,22 +58,29 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.json.JsonCodec.listJsonCodec;
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.deltalake.DataFileInfo.DataFileType.DATA;
 import static io.trino.plugin.deltalake.DeltaLakeColumnType.REGULAR;
+import static io.trino.plugin.deltalake.DeltaLakeColumnType.SYNTHESIZED;
 import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_BAD_WRITE;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getCompressionCodec;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterBlockSize;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterPageSize;
+import static io.trino.plugin.deltalake.transactionlog.TransactionLogParser.deserializePartitionValue;
 import static io.trino.spi.block.ColumnarRow.toColumnarRow;
-import static io.trino.spi.connector.MergePage.createDeleteAndInsertPages;
+import static io.trino.spi.predicate.Utils.nativeValueToBlock;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
@@ -80,6 +90,10 @@ public class DeltaLakeMergeSink
         implements ConnectorMergeSink
 {
     private static final JsonCodec<List<String>> PARTITIONS_CODEC = listJsonCodec(String.class);
+    public static final String INSERT_CDF_LABEL = "insert";
+    public static final String DELETE_CDF_LABEL = "delete";
+    public static final String UPDATE_PREIMAGE_CDF_LABEL = "update_preimage";
+    public static final String UPDATE_POSTIMAGE_CDF_LABEL = "update_postimage";
 
     private final TrinoFileSystem fileSystem;
     private final ConnectorSession session;
@@ -91,9 +105,17 @@ public class DeltaLakeMergeSink
     private final String rootTableLocation;
     private final ConnectorPageSink insertPageSink;
     private final List<DeltaLakeColumnHandle> dataColumns;
+    private final List<DeltaLakeColumnHandle> nonSynthesizedColumns;
     private final int tableColumnCount;
     private final int domainCompactionThreshold;
+    private final Supplier<DeltaLakeCdfPageSink> cdfPageSinkSupplier;
+    private final boolean cdfEnabled;
     private final Map<Slice, FileDeletion> fileDeletions = new HashMap<>();
+    private final int[] dataColumnsIndices;
+    private final int[] dataAndRowIdColumnsIndices;
+
+    @Nullable
+    private DeltaLakeCdfPageSink cdfPageSink;
 
     public DeltaLakeMergeSink(
             TrinoFileSystemFactory fileSystemFactory,
@@ -106,7 +128,9 @@ public class DeltaLakeMergeSink
             String rootTableLocation,
             ConnectorPageSink insertPageSink,
             List<DeltaLakeColumnHandle> tableColumns,
-            int domainCompactionThreshold)
+            int domainCompactionThreshold,
+            Supplier<DeltaLakeCdfPageSink> cdfPageSinkSupplier,
+            boolean cdfEnabled)
     {
         this.session = requireNonNull(session, "session is null");
         this.fileSystem = fileSystemFactory.create(session);
@@ -123,30 +147,141 @@ public class DeltaLakeMergeSink
                 .filter(column -> column.getColumnType() == REGULAR)
                 .collect(toImmutableList());
         this.domainCompactionThreshold = domainCompactionThreshold;
+        this.nonSynthesizedColumns = tableColumns.stream()
+                .filter(column -> column.getColumnType() != SYNTHESIZED)
+                .collect(toImmutableList());
+        this.cdfPageSinkSupplier = requireNonNull(cdfPageSinkSupplier);
+        this.cdfEnabled = cdfEnabled;
+        dataColumnsIndices = new int[tableColumnCount];
+        dataAndRowIdColumnsIndices = new int[tableColumnCount + 1];
+        for (int i = 0; i < tableColumnCount; i++) {
+            dataColumnsIndices[i] = i;
+            dataAndRowIdColumnsIndices[i] = i;
+        }
+        dataAndRowIdColumnsIndices[tableColumnCount] = tableColumnCount + 1; // row ID channel
     }
 
     @Override
     public void storeMergedRows(Page page)
     {
-        MergePage mergePage = createDeleteAndInsertPages(page, tableColumnCount);
+        DeltaLakeMergePage mergePage = createPages(page, tableColumnCount);
 
-        mergePage.getInsertionsPage().ifPresent(insertPageSink::appendPage);
+        mergePage.insertionsPage().ifPresent(insertPageSink::appendPage);
+        mergePage.updateInsertionsPage().ifPresent(insertPageSink::appendPage);
 
-        mergePage.getDeletionsPage().ifPresent(deletions -> {
-            ColumnarRow rowIdRow = toColumnarRow(deletions.getBlock(deletions.getChannelCount() - 1));
+        processInsertions(mergePage.insertionsPage(), INSERT_CDF_LABEL);
+        processInsertions(mergePage.updateInsertionsPage(), UPDATE_POSTIMAGE_CDF_LABEL);
 
-            for (int position = 0; position < rowIdRow.getPositionCount(); position++) {
-                Slice filePath = VARCHAR.getSlice(rowIdRow.getField(0), position);
-                long rowPosition = BIGINT.getLong(rowIdRow.getField(1), position);
-                Slice partitions = VARCHAR.getSlice(rowIdRow.getField(2), position);
+        mergePage.deletionsPage().ifPresent(deletions -> processDeletion(deletions, DELETE_CDF_LABEL));
+        mergePage.updateDeletionsPage().ifPresent(deletions -> processDeletion(deletions, UPDATE_PREIMAGE_CDF_LABEL));
+    }
 
-                List<String> partitionValues = PARTITIONS_CODEC.fromJson(partitions.toStringUtf8());
-
-                FileDeletion deletion = fileDeletions.computeIfAbsent(filePath, x -> new FileDeletion(partitionValues));
-
-                deletion.rowsToDelete().addLong(rowPosition);
+    private void processInsertions(Optional<Page> optionalInsertionPage, String cdfOperation)
+    {
+        if (cdfEnabled && optionalInsertionPage.isPresent()) {
+            if (cdfPageSink == null) {
+                cdfPageSink = cdfPageSinkSupplier.get();
             }
-        });
+            Page updateInsertionsPage = optionalInsertionPage.get();
+            Block[] cdfPostUpdateBlocks = new Block[nonSynthesizedColumns.size() + 1];
+            for (int i = 0; i < nonSynthesizedColumns.size(); i++) {
+                cdfPostUpdateBlocks[i] = updateInsertionsPage.getBlock(i);
+            }
+            cdfPostUpdateBlocks[nonSynthesizedColumns.size()] = RunLengthEncodedBlock.create(
+                    nativeValueToBlock(VARCHAR, utf8Slice(cdfOperation)), updateInsertionsPage.getPositionCount());
+            cdfPageSink.appendPage(new Page(updateInsertionsPage.getPositionCount(), cdfPostUpdateBlocks));
+        }
+    }
+
+    private void processDeletion(Page deletions, String cdfOperation)
+    {
+        ColumnarRow rowIdRow = toColumnarRow(deletions.getBlock(deletions.getChannelCount() - 1));
+
+        for (int position = 0; position < rowIdRow.getPositionCount(); position++) {
+            Slice filePath = VARCHAR.getSlice(rowIdRow.getField(0), position);
+            long rowPosition = BIGINT.getLong(rowIdRow.getField(1), position);
+            Slice partitions = VARCHAR.getSlice(rowIdRow.getField(2), position);
+
+            List<String> partitionValues = PARTITIONS_CODEC.fromJson(partitions.toStringUtf8());
+
+            FileDeletion deletion = fileDeletions.computeIfAbsent(filePath, x -> new FileDeletion(partitionValues, cdfOperation));
+
+            deletion.rowsToDelete().addLong(rowPosition);
+        }
+    }
+
+    private DeltaLakeMergePage createPages(Page inputPage, int dataColumnCount)
+    {
+        int inputChannelCount = inputPage.getChannelCount();
+        if (inputChannelCount != dataColumnCount + 2) {
+            throw new IllegalArgumentException(format("inputPage channelCount (%s) == dataColumns size (%s) + 2", inputChannelCount, dataColumnCount));
+        }
+
+        int positionCount = inputPage.getPositionCount();
+        if (positionCount <= 0) {
+            throw new IllegalArgumentException("positionCount should be > 0, but is " + positionCount);
+        }
+        Block operationBlock = inputPage.getBlock(inputChannelCount - 2);
+        int[] deletePositions = new int[positionCount];
+        int[] insertPositions = new int[positionCount];
+        int[] updateInsertPositions = new int[positionCount];
+        int[] updateDeletePositions = new int[positionCount];
+        int deletePositionCount = 0;
+        int insertPositionCount = 0;
+        int updateInsertPositionCount = 0;
+        int updateDeletePositionCount = 0;
+
+        for (int position = 0; position < positionCount; position++) {
+            int operation = toIntExact(TINYINT.getLong(operationBlock, position));
+            switch (operation) {
+                case DELETE_OPERATION_NUMBER:
+                    deletePositions[deletePositionCount] = position;
+                    deletePositionCount++;
+                    break;
+                case INSERT_OPERATION_NUMBER:
+                    insertPositions[insertPositionCount] = position;
+                    insertPositionCount++;
+                    break;
+                case UPDATE_INSERT_OPERATION_NUMBER:
+                    updateInsertPositions[updateInsertPositionCount] = position;
+                    updateInsertPositionCount++;
+                    break;
+                case UPDATE_DELETE_OPERATION_NUMBER:
+                    updateDeletePositions[updateDeletePositionCount] = position;
+                    updateDeletePositionCount++;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Invalid merge operation: " + operation);
+            }
+        }
+        Optional<Page> deletePage = Optional.empty();
+        if (deletePositionCount > 0) {
+            deletePage = Optional.of(inputPage
+                    .getColumns(dataAndRowIdColumnsIndices)
+                    .getPositions(deletePositions, 0, deletePositionCount));
+        }
+
+        Optional<Page> insertPage = Optional.empty();
+        if (insertPositionCount > 0) {
+            insertPage = Optional.of(inputPage
+                    .getColumns(dataColumnsIndices)
+                    .getPositions(insertPositions, 0, insertPositionCount));
+        }
+
+        Optional<Page> updateInsertPage = Optional.empty();
+        if (updateInsertPositionCount > 0) {
+            updateInsertPage = Optional.of(inputPage
+                    .getColumns(dataColumnsIndices)
+                    .getPositions(updateInsertPositions, 0, updateInsertPositionCount));
+        }
+
+        Optional<Page> updateDeletePage = Optional.empty();
+        if (updateDeletePositionCount > 0) {
+            updateDeletePage = Optional.of(inputPage
+                    .getColumns(dataAndRowIdColumnsIndices)
+                    .getPositions(updateDeletePositions, 0, updateDeletePositionCount));
+        }
+        return new DeltaLakeMergePage(deletePage, insertPage, updateInsertPage, updateDeletePage);
     }
 
     @Override
@@ -164,6 +299,16 @@ public class DeltaLakeMergeSink
 
         fileDeletions.forEach((path, deletion) ->
                 fragments.addAll(rewriteFile(new Path(path.toStringUtf8()), deletion)));
+
+        if (cdfEnabled && cdfPageSink != null) { // cdf may be enabled but there may be no update/deletion so sink was not instantiated
+            MoreFutures.getDone(cdfPageSink.finish()).stream()
+                    .map(Slice::getBytes)
+                    .map(dataFileInfoCodec::fromJson)
+                    .map(info -> new DeltaLakeMergeResult(Optional.empty(), Optional.of(info)))
+                    .map(mergeResultJsonCodec::toJsonBytes)
+                    .map(Slices::wrappedBuffer)
+                    .forEach(fragments::add);
+        }
 
         return completedFuture(fragments);
     }
@@ -186,9 +331,10 @@ public class DeltaLakeMergeSink
                     targetRelativePath,
                     deletion.partitionValues(),
                     writerStats,
-                    dataColumns);
+                    dataColumns,
+                    DATA);
 
-            Optional<DataFileInfo> newFileInfo = rewriteParquetFile(sourcePath, deletion.rowsToDelete(), writer);
+            Optional<DataFileInfo> newFileInfo = rewriteParquetFile(sourcePath, deletion, writer);
 
             DeltaLakeMergeResult result = new DeltaLakeMergeResult(Optional.of(sourceRelativePath), newFileInfo);
             return ImmutableList.of(utf8Slice(mergeResultJsonCodec.toJson(result)));
@@ -249,9 +395,10 @@ public class DeltaLakeMergeSink
         }
     }
 
-    private Optional<DataFileInfo> rewriteParquetFile(Path path, ImmutableLongBitmapDataProvider rowsToDelete, DeltaLakeWriter fileWriter)
+    private Optional<DataFileInfo> rewriteParquetFile(Path path, FileDeletion deletion, DeltaLakeWriter fileWriter)
             throws IOException
     {
+        LongBitmapDataProvider rowsToDelete = deletion.rowsToDelete;
         try (ConnectorPageSource connectorPageSource = createParquetPageSource(path).get()) {
             long filePosition = 0;
             while (!connectorPageSource.isFinished()) {
@@ -262,14 +409,23 @@ public class DeltaLakeMergeSink
 
                 int positionCount = page.getPositionCount();
                 int[] retained = new int[positionCount];
+                int[] deleted = new int[positionCount];
                 int retainedCount = 0;
+                int deletedCount = 0;
                 for (int position = 0; position < positionCount; position++) {
                     if (!rowsToDelete.contains(filePosition)) {
                         retained[retainedCount] = position;
                         retainedCount++;
                     }
+                    else {
+                        deleted[deletedCount] = position;
+                        deletedCount++;
+                    }
                     filePosition++;
                 }
+
+                storeCdfEntries(page, deleted, deletedCount, deletion);
+
                 if (retainedCount != positionCount) {
                     page = page.getPositions(retained, 0, retainedCount);
                 }
@@ -299,6 +455,39 @@ public class DeltaLakeMergeSink
         return Optional.of(fileWriter.getDataFileInfo());
     }
 
+    private void storeCdfEntries(Page page, int[] deleted, int deletedCount, FileDeletion deletion)
+    {
+        if (cdfEnabled && page.getPositionCount() > 0) {
+            if (cdfPageSink == null) {
+                cdfPageSink = cdfPageSinkSupplier.get();
+            }
+            Page cdfPage = page.getPositions(deleted, 0, deletedCount);
+            Block[] outputBlocks = new Block[nonSynthesizedColumns.size() + 1];
+            int cdfPageIndex = 0;
+            int partitionIndex = 0;
+            List<String> partitionValues = deletion.partitionValues;
+            for (int i = 0; i < nonSynthesizedColumns.size(); i++) {
+                if (nonSynthesizedColumns.get(i).getColumnType() == REGULAR) {
+                    outputBlocks[i] = cdfPage.getBlock(cdfPageIndex);
+                    cdfPageIndex++;
+                }
+                else {
+                    outputBlocks[i] = RunLengthEncodedBlock.create(nativeValueToBlock(
+                                    nonSynthesizedColumns.get(i).getType(),
+                                    deserializePartitionValue(
+                                            nonSynthesizedColumns.get(i),
+                                            Optional.ofNullable(partitionValues.get(partitionIndex)))),
+                            cdfPage.getPositionCount());
+                    partitionIndex++;
+                }
+            }
+            Block cdfOperationBlock = RunLengthEncodedBlock.create(
+                    nativeValueToBlock(VARCHAR, utf8Slice(deletion.getCdfOperation())), cdfPage.getPositionCount());
+            outputBlocks[nonSynthesizedColumns.size()] = cdfOperationBlock;
+            cdfPageSink.appendPage(new Page(cdfPage.getPositionCount(), outputBlocks));
+        }
+    }
+
     private ReaderPageSource createParquetPageSource(Path path)
             throws IOException
     {
@@ -320,16 +509,26 @@ public class DeltaLakeMergeSink
                 domainCompactionThreshold);
     }
 
+    @Override
+    public void abort()
+    {
+        if (cdfPageSink != null) {
+            cdfPageSink.abort();
+        }
+    }
+
     private static class FileDeletion
     {
         private final List<String> partitionValues;
         private final LongBitmapDataProvider rowsToDelete = new Roaring64Bitmap();
+        private final String cdfOperation;
 
-        private FileDeletion(List<String> partitionValues)
+        private FileDeletion(List<String> partitionValues, String cdfOperation)
         {
             // Use ArrayList since Delta Lake allows NULL partition values, and wrap it in
             // an unmodifiableList.
             this.partitionValues = unmodifiableList(new ArrayList<>(requireNonNull(partitionValues, "partitionValues is null")));
+            this.cdfOperation = requireNonNull(cdfOperation, "cdfOperation is null");
         }
 
         public List<String> partitionValues()
@@ -340,6 +539,26 @@ public class DeltaLakeMergeSink
         public LongBitmapDataProvider rowsToDelete()
         {
             return rowsToDelete;
+        }
+
+        public String getCdfOperation()
+        {
+            return cdfOperation;
+        }
+    }
+
+    private record DeltaLakeMergePage(
+            Optional<Page> deletionsPage,
+            Optional<Page> insertionsPage,
+            Optional<Page> updateInsertionsPage,
+            Optional<Page> updateDeletionsPage)
+    {
+        public DeltaLakeMergePage
+        {
+            requireNonNull(deletionsPage, "deletionsPage is null");
+            requireNonNull(insertionsPage, "insertionsPage is null");
+            requireNonNull(updateInsertionsPage, "updateInsertionsPage is null");
+            requireNonNull(updateDeletionsPage, "updateDeletionsPage is null");
         }
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
@@ -14,97 +14,17 @@
 package io.trino.plugin.deltalake;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Streams;
-import com.google.common.primitives.Ints;
-import com.google.common.util.concurrent.Futures;
-import io.airlift.concurrent.MoreFutures;
 import io.airlift.json.JsonCodec;
-import io.airlift.log.Logger;
-import io.airlift.slice.Slice;
-import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
-import io.trino.parquet.writer.ParquetSchemaConverter;
-import io.trino.parquet.writer.ParquetWriterOptions;
-import io.trino.plugin.hive.FileWriter;
-import io.trino.plugin.hive.HivePartitionKey;
-import io.trino.plugin.hive.parquet.ParquetFileWriter;
-import io.trino.plugin.hive.util.HiveUtil;
-import io.trino.plugin.hive.util.HiveWriteUtils;
-import io.trino.spi.Page;
-import io.trino.spi.PageIndexer;
 import io.trino.spi.PageIndexerFactory;
-import io.trino.spi.TrinoException;
-import io.trino.spi.block.Block;
-import io.trino.spi.connector.ConnectorPageSink;
 import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
-import org.apache.hadoop.fs.Path;
-import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-
-import static com.google.common.base.Verify.verify;
-import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.airlift.slice.Slices.wrappedBuffer;
-import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_BAD_WRITE;
-import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getCompressionCodec;
-import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterBlockSize;
-import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterPageSize;
-import static io.trino.plugin.deltalake.transactionlog.TransactionLogAccess.canonicalizeColumnName;
-import static io.trino.plugin.hive.util.HiveUtil.escapePathName;
-import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
-import static java.lang.String.format;
-import static java.util.Objects.requireNonNull;
-import static java.util.UUID.randomUUID;
-import static java.util.stream.Collectors.toList;
 
 public class DeltaLakePageSink
-        implements ConnectorPageSink
+        extends AbstractDeltaLakePageSink
 {
-    private static final Logger LOG = Logger.get(DeltaLakePageSink.class);
-
-    private static final int MAX_PAGE_POSITIONS = 4096;
-
-    private final List<DeltaLakeColumnHandle> dataColumnHandles;
-    private final int[] dataColumnInputIndex;
-    private final List<String> dataColumnNames;
-    private final List<Type> dataColumnTypes;
-
-    private final int[] partitionColumnsInputIndex;
-    private final List<String> originalPartitionColumnNames;
-    private final List<Type> partitionColumnTypes;
-
-    private final PageIndexer pageIndexer;
-    private final TrinoFileSystem fileSystem;
-
-    private final int maxOpenWriters;
-
-    private final JsonCodec<DataFileInfo> dataFileInfoCodec;
-
-    private final List<DeltaLakeWriter> writers = new ArrayList<>();
-
-    private final String outputPath;
-    private final ConnectorSession session;
-    private final DeltaLakeWriterStats stats;
-    private final String trinoVersion;
-    private final long targetMaxFileSize;
-
-    private long writtenBytes;
-    private long memoryUsage;
-
-    private final List<Closeable> closedWriterRollbackActions = new ArrayList<>();
-    private final ImmutableList.Builder<Slice> dataFileInfos = ImmutableList.builder();
-
     public DeltaLakePageSink(
             List<DeltaLakeColumnHandle> inputColumns,
             List<String> originalPartitionColumns,
@@ -112,376 +32,42 @@ public class DeltaLakePageSink
             TrinoFileSystemFactory fileSystemFactory,
             int maxOpenWriters,
             JsonCodec<DataFileInfo> dataFileInfoCodec,
-            String outputPath,
+            String tableLocation,
             ConnectorSession session,
             DeltaLakeWriterStats stats,
             String trinoVersion)
     {
-        requireNonNull(inputColumns, "inputColumns is null");
-
-        requireNonNull(pageIndexerFactory, "pageIndexerFactory is null");
-
-        this.fileSystem = requireNonNull(fileSystemFactory, "fileSystemFactory is null").create(session);
-        this.maxOpenWriters = maxOpenWriters;
-        this.dataFileInfoCodec = requireNonNull(dataFileInfoCodec, "dataFileInfoCodec is null");
-
-        // determine the input index of the partition columns and data columns
-        int[] partitionColumnInputIndex = new int[originalPartitionColumns.size()];
-        ImmutableList.Builder<Integer> dataColumnsInputIndex = ImmutableList.builder();
-
-        Type[] partitionColumnTypes = new Type[originalPartitionColumns.size()];
-        String[] originalPartitionColumnNames = new String[originalPartitionColumns.size()];
-
-        ImmutableList.Builder<DeltaLakeColumnHandle> dataColumnHandles = ImmutableList.builder();
-        ImmutableList.Builder<Type> dataColumnTypes = ImmutableList.builder();
-        ImmutableList.Builder<String> dataColumnNames = ImmutableList.builder();
-
-        Map<String, String> canonicalToOriginalPartitionColumns = new HashMap<>();
-        Map<String, Integer> canonicalToOriginalPartitionPositions = new HashMap<>();
-        int partitionColumnPosition = 0;
-        for (String partitionColumnName : originalPartitionColumns) {
-            String canonicalizeColumnName = canonicalizeColumnName(partitionColumnName);
-            canonicalToOriginalPartitionColumns.put(canonicalizeColumnName, partitionColumnName);
-            canonicalToOriginalPartitionPositions.put(canonicalizeColumnName, partitionColumnPosition++);
-        }
-        for (int inputIndex = 0; inputIndex < inputColumns.size(); inputIndex++) {
-            DeltaLakeColumnHandle column = inputColumns.get(inputIndex);
-            switch (column.getColumnType()) {
-                case PARTITION_KEY:
-                    int partitionPosition = canonicalToOriginalPartitionPositions.get(column.getName());
-                    partitionColumnInputIndex[partitionPosition] = inputIndex;
-                    originalPartitionColumnNames[partitionPosition] = canonicalToOriginalPartitionColumns.get(column.getName());
-                    partitionColumnTypes[partitionPosition] = column.getType();
-                    break;
-                case REGULAR:
-                    dataColumnHandles.add(column);
-                    dataColumnsInputIndex.add(inputIndex);
-                    dataColumnNames.add(column.getName());
-                    dataColumnTypes.add(column.getType());
-                    break;
-                case SYNTHESIZED:
-                default:
-                    throw new IllegalStateException("Unexpected column type: " + column.getColumnType());
-            }
-        }
-        this.partitionColumnsInputIndex = partitionColumnInputIndex;
-        this.dataColumnInputIndex = Ints.toArray(dataColumnsInputIndex.build());
-        this.originalPartitionColumnNames = ImmutableList.copyOf(originalPartitionColumnNames);
-        this.dataColumnHandles = dataColumnHandles.build();
-        this.partitionColumnTypes = ImmutableList.copyOf(partitionColumnTypes);
-        this.dataColumnNames = dataColumnNames.build();
-        this.dataColumnTypes = dataColumnTypes.build();
-
-        this.pageIndexer = pageIndexerFactory.createPageIndexer(this.partitionColumnTypes);
-
-        this.outputPath = outputPath;
-        this.session = requireNonNull(session, "session is null");
-        this.stats = stats;
-        this.trinoVersion = requireNonNull(trinoVersion, "trinoVersion is null");
-        this.targetMaxFileSize = DeltaLakeSessionProperties.getTargetMaxFileSize(session);
+        super(
+                inputColumns,
+                originalPartitionColumns,
+                pageIndexerFactory,
+                fileSystemFactory,
+                maxOpenWriters,
+                dataFileInfoCodec,
+                tableLocation,
+                tableLocation,
+                session,
+                stats,
+                trinoVersion);
     }
 
     @Override
-    public long getCompletedBytes()
+    protected void processSynthesizedColumn(DeltaLakeColumnHandle column)
     {
-        return writtenBytes;
+        throw new IllegalStateException("Unexpected column type: " + column.getColumnType());
     }
 
     @Override
-    public long getMemoryUsage()
-    {
-        return memoryUsage;
-    }
+    protected void addSpecialColumns(
+            List<DeltaLakeColumnHandle> inputColumns,
+            ImmutableList.Builder<DeltaLakeColumnHandle> dataColumnHandles,
+            ImmutableList.Builder<Integer> dataColumnsInputIndex,
+            ImmutableList.Builder<String> dataColumnNames,
+            ImmutableList.Builder<Type> dataColumnTypes) {}
 
     @Override
-    public long getValidationCpuNanos()
+    protected String getPathPrefix()
     {
-        return 0;
-    }
-
-    @Override
-    public CompletableFuture<Collection<Slice>> finish()
-    {
-        for (int writerIndex = 0; writerIndex < writers.size(); writerIndex++) {
-            closeWriter(writerIndex);
-        }
-        writers.clear();
-
-        List<Slice> result = dataFileInfos.build();
-
-        return MoreFutures.toCompletableFuture(Futures.immediateFuture(result));
-    }
-
-    @Override
-    public void abort()
-    {
-        List<Closeable> rollbackActions = Streams.concat(
-                        writers.stream()
-                                // writers can contain nulls if an exception is thrown when doAppend expands the writer list
-                                .filter(Objects::nonNull)
-                                .map(writer -> writer::rollback),
-                        closedWriterRollbackActions.stream())
-                .collect(toImmutableList());
-        RuntimeException rollbackException = null;
-        for (Closeable rollbackAction : rollbackActions) {
-            try {
-                rollbackAction.close();
-            }
-            catch (Throwable t) {
-                if (rollbackException == null) {
-                    rollbackException = new TrinoException(DELTA_LAKE_BAD_WRITE, "Error rolling back write to Delta Lake");
-                }
-                rollbackException.addSuppressed(t);
-            }
-        }
-        if (rollbackException != null) {
-            throw rollbackException;
-        }
-    }
-
-    @Override
-    public CompletableFuture<?> appendPage(Page page)
-    {
-        if (page.getPositionCount() == 0) {
-            return NOT_BLOCKED;
-        }
-
-        while (page.getPositionCount() > MAX_PAGE_POSITIONS) {
-            Page chunk = page.getRegion(0, MAX_PAGE_POSITIONS);
-            page = page.getRegion(MAX_PAGE_POSITIONS, page.getPositionCount() - MAX_PAGE_POSITIONS);
-            writePage(chunk);
-        }
-
-        writePage(page);
-        return NOT_BLOCKED;
-    }
-
-    private void writePage(Page page)
-    {
-        int[] writerIndexes = getWriterIndexes(page);
-
-        // position count for each writer
-        int[] sizes = new int[writers.size()];
-        for (int index : writerIndexes) {
-            sizes[index]++;
-        }
-
-        // record which positions are used by which writer
-        int[][] writerPositions = new int[writers.size()][];
-        int[] counts = new int[writers.size()];
-
-        for (int position = 0; position < page.getPositionCount(); position++) {
-            int index = writerIndexes[position];
-
-            int count = counts[index];
-            if (count == 0) {
-                writerPositions[index] = new int[sizes[index]];
-            }
-            writerPositions[index][count] = position;
-            counts[index] = count + 1;
-        }
-
-        // invoke the writers
-        Page dataPage = getDataPage(page);
-        for (int index = 0; index < writerPositions.length; index++) {
-            int[] positions = writerPositions[index];
-            if (positions == null) {
-                continue;
-            }
-
-            // If write is partitioned across multiple writers, filter page using dictionary blocks
-            Page pageForWriter = dataPage;
-            if (positions.length != dataPage.getPositionCount()) {
-                verify(positions.length == counts[index]);
-                pageForWriter = pageForWriter.getPositions(positions, 0, positions.length);
-            }
-
-            DeltaLakeWriter writer = writers.get(index);
-
-            long currentWritten = writer.getWrittenBytes();
-            long currentMemory = writer.getMemoryUsage();
-
-            writer.appendRows(pageForWriter);
-
-            writtenBytes += (writer.getWrittenBytes() - currentWritten);
-            memoryUsage += (writer.getMemoryUsage() - currentMemory);
-        }
-    }
-
-    private int[] getWriterIndexes(Page page)
-    {
-        Page partitionColumns = extractColumns(page, partitionColumnsInputIndex);
-        int[] writerIndexes = pageIndexer.indexPage(partitionColumns);
-        if (pageIndexer.getMaxIndex() >= maxOpenWriters) {
-            throw new TrinoException(DELTA_LAKE_BAD_WRITE, format("Exceeded limit of %s open writers for partitions", maxOpenWriters));
-        }
-
-        // expand writers list to new size
-        while (writers.size() <= pageIndexer.getMaxIndex()) {
-            writers.add(null);
-        }
-        // create missing writers
-        for (int position = 0; position < page.getPositionCount(); position++) {
-            int writerIndex = writerIndexes[position];
-            DeltaLakeWriter deltaLakeWriter = writers.get(writerIndex);
-            if (deltaLakeWriter != null) {
-                if (deltaLakeWriter.getWrittenBytes() <= targetMaxFileSize) {
-                    continue;
-                }
-                closeWriter(writerIndex);
-            }
-
-            Path filePath = new Path(outputPath);
-
-            List<String> partitionValues = createPartitionValues(partitionColumnTypes, partitionColumns, position);
-            Optional<String> partitionName = Optional.empty();
-            if (!originalPartitionColumnNames.isEmpty()) {
-                String partName = makePartName(originalPartitionColumnNames, partitionValues);
-                filePath = new Path(outputPath, partName);
-                partitionName = Optional.of(partName);
-            }
-
-            String fileName = session.getQueryId() + "-" + randomUUID();
-            filePath = new Path(filePath, fileName);
-
-            FileWriter fileWriter = createParquetFileWriter(filePath.toString());
-
-            Path rootTableLocation = new Path(outputPath);
-            DeltaLakeWriter writer = new DeltaLakeWriter(
-                    fileSystem,
-                    fileWriter,
-                    rootTableLocation,
-                    partitionName.map(partition -> new Path(partition, fileName).toString()).orElse(fileName),
-                    partitionValues,
-                    stats,
-                    dataColumnHandles);
-
-            writers.set(writerIndex, writer);
-            memoryUsage += writer.getMemoryUsage();
-        }
-        verify(writers.size() == pageIndexer.getMaxIndex() + 1);
-        verify(!writers.contains(null));
-
-        return writerIndexes;
-    }
-
-    private void closeWriter(int writerIndex)
-    {
-        DeltaLakeWriter writer = writers.get(writerIndex);
-
-        long currentWritten = writer.getWrittenBytes();
-        long currentMemory = writer.getMemoryUsage();
-
-        closedWriterRollbackActions.add(writer.commit());
-
-        writtenBytes += writer.getWrittenBytes() - currentWritten;
-        memoryUsage -= currentMemory;
-
-        writers.set(writerIndex, null);
-
-        try {
-            DataFileInfo dataFileInfo = writer.getDataFileInfo();
-            dataFileInfos.add(wrappedBuffer(dataFileInfoCodec.toJsonBytes(dataFileInfo)));
-        }
-        catch (IOException e) {
-            LOG.warn("exception '%s' while finishing write on %s", e, writer);
-            throw new TrinoException(DELTA_LAKE_BAD_WRITE, "Error committing Parquet file to Delta Lake", e);
-        }
-    }
-
-    /**
-     * Copy of {@link HiveUtil#makePartName} modified to preserve case of partition columns.
-     */
-    private static String makePartName(List<String> partitionColumns, List<String> partitionValues)
-    {
-        StringBuilder name = new StringBuilder();
-
-        for (int i = 0; i < partitionColumns.size(); ++i) {
-            if (i > 0) {
-                name.append("/");
-            }
-
-            name.append(escapePathName(partitionColumns.get(i)));
-            name.append('=');
-            name.append(escapePathName(partitionValues.get(i)));
-        }
-
-        return name.toString();
-    }
-
-    public static List<String> createPartitionValues(List<Type> partitionColumnTypes, Page partitionColumns, int position)
-    {
-        return HiveWriteUtils.createPartitionValues(partitionColumnTypes, partitionColumns, position).stream()
-                .map(value -> value.equals(HivePartitionKey.HIVE_DEFAULT_DYNAMIC_PARTITION) ? null : value)
-                .collect(toList());
-    }
-
-    private FileWriter createParquetFileWriter(String path)
-    {
-        ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
-                .setMaxBlockSize(getParquetWriterBlockSize(session))
-                .setMaxPageSize(getParquetWriterPageSize(session))
-                .build();
-        CompressionCodecName compressionCodecName = getCompressionCodec(session).getParquetCompressionCodec();
-
-        try {
-            Closeable rollbackAction = () -> fileSystem.deleteFile(path);
-
-            List<Type> parquetTypes = dataColumnTypes.stream()
-                    .map(type -> {
-                        if (type instanceof TimestampWithTimeZoneType) {
-                            verify(((TimestampWithTimeZoneType) type).getPrecision() == 3, "Unsupported type: %s", type);
-                            return TIMESTAMP_MILLIS;
-                        }
-                        return type;
-                    })
-                    .collect(toImmutableList());
-
-            // we use identity column mapping; input page already contains only data columns per
-            // DataLagePageSink.getDataPage()
-            int[] identityMapping = new int[dataColumnTypes.size()];
-            for (int i = 0; i < identityMapping.length; ++i) {
-                identityMapping[i] = i;
-            }
-
-            ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(parquetTypes, dataColumnNames, false, false);
-            return new ParquetFileWriter(
-                    fileSystem.newOutputFile(path),
-                    rollbackAction,
-                    parquetTypes,
-                    dataColumnNames,
-                    schemaConverter.getMessageType(),
-                    schemaConverter.getPrimitiveTypes(),
-                    parquetWriterOptions,
-                    identityMapping,
-                    compressionCodecName,
-                    trinoVersion,
-                    false,
-                    Optional.empty(),
-                    Optional.empty());
-        }
-        catch (IOException e) {
-            throw new TrinoException(DELTA_LAKE_BAD_WRITE, "Error creating Parquet file", e);
-        }
-    }
-
-    private Page getDataPage(Page page)
-    {
-        Block[] blocks = new Block[dataColumnInputIndex.length];
-        for (int i = 0; i < dataColumnInputIndex.length; i++) {
-            int dataColumn = dataColumnInputIndex[i];
-            blocks[i] = page.getBlock(dataColumn);
-        }
-        return new Page(page.getPositionCount(), blocks);
-    }
-
-    private static Page extractColumns(Page page, int[] columns)
-    {
-        Block[] blocks = new Block[columns.length];
-        for (int i = 0; i < columns.length; i++) {
-            int dataColumn = columns[i];
-            blocks[i] = page.getBlock(dataColumn);
-        }
-        return new Page(page.getPositionCount(), blocks);
+        return "";
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSinkProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSinkProvider.java
@@ -17,6 +17,7 @@ import io.airlift.json.JsonCodec;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.plugin.deltalake.procedure.DeltaLakeTableExecuteHandle;
 import io.trino.plugin.deltalake.procedure.DeltaTableOptimizeHandle;
+import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.plugin.hive.NodeVersion;
 import io.trino.spi.PageIndexerFactory;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
@@ -29,10 +30,22 @@ import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableExecuteHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.type.TypeManager;
 import org.joda.time.DateTimeZone;
 
 import javax.inject.Inject;
 
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.plugin.deltalake.DeltaLakeCdfPageSink.CHANGE_DATA_FOLDER_NAME;
+import static io.trino.plugin.deltalake.DeltaLakeColumnType.PARTITION_KEY;
+import static io.trino.plugin.deltalake.DeltaLakeColumnType.REGULAR;
+import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.changeDataFeedEnabled;
+import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.extractSchema;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class DeltaLakePageSinkProvider
@@ -45,6 +58,7 @@ public class DeltaLakePageSinkProvider
     private final DeltaLakeWriterStats stats;
     private final int maxPartitionsPerWriter;
     private final DateTimeZone parquetDateTimeZone;
+    private final TypeManager typeManager;
     private final String trinoVersion;
     private final int domainCompactionThreshold;
 
@@ -56,6 +70,7 @@ public class DeltaLakePageSinkProvider
             JsonCodec<DeltaLakeMergeResult> mergeResultJsonCodec,
             DeltaLakeWriterStats stats,
             DeltaLakeConfig deltaLakeConfig,
+            TypeManager typeManager,
             NodeVersion nodeVersion)
     {
         this.pageIndexerFactory = pageIndexerFactory;
@@ -66,6 +81,7 @@ public class DeltaLakePageSinkProvider
         this.maxPartitionsPerWriter = deltaLakeConfig.getMaxPartitionsPerWriter();
         this.parquetDateTimeZone = deltaLakeConfig.getParquetDateTimeZone();
         this.domainCompactionThreshold = deltaLakeConfig.getDomainCompactionThreshold();
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.trinoVersion = nodeVersion.toString();
     }
 
@@ -144,6 +160,38 @@ public class DeltaLakePageSinkProvider
                 tableHandle.getLocation(),
                 pageSink,
                 tableHandle.getInputColumns(),
-                domainCompactionThreshold);
+                domainCompactionThreshold,
+                () -> createCdfPageSink(merge, session),
+                changeDataFeedEnabled(tableHandle.getMetadataEntry()));
+    }
+
+    private DeltaLakeCdfPageSink createCdfPageSink(
+            DeltaLakeMergeTableHandle mergeTableHandle,
+            ConnectorSession session)
+    {
+        MetadataEntry metadataEntry = mergeTableHandle.getTableHandle().getMetadataEntry();
+        Set<String> partitionKeys = mergeTableHandle.getTableHandle().getMetadataEntry().getOriginalPartitionColumns().stream().collect(toImmutableSet());
+        List<DeltaLakeColumnHandle> allColumns = extractSchema(metadataEntry, typeManager).stream()
+                .map(metadata -> new DeltaLakeColumnHandle(
+                        metadata.getName(),
+                        metadata.getType(),
+                        metadata.getFieldId(),
+                        metadata.getPhysicalName(),
+                        metadata.getPhysicalColumnType(),
+                        partitionKeys.contains(metadata.getName()) ? PARTITION_KEY : REGULAR))
+                .collect(toImmutableList());
+
+        return new DeltaLakeCdfPageSink(
+                allColumns,
+                metadataEntry.getOriginalPartitionColumns(),
+                pageIndexerFactory,
+                fileSystemFactory,
+                maxPartitionsPerWriter,
+                dataFileInfoCodec,
+                format("%s/%s/", mergeTableHandle.getTableHandle().getLocation(), CHANGE_DATA_FOLDER_NAME),
+                mergeTableHandle.getTableHandle().getLocation(),
+                session,
+                stats,
+                trinoVersion);
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
@@ -22,6 +22,7 @@ import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.parquet.ParquetReaderOptions;
 import io.trino.parquet.reader.MetadataReader;
+import io.trino.plugin.deltalake.DataFileInfo.DataFileType;
 import io.trino.plugin.deltalake.transactionlog.statistics.DeltaLakeJsonFileStatistics;
 import io.trino.plugin.hive.FileFormatDataSourceStats;
 import io.trino.plugin.hive.FileWriter;
@@ -77,6 +78,7 @@ public class DeltaLakeWriter
 
     private long rowCount;
     private long inputSizeInBytes;
+    private DataFileType dataFileType;
 
     public DeltaLakeWriter(
             TrinoFileSystem fileSystem,
@@ -85,7 +87,8 @@ public class DeltaLakeWriter
             String relativeFilePath,
             List<String> partitionValues,
             DeltaLakeWriterStats stats,
-            List<DeltaLakeColumnHandle> columnHandles)
+            List<DeltaLakeColumnHandle> columnHandles,
+            DataFileType dataFileType)
     {
         this.fileSystem = requireNonNull(fileSystem, "fileSystem is null");
         this.fileWriter = requireNonNull(fileWriter, "fileWriter is null");
@@ -103,6 +106,7 @@ public class DeltaLakeWriter
             }
         }
         this.timestampColumnIndices = timestampColumnIndices.build();
+        this.dataFileType = dataFileType;
     }
 
     @Override
@@ -175,6 +179,7 @@ public class DeltaLakeWriter
                 relativeFilePath,
                 getWrittenBytes(),
                 creationTime,
+                dataFileType,
                 partitionValues,
                 readStatistics(fileSystem, rootTableLocation, dataColumnNames, dataColumnTypes, relativeFilePath, rowCount));
     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/CdfFileEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/CdfFileEntry.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.transactionlog;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+import static java.lang.String.format;
+
+public class CdfFileEntry
+{
+    private final String path;
+    private final Map<String, String> partitionValues;
+    private final long size;
+    private final boolean dataChange;
+
+    @JsonCreator
+    public CdfFileEntry(
+            @JsonProperty("path") String path,
+            @JsonProperty("partitionValues") Map<String, String> partitionValues,
+            @JsonProperty("size") long size)
+    {
+        this.path = path;
+        this.partitionValues = partitionValues;
+        this.size = size;
+        this.dataChange = false;
+    }
+
+    @JsonProperty
+    public String getPath()
+    {
+        return path;
+    }
+
+    @JsonProperty
+    public Map<String, String> getPartitionValues()
+    {
+        return partitionValues;
+    }
+
+    @JsonProperty
+    public long getSize()
+    {
+        return size;
+    }
+
+    @JsonProperty("dataChange")
+    public boolean isDataChange()
+    {
+        return dataChange;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("CdfFileEntry{path=%s, partitionValues=%s, size=%d, dataChange=%b}",
+                path, partitionValues, size, dataChange);
+    }
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeTransactionLogEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeTransactionLogEntry.java
@@ -28,6 +28,7 @@ public class DeltaLakeTransactionLogEntry
     private final MetadataEntry metaData;
     private final ProtocolEntry protocol;
     private final CommitInfoEntry commitInfo;
+    private final CdfFileEntry cdfFileEntry;
 
     private DeltaLakeTransactionLogEntry(
             TransactionEntry txn,
@@ -35,7 +36,8 @@ public class DeltaLakeTransactionLogEntry
             RemoveFileEntry remove,
             MetadataEntry metaData,
             ProtocolEntry protocol,
-            CommitInfoEntry commitInfo)
+            CommitInfoEntry commitInfo,
+            CdfFileEntry cdfFileEntry)
     {
         this.txn = txn;
         this.add = add;
@@ -43,6 +45,7 @@ public class DeltaLakeTransactionLogEntry
         this.metaData = metaData;
         this.protocol = protocol;
         this.commitInfo = commitInfo;
+        this.cdfFileEntry = cdfFileEntry;
     }
 
     @JsonCreator
@@ -52,45 +55,52 @@ public class DeltaLakeTransactionLogEntry
             @JsonProperty("remove") RemoveFileEntry remove,
             @JsonProperty("metaData") MetadataEntry metaData,
             @JsonProperty("protocol") ProtocolEntry protocol,
-            @JsonProperty("commitInfo") CommitInfoEntry commitInfo)
+            @JsonProperty("commitInfo") CommitInfoEntry commitInfo,
+            @JsonProperty("cdfFileEntry") CdfFileEntry cdfFileEntry)
     {
-        return new DeltaLakeTransactionLogEntry(txn, add, remove, metaData, protocol, commitInfo);
+        return new DeltaLakeTransactionLogEntry(txn, add, remove, metaData, protocol, commitInfo, cdfFileEntry);
     }
 
     public static DeltaLakeTransactionLogEntry transactionEntry(TransactionEntry transaction)
     {
         requireNonNull(transaction, "transaction is null");
-        return new DeltaLakeTransactionLogEntry(transaction, null, null, null, null, null);
+        return new DeltaLakeTransactionLogEntry(transaction, null, null, null, null, null, null);
     }
 
     public static DeltaLakeTransactionLogEntry commitInfoEntry(CommitInfoEntry commitInfo)
     {
         requireNonNull(commitInfo, "commitInfo is null");
-        return new DeltaLakeTransactionLogEntry(null, null, null, null, null, commitInfo);
+        return new DeltaLakeTransactionLogEntry(null, null, null, null, null, commitInfo, null);
     }
 
     public static DeltaLakeTransactionLogEntry protocolEntry(ProtocolEntry protocolEntry)
     {
         requireNonNull(protocolEntry, "protocolEntry is null");
-        return new DeltaLakeTransactionLogEntry(null, null, null, null, protocolEntry, null);
+        return new DeltaLakeTransactionLogEntry(null, null, null, null, protocolEntry, null, null);
     }
 
     public static DeltaLakeTransactionLogEntry metadataEntry(MetadataEntry metadataEntry)
     {
         requireNonNull(metadataEntry, "metadataEntry is null");
-        return new DeltaLakeTransactionLogEntry(null, null, null, metadataEntry, null, null);
+        return new DeltaLakeTransactionLogEntry(null, null, null, metadataEntry, null, null, null);
     }
 
     public static DeltaLakeTransactionLogEntry addFileEntry(AddFileEntry addFileEntry)
     {
         requireNonNull(addFileEntry, "addFileEntry is null");
-        return new DeltaLakeTransactionLogEntry(null, addFileEntry, null, null, null, null);
+        return new DeltaLakeTransactionLogEntry(null, addFileEntry, null, null, null, null, null);
     }
 
     public static DeltaLakeTransactionLogEntry removeFileEntry(RemoveFileEntry removeFileEntry)
     {
         requireNonNull(removeFileEntry, "removeFileEntry is null");
-        return new DeltaLakeTransactionLogEntry(null, null, removeFileEntry, null, null, null);
+        return new DeltaLakeTransactionLogEntry(null, null, removeFileEntry, null, null, null, null);
+    }
+
+    public static DeltaLakeTransactionLogEntry cdfFileEntry(CdfFileEntry cdfFileEntry)
+    {
+        requireNonNull(cdfFileEntry, "cdfFileEntry is null");
+        return new DeltaLakeTransactionLogEntry(null, null, null, null, null, null, cdfFileEntry);
     }
 
     @Nullable
@@ -135,9 +145,16 @@ public class DeltaLakeTransactionLogEntry
         return commitInfo;
     }
 
+    @Nullable
+    @JsonProperty
+    public CdfFileEntry getCDC()
+    {
+        return cdfFileEntry;
+    }
+
     @Override
     public String toString()
     {
-        return String.format("DeltaLakeTransactionLogEntry{%s, %s, %s, %s, %s, %s}", txn, add, remove, metaData, protocol, commitInfo);
+        return String.format("DeltaLakeTransactionLogEntry{%s, %s, %s, %s, %s, %s, %s}", txn, add, remove, metaData, protocol, commitInfo, cdfFileEntry);
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/TransactionLogWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/TransactionLogWriter.java
@@ -16,6 +16,7 @@ package io.trino.plugin.deltalake.transactionlog.writer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.airlift.json.ObjectMapperProvider;
 import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
+import io.trino.plugin.deltalake.transactionlog.CdfFileEntry;
 import io.trino.plugin.deltalake.transactionlog.CommitInfoEntry;
 import io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
@@ -78,6 +79,11 @@ public class TransactionLogWriter
     public void appendRemoveFileEntry(RemoveFileEntry removeFileEntry)
     {
         entries.add(DeltaLakeTransactionLogEntry.removeFileEntry(removeFileEntry));
+    }
+
+    public void appendCdfFileEntry(CdfFileEntry cdfFileEntry)
+    {
+        entries.add(DeltaLakeTransactionLogEntry.cdfFileEntry(cdfFileEntry));
     }
 
     public boolean isUnsafe()

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
@@ -26,6 +26,7 @@ import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.ConnectorPageSink;
+import io.trino.spi.type.TestingTypeManager;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
 import io.trino.sql.gen.JoinCompiler;
@@ -166,6 +167,7 @@ public class TestDeltaLakePageSink
                 JsonCodec.jsonCodec(DeltaLakeMergeResult.class),
                 stats,
                 deltaLakeConfig,
+                new TestingTypeManager(),
                 new NodeVersion("test-version"));
 
         return provider.createPageSink(transaction, SESSION, tableHandle, TESTING_PAGE_SINK_ID);

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
@@ -48,6 +48,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
@@ -214,6 +215,15 @@ public class KuduPageSink
         try (KuduOperationApplier operationApplier = KuduOperationApplier.fromKuduClientSession(session)) {
             for (int position = 0; position < page.getPositionCount(); position++) {
                 long operation = TINYINT.getLong(operationBlock, position);
+
+                checkState(operation == UPDATE_OPERATION_NUMBER ||
+                                operation == INSERT_OPERATION_NUMBER ||
+                                operation == DELETE_OPERATION_NUMBER,
+                        "Invalid operation value, supported are " +
+                                        "%s INSERT_OPERATION_NUMBER, " +
+                                        "%s DELETE_OPERATION_NUMBER and " +
+                                        "%s UPDATE_OPERATION_NUMBER",
+                                INSERT_OPERATION_NUMBER, DELETE_OPERATION_NUMBER, UPDATE_OPERATION_NUMBER);
 
                 if (operation == DELETE_OPERATION_NUMBER || operation == UPDATE_OPERATION_NUMBER) {
                     Delete delete = table.newDelete();

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksChangeDataFeedCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksChangeDataFeedCompatibility.java
@@ -1,0 +1,419 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.deltalake;
+
+import org.testng.annotations.Test;
+
+import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
+import static io.trino.tempto.assertions.QueryAssert.assertThat;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_DATABRICKS;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_EXCLUDE_73;
+import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.utils.QueryExecutors.onDelta;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+import static java.lang.String.format;
+
+public class TestDeltaLakeDatabricksChangeDataFeedCompatibility
+        extends BaseTestDeltaLakeS3Storage
+{
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
+    public void testUpdateTableWithCdf()
+    {
+        String tableName = "test_updates_to_table_with_cdf_" + randomNameSuffix();
+        try {
+            onDelta().executeQuery("CREATE TABLE default." + tableName + " (col1 STRING, updated_column INT) " +
+                    "USING DELTA " +
+                    "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
+                    "TBLPROPERTIES (delta.enableChangeDataFeed = true)");
+
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES ('testValue1', 1)");
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES ('testValue2', 2)");
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES ('testValue3', 3)");
+            onTrino().executeQuery("UPDATE delta.default." + tableName +
+                    " SET updated_column = 5 WHERE col1 = 'testValue3'");
+            onTrino().executeQuery("UPDATE delta.default." + tableName +
+                    " SET updated_column = 4, col1 = 'testValue4' WHERE col1 = 'testValue3'");
+
+            assertThat(onDelta().executeQuery("SELECT col1, updated_column, _change_type, _commit_version " +
+                    "FROM table_changes('default." + tableName + "', 0)"))
+                    .containsOnly(
+                            row("testValue1", 1, "insert", 1L),
+                            row("testValue2", 2, "insert", 2L),
+                            row("testValue3", 3, "insert", 3L),
+                            row("testValue3", 3, "update_preimage", 4L),
+                            row("testValue3", 5, "update_postimage", 4L),
+                            row("testValue3", 5, "update_preimage", 5L),
+                            row("testValue4", 4, "update_postimage", 5L));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE IF EXISTS default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
+    public void testUpdatePartitionedTableWithCdf()
+    {
+        String tableName = "test_updates_to_partitioned_table_with_cdf_" + randomNameSuffix();
+        try {
+            onDelta().executeQuery("CREATE TABLE default." + tableName + " (updated_column STRING, partitioning_column_1 INT, partitioning_column_2 STRING) " +
+                    "USING DELTA " +
+                    "PARTITIONED BY (partitioning_column_1, partitioning_column_2) " +
+                    "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
+                    "TBLPROPERTIES (delta.enableChangeDataFeed = true)");
+
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES ('testValue1', 1, 'partition1')");
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES ('testValue2', 2, 'partition2')");
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES ('testValue3', 3, 'partition3')");
+            onTrino().executeQuery("UPDATE delta.default." + tableName + " SET updated_column = 'testValue5' WHERE partitioning_column_1 = 3");
+
+            assertThat(onDelta().executeQuery(
+                    "SELECT updated_column, partitioning_column_1, partitioning_column_2, _change_type, _commit_version " +
+                            "FROM table_changes('default." + tableName + "', 0)"))
+                    .containsOnly(
+                            row("testValue1", 1, "partition1", "insert", 1L),
+                            row("testValue2", 2, "partition2", "insert", 2L),
+                            row("testValue3", 3, "partition3", "insert", 3L),
+                            row("testValue3", 3, "partition3", "update_preimage", 4L),
+                            row("testValue5", 3, "partition3", "update_postimage", 4L));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE IF EXISTS default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
+    public void testUpdateTableWithManyRowsInsertedInTheSameQueryAndCdfEnabled()
+    {
+        String tableName = "test_updates_to_table_with_many_rows_inserted_in_one_query_cdf_" + randomNameSuffix();
+        try {
+            onDelta().executeQuery("CREATE TABLE default." + tableName + " (col1 STRING, updated_column INT) " +
+                    "USING DELTA " +
+                    "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
+                    "TBLPROPERTIES (delta.enableChangeDataFeed = true)");
+
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES ('testValue1', 1), ('testValue2', 2), ('testValue3', 3)");
+            onTrino().executeQuery("UPDATE delta.default." + tableName + " SET updated_column = 5 WHERE col1 = 'testValue3'");
+
+            assertThat(onDelta().executeQuery("SELECT col1, updated_column, _change_type, _commit_version " +
+                    "FROM table_changes('default." + tableName + "', 0)"))
+                    .containsOnly(
+                            row("testValue1", 1, "insert", 1L),
+                            row("testValue2", 2, "insert", 1L),
+                            row("testValue3", 3, "insert", 1L),
+                            row("testValue3", 3, "update_preimage", 2L),
+                            row("testValue3", 5, "update_postimage", 2L));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE IF EXISTS default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
+    public void testUpdatePartitionedTableWithManyRowsInsertedInTheSameRequestAndCdfEnabled()
+    {
+        String tableName = "test_updates_to_partitioned_table_with_many_rows_inserted_in_one_query_cdf_" + randomNameSuffix();
+        try {
+            onDelta().executeQuery("CREATE TABLE default." + tableName + " (updated_column STRING, partitioning_column_1 INT, partitioning_column_2 STRING) " +
+                    "USING DELTA " +
+                    "PARTITIONED BY (partitioning_column_1, partitioning_column_2) " +
+                    "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
+                    "TBLPROPERTIES (delta.enableChangeDataFeed = true)");
+
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES " +
+                    "('testValue1', 1, 'partition1'), " +
+                    "('testValue2', 2, 'partition2'), " +
+                    "('testValue3', 3, 'partition3')");
+            onTrino().executeQuery("UPDATE delta.default." + tableName + " SET updated_column = 'testValue5' WHERE partitioning_column_1 = 3");
+
+            assertThat(onDelta().executeQuery(
+                    "SELECT updated_column, partitioning_column_1, partitioning_column_2, _change_type, _commit_version " +
+                            "FROM table_changes('default." + tableName + "', 0)"))
+                    .containsOnly(
+                            row("testValue1", 1, "partition1", "insert", 1L),
+                            row("testValue2", 2, "partition2", "insert", 1L),
+                            row("testValue3", 3, "partition3", "insert", 1L),
+                            row("testValue3", 3, "partition3", "update_preimage", 2L),
+                            row("testValue5", 3, "partition3", "update_postimage", 2L));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE IF EXISTS default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
+    public void testUpdatePartitionedTableCdfEnabledAndPartitioningColumnUpdated()
+    {
+        String tableName = "test_updates_partitioning_column_in_table_with_cdf_" + randomNameSuffix();
+        try {
+            onDelta().executeQuery("CREATE TABLE default." + tableName + " (updated_column STRING, partitioning_column_1 INT, partitioning_column_2 STRING) " +
+                    "USING DELTA " +
+                    "PARTITIONED BY (partitioning_column_1, partitioning_column_2) " +
+                    "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
+                    "TBLPROPERTIES (delta.enableChangeDataFeed = true)");
+
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES " +
+                    "('testValue1', 1, 'partition1'), " +
+                    "('testValue2', 2, 'partition2'), " +
+                    "('testValue3', 3, 'partition3')");
+            onTrino().executeQuery("UPDATE delta.default." + tableName +
+                    " SET partitioning_column_1 = 5 WHERE partitioning_column_2 = 'partition1'");
+            onTrino().executeQuery("UPDATE delta.default." + tableName +
+                    " SET partitioning_column_1 = 4, updated_column = 'testValue4' WHERE partitioning_column_2 = 'partition2'");
+
+            assertThat(onDelta().executeQuery(
+                    "SELECT updated_column, partitioning_column_1, partitioning_column_2, _change_type, _commit_version " +
+                            "FROM table_changes('default." + tableName + "', 0)"))
+                    .containsOnly(
+                            row("testValue1", 1, "partition1", "insert", 1L),
+                            row("testValue2", 2, "partition2", "insert", 1L),
+                            row("testValue3", 3, "partition3", "insert", 1L),
+                            row("testValue1", 1, "partition1", "update_preimage", 2L),
+                            row("testValue1", 5, "partition1", "update_postimage", 2L),
+                            row("testValue2", 2, "partition2", "update_preimage", 3L),
+                            row("testValue4", 4, "partition2", "update_postimage", 3L));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE IF EXISTS default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
+    public void testUpdateTableWithCdfEnabledAfterTableIsAlreadyCreated()
+    {
+        String tableName = "test_updates_to_table_with_cdf_enabled_later_" + randomNameSuffix();
+        try {
+            onDelta().executeQuery("CREATE TABLE default." + tableName + " (col1 STRING, updated_column INT) " +
+                    "USING DELTA " +
+                    "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'");
+
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES ('testValue1', 1)");
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES ('testValue2', 2)");
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES ('testValue3', 3)");
+            onTrino().executeQuery("UPDATE delta.default." + tableName + " SET updated_column = 5 WHERE col1 = 'testValue3'");
+            onDelta().executeQuery("ALTER TABLE default." + tableName + " SET TBLPROPERTIES (delta.enableChangeDataFeed = true)");
+            long versionWithCdfEnabled = (long) onDelta().executeQuery("DESCRIBE HISTORY default." + tableName + " LIMIT 1")
+                    .row(0)
+                    .get(0);
+            onTrino().executeQuery("UPDATE delta.default." + tableName + " SET updated_column = 4 WHERE col1 = 'testValue3'");
+
+            assertQueryFailure(() -> onDelta().executeQuery("SELECT col1, updated_column, _change_type, _commit_version " +
+                    "FROM table_changes('default." + tableName + "', 0)"))
+                    .hasMessageMatching("(?s)(.*Error getting change data for range \\[0 , 6] as change data was not\nrecorded for version \\[0].*)");
+
+            onTrino().executeQuery("INSERT INTO delta.default." + tableName + " VALUES ('testValue6', 6)");
+            assertThat(onDelta().executeQuery(
+                    format("SELECT col1, updated_column, _change_type, _commit_version FROM table_changes('default.%s', %d)",
+                            tableName,
+                            versionWithCdfEnabled)))
+                    .containsOnly(
+                            row("testValue3", 5, "update_preimage", 6L),
+                            row("testValue3", 4, "update_postimage", 6L),
+                            row("testValue6", 6, "insert", 7L));
+
+            long lastVersionWithCdf = (long) onDelta().executeQuery("DESCRIBE HISTORY default." + tableName + " LIMIT 1")
+                    .row(0)
+                    .get(0);
+            onDelta().executeQuery("ALTER TABLE default." + tableName + " SET TBLPROPERTIES (delta.enableChangeDataFeed = false)");
+            onTrino().executeQuery("INSERT INTO delta.default." + tableName + " VALUES ('testValue7', 7)");
+
+            assertThat(onDelta().executeQuery("SELECT col1, updated_column, _change_type, _commit_version " +
+                    format("FROM table_changes('default.%s', %d, %d)", tableName, versionWithCdfEnabled, lastVersionWithCdf)))
+                    .containsOnly(
+                            row("testValue3", 5, "update_preimage", 6L),
+                            row("testValue3", 4, "update_postimage", 6L),
+                            row("testValue6", 6, "insert", 7L));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE IF EXISTS default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
+    public void testDeleteFromTableWithCdf()
+    {
+        String tableName = "test_deletes_from_table_with_cdf_" + randomNameSuffix();
+        try {
+            onDelta().executeQuery("CREATE TABLE default." + tableName + " (col1 STRING, updated_column INT) " +
+                    "USING DELTA " +
+                    "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
+                    "TBLPROPERTIES (delta.enableChangeDataFeed = true)");
+
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES('testValue1', 1)");
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES('testValue2', 2)");
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES('testValue3', 3)");
+            onTrino().executeQuery("DELETE FROM delta.default." + tableName + " WHERE col1 = 'testValue3'");
+
+            assertThat(onDelta().executeQuery("SELECT col1, updated_column, _change_type, _commit_version " +
+                    "FROM table_changes('default." + tableName + "', 0)"))
+                    .containsOnly(
+                            row("testValue1", 1, "insert", 1L),
+                            row("testValue2", 2, "insert", 2L),
+                            row("testValue3", 3, "insert", 3L),
+                            row("testValue3", 3, "delete", 4L));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE IF EXISTS default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
+    public void testMergeUpdateIntoTableWithCdfEnabled()
+    {
+        String tableName1 = "test_merge_update_into_table_with_cdf_" + randomNameSuffix();
+        String tableName2 = "test_merge_update_into_table_with_cdf_data_table_" + randomNameSuffix();
+        try {
+            onDelta().executeQuery("CREATE TABLE default." + tableName1 + " (nationkey INT, name STRING, regionkey INT) " +
+                    "USING DELTA " +
+                    "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName1 + "'" +
+                    "TBLPROPERTIES (delta.enableChangeDataFeed = true)");
+            onDelta().executeQuery("CREATE TABLE default." + tableName2 + " (nationkey INT, name STRING, regionkey INT) " +
+                    "USING DELTA " +
+                    "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName2 + "'" +
+                    "TBLPROPERTIES (delta.enableChangeDataFeed = true)");
+
+            onDelta().executeQuery("INSERT INTO default." + tableName1 + " VALUES (1, 'nation1', 100)");
+            onDelta().executeQuery("INSERT INTO default." + tableName1 + " VALUES (2, 'nation2', 200)");
+            onDelta().executeQuery("INSERT INTO default." + tableName1 + " VALUES (3, 'nation3', 300)");
+
+            onDelta().executeQuery("INSERT INTO default." + tableName2 + " VALUES (1000, 'nation1000', 1000)");
+            onDelta().executeQuery("INSERT INTO default." + tableName2 + " VALUES (2, 'nation2', 20000)");
+            onDelta().executeQuery("INSERT INTO default." + tableName2 + " VALUES (3000, 'nation3000', 3000)");
+
+            onTrino().executeQuery("MERGE INTO delta.default." + tableName1 + " cdf USING delta.default." + tableName2 + " n " +
+                    "ON (cdf.nationkey = n.nationkey) " +
+                    "WHEN MATCHED " +
+                    "THEN UPDATE SET nationkey = (cdf.nationkey + n.nationkey + n.regionkey) " +
+                    "WHEN NOT MATCHED " +
+                    "THEN INSERT (nationkey, name, regionkey) VALUES (n.nationkey, n.name, n.regionkey)");
+
+            assertThat(onDelta().executeQuery("SELECT * FROM " + tableName1))
+                    .containsOnly(
+                            row(1000, "nation1000", 1000),
+                            row(3000, "nation3000", 3000),
+                            row(1, "nation1", 100),
+                            row(3, "nation3", 300),
+                            row(20004, "nation2", 200));
+
+            assertThat(onDelta().executeQuery(
+                    "SELECT nationkey, name, regionkey, _change_type, _commit_version " +
+                            "FROM table_changes('default." + tableName1 + "', 0)"))
+                    .containsOnly(
+                            row(1, "nation1", 100, "insert", 1),
+                            row(2, "nation2", 200, "insert", 2),
+                            row(3, "nation3", 300, "insert", 3),
+                            row(1000, "nation1000", 1000, "insert", 4),
+                            row(3000, "nation3000", 3000, "insert", 4),
+                            row(2, "nation2", 200, "update_preimage", 4),
+                            row(20004, "nation2", 200, "update_postimage", 4));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE IF EXISTS default." + tableName1);
+            onDelta().executeQuery("DROP TABLE IF EXISTS default." + tableName2);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
+    public void testMergeDeleteIntoTableWithCdfEnabled()
+    {
+        String tableName1 = "test_merge_delete_into_table_with_cdf_" + randomNameSuffix();
+        String tableName2 = "test_merge_delete_into_table_with_cdf_data_table_" + randomNameSuffix();
+        try {
+            onDelta().executeQuery("CREATE TABLE default." + tableName1 + " (nationkey INT, name STRING, regionkey INT) " +
+                    "USING DELTA " +
+                    "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName1 + "'" +
+                    "TBLPROPERTIES (delta.enableChangeDataFeed = true)");
+            onDelta().executeQuery("CREATE TABLE default." + tableName2 + " (nationkey INT, name STRING, regionkey INT) " +
+                    "USING DELTA " +
+                    "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName2 + "'" +
+                    "TBLPROPERTIES (delta.enableChangeDataFeed = true)");
+
+            onDelta().executeQuery("INSERT INTO default." + tableName1 + " VALUES (1, 'nation1', 100)");
+            onDelta().executeQuery("INSERT INTO default." + tableName1 + " VALUES (2, 'nation2', 200)");
+            onDelta().executeQuery("INSERT INTO default." + tableName1 + " VALUES (3, 'nation3', 300)");
+
+            onDelta().executeQuery("INSERT INTO default." + tableName2 + " VALUES (1000, 'nation1000', 1000)");
+            onDelta().executeQuery("INSERT INTO default." + tableName2 + " VALUES (2, 'nation2', 20000)");
+            onDelta().executeQuery("INSERT INTO default." + tableName2 + " VALUES (3000, 'nation3000', 3000)");
+
+            onTrino().executeQuery("MERGE INTO delta.default." + tableName1 + " cdf USING delta.default." + tableName2 + " n " +
+                    "ON (cdf.nationkey = n.nationkey) " +
+                    "WHEN MATCHED " +
+                    "THEN DELETE " +
+                    "WHEN NOT MATCHED " +
+                    "THEN INSERT (nationkey, name, regionkey) VALUES (n.nationkey, n.name, n.regionkey)");
+
+            assertThat(onDelta().executeQuery("SELECT * FROM " + tableName1))
+                    .containsOnly(
+                            row(1000, "nation1000", 1000),
+                            row(3000, "nation3000", 3000),
+                            row(1, "nation1", 100),
+                            row(3, "nation3", 300));
+
+            assertThat(onDelta().executeQuery(
+                    "SELECT nationkey, name, regionkey, _change_type, _commit_version " +
+                            "FROM table_changes('default." + tableName1 + "', 0)"))
+                    .containsOnly(
+                            row(1, "nation1", 100, "insert", 1),
+                            row(2, "nation2", 200, "insert", 2),
+                            row(3, "nation3", 300, "insert", 3),
+                            row(1000, "nation1000", 1000, "insert", 4),
+                            row(3000, "nation3000", 3000, "insert", 4),
+                            row(2, "nation2", 200, "delete", 4));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE IF EXISTS default." + tableName1);
+            onDelta().executeQuery("DROP TABLE IF EXISTS default." + tableName2);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
+    public void testDeleteFromNullPartitionWithCdfEnabled()
+    {
+        String tableName = "test_delete_from_null_partition_with_cdf_enabled" + randomNameSuffix();
+        try {
+            onDelta().executeQuery("CREATE TABLE default." + tableName + " (updated_column STRING, partitioning_column_1 INT, partitioning_column_2 STRING) " +
+                    "USING DELTA " +
+                    "PARTITIONED BY (partitioning_column_1, partitioning_column_2) " +
+                    "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
+                    "TBLPROPERTIES (delta.enableChangeDataFeed = true)");
+
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES " +
+                    "('testValue1', 1, 'partition1'), " +
+                    "('testValue2', 2, 'partition2'), " +
+                    "('testValue3', 3, NULL)");
+            onTrino().executeQuery("DELETE FROM delta.default." + tableName +
+                    " WHERE partitioning_column_2 IS NULL");
+
+            assertThat(onTrino().executeQuery(
+                    "SELECT * FROM delta.default." + tableName
+            )).containsOnly(
+                    row("testValue1", 1, "partition1"),
+                    row("testValue2", 2, "partition2"));
+
+            assertThat(onDelta().executeQuery(
+                    "SELECT updated_column, partitioning_column_1, partitioning_column_2, _change_type, _commit_version " +
+                            "FROM table_changes('default." + tableName + "', 0)"))
+                    .containsOnly(
+                            row("testValue1", 1, "partition1", "insert", 1L),
+                            row("testValue2", 2, "partition2", "insert", 1L),
+                            row("testValue3", 3, null, "insert", 1L),
+                            row("testValue3", 3, null, "delete", 2L));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE IF EXISTS default." + tableName);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Adds support for CDF write in delta lake connector.

Change Data Feed allows to track low level changes between versions of delta lake table.
Details [here](https://docs.databricks.com/delta/delta-change-data-feed.html).

Originally the idea was to implement CDF write separately for UPDATE, DELETE and MERGE operations but it turned out that they are so interconnected that it turned out to be impossible and thus all are implemented in the same PR. 

Please note that currently there is no possibility to enable CDF from trino. It has to be enabled using databricks engine.
 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Delta
* Adds supports for CDF writes. ({issue}`issuenumber`)
```
