### PR TITLE
Remove deprecated randomTableSuffix use randomNameSuffix instead

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
@@ -35,7 +35,7 @@ import static io.trino.plugin.iceberg.catalog.rest.IcebergRestCatalogConfig.Sess
 import static io.trino.plugin.iceberg.catalog.rest.RestCatalogTestUtils.backendCatalog;
 import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
 import static io.trino.testing.TestingConnectorSession.SESSION;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -72,7 +72,7 @@ public class TestTrinoRestCatalog
     {
         TrinoCatalog catalog = createTrinoCatalog(false);
 
-        String namespace = "testNonLowercaseNamespace" + randomTableSuffix();
+        String namespace = "testNonLowercaseNamespace" + randomNameSuffix();
         String schema = namespace.toLowerCase(ENGLISH);
 
         catalog.createNamespace(SESSION, namespace, defaultNamespaceProperties(namespace), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/BaseKuduConnectorSmokeTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/BaseKuduConnectorSmokeTest.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 import static io.trino.plugin.kudu.KuduQueryRunnerFactory.createKuduQueryRunnerTpch;
 import static io.trino.plugin.kudu.TestKuduConnectorTest.REGION_COLUMNS;
 import static io.trino.plugin.kudu.TestKuduConnectorTest.createKuduTableForWrites;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class BaseKuduConnectorSmokeTest
@@ -115,7 +115,7 @@ public abstract class BaseKuduConnectorSmokeTest
     @Override
     public void testDeleteAllDataFromTable()
     {
-        String tableName = "test_delete_all_data_" + randomTableSuffix();
+        String tableName = "test_delete_all_data_" + randomNameSuffix();
         assertUpdate(createKuduTableForWrites("CREATE TABLE %s %s".formatted(tableName, REGION_COLUMNS)));
         assertUpdate("INSERT INTO %s SELECT * FROM region".formatted(tableName), 5);
 
@@ -128,7 +128,7 @@ public abstract class BaseKuduConnectorSmokeTest
     @Override
     public void testRowLevelDelete()
     {
-        String tableName = "test_row_delete_" + randomTableSuffix();
+        String tableName = "test_row_delete_" + randomNameSuffix();
         assertUpdate(createKuduTableForWrites("CREATE TABLE %s %s".formatted(tableName, REGION_COLUMNS)));
         assertUpdate("INSERT INTO %s SELECT * FROM region".formatted(tableName), 5);
 
@@ -145,7 +145,7 @@ public abstract class BaseKuduConnectorSmokeTest
     @Override
     public void testUpdate()
     {
-        String tableName = "test_update_" + randomTableSuffix();
+        String tableName = "test_update_" + randomNameSuffix();
         assertUpdate("CREATE TABLE %s %s".formatted(tableName, getCreateTableDefaultDefinition()));
         assertUpdate("INSERT INTO " + tableName + " (a, b) SELECT regionkey, regionkey * 2.5 FROM region", "SELECT count(*) FROM region");
         assertThat(query("SELECT a, b FROM " + tableName))

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/delta/TestDeltaFaultTolerantExecutionTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/delta/TestDeltaFaultTolerantExecutionTest.java
@@ -25,7 +25,7 @@ import io.trino.testing.QueryRunner;
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.createS3DeltaLakeQueryRunner;
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -33,7 +33,7 @@ public class TestDeltaFaultTolerantExecutionTest
         extends BaseFaultTolerantExecutionTest
 {
     private static final String SCHEMA = "fte_preferred_write_partitioning";
-    private static final String BUCKET_NAME = "test-fte-preferred-write-partitioning-" + randomTableSuffix();
+    private static final String BUCKET_NAME = "test-fte-preferred-write-partitioning-" + randomNameSuffix();
 
     public TestDeltaFaultTolerantExecutionTest()
     {

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveFaultTolerantExecutionTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveFaultTolerantExecutionTest.java
@@ -22,7 +22,7 @@ import io.trino.testing.FaultTolerantExecutionConnectorTestHelper;
 import io.trino.testing.QueryRunner;
 
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 
 public class TestHiveFaultTolerantExecutionTest
         extends BaseFaultTolerantExecutionTest
@@ -36,7 +36,7 @@ public class TestHiveFaultTolerantExecutionTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        MinioStorage minioStorage = closeAfterClass(new MinioStorage("test-exchange-spooling-" + randomTableSuffix()));
+        MinioStorage minioStorage = closeAfterClass(new MinioStorage("test-exchange-spooling-" + randomNameSuffix()));
         minioStorage.start();
 
         return HiveQueryRunner.builder()

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/iceberg/TestIcebergFaultTolerantExecutionTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/iceberg/TestIcebergFaultTolerantExecutionTest.java
@@ -21,7 +21,7 @@ import io.trino.testing.FaultTolerantExecutionConnectorTestHelper;
 import io.trino.testing.QueryRunner;
 
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
-import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestIcebergFaultTolerantExecutionTest
@@ -36,7 +36,7 @@ public class TestIcebergFaultTolerantExecutionTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        MinioStorage minioStorage = closeAfterClass(new MinioStorage("test-exchange-spooling-" + randomTableSuffix()));
+        MinioStorage minioStorage = closeAfterClass(new MinioStorage("test-exchange-spooling-" + randomNameSuffix()));
         minioStorage.start();
 
         return IcebergQueryRunner.builder()

--- a/testing/trino-testing/src/main/java/io/trino/testing/sql/TestTable.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/sql/TestTable.java
@@ -47,7 +47,7 @@ public class TestTable
     public TestTable(SqlExecutor sqlExecutor, String namePrefix)
     {
         this.sqlExecutor = sqlExecutor;
-        this.name = namePrefix + randomTableSuffix();
+        this.name = namePrefix + randomNameSuffix();
         this.tableDefinition = null;
     }
 
@@ -128,11 +128,5 @@ public class TestTable
     public void close()
     {
         sqlExecutor.execute("DROP TABLE " + name);
-    }
-
-    @Deprecated
-    public static String randomTableSuffix()
-    {
-        return randomNameSuffix();
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Remove deprecated randomTableSuffix use randomNameSuffix instead

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
