### PR TITLE
Recreate thrift client during alternate calls

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/DefaultThriftMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/DefaultThriftMetastoreClientFactory.java
@@ -16,6 +16,7 @@ package io.trino.plugin.hive.metastore.thrift;
 import com.google.common.net.HostAndPort;
 import io.airlift.security.pem.PemReader;
 import io.airlift.units.Duration;
+import io.trino.plugin.hive.metastore.thrift.ThriftHiveMetastoreClient.TransportSupplier;
 import io.trino.spi.NodeManager;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
@@ -101,13 +102,14 @@ public class DefaultThriftMetastoreClientFactory
     public ThriftMetastoreClient create(HostAndPort address, Optional<String> delegationToken)
             throws TTransportException
     {
-        return create(createTransport(address, delegationToken), hostname);
+        return create(() -> createTransport(address, delegationToken), hostname);
     }
 
-    protected ThriftMetastoreClient create(TTransport transport, String hostname)
+    protected ThriftMetastoreClient create(TransportSupplier transportSupplier, String hostname)
+            throws TTransportException
     {
         return new ThriftHiveMetastoreClient(
-                transport,
+                transportSupplier,
                 hostname,
                 metastoreSupportsDateStatistics,
                 chosenGetTableAlternative,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -71,6 +71,7 @@ import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -108,8 +109,9 @@ public class ThriftHiveMetastoreClient
     private static final Pattern TABLE_PARAMETER_SAFE_KEY_PATTERN = Pattern.compile("^[a-zA-Z_]+$");
     private static final Pattern TABLE_PARAMETER_SAFE_VALUE_PATTERN = Pattern.compile("^[a-zA-Z0-9\\s]*$");
 
-    private final TTransport transport;
-    protected final ThriftHiveMetastore.Iface client;
+    private final TransportSupplier transportSupplier;
+    private TTransport transport;
+    protected ThriftHiveMetastore.Iface client;
     private final String hostname;
 
     private final MetastoreSupportsDateStatistics metastoreSupportsDateStatistics;
@@ -120,7 +122,7 @@ public class ThriftHiveMetastoreClient
     private final AtomicInteger chosenAlterPartitionsAlternative;
 
     public ThriftHiveMetastoreClient(
-            TTransport transport,
+            TransportSupplier transportSupplier,
             String hostname,
             MetastoreSupportsDateStatistics metastoreSupportsDateStatistics,
             AtomicInteger chosenGetTableAlternative,
@@ -128,15 +130,9 @@ public class ThriftHiveMetastoreClient
             AtomicInteger chosenGetAllViewsAlternative,
             AtomicInteger chosenAlterTransactionalTableAlternative,
             AtomicInteger chosenAlterPartitionsAlternative)
+            throws TTransportException
     {
-        this.transport = requireNonNull(transport, "transport is null");
-        ThriftHiveMetastore.Client client = new ThriftHiveMetastore.Client(new TBinaryProtocol(transport));
-        if (log.isDebugEnabled()) {
-            this.client = newProxy(ThriftHiveMetastore.Iface.class, new LoggingInvocationHandler(client, PARAMETER_NAMES_PROVIDER, log::debug));
-        }
-        else {
-            this.client = client;
-        }
+        this.transportSupplier = requireNonNull(transportSupplier, "transportSupplier is null");
         this.hostname = requireNonNull(hostname, "hostname is null");
         this.metastoreSupportsDateStatistics = requireNonNull(metastoreSupportsDateStatistics, "metastoreSupportsDateStatistics is null");
         this.chosenGetTableAlternative = requireNonNull(chosenGetTableAlternative, "chosenGetTableAlternative is null");
@@ -144,10 +140,28 @@ public class ThriftHiveMetastoreClient
         this.chosenGetAllViewsAlternative = requireNonNull(chosenGetAllViewsAlternative, "chosenGetAllViewsAlternative is null");
         this.chosenAlterTransactionalTableAlternative = requireNonNull(chosenAlterTransactionalTableAlternative, "chosenAlterTransactionalTableAlternative is null");
         this.chosenAlterPartitionsAlternative = requireNonNull(chosenAlterPartitionsAlternative, "chosenAlterPartitionsAlternative is null");
+
+        connect();
+    }
+
+    private void connect()
+            throws TTransportException
+    {
+        transport = transportSupplier.createTransport();
+        ThriftHiveMetastore.Iface client = new ThriftHiveMetastore.Client(new TBinaryProtocol(transport));
+        if (log.isDebugEnabled()) {
+            client = newProxy(ThriftHiveMetastore.Iface.class, new LoggingInvocationHandler(client, PARAMETER_NAMES_PROVIDER, log::debug));
+        }
+        this.client = client;
     }
 
     @Override
     public void close()
+    {
+        disconnect();
+    }
+
+    private void disconnect()
     {
         transport.close();
     }
@@ -729,7 +743,7 @@ public class ThriftHiveMetastoreClient
     }
 
     @SafeVarargs
-    private static <T> T alternativeCall(
+    private <T> T alternativeCall(
             Predicate<Exception> isValidExceptionalResponse,
             AtomicInteger chosenAlternative,
             AlternativeCall<T>... alternatives)
@@ -763,6 +777,10 @@ public class ThriftHiveMetastoreClient
                 else if (firstException != exception) {
                     firstException.addSuppressed(exception);
                 }
+                // Client that threw exception is in an unknown state. We need to open it again to
+                // make sure it will respond properly to the next call.
+                disconnect();
+                connect();
             }
         }
 
@@ -817,5 +835,11 @@ public class ThriftHiveMetastoreClient
     {
         void call(A arg)
                 throws TException;
+    }
+
+    public interface TransportSupplier
+    {
+        TTransport createTransport()
+                throws TTransportException;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -270,16 +270,6 @@ public class ThriftHiveMetastoreClient
                 () -> client.get_table(databaseName, tableName));
     }
 
-    private Table getTableWithCapabilities(String databaseName, String tableName)
-            throws TException
-    {
-        GetTableRequest request = new GetTableRequest();
-        request.setDbName(databaseName);
-        request.setTblName(tableName);
-        request.setCapabilities(new ClientCapabilities(ImmutableList.of(ClientCapability.INSERT_ONLY_TABLES)));
-        return client.get_table_req(request).getTable();
-    }
-
     @Override
     public List<FieldSchema> getFields(String databaseName, String tableName)
             throws TException


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

An alternative approach to https://github.com/trinodb/trino/pull/15433
The connection is being closed and created again after an alternative call ends up with an exception.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
