### PR TITLE
Make concurrency group in CI less specific

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,11 @@ concurrency:
   # Cancel all workflow runs except latest within a concurrency group. This is achieved by defining a concurrency group for the PR.
   # Non-PR builds have singleton concurrency groups.
   # When triggered by the repository_dispatch, add the expected SHA to avoid cancelling the run from the PR.
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.number || github.sha }}-${{ github.event_name == 'repository_dispatch' && github.event.client_payload.slash_command.args.named.sha || github.sha }}
+  group: |
+    workflow=${{ github.workflow }},
+    pr_number=${{ github.event_name == 'pull_request' && github.event.number || 'NA' }},
+    dispatch_sha=${{ github.event_name == 'repository_dispatch' && github.event.client_payload.slash_command.args.named.sha || 'NA' }},
+    commit_sha=${{ github.event_name != 'pull_request' && github.event_name != 'repository_dispatch' && github.sha || 'NA' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Since 93f4cfc429677c1b8ef18fcadb4a89c3c663f4b7 (#12817) the concurrency group also handles repository dispatch events, but it incorrectly includes the SHA, making it too specific. SHA should only be used for events other than pull requests or repository dispatch.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

n/a

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
