### PR TITLE
Remove unnecessary `Block.isNull` method call in `SliceDictionaryColumnWriter.writeBlock`

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/DictionaryBuilder.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/DictionaryBuilder.java
@@ -72,6 +72,11 @@ public class DictionaryBuilder
         this.containsNullElement = false;
     }
 
+    public static boolean isNullIndex(int index)
+    {
+        return index == NULL_POSITION;
+    }
+
     public long getSizeInBytes()
     {
         return elementBlock.getSizeInBytes();

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/SliceDictionaryColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/SliceDictionaryColumnWriter.java
@@ -288,7 +288,7 @@ public class SliceDictionaryColumnWriter
             rowGroupValueCount++;
             totalValueCount++;
 
-            if (!block.isNull(position)) {
+            if (!DictionaryBuilder.isNullIndex(index)) {
                 // todo min/max statistics only need to be updated if value was not already in the dictionary, but non-null count does
                 statisticsBuilder.addValue(type.getSlice(block, position));
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In `SliceDictionaryColumnWriter`, the following branch statement is used to write statistical information when the data of the position currently being written is not NULL.

```
if (!block.isNull(position)) { <-- here!!
    statisticsBuilder.addValue(type.getSlice(block, position));

    rawBytes += block.getSliceLength(position);
    totalNonNullValueCount++;
}
```

However, at the point of calling `DictionaryBuilder::putIfAbsent`, we already perform NULL checking of the position data, so we simply check that the returned Index is NULL_POSITION.

```
public int putIfAbsent(Block block, int position)
{
    requireNonNull(block, "block must not be null");

    if (block.isNull(position)) { <-- here!!
        containsNullElement = true;
        return NULL_POSITION; <-- here!!
    }
```
Below is the assembly code for the C2 compiled DictionaryBlock's isNull method.

```
[Entry Point]
 ...
  0x000000011f7931c8:   sub    $0x30,%rsp                   ;*synchronization entry
                                                            ; - io.trino.spi.block.DictionaryBlock::isNull@-1 (line 498)
  0x000000011f7931cc:   movzbl 0x31(%rsi),%r11d             ;*getfield mayHaveNull {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - io.trino.spi.block.DictionaryBlock::isNull@1 (line 498)
  0x000000011f7931d1:   test   %r11d,%r11d
  0x000000011f7931d4:   je     0x000000011f793308           ;*ifne {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - io.trino.spi.block.DictionaryBlock::isNull@4 (line 498)
  0x000000011f7931da:   mov    0xc(%rsi),%ebp               ;*getfield positionCount {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - io.trino.spi.block.DictionaryBlock::isNull@11 (line 501)
  0x000000011f7931dd:   data16 xchg %ax,%ax
  0x000000011f7931e0:   test   %edx,%edx
  0x000000011f7931e2:   jl     0x000000011f7932d8           ;*iflt {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - io.trino.spi.block.BlockUtil::checkValidPosition@1 (line 71)
                                                            ; - io.trino.spi.block.DictionaryBlock::isNull@14 (line 501)
  0x000000011f7931e8:   cmp    %ebp,%edx
  0x000000011f7931ea:   jge    0x000000011f793320           ;*if_icmplt {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - io.trino.spi.block.BlockUtil::checkValidPosition@6 (line 71)
                                                            ; - io.trino.spi.block.DictionaryBlock::isNull@14 (line 501)
  0x000000011f7931f0:   add    0x28(%rsi),%edx              ;*iadd {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - io.trino.spi.block.DictionaryBlock::getIdUnchecked@9 (line 631)
                                                            ; - io.trino.spi.block.DictionaryBlock::isNull@23 (line 502)
  0x000000011f7931f3:   mov    0x38(%rsi),%r11d             ;*getfield ids {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - io.trino.spi.block.DictionaryBlock::getIdUnchecked@1 (line 631)
                                                            ; - io.trino.spi.block.DictionaryBlock::isNull@23 (line 502)
  0x000000011f7931f7:   nopw   0x0(%rax,%rax,1)
  0x000000011f793200:   mov    0xc(%r12,%r11,8),%r10d       ; implicit exception: dispatches to 0x000000011f79335c
  0x000000011f793205:   mov    0x34(%rsi),%r8d              ;*getfield dictionary {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - io.trino.spi.block.DictionaryBlock::isNull@18 (line 502)
  0x000000011f793209:   cmp    %r10d,%edx
  0x000000011f79320c:   jae    0x000000011f79329e
  0x000000011f793212:   lea    (%r12,%r11,8),%r10
  0x000000011f793216:   mov    0x10(%r10,%rdx,4),%r9d       ;*iaload {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - io.trino.spi.block.DictionaryBlock::getIdUnchecked@10 (line 631)
                                                            ; - io.trino.spi.block.DictionaryBlock::isNull@23 (line 502)
  0x000000011f79321b:   nopl   0x0(%rax,%rax,1)
  0x000000011f793220:   mov    0x8(%r12,%r8,8),%r11d        ; implicit exception: dispatches to 0x000000011f793368
  0x000000011f793225:   cmp    $0x11169c0,%r11d             ;   {metadata('io/trino/spi/block/VariableWidthBlock')}
  0x000000011f79322c:   jne    0x000000011f7932c4
  0x000000011f793232:   lea    (%r12,%r8,8),%r11            ;*invokeinterface isNull {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - io.trino.spi.block.DictionaryBlock::isNull@26 (line 502)
  0x000000011f793236:   mov    0x20(%r11),%ebp              ;*getfield positionCount {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - io.trino.spi.block.VariableWidthBlock::getPositionCount@1 (line 134)
                                                            ; - io.trino.spi.block.BlockUtil::checkReadablePosition@2 (line 78)
                                                            ; - io.trino.spi.block.AbstractVariableWidthBlock::isNull@2 (line 147)
                                                            ; - io.trino.spi.block.DictionaryBlock::isNull@26 (line 502)
  0x000000011f79323a:   nopw   0x0(%rax,%rax,1)
  0x000000011f793240:   test   %r9d,%r9d
  0x000000011f793243:   jl     0x000000011f7932f0           ;*iflt {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - io.trino.spi.block.BlockUtil::checkValidPosition@1 (line 71)
                                                            ; - io.trino.spi.block.BlockUtil::checkReadablePosition@7 (line 78)
                                                            ; - io.trino.spi.block.AbstractVariableWidthBlock::isNull@2 (line 147)
                                                            ; - io.trino.spi.block.DictionaryBlock::isNull@26 (line 502)
```

Below is the assembly code for the C2 compiled DictionaryBlock's isNullIndex method.

```
[Verified Entry Point]
  # {method} {0x00000001265d7c40} 'isNullIndex' '(I)Z' in 'io/trino/orc/writer/DictionaryBuilder'
  # parm0:    rsi       = int
  #           [sp+0x20]  (sp of caller)
  0x0000000116493880:   mov    %eax,-0x14000(%rsp)
  0x0000000116493887:   push   %rbp
  0x0000000116493888:   sub    $0x10,%rsp                   ;*synchronization entry
                                                            ; - io.trino.orc.writer.DictionaryBuilder::isNullIndex@-1 (line 76)
  0x000000011649388c:   test   %esi,%esi
  0x000000011649388e:   jne    0x00000001164938a8           ;*ifne {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - io.trino.orc.writer.DictionaryBuilder::isNullIndex@1 (line 76)
  0x0000000116493890:   mov    $0x1,%eax
  0x0000000116493895:   add    $0x10,%rsp
  0x0000000116493899:   pop    %rbp
  0x000000011649389a:   cmp    0x348(%r15),%rsp             ;   {poll_return}
  0x00000001164938a1:   ja     0x00000001164938b4
  0x00000001164938a7:   ret    
  0x00000001164938a8:   mov    %esi,%ebp
  0x00000001164938aa:   mov    $0xffffff45,%esi
```

It is expected that the more NULL values, the more CPU cycles can be reduced.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Related discussion: [Slack](https://trinodb.slack.com/archives/CP1MUNEUX/p1671796626058779)

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
