### PR TITLE
Improve Hive test verify method

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveMerge.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveMerge.java
@@ -63,7 +63,7 @@ public class TestHiveMerge
 
                 onTrino().executeQuery(sql);
 
-                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE", row("Aaron", 11, "Arches"), row("Ed", 7, "Etherville"), row("Bill", 7, "Buena"), row("Dave", 22, "Darbyshire"));
+                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, row("Aaron", 11, "Arches"), row("Ed", 7, "Etherville"), row("Bill", 7, "Buena"), row("Dave", 22, "Darbyshire"));
             });
         });
     }
@@ -88,7 +88,7 @@ public class TestHiveMerge
 
                 onTrino().executeQuery(sql);
 
-                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE", row("Aaron", 11, "Arches"), row("Ed", 7, "Etherville"), row("Bill", 7, "Buena"), row("Dave", 22, "Darbyshire"));
+                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, row("Aaron", 11, "Arches"), row("Ed", 7, "Etherville"), row("Bill", 7, "Buena"), row("Dave", 22, "Darbyshire"));
             });
         });
     }
@@ -111,7 +111,7 @@ public class TestHiveMerge
             onHive().executeQuery(builder.toString());
 
             onTrino().executeQuery(format("INSERT INTO %s (customer, purchase) VALUES ('Dave', 'dates'), ('Lou', 'limes'), ('Carol', 'candles')", targetTable));
-            verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE", row("Dave", "dates"), row("Lou", "limes"), row("Carol", "candles"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, row("Dave", "dates"), row("Lou", "limes"), row("Carol", "candles"));
 
             withTemporaryTable("merge_update_with_various_formats_source", true, false, NONE, sourceTable -> {
                 onTrino().executeQuery(format("CREATE TABLE %s (customer VARCHAR, purchase VARCHAR) WITH (transactional = true)", sourceTable));
@@ -125,7 +125,7 @@ public class TestHiveMerge
 
                 onTrino().executeQuery(sql);
 
-                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE", row("Dave", "dates"), row("Carol_Craig", "candles"), row("Joe", "jellybeans"));
+                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, row("Dave", "dates"), row("Carol_Craig", "candles"), row("Joe", "jellybeans"));
             });
         });
     }
@@ -137,7 +137,7 @@ public class TestHiveMerge
             onTrino().executeQuery(format("CREATE TABLE %s (customer VARCHAR, purchase VARCHAR) WITH (transactional = true)", targetTable));
 
             onTrino().executeQuery(format("INSERT INTO %s (customer, purchase) VALUES ('Dave', 'dates'), ('Lou', 'limes'), ('Carol', 'candles')", targetTable));
-            verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE", row("Dave", "dates"), row("Lou", "limes"), row("Carol", "candles"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, row("Dave", "dates"), row("Lou", "limes"), row("Carol", "candles"));
 
             withTemporaryTable("merge_with_various_formats_failure_source", true, false, NONE, sourceTable -> {
                 onTrino().executeQuery(format("CREATE TABLE %s (customer VARCHAR, purchase VARCHAR) WITH (transactional = true)", sourceTable));
@@ -151,7 +151,7 @@ public class TestHiveMerge
 
                 onTrino().executeQuery(sql);
 
-                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE", row("Dave", "dates"), row("Carol_Craig", "candles"), row("Joe", "jellybeans"));
+                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, row("Dave", "dates"), row("Carol_Craig", "candles"), row("Joe", "jellybeans"));
             });
         });
     }
@@ -276,7 +276,7 @@ public class TestHiveMerge
                     "    WHEN MATCHED THEN UPDATE SET purchases = s.purchases + t.purchases, address = s.address" +
                     "    WHEN NOT MATCHED THEN INSERT (customer, purchases, address) VALUES(s.customer, s.purchases, s.address)");
 
-            verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE", row("Aaron", 11, "Arches"), row("Bill", 7, "Buena"), row("Dave", 22, "Darbyshire"), row("Ed", 7, "Etherville"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, row("Aaron", 11, "Arches"), row("Bill", 7, "Buena"), row("Dave", 22, "Darbyshire"), row("Ed", 7, "Etherville"));
         });
     }
 
@@ -294,7 +294,7 @@ public class TestHiveMerge
                     "ON (t.customer = s.customer)" +
                     "    WHEN NOT MATCHED THEN INSERT (customer, purchases, address) VALUES(s.customer, s.purchases, s.address)");
 
-            verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE", row("Aaron", 11, "Antioch"), row("Bill", 7, "Buena"), row("Carol", 9, "Centreville"), row("Dave", 22, "Darbyshire"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, row("Aaron", 11, "Antioch"), row("Bill", 7, "Buena"), row("Carol", 9, "Centreville"), row("Dave", 22, "Darbyshire"));
         });
     }
 
@@ -315,7 +315,7 @@ public class TestHiveMerge
                     "    WHEN NOT MATCHED THEN INSERT (customer, purchases, address) VALUES(s.customer, s.purchases, s.address)";
             onTrino().executeQuery(query);
 
-            verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE", row("Aaron", 11, "Arches"), row("Bill", 7, "Buena"), row("Dave", 22, "Darbyshire"), row("Ed", 7, "Etherville"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, row("Aaron", 11, "Arches"), row("Bill", 7, "Buena"), row("Dave", 22, "Darbyshire"), row("Ed", 7, "Etherville"));
         });
     }
 
@@ -335,7 +335,7 @@ public class TestHiveMerge
                 onTrino().executeQuery(format("MERGE INTO %s t USING %s s ON (t.customer = s.customer)", targetTable, sourceTable) +
                         "    WHEN MATCHED THEN UPDATE SET customer = CONCAT(t.customer, '_updated'), purchases = s.purchases + t.purchases, address = s.address");
 
-                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE", row("Dave_updated", 22, "Darbyshire"), row("Aaron_updated", 11, "Arches"), row("Bill", 7, "Buena"), row("Carol_updated", 12, "Centreville"));
+                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, row("Dave_updated", 22, "Darbyshire"), row("Aaron_updated", 11, "Arches"), row("Bill", 7, "Buena"), row("Carol_updated", 12, "Centreville"));
             });
         });
     }
@@ -356,7 +356,7 @@ public class TestHiveMerge
                 onTrino().executeQuery(format("MERGE INTO %s t USING %s s ON (t.customer = s.customer)", targetTable, sourceTable) +
                         "    WHEN MATCHED THEN DELETE");
 
-                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE", row("Bill", 7, "Buena"));
+                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, row("Bill", 7, "Buena"));
             });
         });
     }
@@ -380,7 +380,7 @@ public class TestHiveMerge
 
                 onTrino().executeQuery(format("MERGE INTO %s t USING %s s ON (t.customer = s.customer)", targetTable, sourceTable) +
                         "    WHEN MATCHED AND s.address = 'Adelphi' THEN UPDATE SET address = s.address");
-                verifySelectForTrinoAndHive("SELECT customer, purchases, address FROM " + targetTable, "TRUE", row("Aaron", 5, "Adelphi"), row("Bill", 7, "Antioch"));
+                verifySelectForTrinoAndHive("SELECT customer, purchases, address FROM " + targetTable, row("Aaron", 5, "Adelphi"), row("Bill", 7, "Antioch"));
             });
         });
     }
@@ -418,7 +418,7 @@ public class TestHiveMerge
 
                 onTrino().executeQuery(sql);
 
-                verifySelectForTrinoAndHive("SELECT customer, purchases, address FROM " + targetTable, "TRUE", row("Aaron", 11, "Arches"), row("Ed", 7, "Etherville"), row("Bill", 7, "Buena"), row("Dave", 22, "Darbyshire"));
+                verifySelectForTrinoAndHive("SELECT customer, purchases, address FROM " + targetTable, row("Aaron", 11, "Arches"), row("Ed", 7, "Etherville"), row("Bill", 7, "Buena"), row("Dave", 22, "Darbyshire"));
             });
         });
     }
@@ -457,7 +457,7 @@ public class TestHiveMerge
 
                 onTrino().executeQuery(sql);
 
-                verifySelectForTrinoAndHive("SELECT customer, purchases, address FROM " + targetTable, "TRUE", row("Aaron", 11, "Arches"), row("Ed", 7, "Etherville"), row("Bill", 7, "Buena"), row("Dave", 22, "Darbyshire"));
+                verifySelectForTrinoAndHive("SELECT customer, purchases, address FROM " + targetTable, row("Aaron", 11, "Arches"), row("Ed", 7, "Etherville"), row("Bill", 7, "Buena"), row("Dave", 22, "Darbyshire"));
             });
         });
     }
@@ -514,7 +514,7 @@ public class TestHiveMerge
                     "    WHEN MATCHED THEN UPDATE SET purCHases = s.PurchaseS + t.pUrchases, aDDress = s.addrESs" +
                     "    WHEN NOT MATCHED THEN INSERT (CUSTOMER, purchases, addRESS) VALUES(s.custoMer, s.Purchases, s.ADDress)");
 
-            verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE", row("Aaron", 11, "Arches"), row("Bill", 7, "Buena"), row("Dave", 22, "Darbyshire"), row("Ed", 7, "Etherville"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, row("Aaron", 11, "Arches"), row("Bill", 7, "Buena"), row("Dave", 22, "Darbyshire"), row("Ed", 7, "Etherville"));
         });
     }
 
@@ -537,7 +537,7 @@ public class TestHiveMerge
                         format("    WHEN MATCHED THEN UPDATE SET purchases = %s.pURCHases + %s.pUrchases, aDDress = %s.addrESs", sourceTable, targetTable, sourceTable) +
                         format("    WHEN NOT MATCHED THEN INSERT (cusTomer, purchases, addRESS) VALUES(%s.custoMer, %s.Purchases, %s.ADDress)", sourceTable, sourceTable, sourceTable));
 
-                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE", row("Aaron", 11, "Arches"), row("Bill", 7, "Buena"), row("Dave", 22, "Darbyshire"), row("Ed", 7, "Etherville"));
+                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, row("Aaron", 11, "Arches"), row("Bill", 7, "Buena"), row("Dave", 22, "Darbyshire"), row("Ed", 7, "Etherville"));
             });
         });
     }
@@ -561,7 +561,7 @@ public class TestHiveMerge
                         "    WHEN MATCHED THEN UPDATE SET purchases = s.purchases + t.purchases, address = s.address" +
                         "    WHEN NOT MATCHED THEN INSERT (customer, purchases, address) VALUES(s.customer, s.purchases, s.address)");
 
-                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE",
+                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable,
                         row("Aaron", 11, "Arches"), row("Bill", 7, "Buena"), row("Dave", 11, "Darbyshire"), row("Dave", 11, "Devon"), row("Ed", 7, "Etherville"));
 
                 onTrino().executeQuery(format("MERGE INTO %s t USING %s s", targetTable, sourceTable) +
@@ -573,11 +573,11 @@ public class TestHiveMerge
                         "    WHEN NOT MATCHED" +
                         "        THEN INSERT (customer, purchases, address) VALUES(s.customer, s.purchases, s.address)");
 
-                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE",
+                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable,
                         row("Aaron", 17, "Arches/Arches"), row("Bill", 7, "Buena"), row("Carol", 9, "Centreville"), row("Dave", 22, "Darbyshire/Darbyshire"), row("Ed", 14, "Etherville/Etherville"));
 
                 onTrino().executeQuery(format("INSERT INTO %s (customer, purchases, address) VALUES('Fred', 30, 'Franklin')", targetTable));
-                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE",
+                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable,
                         row("Aaron", 17, "Arches/Arches"), row("Bill", 7, "Buena"), row("Carol", 9, "Centreville"), row("Dave", 22, "Darbyshire/Darbyshire"), row("Ed", 14, "Etherville/Etherville"), row("Fred", 30, "Franklin"));
             });
         });
@@ -603,7 +603,7 @@ public class TestHiveMerge
                         "        THEN DELETE");
 
                 // BUG: The actual row are [Dave, 11, Devon].  Why did the wrong one get deleted?
-                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE", row("Dave", 11, "Darbyshire"));
+                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, row("Dave", 11, "Darbyshire"));
             });
         });
     }
@@ -625,7 +625,7 @@ public class TestHiveMerge
                         "    ON (t.col1 + 1 = s.col1)" +
                         "    WHEN MATCHED THEN UPDATE SET col1 = s.col1, col2 = s.col2, col3 = s.col3, col4 = s.col4, col5 = s.col5, col6 = s.col6");
 
-                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE", row(2, 3, 4, 5, 6.0, 7.0));
+                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, row(2, 3, 4, 5, 6.0, 7.0));
             });
         });
     }
@@ -650,7 +650,7 @@ public class TestHiveMerge
                         "    WHEN NOT MATCHED AND s.region_name = 'EUROPE'" +
                         "        THEN INSERT VALUES(s.nation_name, (SELECT 'EUROPE'))");
 
-                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE", row("FRANCE", "EUROPE"), row("GERMANY", "EUROPE"), row("RUSSIA", "EUROPE"));
+                verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, row("FRANCE", "EUROPE"), row("GERMANY", "EUROPE"), row("RUSSIA", "EUROPE"));
             });
         });
     }
@@ -673,7 +673,7 @@ public class TestHiveMerge
                     "    WHEN MATCHED" +
                     "        THEN UPDATE SET name = 'EUROPEAN'");
 
-            verifySelectForTrinoAndHive("SELECT name  FROM " + targetTable, "name LIKE('EU%')", row("EUROPEAN"));
+            verifySelectForTrinoAndHive("SELECT name  FROM %s WHERE name LIKE('EU%%')".formatted(targetTable), row("EUROPEAN"));
         });
     }
 
@@ -691,7 +691,7 @@ public class TestHiveMerge
 
             onTrino().executeQuery(sql);
 
-            verifySelectForTrinoAndHive(format("SELECT count(*) FROM %s t", targetTable), "mod(t.orderkey, 3) = 1", row(0));
+            verifySelectForTrinoAndHive(format("SELECT count(*) FROM %s t WHERE mod(t.orderkey, 3) = 1", targetTable), row(0));
         });
     }
 
@@ -709,7 +709,7 @@ public class TestHiveMerge
                       ON (FALSE)
                         WHEN NOT MATCHED THEN INSERT (customer, purchases, address) VALUES(s.customer, s.purchases, s.address)
                     """.formatted(targetTable));
-            verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE", row("Aaron", 11, "Antioch"), row("Bill", 7, "Buena"), row("Carol", 9, "Centreville"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, row("Aaron", 11, "Antioch"), row("Bill", 7, "Buena"), row("Carol", 9, "Centreville"));
 
             // Test a constant-folded false expression
             onTrino().executeQuery("""
@@ -717,7 +717,7 @@ public class TestHiveMerge
                       ON (t.customer != t.customer)
                         WHEN NOT MATCHED THEN INSERT (customer, purchases, address) VALUES(s.customer, s.purchases, s.address)
                     """.formatted(targetTable));
-            verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE", row("Aaron", 11, "Antioch"), row("Bill", 7, "Buena"), row("Carol", 9, "Centreville"), row("Dave", 22, "Darbyshire"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, row("Aaron", 11, "Antioch"), row("Bill", 7, "Buena"), row("Carol", 9, "Centreville"), row("Dave", 22, "Darbyshire"));
 
             onTrino().executeQuery("""
                     MERGE INTO %s t USING (VALUES ('Ed', 7, 'Etherville')) AS s(customer, purchases, address)
@@ -725,7 +725,7 @@ public class TestHiveMerge
                         WHEN MATCHED THEN UPDATE SET customer = concat(s.customer, '_fooled_you')
                         WHEN NOT MATCHED THEN INSERT (customer, purchases, address) VALUES(s.customer, s.purchases, s.address)
                     """.formatted(targetTable));
-            verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, "TRUE", row("Aaron", 11, "Antioch"), row("Bill", 7, "Buena"), row("Carol", 9, "Centreville"), row("Dave", 22, "Darbyshire"), row("Ed", 7, "Etherville"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + targetTable, row("Aaron", 11, "Antioch"), row("Bill", 7, "Buena"), row("Carol", 9, "Centreville"), row("Dave", 22, "Darbyshire"), row("Ed", 7, "Etherville"));
         });
     }
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
@@ -577,11 +577,11 @@ public class TestHiveTransactionalTable
 
             onTrino().executeQuery(insertQuery);
 
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(11, 100L), row(12, 200L), row(13, 300L));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(11, 100L), row(12, 200L), row(13, 300L));
 
             onTrino().executeQuery(format("INSERT INTO %s VALUES (14, 400), (15, 500), (16, 600)", tableName));
 
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(11, 100L), row(12, 200L), row(13, 300L), row(14, 400L), row(15, 500L), row(16, 600L));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(11, 100L), row(12, 200L), row(13, 300L), row(14, 400L), row(15, 500L), row(16, 600L));
         });
     }
 
@@ -596,25 +596,25 @@ public class TestHiveTransactionalTable
                     makeInsertValues(1, 1, 20),
                     makeInsertValues(2, 1, 20)));
 
-            verifySelectForTrinoAndHive(format("SELECT COUNT(*) FROM %s", tableName), "column1 > 10", row(20));
+            verifySelectForTrinoAndHive(format("SELECT COUNT(*) FROM %s WHERE column1 > 10", tableName), row(20));
 
             onTrino().executeQuery(format("INSERT INTO %s (column2, column1) VALUES %s, %s",
                     tableName,
                     makeInsertValues(1, 21, 30),
                     makeInsertValues(2, 21, 30)));
 
-            verifySelectForTrinoAndHive(format("SELECT COUNT(*) FROM %s", tableName), "column1 > 15 AND column1 <= 25", row(20));
+            verifySelectForTrinoAndHive(format("SELECT COUNT(*) FROM %s WHERE column1 > 15 AND column1 <= 25", tableName), row(20));
 
             onHive().executeQuery(format("DELETE FROM %s WHERE column1 > 15 AND column1 <= 25", tableName));
 
-            verifySelectForTrinoAndHive(format("SELECT COUNT(*) FROM %s", tableName), "column1 > 15 AND column1 <= 25", row(0));
+            verifySelectForTrinoAndHive(format("SELECT COUNT(*) FROM %s WHERE column1 > 15 AND column1 <= 25", tableName), row(0));
 
             onTrino().executeQuery(format("INSERT INTO %s (column2, column1) VALUES %s, %s",
                     tableName,
                     makeInsertValues(1, 20, 23),
                     makeInsertValues(2, 20, 23)));
 
-            verifySelectForTrinoAndHive(format("SELECT COUNT(*) FROM %s", tableName), "column1 > 15 AND column1 <= 25", row(8));
+            verifySelectForTrinoAndHive(format("SELECT COUNT(*) FROM %s WHERE column1 > 15 AND column1 <= 25", tableName), row(8));
         });
     }
 
@@ -643,16 +643,16 @@ public class TestHiveTransactionalTable
                     " ('Ann', 'cards'), ('Ann', 'cereal'), ('Ann', 'lemons'), ('Ann', 'chips')," +
                     " ('Lou', 'cards'), ('Lou', 'cereal'), ('Lou', 'lemons'), ('Lou', 'chips')");
 
-            verifySelectForTrinoAndHive(format("SELECT customer FROM %s", tableName), "purchase = 'lemons'", row("Ann"), row("Lou"));
+            verifySelectForTrinoAndHive(format("SELECT customer FROM %s WHERE purchase = 'lemons'", tableName), row("Ann"), row("Lou"));
 
-            verifySelectForTrinoAndHive(format("SELECT purchase FROM %s", tableName), "customer = 'Fred'", row("cards"), row("cereal"), row("limes"), row("chips"));
+            verifySelectForTrinoAndHive(format("SELECT purchase FROM %s WHERE customer = 'Fred'", tableName), row("cards"), row("cereal"), row("limes"), row("chips"));
 
             onTrino().executeQuery(format("INSERT INTO %s (customer, purchase) VALUES", tableName) +
                     " ('Ernie', 'cards'), ('Ernie', 'cereal')," +
                     " ('Debby', 'corn'), ('Debby', 'chips')," +
                     " ('Joe', 'corn'), ('Joe', 'lemons'), ('Joe', 'candy')");
 
-            verifySelectForTrinoAndHive(format("SELECT customer FROM %s", tableName), "purchase = 'corn'", row("Debby"), row("Joe"));
+            verifySelectForTrinoAndHive(format("SELECT customer FROM %s WHERE purchase = 'corn'", tableName), row("Debby"), row("Joe"));
         });
     }
 
@@ -663,14 +663,14 @@ public class TestHiveTransactionalTable
             onTrino().executeQuery(format("CREATE TABLE %s (column1 INTEGER, column2 BIGINT) WITH (format = 'ORC', transactional = true)", tableName));
             execute(inserter, format("INSERT INTO %s (column1, column2) VALUES (1, 100), (2, 200), (3, 300), (4, 400), (5, 500)", tableName));
             execute(deleter, format("DELETE FROM %s WHERE column2 = 100", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(2, 200), row(3, 300), row(4, 400), row(5, 500));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(2, 200), row(3, 300), row(4, 400), row(5, 500));
 
             execute(inserter, format("INSERT INTO %s VALUES (6, 600), (7, 700)", tableName));
             execute(deleter, format("DELETE FROM %s WHERE column1 = 4", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(2, 200), row(3, 300), row(5, 500), row(6, 600), row(7, 700));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(2, 200), row(3, 300), row(5, 500), row(6, 600), row(7, 700));
 
             execute(deleter, format("DELETE FROM %s WHERE column1 <= 3 OR column1 = 6", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(5, 500), row(7, 700));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(5, 500), row(7, 700));
         });
     }
 
@@ -684,7 +684,7 @@ public class TestHiveTransactionalTable
 
             execute(deleter, format("DELETE FROM %s WHERE column1 = 9", tableName));
             execute(deleter, format("DELETE FROM %s WHERE column1 = 2 OR column1 = 3", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, 100), row(4, 400), row(5, 500), row(6, 600), row(7, 700), row(8, 800), row(10, 1000));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, 100), row(4, 400), row(5, 500), row(6, 600), row(7, 700), row(8, 800), row(10, 1000));
         });
     }
 
@@ -712,7 +712,7 @@ public class TestHiveTransactionalTable
                         dataTableName,
                         tableName));
                 onHive().executeQuery(format("DELETE FROM %s WHERE b = 1", tableName));
-                verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(0, 0, "c1"));
+                verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(0, 0, "c1"));
             });
         });
     }
@@ -728,7 +728,7 @@ public class TestHiveTransactionalTable
                     makeInsertValues(2, 1, 20)));
 
             execute(deleter, format("DELETE FROM %s WHERE column2 = 1", tableName));
-            verifySelectForTrinoAndHive("SELECT COUNT(*) FROM " + tableName, "column2 = 1", row(0));
+            verifySelectForTrinoAndHive("SELECT COUNT(*) FROM %s WHERE column2 = 1".formatted(tableName), row(0));
         });
     }
 
@@ -749,7 +749,7 @@ public class TestHiveTransactionalTable
                     makeInsertValues(2, 11, 20)));
 
             execute(Engine.TRINO, format("DELETE FROM %s WHERE column1 = 1", tableName));
-            verifySelectForTrinoAndHive("SELECT COUNT(*) FROM " + tableName, "column1 = 1", row(0));
+            verifySelectForTrinoAndHive("SELECT COUNT(*) FROM %s WHERE column1 = 1".formatted(tableName), row(0));
         });
     }
 
@@ -760,7 +760,7 @@ public class TestHiveTransactionalTable
             onTrino().executeQuery(format("CREATE TABLE %s (column1 INT, column2 BIGINT) WITH (transactional = true)", tableName));
             execute(inserter, format("INSERT INTO %s VALUES (1, 100), (2, 200), (3, 300), (4, 400), (5, 500)", tableName));
             execute(deleter, "DELETE FROM " + tableName);
-            verifySelectForTrinoAndHive("SELECT COUNT(*) FROM " + tableName, "true", row(0));
+            verifySelectForTrinoAndHive("SELECT COUNT(*) FROM " + tableName, row(0));
         });
     }
 
@@ -772,7 +772,7 @@ public class TestHiveTransactionalTable
             execute(inserter, format("INSERT INTO %s VALUES (1, 100), (2, 200), (3, 300), (4, 400), (5, 500)", tableName));
             String where = " WHERE column1 >= 2 AND column2 <= 400";
             execute(deleter, format("DELETE FROM %s %s", tableName, where));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "column1 IN (1, 5)", row(1, 100), row(5, 500));
+            verifySelectForTrinoAndHive("SELECT * FROM %s WHERE column1 IN (1, 5)".formatted(tableName), row(1, 100), row(5, 500));
         });
     }
 
@@ -785,7 +785,7 @@ public class TestHiveTransactionalTable
             execute(inserter, format("INSERT INTO %s (column1, column2) VALUES (1, 100), (1, 200), (2, 300), (2, 400), (2, 500)", tableName));
             String where = " WHERE column1 = 2 OR column2 = 200";
             execute(deleter, format("DELETE FROM %s %s", tableName, where));
-            verifySelectForTrinoAndHive("SELECT column1, column2 FROM " + tableName, "true", row(1, 100));
+            verifySelectForTrinoAndHive("SELECT column1, column2 FROM " + tableName, row(1, 100));
         });
     }
 
@@ -804,11 +804,11 @@ public class TestHiveTransactionalTable
                     makeInsertValues(1, 21, 40),
                     makeInsertValues(2, 21, 40)));
 
-            verifySelectForTrinoAndHive("SELECT COUNT(*) FROM " + tableName, "column2 > 10 AND column2 <= 30", row(40));
+            verifySelectForTrinoAndHive("SELECT COUNT(*) FROM %s WHERE column2 > 10 AND column2 <= 30".formatted(tableName), row(40));
 
             execute(deleter, format("DELETE FROM %s WHERE column2 > 10 AND column2 <= 30", tableName));
-            verifySelectForTrinoAndHive("SELECT COUNT(*) FROM " + tableName, "column2 > 10 AND column2 <= 30", row(0));
-            verifySelectForTrinoAndHive("SELECT COUNT(*) FROM " + tableName, "true", row(40));
+            verifySelectForTrinoAndHive("SELECT COUNT(*) FROM %s WHERE column2 > 10 AND column2 <= 30".formatted(tableName), row(0));
+            verifySelectForTrinoAndHive("SELECT COUNT(*) FROM " + tableName, row(40));
         });
     }
 
@@ -824,22 +824,22 @@ public class TestHiveTransactionalTable
                     " ('Ann', 'cards'), ('Ann', 'cereal'), ('Ann', 'lemons'), ('Ann', 'chips')," +
                     " ('Lou', 'cards'), ('Lou', 'cereal'), ('Lou', 'lemons'), ('Lou', 'chips')");
 
-            verifySelectForTrinoAndHive(format("SELECT customer FROM %s", tableName), "purchase = 'lemons'", row("Ann"), row("Lou"));
+            verifySelectForTrinoAndHive(format("SELECT customer FROM %s WHERE purchase = 'lemons'", tableName), row("Ann"), row("Lou"));
 
-            verifySelectForTrinoAndHive(format("SELECT purchase FROM %s", tableName), "customer = 'Fred'", row("cards"), row("cereal"), row("limes"), row("chips"));
+            verifySelectForTrinoAndHive(format("SELECT purchase FROM %s WHERE customer = 'Fred'", tableName), row("cards"), row("cereal"), row("limes"), row("chips"));
 
             execute(inserter, format("INSERT INTO %s (customer, purchase) VALUES", tableName) +
                     " ('Ernie', 'cards'), ('Ernie', 'cereal')," +
                     " ('Debby', 'corn'), ('Debby', 'chips')," +
                     " ('Joe', 'corn'), ('Joe', 'lemons'), ('Joe', 'candy')");
 
-            verifySelectForTrinoAndHive("SELECT customer FROM " + tableName, "purchase = 'corn'", row("Debby"), row("Joe"));
+            verifySelectForTrinoAndHive("SELECT customer FROM %s WHERE purchase = 'corn'".formatted(tableName), row("Debby"), row("Joe"));
 
             execute(deleter, format("DELETE FROM %s WHERE purchase = 'lemons'", tableName));
-            verifySelectForTrinoAndHive("SELECT purchase FROM " + tableName, "customer = 'Ann'", row("cards"), row("cereal"), row("chips"));
+            verifySelectForTrinoAndHive("SELECT purchase FROM %s WHERE customer = 'Ann'".formatted(tableName), row("cards"), row("cereal"), row("chips"));
 
             execute(deleter, format("DELETE FROM %s WHERE purchase like('c%%')", tableName));
-            verifySelectForTrinoAndHive("SELECT customer, purchase FROM " + tableName, "true", row("Fred", "limes"));
+            verifySelectForTrinoAndHive("SELECT customer, purchase FROM " + tableName, row("Fred", "limes"));
         });
     }
 
@@ -856,7 +856,7 @@ public class TestHiveTransactionalTable
             onTrino().executeQuery(format("DELETE FROM %s WHERE customer = 'Fred'", tableName));
 
             log.info("About to verify");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "TRUE", row("lemons", "Ann"), row("chips", "Ann"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row("lemons", "Ann"), row("chips", "Ann"));
         });
     }
 
@@ -870,7 +870,7 @@ public class TestHiveTransactionalTable
 
             onTrino().executeQuery(format("DELETE FROM %s WHERE id = 2", tableName));
 
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1), row(3));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1), row(3));
 
             onTrino().executeQuery("DELETE FROM " + tableName);
 
@@ -888,7 +888,7 @@ public class TestHiveTransactionalTable
 
             onTrino().executeQuery(format("DELETE FROM %s WHERE id = 2", tableName));
 
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1), row(3));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1), row(3));
 
             // A predicate sufficient to fool statistics-based optimization
             onTrino().executeQuery(format("DELETE FROM %s WHERE id != 2", tableName));
@@ -908,22 +908,22 @@ public class TestHiveTransactionalTable
                     " ('Ann', 'cards'), ('Ann', 'cereal'), ('Ann', 'lemons'), ('Ann', 'chips')," +
                     " ('Lou', 'cards'), ('Lou', 'cereal'), ('Lou', 'lemons'), ('Lou', 'chips')");
 
-            verifySelectForTrinoAndHive(format("SELECT customer FROM %s", tableName), "purchase = 'lemons'", row("Ann"), row("Lou"));
+            verifySelectForTrinoAndHive(format("SELECT customer FROM %s WHERE purchase = 'lemons'", tableName), row("Ann"), row("Lou"));
 
-            verifySelectForTrinoAndHive(format("SELECT purchase FROM %s", tableName), "customer = 'Fred'", row("cards"), row("cereal"), row("limes"), row("chips"));
+            verifySelectForTrinoAndHive(format("SELECT purchase FROM %s WHERE customer = 'Fred'", tableName), row("cards"), row("cereal"), row("limes"), row("chips"));
 
             execute(inserter, format("INSERT INTO %s (customer, purchase) VALUES", tableName) +
                     " ('Ernie', 'cards'), ('Ernie', 'cereal')," +
                     " ('Debby', 'corn'), ('Debby', 'chips')," +
                     " ('Joe', 'corn'), ('Joe', 'lemons'), ('Joe', 'candy')");
 
-            verifySelectForTrinoAndHive("SELECT customer FROM " + tableName, "purchase = 'corn'", row("Debby"), row("Joe"));
+            verifySelectForTrinoAndHive("SELECT customer FROM %s WHERE purchase = 'corn'".formatted(tableName), row("Debby"), row("Joe"));
 
             execute(deleter, format("DELETE FROM %s WHERE purchase = 'lemons'", tableName));
-            verifySelectForTrinoAndHive("SELECT purchase FROM " + tableName, "customer = 'Ann'", row("cards"), row("cereal"), row("chips"));
+            verifySelectForTrinoAndHive("SELECT purchase FROM %s WHERE customer = 'Ann'".formatted(tableName), row("cards"), row("cereal"), row("chips"));
 
             execute(deleter, format("DELETE FROM %s WHERE purchase like('c%%')", tableName));
-            verifySelectForTrinoAndHive("SELECT customer, purchase FROM " + tableName, "true", row("Fred", "limes"));
+            verifySelectForTrinoAndHive("SELECT customer, purchase FROM " + tableName, row("Fred", "limes"));
         });
     }
 
@@ -936,7 +936,7 @@ public class TestHiveTransactionalTable
             log.info("About to delete selected rows");
             onTrino().executeQuery(format("DELETE FROM %s WHERE clerk = 'Clerk#000004942'", tableName));
 
-            verifySelectForTrinoAndHive("SELECT COUNT(*) FROM " + tableName, "clerk = 'Clerk#000004942'", row(0));
+            verifySelectForTrinoAndHive("SELECT COUNT(*) FROM %s WHERE clerk = 'Clerk#000004942'".formatted(tableName), row(0));
         });
     }
 
@@ -948,7 +948,7 @@ public class TestHiveTransactionalTable
 
             execute(inserter, format("INSERT INTO %s VALUES (1, 100, 'a'), (2, 200, 'b'), (3, 300, 'c'), (4, 400, 'a'), (5, 500, 'b'), (6, 600, 'c')", tableName));
             execute(deleter, format("DELETE FROM %s WHERE col2 = 200", tableName));
-            verifySelectForTrinoAndHive("SELECT COUNT(*) FROM " + tableName, "true", row(5));
+            verifySelectForTrinoAndHive("SELECT COUNT(*) FROM " + tableName, row(5));
         });
     }
 
@@ -961,18 +961,18 @@ public class TestHiveTransactionalTable
                     tableName, bucketed ? "CLUSTERED BY (col2) INTO 3 BUCKETS" : ""));
 
             execute(inserter1, format("INSERT INTO %s VALUES (1, 100, 'a'), (2, 200, 'b')", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, 100, "a"), row(2, 200, "b"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, 100, "a"), row(2, 200, "b"));
 
             execute(inserter2, format("INSERT INTO %s VALUES (3, 300, 'c'), (4, 400, 'a')", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, 100, "a"), row(2, 200, "b"), row(3, 300, "c"), row(4, 400, "a"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, 100, "a"), row(2, 200, "b"), row(3, 300, "c"), row(4, 400, "a"));
 
             execute(inserter1, format("INSERT INTO %s VALUES (5, 500, 'b'), (6, 600, 'c')", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, 100, "a"), row(2, 200, "b"), row(3, 300, "c"), row(4, 400, "a"), row(5, 500, "b"), row(6, 600, "c"));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "col2 > 300", row(4, 400, "a"), row(5, 500, "b"), row(6, 600, "c"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, 100, "a"), row(2, 200, "b"), row(3, 300, "c"), row(4, 400, "a"), row(5, 500, "b"), row(6, 600, "c"));
+            verifySelectForTrinoAndHive("SELECT * FROM %s WHERE col2 > 300".formatted(tableName), row(4, 400, "a"), row(5, 500, "b"), row(6, 600, "c"));
 
             execute(inserter2, format("INSERT INTO %s VALUES (7, 700, 'b'), (8, 800, 'c')", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, 100, "a"), row(2, 200, "b"), row(3, 300, "c"), row(4, 400, "a"), row(5, 500, "b"), row(6, 600, "c"), row(7, 700, "b"), row(8, 800, "c"));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "col3 = 'c'", row(3, 300, "c"), row(6, 600, "c"), row(8, 800, "c"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, 100, "a"), row(2, 200, "b"), row(3, 300, "c"), row(4, 400, "a"), row(5, 500, "b"), row(6, 600, "c"), row(7, 700, "b"), row(8, 800, "c"));
+            verifySelectForTrinoAndHive("SELECT * FROM %s WHERE col3 = 'c'".formatted(tableName), row(3, 300, "c"), row(6, 600, "c"), row(8, 800, "c"));
         });
     }
 
@@ -1038,23 +1038,23 @@ public class TestHiveTransactionalTable
     private void testOrcColumnRenames(String tableName)
     {
         onTrino().executeQuery(format("INSERT INTO %s VALUES (111, 'Katy', 57, 'CA'), (222, 'Joe', 72, 'WA')", tableName));
-        verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(111, "Katy", 57, "CA"), row(222, "Joe", 72, "WA"));
+        verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(111, "Katy", 57, "CA"), row(222, "Joe", 72, "WA"));
 
         onTrino().executeQuery(format("ALTER TABLE %s RENAME COLUMN old_name TO new_name", tableName));
         log.info("This shows that Trino and Hive can still query old data after a single rename");
-        verifySelectForTrinoAndHive("SELECT age FROM " + tableName, "new_name = 'Katy'", row(57));
+        verifySelectForTrinoAndHive("SELECT age FROM %s WHERE new_name = 'Katy'".formatted(tableName), row(57));
 
         onTrino().executeQuery(format("INSERT INTO %s VALUES(333, 'Joan', 23, 'OR')", tableName));
-        verifySelectForTrinoAndHive("SELECT age FROM " + tableName, "new_name != 'Joe'", row(57), row(23));
+        verifySelectForTrinoAndHive("SELECT age FROM %s WHERE new_name != 'Joe'".formatted(tableName), row(57), row(23));
 
         onTrino().executeQuery(format("ALTER TABLE %s RENAME COLUMN new_name TO newer_name", tableName));
         log.info("This shows that Trino and Hive can still query old data after a double rename");
-        verifySelectForTrinoAndHive("SELECT age FROM " + tableName, "newer_name = 'Katy'", row(57));
+        verifySelectForTrinoAndHive("SELECT age FROM %s WHERE newer_name = 'Katy'".formatted(tableName), row(57));
 
         onTrino().executeQuery(format("ALTER TABLE %s RENAME COLUMN newer_name TO old_name", tableName));
         log.info("This shows that Trino and Hive can still query old data after a rename back to the original name");
-        verifySelectForTrinoAndHive("SELECT age FROM " + tableName, "old_name = 'Katy'", row(57));
-        verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(111, "Katy", 57, "CA"), row(222, "Joe", 72, "WA"), row(333, "Joan", 23, "OR"));
+        verifySelectForTrinoAndHive("SELECT age FROM %s WHERE old_name = 'Katy'".formatted(tableName), row(57));
+        verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(111, "Katy", 57, "CA"), row(222, "Joe", 72, "WA"), row(333, "Joan", 23, "OR"));
     }
 
     @Test(groups = HIVE_TRANSACTIONAL, dataProvider = "transactionModeProvider")
@@ -1064,13 +1064,13 @@ public class TestHiveTransactionalTable
         withTemporaryTable("test_orc_column_renames", transactional, false, NONE, tableName -> {
             onTrino().executeQuery(format("CREATE TABLE %s (name VARCHAR, state VARCHAR) WITH (format = 'ORC', transactional = %s)", tableName, transactional));
             onTrino().executeQuery(format("INSERT INTO %s VALUES ('Katy', 'CA'), ('Joe', 'WA')", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row("Katy", "CA"), row("Joe", "WA"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row("Katy", "CA"), row("Joe", "WA"));
 
             onTrino().executeQuery(format("ALTER TABLE %s RENAME COLUMN name TO new_name", tableName));
             onTrino().executeQuery(format("ALTER TABLE %s RENAME COLUMN state TO name", tableName));
             onTrino().executeQuery(format("ALTER TABLE %s RENAME COLUMN new_name TO state", tableName));
             log.info("This shows that Trino and Hive can still query old data, but because of the renames, columns are swapped!");
-            verifySelectForTrinoAndHive("SELECT state, name FROM " + tableName, "TRUE", row("Katy", "CA"), row("Joe", "WA"));
+            verifySelectForTrinoAndHive("SELECT state, name FROM " + tableName, row("Katy", "CA"), row("Joe", "WA"));
         });
     }
 
@@ -1081,19 +1081,19 @@ public class TestHiveTransactionalTable
         withTemporaryTable("test_parquet_column_renames", false, false, NONE, tableName -> {
             onTrino().executeQuery(format("CREATE TABLE %s (id BIGINT, old_name VARCHAR, age INT, old_state VARCHAR) WITH (format = 'PARQUET', transactional = false)", tableName));
             onTrino().executeQuery(format("INSERT INTO %s VALUES (111, 'Katy', 57, 'CA'), (222, 'Joe', 72, 'WA')", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(111, "Katy", 57, "CA"), row(222, "Joe", 72, "WA"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(111, "Katy", 57, "CA"), row(222, "Joe", 72, "WA"));
 
             onTrino().executeQuery(format("ALTER TABLE %s RENAME COLUMN old_name TO new_name", tableName));
 
             onTrino().executeQuery(format("INSERT INTO %s VALUES (333, 'Fineas', 31, 'OR')", tableName));
 
             log.info("This shows that Hive and Trino do not see old data after a rename");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "TRUE", row(111, null, 57, "CA"), row(222, null, 72, "WA"), row(333, "Fineas", 31, "OR"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(111, null, 57, "CA"), row(222, null, 72, "WA"), row(333, "Fineas", 31, "OR"));
 
             onTrino().executeQuery(format("ALTER TABLE %s RENAME COLUMN new_name TO old_name", tableName));
             onTrino().executeQuery(format("INSERT INTO %s VALUES (444, 'Gladys', 47, 'WA')", tableName));
             log.info("This shows that Trino and Hive both see data in old data files after renaming back to the original column name");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "TRUE", row(111, "Katy", 57, "CA"), row(222, "Joe", 72, "WA"), row(333, null, 31, "OR"), row(444, "Gladys", 47, "WA"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(111, "Katy", 57, "CA"), row(222, "Joe", 72, "WA"), row(333, null, 31, "OR"), row(444, "Gladys", 47, "WA"));
         });
     }
 
@@ -1104,18 +1104,18 @@ public class TestHiveTransactionalTable
         withTemporaryTable("test_orc_add_drop", transactional, false, NONE, tableName -> {
             onTrino().executeQuery(format("CREATE TABLE %s (id BIGINT, old_name VARCHAR, age INT, old_state VARCHAR) WITH (transactional = %s)", tableName, transactional));
             onTrino().executeQuery(format("INSERT INTO %s VALUES (111, 'Katy', 57, 'CA'), (222, 'Joe', 72, 'WA')", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(111, "Katy", 57, "CA"), row(222, "Joe", 72, "WA"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(111, "Katy", 57, "CA"), row(222, "Joe", 72, "WA"));
 
             onTrino().executeQuery(format("ALTER TABLE %s DROP COLUMN old_state", tableName));
             log.info("This shows that neither Trino nor Hive see the old data after a column is dropped");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(111, "Katy", 57), row(222, "Joe", 72));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(111, "Katy", 57), row(222, "Joe", 72));
 
             onTrino().executeQuery(format("INSERT INTO %s VALUES (333, 'Kelly', 45)", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(111, "Katy", 57), row(222, "Joe", 72), row(333, "Kelly", 45));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(111, "Katy", 57), row(222, "Joe", 72), row(333, "Kelly", 45));
 
             onTrino().executeQuery(format("ALTER TABLE %s ADD COLUMN new_state VARCHAR", tableName));
             log.info("This shows that for ORC, Trino and Hive both see data inserted into a dropped column when a column of the same type but different name is added");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(111, "Katy", 57, "CA"), row(222, "Joe", 72, "WA"), row(333, "Kelly", 45, null));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(111, "Katy", 57, "CA"), row(222, "Joe", 72, "WA"), row(333, "Kelly", 45, null));
         });
     }
 
@@ -1126,7 +1126,7 @@ public class TestHiveTransactionalTable
         withTemporaryTable("test_orc_column_type_change", transactional, false, NONE, tableName -> {
             onTrino().executeQuery(format("CREATE TABLE %s (id INT, old_name VARCHAR, age TINYINT, old_state VARCHAR) WITH (transactional = %s)", tableName, transactional));
             onTrino().executeQuery(format("INSERT INTO %s VALUES (111, 'Katy', 57, 'CA'), (222, 'Joe', 72, 'WA')", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(111, "Katy", 57, "CA"), row(222, "Joe", 72, "WA"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(111, "Katy", 57, "CA"), row(222, "Joe", 72, "WA"));
 
             onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN age age INT", tableName));
             log.info("This shows that Hive see the old data after a column is widened");
@@ -1145,23 +1145,23 @@ public class TestHiveTransactionalTable
         withTemporaryTable("test_parquet_add_drop", false, false, NONE, tableName -> {
             onTrino().executeQuery(format("CREATE TABLE %s (id BIGINT, old_name VARCHAR, age INT, state VARCHAR) WITH (format = 'PARQUET')", tableName));
             onTrino().executeQuery(format("INSERT INTO %s VALUES (111, 'Katy', 57, 'CA'), (222, 'Joe', 72, 'WA')", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(111, "Katy", 57, "CA"), row(222, "Joe", 72, "WA"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(111, "Katy", 57, "CA"), row(222, "Joe", 72, "WA"));
 
             onTrino().executeQuery(format("ALTER TABLE %s DROP COLUMN state", tableName));
             log.info("This shows that neither Trino nor Hive see the old data after a column is dropped");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(111, "Katy", 57), row(222, "Joe", 72));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(111, "Katy", 57), row(222, "Joe", 72));
 
             onTrino().executeQuery(format("INSERT INTO %s VALUES (333, 'Kelly', 45)", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(111, "Katy", 57), row(222, "Joe", 72), row(333, "Kelly", 45));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(111, "Katy", 57), row(222, "Joe", 72), row(333, "Kelly", 45));
 
             onTrino().executeQuery(format("ALTER TABLE %s ADD COLUMN state VARCHAR", tableName));
             log.info("This shows that for Parquet, Trino and Hive both see data inserted into a dropped column when a column of the same name and type is added");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(111, "Katy", 57, "CA"), row(222, "Joe", 72, "WA"), row(333, "Kelly", 45, null));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(111, "Katy", 57, "CA"), row(222, "Joe", 72, "WA"), row(333, "Kelly", 45, null));
 
             onTrino().executeQuery(format("ALTER TABLE %s DROP COLUMN state", tableName));
             onTrino().executeQuery(format("ALTER TABLE %s ADD COLUMN new_state VARCHAR", tableName));
 
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "TRUE", row(111, "Katy", 57, null), row(222, "Joe", 72, null), row(333, "Kelly", 45, null));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(111, "Katy", 57, null), row(222, "Joe", 72, null), row(333, "Kelly", 45, null));
         });
     }
 
@@ -1251,7 +1251,7 @@ public class TestHiveTransactionalTable
             onTrino().executeQuery(format("UPDATE %s SET col3 = 17 WHERE col3 = 7", tableName));
 
             log.info("Verify the update");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(17, "S1", 17));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(17, "S1", 17));
         });
     }
 
@@ -1268,7 +1268,7 @@ public class TestHiveTransactionalTable
             onTrino().executeQuery(format("UPDATE %s SET purchase = 'bread' WHERE customer = 'Fred'", tableName));
 
             log.info("Verifying update");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row("Fred", "bread"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row("Fred", "bread"));
         });
     }
 
@@ -1297,7 +1297,7 @@ public class TestHiveTransactionalTable
             log.info("About to update");
             onTrino().executeQuery(format("UPDATE %s SET col2 = 'DEUX', col3 = col3 + 20 + col1 + col5 WHERE col1 = 13", tableName));
             log.info("Finished update");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(7, "ONE", 1000, true, 101), row(13, "DEUX", 2235, false, 202));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(7, "ONE", 1000, true, 101), row(13, "DEUX", 2235, false, 202));
         });
     }
 
@@ -1311,7 +1311,7 @@ public class TestHiveTransactionalTable
             log.info("About to update %s", tableName);
             onTrino().executeQuery(format("UPDATE %s SET col2 = 'DEUX', col3 = col3 + 20 + col1 + col5 WHERE col1 = 13", tableName));
             log.info("Finished update");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(7, "ONE", 1000, true, 101), row(13, "DEUX", 2235, false, 202));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(7, "ONE", 1000, true, 101), row(13, "DEUX", 2235, false, 202));
         });
     }
 
@@ -1325,7 +1325,7 @@ public class TestHiveTransactionalTable
             log.info("About to update");
             onTrino().executeQuery(format("UPDATE %s SET col1 = col2 WHERE col1 = 13", tableName));
             log.info("Finished update");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(7, 15, "ONE"), row(17, 17, "DEUX"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(7, 15, "ONE"), row(17, 17, "DEUX"));
         });
     }
 
@@ -1339,11 +1339,11 @@ public class TestHiveTransactionalTable
             log.info("About to run first update");
             onTrino().executeQuery(format("UPDATE %s SET col2 = NULL, col3 = NULL WHERE col1 = 2", tableName));
             log.info("Finished first update");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, "ONE", 1000, true, 101), row(2, null, null, false, 202));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, "ONE", 1000, true, 101), row(2, null, null, false, 202));
             log.info("About to run second update");
             onTrino().executeQuery(format("UPDATE %s SET col1 = NULL, col2 = NULL, col3 = NULL, col4 = NULL WHERE col1 = 1", tableName));
             log.info("Finished first update");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(null, null, null, null, 101), row(2, null, null, false, 202));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(null, null, null, null, 101), row(2, null, null, false, 202));
         });
     }
 
@@ -1358,11 +1358,11 @@ public class TestHiveTransactionalTable
             // Use IF(RAND()<0, NULL) as a way to compute null
             onTrino().executeQuery(format("UPDATE %s SET col2 = IF(RAND()<0, NULL), col3 = IF(RAND()<0, NULL) WHERE col1 = 2", tableName));
             log.info("Finished first update");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, "ONE", 1000, true, 101), row(2, null, null, false, 202));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, "ONE", 1000, true, 101), row(2, null, null, false, 202));
             log.info("About to run second update");
             onTrino().executeQuery(format("UPDATE %s SET col1 = IF(RAND()<0, NULL), col2 = IF(RAND()<0, NULL), col3 = IF(RAND()<0, NULL), col4 = IF(RAND()<0, NULL) WHERE col1 = 1", tableName));
             log.info("Finished first update");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(null, null, null, null, 101), row(2, null, null, false, 202));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(null, null, null, null, 101), row(2, null, null, false, 202));
         });
     }
 
@@ -1376,7 +1376,7 @@ public class TestHiveTransactionalTable
             log.info("About to update");
             onTrino().executeQuery(format("UPDATE %s SET col1 = NULL, col2 = NULL, col3 = NULL, col4 = NULL, col5 = null WHERE col1 = 1", tableName));
             log.info("Finished first update");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(null, null, null, null, null), row(2, "TWO", 2000, false, 202));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(null, null, null, null, null), row(2, "TWO", 2000, false, 202));
         });
     }
 
@@ -1391,7 +1391,7 @@ public class TestHiveTransactionalTable
             // Use IF(RAND()<0, NULL) as a way to compute null
             onTrino().executeQuery(format("UPDATE %s SET col1 = IF(RAND()<0, NULL), col2 = IF(RAND()<0, NULL), col3 = IF(RAND()<0, NULL), col4 = IF(RAND()<0, NULL), col5 = IF(RAND()<0, NULL) WHERE col1 = 1", tableName));
             log.info("Finished first update");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(null, null, null, null, null), row(2, "TWO", 2000, false, 202));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(null, null, null, null, null), row(2, "TWO", 2000, false, 202));
         });
     }
 
@@ -1405,7 +1405,7 @@ public class TestHiveTransactionalTable
             log.info("About to update");
             onTrino().executeQuery(format("UPDATE %s SET col3 = col3 + 20 + col1 + col5, col1 = 3, col2 = 'DEUX' WHERE col1 = 2", tableName));
             log.info("Finished update");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, "ONE", 1000, true, 101), row(3, "DEUX", 2224, false, 202));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, "ONE", 1000, true, 101), row(3, "DEUX", 2224, false, 202));
         });
     }
 
@@ -1419,7 +1419,7 @@ public class TestHiveTransactionalTable
             log.info("About to update");
             onTrino().executeQuery(format("UPDATE %s SET col5 = 303, col1 = 3, col3 = col3 + 20 + col1 + col5, col4 = true, col2 = 'DUO' WHERE col1 = 2", tableName));
             log.info("Finished update");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, "ONE", 1000, true, 101), row(3, "DUO", 2224, true, 303));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, "ONE", 1000, true, 101), row(3, "DUO", 2224, true, 303));
         });
     }
 
@@ -1433,7 +1433,7 @@ public class TestHiveTransactionalTable
             log.info("About to update");
             onTrino().executeQuery(format("UPDATE %s SET col5 = col4, col1 = col3, col3 = col2, col4 = col5, col2 = col1 WHERE col1 = 21", tableName));
             log.info("Finished update");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, 2, 3, 4, 5), row(23, 21, 22, 25, 24));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, 2, 3, 4, 5), row(23, 21, 22, 25, 24));
         });
     }
 
@@ -1445,11 +1445,11 @@ public class TestHiveTransactionalTable
 
             log.info("About to insert");
             onTrino().executeQuery(format("INSERT INTO %s (col1, col2, col3) VALUES (13, 'T1', 3), (23, 'T2', 3), (17, 'S1', 7)", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "TRUE", row(13, "T1", 3), row(23, "T2", 3), row(17, "S1", 7));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(13, "T1", 3), row(23, "T2", 3), row(17, "S1", 7));
 
             log.info("About to update");
             onTrino().executeQuery(format("UPDATE %s SET col1 = col1 + 1 WHERE col3 = 3 AND col1 > 15", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "TRUE", row(13, "T1", 3), row(24, "T2", 3), row(17, "S1", 7));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(13, "T1", 3), row(24, "T2", 3), row(17, "S1", 7));
         });
     }
 
@@ -1461,11 +1461,11 @@ public class TestHiveTransactionalTable
 
             log.info("About to insert");
             onTrino().executeQuery(format("INSERT INTO %s (customer, purchase) VALUES ('Fred', 'cards'), ('Fred', 'limes'), ('Ann', 'lemons')", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "TRUE", row("Fred", "cards"), row("Fred", "limes"), row("Ann", "lemons"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row("Fred", "cards"), row("Fred", "limes"), row("Ann", "lemons"));
 
             log.info("About to update");
             onTrino().executeQuery(format("UPDATE %s SET purchase = 'bread' WHERE customer = 'Ann'", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "TRUE", row("Fred", "cards"), row("Fred", "limes"), row("Ann", "bread"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row("Fred", "cards"), row("Fred", "limes"), row("Ann", "bread"));
         });
     }
 
@@ -1476,17 +1476,17 @@ public class TestHiveTransactionalTable
             onTrino().executeQuery(format("CREATE TABLE %s (column1 INT, column2 BIGINT) WITH (transactional = true)", tableName));
             onTrino().executeQuery(format("INSERT INTO %s VALUES (11, 100)", tableName));
             onTrino().executeQuery(format("INSERT INTO %s VALUES (22, 200)", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(11, 100L), row(22, 200L));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(11, 100L), row(22, 200L));
             log.info("About to compact");
             compactTableAndWait(MAJOR, tableName, "", new Duration(6, MINUTES));
             log.info("About to update");
             onTrino().executeQuery(format("UPDATE %s SET column1 = 33 WHERE column2 = 200", tableName));
             log.info("About to select");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(11, 100L), row(33, 200L));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(11, 100L), row(33, 200L));
             onTrino().executeQuery(format("INSERT INTO %s VALUES (44, 400), (55, 500)", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(11, 100L), row(33, 200L), row(44, 400L), row(55, 500L));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(11, 100L), row(33, 200L), row(44, 400L), row(55, 500L));
             onTrino().executeQuery(format("DELETE FROM %s WHERE column2 IN (100, 500)", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(33, 200L), row(44, 400L));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(33, 200L), row(44, 400L));
         });
     }
 
@@ -1500,7 +1500,7 @@ public class TestHiveTransactionalTable
 
             // WHERE with uncorrelated subquery
             onTrino().executeQuery(format("UPDATE %s SET column2 = 'row updated' WHERE column1 = (SELECT min(regionkey) + 1 FROM tpch.tiny.region)", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, "row updated"), row(2, "y"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, "row updated"), row(2, "y"));
 
             withTemporaryTable("second_table", true, false, NONE, secondTable -> {
                 onTrino().executeQuery(format("CREATE TABLE %s (regionkey bigint, name varchar(25), comment varchar(152)) WITH (transactional = true)", secondTable));
@@ -1508,15 +1508,15 @@ public class TestHiveTransactionalTable
 
                 // UPDATE while reading from another transactional table. Multiple transactional could interfere with ConnectorMetadata.beginQuery
                 onTrino().executeQuery(format("UPDATE %s SET column2 = 'another row updated' WHERE column1 = (SELECT min(regionkey) + 2 FROM %s)", tableName, secondTable));
-                verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, "row updated"), row(2, "another row updated"));
+                verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, "row updated"), row(2, "another row updated"));
             });
 
             // WHERE with correlated subquery
             onTrino().executeQuery(format("UPDATE %s SET column2 = 'row updated yet again' WHERE column2 = (SELECT name FROM tpch.tiny.region WHERE regionkey = column1)", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, "row updated"), row(2, "another row updated"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, "row updated"), row(2, "another row updated"));
 
             onTrino().executeQuery(format("UPDATE %s SET column2 = 'row updated yet again' WHERE column2 != (SELECT name FROM tpch.tiny.region WHERE regionkey = column1)", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, "row updated yet again"), row(2, "row updated yet again"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, "row updated yet again"), row(2, "row updated yet again"));
         });
     }
 
@@ -1530,7 +1530,7 @@ public class TestHiveTransactionalTable
 
             // SET with uncorrelated subquery
             onTrino().executeQuery(format("UPDATE %s SET column2 = (SELECT max(name) FROM tpch.tiny.region)", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, "MIDDLE EAST"), row(2, "MIDDLE EAST"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, "MIDDLE EAST"), row(2, "MIDDLE EAST"));
 
             withTemporaryTable("second_table", true, false, NONE, secondTable -> {
                 onTrino().executeQuery(format("CREATE TABLE %s (regionkey bigint, name varchar(25), comment varchar(152)) WITH (transactional = true)", secondTable));
@@ -1538,15 +1538,15 @@ public class TestHiveTransactionalTable
 
                 // UPDATE while reading from another transactional table. Multiple transactional could interfere with ConnectorMetadata.beginQuery
                 onTrino().executeQuery(format("UPDATE %s SET column2 = (SELECT min(name) FROM %s)", tableName, secondTable));
-                verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, "AFRICA"), row(2, "AFRICA"));
+                verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, "AFRICA"), row(2, "AFRICA"));
 
                 onTrino().executeQuery(format("UPDATE %s SET column2 = (SELECT name FROM %s WHERE column1 = regionkey + 1)", tableName, secondTable));
-                verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, "AFRICA"), row(2, "AMERICA"));
+                verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, "AFRICA"), row(2, "AMERICA"));
             });
 
             // SET with correlated subquery
             onTrino().executeQuery(format("UPDATE %s SET column2 = (SELECT name FROM tpch.tiny.region WHERE column1 = regionkey)", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, "AMERICA"), row(2, "ASIA"));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, "AMERICA"), row(2, "ASIA"));
         });
     }
 
@@ -1620,31 +1620,31 @@ public class TestHiveTransactionalTable
 
             log.info("Performing first insert on Trino");
             onTrino().executeQuery(format("INSERT INTO %s (col1, col2, col3, col4, col5) VALUES (1, 2, 3, 4, 5), (21, 22, 23, 24, 25)", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "TRUE", row(1, 2, 3, 4, 5), row(21, 22, 23, 24, 25));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, 2, 3, 4, 5), row(21, 22, 23, 24, 25));
 
             log.info("Performing first update on Trino");
             onTrino().executeQuery(format("UPDATE %s SET col5 = col4, col1 = col3, col3 = col2, col4 = col5, col2 = col1 WHERE col1 = 21", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, 2, 3, 4, 5), row(23, 21, 22, 25, 24));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, 2, 3, 4, 5), row(23, 21, 22, 25, 24));
 
             log.info("Performing second insert on Hive");
             onHive().executeQuery(format("INSERT INTO %s (col1, col2, col3, col4, col5) VALUES (31, 32, 33, 34, 35)", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, 2, 3, 4, 5), row(23, 21, 22, 25, 24), row(31, 32, 33, 34, 35));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, 2, 3, 4, 5), row(23, 21, 22, 25, 24), row(31, 32, 33, 34, 35));
 
             log.info("Performing first delete on Trino");
             onTrino().executeQuery(format("DELETE FROM %s WHERE col1 = 23", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, 2, 3, 4, 5), row(31, 32, 33, 34, 35));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, 2, 3, 4, 5), row(31, 32, 33, 34, 35));
 
             log.info("Performing second update on Hive");
             onHive().executeQuery(format("UPDATE %s SET col5 = col4, col1 = col3, col3 = col2, col4 = col5, col2 = col1 WHERE col1 = 31", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, 2, 3, 4, 5), row(33, 31, 32, 35, 34));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, 2, 3, 4, 5), row(33, 31, 32, 35, 34));
 
             log.info("Performing more inserts on Trino");
             onTrino().executeQuery(format("INSERT INTO %s (col1, col2, col3, col4, col5) VALUES (41, 42, 43, 44, 45), (51, 52, 53, 54, 55)", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "TRUE", row(1, 2, 3, 4, 5), row(33, 31, 32, 35, 34), row(41, 42, 43, 44, 45), row(51, 52, 53, 54, 55));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(1, 2, 3, 4, 5), row(33, 31, 32, 35, 34), row(41, 42, 43, 44, 45), row(51, 52, 53, 54, 55));
 
             log.info("Performing second delete on Hive");
             onHive().executeQuery(format("DELETE FROM %s WHERE col5 = 5", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "TRUE", row(33, 31, 32, 35, 34), row(41, 42, 43, 44, 45), row(51, 52, 53, 54, 55));
+            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(33, 31, 32, 35, 34), row(41, 42, 43, 44, 45), row(51, 52, 53, 54, 55));
         });
     }
 
@@ -1655,11 +1655,11 @@ public class TestHiveTransactionalTable
             onTrino().executeQuery(format("CREATE TABLE %s WITH (transactional = true, partitioned_by = ARRAY['regionkey'])" +
                     " AS SELECT nationkey, name, regionkey FROM tpch.tiny.nation", tableName));
             verifyOriginalFiles(tableName, "WHERE regionkey = 4");
-            verifySelectForTrinoAndHive("SELECT count(*) FROM " + tableName, "true", row(25));
-            verifySelectForTrinoAndHive(format("SELECT nationkey, name FROM %s", tableName), "regionkey = 4", row(4, "EGYPT"), row(10, "IRAN"), row(11, "IRAQ"), row(13, "JORDAN"), row(20, "SAUDI ARABIA"));
+            verifySelectForTrinoAndHive("SELECT count(*) FROM " + tableName, row(25));
+            verifySelectForTrinoAndHive(format("SELECT nationkey, name FROM %s WHERE regionkey = 4", tableName), row(4, "EGYPT"), row(10, "IRAN"), row(11, "IRAQ"), row(13, "JORDAN"), row(20, "SAUDI ARABIA"));
             onTrino().executeQuery(format("DELETE FROM %s WHERE regionkey = 4 AND nationkey %% 10 = 3", tableName));
-            verifySelectForTrinoAndHive("SELECT count(*) FROM " + tableName, "true", row(24));
-            verifySelectForTrinoAndHive(format("SELECT nationkey, name FROM %s", tableName), "regionkey = 4", row(4, "EGYPT"), row(10, "IRAN"), row(11, "IRAQ"), row(20, "SAUDI ARABIA"));
+            verifySelectForTrinoAndHive("SELECT count(*) FROM " + tableName, row(24));
+            verifySelectForTrinoAndHive(format("SELECT nationkey, name FROM %s WHERE regionkey = 4", tableName), row(4, "EGYPT"), row(10, "IRAN"), row(11, "IRAQ"), row(20, "SAUDI ARABIA"));
         });
     }
 
@@ -1692,7 +1692,7 @@ public class TestHiveTransactionalTable
                 onTrino().executeQuery(format("INSERT INTO %s SELECT nationkey, name, regionkey FROM tpch.tiny.nation", tableName));
             }
 
-            verifySelectForTrinoAndHive("SELECT count(*) FROM " + tableName, "true", row(25));
+            verifySelectForTrinoAndHive("SELECT count(*) FROM " + tableName, row(25));
 
             // verify all partitions exist
             assertThat(onTrino().executeQuery(format("SELECT * FROM \"%s$partitions\"", tableName)))
@@ -1700,7 +1700,7 @@ public class TestHiveTransactionalTable
 
             // run delete and verify row count
             onTrino().executeQuery(format("DELETE FROM %s WHERE regionkey = 4", tableName));
-            verifySelectForTrinoAndHive("SELECT count(*) FROM " + tableName, "true", row(20));
+            verifySelectForTrinoAndHive("SELECT count(*) FROM " + tableName, row(20));
 
             // verify all partitions still exist
             assertThat(onTrino().executeQuery(format("SELECT * FROM \"%s$partitions\"", tableName)))
@@ -1715,9 +1715,9 @@ public class TestHiveTransactionalTable
             onTrino().executeQuery(format("CREATE TABLE %s WITH (transactional = true, partitioned_by = ARRAY['regionkey'])" +
                     " AS SELECT nationkey, name, regionkey FROM tpch.tiny.nation", tableName));
             verifyOriginalFiles(tableName, "WHERE regionkey = 4");
-            verifySelectForTrinoAndHive("SELECT nationkey, name FROM " + tableName, "regionkey = 4", row(4, "EGYPT"), row(10, "IRAN"), row(11, "IRAQ"), row(13, "JORDAN"), row(20, "SAUDI ARABIA"));
+            verifySelectForTrinoAndHive("SELECT nationkey, name FROM %s WHERE regionkey = 4".formatted(tableName), row(4, "EGYPT"), row(10, "IRAN"), row(11, "IRAQ"), row(13, "JORDAN"), row(20, "SAUDI ARABIA"));
             onTrino().executeQuery(format("UPDATE %s SET nationkey = 100 WHERE regionkey = 4 AND nationkey %% 10 = 3", tableName));
-            verifySelectForTrinoAndHive("SELECT nationkey, name FROM " + tableName, "regionkey = 4", row(4, "EGYPT"), row(10, "IRAN"), row(11, "IRAQ"), row(100, "JORDAN"), row(20, "SAUDI ARABIA"));
+            verifySelectForTrinoAndHive("SELECT nationkey, name FROM %s WHERE regionkey = 4".formatted(tableName), row(4, "EGYPT"), row(10, "IRAN"), row(11, "IRAQ"), row(100, "JORDAN"), row(20, "SAUDI ARABIA"));
         });
     }
 
@@ -1728,9 +1728,9 @@ public class TestHiveTransactionalTable
             onTrino().executeQuery(format("CREATE TABLE %s WITH (transactional = true)" +
                     " AS SELECT nationkey, name, regionkey FROM tpch.tiny.nation", tableName));
             verifyOriginalFiles(tableName, "WHERE regionkey = 4");
-            verifySelectForTrinoAndHive("SELECT nationkey, name, regionkey FROM " + tableName, "nationkey % 10 = 3", row(3, "CANADA", 1), row(13, "JORDAN", 4), row(23, "UNITED KINGDOM", 3));
+            verifySelectForTrinoAndHive("SELECT nationkey, name, regionkey FROM %s WHERE nationkey %% 10 = 3".formatted(tableName), row(3, "CANADA", 1), row(13, "JORDAN", 4), row(23, "UNITED KINGDOM", 3));
             onTrino().executeQuery(format("UPDATE %s SET nationkey = nationkey + 100 WHERE nationkey %% 10 = 3", tableName));
-            verifySelectForTrinoAndHive("SELECT nationkey, name, regionkey FROM " + tableName, "nationkey % 10 = 3", row(103, "CANADA", 1), row(113, "JORDAN", 4), row(123, "UNITED KINGDOM", 3));
+            verifySelectForTrinoAndHive("SELECT nationkey, name, regionkey FROM %s WHERE nationkey %% 10 = 3".formatted(tableName), row(103, "CANADA", 1), row(113, "JORDAN", 4), row(123, "UNITED KINGDOM", 3));
         });
     }
 
@@ -1892,7 +1892,7 @@ public class TestHiveTransactionalTable
             onTrino().executeQuery("INSERT INTO test_double_update VALUES(2, 'y')");
             onTrino().executeQuery("UPDATE test_double_update SET column2 = 'xy1'");
             onTrino().executeQuery("UPDATE test_double_update SET column2 = 'xy2'");
-            verifySelectForTrinoAndHive("SELECT * FROM test_double_update", "true", row(1, "xy2"), row(2, "xy2"));
+            verifySelectForTrinoAndHive("SELECT * FROM test_double_update", row(1, "xy2"), row(2, "xy2"));
         });
     }
 
@@ -1913,7 +1913,7 @@ public class TestHiveTransactionalTable
             validateFileIsDirectlyUnderTableLocation(tableName);
 
             onTrino().executeQuery(format("DELETE FROM %s", tableName));
-            verifySelectForTrinoAndHive(format("SELECT COUNT(*) FROM %s", tableName), "TRUE", row(0));
+            verifySelectForTrinoAndHive(format("SELECT COUNT(*) FROM %s", tableName), row(0));
         });
     }
 
@@ -1961,7 +1961,7 @@ public class TestHiveTransactionalTable
             onTrino().executeQuery(format("CREATE TABLE %s WITH (transactional = true) AS SELECT * FROM tpch.tiny.nation", tableName));
             compactTableAndWait(MAJOR, tableName, "", new Duration(3, MINUTES));
             onTrino().executeQuery(format("DELETE FROM %s", tableName));
-            verifySelectForTrinoAndHive(format("SELECT COUNT(*) FROM %s", tableName), "true", row(0));
+            verifySelectForTrinoAndHive(format("SELECT COUNT(*) FROM %s", tableName), row(0));
         });
     }
 
@@ -2219,17 +2219,15 @@ public class TestHiveTransactionalTable
         }
     }
 
-    public static void verifySelectForTrinoAndHive(String select, String whereClause, Row... rows)
+    public static void verifySelectForTrinoAndHive(String select, Row... rows)
     {
-        verifySelect("onTrino", onTrino(), select, whereClause, rows);
-        verifySelect("onHive", onHive(), select, whereClause, rows);
+        verifySelect("onTrino", onTrino(), select, rows);
+        verifySelect("onHive", onHive(), select, rows);
     }
 
-    public static void verifySelect(String name, QueryExecutor executor, String select, String whereClause, Row... rows)
+    public static void verifySelect(String name, QueryExecutor executor, String select, Row... rows)
     {
-        String fullQuery = format("%s WHERE %s", select, whereClause);
-
-        assertThat(executor.executeQuery(fullQuery))
+        assertThat(executor.executeQuery(select))
                 .describedAs(name)
                 .containsOnly(rows);
     }


### PR DESCRIPTION
Before this commit, TestHiveTransactionalTable.verifySelectForTrinoAndHive accepted separate string arguments for the SELECT portion of the query and the WHERE clause.  In practice this convention was confusing.

This commit removes the extra argument to verifySelectForTrinoAndHive specifying the WHERE clause, updating the SELECT strings to include the WHERE clause.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
