### PR TITLE
Account for memory usage of parquet column readers

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
@@ -13,6 +13,8 @@
  */
 package io.trino.parquet.reader;
 
+import io.trino.memory.context.AggregatedMemoryContext;
+import io.trino.memory.context.LocalMemoryContext;
 import io.trino.parquet.PrimitiveField;
 import io.trino.parquet.reader.decoders.TransformingValueDecoders;
 import io.trino.parquet.reader.decoders.ValueDecoders;
@@ -78,81 +80,84 @@ public final class ColumnReaderFactory
 {
     private ColumnReaderFactory() {}
 
-    public static ColumnReader create(PrimitiveField field, DateTimeZone timeZone, boolean useBatchedColumnReaders)
+    public static ColumnReader create(PrimitiveField field, DateTimeZone timeZone, AggregatedMemoryContext aggregatedMemoryContext, boolean useBatchedColumnReaders)
     {
         Type type = field.getType();
         PrimitiveTypeName primitiveType = field.getDescriptor().getPrimitiveType().getPrimitiveTypeName();
         LogicalTypeAnnotation annotation = field.getDescriptor().getPrimitiveType().getLogicalTypeAnnotation();
+        LocalMemoryContext memoryContext = aggregatedMemoryContext.newLocalMemoryContext(ColumnReader.class.getSimpleName());
         if (useBatchedColumnReaders && field.getDescriptor().getPath().length == 1) {
             if (BOOLEAN.equals(type) && primitiveType == PrimitiveTypeName.BOOLEAN) {
-                return new FlatColumnReader<>(field, ValueDecoders::getBooleanDecoder, BOOLEAN_ADAPTER);
+                return new FlatColumnReader<>(field, ValueDecoders::getBooleanDecoder, BOOLEAN_ADAPTER, memoryContext);
             }
             if (TINYINT.equals(type) && primitiveType == INT32) {
                 if (isIntegerAnnotation(annotation)) {
-                    return new FlatColumnReader<>(field, ValueDecoders::getByteDecoder, BYTE_ADAPTER);
+                    return new FlatColumnReader<>(field, ValueDecoders::getByteDecoder, BYTE_ADAPTER, memoryContext);
                 }
                 throw unsupportedException(type, field);
             }
             if (SMALLINT.equals(type) && primitiveType == INT32) {
                 if (isIntegerAnnotation(annotation)) {
-                    return new FlatColumnReader<>(field, ValueDecoders::getShortDecoder, SHORT_ADAPTER);
+                    return new FlatColumnReader<>(field, ValueDecoders::getShortDecoder, SHORT_ADAPTER, memoryContext);
                 }
                 throw unsupportedException(type, field);
             }
             if (DATE.equals(type) && primitiveType == INT32) {
                 if (annotation == null || annotation instanceof DateLogicalTypeAnnotation) {
-                    return new FlatColumnReader<>(field, ValueDecoders::getIntDecoder, INT_ADAPTER);
+                    return new FlatColumnReader<>(field, ValueDecoders::getIntDecoder, INT_ADAPTER, memoryContext);
                 }
                 throw unsupportedException(type, field);
             }
             if (type instanceof AbstractIntType && primitiveType == INT32) {
                 if (isIntegerAnnotation(annotation)) {
-                    return new FlatColumnReader<>(field, ValueDecoders::getIntDecoder, INT_ADAPTER);
+                    return new FlatColumnReader<>(field, ValueDecoders::getIntDecoder, INT_ADAPTER, memoryContext);
                 }
                 throw unsupportedException(type, field);
             }
             if (type instanceof AbstractLongType && primitiveType == INT32) {
                 if (isIntegerAnnotation(annotation)) {
-                    return new FlatColumnReader<>(field, ValueDecoders::getIntToLongDecoder, LONG_ADAPTER);
+                    return new FlatColumnReader<>(field, ValueDecoders::getIntToLongDecoder, LONG_ADAPTER, memoryContext);
                 }
                 throw unsupportedException(type, field);
             }
             if (type instanceof TimeType && primitiveType == INT64) {
                 if (annotation instanceof TimeLogicalTypeAnnotation timeAnnotation && timeAnnotation.getUnit() == MICROS) {
-                    return new FlatColumnReader<>(field, TransformingValueDecoders::getTimeMicrosDecoder, LONG_ADAPTER);
+                    return new FlatColumnReader<>(field, TransformingValueDecoders::getTimeMicrosDecoder, LONG_ADAPTER, memoryContext);
                 }
                 throw unsupportedException(type, field);
             }
             if (type instanceof AbstractLongType && primitiveType == INT64) {
                 if (BIGINT.equals(type) && annotation instanceof TimestampLogicalTypeAnnotation) {
-                    return new FlatColumnReader<>(field, ValueDecoders::getLongDecoder, LONG_ADAPTER);
+                    return new FlatColumnReader<>(field, ValueDecoders::getLongDecoder, LONG_ADAPTER, memoryContext);
                 }
                 if (isIntegerAnnotation(annotation)) {
-                    return new FlatColumnReader<>(field, ValueDecoders::getLongDecoder, LONG_ADAPTER);
+                    return new FlatColumnReader<>(field, ValueDecoders::getLongDecoder, LONG_ADAPTER, memoryContext);
                 }
                 throw unsupportedException(type, field);
             }
             if (REAL.equals(type) && primitiveType == FLOAT) {
-                return new FlatColumnReader<>(field, ValueDecoders::getRealDecoder, INT_ADAPTER);
+                return new FlatColumnReader<>(field, ValueDecoders::getRealDecoder, INT_ADAPTER, memoryContext);
             }
             if (DOUBLE.equals(type) && primitiveType == PrimitiveTypeName.DOUBLE) {
-                return new FlatColumnReader<>(field, ValueDecoders::getDoubleDecoder, LONG_ADAPTER);
+                return new FlatColumnReader<>(field, ValueDecoders::getDoubleDecoder, LONG_ADAPTER, memoryContext);
             }
             if (type instanceof TimestampType timestampType && primitiveType == INT96) {
                 if (timestampType.isShort()) {
                     return new FlatColumnReader<>(
                             field,
                             (encoding, primitiveField) -> getInt96ToShortTimestampDecoder(encoding, primitiveField, timeZone),
-                            LONG_ADAPTER);
+                            LONG_ADAPTER,
+                            memoryContext);
                 }
                 return new FlatColumnReader<>(
                         field,
                         (encoding, primitiveField) -> getInt96ToLongTimestampDecoder(encoding, primitiveField, timeZone),
-                        INT96_ADAPTER);
+                        INT96_ADAPTER,
+                        memoryContext);
             }
             if (type instanceof TimestampWithTimeZoneType timestampWithTimeZoneType && primitiveType == INT96) {
                 if (timestampWithTimeZoneType.isShort()) {
-                    return new FlatColumnReader<>(field, TransformingValueDecoders::getInt96ToShortTimestampWithTimeZoneDecoder, LONG_ADAPTER);
+                    return new FlatColumnReader<>(field, TransformingValueDecoders::getInt96ToShortTimestampWithTimeZoneDecoder, LONG_ADAPTER, memoryContext);
                 }
                 throw unsupportedException(type, field);
             }
@@ -162,15 +167,15 @@ public final class ColumnReaderFactory
                 }
                 if (timestampType.isShort()) {
                     return switch (timestampAnnotation.getUnit()) {
-                        case MILLIS -> new FlatColumnReader<>(field, TransformingValueDecoders::getInt64TimestampMillsToShortTimestampDecoder, LONG_ADAPTER);
-                        case MICROS -> new FlatColumnReader<>(field, TransformingValueDecoders::getInt64TimestampMicrosToShortTimestampDecoder, LONG_ADAPTER);
-                        case NANOS -> new FlatColumnReader<>(field, TransformingValueDecoders::getInt64TimestampNanosToShortTimestampDecoder, LONG_ADAPTER);
+                        case MILLIS -> new FlatColumnReader<>(field, TransformingValueDecoders::getInt64TimestampMillsToShortTimestampDecoder, LONG_ADAPTER, memoryContext);
+                        case MICROS -> new FlatColumnReader<>(field, TransformingValueDecoders::getInt64TimestampMicrosToShortTimestampDecoder, LONG_ADAPTER, memoryContext);
+                        case NANOS -> new FlatColumnReader<>(field, TransformingValueDecoders::getInt64TimestampNanosToShortTimestampDecoder, LONG_ADAPTER, memoryContext);
                     };
                 }
                 return switch (timestampAnnotation.getUnit()) {
-                    case MILLIS -> new FlatColumnReader<>(field, TransformingValueDecoders::getInt64TimestampMillisToLongTimestampDecoder, INT96_ADAPTER);
-                    case MICROS -> new FlatColumnReader<>(field, TransformingValueDecoders::getInt64TimestampMicrosToLongTimestampDecoder, INT96_ADAPTER);
-                    case NANOS -> new FlatColumnReader<>(field, TransformingValueDecoders::getInt64TimestampNanosToLongTimestampDecoder, INT96_ADAPTER);
+                    case MILLIS -> new FlatColumnReader<>(field, TransformingValueDecoders::getInt64TimestampMillisToLongTimestampDecoder, INT96_ADAPTER, memoryContext);
+                    case MICROS -> new FlatColumnReader<>(field, TransformingValueDecoders::getInt64TimestampMicrosToLongTimestampDecoder, INT96_ADAPTER, memoryContext);
+                    case NANOS -> new FlatColumnReader<>(field, TransformingValueDecoders::getInt64TimestampNanosToLongTimestampDecoder, INT96_ADAPTER, memoryContext);
                 };
             }
             if (type instanceof TimestampWithTimeZoneType timestampWithTimeZoneType && primitiveType == INT64) {
@@ -179,42 +184,42 @@ public final class ColumnReaderFactory
                 }
                 if (timestampWithTimeZoneType.isShort()) {
                     return switch (timestampAnnotation.getUnit()) {
-                        case MILLIS -> new FlatColumnReader<>(field, TransformingValueDecoders::getInt64TimestampMillsToShortTimestampWithTimeZoneDecoder, LONG_ADAPTER);
-                        case MICROS -> new FlatColumnReader<>(field, TransformingValueDecoders::getInt64TimestampMicrosToShortTimestampWithTimeZoneDecoder, LONG_ADAPTER);
+                        case MILLIS -> new FlatColumnReader<>(field, TransformingValueDecoders::getInt64TimestampMillsToShortTimestampWithTimeZoneDecoder, LONG_ADAPTER, memoryContext);
+                        case MICROS -> new FlatColumnReader<>(field, TransformingValueDecoders::getInt64TimestampMicrosToShortTimestampWithTimeZoneDecoder, LONG_ADAPTER, memoryContext);
                         case NANOS -> throw unsupportedException(type, field);
                     };
                 }
                 return switch (timestampAnnotation.getUnit()) {
                     case MILLIS, NANOS -> throw unsupportedException(type, field);
-                    case MICROS -> new FlatColumnReader<>(field, TransformingValueDecoders::getInt64TimestampMicrosToLongTimestampWithTimeZoneDecoder, INT96_ADAPTER);
+                    case MICROS -> new FlatColumnReader<>(field, TransformingValueDecoders::getInt64TimestampMicrosToLongTimestampWithTimeZoneDecoder, INT96_ADAPTER, memoryContext);
                 };
             }
             if (type instanceof DecimalType decimalType && decimalType.isShort()
                     && (primitiveType == INT32 || primitiveType == INT64 || primitiveType == FIXED_LEN_BYTE_ARRAY)) {
                 if (annotation instanceof DecimalLogicalTypeAnnotation decimalAnnotation && !isDecimalRescaled(decimalAnnotation, decimalType)) {
-                    return new FlatColumnReader<>(field, ValueDecoders::getShortDecimalDecoder, LONG_ADAPTER);
+                    return new FlatColumnReader<>(field, ValueDecoders::getShortDecimalDecoder, LONG_ADAPTER, memoryContext);
                 }
             }
             if (type instanceof DecimalType decimalType && !decimalType.isShort()
                     && (primitiveType == BINARY || primitiveType == FIXED_LEN_BYTE_ARRAY)) {
                 if (annotation instanceof DecimalLogicalTypeAnnotation decimalAnnotation && !isDecimalRescaled(decimalAnnotation, decimalType)) {
-                    return new FlatColumnReader<>(field, ValueDecoders::getLongDecimalDecoder, INT128_ADAPTER);
+                    return new FlatColumnReader<>(field, ValueDecoders::getLongDecimalDecoder, INT128_ADAPTER, memoryContext);
                 }
             }
             if (type instanceof VarcharType varcharType && !varcharType.isUnbounded() && primitiveType == BINARY) {
-                return new FlatColumnReader<>(field, ValueDecoders::getBoundedVarcharBinaryDecoder, BINARY_ADAPTER);
+                return new FlatColumnReader<>(field, ValueDecoders::getBoundedVarcharBinaryDecoder, BINARY_ADAPTER, memoryContext);
             }
             if (type instanceof CharType && primitiveType == BINARY) {
-                return new FlatColumnReader<>(field, ValueDecoders::getCharBinaryDecoder, BINARY_ADAPTER);
+                return new FlatColumnReader<>(field, ValueDecoders::getCharBinaryDecoder, BINARY_ADAPTER, memoryContext);
             }
             if (type instanceof AbstractVariableWidthType && primitiveType == BINARY) {
-                return new FlatColumnReader<>(field, ValueDecoders::getBinaryDecoder, BINARY_ADAPTER);
+                return new FlatColumnReader<>(field, ValueDecoders::getBinaryDecoder, BINARY_ADAPTER, memoryContext);
             }
             if (UUID.equals(type) && primitiveType == FIXED_LEN_BYTE_ARRAY) {
                 // Iceberg 0.11.1 writes UUID as FIXED_LEN_BYTE_ARRAY without logical type annotation (see https://github.com/apache/iceberg/pull/2913)
                 // To support such files, we bet on the logical type to be UUID based on the Trino UUID type check.
                 if (annotation == null || isLogicalUuid(annotation)) {
-                    return new FlatColumnReader<>(field, ValueDecoders::getUuidDecoder, INT128_ADAPTER);
+                    return new FlatColumnReader<>(field, ValueDecoders::getUuidDecoder, INT128_ADAPTER, memoryContext);
                 }
                 throw unsupportedException(type, field);
             }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PageReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PageReader.java
@@ -172,6 +172,11 @@ public final class PageReader
         compressedPages.next();
     }
 
+    public boolean arePagesCompressed()
+    {
+        return codec != CompressionCodecName.UNCOMPRESSED;
+    }
+
     private void verifyDictionaryPageRead()
     {
         if (hasDictionaryPage) {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
@@ -13,6 +13,7 @@
  */
 package io.trino.parquet.reader.decoders;
 
+import io.airlift.slice.Slice;
 import io.trino.parquet.DictionaryPage;
 import io.trino.parquet.ParquetEncoding;
 import io.trino.parquet.PrimitiveField;
@@ -259,9 +260,10 @@ public final class ValueDecoders
     {
         int size = dictionaryPage.getDictionarySize();
         T dictionary = columnAdapter.createBuffer(size);
-        plainValuesDecoder.init(new SimpleSliceInputStream(dictionaryPage.getSlice()));
+        Slice dictionarySlice = dictionaryPage.getSlice();
+        plainValuesDecoder.init(new SimpleSliceInputStream(dictionarySlice));
         plainValuesDecoder.read(dictionary, 0, size);
-        return new DictionaryDecoder<>(dictionary, columnAdapter);
+        return new DictionaryDecoder<>(dictionary, columnAdapter, columnAdapter.getSizeInBytes(dictionary));
     }
 
     private static ValuesReader getApacheParquetReader(ParquetEncoding encoding, PrimitiveField field)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/BinaryBuffer.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/BinaryBuffer.java
@@ -19,6 +19,7 @@ import io.airlift.slice.Slices;
 import java.util.ArrayList;
 import java.util.List;
 
+import static io.airlift.slice.SizeOf.sizeOf;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -106,5 +107,14 @@ public class BinaryBuffer
     public int getValueCount()
     {
         return offsets.length - 1;
+    }
+
+    public long getRetainedSize()
+    {
+        long chunksSizeInBytes = 0;
+        for (Slice slice : chunks) {
+            chunksSizeInBytes += slice.getRetainedSize();
+        }
+        return sizeOf(offsets) + chunksSizeInBytes;
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/BinaryColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/BinaryColumnAdapter.java
@@ -104,4 +104,10 @@ public class BinaryColumnAdapter
 
         values.addChunk(Slices.wrappedBuffer(outputChunk));
     }
+
+    @Override
+    public long getSizeInBytes(BinaryBuffer values)
+    {
+        return values.getRetainedSize();
+    }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/BooleanColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/BooleanColumnAdapter.java
@@ -18,6 +18,8 @@ import io.trino.spi.block.ByteArrayBlock;
 
 import java.util.Optional;
 
+import static io.airlift.slice.SizeOf.sizeOf;
+
 public class BooleanColumnAdapter
         implements ColumnAdapter<byte[]>
 {
@@ -53,5 +55,11 @@ public class BooleanColumnAdapter
         for (int i = 0; i < length; i++) {
             values[offset + i] = dictionary[ids[i]];
         }
+    }
+
+    @Override
+    public long getSizeInBytes(byte[] values)
+    {
+        return sizeOf(values);
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ByteColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ByteColumnAdapter.java
@@ -18,6 +18,8 @@ import io.trino.spi.block.ByteArrayBlock;
 
 import java.util.Optional;
 
+import static io.airlift.slice.SizeOf.sizeOf;
+
 public class ByteColumnAdapter
         implements ColumnAdapter<byte[]>
 {
@@ -53,5 +55,11 @@ public class ByteColumnAdapter
         for (int i = 0; i < length; i++) {
             values[offset + i] = dictionary[ids[i]];
         }
+    }
+
+    @Override
+    public long getSizeInBytes(byte[] values)
+    {
+        return sizeOf(values);
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ColumnAdapter.java
@@ -47,4 +47,6 @@ public interface ColumnAdapter<BufferType>
     }
 
     void decodeDictionaryIds(BufferType values, int offset, int length, int[] ids, BufferType dictionary);
+
+    long getSizeInBytes(BufferType values);
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/DictionaryDecoder.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/DictionaryDecoder.java
@@ -28,13 +28,15 @@ public final class DictionaryDecoder<T>
 {
     private final T dictionary;
     private final ColumnAdapter<T> columnAdapter;
+    private final long retainedSizeInBytes;
 
     private RunLengthBitPackingHybridDecoder dictionaryIdsReader;
 
-    public DictionaryDecoder(T dictionary, ColumnAdapter<T> columnAdapter)
+    public DictionaryDecoder(T dictionary, ColumnAdapter<T> columnAdapter, long retainedSizeInBytes)
     {
         this.columnAdapter = requireNonNull(columnAdapter, "columnAdapter is null");
         this.dictionary = requireNonNull(dictionary, "dictionary is null");
+        this.retainedSizeInBytes = retainedSizeInBytes;
     }
 
     @Override
@@ -70,5 +72,10 @@ public final class DictionaryDecoder<T>
         catch (IOException e) {
             throw new ParquetDecodingException(e);
         }
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        return retainedSizeInBytes;
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/Int128ColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/Int128ColumnAdapter.java
@@ -18,6 +18,8 @@ import io.trino.spi.block.Int128ArrayBlock;
 
 import java.util.Optional;
 
+import static io.airlift.slice.SizeOf.sizeOf;
+
 public class Int128ColumnAdapter
         implements ColumnAdapter<long[]>
 {
@@ -57,5 +59,11 @@ public class Int128ColumnAdapter
             values[destinationIndex] = dictionary[id];
             values[destinationIndex + 1] = dictionary[id + 1];
         }
+    }
+
+    @Override
+    public long getSizeInBytes(long[] values)
+    {
+        return sizeOf(values);
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/Int96ColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/Int96ColumnAdapter.java
@@ -18,6 +18,8 @@ import io.trino.spi.block.Int96ArrayBlock;
 
 import java.util.Optional;
 
+import static io.airlift.slice.SizeOf.sizeOf;
+
 public class Int96ColumnAdapter
         implements ColumnAdapter<Int96ColumnAdapter.Int96Buffer>
 {
@@ -55,6 +57,12 @@ public class Int96ColumnAdapter
             values.longs[offset + i] = dictionary.longs[ids[i]];
             values.ints[offset + i] = dictionary.ints[ids[i]];
         }
+    }
+
+    @Override
+    public long getSizeInBytes(Int96Buffer values)
+    {
+        return sizeOf(values.longs) + sizeOf(values.ints);
     }
 
     public static class Int96Buffer

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/IntColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/IntColumnAdapter.java
@@ -18,6 +18,8 @@ import io.trino.spi.block.IntArrayBlock;
 
 import java.util.Optional;
 
+import static io.airlift.slice.SizeOf.sizeOf;
+
 public class IntColumnAdapter
         implements ColumnAdapter<int[]>
 {
@@ -53,5 +55,11 @@ public class IntColumnAdapter
         for (int i = 0; i < length; i++) {
             values[offset + i] = dictionary[ids[i]];
         }
+    }
+
+    @Override
+    public long getSizeInBytes(int[] values)
+    {
+        return sizeOf(values);
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/LongColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/LongColumnAdapter.java
@@ -18,6 +18,8 @@ import io.trino.spi.block.LongArrayBlock;
 
 import java.util.Optional;
 
+import static io.airlift.slice.SizeOf.sizeOf;
+
 public class LongColumnAdapter
         implements ColumnAdapter<long[]>
 {
@@ -53,5 +55,11 @@ public class LongColumnAdapter
         for (int i = 0; i < length; i++) {
             values[offset + i] = dictionary[ids[i]];
         }
+    }
+
+    @Override
+    public long getSizeInBytes(long[] values)
+    {
+        return sizeOf(values);
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ShortColumnAdapter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/ShortColumnAdapter.java
@@ -18,6 +18,8 @@ import io.trino.spi.block.ShortArrayBlock;
 
 import java.util.Optional;
 
+import static io.airlift.slice.SizeOf.sizeOf;
+
 public class ShortColumnAdapter
         implements ColumnAdapter<short[]>
 {
@@ -53,5 +55,11 @@ public class ShortColumnAdapter
         for (int i = 0; i < length; i++) {
             values[offset + i] = dictionary[ids[i]];
         }
+    }
+
+    @Override
+    public long getSizeInBytes(short[] values)
+    {
+        return sizeOf(values);
     }
 }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/AbstractColumnReaderBenchmark.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/AbstractColumnReaderBenchmark.java
@@ -38,6 +38,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 
 import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.parquet.ParquetEncoding.RLE;
 import static io.trino.parquet.ParquetTypeUtils.getParquetEncoding;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -101,7 +102,7 @@ public abstract class AbstractColumnReaderBenchmark<VALUES>
     public int read()
             throws IOException
     {
-        ColumnReader columnReader = ColumnReaderFactory.create(field, UTC, true);
+        ColumnReader columnReader = ColumnReaderFactory.create(field, UTC, newSimpleAggregatedMemoryContext(), true);
         columnReader.setPageReader(new PageReader(UNCOMPRESSED, new LinkedList<>(dataPages).iterator(), false, false), Optional.empty());
         int rowsRead = 0;
         while (rowsRead < dataPositions) {

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReader.java
@@ -15,6 +15,7 @@ package io.trino.parquet.reader;
 
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slices;
+import io.trino.memory.context.LocalMemoryContext;
 import io.trino.parquet.DataPage;
 import io.trino.parquet.DataPageV2;
 import io.trino.parquet.Page;
@@ -54,6 +55,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.parquet.ParquetTypeUtils.getParquetEncoding;
 import static io.trino.parquet.reader.FilteredRowRanges.RowRange;
 import static io.trino.parquet.reader.TestingColumnReader.toTrinoDictionaryPage;
@@ -79,6 +81,7 @@ public class TestColumnReader
     private static final PrimitiveType OPTIONAL_TYPE = new PrimitiveType(OPTIONAL, INT32, "");
     private static final PrimitiveField NULLABLE_FIELD = new PrimitiveField(INTEGER, false, new ColumnDescriptor(new String[] {}, OPTIONAL_TYPE, 0, 1), 0);
     private static final PrimitiveField FIELD = new PrimitiveField(INTEGER, true, new ColumnDescriptor(new String[] {}, REQUIRED_TYPE, 0, 0), 0);
+    private static final LocalMemoryContext MEMORY_CONTEXT = newSimpleAggregatedMemoryContext().newLocalMemoryContext("test");
 
     @Test(dataProvider = "testRowRangesProvider")
     public void testReadFilteredPage(
@@ -179,8 +182,8 @@ public class TestColumnReader
     {
         INT_PRIMITIVE_NO_NULLS(() -> new IntColumnReader(FIELD), FIELD),
         INT_PRIMITIVE_NULLABLE(() -> new IntColumnReader(NULLABLE_FIELD), NULLABLE_FIELD),
-        INT_FLAT_NO_NULLS(() -> new FlatColumnReader<>(FIELD, ValueDecoders::getIntDecoder, INT_ADAPTER), FIELD),
-        INT_FLAT_NULLABLE(() -> new FlatColumnReader<>(NULLABLE_FIELD, ValueDecoders::getIntDecoder, INT_ADAPTER), NULLABLE_FIELD);
+        INT_FLAT_NO_NULLS(() -> new FlatColumnReader<>(FIELD, ValueDecoders::getIntDecoder, INT_ADAPTER, MEMORY_CONTEXT), FIELD),
+        INT_FLAT_NULLABLE(() -> new FlatColumnReader<>(NULLABLE_FIELD, ValueDecoders::getIntDecoder, INT_ADAPTER, MEMORY_CONTEXT), NULLABLE_FIELD);
 
         private final Supplier<ColumnReader> columnReader;
         private final PrimitiveField field;

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReaderFactory.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReaderFactory.java
@@ -19,6 +19,7 @@ import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.schema.PrimitiveType;
 import org.testng.annotations.Test;
 
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
@@ -35,9 +36,9 @@ public class TestColumnReaderFactory
                 false,
                 new ColumnDescriptor(new String[] {"test"}, new PrimitiveType(OPTIONAL, INT32, "test"), 0, 1),
                 0);
-        assertThat(ColumnReaderFactory.create(field, UTC, false))
+        assertThat(ColumnReaderFactory.create(field, UTC, newSimpleAggregatedMemoryContext(), false))
                 .isNotInstanceOf(FlatColumnReader.class);
-        assertThat(ColumnReaderFactory.create(field, UTC, true))
+        assertThat(ColumnReaderFactory.create(field, UTC, newSimpleAggregatedMemoryContext(), true))
                 .isInstanceOf(FlatColumnReader.class);
     }
 
@@ -49,9 +50,9 @@ public class TestColumnReaderFactory
                 false,
                 new ColumnDescriptor(new String[] {"level1", "level2"}, new PrimitiveType(OPTIONAL, INT32, "test"), 1, 2),
                 0);
-        assertThat(ColumnReaderFactory.create(field, UTC, false))
+        assertThat(ColumnReaderFactory.create(field, UTC, newSimpleAggregatedMemoryContext(), false))
                 .isNotInstanceOf(FlatColumnReader.class);
-        assertThat(ColumnReaderFactory.create(field, UTC, true))
+        assertThat(ColumnReaderFactory.create(field, UTC, newSimpleAggregatedMemoryContext(), true))
                 .isNotInstanceOf(FlatColumnReader.class);
     }
 }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestInt96Timestamp.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestInt96Timestamp.java
@@ -39,6 +39,7 @@ import java.util.OptionalLong;
 import java.util.function.BiFunction;
 
 import static io.airlift.slice.Slices.EMPTY_SLICE;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.parquet.ParquetEncoding.PLAIN;
 import static io.trino.parquet.reader.TestingColumnReader.encodeInt96Timestamp;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
@@ -105,7 +106,7 @@ public class TestInt96Timestamp
                 null,
                 false);
         // Read and assert
-        ColumnReader reader = ColumnReaderFactory.create(field, DateTimeZone.UTC, true);
+        ColumnReader reader = ColumnReaderFactory.create(field, DateTimeZone.UTC, newSimpleAggregatedMemoryContext(), true);
         reader.setPageReader(
                 new PageReader(UNCOMPRESSED, List.of(dataPage).iterator(), false, false),
                 Optional.empty());

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReaderMemoryUsage.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReaderMemoryUsage.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
+import io.trino.memory.context.AggregatedMemoryContext;
+import io.trino.parquet.Field;
+import io.trino.parquet.ParquetDataSource;
+import io.trino.parquet.ParquetReaderOptions;
+import io.trino.parquet.writer.ParquetSchemaConverter;
+import io.trino.parquet.writer.ParquetWriter;
+import io.trino.parquet.writer.ParquetWriterOptions;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.LazyBlock;
+import io.trino.spi.type.Type;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.io.MessageColumnIO;
+import org.joda.time.DateTimeZone;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.parquet.ParquetTypeUtils.constructField;
+import static io.trino.parquet.ParquetTypeUtils.getColumnIO;
+import static io.trino.parquet.ParquetTypeUtils.lookupColumnByName;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.TypeUtils.writeNativeValue;
+import static java.util.Collections.nCopies;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.joda.time.DateTimeZone.UTC;
+
+public class TestParquetReaderMemoryUsage
+{
+    @Test
+    public void testColumnReaderMemoryUsage()
+            throws IOException
+    {
+        // Write a file with 100 rows per row-group
+        List<String> columnNames = ImmutableList.of("columnA", "columnB");
+        List<Type> types = ImmutableList.of(INTEGER, BIGINT);
+
+        ParquetDataSource dataSource = new TestingParquetDataSource(writeParquetFile(types, columnNames), new ParquetReaderOptions());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        assertThat(parquetMetadata.getBlocks().size()).isGreaterThan(1);
+        // Verify file has only non-dictionary encodings as dictionary memory usage is already tested in TestFlatColumnReader#testMemoryUsage
+        parquetMetadata.getBlocks().forEach(block -> {
+            block.getColumns()
+                    .forEach(columnChunkMetaData -> assertThat(columnChunkMetaData.getEncodingStats().hasDictionaryEncodedPages()).isFalse());
+            assertThat(block.getRowCount()).isEqualTo(100);
+        });
+
+        AggregatedMemoryContext memoryContext = newSimpleAggregatedMemoryContext();
+        ParquetReader reader = createParquetReader(dataSource, parquetMetadata, memoryContext, types, columnNames);
+
+        Page page = reader.nextPage();
+        assertThat(page.getBlock(0)).isInstanceOf(LazyBlock.class);
+        assertThat(memoryContext.getBytes()).isEqualTo(0);
+        page.getBlock(0).getLoadedBlock();
+        // Memory usage due to reading data and decoding parquet page of 1st block
+        long initialMemoryUsage = memoryContext.getBytes();
+        assertThat(initialMemoryUsage).isGreaterThan(0);
+
+        // Memory usage due to decoding parquet page of 2nd block
+        page.getBlock(1).getLoadedBlock();
+        long currentMemoryUsage = memoryContext.getBytes();
+        assertThat(currentMemoryUsage).isGreaterThan(initialMemoryUsage);
+
+        // Memory usage does not change until next row group (1 page per row-group)
+        long rowGroupRowCount = parquetMetadata.getBlocks().get(0).getRowCount();
+        int rowsRead = page.getPositionCount();
+        while (rowsRead < rowGroupRowCount) {
+            rowsRead += reader.nextPage().getPositionCount();
+            if (rowsRead <= rowGroupRowCount) {
+                assertThat(memoryContext.getBytes()).isEqualTo(currentMemoryUsage);
+            }
+        }
+
+        // New row-group should release memory from old column readers, while using some memory for data read
+        reader.nextPage();
+        assertThat(memoryContext.getBytes()).isBetween(1L, currentMemoryUsage - 1);
+
+        reader.close();
+        assertThat(memoryContext.getBytes()).isEqualTo(0);
+    }
+
+    private static Slice writeParquetFile(List<Type> types, List<String> columnNames)
+            throws IOException
+    {
+        checkArgument(types.size() == columnNames.size());
+        ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(types, columnNames, false, false);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ParquetWriter writer = new ParquetWriter(
+                outputStream,
+                schemaConverter.getMessageType(),
+                schemaConverter.getPrimitiveTypes(),
+                ParquetWriterOptions.builder()
+                        .setMaxPageSize(DataSize.ofBytes(100))
+                        .setMaxBlockSize(DataSize.ofBytes(1))
+                        .build(),
+                CompressionCodecName.SNAPPY,
+                "test-version",
+                false,
+                Optional.of(DateTimeZone.getDefault()),
+                Optional.empty());
+
+        for (io.trino.spi.Page inputPage : generateInputPages(types, 100, 5)) {
+            checkArgument(types.size() == inputPage.getChannelCount());
+            writer.write(inputPage);
+        }
+        writer.close();
+        return Slices.wrappedBuffer(outputStream.toByteArray());
+    }
+
+    private static List<io.trino.spi.Page> generateInputPages(List<Type> types, int positionsPerPage, int pageCount)
+    {
+        ImmutableList.Builder<io.trino.spi.Page> pagesBuilder = ImmutableList.builder();
+        for (int i = 0; i < pageCount; i++) {
+            List<Block> blocks = types.stream()
+                    .map(type -> generateBlock(type, positionsPerPage))
+                    .collect(toImmutableList());
+            pagesBuilder.add(new Page(blocks.toArray(Block[]::new)));
+        }
+        return pagesBuilder.build();
+    }
+
+    private static Block generateBlock(Type type, int positions)
+    {
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, positions);
+        for (int i = 0; i < positions; i++) {
+            writeNativeValue(type, blockBuilder, ThreadLocalRandom.current().nextLong(0, 1000));
+        }
+        return blockBuilder.build();
+    }
+
+    private static ParquetReader createParquetReader(
+            ParquetDataSource input,
+            ParquetMetadata parquetMetadata,
+            AggregatedMemoryContext memoryContext,
+            List<Type> types,
+            List<String> columnNames)
+            throws IOException
+    {
+        org.apache.parquet.hadoop.metadata.FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
+        MessageColumnIO messageColumnIO = getColumnIO(fileMetaData.getSchema(), fileMetaData.getSchema());
+        ImmutableList.Builder<Field> columnFields = ImmutableList.builder();
+        for (int i = 0; i < types.size(); i++) {
+            columnFields.add(constructField(
+                    types.get(i),
+                    lookupColumnByName(messageColumnIO, columnNames.get(i)))
+                    .orElseThrow());
+        }
+        long nextStart = 0;
+        ImmutableList.Builder<Long> blockStartsBuilder = ImmutableList.builder();
+        for (BlockMetaData block : parquetMetadata.getBlocks()) {
+            blockStartsBuilder.add(nextStart);
+            nextStart += block.getRowCount();
+        }
+        List<Long> blockStarts = blockStartsBuilder.build();
+        return new ParquetReader(
+                Optional.ofNullable(fileMetaData.getCreatedBy()),
+                columnFields.build(),
+                parquetMetadata.getBlocks(),
+                blockStarts,
+                input,
+                UTC,
+                memoryContext,
+                new ParquetReaderOptions(),
+                exception -> {
+                    throwIfUnchecked(exception);
+                    return new RuntimeException(exception);
+                },
+                Optional.empty(),
+                nCopies(blockStarts.size(), Optional.empty()),
+                Optional.empty());
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/TestFlatColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/TestFlatColumnReader.java
@@ -45,7 +45,6 @@ import javax.annotation.Nullable;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -145,7 +144,7 @@ public class TestFlatColumnReader
         DataPage page = createDataPage(version, RLE_DICTIONARY, dictionaryWriter, 2);
         DictionaryPage dictionaryPage = getDictionaryPage(dictionaryWriter);
         // Read and assert
-        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page)), dictionaryPage), Optional.empty());
+        reader.setPageReader(getPageReaderMock(List.of(page), dictionaryPage), Optional.empty());
         reader.prepareNextRead(2);
         Block actual = reader.readPrimitive().getBlock();
         format.assertBlock(values, actual);
@@ -164,7 +163,7 @@ public class TestFlatColumnReader
         DataPage page = createNullableDataPage(version, RLE_DICTIONARY, dictionaryWriter, false, true);
         DictionaryPage dictionaryPage = getDictionaryPage(dictionaryWriter);
         // Read and assert
-        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page)), dictionaryPage), Optional.empty());
+        reader.setPageReader(getPageReaderMock(List.of(page), dictionaryPage), Optional.empty());
         reader.prepareNextRead(2);
         Block actual = reader.readPrimitive().getBlock();
         format.assertBlock(values, actual);
@@ -183,7 +182,7 @@ public class TestFlatColumnReader
         DataPage page = createNullableDataPage(version, RLE_DICTIONARY, dictionaryWriter, false, false);
         DictionaryPage dictionaryPage = getDictionaryPage(dictionaryWriter);
         // Read and assert
-        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page)), dictionaryPage), Optional.empty());
+        reader.setPageReader(getPageReaderMock(List.of(page), dictionaryPage), Optional.empty());
         reader.prepareNextRead(2);
         Block actual = reader.readPrimitive().getBlock();
         format.assertBlock(values, actual);
@@ -202,7 +201,7 @@ public class TestFlatColumnReader
         DataPage page = createNullableDataPage(version, RLE_DICTIONARY, dictionaryWriter, false, false);
         DictionaryPage dictionaryPage = getDictionaryPage(dictionaryWriter);
         // Read and assert
-        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page)), dictionaryPage, false), Optional.empty());
+        reader.setPageReader(getPageReaderMock(List.of(page), dictionaryPage, false), Optional.empty());
         reader.prepareNextRead(2);
         Block actual = reader.readPrimitive().getBlock();
         format.assertBlock(values, actual);
@@ -223,7 +222,7 @@ public class TestFlatColumnReader
         DataPage page = createNullableDataPage(version, RLE_DICTIONARY, dictionaryWriter, true, true);
         DictionaryPage dictionaryPage = getDictionaryPage(dictionaryWriter);
         // Read and assert
-        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page)), dictionaryPage), Optional.empty());
+        reader.setPageReader(getPageReaderMock(List.of(page), dictionaryPage), Optional.empty());
         reader.prepareNextRead(2);
         Block actual = reader.readPrimitive().getBlock();
         format.assertBlock(values, actual);
@@ -245,7 +244,7 @@ public class TestFlatColumnReader
         T[] values3 = format.resetAndWrite(writer, new Integer[] {4});
         DataPage page3 = createDataPage(version, PLAIN, writer, 1);
         // Read and assert
-        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page1, page2, page3)), null), Optional.empty());
+        reader.setPageReader(getPageReaderMock(List.of(page1, page2, page3), null), Optional.empty());
         Block actual1 = readBlock(reader, 1); // Parquet/Trino page size the same
         Block actual2 = readBlock(reader, 1); // Parquet page bigger than Trino
         Block actual3 = readBlock(reader, 2); // Parquet page smaller than Trino
@@ -272,7 +271,7 @@ public class TestFlatColumnReader
         DataPage page2 = createDataPage(version, PLAIN, writer, 1);
         DictionaryPage dictionaryPage = getDictionaryPage(dictionaryWriter);
         // Read and assert
-        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page1, page2)), dictionaryPage), Optional.empty());
+        reader.setPageReader(getPageReaderMock(List.of(page1, page2), dictionaryPage), Optional.empty());
         reader.prepareNextRead(3);
         Block actual = reader.readPrimitive().getBlock();
         format.assertBlock(values1, actual, 0, 0, 2);
@@ -293,7 +292,7 @@ public class TestFlatColumnReader
         T[] values2 = format.write(writer, new Integer[] {null, null});
         DataPage page2 = createNullableDataPage(version, PLAIN, writer, true, true);
         // Read and assert
-        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page1, page2)), null), Optional.empty());
+        reader.setPageReader(getPageReaderMock(List.of(page1, page2), null), Optional.empty());
         // Deliberate mismatch between Trino/Parquet page sizes
         Block actual1 = readBlock(reader, 2);
         Block actual2 = readBlock(reader, 1);
@@ -319,7 +318,7 @@ public class TestFlatColumnReader
         T[] values3 = format.resetAndWrite(writer, new Integer[] {3, null, 4});
         DataPage page3 = createNullableDataPage(version, PLAIN, writer, false, true, false);
         // Read and assert
-        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page1, page2, page3)), null), Optional.empty());
+        reader.setPageReader(getPageReaderMock(List.of(page1, page2, page3), null), Optional.empty());
         // Deliberate mismatch between Trino/Parquet page sizes
         Block actual1 = readBlock(reader, 2);
         Block actual2 = readBlock(reader, 2);
@@ -343,7 +342,7 @@ public class TestFlatColumnReader
         T[] values1 = format.write(writer, new Integer[] {1, 2});
         DataPage page1 = createNullableDataPage(version, PLAIN, writer, false, false);
         // Read and assert
-        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page1)), null), Optional.empty());
+        reader.setPageReader(getPageReaderMock(List.of(page1), null), Optional.empty());
         // Deliberate mismatch between Trino/Parquet page sizes
         Block actual1 = readBlock(reader, 2);
 
@@ -362,7 +361,7 @@ public class TestFlatColumnReader
         T[] values1 = format.write(writer, new Integer[] {1, 2});
         DataPage page1 = createNullableDataPage(version, PLAIN, writer, false, false);
         // Read and assert
-        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page1)), null, true), Optional.empty());
+        reader.setPageReader(getPageReaderMock(List.of(page1), null, true), Optional.empty());
         // Deliberate mismatch between Trino/Parquet page sizes
         Block actual1 = readBlock(reader, 2);
         assertThat(actual1.mayHaveNull()).isFalse();
@@ -385,7 +384,7 @@ public class TestFlatColumnReader
         DataPage page2 = createDataPage(version, PLAIN, writer, 3);
         DictionaryPage dictionaryPage = getDictionaryPage(dictionaryWriter);
         // Read and assert
-        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page1, page2)), dictionaryPage), Optional.empty());
+        reader.setPageReader(getPageReaderMock(List.of(page1, page2), dictionaryPage), Optional.empty());
         // Deliberate mismatch between Trino/Parquet page sizes
         Block actual1 = readBlock(reader, 2); // Only dictionary
         Block actual2 = readBlock(reader, 2); // Mixed
@@ -413,7 +412,7 @@ public class TestFlatColumnReader
         T[] values3 = format.resetAndWrite(writer, new Integer[] {2});
         DataPage page3 = createNullableDataPage(version, PLAIN, writer, false);
         // Read and assert
-        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page1, page2, page3)), null), Optional.empty());
+        reader.setPageReader(getPageReaderMock(List.of(page1, page2, page3), null), Optional.empty());
         // Deliberate mismatch between Trino/Parquet page sizes
         Block actual = readBlock(reader, 3);
 
@@ -438,7 +437,7 @@ public class TestFlatColumnReader
         DataPage page2 = createDataPage(version, RLE_DICTIONARY, dictionaryWriter, 3);
         DictionaryPage dictionaryPage = getDictionaryPage(dictionaryWriter);
         // Read and assert
-        reader.setPageReader(getPageReaderMock(new LinkedList<>(List.of(page1, page2)), dictionaryPage), Optional.empty());
+        reader.setPageReader(getPageReaderMock(List.of(page1, page2), dictionaryPage), Optional.empty());
         reader.prepareNextRead(1); // skip
         Block actual = readBlock(reader, 2);
         reader.prepareNextRead(1); // skip
@@ -539,11 +538,10 @@ public class TestFlatColumnReader
     private static PageReader getSimplePageReaderMock(ParquetEncoding encoding)
             throws IOException
     {
-        LinkedList<DataPage> pages = new LinkedList<>();
         ValuesWriter writer = PLAIN_WRITER.apply(1);
         writer.writeInteger(42);
         byte[] valueBytes = writer.getBytes().toByteArray();
-        pages.add(new DataPageV1(
+        List<DataPage> pages = ImmutableList.of(new DataPageV1(
                 Slices.wrappedBuffer(valueBytes),
                 1,
                 valueBytes.length,
@@ -557,11 +555,10 @@ public class TestFlatColumnReader
     private static PageReader getNullOnlyPageReaderMock()
             throws IOException
     {
-        LinkedList<DataPage> pages = new LinkedList<>();
         RunLengthBitPackingHybridValuesWriter nullsWriter = new RunLengthBitPackingHybridValuesWriter(1, 1, 1, HeapByteBufferAllocator.getInstance());
         nullsWriter.writeInteger(0);
         byte[] nullBytes = nullsWriter.getBytes().toByteArray();
-        pages.add(new DataPageV1(
+        List<DataPage> pages = ImmutableList.of(new DataPageV1(
                 Slices.wrappedBuffer(nullBytes),
                 1,
                 nullBytes.length,
@@ -572,12 +569,12 @@ public class TestFlatColumnReader
         return new PageReader(UNCOMPRESSED, pages.iterator(), false, false);
     }
 
-    private static PageReader getPageReaderMock(LinkedList<DataPage> dataPages, @Nullable DictionaryPage dictionaryPage)
+    private static PageReader getPageReaderMock(List<DataPage> dataPages, @Nullable DictionaryPage dictionaryPage)
     {
         return getPageReaderMock(dataPages, dictionaryPage, false);
     }
 
-    private static PageReader getPageReaderMock(LinkedList<DataPage> dataPages, @Nullable DictionaryPage dictionaryPage, boolean hasNoNulls)
+    private static PageReader getPageReaderMock(List<DataPage> dataPages, @Nullable DictionaryPage dictionaryPage, boolean hasNoNulls)
     {
         if (dictionaryPage != null) {
             return new PageReader(


### PR DESCRIPTION
## Description

Added accounting of memory usage to batched column readers.
This takes into account the dictionary retained for decoding
dictionary data pages and the extra memory usage of decompressed
values from data pages.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes https://github.com/trinodb/trino/issues/10061

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Hudi, Iceberg, Delta
* Improve accounting of memory usage by parquet reader. ({issue}`15554`)
```
