### PR TITLE
Use RoundingMode enum instead of deprecated BigDecimal constant

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/AbstractTrinoResultSet.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/AbstractTrinoResultSet.java
@@ -80,7 +80,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.jdbc.ColumnInfo.setTypeInfo;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
-import static java.math.BigDecimal.ROUND_HALF_UP;
+import static java.math.RoundingMode.HALF_UP;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Locale.ENGLISH;
@@ -311,7 +311,7 @@ abstract class AbstractTrinoResultSet
     {
         BigDecimal bigDecimal = getBigDecimal(columnIndex);
         if (bigDecimal != null) {
-            bigDecimal = bigDecimal.setScale(scale, ROUND_HALF_UP);
+            bigDecimal = bigDecimal.setScale(scale, HALF_UP);
         }
         return bigDecimal;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/DecimalAverageAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/DecimalAverageAggregation.java
@@ -41,7 +41,7 @@ import static io.trino.spi.type.Decimals.overflows;
 import static io.trino.spi.type.Decimals.writeShortDecimal;
 import static io.trino.spi.type.Int128Math.addWithOverflow;
 import static io.trino.spi.type.Int128Math.divideRoundUp;
-import static java.math.BigDecimal.ROUND_HALF_UP;
+import static java.math.RoundingMode.HALF_UP;
 
 @AggregationFunction("avg")
 @Description("Calculates the average value")
@@ -169,7 +169,7 @@ public final class DecimalAverageAggregation
             sum = sum.add(new BigDecimal(OVERFLOW_MULTIPLIER.multiply(BigInteger.valueOf(overflow))));
 
             BigDecimal count = BigDecimal.valueOf(state.getLong());
-            return Decimals.encodeScaledValue(sum.divide(count, type.getScale(), ROUND_HALF_UP), type.getScale());
+            return Decimals.encodeScaledValue(sum.divide(count, type.getScale(), HALF_UP), type.getScale());
         }
 
         Int128 result = divideRoundUp(decimal[offset], decimal[offset + 1], 0, 0, state.getLong(), 0);

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/AbstractTestDecimalAverageAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/AbstractTestDecimalAverageAggregation.java
@@ -20,8 +20,8 @@ import io.trino.spi.type.SqlDecimal;
 
 import java.math.BigDecimal;
 
-import static java.math.BigDecimal.ROUND_DOWN;
-import static java.math.BigDecimal.ROUND_HALF_UP;
+import static java.math.RoundingMode.DOWN;
+import static java.math.RoundingMode.HALF_UP;
 
 public abstract class AbstractTestDecimalAverageAggregation
         extends AbstractTestAggregationFunction
@@ -45,7 +45,7 @@ public abstract class AbstractTestDecimalAverageAggregation
     private static BigDecimal getBigDecimalForCounter(int i)
     {
         String iAsString = String.valueOf(Math.abs(i));
-        return new BigDecimal(String.valueOf(i) + "." + iAsString + iAsString).setScale(2, ROUND_DOWN);
+        return new BigDecimal(String.valueOf(i) + "." + iAsString + iAsString).setScale(2, DOWN);
     }
 
     @Override
@@ -58,7 +58,7 @@ public abstract class AbstractTestDecimalAverageAggregation
         for (int i = start; i < start + length; i++) {
             avg = avg.add(getBigDecimalForCounter(i));
         }
-        avg = avg.divide(BigDecimal.valueOf(length), ROUND_HALF_UP);
+        avg = avg.divide(BigDecimal.valueOf(length), HALF_UP);
         DecimalType expectedType = getExpectedType();
         return new SqlDecimal(avg.unscaledValue(), expectedType.getPrecision(), expectedType.getScale());
     }

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/AbstractTestDecimalSumAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/AbstractTestDecimalSumAggregation.java
@@ -20,7 +20,7 @@ import io.trino.spi.type.SqlDecimal;
 
 import java.math.BigDecimal;
 
-import static java.math.BigDecimal.ROUND_DOWN;
+import static java.math.RoundingMode.DOWN;
 
 public abstract class AbstractTestDecimalSumAggregation
         extends AbstractTestAggregationFunction
@@ -44,7 +44,7 @@ public abstract class AbstractTestDecimalSumAggregation
     private static BigDecimal getBigDecimalForCounter(int i)
     {
         String iAsString = String.valueOf(Math.abs(i));
-        return new BigDecimal(String.valueOf(i) + "." + iAsString + iAsString).setScale(2, ROUND_DOWN);
+        return new BigDecimal(String.valueOf(i) + "." + iAsString + iAsString).setScale(2, DOWN);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
@@ -163,7 +163,7 @@ import static java.lang.Long.parseLong;
 import static java.lang.Math.floorDiv;
 import static java.lang.Short.parseShort;
 import static java.lang.String.format;
-import static java.math.BigDecimal.ROUND_UNNECESSARY;
+import static java.math.RoundingMode.UNNECESSARY;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Locale.ENGLISH;
 import static java.util.stream.Collectors.joining;
@@ -799,7 +799,7 @@ public final class HiveUtil
             }
 
             BigDecimal decimal = new BigDecimal(value);
-            decimal = decimal.setScale(type.getScale(), ROUND_UNNECESSARY);
+            decimal = decimal.setScale(type.getScale(), UNNECESSARY);
             if (decimal.precision() > type.getPrecision()) {
                 throw new TrinoException(HIVE_INVALID_PARTITION_VALUE, format("Invalid partition value '%s' for %s partition key: %s", value, type, name));
             }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -132,6 +132,7 @@ import static java.lang.Float.parseFloat;
 import static java.lang.Integer.parseInt;
 import static java.lang.Long.parseLong;
 import static java.lang.String.format;
+import static java.math.RoundingMode.UNNECESSARY;
 import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
@@ -480,7 +481,7 @@ public final class IcebergUtil
             }
             if (type instanceof DecimalType decimalType) {
                 BigDecimal decimal = new BigDecimal(valueString);
-                decimal = decimal.setScale(decimalType.getScale(), BigDecimal.ROUND_UNNECESSARY);
+                decimal = decimal.setScale(decimalType.getScale(), UNNECESSARY);
                 if (decimal.precision() > decimalType.getPrecision()) {
                     throw new IllegalArgumentException();
                 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/H2QueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/H2QueryRunner.java
@@ -86,6 +86,7 @@ import static io.trino.type.JsonType.JSON;
 import static io.trino.type.UnknownType.UNKNOWN;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
+import static java.math.RoundingMode.HALF_UP;
 import static java.util.Collections.nCopies;
 
 public class H2QueryRunner
@@ -375,7 +376,7 @@ public class H2QueryRunner
                     }
                     else {
                         row.add(decimalValue
-                                .setScale(decimalType.getScale(), BigDecimal.ROUND_HALF_UP)
+                                .setScale(decimalType.getScale(), HALF_UP)
                                 .round(new MathContext(decimalType.getPrecision())));
                     }
                 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
BigDecimal constants are deprecated from Java 9.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
NA


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
