### PR TITLE
Fix test configuration method duplicated logging

### DIFF
--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/ProgressLoggingListener.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/ProgressLoggingListener.java
@@ -69,7 +69,7 @@ public class ProgressLoggingListener
             LOGGER.info("[TEST START] %s", formatTestName(testResult));
         }
         if (configurationMethod) {
-            LOGGER.info("[CONFIGURATION] %s for %s", method, formatTestName(testResult));
+            LOGGER.info("[CONFIGURATION] %s", method);
         }
         if (!testMethod && !configurationMethod) {
             LOGGER.info("[UNKNOWN THING] %s for %s", method, formatTestName(testResult));


### PR DESCRIPTION
Before the change it would log something like

> [CONFIGURATION] TestOrcPageSourceMemoryTracking.setUp()[pri:0,
> instance:io.trino.plugin.hive.TestOrcPageSourceMemoryTracking@7ef9c8a5]
> 2130299045 for
> io.trino.plugin.hive.TestOrcPageSourceMemoryTracking.setUp

Follows https://github.com/trinodb/trino/pull/15165