### PR TITLE
Reduce Iceberg metrics reporting verbosity in logs

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -103,6 +103,7 @@ import static io.trino.plugin.iceberg.IcebergTableProperties.getOrcBloomFilterCo
 import static io.trino.plugin.iceberg.IcebergTableProperties.getOrcBloomFilterFpp;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getPartitioning;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getTableLocation;
+import static io.trino.plugin.iceberg.TrinoMetricsReporter.TRINO_METRICS_REPORTER;
 import static io.trino.plugin.iceberg.PartitionFields.parsePartitionFields;
 import static io.trino.plugin.iceberg.PartitionFields.toPartitionFields;
 import static io.trino.plugin.iceberg.TypeConverter.toIcebergType;
@@ -171,7 +172,7 @@ public final class IcebergUtil
                 table.getTableName(),
                 Optional.empty(),
                 Optional.empty());
-        return new BaseTable(operations, quotedTableName(table));
+        return new BaseTable(operations, quotedTableName(table), TRINO_METRICS_REPORTER);
     }
 
     public static Table getIcebergTableWithMetadata(
@@ -189,7 +190,7 @@ public final class IcebergUtil
                 Optional.empty(),
                 Optional.empty());
         operations.initializeFromMetadata(tableMetadata);
-        return new BaseTable(operations, quotedTableName(table));
+        return new BaseTable(operations, quotedTableName(table), TRINO_METRICS_REPORTER);
     }
 
     public static Map<String, Object> getIcebergTableProperties(Table icebergTable)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoMetricsReporter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoMetricsReporter.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import io.airlift.log.Logger;
+import org.apache.iceberg.metrics.LoggingMetricsReporter;
+import org.apache.iceberg.metrics.MetricsReport;
+import org.apache.iceberg.metrics.MetricsReporter;
+
+/**
+ * Trino default {@link MetricsReporter} implementation.
+ * <p>
+ * Similar to Iceberg's default {@link MetricsReporter} implementation,
+ * the {@link LoggingMetricsReporter}, but does not log at {@code INFO} level,
+ * just eliminating log file size impact.
+ *
+ * @see LoggingMetricsReporter
+ */
+public enum TrinoMetricsReporter
+        implements MetricsReporter
+{
+    TRINO_METRICS_REPORTER;
+
+    private static final Logger log = Logger.get(TrinoMetricsReporter.class);
+
+    @Override
+    public void report(MetricsReport report)
+    {
+        log.debug("Received metrics report: %s", report);
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -101,6 +101,7 @@ import static io.trino.plugin.iceberg.IcebergSessionProperties.getHiveCatalogNam
 import static io.trino.plugin.iceberg.IcebergUtil.getIcebergTableWithMetadata;
 import static io.trino.plugin.iceberg.IcebergUtil.quotedTableName;
 import static io.trino.plugin.iceberg.IcebergUtil.validateTableCanBeDropped;
+import static io.trino.plugin.iceberg.TrinoMetricsReporter.TRINO_METRICS_REPORTER;
 import static io.trino.plugin.iceberg.catalog.glue.GlueIcebergUtil.getMaterializedViewTableInput;
 import static io.trino.plugin.iceberg.catalog.glue.GlueIcebergUtil.getTableInput;
 import static io.trino.plugin.iceberg.catalog.glue.GlueIcebergUtil.getViewTableInput;
@@ -330,7 +331,7 @@ public class TrinoGlueCatalog
                             table.getTableName(),
                             Optional.empty(),
                             Optional.empty());
-                    return new BaseTable(operations, quotedTableName(table)).operations().current();
+                    return new BaseTable(operations, quotedTableName(table), TRINO_METRICS_REPORTER).operations().current();
                 });
 
         return getIcebergTableWithMetadata(


### PR DESCRIPTION
Iceberg's new feature, metrics reporting, by default logs quite long log lines at INFO level for every table scanned in the query. This is quite verbose, potentially affecting log rotation on production installations and affecting Trino CI Github Actions logs.

Move the metrics reporting to DEBUG log level, at least for table instances instantiated directly in Trino code.

Hopefully fixes https://github.com/trinodb/trino/issues/15492 