### PR TITLE
Fix typos in Trino Kubernetes install docs

### DIFF
--- a/docs/src/main/sphinx/installation/kubernetes.rst
+++ b/docs/src/main/sphinx/installation/kubernetes.rst
@@ -166,7 +166,7 @@ this by running the commands generated upon installation.
 
    .. code-block:: text
 
-       POD_NAME=$(kubectl get pods -l "app=trino,release=my-trino-cluster,component=coordinator" -o name)
+       POD_NAME=$(kubectl get pods -l "app=trino,release=example-trino-cluster,component=coordinator" -o name)
 
 #. Create the tunnel from the coordinator pod to the client.
 
@@ -177,7 +177,7 @@ this by running the commands generated upon installation.
    Now you can connect to the Trino coordinator at ``http://localhost:8080``.
 
 #. To connect to Trino, you can use the
-   :doc:`commond-line interface </client/cli>`, a
+   :doc:`command-line interface </client/cli>`, a
    :doc:`JDBC client </client/jdbc>`, or any of the
    :doc:`other clients </client>`. For this example,
    :ref:`install the command-line interface <cli-installation>`, and connect to


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fixing small typos in the documentation of the Trino Kubernetes install with Helm, as well as a wrong Kubernetes label in the query example

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Simply a docs-related PR which I noticed while deploying Trino in my Kubernetes cluster

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
