### PR TITLE
Add fast implemention to parse date in format yyyy-MM-dd

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
@@ -379,7 +379,8 @@ public final class DateTimeFunctions
             try {
                 int days = DateTimeUtils.parseDate(dateTime.toStringUtf8());
                 return scaleEpochMillisToMicros(days * MILLIS_PER_DAY);
-            } catch (DateTimeException e) {
+            }
+            catch (DateTimeException e) {
                 throw new TrinoException(INVALID_FUNCTION_ARGUMENT, e);
             }
         }

--- a/core/trino-main/src/main/java/io/trino/type/DateOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/DateOperators.java
@@ -22,6 +22,8 @@ import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
 
+import java.time.DateTimeException;
+
 import static io.airlift.slice.SliceUtf8.trim;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
@@ -60,7 +62,7 @@ public final class DateOperators
         try {
             return parseDate(trim(value).toStringUtf8());
         }
-        catch (IllegalArgumentException | ArithmeticException e) {
+        catch (IllegalArgumentException | ArithmeticException | DateTimeException e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to date: " + value.toStringUtf8(), e);
         }
     }

--- a/core/trino-main/src/test/java/io/trino/util/TestDateTimeUtils.java
+++ b/core/trino-main/src/test/java/io/trino/util/TestDateTimeUtils.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.util;
+
+import org.testng.annotations.Test;
+
+import java.time.DateTimeException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
+
+public class TestDateTimeUtils
+{
+    @Test
+    public void testTryParseDateYyyyMmDd()
+    {
+        // valid dates
+        int days = DateTimeUtils.tryParseDateYyyyMmDd("1970-01-01");
+        assertEquals(0, days);
+        days = DateTimeUtils.tryParseDateYyyyMmDd("1970-02-01");
+        assertEquals(31, days);
+        days = DateTimeUtils.tryParseDateYyyyMmDd("1969-12-01");
+        assertEquals(-31, days);
+
+        // format invalid
+        days = DateTimeUtils.tryParseDateYyyyMmDd("1970-2-01");
+        assertEquals(Integer.MIN_VALUE, days);
+        days = DateTimeUtils.tryParseDateYyyyMmDd("1970-02-1");
+        assertEquals(Integer.MIN_VALUE, days);
+        days = DateTimeUtils.tryParseDateYyyyMmDd("1970/02/01");
+        assertEquals(Integer.MIN_VALUE, days);
+        days = DateTimeUtils.tryParseDateYyyyMmDd("Dec 24 2022");
+        assertEquals(Integer.MIN_VALUE, days);
+
+        // format ok, but illegal value
+        assertThatThrownBy(() -> DateTimeUtils.tryParseDateYyyyMmDd("2022-02-29"))
+                .isInstanceOf(DateTimeException.class)
+                .hasMessage("Invalid date 'February 29' as '2022' is not a leap year");
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



## Additional context and related issues
Parse a date string is kind of slow, since most of the time people work with date in format yyyy-MM-dd, we can implement a fast  parser for this widely used format.
The following functions are impacted:
date(<str>)
cast(<str> as date)
date_parse(<str>, '%Y-%m-%D')



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`15229`)
```
