### PR TITLE
Implement optimized decoder for RLE encoding in parquet

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderUtils.java
@@ -73,6 +73,21 @@ public final class ParquetReaderUtils
         return value | inputByte << 28;
     }
 
+    public static int readFixedWidthInt(SimpleSliceInputStream input, int bytesWidth)
+    {
+        return switch (bytesWidth) {
+            case 0 -> 0;
+            case 1 -> input.readByte() & 0xFF;
+            case 2 -> input.readShort() & 0xFFFF;
+            case 3 -> {
+                int value = input.readShort() & 0xFFFF;
+                yield ((input.readByte() & 0xFF) << 16) | value;
+            }
+            case 4 -> input.readInt();
+            default -> throw new IllegalArgumentException(format("Encountered bytesWidth (%d) that requires more than 4 bytes", bytesWidth));
+        };
+    }
+
     /**
      * Propagate the sign bit in values that are shorter than 8 bytes.
      * <p>

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/IntBitUnpacker.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/IntBitUnpacker.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.trino.parquet.reader.SimpleSliceInputStream;
+
+public interface IntBitUnpacker
+{
+    /**
+     * @param length must be a multiple of 8
+     */
+    void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length);
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/IntBitUnpackers.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/IntBitUnpackers.java
@@ -1,0 +1,1533 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.trino.parquet.reader.SimpleSliceInputStream;
+
+public final class IntBitUnpackers
+{
+    private static final IntBitUnpacker[] UNPACKERS = {
+            new Unpacker0(),
+            new Unpacker1(),
+            new Unpacker2(),
+            new Unpacker3(),
+            new Unpacker4(),
+            new Unpacker5(),
+            new Unpacker6(),
+            new Unpacker7(),
+            new Unpacker8(),
+            new Unpacker9(),
+            new Unpacker10(),
+            new Unpacker11(),
+            new Unpacker12(),
+            new Unpacker13(),
+            new Unpacker14(),
+            new Unpacker15(),
+            new Unpacker16(),
+            new Unpacker17(),
+            new Unpacker18(),
+            new Unpacker19(),
+            new Unpacker20(),
+            new Unpacker21(),
+            new Unpacker22(),
+            new Unpacker23(),
+            new Unpacker24(),
+            new Unpacker25(),
+            new Unpacker26(),
+            new Unpacker27(),
+            new Unpacker28(),
+            new Unpacker29(),
+            new Unpacker30(),
+            new Unpacker31(),
+            new Unpacker32()};
+
+    public static IntBitUnpacker getIntBitUnpacker(int bitWidth)
+    {
+        return UNPACKERS[bitWidth];
+    }
+
+    private IntBitUnpackers()
+    {
+    }
+
+    private static final class Unpacker0
+            implements IntBitUnpacker
+    {
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input,
+                int length)
+        {
+            // Do nothing
+        }
+    }
+
+    private static final class Unpacker1
+            implements IntBitUnpacker
+    {
+        private static void unpack64(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            output[outputOffset] = (int) (v0 & 0b1L);
+            output[outputOffset + 1] = (int) ((v0 >>> 1) & 0b1L);
+            output[outputOffset + 2] = (int) ((v0 >>> 2) & 0b1L);
+            output[outputOffset + 3] = (int) ((v0 >>> 3) & 0b1L);
+            output[outputOffset + 4] = (int) ((v0 >>> 4) & 0b1L);
+            output[outputOffset + 5] = (int) ((v0 >>> 5) & 0b1L);
+            output[outputOffset + 6] = (int) ((v0 >>> 6) & 0b1L);
+            output[outputOffset + 7] = (int) ((v0 >>> 7) & 0b1L);
+            output[outputOffset + 8] = (int) ((v0 >>> 8) & 0b1L);
+            output[outputOffset + 9] = (int) ((v0 >>> 9) & 0b1L);
+            output[outputOffset + 10] = (int) ((v0 >>> 10) & 0b1L);
+            output[outputOffset + 11] = (int) ((v0 >>> 11) & 0b1L);
+            output[outputOffset + 12] = (int) ((v0 >>> 12) & 0b1L);
+            output[outputOffset + 13] = (int) ((v0 >>> 13) & 0b1L);
+            output[outputOffset + 14] = (int) ((v0 >>> 14) & 0b1L);
+            output[outputOffset + 15] = (int) ((v0 >>> 15) & 0b1L);
+            output[outputOffset + 16] = (int) ((v0 >>> 16) & 0b1L);
+            output[outputOffset + 17] = (int) ((v0 >>> 17) & 0b1L);
+            output[outputOffset + 18] = (int) ((v0 >>> 18) & 0b1L);
+            output[outputOffset + 19] = (int) ((v0 >>> 19) & 0b1L);
+            output[outputOffset + 20] = (int) ((v0 >>> 20) & 0b1L);
+            output[outputOffset + 21] = (int) ((v0 >>> 21) & 0b1L);
+            output[outputOffset + 22] = (int) ((v0 >>> 22) & 0b1L);
+            output[outputOffset + 23] = (int) ((v0 >>> 23) & 0b1L);
+            output[outputOffset + 24] = (int) ((v0 >>> 24) & 0b1L);
+            output[outputOffset + 25] = (int) ((v0 >>> 25) & 0b1L);
+            output[outputOffset + 26] = (int) ((v0 >>> 26) & 0b1L);
+            output[outputOffset + 27] = (int) ((v0 >>> 27) & 0b1L);
+            output[outputOffset + 28] = (int) ((v0 >>> 28) & 0b1L);
+            output[outputOffset + 29] = (int) ((v0 >>> 29) & 0b1L);
+            output[outputOffset + 30] = (int) ((v0 >>> 30) & 0b1L);
+            output[outputOffset + 31] = (int) ((v0 >>> 31) & 0b1L);
+            output[outputOffset + 32] = (int) ((v0 >>> 32) & 0b1L);
+            output[outputOffset + 33] = (int) ((v0 >>> 33) & 0b1L);
+            output[outputOffset + 34] = (int) ((v0 >>> 34) & 0b1L);
+            output[outputOffset + 35] = (int) ((v0 >>> 35) & 0b1L);
+            output[outputOffset + 36] = (int) ((v0 >>> 36) & 0b1L);
+            output[outputOffset + 37] = (int) ((v0 >>> 37) & 0b1L);
+            output[outputOffset + 38] = (int) ((v0 >>> 38) & 0b1L);
+            output[outputOffset + 39] = (int) ((v0 >>> 39) & 0b1L);
+            output[outputOffset + 40] = (int) ((v0 >>> 40) & 0b1L);
+            output[outputOffset + 41] = (int) ((v0 >>> 41) & 0b1L);
+            output[outputOffset + 42] = (int) ((v0 >>> 42) & 0b1L);
+            output[outputOffset + 43] = (int) ((v0 >>> 43) & 0b1L);
+            output[outputOffset + 44] = (int) ((v0 >>> 44) & 0b1L);
+            output[outputOffset + 45] = (int) ((v0 >>> 45) & 0b1L);
+            output[outputOffset + 46] = (int) ((v0 >>> 46) & 0b1L);
+            output[outputOffset + 47] = (int) ((v0 >>> 47) & 0b1L);
+            output[outputOffset + 48] = (int) ((v0 >>> 48) & 0b1L);
+            output[outputOffset + 49] = (int) ((v0 >>> 49) & 0b1L);
+            output[outputOffset + 50] = (int) ((v0 >>> 50) & 0b1L);
+            output[outputOffset + 51] = (int) ((v0 >>> 51) & 0b1L);
+            output[outputOffset + 52] = (int) ((v0 >>> 52) & 0b1L);
+            output[outputOffset + 53] = (int) ((v0 >>> 53) & 0b1L);
+            output[outputOffset + 54] = (int) ((v0 >>> 54) & 0b1L);
+            output[outputOffset + 55] = (int) ((v0 >>> 55) & 0b1L);
+            output[outputOffset + 56] = (int) ((v0 >>> 56) & 0b1L);
+            output[outputOffset + 57] = (int) ((v0 >>> 57) & 0b1L);
+            output[outputOffset + 58] = (int) ((v0 >>> 58) & 0b1L);
+            output[outputOffset + 59] = (int) ((v0 >>> 59) & 0b1L);
+            output[outputOffset + 60] = (int) ((v0 >>> 60) & 0b1L);
+            output[outputOffset + 61] = (int) ((v0 >>> 61) & 0b1L);
+            output[outputOffset + 62] = (int) ((v0 >>> 62) & 0b1L);
+            output[outputOffset + 63] = (int) ((v0 >>> 63) & 0b1L);
+        }
+
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            byte v0 = input.readByte();
+            output[outputOffset] = (int) (v0 & 0b1L);
+            output[outputOffset + 1] = (int) ((v0 >>> 1) & 0b1L);
+            output[outputOffset + 2] = (int) ((v0 >>> 2) & 0b1L);
+            output[outputOffset + 3] = (int) ((v0 >>> 3) & 0b1L);
+            output[outputOffset + 4] = (int) ((v0 >>> 4) & 0b1L);
+            output[outputOffset + 5] = (int) ((v0 >>> 5) & 0b1L);
+            output[outputOffset + 6] = (int) ((v0 >>> 6) & 0b1L);
+            output[outputOffset + 7] = (int) ((v0 >>> 7) & 0b1L);
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 64) {
+                unpack64(output, outputOffset, input);
+                outputOffset += 64;
+                length -= 64;
+            }
+            switch (length) {
+                case 56:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 48:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 40:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 32:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 24:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 16:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 8:
+                    unpack8(output, outputOffset, input);
+            }
+        }
+    }
+
+    private static final class Unpacker2
+            implements IntBitUnpacker
+    {
+        private static void unpack32(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            output[outputOffset] = (int) (v0 & 0b11L);
+            output[outputOffset + 1] = (int) ((v0 >>> 2) & 0b11L);
+            output[outputOffset + 2] = (int) ((v0 >>> 4) & 0b11L);
+            output[outputOffset + 3] = (int) ((v0 >>> 6) & 0b11L);
+            output[outputOffset + 4] = (int) ((v0 >>> 8) & 0b11L);
+            output[outputOffset + 5] = (int) ((v0 >>> 10) & 0b11L);
+            output[outputOffset + 6] = (int) ((v0 >>> 12) & 0b11L);
+            output[outputOffset + 7] = (int) ((v0 >>> 14) & 0b11L);
+            output[outputOffset + 8] = (int) ((v0 >>> 16) & 0b11L);
+            output[outputOffset + 9] = (int) ((v0 >>> 18) & 0b11L);
+            output[outputOffset + 10] = (int) ((v0 >>> 20) & 0b11L);
+            output[outputOffset + 11] = (int) ((v0 >>> 22) & 0b11L);
+            output[outputOffset + 12] = (int) ((v0 >>> 24) & 0b11L);
+            output[outputOffset + 13] = (int) ((v0 >>> 26) & 0b11L);
+            output[outputOffset + 14] = (int) ((v0 >>> 28) & 0b11L);
+            output[outputOffset + 15] = (int) ((v0 >>> 30) & 0b11L);
+            output[outputOffset + 16] = (int) ((v0 >>> 32) & 0b11L);
+            output[outputOffset + 17] = (int) ((v0 >>> 34) & 0b11L);
+            output[outputOffset + 18] = (int) ((v0 >>> 36) & 0b11L);
+            output[outputOffset + 19] = (int) ((v0 >>> 38) & 0b11L);
+            output[outputOffset + 20] = (int) ((v0 >>> 40) & 0b11L);
+            output[outputOffset + 21] = (int) ((v0 >>> 42) & 0b11L);
+            output[outputOffset + 22] = (int) ((v0 >>> 44) & 0b11L);
+            output[outputOffset + 23] = (int) ((v0 >>> 46) & 0b11L);
+            output[outputOffset + 24] = (int) ((v0 >>> 48) & 0b11L);
+            output[outputOffset + 25] = (int) ((v0 >>> 50) & 0b11L);
+            output[outputOffset + 26] = (int) ((v0 >>> 52) & 0b11L);
+            output[outputOffset + 27] = (int) ((v0 >>> 54) & 0b11L);
+            output[outputOffset + 28] = (int) ((v0 >>> 56) & 0b11L);
+            output[outputOffset + 29] = (int) ((v0 >>> 58) & 0b11L);
+            output[outputOffset + 30] = (int) ((v0 >>> 60) & 0b11L);
+            output[outputOffset + 31] = (int) ((v0 >>> 62) & 0b11L);
+        }
+
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            short v0 = input.readShort();
+            output[outputOffset] = (int) (v0 & 0b11L);
+            output[outputOffset + 1] = (int) ((v0 >>> 2) & 0b11L);
+            output[outputOffset + 2] = (int) ((v0 >>> 4) & 0b11L);
+            output[outputOffset + 3] = (int) ((v0 >>> 6) & 0b11L);
+            output[outputOffset + 4] = (int) ((v0 >>> 8) & 0b11L);
+            output[outputOffset + 5] = (int) ((v0 >>> 10) & 0b11L);
+            output[outputOffset + 6] = (int) ((v0 >>> 12) & 0b11L);
+            output[outputOffset + 7] = (int) ((v0 >>> 14) & 0b11L);
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+            switch (length) {
+                case 24:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 16:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 8:
+                    unpack8(output, outputOffset, input);
+            }
+        }
+    }
+
+    private static final class Unpacker3
+            implements IntBitUnpacker
+    {
+        private static void unpack64(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            output[outputOffset] = (int) (v0 & 0b111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 3) & 0b111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 6) & 0b111L);
+            output[outputOffset + 3] = (int) ((v0 >>> 9) & 0b111L);
+            output[outputOffset + 4] = (int) ((v0 >>> 12) & 0b111L);
+            output[outputOffset + 5] = (int) ((v0 >>> 15) & 0b111L);
+            output[outputOffset + 6] = (int) ((v0 >>> 18) & 0b111L);
+            output[outputOffset + 7] = (int) ((v0 >>> 21) & 0b111L);
+            output[outputOffset + 8] = (int) ((v0 >>> 24) & 0b111L);
+            output[outputOffset + 9] = (int) ((v0 >>> 27) & 0b111L);
+            output[outputOffset + 10] = (int) ((v0 >>> 30) & 0b111L);
+            output[outputOffset + 11] = (int) ((v0 >>> 33) & 0b111L);
+            output[outputOffset + 12] = (int) ((v0 >>> 36) & 0b111L);
+            output[outputOffset + 13] = (int) ((v0 >>> 39) & 0b111L);
+            output[outputOffset + 14] = (int) ((v0 >>> 42) & 0b111L);
+            output[outputOffset + 15] = (int) ((v0 >>> 45) & 0b111L);
+            output[outputOffset + 16] = (int) ((v0 >>> 48) & 0b111L);
+            output[outputOffset + 17] = (int) ((v0 >>> 51) & 0b111L);
+            output[outputOffset + 18] = (int) ((v0 >>> 54) & 0b111L);
+            output[outputOffset + 19] = (int) ((v0 >>> 57) & 0b111L);
+            output[outputOffset + 20] = (int) ((v0 >>> 60) & 0b111L);
+            output[outputOffset + 21] = (int) (((v0 >>> 63) & 0b1L) | ((v1 & 0b11L) << 1));
+            output[outputOffset + 22] = (int) ((v1 >>> 2) & 0b111L);
+            output[outputOffset + 23] = (int) ((v1 >>> 5) & 0b111L);
+            output[outputOffset + 24] = (int) ((v1 >>> 8) & 0b111L);
+            output[outputOffset + 25] = (int) ((v1 >>> 11) & 0b111L);
+            output[outputOffset + 26] = (int) ((v1 >>> 14) & 0b111L);
+            output[outputOffset + 27] = (int) ((v1 >>> 17) & 0b111L);
+            output[outputOffset + 28] = (int) ((v1 >>> 20) & 0b111L);
+            output[outputOffset + 29] = (int) ((v1 >>> 23) & 0b111L);
+            output[outputOffset + 30] = (int) ((v1 >>> 26) & 0b111L);
+            output[outputOffset + 31] = (int) ((v1 >>> 29) & 0b111L);
+            output[outputOffset + 32] = (int) ((v1 >>> 32) & 0b111L);
+            output[outputOffset + 33] = (int) ((v1 >>> 35) & 0b111L);
+            output[outputOffset + 34] = (int) ((v1 >>> 38) & 0b111L);
+            output[outputOffset + 35] = (int) ((v1 >>> 41) & 0b111L);
+            output[outputOffset + 36] = (int) ((v1 >>> 44) & 0b111L);
+            output[outputOffset + 37] = (int) ((v1 >>> 47) & 0b111L);
+            output[outputOffset + 38] = (int) ((v1 >>> 50) & 0b111L);
+            output[outputOffset + 39] = (int) ((v1 >>> 53) & 0b111L);
+            output[outputOffset + 40] = (int) ((v1 >>> 56) & 0b111L);
+            output[outputOffset + 41] = (int) ((v1 >>> 59) & 0b111L);
+            output[outputOffset + 42] = (int) (((v1 >>> 62) & 0b11L) | ((v2 & 0b1L) << 2));
+            output[outputOffset + 43] = (int) ((v2 >>> 1) & 0b111L);
+            output[outputOffset + 44] = (int) ((v2 >>> 4) & 0b111L);
+            output[outputOffset + 45] = (int) ((v2 >>> 7) & 0b111L);
+            output[outputOffset + 46] = (int) ((v2 >>> 10) & 0b111L);
+            output[outputOffset + 47] = (int) ((v2 >>> 13) & 0b111L);
+            output[outputOffset + 48] = (int) ((v2 >>> 16) & 0b111L);
+            output[outputOffset + 49] = (int) ((v2 >>> 19) & 0b111L);
+            output[outputOffset + 50] = (int) ((v2 >>> 22) & 0b111L);
+            output[outputOffset + 51] = (int) ((v2 >>> 25) & 0b111L);
+            output[outputOffset + 52] = (int) ((v2 >>> 28) & 0b111L);
+            output[outputOffset + 53] = (int) ((v2 >>> 31) & 0b111L);
+            output[outputOffset + 54] = (int) ((v2 >>> 34) & 0b111L);
+            output[outputOffset + 55] = (int) ((v2 >>> 37) & 0b111L);
+            output[outputOffset + 56] = (int) ((v2 >>> 40) & 0b111L);
+            output[outputOffset + 57] = (int) ((v2 >>> 43) & 0b111L);
+            output[outputOffset + 58] = (int) ((v2 >>> 46) & 0b111L);
+            output[outputOffset + 59] = (int) ((v2 >>> 49) & 0b111L);
+            output[outputOffset + 60] = (int) ((v2 >>> 52) & 0b111L);
+            output[outputOffset + 61] = (int) ((v2 >>> 55) & 0b111L);
+            output[outputOffset + 62] = (int) ((v2 >>> 58) & 0b111L);
+            output[outputOffset + 63] = (int) ((v2 >>> 61) & 0b111L);
+        }
+
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            short v0 = input.readShort();
+            byte v1 = input.readByte();
+            output[outputOffset] = (int) (v0 & 0b111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 3) & 0b111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 6) & 0b111L);
+            output[outputOffset + 3] = (int) ((v0 >>> 9) & 0b111L);
+            output[outputOffset + 4] = (int) ((v0 >>> 12) & 0b111L);
+            output[outputOffset + 5] = (int) (((v0 >>> 15) & 0b1L) | ((v1 & 0b11L) << 1));
+            output[outputOffset + 6] = (int) ((v1 >>> 2) & 0b111L);
+            output[outputOffset + 7] = (int) ((v1 >>> 5) & 0b111L);
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 64) {
+                unpack64(output, outputOffset, input);
+                outputOffset += 64;
+                length -= 64;
+            }
+            switch (length) {
+                case 56:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 48:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 40:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 32:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 24:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 16:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 8:
+                    unpack8(output, outputOffset, input);
+            }
+        }
+    }
+
+    private static final class Unpacker4
+            implements IntBitUnpacker
+    {
+        private static void unpack16(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            output[outputOffset] = (int) (v0 & 0b1111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 4) & 0b1111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 8) & 0b1111L);
+            output[outputOffset + 3] = (int) ((v0 >>> 12) & 0b1111L);
+            output[outputOffset + 4] = (int) ((v0 >>> 16) & 0b1111L);
+            output[outputOffset + 5] = (int) ((v0 >>> 20) & 0b1111L);
+            output[outputOffset + 6] = (int) ((v0 >>> 24) & 0b1111L);
+            output[outputOffset + 7] = (int) ((v0 >>> 28) & 0b1111L);
+            output[outputOffset + 8] = (int) ((v0 >>> 32) & 0b1111L);
+            output[outputOffset + 9] = (int) ((v0 >>> 36) & 0b1111L);
+            output[outputOffset + 10] = (int) ((v0 >>> 40) & 0b1111L);
+            output[outputOffset + 11] = (int) ((v0 >>> 44) & 0b1111L);
+            output[outputOffset + 12] = (int) ((v0 >>> 48) & 0b1111L);
+            output[outputOffset + 13] = (int) ((v0 >>> 52) & 0b1111L);
+            output[outputOffset + 14] = (int) ((v0 >>> 56) & 0b1111L);
+            output[outputOffset + 15] = (int) ((v0 >>> 60) & 0b1111L);
+        }
+
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            int v0 = input.readInt();
+            output[outputOffset] = (int) (v0 & 0b1111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 4) & 0b1111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 8) & 0b1111L);
+            output[outputOffset + 3] = (int) ((v0 >>> 12) & 0b1111L);
+            output[outputOffset + 4] = (int) ((v0 >>> 16) & 0b1111L);
+            output[outputOffset + 5] = (int) ((v0 >>> 20) & 0b1111L);
+            output[outputOffset + 6] = (int) ((v0 >>> 24) & 0b1111L);
+            output[outputOffset + 7] = (int) ((v0 >>> 28) & 0b1111L);
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 16) {
+                unpack16(output, outputOffset, input);
+                outputOffset += 16;
+                length -= 16;
+            }
+            if (length >= 8) {
+                unpack8(output, outputOffset, input);
+            }
+        }
+    }
+
+    private static final class Unpacker5
+            implements IntBitUnpacker
+    {
+        private static void unpack64(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            output[outputOffset] = (int) (v0 & 0b11111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 5) & 0b11111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 10) & 0b11111L);
+            output[outputOffset + 3] = (int) ((v0 >>> 15) & 0b11111L);
+            output[outputOffset + 4] = (int) ((v0 >>> 20) & 0b11111L);
+            output[outputOffset + 5] = (int) ((v0 >>> 25) & 0b11111L);
+            output[outputOffset + 6] = (int) ((v0 >>> 30) & 0b11111L);
+            output[outputOffset + 7] = (int) ((v0 >>> 35) & 0b11111L);
+            output[outputOffset + 8] = (int) ((v0 >>> 40) & 0b11111L);
+            output[outputOffset + 9] = (int) ((v0 >>> 45) & 0b11111L);
+            output[outputOffset + 10] = (int) ((v0 >>> 50) & 0b11111L);
+            output[outputOffset + 11] = (int) ((v0 >>> 55) & 0b11111L);
+            output[outputOffset + 12] = (int) (((v0 >>> 60) & 0b1111L) | ((v1 & 0b1L) << 4));
+            output[outputOffset + 13] = (int) ((v1 >>> 1) & 0b11111L);
+            output[outputOffset + 14] = (int) ((v1 >>> 6) & 0b11111L);
+            output[outputOffset + 15] = (int) ((v1 >>> 11) & 0b11111L);
+            output[outputOffset + 16] = (int) ((v1 >>> 16) & 0b11111L);
+            output[outputOffset + 17] = (int) ((v1 >>> 21) & 0b11111L);
+            output[outputOffset + 18] = (int) ((v1 >>> 26) & 0b11111L);
+            output[outputOffset + 19] = (int) ((v1 >>> 31) & 0b11111L);
+            output[outputOffset + 20] = (int) ((v1 >>> 36) & 0b11111L);
+            output[outputOffset + 21] = (int) ((v1 >>> 41) & 0b11111L);
+            output[outputOffset + 22] = (int) ((v1 >>> 46) & 0b11111L);
+            output[outputOffset + 23] = (int) ((v1 >>> 51) & 0b11111L);
+            output[outputOffset + 24] = (int) ((v1 >>> 56) & 0b11111L);
+            output[outputOffset + 25] = (int) (((v1 >>> 61) & 0b111L) | ((v2 & 0b11L) << 3));
+            output[outputOffset + 26] = (int) ((v2 >>> 2) & 0b11111L);
+            output[outputOffset + 27] = (int) ((v2 >>> 7) & 0b11111L);
+            output[outputOffset + 28] = (int) ((v2 >>> 12) & 0b11111L);
+            output[outputOffset + 29] = (int) ((v2 >>> 17) & 0b11111L);
+            output[outputOffset + 30] = (int) ((v2 >>> 22) & 0b11111L);
+            output[outputOffset + 31] = (int) ((v2 >>> 27) & 0b11111L);
+            output[outputOffset + 32] = (int) ((v2 >>> 32) & 0b11111L);
+            output[outputOffset + 33] = (int) ((v2 >>> 37) & 0b11111L);
+            output[outputOffset + 34] = (int) ((v2 >>> 42) & 0b11111L);
+            output[outputOffset + 35] = (int) ((v2 >>> 47) & 0b11111L);
+            output[outputOffset + 36] = (int) ((v2 >>> 52) & 0b11111L);
+            output[outputOffset + 37] = (int) ((v2 >>> 57) & 0b11111L);
+            output[outputOffset + 38] = (int) (((v2 >>> 62) & 0b11L) | ((v3 & 0b111L) << 2));
+            output[outputOffset + 39] = (int) ((v3 >>> 3) & 0b11111L);
+            output[outputOffset + 40] = (int) ((v3 >>> 8) & 0b11111L);
+            output[outputOffset + 41] = (int) ((v3 >>> 13) & 0b11111L);
+            output[outputOffset + 42] = (int) ((v3 >>> 18) & 0b11111L);
+            output[outputOffset + 43] = (int) ((v3 >>> 23) & 0b11111L);
+            output[outputOffset + 44] = (int) ((v3 >>> 28) & 0b11111L);
+            output[outputOffset + 45] = (int) ((v3 >>> 33) & 0b11111L);
+            output[outputOffset + 46] = (int) ((v3 >>> 38) & 0b11111L);
+            output[outputOffset + 47] = (int) ((v3 >>> 43) & 0b11111L);
+            output[outputOffset + 48] = (int) ((v3 >>> 48) & 0b11111L);
+            output[outputOffset + 49] = (int) ((v3 >>> 53) & 0b11111L);
+            output[outputOffset + 50] = (int) ((v3 >>> 58) & 0b11111L);
+            output[outputOffset + 51] = (int) (((v3 >>> 63) & 0b1L) | ((v4 & 0b1111L) << 1));
+            output[outputOffset + 52] = (int) ((v4 >>> 4) & 0b11111L);
+            output[outputOffset + 53] = (int) ((v4 >>> 9) & 0b11111L);
+            output[outputOffset + 54] = (int) ((v4 >>> 14) & 0b11111L);
+            output[outputOffset + 55] = (int) ((v4 >>> 19) & 0b11111L);
+            output[outputOffset + 56] = (int) ((v4 >>> 24) & 0b11111L);
+            output[outputOffset + 57] = (int) ((v4 >>> 29) & 0b11111L);
+            output[outputOffset + 58] = (int) ((v4 >>> 34) & 0b11111L);
+            output[outputOffset + 59] = (int) ((v4 >>> 39) & 0b11111L);
+            output[outputOffset + 60] = (int) ((v4 >>> 44) & 0b11111L);
+            output[outputOffset + 61] = (int) ((v4 >>> 49) & 0b11111L);
+            output[outputOffset + 62] = (int) ((v4 >>> 54) & 0b11111L);
+            output[outputOffset + 63] = (int) ((v4 >>> 59) & 0b11111L);
+        }
+
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            int v0 = input.readInt();
+            byte v1 = input.readByte();
+            output[outputOffset] = (int) (v0 & 0b11111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 5) & 0b11111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 10) & 0b11111L);
+            output[outputOffset + 3] = (int) ((v0 >>> 15) & 0b11111L);
+            output[outputOffset + 4] = (int) ((v0 >>> 20) & 0b11111L);
+            output[outputOffset + 5] = (int) ((v0 >>> 25) & 0b11111L);
+            output[outputOffset + 6] = (int) (((v0 >>> 30) & 0b11L) | ((v1 & 0b111L) << 2));
+            output[outputOffset + 7] = (int) ((v1 >>> 3) & 0b11111L);
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 64) {
+                unpack64(output, outputOffset, input);
+                outputOffset += 64;
+                length -= 64;
+            }
+            switch (length) {
+                case 56:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 48:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 40:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 32:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 24:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 16:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 8:
+                    unpack8(output, outputOffset, input);
+            }
+        }
+    }
+
+    private static final class Unpacker6
+            implements IntBitUnpacker
+    {
+        private static void unpack32(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            output[outputOffset] = (int) (v0 & 0b111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 6) & 0b111111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 12) & 0b111111L);
+            output[outputOffset + 3] = (int) ((v0 >>> 18) & 0b111111L);
+            output[outputOffset + 4] = (int) ((v0 >>> 24) & 0b111111L);
+            output[outputOffset + 5] = (int) ((v0 >>> 30) & 0b111111L);
+            output[outputOffset + 6] = (int) ((v0 >>> 36) & 0b111111L);
+            output[outputOffset + 7] = (int) ((v0 >>> 42) & 0b111111L);
+            output[outputOffset + 8] = (int) ((v0 >>> 48) & 0b111111L);
+            output[outputOffset + 9] = (int) ((v0 >>> 54) & 0b111111L);
+            output[outputOffset + 10] = (int) (((v0 >>> 60) & 0b1111L) | ((v1 & 0b11L) << 4));
+            output[outputOffset + 11] = (int) ((v1 >>> 2) & 0b111111L);
+            output[outputOffset + 12] = (int) ((v1 >>> 8) & 0b111111L);
+            output[outputOffset + 13] = (int) ((v1 >>> 14) & 0b111111L);
+            output[outputOffset + 14] = (int) ((v1 >>> 20) & 0b111111L);
+            output[outputOffset + 15] = (int) ((v1 >>> 26) & 0b111111L);
+            output[outputOffset + 16] = (int) ((v1 >>> 32) & 0b111111L);
+            output[outputOffset + 17] = (int) ((v1 >>> 38) & 0b111111L);
+            output[outputOffset + 18] = (int) ((v1 >>> 44) & 0b111111L);
+            output[outputOffset + 19] = (int) ((v1 >>> 50) & 0b111111L);
+            output[outputOffset + 20] = (int) ((v1 >>> 56) & 0b111111L);
+            output[outputOffset + 21] = (int) (((v1 >>> 62) & 0b11L) | ((v2 & 0b1111L) << 2));
+            output[outputOffset + 22] = (int) ((v2 >>> 4) & 0b111111L);
+            output[outputOffset + 23] = (int) ((v2 >>> 10) & 0b111111L);
+            output[outputOffset + 24] = (int) ((v2 >>> 16) & 0b111111L);
+            output[outputOffset + 25] = (int) ((v2 >>> 22) & 0b111111L);
+            output[outputOffset + 26] = (int) ((v2 >>> 28) & 0b111111L);
+            output[outputOffset + 27] = (int) ((v2 >>> 34) & 0b111111L);
+            output[outputOffset + 28] = (int) ((v2 >>> 40) & 0b111111L);
+            output[outputOffset + 29] = (int) ((v2 >>> 46) & 0b111111L);
+            output[outputOffset + 30] = (int) ((v2 >>> 52) & 0b111111L);
+            output[outputOffset + 31] = (int) ((v2 >>> 58) & 0b111111L);
+        }
+
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            int v0 = input.readInt();
+            short v1 = input.readShort();
+            output[outputOffset] = (int) (v0 & 0b111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 6) & 0b111111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 12) & 0b111111L);
+            output[outputOffset + 3] = (int) ((v0 >>> 18) & 0b111111L);
+            output[outputOffset + 4] = (int) ((v0 >>> 24) & 0b111111L);
+            output[outputOffset + 5] = (int) (((v0 >>> 30) & 0b11L) | ((v1 & 0b1111L) << 2));
+            output[outputOffset + 6] = (int) ((v1 >>> 4) & 0b111111L);
+            output[outputOffset + 7] = (int) ((v1 >>> 10) & 0b111111L);
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+            switch (length) {
+                case 24:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 16:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 8:
+                    unpack8(output, outputOffset, input);
+            }
+        }
+    }
+
+    private static final class Unpacker7
+            implements IntBitUnpacker
+    {
+        private static void unpack64(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            output[outputOffset] = (int) (v0 & 0b1111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 7) & 0b1111111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 14) & 0b1111111L);
+            output[outputOffset + 3] = (int) ((v0 >>> 21) & 0b1111111L);
+            output[outputOffset + 4] = (int) ((v0 >>> 28) & 0b1111111L);
+            output[outputOffset + 5] = (int) ((v0 >>> 35) & 0b1111111L);
+            output[outputOffset + 6] = (int) ((v0 >>> 42) & 0b1111111L);
+            output[outputOffset + 7] = (int) ((v0 >>> 49) & 0b1111111L);
+            output[outputOffset + 8] = (int) ((v0 >>> 56) & 0b1111111L);
+            output[outputOffset + 9] = (int) (((v0 >>> 63) & 0b1L) | ((v1 & 0b111111L) << 1));
+            output[outputOffset + 10] = (int) ((v1 >>> 6) & 0b1111111L);
+            output[outputOffset + 11] = (int) ((v1 >>> 13) & 0b1111111L);
+            output[outputOffset + 12] = (int) ((v1 >>> 20) & 0b1111111L);
+            output[outputOffset + 13] = (int) ((v1 >>> 27) & 0b1111111L);
+            output[outputOffset + 14] = (int) ((v1 >>> 34) & 0b1111111L);
+            output[outputOffset + 15] = (int) ((v1 >>> 41) & 0b1111111L);
+            output[outputOffset + 16] = (int) ((v1 >>> 48) & 0b1111111L);
+            output[outputOffset + 17] = (int) ((v1 >>> 55) & 0b1111111L);
+            output[outputOffset + 18] = (int) (((v1 >>> 62) & 0b11L) | ((v2 & 0b11111L) << 2));
+            output[outputOffset + 19] = (int) ((v2 >>> 5) & 0b1111111L);
+            output[outputOffset + 20] = (int) ((v2 >>> 12) & 0b1111111L);
+            output[outputOffset + 21] = (int) ((v2 >>> 19) & 0b1111111L);
+            output[outputOffset + 22] = (int) ((v2 >>> 26) & 0b1111111L);
+            output[outputOffset + 23] = (int) ((v2 >>> 33) & 0b1111111L);
+            output[outputOffset + 24] = (int) ((v2 >>> 40) & 0b1111111L);
+            output[outputOffset + 25] = (int) ((v2 >>> 47) & 0b1111111L);
+            output[outputOffset + 26] = (int) ((v2 >>> 54) & 0b1111111L);
+            output[outputOffset + 27] = (int) (((v2 >>> 61) & 0b111L) | ((v3 & 0b1111L) << 3));
+            output[outputOffset + 28] = (int) ((v3 >>> 4) & 0b1111111L);
+            output[outputOffset + 29] = (int) ((v3 >>> 11) & 0b1111111L);
+            output[outputOffset + 30] = (int) ((v3 >>> 18) & 0b1111111L);
+            output[outputOffset + 31] = (int) ((v3 >>> 25) & 0b1111111L);
+            output[outputOffset + 32] = (int) ((v3 >>> 32) & 0b1111111L);
+            output[outputOffset + 33] = (int) ((v3 >>> 39) & 0b1111111L);
+            output[outputOffset + 34] = (int) ((v3 >>> 46) & 0b1111111L);
+            output[outputOffset + 35] = (int) ((v3 >>> 53) & 0b1111111L);
+            output[outputOffset + 36] = (int) (((v3 >>> 60) & 0b1111L) | ((v4 & 0b111L) << 4));
+            output[outputOffset + 37] = (int) ((v4 >>> 3) & 0b1111111L);
+            output[outputOffset + 38] = (int) ((v4 >>> 10) & 0b1111111L);
+            output[outputOffset + 39] = (int) ((v4 >>> 17) & 0b1111111L);
+            output[outputOffset + 40] = (int) ((v4 >>> 24) & 0b1111111L);
+            output[outputOffset + 41] = (int) ((v4 >>> 31) & 0b1111111L);
+            output[outputOffset + 42] = (int) ((v4 >>> 38) & 0b1111111L);
+            output[outputOffset + 43] = (int) ((v4 >>> 45) & 0b1111111L);
+            output[outputOffset + 44] = (int) ((v4 >>> 52) & 0b1111111L);
+            output[outputOffset + 45] = (int) (((v4 >>> 59) & 0b11111L) | ((v5 & 0b11L) << 5));
+            output[outputOffset + 46] = (int) ((v5 >>> 2) & 0b1111111L);
+            output[outputOffset + 47] = (int) ((v5 >>> 9) & 0b1111111L);
+            output[outputOffset + 48] = (int) ((v5 >>> 16) & 0b1111111L);
+            output[outputOffset + 49] = (int) ((v5 >>> 23) & 0b1111111L);
+            output[outputOffset + 50] = (int) ((v5 >>> 30) & 0b1111111L);
+            output[outputOffset + 51] = (int) ((v5 >>> 37) & 0b1111111L);
+            output[outputOffset + 52] = (int) ((v5 >>> 44) & 0b1111111L);
+            output[outputOffset + 53] = (int) ((v5 >>> 51) & 0b1111111L);
+            output[outputOffset + 54] = (int) (((v5 >>> 58) & 0b111111L) | ((v6 & 0b1L) << 6));
+            output[outputOffset + 55] = (int) ((v6 >>> 1) & 0b1111111L);
+            output[outputOffset + 56] = (int) ((v6 >>> 8) & 0b1111111L);
+            output[outputOffset + 57] = (int) ((v6 >>> 15) & 0b1111111L);
+            output[outputOffset + 58] = (int) ((v6 >>> 22) & 0b1111111L);
+            output[outputOffset + 59] = (int) ((v6 >>> 29) & 0b1111111L);
+            output[outputOffset + 60] = (int) ((v6 >>> 36) & 0b1111111L);
+            output[outputOffset + 61] = (int) ((v6 >>> 43) & 0b1111111L);
+            output[outputOffset + 62] = (int) ((v6 >>> 50) & 0b1111111L);
+            output[outputOffset + 63] = (int) ((v6 >>> 57) & 0b1111111L);
+        }
+
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            int v0 = input.readInt();
+            short v1 = input.readShort();
+            byte v2 = input.readByte();
+            output[outputOffset] = (int) (v0 & 0b1111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 7) & 0b1111111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 14) & 0b1111111L);
+            output[outputOffset + 3] = (int) ((v0 >>> 21) & 0b1111111L);
+            output[outputOffset + 4] = (int) (((v0 >>> 28) & 0b1111L) | ((v1 & 0b111L) << 4));
+            output[outputOffset + 5] = (int) ((v1 >>> 3) & 0b1111111L);
+            output[outputOffset + 6] = (int) (((v1 >>> 10) & 0b111111L) | ((v2 & 0b1L) << 6));
+            output[outputOffset + 7] = (int) ((v2 >>> 1) & 0b1111111L);
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input,
+                int length)
+        {
+            while (length >= 64) {
+                unpack64(output, outputOffset, input);
+                outputOffset += 64;
+                length -= 64;
+            }
+            switch (length) {
+                case 56:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 48:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 40:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 32:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 24:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 16:
+                    unpack8(output, outputOffset, input);
+                    outputOffset += 8;
+                    // fall through
+                case 8:
+                    unpack8(output, outputOffset, input);
+            }
+        }
+    }
+
+    private static final class Unpacker8
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            output[outputOffset] = (int) (v0 & 0b11111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 8) & 0b11111111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 16) & 0b11111111L);
+            output[outputOffset + 3] = (int) ((v0 >>> 24) & 0b11111111L);
+            output[outputOffset + 4] = (int) ((v0 >>> 32) & 0b11111111L);
+            output[outputOffset + 5] = (int) ((v0 >>> 40) & 0b11111111L);
+            output[outputOffset + 6] = (int) ((v0 >>> 48) & 0b11111111L);
+            output[outputOffset + 7] = (int) ((v0 >>> 56) & 0b11111111L);
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker9
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            byte v1 = input.readByte();
+            output[outputOffset] = (int) (v0 & 0b111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 9) & 0b111111111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 18) & 0b111111111L);
+            output[outputOffset + 3] = (int) ((v0 >>> 27) & 0b111111111L);
+            output[outputOffset + 4] = (int) ((v0 >>> 36) & 0b111111111L);
+            output[outputOffset + 5] = (int) ((v0 >>> 45) & 0b111111111L);
+            output[outputOffset + 6] = (int) ((v0 >>> 54) & 0b111111111L);
+            output[outputOffset + 7] = (int) (((v0 >>> 63) & 0b1L) | ((v1 & 0b11111111L) << 1));
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker10
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            short v1 = input.readShort();
+            output[outputOffset] = (int) (v0 & 0b1111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 10) & 0b1111111111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 20) & 0b1111111111L);
+            output[outputOffset + 3] = (int) ((v0 >>> 30) & 0b1111111111L);
+            output[outputOffset + 4] = (int) ((v0 >>> 40) & 0b1111111111L);
+            output[outputOffset + 5] = (int) ((v0 >>> 50) & 0b1111111111L);
+            output[outputOffset + 6] = (int) (((v0 >>> 60) & 0b1111L) | ((v1 & 0b111111L) << 4));
+            output[outputOffset + 7] = (int) ((v1 >>> 6) & 0b1111111111L);
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker11
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            short v1 = input.readShort();
+            byte v2 = input.readByte();
+            output[outputOffset] = (int) (v0 & 0b11111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 11) & 0b11111111111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 22) & 0b11111111111L);
+            output[outputOffset + 3] = (int) ((v0 >>> 33) & 0b11111111111L);
+            output[outputOffset + 4] = (int) ((v0 >>> 44) & 0b11111111111L);
+            output[outputOffset + 5] = (int) (((v0 >>> 55) & 0b111111111L) | ((v1 & 0b11L) << 9));
+            output[outputOffset + 6] = (int) ((v1 >>> 2) & 0b11111111111L);
+            output[outputOffset + 7] = (int) (((v1 >>> 13) & 0b111L) | ((v2 & 0b11111111L) << 3));
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker12
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            int v1 = input.readInt();
+            output[outputOffset] = (int) (v0 & 0b111111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 12) & 0b111111111111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 24) & 0b111111111111L);
+            output[outputOffset + 3] = (int) ((v0 >>> 36) & 0b111111111111L);
+            output[outputOffset + 4] = (int) ((v0 >>> 48) & 0b111111111111L);
+            output[outputOffset + 5] = (int) (((v0 >>> 60) & 0b1111L) | ((v1 & 0b11111111L) << 4));
+            output[outputOffset + 6] = (int) ((v1 >>> 8) & 0b111111111111L);
+            output[outputOffset + 7] = (int) ((v1 >>> 20) & 0b111111111111L);
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker13
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            int v1 = input.readInt();
+            byte v2 = input.readByte();
+            output[outputOffset] = (int) (v0 & 0b1111111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 13) & 0b1111111111111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 26) & 0b1111111111111L);
+            output[outputOffset + 3] = (int) ((v0 >>> 39) & 0b1111111111111L);
+            output[outputOffset + 4] = (int) (((v0 >>> 52) & 0b111111111111L) | ((v1 & 0b1L) << 12));
+            output[outputOffset + 5] = (int) ((v1 >>> 1) & 0b1111111111111L);
+            output[outputOffset + 6] = (int) ((v1 >>> 14) & 0b1111111111111L);
+            output[outputOffset + 7] = (int) (((v1 >>> 27) & 0b11111L) | ((v2 & 0b11111111L) << 5));
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker14
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            int v1 = input.readInt();
+            short v2 = input.readShort();
+            output[outputOffset] = (int) (v0 & 0b11111111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 14) & 0b11111111111111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 28) & 0b11111111111111L);
+            output[outputOffset + 3] = (int) ((v0 >>> 42) & 0b11111111111111L);
+            output[outputOffset + 4] = (int) (((v0 >>> 56) & 0b11111111L) | ((v1 & 0b111111L) << 8));
+            output[outputOffset + 5] = (int) ((v1 >>> 6) & 0b11111111111111L);
+            output[outputOffset + 6] = (int) (((v1 >>> 20) & 0b111111111111L) | ((v2 & 0b11L) << 12));
+            output[outputOffset + 7] = (int) ((v2 >>> 2) & 0b11111111111111L);
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker15
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            int v1 = input.readInt();
+            short v2 = input.readShort();
+            byte v3 = input.readByte();
+            output[outputOffset] = (int) (v0 & 0b111111111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 15) & 0b111111111111111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 30) & 0b111111111111111L);
+            output[outputOffset + 3] = (int) ((v0 >>> 45) & 0b111111111111111L);
+            output[outputOffset + 4] = (int) (((v0 >>> 60) & 0b1111L) | ((v1 & 0b11111111111L) << 4));
+            output[outputOffset + 5] = (int) ((v1 >>> 11) & 0b111111111111111L);
+            output[outputOffset + 6] = (int) (((v1 >>> 26) & 0b111111L) | ((v2 & 0b111111111L) << 6));
+            output[outputOffset + 7] = (int) (((v2 >>> 9) & 0b1111111L) | ((v3 & 0b11111111L) << 7));
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker16
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            output[outputOffset] = (int) (v0 & 0b1111111111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 16) & 0b1111111111111111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 32) & 0b1111111111111111L);
+            output[outputOffset + 3] = (int) ((v0 >>> 48) & 0b1111111111111111L);
+            output[outputOffset + 4] = (int) (v1 & 0b1111111111111111L);
+            output[outputOffset + 5] = (int) ((v1 >>> 16) & 0b1111111111111111L);
+            output[outputOffset + 6] = (int) ((v1 >>> 32) & 0b1111111111111111L);
+            output[outputOffset + 7] = (int) ((v1 >>> 48) & 0b1111111111111111L);
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker17
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            byte v2 = input.readByte();
+            output[outputOffset] = (int) (v0 & 0b11111111111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 17) & 0b11111111111111111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 34) & 0b11111111111111111L);
+            output[outputOffset + 3] = (int) (((v0 >>> 51) & 0b1111111111111L) | ((v1 & 0b1111L) << 13));
+            output[outputOffset + 4] = (int) ((v1 >>> 4) & 0b11111111111111111L);
+            output[outputOffset + 5] = (int) ((v1 >>> 21) & 0b11111111111111111L);
+            output[outputOffset + 6] = (int) ((v1 >>> 38) & 0b11111111111111111L);
+            output[outputOffset + 7] = (int) (((v1 >>> 55) & 0b111111111L) | ((v2 & 0b11111111L) << 9));
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker18
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            short v2 = input.readShort();
+            output[outputOffset] = (int) (v0 & 0b111111111111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 18) & 0b111111111111111111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 36) & 0b111111111111111111L);
+            output[outputOffset + 3] = (int) (((v0 >>> 54) & 0b1111111111L) | ((v1 & 0b11111111L) << 10));
+            output[outputOffset + 4] = (int) ((v1 >>> 8) & 0b111111111111111111L);
+            output[outputOffset + 5] = (int) ((v1 >>> 26) & 0b111111111111111111L);
+            output[outputOffset + 6] = (int) ((v1 >>> 44) & 0b111111111111111111L);
+            output[outputOffset + 7] = (int) (((v1 >>> 62) & 0b11L) | ((v2 & 0b1111111111111111L) << 2));
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker19
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            short v2 = input.readShort();
+            byte v3 = input.readByte();
+            output[outputOffset] = (int) (v0 & 0b1111111111111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 19) & 0b1111111111111111111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 38) & 0b1111111111111111111L);
+            output[outputOffset + 3] = (int) (((v0 >>> 57) & 0b1111111L) | ((v1 & 0b111111111111L) << 7));
+            output[outputOffset + 4] = (int) ((v1 >>> 12) & 0b1111111111111111111L);
+            output[outputOffset + 5] = (int) ((v1 >>> 31) & 0b1111111111111111111L);
+            output[outputOffset + 6] = (int) (((v1 >>> 50) & 0b11111111111111L) | ((v2 & 0b11111L) << 14));
+            output[outputOffset + 7] = (int) (((v2 >>> 5) & 0b11111111111L) | ((v3 & 0b11111111L) << 11));
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker20
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            int v2 = input.readInt();
+            output[outputOffset] = (int) (v0 & 0b11111111111111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 20) & 0b11111111111111111111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 40) & 0b11111111111111111111L);
+            output[outputOffset + 3] = (int) (((v0 >>> 60) & 0b1111L) | ((v1 & 0b1111111111111111L) << 4));
+            output[outputOffset + 4] = (int) ((v1 >>> 16) & 0b11111111111111111111L);
+            output[outputOffset + 5] = (int) ((v1 >>> 36) & 0b11111111111111111111L);
+            output[outputOffset + 6] = (int) (((v1 >>> 56) & 0b11111111L) | ((v2 & 0b111111111111L) << 8));
+            output[outputOffset + 7] = (int) ((v2 >>> 12) & 0b11111111111111111111L);
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker21
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            int v2 = input.readInt();
+            byte v3 = input.readByte();
+            output[outputOffset] = (int) (v0 & 0b111111111111111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 21) & 0b111111111111111111111L);
+            output[outputOffset + 2] = (int) ((v0 >>> 42) & 0b111111111111111111111L);
+            output[outputOffset + 3] = (int) (((v0 >>> 63) & 0b1L) | ((v1 & 0b11111111111111111111L) << 1));
+            output[outputOffset + 4] = (int) ((v1 >>> 20) & 0b111111111111111111111L);
+            output[outputOffset + 5] = (int) ((v1 >>> 41) & 0b111111111111111111111L);
+            output[outputOffset + 6] = (int) (((v1 >>> 62) & 0b11L) | ((v2 & 0b1111111111111111111L) << 2));
+            output[outputOffset + 7] = (int) (((v2 >>> 19) & 0b1111111111111L) | ((v3 & 0b11111111L) << 13));
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker22
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            int v2 = input.readInt();
+            short v3 = input.readShort();
+            output[outputOffset] = (int) (v0 & 0b1111111111111111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 22) & 0b1111111111111111111111L);
+            output[outputOffset + 2] = (int) (((v0 >>> 44) & 0b11111111111111111111L) | ((v1 & 0b11L) << 20));
+            output[outputOffset + 3] = (int) ((v1 >>> 2) & 0b1111111111111111111111L);
+            output[outputOffset + 4] = (int) ((v1 >>> 24) & 0b1111111111111111111111L);
+            output[outputOffset + 5] = (int) (((v1 >>> 46) & 0b111111111111111111L) | ((v2 & 0b1111L) << 18));
+            output[outputOffset + 6] = (int) ((v2 >>> 4) & 0b1111111111111111111111L);
+            output[outputOffset + 7] = (int) (((v2 >>> 26) & 0b111111L) | ((v3 & 0b1111111111111111L) << 6));
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker23
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            int v2 = input.readInt();
+            short v3 = input.readShort();
+            byte v4 = input.readByte();
+            output[outputOffset] = (int) (v0 & 0b11111111111111111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 23) & 0b11111111111111111111111L);
+            output[outputOffset + 2] = (int) (((v0 >>> 46) & 0b111111111111111111L) | ((v1 & 0b11111L) << 18));
+            output[outputOffset + 3] = (int) ((v1 >>> 5) & 0b11111111111111111111111L);
+            output[outputOffset + 4] = (int) ((v1 >>> 28) & 0b11111111111111111111111L);
+            output[outputOffset + 5] = (int) (((v1 >>> 51) & 0b1111111111111L) | ((v2 & 0b1111111111L) << 13));
+            output[outputOffset + 6] = (int) (((v2 >>> 10) & 0b1111111111111111111111L) | ((v3 & 0b1L) << 22));
+            output[outputOffset + 7] = (int) (((v3 >>> 1) & 0b111111111111111L) | ((v4 & 0b11111111L) << 15));
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker24
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            output[outputOffset] = (int) (v0 & 0b111111111111111111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 24) & 0b111111111111111111111111L);
+            output[outputOffset + 2] = (int) (((v0 >>> 48) & 0b1111111111111111L) | ((v1 & 0b11111111L) << 16));
+            output[outputOffset + 3] = (int) ((v1 >>> 8) & 0b111111111111111111111111L);
+            output[outputOffset + 4] = (int) ((v1 >>> 32) & 0b111111111111111111111111L);
+            output[outputOffset + 5] = (int) (((v1 >>> 56) & 0b11111111L) | ((v2 & 0b1111111111111111L) << 8));
+            output[outputOffset + 6] = (int) ((v2 >>> 16) & 0b111111111111111111111111L);
+            output[outputOffset + 7] = (int) ((v2 >>> 40) & 0b111111111111111111111111L);
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker25
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            byte v3 = input.readByte();
+            output[outputOffset] = (int) (v0 & 0b1111111111111111111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 25) & 0b1111111111111111111111111L);
+            output[outputOffset + 2] = (int) (((v0 >>> 50) & 0b11111111111111L) | ((v1 & 0b11111111111L) << 14));
+            output[outputOffset + 3] = (int) ((v1 >>> 11) & 0b1111111111111111111111111L);
+            output[outputOffset + 4] = (int) ((v1 >>> 36) & 0b1111111111111111111111111L);
+            output[outputOffset + 5] = (int) (((v1 >>> 61) & 0b111L) | ((v2 & 0b1111111111111111111111L) << 3));
+            output[outputOffset + 6] = (int) ((v2 >>> 22) & 0b1111111111111111111111111L);
+            output[outputOffset + 7] = (int) (((v2 >>> 47) & 0b11111111111111111L) | ((v3 & 0b11111111L) << 17));
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker26
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            short v3 = input.readShort();
+            output[outputOffset] = (int) (v0 & 0b11111111111111111111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 26) & 0b11111111111111111111111111L);
+            output[outputOffset + 2] = (int) (((v0 >>> 52) & 0b111111111111L) | ((v1 & 0b11111111111111L) << 12));
+            output[outputOffset + 3] = (int) ((v1 >>> 14) & 0b11111111111111111111111111L);
+            output[outputOffset + 4] = (int) (((v1 >>> 40) & 0b111111111111111111111111L) | ((v2 & 0b11L) << 24));
+            output[outputOffset + 5] = (int) ((v2 >>> 2) & 0b11111111111111111111111111L);
+            output[outputOffset + 6] = (int) ((v2 >>> 28) & 0b11111111111111111111111111L);
+            output[outputOffset + 7] = (int) (((v2 >>> 54) & 0b1111111111L) | ((v3 & 0b1111111111111111L) << 10));
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker27
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            short v3 = input.readShort();
+            byte v4 = input.readByte();
+            output[outputOffset] = (int) (v0 & 0b111111111111111111111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 27) & 0b111111111111111111111111111L);
+            output[outputOffset + 2] = (int) (((v0 >>> 54) & 0b1111111111L) | ((v1 & 0b11111111111111111L) << 10));
+            output[outputOffset + 3] = (int) ((v1 >>> 17) & 0b111111111111111111111111111L);
+            output[outputOffset + 4] = (int) (((v1 >>> 44) & 0b11111111111111111111L) | ((v2 & 0b1111111L) << 20));
+            output[outputOffset + 5] = (int) ((v2 >>> 7) & 0b111111111111111111111111111L);
+            output[outputOffset + 6] = (int) ((v2 >>> 34) & 0b111111111111111111111111111L);
+            output[outputOffset + 7] = (int) (((v2 >>> 61) & 0b111L) | ((v3 & 0b1111111111111111L) << 3) | ((v4 & 0b11111111L) << 19));
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker28
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            int v3 = input.readInt();
+            output[outputOffset] = (int) (v0 & 0b1111111111111111111111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 28) & 0b1111111111111111111111111111L);
+            output[outputOffset + 2] = (int) (((v0 >>> 56) & 0b11111111L) | ((v1 & 0b11111111111111111111L) << 8));
+            output[outputOffset + 3] = (int) ((v1 >>> 20) & 0b1111111111111111111111111111L);
+            output[outputOffset + 4] = (int) (((v1 >>> 48) & 0b1111111111111111L) | ((v2 & 0b111111111111L) << 16));
+            output[outputOffset + 5] = (int) ((v2 >>> 12) & 0b1111111111111111111111111111L);
+            output[outputOffset + 6] = (int) (((v2 >>> 40) & 0b111111111111111111111111L) | ((v3 & 0b1111L) << 24));
+            output[outputOffset + 7] = (int) ((v3 >>> 4) & 0b1111111111111111111111111111L);
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker29
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            int v3 = input.readInt();
+            byte v4 = input.readByte();
+            output[outputOffset] = (int) (v0 & 0b11111111111111111111111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 29) & 0b11111111111111111111111111111L);
+            output[outputOffset + 2] = (int) (((v0 >>> 58) & 0b111111L) | ((v1 & 0b11111111111111111111111L) << 6));
+            output[outputOffset + 3] = (int) ((v1 >>> 23) & 0b11111111111111111111111111111L);
+            output[outputOffset + 4] = (int) (((v1 >>> 52) & 0b111111111111L) | ((v2 & 0b11111111111111111L) << 12));
+            output[outputOffset + 5] = (int) ((v2 >>> 17) & 0b11111111111111111111111111111L);
+            output[outputOffset + 6] = (int) (((v2 >>> 46) & 0b111111111111111111L) | ((v3 & 0b11111111111L) << 18));
+            output[outputOffset + 7] = (int) (((v3 >>> 11) & 0b111111111111111111111L) | ((v4 & 0b11111111L) << 21));
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input,
+                int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker30
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            int v3 = input.readInt();
+            short v4 = input.readShort();
+            output[outputOffset] = (int) (v0 & 0b111111111111111111111111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 30) & 0b111111111111111111111111111111L);
+            output[outputOffset + 2] = (int) (((v0 >>> 60) & 0b1111L) | ((v1 & 0b11111111111111111111111111L) << 4));
+            output[outputOffset + 3] = (int) ((v1 >>> 26) & 0b111111111111111111111111111111L);
+            output[outputOffset + 4] = (int) (((v1 >>> 56) & 0b11111111L) | ((v2 & 0b1111111111111111111111L) << 8));
+            output[outputOffset + 5] = (int) ((v2 >>> 22) & 0b111111111111111111111111111111L);
+            output[outputOffset + 6] = (int) (((v2 >>> 52) & 0b111111111111L) | ((v3 & 0b111111111111111111L) << 12));
+            output[outputOffset + 7] = (int) (((v3 >>> 18) & 0b11111111111111L) | ((v4 & 0b1111111111111111L) << 14));
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input,
+                int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker31
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            int v3 = input.readInt();
+            short v4 = input.readShort();
+            byte v5 = input.readByte();
+            output[outputOffset] = (int) (v0 & 0b1111111111111111111111111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 31) & 0b1111111111111111111111111111111L);
+            output[outputOffset + 2] = (int) (((v0 >>> 62) & 0b11L) | ((v1 & 0b11111111111111111111111111111L) << 2));
+            output[outputOffset + 3] = (int) ((v1 >>> 29) & 0b1111111111111111111111111111111L);
+            output[outputOffset + 4] = (int) (((v1 >>> 60) & 0b1111L) | ((v2 & 0b111111111111111111111111111L) << 4));
+            output[outputOffset + 5] = (int) ((v2 >>> 27) & 0b1111111111111111111111111111111L);
+            output[outputOffset + 6] = (int) (((v2 >>> 58) & 0b111111L) | ((v3 & 0b1111111111111111111111111L) << 6));
+            output[outputOffset + 7] = (int) (((v3 >>> 25) & 0b1111111L) | ((v4 & 0b1111111111111111L) << 7) | ((v5 & 0b11111111L) << 23));
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+
+    private static final class Unpacker32
+            implements IntBitUnpacker
+    {
+        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            output[outputOffset] = (int) (v0 & 0b11111111111111111111111111111111L);
+            output[outputOffset + 1] = (int) ((v0 >>> 32) & 0b11111111111111111111111111111111L);
+            output[outputOffset + 2] = (int) (v1 & 0b11111111111111111111111111111111L);
+            output[outputOffset + 3] = (int) ((v1 >>> 32) & 0b11111111111111111111111111111111L);
+            output[outputOffset + 4] = (int) (v2 & 0b11111111111111111111111111111111L);
+            output[outputOffset + 5] = (int) ((v2 >>> 32) & 0b11111111111111111111111111111111L);
+            output[outputOffset + 6] = (int) (v3 & 0b11111111111111111111111111111111L);
+            output[outputOffset + 7] = (int) ((v3 >>> 32) & 0b11111111111111111111111111111111L);
+        }
+
+        @Override
+        public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 8) {
+                unpack8(output, outputOffset, input);
+                outputOffset += 8;
+                length -= 8;
+            }
+        }
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/RleBitPackingHybridDecoder.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/RleBitPackingHybridDecoder.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.trino.parquet.reader.SimpleSliceInputStream;
+
+import java.util.Arrays;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.parquet.ParquetReaderUtils.readFixedWidthInt;
+import static io.trino.parquet.ParquetReaderUtils.readUleb128Int;
+import static io.trino.parquet.reader.decoders.IntBitUnpackers.getIntBitUnpacker;
+import static java.lang.Math.min;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * <a href="https://github.com/apache/parquet-format/blob/master/Encodings.md#run-length-encoding--bit-packing-hybrid-rle--3">
+ * Run Length Encoding / Bit-Packing Hybrid (RLE)
+ * </a>
+ * This class is similar to {@link io.trino.parquet.reader.flat.NullsDecoder} but specialized for reading integers stored in bit width of 0 - 32.
+ * It is used specifically for decoding dictionary ids currently.
+ * It can be used for decoding definition and repetition levels of nested columns in future.
+ */
+public final class RleBitPackingHybridDecoder
+        implements ValueDecoder<int[]>
+{
+    // Bit-packed values comes in batches of 8 according to specs
+    private static final int EXTRACT_BATCH_SIZE = 8;
+
+    private final int bitWidth;
+    private final int byteWidth;
+    private final IntBitUnpacker unpacker;
+
+    private SimpleSliceInputStream input;
+
+    // Encoding type if decoding stopped in the middle of the group
+    private boolean isRle;
+    // Values left to decode in the current group
+    private int valuesLeftInGroup;
+    // With RLE encoding - the current value
+    private int rleValue;
+    // With bit-packing - buffer of EXTRACT_BATCH_SIZE values currently read.
+    private int[] valuesBuffer;
+    // Number of values already read in the current buffer while reading bit-packed values
+    private int alreadyReadInBuffer;
+
+    public RleBitPackingHybridDecoder(int bitWidth)
+    {
+        checkArgument(bitWidth >= 0 && bitWidth <= 32, "bit width need to be between 0 and 32");
+        this.bitWidth = bitWidth;
+        this.byteWidth = byteWidth(bitWidth);
+        this.unpacker = getIntBitUnpacker(bitWidth);
+    }
+
+    @Override
+    public void init(SimpleSliceInputStream input)
+    {
+        this.input = requireNonNull(input, "input is null");
+        this.valuesBuffer = new int[EXTRACT_BATCH_SIZE];
+    }
+
+    @Override
+    public void read(int[] values, int offset, int length)
+    {
+        while (length > 0) {
+            if (valuesLeftInGroup == 0) {
+                readGroupHeader();
+            }
+
+            if (isRle) {
+                int chunkSize = min(length, valuesLeftInGroup);
+                Arrays.fill(values, offset, offset + chunkSize, rleValue);
+                valuesLeftInGroup -= chunkSize;
+                offset += chunkSize;
+                length -= chunkSize;
+            }
+            else if (alreadyReadInBuffer != 0) { // bit-packed - read remaining bytes stored in the buffer
+                int remainingValues = EXTRACT_BATCH_SIZE - alreadyReadInBuffer;
+                int chunkSize = min(remainingValues, length);
+                System.arraycopy(valuesBuffer, alreadyReadInBuffer, values, offset, chunkSize);
+                valuesLeftInGroup -= chunkSize;
+                alreadyReadInBuffer = (alreadyReadInBuffer + chunkSize) % EXTRACT_BATCH_SIZE;
+                offset += chunkSize;
+                length -= chunkSize;
+            }
+            else { // bit-packed
+                // At this point we have only full batches to read and valuesLeftInGroup is a multiplication of 8
+                int chunkSize = min(length, valuesLeftInGroup);
+                int leftToRead = chunkSize % EXTRACT_BATCH_SIZE;
+                int fullBatchesToRead = chunkSize - leftToRead;
+                unpacker.unpack(values, offset, input, fullBatchesToRead);
+                offset += fullBatchesToRead;
+                if (leftToRead > 0) {
+                    unpacker.unpack(valuesBuffer, 0, input, EXTRACT_BATCH_SIZE); // Unpack to temporary buffer
+                    System.arraycopy(valuesBuffer, 0, values, offset, leftToRead);
+                    offset += leftToRead;
+                }
+                alreadyReadInBuffer = leftToRead;
+                valuesLeftInGroup -= chunkSize;
+                length -= chunkSize;
+            }
+        }
+    }
+
+    @Override
+    public void skip(int n)
+    {
+        while (n > 0) {
+            if (valuesLeftInGroup == 0) {
+                readGroupHeader();
+            }
+
+            if (isRle) {
+                int chunkSize = min(n, valuesLeftInGroup);
+                valuesLeftInGroup -= chunkSize;
+                n -= chunkSize;
+            }
+            else if (alreadyReadInBuffer != 0) { // bit-packed - skip remaining bytes stored in the buffer
+                int remainingValues = EXTRACT_BATCH_SIZE - alreadyReadInBuffer;
+                int chunkSize = min(remainingValues, n);
+                valuesLeftInGroup -= chunkSize;
+                alreadyReadInBuffer = (alreadyReadInBuffer + chunkSize) % EXTRACT_BATCH_SIZE;
+                n -= chunkSize;
+            }
+            else { // bit-packed
+                int chunkSize = min(n, valuesLeftInGroup);
+                int fullBatchesToRead = chunkSize / EXTRACT_BATCH_SIZE;
+                input.skip(fullBatchesToRead * bitWidth * EXTRACT_BATCH_SIZE / Byte.SIZE);
+                int leftToRead = chunkSize % EXTRACT_BATCH_SIZE;
+                if (leftToRead > 0) {
+                    unpacker.unpack(valuesBuffer, 0, input, EXTRACT_BATCH_SIZE);
+                }
+                alreadyReadInBuffer = leftToRead;
+                valuesLeftInGroup -= chunkSize;
+                n -= chunkSize;
+            }
+        }
+    }
+
+    private void readGroupHeader()
+    {
+        int header = readUleb128Int(input);
+        isRle = (header & 1) == 0;
+        valuesLeftInGroup = header >>> 1;
+        if (isRle) {
+            rleValue = readFixedWidthInt(input, byteWidth);
+        }
+        else {
+            // Only full bytes are encoded
+            valuesLeftInGroup *= 8;
+        }
+    }
+
+    private static int byteWidth(int bitWidth)
+    {
+        // Equivalent of Math.ceil(bitWidth / Byte.SIZE) but without double arithmetics
+        return (bitWidth + Byte.SIZE - 1) / Byte.SIZE;
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkReadFixedWidthInt.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkReadFixedWidthInt.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.parquet.ParquetReaderUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.jmh.Benchmarks.benchmark;
+import static org.apache.parquet.bytes.BytesUtils.writeIntLittleEndianPaddedOnBitWidth;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Measurement(iterations = 15, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+public class BenchmarkReadFixedWidthInt
+{
+    private Slice[] inputValues;
+
+    @Param("1000")
+    public int size;
+
+    @Param({"1", "2", "3", "4"})
+    public int byteWidth;
+
+    @Setup
+    public void setUp()
+            throws IOException
+    {
+        inputValues = new Slice[size];
+        Random random = new Random(1);
+        for (int i = 0; i < size; i++) {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            writeIntLittleEndianPaddedOnBitWidth(bos, random.nextInt(), byteWidth * Byte.SIZE);
+            inputValues[i] = Slices.wrappedBuffer(bos.toByteArray());
+        }
+    }
+
+    @Benchmark
+    public void readFixedWidthInt()
+    {
+        for (Slice input : inputValues) {
+            sink(ParquetReaderUtils.readFixedWidthInt(new SimpleSliceInputStream(input), byteWidth));
+        }
+    }
+
+    @Benchmark
+    public void readFixedWidthIntLoop()
+    {
+        for (Slice input : inputValues) {
+            sink(readFixedWidthIntLoop(new SimpleSliceInputStream(input), byteWidth));
+        }
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static void sink(int value)
+    {
+        // IT IS VERY IMPORTANT TO MATCH THE SIGNATURE TO AVOID AUTOBOXING.
+        // The method intentionally does nothing.
+    }
+
+    private static int readFixedWidthIntLoop(SimpleSliceInputStream input, int bytes)
+    {
+        int result = 0;
+        for (int i = 0; i < bytes; i++) {
+            result |= (input.readByte() & 0xFF) << (i * Byte.SIZE);
+        }
+        return result;
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        benchmark(BenchmarkReadFixedWidthInt.class)
+                .withOptions(optionsBuilder -> optionsBuilder.jvmArgsAppend("-Xmx4g", "-Xms4g"))
+                .run();
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestData.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestData.java
@@ -136,6 +136,18 @@ public final class TestData
         return propagateSignBit(r.nextInt(), 32 - bitWidth);
     }
 
+    public static int randomUnsignedInt(Random r, int bitWidth)
+    {
+        checkArgument(bitWidth <= 32 && bitWidth >= 0, "bit width must be in range 0 - 32 inclusive");
+        if (bitWidth == 32) {
+            return r.nextInt();
+        }
+        else if (bitWidth == 31) {
+            return r.nextInt() & ((1 << 31) - 1);
+        }
+        return r.nextInt(1 << bitWidth);
+    }
+
     public static long randomLong(Random r, int bitWidth)
     {
         checkArgument(bitWidth <= 64 && bitWidth > 0, "bit width must be in range 1 - 64 inclusive");

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReaderUtils.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReaderUtils.java
@@ -22,8 +22,10 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Random;
 
+import static io.trino.parquet.ParquetReaderUtils.readFixedWidthInt;
 import static io.trino.parquet.ParquetReaderUtils.readUleb128Int;
-import static io.trino.parquet.reader.TestData.randomInt;
+import static io.trino.parquet.reader.TestData.randomUnsignedInt;
+import static org.apache.parquet.bytes.BytesUtils.writeIntLittleEndianPaddedOnBitWidth;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestParquetReaderUtils
@@ -35,13 +37,42 @@ public class TestParquetReaderUtils
         Random random = new Random(1);
         for (int bitWidth = 1; bitWidth <= 32; bitWidth++) {
             for (int i = 0; i < 10; i++) {
-                int value = randomInt(random, bitWidth);
+                int value = randomUnsignedInt(random, bitWidth);
                 SimpleSliceInputStream sliceInputStream = getSliceInputStream(BytesUtils::writeUnsignedVarInt, value);
                 assertThat(readUleb128Int(sliceInputStream))
                         .isEqualTo(value);
                 assertThat(sliceInputStream.asSlice().length())
                         .isEqualTo(0);
             }
+        }
+    }
+
+    @Test
+    public void testReadFixedWidthInt()
+            throws IOException
+    {
+        Random random = new Random(1);
+        for (int bytesWidth = 0; bytesWidth <= 4; bytesWidth++) {
+            int value = randomUnsignedInt(random, bytesWidth * Byte.SIZE);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            writeIntLittleEndianPaddedOnBitWidth(out, value, bytesWidth * Byte.SIZE);
+            SimpleSliceInputStream sliceInputStream = new SimpleSliceInputStream(Slices.wrappedBuffer(out.toByteArray()));
+            assertThat(readFixedWidthInt(sliceInputStream, bytesWidth))
+                    .isEqualTo(value);
+            assertThat(sliceInputStream.asSlice().length())
+                    .isEqualTo(0);
+        }
+
+        long[] bytesWidthMaxValues = new long[] {(1 << 8) - 1, (1 << 16) - 1, (1 << 24) - 1, (1L << 32) - 1};
+        for (int bytesWidth = 1; bytesWidth <= 4; bytesWidth++) {
+            int value = (int) bytesWidthMaxValues[bytesWidth - 1];
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            writeIntLittleEndianPaddedOnBitWidth(out, value, bytesWidth * Byte.SIZE);
+            SimpleSliceInputStream sliceInputStream = new SimpleSliceInputStream(Slices.wrappedBuffer(out.toByteArray()));
+            assertThat(readFixedWidthInt(sliceInputStream, bytesWidth))
+                    .isEqualTo(value);
+            assertThat(sliceInputStream.asSlice().length())
+                    .isEqualTo(0);
         }
     }
 

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReaderUtilsBenchmarks.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReaderUtilsBenchmarks.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+public class TestParquetReaderUtilsBenchmarks
+{
+    @Test
+    public void testBenchmarkReadUleb128Int()
+            throws IOException
+    {
+        BenchmarkReadUleb128Int benchmark = new BenchmarkReadUleb128Int(10000, Integer.MAX_VALUE);
+        benchmark.setUp();
+        benchmark.readUleb128Int();
+    }
+
+    @Test
+    public void testBenchmarkReadFixedWidthInt()
+            throws IOException
+    {
+        for (int byteWidth = 0; byteWidth <= 4; byteWidth++) {
+            BenchmarkReadFixedWidthInt benchmark = new BenchmarkReadFixedWidthInt();
+            benchmark.size = 1000;
+            benchmark.byteWidth = byteWidth;
+            benchmark.setUp();
+            benchmark.readFixedWidthInt();
+        }
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/ApacheParquetIntUnpacker.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/ApacheParquetIntUnpacker.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import org.apache.parquet.column.values.bitpacking.BytePacker;
+import org.apache.parquet.column.values.bitpacking.Packer;
+
+class ApacheParquetIntUnpacker
+{
+    private final BytePacker delegate;
+    private final int bitWidth;
+
+    public ApacheParquetIntUnpacker(int bitWidth)
+    {
+        this.bitWidth = bitWidth;
+        this.delegate = Packer.LITTLE_ENDIAN.newBytePacker(bitWidth);
+    }
+
+    public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
+    {
+        int byteWidth = bitWidth * 8 / Byte.SIZE;
+        Slice sliceBuffer = Slices.wrappedBuffer(new byte[byteWidth]);
+        for (int i = outputOffset; i < outputOffset + length; i += 8) {
+            input.readBytes(sliceBuffer, 0, byteWidth);
+            int[] outputBuffer = new int[8];
+            delegate.unpack8Values(sliceBuffer.toByteBuffer(), 0, outputBuffer, 0);
+            System.arraycopy(outputBuffer, 0, output, i, 8);
+        }
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/BenchmarkRleBitPackingDecoder.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/BenchmarkRleBitPackingDecoder.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesWriter;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.options.WarmupMode;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Random;
+
+import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.parquet.reader.TestData.generateMixedData;
+import static io.trino.parquet.reader.TestData.randomUnsignedInt;
+import static java.lang.Math.min;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+@State(Scope.Thread)
+@OutputTimeUnit(SECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = MILLISECONDS)
+@Warmup(iterations = 5, time = 500, timeUnit = MILLISECONDS)
+@Fork(1)
+public class BenchmarkRleBitPackingDecoder
+{
+    private static final int MAX_VALUES = 5_000_000;
+    private static final int READ_BATCH_SIZE = 4096;
+
+    private Slice inputSlice;
+    private int[] output;
+
+    @Param
+    public DataSet dataSet;
+
+    @Param({
+            // This encoding is not meant to store big numbers so 2^20 is enough
+            "1", "2", "3", "4", "5", "6", "7", "8",
+            "9", "10", "13", "16", "17", "18", "20",
+    })
+    public int bitWidth;
+
+    public enum DataSet
+    {
+        RANDOM {
+            @Override
+            int[] getData(int size, int bitWidth)
+            {
+                Random random = new Random((long) size * bitWidth);
+                int[] values = new int[size];
+                for (int i = 0; i < size; i++) {
+                    values[i] = randomUnsignedInt(random, bitWidth);
+                }
+                return values;
+            }
+        },
+        MIXED_AND_GROUPS_SMALL {
+            @Override
+            int[] getData(int size, int bitWidth)
+            {
+                Random random = new Random((long) size * bitWidth);
+                return generateMixedData(random, size, 23, bitWidth);
+            }
+        },
+        MIXED_AND_GROUPS_LARGE {
+            @Override
+            int[] getData(int size, int bitWidth)
+            {
+                Random random = new Random((long) size * bitWidth);
+                return generateMixedData(random, size, 127, bitWidth);
+            }
+        },
+        MIXED_AND_GROUPS_HUGE {
+            @Override
+            int[] getData(int size, int bitWidth)
+            {
+                Random random = new Random((long) size * bitWidth);
+                return generateMixedData(random, size, 2111, bitWidth);
+            }
+        },
+        /**/;
+
+        abstract int[] getData(int size, int bitWidth);
+    }
+
+    @Setup
+    public void setup()
+            throws IOException
+    {
+        ValuesWriter writer = createValuesWriter(1_000_000);
+        for (int value : generateDataBatch(MAX_VALUES)) {
+            writer.writeInteger(value);
+        }
+        inputSlice = getInputSlice(writer.getBytes().toByteArray());
+        output = new int[READ_BATCH_SIZE];
+    }
+
+    @Benchmark
+    public void rleBitPackingHybridDecoder()
+    {
+        ValueDecoder<int[]> decoder = new RleBitPackingHybridDecoder(bitWidth);
+        decoder.init(new SimpleSliceInputStream(inputSlice));
+        for (int i = 0; i < MAX_VALUES; i += READ_BATCH_SIZE) {
+            decoder.read(output, 0, min(READ_BATCH_SIZE, MAX_VALUES - i));
+        }
+    }
+
+    @Benchmark
+    public void apacheRunLengthBitPackingHybridDecoder()
+    {
+        RunLengthBitPackingHybridDecoder decoder = new RunLengthBitPackingHybridDecoder(bitWidth, ByteBufferInputStream.wrap(inputSlice.toByteBuffer()));
+        for (int i = 0; i < MAX_VALUES; i += READ_BATCH_SIZE) {
+            try {
+                for (int batchIndex = 0; batchIndex < min(READ_BATCH_SIZE, MAX_VALUES - i); batchIndex++) {
+                    output[batchIndex] = decoder.readInt();
+                }
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+
+    private ValuesWriter createValuesWriter(int bufferSize)
+    {
+        return new RunLengthBitPackingHybridValuesWriter(bitWidth, bufferSize, bufferSize, HeapByteBufferAllocator.getInstance());
+    }
+
+    private int[] generateDataBatch(int size)
+    {
+        return dataSet.getData(size, bitWidth);
+    }
+
+    private Slice getInputSlice(byte[] data)
+    {
+        // Skip size encoded as first 4 bytes by Apache writer
+        return Slices.wrappedBuffer(data, Integer.BYTES, data.length - Integer.BYTES);
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        benchmark(BenchmarkRleBitPackingDecoder.class, WarmupMode.BULK)
+                .withOptions(optionsBuilder -> optionsBuilder.jvmArgsAppend("-Xmx4g", "-Xms4g"))
+                .run();
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestBitUnpackers.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestBitUnpackers.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.airlift.slice.Slices;
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Random;
+
+import static io.trino.parquet.reader.decoders.IntBitUnpackers.getIntBitUnpacker;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestBitUnpackers
+{
+    @Test(dataProvider = "length")
+    public void testIntUnpackersUnpack(int length)
+    {
+        for (int i = 0; i < 500; i++) {
+            long seed = (long) i * length;
+            Random random = new Random(seed);
+            for (int bitWidth = 0; bitWidth <= 32; bitWidth++) {
+                ApacheParquetIntUnpacker parquetUnpacker = new ApacheParquetIntUnpacker(bitWidth);
+                IntBitUnpacker optimizedUnpacker = getIntBitUnpacker(bitWidth);
+
+                byte[] buffer = new byte[(bitWidth * length) / Byte.SIZE + 1];
+                random.nextBytes(buffer);
+
+                int[] parquetUnpackerOutput = new int[length];
+                int[] optimizedUnpackerOutput = new int[length];
+                parquetUnpacker.unpack(parquetUnpackerOutput, 0, asSliceStream(buffer), length);
+                optimizedUnpacker.unpack(optimizedUnpackerOutput, 0, asSliceStream(buffer), length);
+
+                assertThat(optimizedUnpackerOutput)
+                        .as("Error at bit width %d, random seed %d", bitWidth, seed)
+                        .isEqualTo(parquetUnpackerOutput);
+            }
+        }
+    }
+
+    @DataProvider(name = "length")
+    public static Object[][] length()
+    {
+        return new Object[][] {{24}, {72}, {168}, {304}, {376}, {8192}};
+    }
+
+    private SimpleSliceInputStream asSliceStream(byte[] buffer)
+    {
+        return new SimpleSliceInputStream(Slices.wrappedBuffer(buffer));
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestRleBitPackingDecoderBenchmark.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestRleBitPackingDecoderBenchmark.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+public class TestRleBitPackingDecoderBenchmark
+{
+    @Test
+    public void testRleBitPackingDecoderBenchmark()
+            throws IOException
+    {
+        for (int bitWidth = 1; bitWidth <= 20; bitWidth++) {
+            for (BenchmarkRleBitPackingDecoder.DataSet dataSet : BenchmarkRleBitPackingDecoder.DataSet.values()) {
+                BenchmarkRleBitPackingDecoder benchmark = new BenchmarkRleBitPackingDecoder();
+                benchmark.bitWidth = bitWidth;
+                benchmark.dataSet = dataSet;
+                benchmark.setup();
+                benchmark.apacheRunLengthBitPackingHybridDecoder();
+                benchmark.rleBitPackingHybridDecoder();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

```
Benchmark                      (bitWidth)               (dataSet)   Mode Cnt  parquet-mr decoder  optimized decoder
BenchmarkRleBitPackingDecoder           1                  RANDOM  thrpt  10  48.439 ± 10.260     329.209 ± 21.345  ops/s
BenchmarkRleBitPackingDecoder           1  MIXED_AND_GROUPS_SMALL  thrpt  10  43.804 ±  3.277     135.929 ±  2.441  ops/s
BenchmarkRleBitPackingDecoder           1  MIXED_AND_GROUPS_LARGE  thrpt  10  54.062 ± 12.215     319.990 ±  8.851  ops/s
BenchmarkRleBitPackingDecoder           1   MIXED_AND_GROUPS_HUGE  thrpt  10  62.038 ±  5.931     554.925 ± 83.815  ops/s
BenchmarkRleBitPackingDecoder           3                  RANDOM  thrpt  10  47.090 ±  2.948     379.213 ± 26.552  ops/s
BenchmarkRleBitPackingDecoder           3  MIXED_AND_GROUPS_SMALL  thrpt  10  40.741 ±  4.783     130.873 ±  8.000  ops/s
BenchmarkRleBitPackingDecoder           3  MIXED_AND_GROUPS_LARGE  thrpt  10  57.778 ±  1.478     301.589 ± 20.625  ops/s
BenchmarkRleBitPackingDecoder           3   MIXED_AND_GROUPS_HUGE  thrpt  10  59.751 ±  8.778     607.841 ± 34.334  ops/s
BenchmarkRleBitPackingDecoder           4                  RANDOM  thrpt  10  46.935 ±  8.119     240.348 ±  3.611  ops/s
BenchmarkRleBitPackingDecoder           4  MIXED_AND_GROUPS_SMALL  thrpt  10  44.051 ±  0.983     118.759 ±  1.329  ops/s
BenchmarkRleBitPackingDecoder           4  MIXED_AND_GROUPS_LARGE  thrpt  10  59.990 ±  2.302     247.360 ±  6.840  ops/s
BenchmarkRleBitPackingDecoder           4   MIXED_AND_GROUPS_HUGE  thrpt  10  58.873 ±  9.349     429.068 ±  7.466  ops/s
BenchmarkRleBitPackingDecoder           7                  RANDOM  thrpt  10  43.622 ±  8.074     307.890 ±  2.369  ops/s
BenchmarkRleBitPackingDecoder           7  MIXED_AND_GROUPS_SMALL  thrpt  10  39.158 ±  4.524     114.420 ±  0.856  ops/s
BenchmarkRleBitPackingDecoder           7  MIXED_AND_GROUPS_LARGE  thrpt  10  51.427 ±  5.814     260.650 ±  4.533  ops/s
BenchmarkRleBitPackingDecoder           7   MIXED_AND_GROUPS_HUGE  thrpt  10  62.398 ±  3.298     493.724 ± 31.458  ops/s
BenchmarkRleBitPackingDecoder           8                  RANDOM  thrpt  10  48.234 ±  8.967     275.272 ± 24.564  ops/s
BenchmarkRleBitPackingDecoder           8  MIXED_AND_GROUPS_SMALL  thrpt  10  43.391 ±  2.747     125.800 ±  1.998  ops/s
BenchmarkRleBitPackingDecoder           8  MIXED_AND_GROUPS_LARGE  thrpt  10  35.055 ±  4.960     273.107 ±  5.114  ops/s
BenchmarkRleBitPackingDecoder          13                  RANDOM  thrpt  10  35.541 ±  8.536     201.133 ±  1.830  ops/s
BenchmarkRleBitPackingDecoder          13  MIXED_AND_GROUPS_SMALL  thrpt  10  36.722 ±  2.799     112.277 ±  7.407  ops/s
BenchmarkRleBitPackingDecoder          13  MIXED_AND_GROUPS_LARGE  thrpt  10  46.098 ± 11.580     220.572 ± 12.721  ops/s
BenchmarkRleBitPackingDecoder          13   MIXED_AND_GROUPS_HUGE  thrpt  10  51.874 ±  7.623     359.035 ±  8.791  ops/s
BenchmarkRleBitPackingDecoder          16                  RANDOM  thrpt  10  38.571 ±  7.859     245.854 ±  3.984  ops/s
BenchmarkRleBitPackingDecoder          16  MIXED_AND_GROUPS_SMALL  thrpt  10  27.728 ±  1.250     122.098 ±  2.845  ops/s
BenchmarkRleBitPackingDecoder          16  MIXED_AND_GROUPS_LARGE  thrpt  10  47.763 ± 10.970     250.234 ±  3.520  ops/s
BenchmarkRleBitPackingDecoder          16   MIXED_AND_GROUPS_HUGE  thrpt  10  47.366 ± 10.993     444.377 ± 19.890  ops/s

Benchmark                                         (byteWidth)  (size)   Mode  Cnt    Score   Error   Units
BenchmarkReadFixedWidthInt.readFixedWidthInt                1    1000  thrpt   15  230.432 ± 2.657  ops/ms
BenchmarkReadFixedWidthInt.readFixedWidthInt                2    1000  thrpt   15  233.950 ± 7.937  ops/ms
BenchmarkReadFixedWidthInt.readFixedWidthInt                3    1000  thrpt   15  193.184 ± 1.215  ops/ms
BenchmarkReadFixedWidthInt.readFixedWidthInt                4    1000  thrpt   15  236.300 ± 1.938  ops/ms
BenchmarkReadFixedWidthInt.readFixedWidthIntLoop            1    1000  thrpt   15  164.337 ± 2.350  ops/ms
BenchmarkReadFixedWidthInt.readFixedWidthIntLoop            2    1000  thrpt   15  132.649 ± 2.961  ops/ms
BenchmarkReadFixedWidthInt.readFixedWidthIntLoop            3    1000  thrpt   15  100.333 ± 1.664  ops/ms
BenchmarkReadFixedWidthInt.readFixedWidthIntLoop            4    1000  thrpt   15   81.733 ± 2.085  ops/ms
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Hudi, Delta, Iceberg
* Improve performance of reading from parquet files. ({issue}`15498`)
```
