### PR TITLE
Move FailureRecovery tests to plugin modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -541,14 +541,16 @@ jobs:
             - { modules: plugin/trino-singlestore }
             - { modules: plugin/trino-sqlserver }
             - { modules: testing/trino-faulttolerant-tests, profile: default }
+            - { modules: plugin/trino-delta-lake, profile: fte-tests }
             - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-delta }
-            - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-hive-1 }
-            - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-hive-2 }
+            - { modules: plugin/trino-hive, profile: fte-tests }
+            - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-hive }
+            - { modules: plugin/trino-iceberg, profile: fte-tests }
             - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-iceberg }
-            - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-postgresql }
-            - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-mongodb }
-            - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-mysql }
-            - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-sqlserver }
+            - { modules: plugin/trino-postgresql, profile: fte-tests }
+            - { modules: plugin/trino-mongodb, profile: fte-tests }
+            - { modules: plugin/trino-mysql, profile: fte-tests }
+            - { modules: plugin/trino-sqlserver, profile: fte-tests }
             - { modules: testing/trino-tests }
           EOF
           ./.github/bin/build-matrix-from-impacted.py -v -i gib-impacted.log -m .github/test-matrix.yaml -o matrix.json

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcFailureRecoveryTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcFailureRecoveryTest.java
@@ -11,13 +11,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.faulttolerant.jdbc;
+package io.trino.plugin.jdbc;
 
-import io.trino.faulttolerant.BaseFailureRecoveryTest;
 import io.trino.operator.RetryPolicy;
+import io.trino.testing.BaseFailureRecoveryTest;
 import org.testng.SkipException;
 
-import java.util.List;
 import java.util.Optional;
 
 import static io.trino.spi.connector.ConnectorMetadata.MODIFYING_ROWS_MESSAGE;
@@ -29,27 +28,6 @@ public abstract class BaseJdbcFailureRecoveryTest
     public BaseJdbcFailureRecoveryTest(RetryPolicy retryPolicy)
     {
         super(retryPolicy);
-    }
-
-    @Override
-    protected void createPartitionedLineitemTable(String tableName, List<String> columns, String partitionColumn)
-    {
-    }
-
-    @Override
-    public void testJoinDynamicFilteringDisabled()
-    {
-        assertThatThrownBy(super::testJoinDynamicFilteringDisabled)
-                .hasMessageContaining("partitioned_lineitem' does not exist");
-        throw new SkipException("skipped");
-    }
-
-    @Override
-    public void testJoinDynamicFilteringEnabled()
-    {
-        assertThatThrownBy(super::testJoinDynamicFilteringEnabled)
-                .hasMessageContaining("partitioned_lineitem' does not exist");
-        throw new SkipException("skipped");
     }
 
     @Override

--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -236,6 +236,19 @@
         <!-- for testing -->
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-exchange-filesystem</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-exchange-filesystem</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-hive</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
@@ -454,6 +467,7 @@
                                 <exclude>**/TestDeltaLakeRegisterTableProcedureWithGlue.java</exclude>
                                 <exclude>**/TestDeltaLakeViewsGlueMetastore.java</exclude>
                                 <exclude>**/TestDeltaLakeGcsConnectorSmokeTest.java</exclude>
+                                <exclude>**/Test*FailureRecoveryTest.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -481,6 +495,23 @@
                                 <include>**/TestDeltaLakeRenameToWithGlueMetastore.java</include>
                                 <include>**/TestDeltaLakeRegisterTableProcedureWithGlue.java</include>
                                 <include>**/TestDeltaLakeViewsGlueMetastore.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>fte-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/Test*FailureRecoveryTest.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaTaskFailureRecoveryTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaTaskFailureRecoveryTest.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.faulttolerant.delta;
+package io.trino.plugin.deltalake;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.operator.RetryPolicy;

--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -336,6 +336,19 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-exchange-filesystem</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-exchange-filesystem</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
@@ -523,7 +536,25 @@
                                 <exclude>**/TestHiveGlueMetastore.java</exclude>
                                 <exclude>**/TestTrinoS3FileSystemAwsS3.java</exclude>
                                 <exclude>**/TestFullParquetReader.java</exclude>
+                                <exclude>**/Test*FailureRecoveryTest.java</exclude>
                             </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>fte-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/Test*FailureRecoveryTest.java</include>
+                            </includes>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveFailureRecoveryTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveFailureRecoveryTest.java
@@ -11,11 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.faulttolerant.hive;
+package io.trino.plugin.hive;
 
 import io.trino.Session;
-import io.trino.faulttolerant.BaseFailureRecoveryTest;
 import io.trino.operator.RetryPolicy;
+import io.trino.testing.ExtendedFailureRecoveryTest;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -26,7 +26,7 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public abstract class BaseHiveFailureRecoveryTest
-        extends BaseFailureRecoveryTest
+        extends ExtendedFailureRecoveryTest
 {
     protected BaseHiveFailureRecoveryTest(RetryPolicy retryPolicy)
     {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveQueryFailureRecoveryTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveQueryFailureRecoveryTest.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.faulttolerant.hive;
+package io.trino.plugin.hive;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.operator.RetryPolicy;
@@ -29,12 +29,12 @@ import java.util.Map;
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 
-public class TestHiveTaskFailureRecoveryTest
+public class TestHiveQueryFailureRecoveryTest
         extends BaseHiveFailureRecoveryTest
 {
-    public TestHiveTaskFailureRecoveryTest()
+    public TestHiveQueryFailureRecoveryTest()
     {
-        super(RetryPolicy.TASK);
+        super(RetryPolicy.QUERY);
     }
 
     private HiveMinioDataLake hiveMinioDataLake;

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -325,6 +325,19 @@
         <!-- for testing -->
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-exchange-filesystem</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-exchange-filesystem</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-hive</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
@@ -508,7 +521,25 @@
                                 <exclude>**/TestIcebergGlueTableOperationsInsertFailure.java</exclude>
                                 <exclude>**/TestIcebergGlueCatalogSkipArchive.java</exclude>
                                 <exclude>**/TestIcebergGcsConnectorSmokeTest.java</exclude>
+                                <exclude>**/Test*FailureRecoveryTest.java</exclude>
                             </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>fte-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/Test*FailureRecoveryTest.java</include>
+                            </includes>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergFailureRecoveryTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergFailureRecoveryTest.java
@@ -11,14 +11,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.faulttolerant.delta;
+package io.trino.plugin.iceberg;
 
-import io.trino.faulttolerant.BaseFailureRecoveryTest;
 import io.trino.operator.RetryPolicy;
 import io.trino.spi.ErrorType;
+import io.trino.testing.BaseFailureRecoveryTest;
 import org.testng.annotations.Test;
 
-import java.util.List;
 import java.util.Optional;
 
 import static io.trino.execution.FailureInjector.FAILURE_INJECTION_MESSAGE;
@@ -27,13 +26,11 @@ import static io.trino.execution.FailureInjector.InjectedFailureType.TASK_GET_RE
 import static io.trino.execution.FailureInjector.InjectedFailureType.TASK_GET_RESULTS_REQUEST_TIMEOUT;
 import static io.trino.execution.FailureInjector.InjectedFailureType.TASK_MANAGEMENT_REQUEST_FAILURE;
 import static io.trino.execution.FailureInjector.InjectedFailureType.TASK_MANAGEMENT_REQUEST_TIMEOUT;
-import static java.lang.String.format;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-public abstract class BaseDeltaFailureRecoveryTest
+public abstract class BaseIcebergFailureRecoveryTest
         extends BaseFailureRecoveryTest
 {
-    protected BaseDeltaFailureRecoveryTest(RetryPolicy retryPolicy)
+    protected BaseIcebergFailureRecoveryTest(RetryPolicy retryPolicy)
     {
         super(retryPolicy);
     }
@@ -44,6 +41,16 @@ public abstract class BaseDeltaFailureRecoveryTest
         return true;
     }
 
+    @Test(invocationCount = INVOCATION_COUNT)
+    public void testCreatePartitionedTable()
+    {
+        testTableModification(
+                Optional.empty(),
+                "CREATE TABLE <table> WITH (partitioning = ARRAY['p']) AS SELECT *, 'partition1' p FROM orders",
+                Optional.of("DROP TABLE <table>"));
+    }
+
+    // Copied from BaseDeltaFailureRecoveryTest
     @Override
     public void testDelete()
     {
@@ -85,14 +92,6 @@ public abstract class BaseDeltaFailureRecoveryTest
                 .failsWithoutRetries(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE))
                 .finishesSuccessfully();
 
-        // DELETE plan is too simplistic for testing with `intermediateDistributedStage`
-        assertThatQuery(deleteQuery)
-                .withSetupQuery(setupQuery)
-                .withCleanupQuery(cleanupQuery)
-                .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
-                .at(intermediateDistributedStage())
-                .failsWithoutRetries(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE));
-
         assertThatQuery(deleteQuery)
                 .withSetupQuery(setupQuery)
                 .withCleanupQuery(cleanupQuery)
@@ -106,7 +105,7 @@ public abstract class BaseDeltaFailureRecoveryTest
                 .withCleanupQuery(cleanupQuery)
                 .experiencing(TASK_MANAGEMENT_REQUEST_TIMEOUT)
                 .at(boundaryDistributedStage())
-                .failsWithoutRetries(failure -> failure.hasMessageContaining("Encountered too many errors talking to a worker node"))
+                .failsWithoutRetries(failure -> failure.hasMessageFindingMatch("Encountered too many errors talking to a worker node|Error closing remote buffer"))
                 .finishesSuccessfully();
 
         if (getRetryPolicy() == RetryPolicy.QUERY) {
@@ -128,6 +127,7 @@ public abstract class BaseDeltaFailureRecoveryTest
         }
     }
 
+    // Copied from BaseDeltaFailureRecoveryTest
     @Override
     public void testUpdate()
     {
@@ -168,14 +168,6 @@ public abstract class BaseDeltaFailureRecoveryTest
                 .failsWithoutRetries(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE))
                 .finishesSuccessfully();
 
-        // UPDATE plan is too simplistic for testing with `intermediateDistributedStage`
-        assertThatQuery(updateQuery)
-                .withSetupQuery(setupQuery)
-                .withCleanupQuery(cleanupQuery)
-                .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
-                .at(intermediateDistributedStage())
-                .failsWithoutRetries(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE));
-
         assertThatQuery(updateQuery)
                 .withSetupQuery(setupQuery)
                 .withCleanupQuery(cleanupQuery)
@@ -189,7 +181,7 @@ public abstract class BaseDeltaFailureRecoveryTest
                 .withCleanupQuery(cleanupQuery)
                 .experiencing(TASK_MANAGEMENT_REQUEST_TIMEOUT)
                 .at(boundaryDistributedStage())
-                .failsWithoutRetries(failure -> failure.hasMessageContaining("Encountered too many errors talking to a worker node"))
+                .failsWithoutRetries(failure -> failure.hasMessageFindingMatch("Encountered too many errors talking to a worker node|Error closing remote buffer"))
                 .finishesSuccessfully();
 
         if (getRetryPolicy() == RetryPolicy.QUERY) {
@@ -211,39 +203,11 @@ public abstract class BaseDeltaFailureRecoveryTest
         }
     }
 
-    @Override
-    // materialized views are currently not implemented by Delta connector
-    public void testRefreshMaterializedView()
-    {
-        assertThatThrownBy(super::testRefreshMaterializedView)
-                .hasMessageContaining("This connector does not support creating materialized views");
-    }
-
-    @Override
-    protected void createPartitionedLineitemTable(String tableName, List<String> columns, String partitionColumn)
-    {
-        String sql = format(
-                "CREATE TABLE %s WITH (partitioned_by = array['%s']) AS SELECT %s FROM tpch.tiny.lineitem",
-                tableName,
-                partitionColumn,
-                String.join(",", columns));
-        getQueryRunner().execute(sql);
-    }
-
-    @Test(invocationCount = INVOCATION_COUNT)
-    public void testCreatePartitionedTable()
-    {
-        testTableModification(
-                Optional.empty(),
-                "CREATE TABLE <table> WITH (partitioned_by = ARRAY['p']) AS SELECT *, 'partition1' p FROM orders",
-                Optional.of("DROP TABLE <table>"));
-    }
-
     @Test(invocationCount = INVOCATION_COUNT)
     public void testInsertIntoNewPartition()
     {
         testTableModification(
-                Optional.of("CREATE TABLE <table> WITH (partitioned_by = ARRAY['p']) AS SELECT *, 'partition1' p FROM orders"),
+                Optional.of("CREATE TABLE <table> WITH (partitioning = ARRAY['p']) AS SELECT *, 'partition1' p FROM orders"),
                 "INSERT INTO <table> SELECT *, 'partition2' p FROM orders",
                 Optional.of("DROP TABLE <table>"));
     }
@@ -252,8 +216,25 @@ public abstract class BaseDeltaFailureRecoveryTest
     public void testInsertIntoExistingPartition()
     {
         testTableModification(
-                Optional.of("CREATE TABLE <table> WITH (partitioned_by = ARRAY['p']) AS SELECT *, 'partition1' p FROM orders"),
+                Optional.of("CREATE TABLE <table> WITH (partitioning = ARRAY['p']) AS SELECT *, 'partition1' p FROM orders"),
                 "INSERT INTO <table> SELECT *, 'partition1' p FROM orders",
+                Optional.of("DROP TABLE <table>"));
+    }
+
+    @Test(invocationCount = INVOCATION_COUNT)
+    public void testMergePartitionedTable()
+    {
+        testTableModification(
+                Optional.of("CREATE TABLE <table> WITH (partitioning = ARRAY['bucket(orderkey, 10)']) AS SELECT * FROM orders"),
+                """
+                        MERGE INTO <table> t
+                        USING (SELECT orderkey, 'X' clerk FROM <table>) s
+                        ON t.orderkey = s.orderkey
+                        WHEN MATCHED AND s.orderkey > 1000
+                            THEN UPDATE SET clerk = t.clerk || s.clerk
+                        WHEN MATCHED AND s.orderkey <= 1000
+                            THEN DELETE
+                        """,
                 Optional.of("DROP TABLE <table>"));
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergQueryFailureRecoveryTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergQueryFailureRecoveryTest.java
@@ -11,14 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.faulttolerant.hive;
+package io.trino.plugin.iceberg;
 
-import com.google.common.collect.ImmutableMap;
 import io.trino.operator.RetryPolicy;
 import io.trino.plugin.exchange.filesystem.FileSystemExchangePlugin;
 import io.trino.plugin.exchange.filesystem.containers.MinioStorage;
-import io.trino.plugin.hive.containers.HiveMinioDataLake;
-import io.trino.plugin.hive.s3.S3HiveQueryRunner;
 import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
 import org.testng.annotations.AfterClass;
@@ -29,16 +26,15 @@ import java.util.Map;
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 
-public class TestHiveQueryFailureRecoveryTest
-        extends BaseHiveFailureRecoveryTest
+public class TestIcebergQueryFailureRecoveryTest
+        extends BaseIcebergFailureRecoveryTest
 {
-    public TestHiveQueryFailureRecoveryTest()
+    private MinioStorage minioStorage;
+
+    protected TestIcebergQueryFailureRecoveryTest()
     {
         super(RetryPolicy.QUERY);
     }
-
-    private HiveMinioDataLake hiveMinioDataLake;
-    private MinioStorage minioStorage;
 
     @Override
     protected QueryRunner createQueryRunner(
@@ -47,26 +43,17 @@ public class TestHiveQueryFailureRecoveryTest
             Map<String, String> coordinatorProperties)
             throws Exception
     {
-        String bucketName = "test-hive-insert-overwrite-" + randomNameSuffix(); // randomizing bucket name to ensure cached TrinoS3FileSystem objects are not reused
-        this.hiveMinioDataLake = new HiveMinioDataLake(bucketName);
-        hiveMinioDataLake.start();
-
         this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomNameSuffix());
         minioStorage.start();
 
-        return S3HiveQueryRunner.builder(hiveMinioDataLake)
+        return IcebergQueryRunner.builder()
                 .setInitialTables(requiredTpchTables)
-                .setExtraProperties(configProperties)
                 .setCoordinatorProperties(coordinatorProperties)
+                .setExtraProperties(configProperties)
                 .setAdditionalSetup(runner -> {
                     runner.installPlugin(new FileSystemExchangePlugin());
                     runner.loadExchangeManager("filesystem", getExchangeManagerProperties(minioStorage));
                 })
-                .setHiveProperties(ImmutableMap.of(
-                        // Streaming upload allocates non trivial amount of memory for buffering (16MB per output file by default).
-                        // When streaming upload is enabled insert into a table with high number of buckets / partitions may cause
-                        // the tests to run out of memory as the buffer space is eagerly allocated for each output file.
-                        "hive.s3.streaming.enabled", "false"))
                 .build();
     }
 
@@ -74,10 +61,6 @@ public class TestHiveQueryFailureRecoveryTest
     public void destroy()
             throws Exception
     {
-        if (hiveMinioDataLake != null) {
-            hiveMinioDataLake.close();
-            hiveMinioDataLake = null;
-        }
         if (minioStorage != null) {
             minioStorage.close();
             minioStorage = null;

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTaskFailureRecoveryTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTaskFailureRecoveryTest.java
@@ -11,12 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.faulttolerant.iceberg;
+package io.trino.plugin.iceberg;
 
 import io.trino.operator.RetryPolicy;
 import io.trino.plugin.exchange.filesystem.FileSystemExchangePlugin;
 import io.trino.plugin.exchange.filesystem.containers.MinioStorage;
-import io.trino.plugin.iceberg.IcebergQueryRunner;
 import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
 import org.testng.annotations.AfterClass;

--- a/plugin/trino-mongodb/pom.xml
+++ b/plugin/trino-mongodb/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <mongo-java.version>4.4.0</mongo-java.version>
-        <netty.version>4.0.32.Final</netty.version>
+        <netty.version>4.1.72.Final</netty.version>
     </properties>
 
     <dependencies>
@@ -137,6 +137,19 @@
         <!-- for testing -->
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-exchange-filesystem</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-exchange-filesystem</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
             <scope>test</scope>
         </dependency>
@@ -209,4 +222,43 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/Test*FailureRecoveryTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>fte-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/Test*FailureRecoveryTest.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoFailureRecoveryTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoFailureRecoveryTest.java
@@ -11,13 +11,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.faulttolerant.mongodb;
+package io.trino.plugin.mongodb;
 
 import com.google.common.collect.ImmutableMap;
-import io.trino.faulttolerant.BaseFailureRecoveryTest;
 import io.trino.operator.RetryPolicy;
 import io.trino.plugin.exchange.filesystem.FileSystemExchangePlugin;
-import io.trino.plugin.mongodb.MongoServer;
+import io.trino.testing.BaseFailureRecoveryTest;
 import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
 import org.testng.SkipException;
@@ -54,27 +53,6 @@ public abstract class BaseMongoFailureRecoveryTest
                     runner.loadExchangeManager("filesystem", ImmutableMap.of(
                             "exchange.base-directories", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager"));
                 });
-    }
-
-    @Override
-    protected void createPartitionedLineitemTable(String tableName, List<String> columns, String partitionColumn)
-    {
-    }
-
-    @Override
-    public void testJoinDynamicFilteringDisabled()
-    {
-        assertThatThrownBy(super::testJoinDynamicFilteringDisabled)
-                .hasMessageContaining("Unknown session property mongodb.dynamic_filtering_wait_timeout");
-        throw new SkipException("skipped");
-    }
-
-    @Override
-    public void testJoinDynamicFilteringEnabled()
-    {
-        assertThatThrownBy(super::testJoinDynamicFilteringEnabled)
-                .hasMessageContaining("Unknown session property mongodb.dynamic_filtering_wait_timeout");
-        throw new SkipException("skipped");
     }
 
     @Override

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoQueryFailureRecoveryTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoQueryFailureRecoveryTest.java
@@ -11,14 +11,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.faulttolerant.postgresql;
+package io.trino.plugin.mongodb;
 
 import io.trino.operator.RetryPolicy;
 
-public class TestPostgresQueryFailureRecoveryTest
-        extends BasePostgresFailureRecoveryTest
+public class TestMongoQueryFailureRecoveryTest
+        extends BaseMongoFailureRecoveryTest
 {
-    public TestPostgresQueryFailureRecoveryTest()
+    public TestMongoQueryFailureRecoveryTest()
     {
         super(RetryPolicy.QUERY);
     }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTaskFailureRecoveryTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTaskFailureRecoveryTest.java
@@ -11,15 +11,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.faulttolerant.sqlserver;
+package io.trino.plugin.mongodb;
 
 import io.trino.operator.RetryPolicy;
 
-public class TestSqlServerQueryFailureRecoveryTest
-        extends BaseSqlServerFailureRecoveryTest
+public class TestMongoTaskFailureRecoveryTest
+        extends BaseMongoFailureRecoveryTest
 {
-    public TestSqlServerQueryFailureRecoveryTest()
+    public TestMongoTaskFailureRecoveryTest()
     {
-        super(RetryPolicy.QUERY);
+        super(RetryPolicy.TASK);
     }
 }

--- a/plugin/trino-mysql/pom.xml
+++ b/plugin/trino-mysql/pom.xml
@@ -120,6 +120,19 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-exchange-filesystem</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-exchange-filesystem</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
             <scope>test</scope>
         </dependency>
@@ -197,4 +210,43 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/Test*FailureRecoveryTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>fte-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/Test*FailureRecoveryTest.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlFailureRecoveryTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlFailureRecoveryTest.java
@@ -11,25 +11,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.faulttolerant.postgresql;
+package io.trino.plugin.mysql;
 
 import com.google.common.collect.ImmutableMap;
-import io.trino.faulttolerant.jdbc.BaseJdbcFailureRecoveryTest;
 import io.trino.operator.RetryPolicy;
 import io.trino.plugin.exchange.filesystem.FileSystemExchangePlugin;
-import io.trino.plugin.postgresql.TestingPostgreSqlServer;
+import io.trino.plugin.jdbc.BaseJdbcFailureRecoveryTest;
 import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
 
 import java.util.List;
 import java.util.Map;
 
-import static io.trino.plugin.postgresql.PostgreSqlQueryRunner.createPostgreSqlQueryRunner;
+import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
 
-public abstract class BasePostgresFailureRecoveryTest
+public abstract class BaseMySqlFailureRecoveryTest
         extends BaseJdbcFailureRecoveryTest
 {
-    public BasePostgresFailureRecoveryTest(RetryPolicy retryPolicy)
+    public BaseMySqlFailureRecoveryTest(RetryPolicy retryPolicy)
     {
         super(retryPolicy);
     }
@@ -41,8 +40,8 @@ public abstract class BasePostgresFailureRecoveryTest
             Map<String, String> coordinatorProperties)
             throws Exception
     {
-        return createPostgreSqlQueryRunner(
-                closeAfterClass(new TestingPostgreSqlServer()),
+        return createMySqlQueryRunner(
+                closeAfterClass(new TestingMySqlServer()),
                 configProperties,
                 coordinatorProperties,
                 Map.of(),

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlQueryFailureRecoveryTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlQueryFailureRecoveryTest.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.faulttolerant.mysql;
+package io.trino.plugin.mysql;
 
 import io.trino.operator.RetryPolicy;
 

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTaskFailureRecoveryTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTaskFailureRecoveryTest.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.faulttolerant.mysql;
+package io.trino.plugin.mysql;
 
 import io.trino.operator.RetryPolicy;
 

--- a/plugin/trino-postgresql/pom.xml
+++ b/plugin/trino-postgresql/pom.xml
@@ -133,6 +133,19 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-exchange-filesystem</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-exchange-filesystem</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-jmx</artifactId>
             <scope>test</scope>
         </dependency>
@@ -222,4 +235,43 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/Test*FailureRecoveryTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>fte-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/Test*FailureRecoveryTest.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/BasePostgresFailureRecoveryTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/BasePostgresFailureRecoveryTest.java
@@ -11,25 +11,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.faulttolerant.mysql;
+package io.trino.plugin.postgresql;
 
 import com.google.common.collect.ImmutableMap;
-import io.trino.faulttolerant.jdbc.BaseJdbcFailureRecoveryTest;
 import io.trino.operator.RetryPolicy;
 import io.trino.plugin.exchange.filesystem.FileSystemExchangePlugin;
-import io.trino.plugin.mysql.TestingMySqlServer;
+import io.trino.plugin.jdbc.BaseJdbcFailureRecoveryTest;
 import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
 
 import java.util.List;
 import java.util.Map;
 
-import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
+import static io.trino.plugin.postgresql.PostgreSqlQueryRunner.createPostgreSqlQueryRunner;
 
-public abstract class BaseMySqlFailureRecoveryTest
+public abstract class BasePostgresFailureRecoveryTest
         extends BaseJdbcFailureRecoveryTest
 {
-    public BaseMySqlFailureRecoveryTest(RetryPolicy retryPolicy)
+    public BasePostgresFailureRecoveryTest(RetryPolicy retryPolicy)
     {
         super(retryPolicy);
     }
@@ -41,8 +40,8 @@ public abstract class BaseMySqlFailureRecoveryTest
             Map<String, String> coordinatorProperties)
             throws Exception
     {
-        return createMySqlQueryRunner(
-                closeAfterClass(new TestingMySqlServer()),
+        return createPostgreSqlQueryRunner(
+                closeAfterClass(new TestingPostgreSqlServer()),
                 configProperties,
                 coordinatorProperties,
                 Map.of(),

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgresQueryFailureRecoveryTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgresQueryFailureRecoveryTest.java
@@ -11,14 +11,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.faulttolerant.mongodb;
+package io.trino.plugin.postgresql;
 
 import io.trino.operator.RetryPolicy;
 
-public class TestMongoQueryFailureRecoveryTest
-        extends BaseMongoFailureRecoveryTest
+public class TestPostgresQueryFailureRecoveryTest
+        extends BasePostgresFailureRecoveryTest
 {
-    public TestMongoQueryFailureRecoveryTest()
+    public TestPostgresQueryFailureRecoveryTest()
     {
         super(RetryPolicy.QUERY);
     }

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgresTaskFailureRecoveryTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgresTaskFailureRecoveryTest.java
@@ -11,14 +11,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.faulttolerant.mongodb;
+package io.trino.plugin.postgresql;
 
 import io.trino.operator.RetryPolicy;
 
-public class TestMongoTaskFailureRecoveryTest
-        extends BaseMongoFailureRecoveryTest
+public class TestPostgresTaskFailureRecoveryTest
+        extends BasePostgresFailureRecoveryTest
 {
-    public TestMongoTaskFailureRecoveryTest()
+    public TestPostgresTaskFailureRecoveryTest()
     {
         super(RetryPolicy.TASK);
     }

--- a/plugin/trino-sqlserver/pom.xml
+++ b/plugin/trino-sqlserver/pom.xml
@@ -135,6 +135,19 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-exchange-filesystem</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-exchange-filesystem</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
             <scope>test</scope>
         </dependency>
@@ -212,4 +225,43 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/Test*FailureRecoveryTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>fte-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/Test*FailureRecoveryTest.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerFailureRecoveryTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerFailureRecoveryTest.java
@@ -11,13 +11,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.faulttolerant.sqlserver;
+package io.trino.plugin.sqlserver;
 
 import com.google.common.collect.ImmutableMap;
-import io.trino.faulttolerant.jdbc.BaseJdbcFailureRecoveryTest;
 import io.trino.operator.RetryPolicy;
 import io.trino.plugin.exchange.filesystem.FileSystemExchangePlugin;
-import io.trino.plugin.sqlserver.TestingSqlServer;
+import io.trino.plugin.jdbc.BaseJdbcFailureRecoveryTest;
 import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
 

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerQueryFailureRecoveryTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerQueryFailureRecoveryTest.java
@@ -11,15 +11,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.faulttolerant.sqlserver;
+package io.trino.plugin.sqlserver;
 
 import io.trino.operator.RetryPolicy;
 
-public class TestSqlServerTaskFailureRecoveryTest
+public class TestSqlServerQueryFailureRecoveryTest
         extends BaseSqlServerFailureRecoveryTest
 {
-    public TestSqlServerTaskFailureRecoveryTest()
+    public TestSqlServerQueryFailureRecoveryTest()
     {
-        super(RetryPolicy.TASK);
+        super(RetryPolicy.QUERY);
     }
 }

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerTaskFailureRecoveryTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerTaskFailureRecoveryTest.java
@@ -11,14 +11,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.faulttolerant.postgresql;
+package io.trino.plugin.sqlserver;
 
 import io.trino.operator.RetryPolicy;
 
-public class TestPostgresTaskFailureRecoveryTest
-        extends BasePostgresFailureRecoveryTest
+public class TestSqlServerTaskFailureRecoveryTest
+        extends BaseSqlServerFailureRecoveryTest
 {
-    public TestPostgresTaskFailureRecoveryTest()
+    public TestSqlServerTaskFailureRecoveryTest()
     {
         super(RetryPolicy.TASK);
     }

--- a/testing/trino-faulttolerant-tests/pom.xml
+++ b/testing/trino-faulttolerant-tests/pom.xml
@@ -490,10 +490,6 @@
                                 <exclude>**/io/trino/faulttolerant/delta/Test*.java</exclude>
                                 <exclude>**/io/trino/faulttolerant/hive/Test*.java</exclude>
                                 <exclude>**/io/trino/faulttolerant/iceberg/Test*.java</exclude>
-                                <exclude>**/io/trino/faulttolerant/mongodb/Test*.java</exclude>
-                                <exclude>**/io/trino/faulttolerant/mysql/Test*.java</exclude>
-                                <exclude>**/io/trino/faulttolerant/postgresql/Test*.java</exclude>
-                                <exclude>**/io/trino/faulttolerant/sqlserver/Test*.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -502,26 +498,7 @@
         </profile>
 
         <profile>
-            <id>test-fault-tolerant-hive-1</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <!-- Failure recovery tests spend most of the time waiting for a retry -->
-                            <threadCount>4</threadCount>
-                            <includes>
-                                <include>**/io/trino/faulttolerant/hive/*FailureRecoveryTest.java</include>
-                            </includes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>test-fault-tolerant-hive-2</id>
+            <id>test-fault-tolerant-hive</id>
             <build>
                 <plugins>
                     <plugin>
@@ -570,78 +547,6 @@
                             <threadCount>4</threadCount>
                             <includes>
                                 <include>**/io/trino/faulttolerant/iceberg/Test*.java</include>
-                            </includes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>test-fault-tolerant-postgresql</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <threadCount>4</threadCount>
-                            <includes>
-                                <include>**/io/trino/faulttolerant/postgresql/Test*.java</include>
-                            </includes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>test-fault-tolerant-mysql</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <threadCount>4</threadCount>
-                            <includes>
-                                <include>**/io/trino/faulttolerant/mysql/Test*.java</include>
-                            </includes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>test-fault-tolerant-sqlserver</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <threadCount>4</threadCount>
-                            <includes>
-                                <include>**/io/trino/faulttolerant/sqlserver/Test*.java</include>
-                            </includes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>test-fault-tolerant-mongodb</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <threadCount>4</threadCount>
-                            <includes>
-                                <include>**/io/trino/faulttolerant/mongodb/Test*.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/testing/trino-testing/src/main/java/io/trino/testing/ExtendedFailureRecoveryTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/ExtendedFailureRecoveryTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.Session;
+import io.trino.operator.OperatorStats;
+import io.trino.operator.RetryPolicy;
+import io.trino.server.DynamicFilterService.DynamicFilterDomainStats;
+import io.trino.server.DynamicFilterService.DynamicFiltersStats;
+import io.trino.spi.ErrorType;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.SystemSessionProperties.ENABLE_DYNAMIC_FILTERING;
+import static io.trino.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
+import static io.trino.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
+import static io.trino.execution.FailureInjector.FAILURE_INJECTION_MESSAGE;
+import static io.trino.execution.FailureInjector.InjectedFailureType.TASK_FAILURE;
+import static io.trino.execution.FailureInjector.InjectedFailureType.TASK_MANAGEMENT_REQUEST_FAILURE;
+import static io.trino.execution.FailureInjector.InjectedFailureType.TASK_MANAGEMENT_REQUEST_TIMEOUT;
+import static io.trino.spi.predicate.Domain.singleValue;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.planner.OptimizerConfig.JoinDistributionType.PARTITIONED;
+import static io.trino.sql.planner.OptimizerConfig.JoinReorderingStrategy.NONE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public abstract class ExtendedFailureRecoveryTest
+        extends BaseFailureRecoveryTest
+{
+    private static final String PARTITIONED_LINEITEM = "partitioned_lineitem";
+
+    protected ExtendedFailureRecoveryTest(RetryPolicy retryPolicy)
+    {
+        super(retryPolicy);
+    }
+
+    @BeforeClass
+    public void initTables()
+            throws Exception
+    {
+        // setup partitioned fact table for dynamic partition pruning
+        createPartitionedLineitemTable(PARTITIONED_LINEITEM, ImmutableList.of("orderkey", "partkey", "suppkey"), "suppkey");
+    }
+
+    protected abstract void createPartitionedLineitemTable(String tableName, List<String> columns, String partitionColumn);
+
+    @Test(invocationCount = INVOCATION_COUNT)
+    public void testSimpleSelect()
+    {
+        testSelect("SELECT * FROM nation");
+    }
+
+    @Test(invocationCount = INVOCATION_COUNT)
+    public void testAggregation()
+    {
+        testSelect("SELECT orderStatus, count(*) FROM orders GROUP BY orderStatus");
+    }
+
+    @Test(invocationCount = INVOCATION_COUNT)
+    public void testJoinDynamicFilteringDisabled()
+    {
+        @Language("SQL") String selectQuery = "SELECT * FROM partitioned_lineitem JOIN supplier ON partitioned_lineitem.suppkey = supplier.suppkey " +
+                "AND supplier.name = 'Supplier#000000001'";
+        testSelect(selectQuery, Optional.of(enableDynamicFiltering(false)));
+    }
+
+    @Test(invocationCount = INVOCATION_COUNT)
+    public void testJoinDynamicFilteringEnabled()
+    {
+        @Language("SQL") String selectQuery = "SELECT * FROM partitioned_lineitem JOIN supplier ON partitioned_lineitem.suppkey = supplier.suppkey " +
+                "AND supplier.name = 'Supplier#000000001'";
+        testSelect(
+                selectQuery,
+                Optional.of(enableDynamicFiltering(true)),
+                queryId -> {
+                    DynamicFiltersStats dynamicFiltersStats = getDynamicFilteringStats(queryId);
+                    assertThat(dynamicFiltersStats.getLazyDynamicFilters())
+                            .as("Dynamic filter is missing")
+                            .isEqualTo(1);
+                    DynamicFilterDomainStats domainStats = getOnlyElement(dynamicFiltersStats.getDynamicFilterDomainStats());
+                    assertThat(domainStats.getSimplifiedDomain())
+                            .isEqualTo(singleValue(BIGINT, 1L).toString(getSession().toConnectorSession()));
+                    OperatorStats probeStats = searchScanFilterAndProjectOperatorStats(queryId, getQualifiedTableName(PARTITIONED_LINEITEM));
+                    // Currently, stats from all attempts are combined.
+                    // Asserting on multiple of 615L as well in case the probe scan was completed twice
+                    assertThat(probeStats.getInputPositions()).isIn(615L, 1230L);
+                });
+    }
+
+    @Test(invocationCount = INVOCATION_COUNT)
+    public void testUserFailure()
+    {
+        // Some connectors have pushdowns enabled for arithmetic operations (like SqlServer),
+        // so exception will come not from trino, but from datasource itself
+        Session withoutPushdown = Session.builder(this.getSession())
+                .setSystemProperty("allow_pushdown_into_connectors", "false")
+                .build();
+
+        assertThatThrownBy(() -> getQueryRunner().execute(withoutPushdown, "SELECT * FROM nation WHERE regionKey / nationKey - 1 = 0"))
+                .hasMessageMatching("(?i).*Division by zero.*"); // some errors come back with different casing.
+
+        assertThatQuery("SELECT * FROM nation")
+                .experiencing(TASK_FAILURE, Optional.of(ErrorType.USER_ERROR))
+                .at(leafStage())
+                .failsAlways(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE));
+    }
+
+    @Override
+    public void testRequestTimeouts()
+    {
+        // extra test cases not covered by general timeout cases scattered around
+        assertThatQuery("SELECT * FROM nation")
+                .experiencing(TASK_MANAGEMENT_REQUEST_TIMEOUT)
+                .at(leafStage())
+                .failsWithoutRetries(failure -> failure.hasMessageContaining("Encountered too many errors talking to a worker node"))
+                .finishesSuccessfully();
+
+        assertThatQuery("SELECT * FROM nation")
+                .experiencing(TASK_MANAGEMENT_REQUEST_TIMEOUT)
+                .at(boundaryDistributedStage())
+                .failsWithoutRetries(failure -> failure.hasMessageContaining("Encountered too many errors talking to a worker node"))
+                .finishesSuccessfully();
+
+        super.testRequestTimeouts();
+    }
+
+    @Override
+    protected void testNonSelect(Optional<Session> session, Optional<String> setupQuery, String query, Optional<String> cleanupQuery, boolean writesData)
+    {
+        super.testNonSelect(session, setupQuery, query, cleanupQuery, writesData);
+
+        assertThatQuery(query)
+                .withSession(session)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
+                .at(leafStage())
+                .failsWithoutRetries(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE))
+                .finishesSuccessfully();
+
+        assertThatQuery(query)
+                .withSession(session)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
+                .at(intermediateDistributedStage())
+                .failsWithoutRetries(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE))
+                .finishesSuccessfully();
+
+        assertThatQuery(query)
+                .withSession(session)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_MANAGEMENT_REQUEST_FAILURE)
+                .at(boundaryDistributedStage())
+                .failsWithoutRetries(failure -> failure.hasMessageFindingMatch("Error 500 Internal Server Error|Error closing remote buffer, expected 204 got 500"))
+                .finishesSuccessfully();
+    }
+
+    private Session enableDynamicFiltering(boolean enabled)
+    {
+        Session defaultSession = getQueryRunner().getDefaultSession();
+        return Session.builder(defaultSession)
+                .setSystemProperty(ENABLE_DYNAMIC_FILTERING, Boolean.toString(enabled))
+                .setSystemProperty(JOIN_REORDERING_STRATEGY, NONE.name())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, PARTITIONED.name())
+                // Ensure probe side scan wait until DF is collected
+                .setCatalogSessionProperty(defaultSession.getCatalog().orElseThrow(), "dynamic_filtering_wait_timeout", "1h")
+                .build();
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This:
1. Moves the `BaseFailureRecoveryTest` from testing/trino-faulttolerant-tests to testing/trino-testing
2. Moves `BaseJdbcFailureRecoveryTest` to plugin/trino-base-jdbc
3. Moves the implementation test classes to the plugin-specific modules 
4. Restructures ci.yml to keep the FailureRecovery tests as separate CI jobs. 
5. Reduces the number of test cases in the BaseFailureRecoveryTest to reduce the duration of these tests.

The impetus for this move was, when adding these tests for BigQuery, there was a dependency version conflict due to the addition of the trino-bigquery dependency. Furthermore, it was determined that these BigQuery tests were taking longer than an hour to complete (hence the reduction in the number of tests run).

In a follow-up PR, I will introduce a parallelism mechanism to BaseFailureRecovery test that will run several of these in parallel, which ends up further reducing the duration of these tests.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
