### PR TITLE
Use `char(x)` representation for Hive `char` view columns

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
@@ -255,7 +255,7 @@ public final class ViewReaderUtil
                             .collect(joining(",", "row(", ")"));
                 }
                 case CHAR:
-                    return "varchar";
+                    return "char(" + type.getPrecision() + ")";
                 case FLOAT:
                     return "real";
                 case BINARY:

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveViews.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveViews.java
@@ -16,12 +16,14 @@ package io.trino.tests.product.hive;
 import com.google.common.collect.ImmutableList;
 import io.trino.jdbc.Row;
 import io.trino.tempto.Requires;
+import io.trino.tempto.assertions.QueryAssert;
 import io.trino.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements.ImmutableNationTable;
 import io.trino.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements.ImmutableOrdersTable;
 import org.assertj.core.api.Assertions;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
@@ -38,6 +40,18 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestHiveViews
         extends AbstractTestHiveViews
 {
+    // Currently, Trino columns type signature does not correspond one to one with the Hive view columns type in case of `varchar` and `string` columns
+    @Override
+    protected List<QueryAssert.Row> getExpectedHiveViewTextualColumnsTypes()
+    {
+        return ImmutableList.of(
+                row("a_char_1", "char(1)"),
+                row("a_char_255", "char(255)"),
+                row("a_varchar_1", "varchar"),
+                row("a_varchar_65535", "varchar"),
+                row("a_string", "varchar"));
+    }
+
     @Test(groups = HIVE_VIEWS)
     public void testFailingHiveViewsWithMetadataListing()
     {

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveViewsLegacy.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveViewsLegacy.java
@@ -13,14 +13,17 @@
  */
 package io.trino.tests.product.hive;
 
+import com.google.common.collect.ImmutableList;
 import io.trino.tempto.BeforeTestWithContext;
 import io.trino.tempto.Requires;
+import io.trino.tempto.assertions.QueryAssert;
 import io.trino.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements.ImmutableNationTable;
 import io.trino.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements.ImmutableOrdersTable;
 import io.trino.tempto.query.QueryExecutor;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
@@ -133,6 +136,18 @@ public class TestHiveViewsLegacy
     {
         assertThatThrownBy(super::testPmodFunction)
                 .hasMessageContaining("Function 'pmod' not registered");
+    }
+
+    // When doing legacy Hive View translation, Trino columns type signature corresponds one to one with the Hive view columns type
+    @Override
+    protected List<QueryAssert.Row> getExpectedHiveViewTextualColumnsTypes()
+    {
+        return ImmutableList.of(
+                row("a_char_1", "char(1)"),
+                row("a_char_255", "char(255)"),
+                row("a_varchar_1", "varchar(1)"),
+                row("a_varchar_65535", "varchar(65535)"),
+                row("a_string", "varchar"));
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Issue description
Given the following scenario:

`hive`

```
create table test1 (id char(1))
create view v_test1 as select * from test1;
```

In Trino `hive.properties`

```
hive.translate-hive-views=true
```

When selecting in Trino from the hive view, the following exception is encountered:

```
View 'hive.default.v_test1' is stale or in invalid state: column [id] of type char(1) projected from query view at position 0 cannot be coerced to column [id] of type varchar stored in view definition
```


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Solution

Instead of falling back in case of dealing with hive view `char` columns to `varchar`, use `char(x)` type for these columns and avoid therefore issues related to #9031



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Use accurate type translation of the textual hive view columns
```
