### PR TITLE
Avoid reading data in parquet ChunkedInputStream constructor

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/AbstractParquetDataSource.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/AbstractParquetDataSource.java
@@ -326,9 +326,9 @@ public abstract class AbstractParquetDataSource
 
             if (data == null) {
                 byte[] buffer = new byte[toIntExact(range.getLength())];
+                readerMemoryUsage.setBytes(buffer.length);
                 readFully(range.getOffset(), buffer, 0, buffer.length);
                 data = Slices.wrappedBuffer(buffer);
-                readerMemoryUsage.setBytes(data.length());
             }
 
             return data;

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetDataSource.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetDataSource.java
@@ -16,9 +16,11 @@ package io.trino.parquet;
 import com.google.common.collect.ListMultimap;
 import io.airlift.slice.Slice;
 import io.trino.memory.context.AggregatedMemoryContext;
+import io.trino.parquet.reader.ChunkedInputStream;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Map;
 
 public interface ParquetDataSource
         extends Closeable
@@ -37,7 +39,7 @@ public interface ParquetDataSource
     Slice readFully(long position, int length)
             throws IOException;
 
-    <K> ListMultimap<K, ChunkReader> planRead(ListMultimap<K, DiskRange> diskRanges, AggregatedMemoryContext memoryContext);
+    <K> Map<K, ChunkedInputStream> planRead(ListMultimap<K, DiskRange> diskRanges, AggregatedMemoryContext memoryContext);
 
     @Override
     default void close()

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
@@ -69,7 +69,6 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.parquet.ParquetValidationUtils.validateParquet;
 import static io.trino.parquet.ParquetWriteValidation.StatisticsValidation;
@@ -236,8 +235,7 @@ public class ParquetReader
             }
         }
         this.codecMetrics = ImmutableMap.copyOf(codecMetrics);
-        this.chunkReaders = dataSource.planRead(ranges, memoryContext).asMap().entrySet().stream()
-                .collect(toImmutableMap(Map.Entry::getKey, entry -> new ChunkedInputStream(entry.getValue())));
+        this.chunkReaders = dataSource.planRead(ranges, memoryContext);
     }
 
     @Override

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/TrinoColumnIndexStore.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/TrinoColumnIndexStore.java
@@ -16,8 +16,6 @@ package io.trino.parquet.reader;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
-import com.google.common.collect.Multimap;
-import io.trino.parquet.ChunkReader;
 import io.trino.parquet.DiskRange;
 import io.trino.parquet.ParquetDataSource;
 import org.apache.parquet.format.Util;
@@ -143,9 +141,7 @@ public class TrinoColumnIndexStore
             ranges.put(column.getPath(), column.getDiskRange());
         }
 
-        Multimap<ColumnPath, ChunkReader> chunkReaders = dataSource.planRead(ranges, newSimpleAggregatedMemoryContext());
-        Map<ColumnPath, ChunkedInputStream> columnInputStreams = chunkReaders.asMap().entrySet().stream()
-                .collect(toImmutableMap(Map.Entry::getKey, entry -> new ChunkedInputStream(entry.getValue())));
+        Map<ColumnPath, ChunkedInputStream> columnInputStreams = dataSource.planRead(ranges, newSimpleAggregatedMemoryContext());
         try {
             return indexMetadata.stream()
                     .collect(toImmutableMap(

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestChunkedInputStream.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestChunkedInputStream.java
@@ -81,13 +81,12 @@ public class TestChunkedInputStream
 
         // verify available
         ChunkedInputStream availableInput = input(slices);
-        assertEquals(availableInput.available(), chunks.get(0).length);
-        availableInput.skipNBytes(chunks.get(0).length);
+        // nothing is read initially
         assertEquals(availableInput.available(), 0);
-        if (chunks.size() > 1) {
+        for (byte[] chunk : chunks) {
             availableInput.read();
-            assertEquals(availableInput.available(), chunks.get(1).length - 1);
-            availableInput.skipNBytes(chunks.get(1).length - 1);
+            assertEquals(availableInput.available(), chunk.length - 1);
+            availableInput.skipNBytes(chunk.length - 1);
             assertEquals(availableInput.available(), 0);
         }
     }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetDataSource.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetDataSource.java
@@ -45,7 +45,7 @@ public class TestParquetDataSource
                 testingInput,
                 new ParquetReaderOptions().withMaxBufferSize(maxBufferSize));
 
-        ListMultimap<String, ChunkReader> chunkReaders = dataSource.planRead(
+        ListMultimap<String, ChunkReader> chunkReaders = dataSource.planChunksRead(
                 ImmutableListMultimap.<String, DiskRange>builder()
                         .putAll("test", new DiskRange(0, 200), new DiskRange(400, 100), new DiskRange(700, 200))
                         .build(),
@@ -76,7 +76,7 @@ public class TestParquetDataSource
                 testingInput,
                 new ParquetReaderOptions().withMaxBufferSize(DataSize.ofBytes(500)));
         AggregatedMemoryContext memoryContext = newSimpleAggregatedMemoryContext();
-        ListMultimap<String, ChunkReader> chunkReaders = dataSource.planRead(ImmutableListMultimap.<String, DiskRange>builder()
+        ListMultimap<String, ChunkReader> chunkReaders = dataSource.planChunksRead(ImmutableListMultimap.<String, DiskRange>builder()
                         .put("1", new DiskRange(0, 200))
                         .put("2", new DiskRange(400, 100))
                         .put("3", new DiskRange(700, 200))


### PR DESCRIPTION
## Description

Avoid reading data in parquet ChunkedInputStream constructor

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes a perf regression in lazy reading of data from https://github.com/trinodb/trino/pull/15374

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Hudi, Iceberg, Delta
* Fixes a bug which could lead to more data than necessary getting read from parquet files for queries with filters. ({issue}`15552`)
```
