### PR TITLE
Add support for base64 encoded secrets in Google Sheets connector

### DIFF
--- a/docs/src/main/sphinx/connector/googlesheets.rst
+++ b/docs/src/main/sphinx/connector/googlesheets.rst
@@ -30,6 +30,7 @@ The following configuration properties are available:
 Property name                       Description
 =================================== =====================================================================
 ``gsheets.credentials-path``        Path to the Google API JSON key file
+``gsheets.credentials-key``         The base64 encoded credentials key
 ``gsheets.metadata-sheet-id``       Sheet ID of the spreadsheet, that contains the table mapping
 ``gsheets.max-data-cache-size``     Maximum number of spreadsheets to cache, defaults to ``1000``
 ``gsheets.data-cache-ttl``          How long to cache spreadsheet data or metadata, defaults to ``5m``
@@ -55,6 +56,9 @@ The connector requires credentials in order to access the Google Sheets API.
 The key file needs to be available on the Trino coordinator and workers.
 Set the ``gsheets.credentials-path`` configuration property to point to this file.
 The exact name of the file does not matter -- it can be named anything.
+
+Alternatively, set the ``gsheets.credentials-key`` configuration property.
+It should contain the contents of the JSON file, encoded using base64.
 
 Metadata sheet
 --------------

--- a/plugin/trino-google-sheets/pom.xml
+++ b/plugin/trino-google-sheets/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>com.google.api-client</groupId>
             <artifactId>google-api-client</artifactId>
-            <version>1.23.0</version>
+            <version>1.25.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client-jackson2</artifactId>
-            <version>1.23.0</version>
+            <version>1.25.0</version>
         </dependency>
 
         <dependency>

--- a/plugin/trino-google-sheets/pom.xml
+++ b/plugin/trino-google-sheets/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-sheets</artifactId>
-            <version>v4-rev516-1.23.0</version>
+            <version>v4-rev612-1.25.0</version>
         </dependency>
 
         <dependency>

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestSheetsConfig.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestSheetsConfig.java
@@ -14,27 +14,39 @@
 package io.trino.plugin.google.sheets;
 
 import com.google.common.collect.ImmutableMap;
+import io.airlift.configuration.ConfigurationFactory;
 import io.airlift.units.Duration;
 import org.testng.annotations.Test;
+
+import javax.validation.constraints.AssertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertDeprecatedEquivalence;
-import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.testing.ValidationAssertions.assertFailsValidation;
+import static io.airlift.testing.ValidationAssertions.assertValidates;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
 
 public class TestSheetsConfig
 {
+    private static final String BASE_64_ENCODED_TEST_KEY = Base64.getEncoder()
+            .encodeToString("blah blah blah".getBytes(UTF_8));
+
     @Test
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(SheetsConfig.class)
                 .setCredentialsFilePath(null)
+                .setCredentialsKey(null)
                 .setMetadataSheetId(null)
                 .setSheetsDataMaxCacheSize(1000)
                 .setSheetsDataExpireAfterWrite(new Duration(5, TimeUnit.MINUTES))
@@ -42,7 +54,7 @@ public class TestSheetsConfig
     }
 
     @Test
-    public void testExplicitPropertyMappings()
+    public void testExplicitPropertyMappingsCredentialsPath()
             throws IOException
     {
         Path credentialsFile = Files.createTempFile(null, null);
@@ -55,14 +67,37 @@ public class TestSheetsConfig
                 .put("gsheets.read-timeout", "1m")
                 .buildOrThrow();
 
-        SheetsConfig expected = new SheetsConfig()
-                .setCredentialsFilePath(credentialsFile.toString())
-                .setMetadataSheetId("foo_bar_sheet_id#Sheet1")
-                .setSheetsDataMaxCacheSize(2000)
-                .setSheetsDataExpireAfterWrite(new Duration(10, TimeUnit.MINUTES))
-                .setReadTimeout(new Duration(1, TimeUnit.MINUTES));
+        ConfigurationFactory configurationFactory = new ConfigurationFactory(properties);
+        SheetsConfig config = configurationFactory.build(SheetsConfig.class);
 
-        assertFullMapping(properties, expected);
+        assertEquals(config.getCredentialsKey(), Optional.empty());
+        assertEquals(config.getCredentialsFilePath(), Optional.of(credentialsFile.toString()));
+        assertEquals(config.getMetadataSheetId(), "foo_bar_sheet_id#Sheet1");
+        assertEquals(config.getSheetsDataMaxCacheSize(), 2000);
+        assertEquals(config.getSheetsDataExpireAfterWrite(), Duration.valueOf("10m"));
+        assertEquals(config.getReadTimeout(), Duration.valueOf("1m"));
+    }
+
+    @Test
+    public void testExplicitPropertyMappingsCredentialsKey()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("gsheets.credentials-key", BASE_64_ENCODED_TEST_KEY)
+                .put("gsheets.metadata-sheet-id", "foo_bar_sheet_id#Sheet1")
+                .put("gsheets.max-data-cache-size", "2000")
+                .put("gsheets.data-cache-ttl", "10m")
+                .put("gsheets.read-timeout", "1m")
+                .buildOrThrow();
+
+        ConfigurationFactory configurationFactory = new ConfigurationFactory(properties);
+        SheetsConfig config = configurationFactory.build(SheetsConfig.class);
+
+        assertEquals(config.getCredentialsKey(), Optional.of(BASE_64_ENCODED_TEST_KEY));
+        assertEquals(config.getCredentialsFilePath(), Optional.empty());
+        assertEquals(config.getMetadataSheetId(), "foo_bar_sheet_id#Sheet1");
+        assertEquals(config.getSheetsDataMaxCacheSize(), 2000);
+        assertEquals(config.getSheetsDataExpireAfterWrite(), Duration.valueOf("10m"));
+        assertEquals(config.getReadTimeout(), Duration.valueOf("1m"));
     }
 
     @Test
@@ -86,5 +121,42 @@ public class TestSheetsConfig
                 .buildOrThrow();
 
         assertDeprecatedEquivalence(SheetsConfig.class, properties, oldProperties);
+    }
+
+    @Test
+    public void testCredentialValidation()
+            throws IOException
+    {
+        Path credentialsFile = Files.createTempFile(null, null);
+        assertValidates(
+                new SheetsConfig().setMetadataSheetId("foo_bar_sheet_id#Sheet1")
+                        .setCredentialsFilePath(credentialsFile.toString()));
+
+        assertValidates(
+                new SheetsConfig().setMetadataSheetId("foo_bar_sheet_id#Sheet1")
+                        .setCredentialsKey(BASE_64_ENCODED_TEST_KEY));
+    }
+
+    @Test
+    public void testCredentialValidationFailure()
+            throws IOException
+    {
+        Path credentialsFile = Files.createTempFile(null, null);
+        assertFailsCredentialsValidation(
+                new SheetsConfig().setMetadataSheetId("foo_bar_sheet_id#Sheet1")
+                        .setCredentialsFilePath(credentialsFile.toString())
+                        .setCredentialsKey(BASE_64_ENCODED_TEST_KEY));
+
+        assertFailsCredentialsValidation(
+                new SheetsConfig().setMetadataSheetId("foo_bar_sheet_id#Sheet1"));
+    }
+
+    private static void assertFailsCredentialsValidation(SheetsConfig config)
+    {
+        assertFailsValidation(
+                config,
+                "credentialsConfigurationValid",
+                "Exactly one of 'gsheets.credentials-key' or 'gsheets.credentials-path' must be specified",
+                AssertTrue.class);
     }
 }


### PR DESCRIPTION
## Description
Allows the google sheets connector to be configured by base64 encoded string (instead of file). Simplifies deployments of trino since you do not need to configure a file. This is similar to what is supported for the bigquery connector: https://github.com/trinodb/trino/blob/master/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/StaticCredentialsConfig.java#L27

Also updates the google sheets dependency version, the current version: https://mvnrepository.com/artifact/com.google.apis/google-api-services-sheets/v4-rev516-1.23.0 is multiple years old and has a dependency on `google-api-client` with a security vulnerability.

## Additional context and related issues
N/A

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Google Sheets
* Add support for base64 encoded credentials using the `gsheets.credentials-key` config property. 
```
