### PR TITLE
Explicitly specifify release version format for revapi

### DIFF
--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -176,6 +176,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <versionFormat>[0-9]+</versionFormat>
                     <ignoreSuggestionsFormat>xml</ignoreSuggestionsFormat>
                     <analysisConfiguration>
                         <revapi.filter>


### PR DESCRIPTION
    It may happen that revapi picks a wrong version of trino-spi to
    compare against currently built code. Picked version depends on the contents of
    local maven repository. Specifying explitly the format of release versions
    Trino uses helps with the problem.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
