### PR TITLE
Add delta history metadata table

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.rst
+++ b/docs/src/main/sphinx/connector/delta-lake.rst
@@ -616,6 +616,89 @@ Write operations are supported for tables stored on the following systems:
   make sure that no concurrent data modifications are run to avoid data
   corruption.
 
+Metadata tables
+---------------
+
+The connector exposes several metadata tables for each Delta Lake table.
+These metadata tables contain information about the internal structure
+of the Delta Lake table. You can query each metadata table by appending the
+metadata table name to the table name::
+
+   SELECT * FROM "test_table$data"
+
+``$data`` table
+^^^^^^^^^^^^^^^
+
+The ``$data`` table is an alias for the Delta Lake table itself.
+
+The statement::
+
+    SELECT * FROM "test_table$data"
+
+is equivalent to::
+
+    SELECT * FROM test_table
+
+``$history`` table
+^^^^^^^^^^^^^^^^^^
+
+The ``$history`` table provides a log of the metadata changes performed on
+the Delta Lake table.
+
+You can retrieve the changelog of the Delta Lake table ``test_table``
+by using the following query::
+
+    SELECT * FROM "test_table$history"
+
+.. code-block:: text
+
+     version |               timestamp               | user_id | user_name |  operation   |         operation_parameters          |                 cluster_id      | read_version |  isolation_level  | is_blind_append
+    ---------+---------------------------------------+---------+-----------+--------------+---------------------------------------+---------------------------------+--------------+-------------------+----------------
+           2 | 2023-01-19 07:40:54.684 Europe/Vienna | trino   | trino     | WRITE        | {queryId=20230119_064054_00008_4vq5t} | trino-406-trino-coordinator     |            2 | WriteSerializable | true
+           1 | 2023-01-19 07:40:41.373 Europe/Vienna | trino   | trino     | ADD COLUMNS  | {queryId=20230119_064041_00007_4vq5t} | trino-406-trino-coordinator     |            0 | WriteSerializable | true
+           0 | 2023-01-19 07:40:10.497 Europe/Vienna | trino   | trino     | CREATE TABLE | {queryId=20230119_064010_00005_4vq5t} | trino-406-trino-coordinator     |            0 | WriteSerializable | true
+
+The output of the query has the following columns:
+
+.. list-table:: History columns
+  :widths: 30, 30, 40
+  :header-rows: 1
+
+  * - Name
+    - Type
+    - Description
+  * - ``version``
+    - ``bigint``
+    - The version of the table corresponding to the operation
+  * - ``timestamp``
+    - ``timestamp(3) with time zone``
+    - The time when the table version became active
+  * - ``user_id``
+    - ``varchar``
+    - The identifier for the user which performed the operation
+  * - ``user_name``
+    - ``varchar``
+    - The username for the user which performed the operation
+  * - ``operation``
+    - ``varchar``
+    - The name of the operation performed on the table
+  * - ``operation_parameters``
+    - ``map(varchar, varchar)``
+    - Parameters of the operation
+  * - ``cluster_id``
+    - ``varchar``
+    - The ID of the cluster which ran the operation
+  * - ``read_version``
+    - ``bigint``
+    - The version of the table which was read in order to perform the operation
+  * - ``isolation_level``
+    - ``varchar``
+    - The level of isolation used to perform the operation
+  * - ``is_blind_append``
+    - ``boolean``
+    - Whether or not the operation appended data
+
+
 Performance
 -----------
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeHistoryTable.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeHistoryTable.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.deltalake.transactionlog.CommitInfoEntry;
+import io.trino.plugin.deltalake.util.PageListBuilder;
+import io.trino.spi.Page;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.FixedPageSource;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SystemTable;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.TimeZoneKey;
+import io.trino.spi.type.TypeManager;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.TypeSignature.mapType;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Comparator.comparingLong;
+import static java.util.Objects.requireNonNull;
+
+public class DeltaLakeHistoryTable
+        implements SystemTable
+{
+    private final ConnectorTableMetadata tableMetadata;
+    private final List<CommitInfoEntry> commitInfoEntries;
+
+    public DeltaLakeHistoryTable(SchemaTableName tableName, List<CommitInfoEntry> commitInfoEntries, TypeManager typeManager)
+    {
+        requireNonNull(typeManager, "typeManager is null");
+        this.commitInfoEntries = ImmutableList.copyOf(requireNonNull(commitInfoEntries, "commitInfoEntries is null")).stream()
+                .sorted(comparingLong(CommitInfoEntry::getVersion).reversed())
+                .collect(toImmutableList());
+
+        tableMetadata = new ConnectorTableMetadata(
+                requireNonNull(tableName, "tableName is null"),
+                ImmutableList.<ColumnMetadata>builder()
+                        .add(new ColumnMetadata("version", BIGINT))
+                        .add(new ColumnMetadata("timestamp", TIMESTAMP_TZ_MILLIS))
+                        .add(new ColumnMetadata("user_id", VARCHAR))
+                        .add(new ColumnMetadata("user_name", VARCHAR))
+                        .add(new ColumnMetadata("operation", VARCHAR))
+                        .add(new ColumnMetadata("operation_parameters", typeManager.getType(mapType(VARCHAR.getTypeSignature(), VARCHAR.getTypeSignature()))))
+                        .add(new ColumnMetadata("cluster_id", VARCHAR))
+                        .add(new ColumnMetadata("read_version", BIGINT))
+                        .add(new ColumnMetadata("isolation_level", VARCHAR))
+                        .add(new ColumnMetadata("is_blind_append", BOOLEAN))
+                        //TODO add support for operationMetrics, userMetadata, engineInfo
+                        .build());
+    }
+
+    @Override
+    public Distribution getDistribution()
+    {
+        return Distribution.SINGLE_COORDINATOR;
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata()
+    {
+        return tableMetadata;
+    }
+
+    @Override
+    public ConnectorPageSource pageSource(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
+    {
+        if (commitInfoEntries.isEmpty()) {
+            return new FixedPageSource(ImmutableList.of());
+        }
+        return new FixedPageSource(buildPages(session));
+    }
+
+    private List<Page> buildPages(ConnectorSession session)
+    {
+        PageListBuilder pagesBuilder = PageListBuilder.forTable(tableMetadata);
+        TimeZoneKey timeZoneKey = session.getTimeZoneKey();
+
+        commitInfoEntries.forEach(commitInfoEntry -> {
+            pagesBuilder.beginRow();
+
+            pagesBuilder.appendBigint(commitInfoEntry.getVersion());
+            pagesBuilder.appendTimestampTzMillis(commitInfoEntry.getTimestamp(), timeZoneKey);
+            write(commitInfoEntry.getUserId(), pagesBuilder);
+            write(commitInfoEntry.getUserName(), pagesBuilder);
+            write(commitInfoEntry.getOperation(), pagesBuilder);
+            if (commitInfoEntry.getOperationParameters() == null) {
+                pagesBuilder.appendNull();
+            }
+            else {
+                pagesBuilder.appendVarcharVarcharMap(commitInfoEntry.getOperationParameters());
+            }
+            write(commitInfoEntry.getClusterId(), pagesBuilder);
+            pagesBuilder.appendBigint(commitInfoEntry.getReadVersion());
+            write(commitInfoEntry.getIsolationLevel(), pagesBuilder);
+            commitInfoEntry.isBlindAppend().ifPresentOrElse(pagesBuilder::appendBoolean, pagesBuilder::appendNull);
+
+            pagesBuilder.endRow();
+        });
+
+        return pagesBuilder.build();
+    }
+
+    private static void write(String value, PageListBuilder pagesBuilder)
+    {
+        if (value == null) {
+            pagesBuilder.appendNull();
+        }
+        else {
+            pagesBuilder.appendVarchar(value);
+        }
+    }
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -1241,7 +1241,7 @@ public class DeltaLakeMetadata
                         "trino-" + nodeVersion + "-" + nodeId,
                         0,
                         ISOLATION_LEVEL,
-                        true));
+                        Optional.of(true)));
 
         transactionLogWriter.appendProtocolEntry(protocolEntry);
 
@@ -1389,7 +1389,7 @@ public class DeltaLakeMetadata
                             "trino-" + nodeVersion + "-" + nodeId,
                             handle.getReadVersion(), // it is not obvious why we need to persist this readVersion
                             ISOLATION_LEVEL,
-                            true));
+                            Optional.of(true)));
 
             // Note: during writes we want to preserve original case of partition columns
             List<String> partitionColumns = handle.getMetadataEntry().getOriginalPartitionColumns();
@@ -1523,7 +1523,7 @@ public class DeltaLakeMetadata
                             "trino-" + nodeVersion + "-" + nodeId,
                             handle.getReadVersion(),
                             ISOLATION_LEVEL,
-                            true));
+                            Optional.of(true)));
             // TODO: Delta writes another field "operationMetrics" (https://github.com/trinodb/trino/issues/12005)
 
             long writeTimestamp = Instant.now().toEpochMilli();
@@ -1734,7 +1734,7 @@ public class DeltaLakeMetadata
                             "trino-" + nodeVersion + "-" + nodeId,
                             readVersion,
                             ISOLATION_LEVEL,
-                            true));
+                            Optional.of(true)));
             // TODO: Delta writes another field "operationMetrics" that I haven't
             //   seen before. It contains delete/update metrics. Investigate/include it.
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -30,6 +30,7 @@ import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.hdfs.HdfsContext;
 import io.trino.hdfs.HdfsEnvironment;
+import io.trino.plugin.base.classloader.ClassLoaderSafeSystemTable;
 import io.trino.plugin.deltalake.expression.SparkExpressionParser;
 import io.trino.plugin.deltalake.metastore.DeltaLakeMetastore;
 import io.trino.plugin.deltalake.metastore.NotADeltaLakeTableException;
@@ -42,12 +43,14 @@ import io.trino.plugin.deltalake.statistics.ExtendedStatisticsAccess;
 import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
 import io.trino.plugin.deltalake.transactionlog.CdfFileEntry;
 import io.trino.plugin.deltalake.transactionlog.CommitInfoEntry;
+import io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry.Format;
 import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
 import io.trino.plugin.deltalake.transactionlog.RemoveFileEntry;
 import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointWriterManager;
+import io.trino.plugin.deltalake.transactionlog.checkpoint.TransactionLogTail;
 import io.trino.plugin.deltalake.transactionlog.statistics.DeltaLakeFileStatistics;
 import io.trino.plugin.deltalake.transactionlog.writer.TransactionConflictException;
 import io.trino.plugin.deltalake.transactionlog.writer.TransactionLogWriter;
@@ -94,6 +97,7 @@ import io.trino.spi.connector.RowChangeParadigm;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
+import io.trino.spi.connector.SystemTable;
 import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.connector.TableScanRedirectApplicationResult;
@@ -141,6 +145,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
@@ -405,18 +410,24 @@ public class DeltaLakeMetadata
     public DeltaLakeTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
     {
         requireNonNull(tableName, "tableName is null");
-        Optional<Table> table = metastore.getTable(tableName.getSchemaName(), tableName.getTableName());
+        if (!DeltaLakeTableName.isDataTable(tableName.getTableName())) {
+            // Pretend the table does not exist to produce better error message in case of table redirects to Hive
+            return null;
+        }
+        DeltaLakeTableName deltaLakeTableName = DeltaLakeTableName.from(tableName.getTableName());
+        SchemaTableName dataTableName = new SchemaTableName(tableName.getSchemaName(), deltaLakeTableName.getTableName());
+        Optional<Table> table = metastore.getTable(dataTableName.getSchemaName(), dataTableName.getTableName());
         if (table.isEmpty()) {
             return null;
         }
 
-        TableSnapshot tableSnapshot = metastore.getSnapshot(tableName, session);
+        TableSnapshot tableSnapshot = metastore.getSnapshot(dataTableName, session);
         Optional<MetadataEntry> metadata = metastore.getMetadata(tableSnapshot, session);
         metadata.ifPresent(metadataEntry -> verifySupportedColumnMapping(getColumnMappingMode(metadataEntry)));
         return new DeltaLakeTableHandle(
-                tableName.getSchemaName(),
-                tableName.getTableName(),
-                metastore.getTableLocation(tableName, session),
+                dataTableName.getSchemaName(),
+                dataTableName.getTableName(),
+                metastore.getTableLocation(dataTableName, session),
                 metadata,
                 TupleDomain.all(),
                 TupleDomain.all(),
@@ -2429,6 +2440,48 @@ public class DeltaLakeMetadata
         return fileName.startsWith(queryId + "-");
     }
 
+    @Override
+    public Optional<SystemTable> getSystemTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        return getRawSystemTable(session, tableName)
+                .map(systemTable -> new ClassLoaderSafeSystemTable(systemTable, getClass().getClassLoader()));
+    }
+
+    private Optional<SystemTable> getRawSystemTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        if (DeltaLakeTableName.isDataTable(tableName.getTableName())) {
+            return Optional.empty();
+        }
+
+        // Only when dealing with an actual system table proceed to retrieve the table handle
+        String name = DeltaLakeTableName.tableNameFrom(tableName.getTableName());
+        DeltaLakeTableHandle tableHandle;
+        try {
+            tableHandle = getTableHandle(session, new SchemaTableName(tableName.getSchemaName(), name));
+        }
+        catch (NotADeltaLakeTableException e) {
+            // avoid dealing with non Delta Lake tables
+            return Optional.empty();
+        }
+        if (tableHandle == null) {
+            return Optional.empty();
+        }
+
+        Optional<DeltaLakeTableType> tableType = DeltaLakeTableName.tableTypeFrom(tableName.getTableName());
+        if (tableType.isEmpty()) {
+            return Optional.empty();
+        }
+        DeltaLakeTableName deltaLakeTableName = new DeltaLakeTableName(name, tableType.get());
+        SchemaTableName systemTableName = new SchemaTableName(tableName.getSchemaName(), deltaLakeTableName.getTableNameWithType());
+        return switch (deltaLakeTableName.getTableType()) {
+            case DATA -> Optional.empty(); // Handled above
+            case HISTORY -> Optional.of(new DeltaLakeHistoryTable(
+                    systemTableName,
+                    getCommitInfoEntries(tableHandle.getSchemaTableName(), session),
+                    typeManager));
+        };
+    }
+
     private static Map<String, DeltaLakeColumnStatistics> toDeltaLakeColumnStatistics(Collection<ComputedStatistics> computedStatistics)
     {
         // Only statistics for whole table are collected
@@ -2503,6 +2556,23 @@ public class DeltaLakeMetadata
     public DeltaLakeMetastore getMetastore()
     {
         return metastore;
+    }
+
+    private List<CommitInfoEntry> getCommitInfoEntries(SchemaTableName table, ConnectorSession session)
+    {
+        TrinoFileSystem fileSystem = fileSystemFactory.create(session);
+        try {
+            return TransactionLogTail.loadNewTail(fileSystem, new Path(metastore.getTableLocation(table, session)), Optional.empty()).getFileEntries().stream()
+                    .map(DeltaLakeTransactionLogEntry::getCommitInfo)
+                    .filter(Objects::nonNull)
+                    .collect(toImmutableList());
+        }
+        catch (TrinoException e) {
+            throw e;
+        }
+        catch (IOException | RuntimeException e) {
+            throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Error getting commit info entries for " + table, e);
+        }
     }
 
     private static ColumnMetadata getColumnMetadata(DeltaLakeColumnHandle column, @Nullable String comment, boolean nullability)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableName.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableName.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import io.trino.spi.TrinoException;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static io.trino.plugin.deltalake.DeltaLakeTableType.DATA;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class DeltaLakeTableName
+{
+    private static final Pattern TABLE_PATTERN = Pattern.compile("" +
+            "(?<table>[^$@]+)" +
+            "(?:\\$(?<type>[^@]+))?");
+
+    private final String tableName;
+    private final DeltaLakeTableType tableType;
+
+    public DeltaLakeTableName(String tableName, DeltaLakeTableType tableType)
+    {
+        this.tableName = requireNonNull(tableName, "tableName is null");
+        this.tableType = requireNonNull(tableType, "tableType is null");
+    }
+
+    public String getTableName()
+    {
+        return tableName;
+    }
+
+    public DeltaLakeTableType getTableType()
+    {
+        return tableType;
+    }
+
+    public String getTableNameWithType()
+    {
+        return tableName + "$" + tableType.name().toLowerCase(Locale.ENGLISH);
+    }
+
+    @Override
+    public String toString()
+    {
+        return getTableNameWithType();
+    }
+
+    public static DeltaLakeTableName from(String name)
+    {
+        Matcher match = TABLE_PATTERN.matcher(name);
+        if (!match.matches()) {
+            throw new TrinoException(NOT_SUPPORTED, "Invalid Delta Lake table name: " + name);
+        }
+
+        String table = match.group("table");
+        String typeString = match.group("type");
+
+        DeltaLakeTableType type = DeltaLakeTableType.DATA;
+        if (typeString != null) {
+            try {
+                type = DeltaLakeTableType.valueOf(typeString.toUpperCase(Locale.ENGLISH));
+            }
+            catch (IllegalArgumentException e) {
+                throw new TrinoException(NOT_SUPPORTED, format("Invalid Delta Lake table name (unknown type '%s'): %s", typeString, name));
+            }
+        }
+
+        return new DeltaLakeTableName(table, type);
+    }
+
+    public static String tableNameFrom(String name)
+    {
+        Matcher match = TABLE_PATTERN.matcher(name);
+        if (!match.matches()) {
+            throw new TrinoException(NOT_SUPPORTED, "Invalid Delta Lake table name: " + name);
+        }
+
+        return match.group("table");
+    }
+
+    public static Optional<DeltaLakeTableType> tableTypeFrom(String name)
+    {
+        Matcher match = TABLE_PATTERN.matcher(name);
+        if (!match.matches()) {
+            throw new TrinoException(NOT_SUPPORTED, "Invalid Delta Lake table name: " + name);
+        }
+        String typeString = match.group("type");
+        if (typeString == null) {
+            return Optional.of(DATA);
+        }
+        try {
+            return Optional.of(DeltaLakeTableType.valueOf(typeString.toUpperCase(Locale.ENGLISH)));
+        }
+        catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+
+    public static boolean isDataTable(String name)
+    {
+        Matcher match = TABLE_PATTERN.matcher(name);
+        if (!match.matches()) {
+            throw new TrinoException(NOT_SUPPORTED, "Invalid Delta Lake table name: " + name);
+        }
+        String typeString = match.group("type");
+        if (typeString == null) {
+            return true;
+        }
+        try {
+            DeltaLakeTableType type = DeltaLakeTableType.valueOf(typeString.toUpperCase(Locale.ENGLISH));
+            return type == DATA;
+        }
+        catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableType.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableType.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+public enum DeltaLakeTableType
+{
+    DATA,
+    HISTORY,
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/CommitInfoEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/CommitInfoEntry.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import static java.lang.String.format;
 
@@ -34,7 +35,7 @@ public class CommitInfoEntry
     private final String clusterId;
     private final long readVersion;
     private final String isolationLevel;
-    private final boolean isBlindAppend;
+    private final Optional<Boolean> isBlindAppend;
 
     @JsonCreator
     public CommitInfoEntry(
@@ -49,7 +50,7 @@ public class CommitInfoEntry
             @JsonProperty("clusterId") String clusterId,
             @JsonProperty("readVersion") long readVersion,
             @JsonProperty("isolationLevel") String isolationLevel,
-            @JsonProperty("isBlindAppend") boolean isBlindAppend)
+            @JsonProperty("isBlindAppend") Optional<Boolean> isBlindAppend)
     {
         this.version = version;
         this.timestamp = timestamp;
@@ -132,7 +133,7 @@ public class CommitInfoEntry
     }
 
     @JsonProperty
-    public boolean isBlindAppend()
+    public Optional<Boolean> isBlindAppend()
     {
         return isBlindAppend;
     }
@@ -167,7 +168,7 @@ public class CommitInfoEntry
                 Objects.equals(this.clusterId, other.clusterId) &&
                 this.readVersion == other.readVersion &&
                 Objects.equals(this.isolationLevel, other.isolationLevel) &&
-                this.isBlindAppend == other.isBlindAppend;
+                Objects.equals(this.isBlindAppend, other.isBlindAppend);
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/CommitInfoEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/CommitInfoEntry.java
@@ -132,7 +132,7 @@ public class CommitInfoEntry
         return isolationLevel;
     }
 
-    @JsonProperty
+    @JsonProperty("isBlindAppend")
     public Optional<Boolean> isBlindAppend()
     {
         return isBlindAppend;

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/CommitInfoEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/CommitInfoEntry.java
@@ -138,6 +138,11 @@ public class CommitInfoEntry
         return isBlindAppend;
     }
 
+    public CommitInfoEntry withVersion(long version)
+    {
+        return new CommitInfoEntry(version, timestamp, userId, userName, operation, operationParameters, job, notebook, clusterId, readVersion, isolationLevel, isBlindAppend);
+    }
+
     @Override
     public String toString()
     {

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeTransactionLogEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeTransactionLogEntry.java
@@ -152,6 +152,11 @@ public class DeltaLakeTransactionLogEntry
         return cdfFileEntry;
     }
 
+    public DeltaLakeTransactionLogEntry withCommitInfo(CommitInfoEntry commitInfo)
+    {
+        return new DeltaLakeTransactionLogEntry(txn, add, remove, metaData, protocol, commitInfo, cdfFileEntry);
+    }
+
     @Override
     public String toString()
     {

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
@@ -390,7 +390,7 @@ public class TransactionLogAccess
         return forVersions.stream()
                 .flatMap(version -> {
                     try {
-                        Optional<List<DeltaLakeTransactionLogEntry>> entriesFromJson = getEntriesFromJson(getTransactionLogJsonEntryPath(transactionLogDir, version), fileSystem);
+                        Optional<List<DeltaLakeTransactionLogEntry>> entriesFromJson = getEntriesFromJson(version, transactionLogDir, fileSystem);
                         //noinspection SimplifyOptionalCallChains
                         return entriesFromJson.map(List::stream)
                                 // transaction log does not exist. Might have been expired.

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
@@ -267,7 +267,7 @@ public class CheckpointEntryIterator
                 getString(commitInfoEntryBlock, 8),
                 getLong(commitInfoEntryBlock, 9),
                 getString(commitInfoEntryBlock, 10),
-                getByte(commitInfoEntryBlock, 11) != 0);
+                Optional.of(getByte(commitInfoEntryBlock, 11) != 0));
         log.debug("Result: %s", result);
         return DeltaLakeTransactionLogEntry.commitInfoEntry(result);
     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TransactionLogTail.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TransactionLogTail.java
@@ -73,8 +73,7 @@ public class TransactionLogTail
 
         boolean endOfTail = false;
         while (!endOfTail) {
-            Path path = getTransactionLogJsonEntryPath(transactionLogDir, entryNumber);
-            results = getEntriesFromJson(path, fileSystem);
+            results = getEntriesFromJson(entryNumber, transactionLogDir, fileSystem);
             if (results.isPresent()) {
                 entriesBuilder.addAll(results.get());
                 version = entryNumber;
@@ -82,7 +81,7 @@ public class TransactionLogTail
             }
             else {
                 if (endVersion.isPresent()) {
-                    throw new MissingTransactionLogException(path);
+                    throw new MissingTransactionLogException(getTransactionLogJsonEntryPath(transactionLogDir, entryNumber));
                 }
                 endOfTail = true;
             }
@@ -103,10 +102,9 @@ public class TransactionLogTail
         long newVersion = version;
 
         Optional<List<DeltaLakeTransactionLogEntry>> results;
-        Path transactionLogDir = getTransactionLogDir(tableLocation);
         boolean endOfTail = false;
         while (!endOfTail) {
-            results = getEntriesFromJson(getTransactionLogJsonEntryPath(transactionLogDir, newVersion + 1), fileSystem);
+            results = getEntriesFromJson(newVersion + 1, getTransactionLogDir(tableLocation), fileSystem);
             if (results.isPresent()) {
                 if (version == newVersion) {
                     // initialize entriesBuilder with entries we have already read
@@ -126,9 +124,10 @@ public class TransactionLogTail
         return Optional.of(new TransactionLogTail(entriesBuilder.build(), newVersion));
     }
 
-    public static Optional<List<DeltaLakeTransactionLogEntry>> getEntriesFromJson(Path transactionLogFilePath, TrinoFileSystem fileSystem)
+    public static Optional<List<DeltaLakeTransactionLogEntry>> getEntriesFromJson(long entryNumber, Path transactionLogDir, TrinoFileSystem fileSystem)
             throws IOException
     {
+        Path transactionLogFilePath = getTransactionLogJsonEntryPath(transactionLogDir, entryNumber);
         TrinoInputFile inputFile = fileSystem.newInputFile(transactionLogFilePath.toString());
         try (BufferedReader reader = new BufferedReader(
                 new InputStreamReader(inputFile.newInput().inputStream(), UTF_8),
@@ -136,7 +135,12 @@ public class TransactionLogTail
             ImmutableList.Builder<DeltaLakeTransactionLogEntry> resultsBuilder = ImmutableList.builder();
             String line = reader.readLine();
             while (line != null) {
-                resultsBuilder.add(parseJson(line));
+                DeltaLakeTransactionLogEntry deltaLakeTransactionLogEntry = parseJson(line);
+                if (deltaLakeTransactionLogEntry.getCommitInfo() != null && deltaLakeTransactionLogEntry.getCommitInfo().getVersion() == 0L) {
+                    // In case that the commit info version is missing, use the version from the transaction log file name
+                    deltaLakeTransactionLogEntry = deltaLakeTransactionLogEntry.withCommitInfo(deltaLakeTransactionLogEntry.getCommitInfo().withVersion(entryNumber));
+                }
+                resultsBuilder.add(deltaLakeTransactionLogEntry);
                 line = reader.readLine();
             }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/util/PageListBuilder.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/util/PageListBuilder.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.util;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.type.TimeZoneKey;
+import io.trino.spi.type.Type;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+
+public final class PageListBuilder
+{
+    private final int channels;
+    private final PageBuilder pageBuilder;
+
+    private ImmutableList.Builder<Page> pages;
+    private int channel;
+
+    public PageListBuilder(List<Type> types)
+    {
+        this.channels = types.size();
+        this.pageBuilder = new PageBuilder(types);
+        reset();
+    }
+
+    public void reset()
+    {
+        pages = ImmutableList.builder();
+        pageBuilder.reset();
+        channel = -1;
+    }
+
+    public List<Page> build()
+    {
+        checkArgument(channel == -1, "cannot be in row");
+        if (!pageBuilder.isEmpty()) {
+            pages.add(pageBuilder.build());
+            pageBuilder.reset();
+        }
+        return pages.build();
+    }
+
+    public void beginRow()
+    {
+        checkArgument(channel == -1, "already in row");
+        if (pageBuilder.isFull()) {
+            pages.add(pageBuilder.build());
+            pageBuilder.reset();
+        }
+        pageBuilder.declarePosition();
+        channel = 0;
+    }
+
+    public void endRow()
+    {
+        checkArgument(channel == channels, "not at end of row");
+        channel = -1;
+    }
+
+    public void appendNull()
+    {
+        nextColumn().appendNull();
+    }
+
+    public void appendBigint(long value)
+    {
+        BIGINT.writeLong(nextColumn(), value);
+    }
+
+    public void appendBoolean(boolean value)
+    {
+        BOOLEAN.writeBoolean(nextColumn(), value);
+    }
+
+    public void appendTimestampTzMillis(long millisUtc, TimeZoneKey timeZoneKey)
+    {
+        TIMESTAMP_TZ_MILLIS.writeLong(nextColumn(), packDateTimeWithZone(millisUtc, timeZoneKey));
+    }
+
+    public void appendVarchar(String value)
+    {
+        VARCHAR.writeString(nextColumn(), value);
+    }
+
+    public void appendVarcharVarcharMap(Map<String, String> values)
+    {
+        BlockBuilder column = nextColumn();
+        BlockBuilder map = column.beginBlockEntry();
+        values.forEach((key, value) -> {
+            if (key == null) {
+                map.appendNull();
+            }
+            else {
+                VARCHAR.writeString(map, key);
+            }
+            if (value == null) {
+                map.appendNull();
+            }
+            else {
+                VARCHAR.writeString(map, value);
+            }
+        });
+        column.closeEntry();
+    }
+
+    public BlockBuilder nextColumn()
+    {
+        int currentChannel = channel;
+        channel++;
+        return pageBuilder.getBlockBuilder(currentChannel);
+    }
+
+    public static PageListBuilder forTable(ConnectorTableMetadata table)
+    {
+        return new PageListBuilder(table.getColumns().stream()
+                .map(ColumnMetadata::getType)
+                .collect(toImmutableList()));
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSystemTables.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSystemTables.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import org.testng.annotations.Test;
+
+import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
+import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.createDeltaLakeQueryRunner;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestDeltaLakeSystemTables
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        return createDeltaLakeQueryRunner(
+                DELTA_CATALOG,
+                ImmutableMap.of(),
+                ImmutableMap.of("delta.enable-non-concurrent-writes", "true"));
+    }
+
+    @Test
+    public void testDataTable()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_data_table (_bigint BIGINT)");
+            assertUpdate("INSERT INTO test_data_table VALUES 1, 2, 3", 3);
+
+            assertQuery("SELECT * FROM test_data_table", "VALUES 1, 2, 3");
+            assertQuery("SELECT * FROM \"test_data_table$data\"", "VALUES 1, 2, 3");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS test_data_table");
+        }
+    }
+
+    @Test
+    public void testHistoryTable()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_simple_table (_bigint BIGINT)");
+            assertUpdate("INSERT INTO test_simple_table VALUES 1, 2, 3", 3);
+            assertQuery("SELECT count(*) FROM test_simple_table", "VALUES 3");
+
+            assertUpdate("CREATE TABLE test_checkpoint_table (_bigint BIGINT, _date DATE) WITH (partitioned_by = ARRAY['_date'] )");
+            assertUpdate("INSERT INTO test_checkpoint_table VALUES (0, CAST('2019-09-08' AS DATE)), (1, CAST('2019-09-09' AS DATE)), (2, CAST('2019-09-09' AS DATE))", 3);
+            assertUpdate("INSERT INTO test_checkpoint_table VALUES (3, CAST('2019-09-09' AS DATE)), (4, CAST('2019-09-10' AS DATE)), (5, CAST('2019-09-10' AS DATE))", 3);
+            assertUpdate("UPDATE test_checkpoint_table SET _bigint = 50 WHERE _bigint =  BIGINT '5'", 1);
+            assertUpdate("DELETE FROM test_checkpoint_table WHERE _date =  DATE '2019-09-08'", 1);
+            assertQuerySucceeds("ALTER TABLE test_checkpoint_table EXECUTE OPTIMIZE");
+            assertQuery("SELECT count(*) FROM test_checkpoint_table", "VALUES 5");
+
+            assertQuery("SHOW COLUMNS FROM \"test_checkpoint_table$history\"",
+                    """
+                            VALUES
+                            ('version', 'bigint', '', ''),
+                            ('timestamp', 'timestamp(3) with time zone', '', ''),
+                            ('user_id', 'varchar', '', ''),
+                            ('user_name', 'varchar', '', ''),
+                            ('operation', 'varchar', '', ''),
+                            ('operation_parameters', 'map(varchar, varchar)', '', ''),
+                            ('cluster_id', 'varchar', '', ''),
+                            ('read_version', 'bigint', '', ''),
+                            ('isolation_level', 'varchar', '', ''),
+                            ('is_blind_append', 'boolean', '', '')
+                            """);
+
+            // Test the contents of history system table
+            assertThat(query("SELECT version, operation, read_version, isolation_level, is_blind_append FROM \"test_simple_table$history\""))
+                    .matches("""
+                            VALUES
+                                (BIGINT '1', VARCHAR 'WRITE', BIGINT '0', VARCHAR 'WriteSerializable', true),
+                                (BIGINT '0', VARCHAR 'CREATE TABLE', BIGINT '0', VARCHAR 'WriteSerializable', true)
+                            """);
+            assertThat(query("SELECT version, operation, read_version, isolation_level, is_blind_append FROM \"test_checkpoint_table$history\""))
+                    // TODO (https://github.com/trinodb/trino/issues/15763) Use correct operation name for DML statements
+                    .matches("""
+                            VALUES
+                                (BIGINT '5', VARCHAR 'OPTIMIZE', BIGINT '4', VARCHAR 'WriteSerializable', true),
+                                (BIGINT '4', VARCHAR 'MERGE', BIGINT '3', VARCHAR 'WriteSerializable', true),
+                                (BIGINT '3', VARCHAR 'MERGE', BIGINT '2', VARCHAR 'WriteSerializable', true),
+                                (BIGINT '2', VARCHAR 'WRITE', BIGINT '1', VARCHAR 'WriteSerializable', true),
+                                (BIGINT '1', VARCHAR 'WRITE', BIGINT '0', VARCHAR 'WriteSerializable', true),
+                                (BIGINT '0', VARCHAR 'CREATE TABLE', BIGINT '0', VARCHAR 'WriteSerializable', true)
+                            """);
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS test_simple_table");
+            assertUpdate("DROP TABLE IF EXISTS test_checkpoint_table");
+        }
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableName.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableName.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.plugin.deltalake.DeltaLakeTableType.DATA;
+import static io.trino.plugin.deltalake.DeltaLakeTableType.HISTORY;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestDeltaLakeTableName
+{
+    @Test
+    public void testFrom()
+    {
+        assertFrom("abc", "abc", DATA);
+        assertFrom("abc$data", "abc", DATA);
+        assertFrom("abc$history", "abc", DeltaLakeTableType.HISTORY);
+
+        assertInvalid("abc@123", "Invalid Delta Lake table name: abc@123");
+        assertInvalid("abc@xyz", "Invalid Delta Lake table name: abc@xyz");
+        assertInvalid("abc$what", "Invalid Delta Lake table name (unknown type 'what'): abc$what");
+        assertInvalid("abc@123$data@456", "Invalid Delta Lake table name: abc@123$data@456");
+        assertInvalid("xyz$data@456", "Invalid Delta Lake table name: xyz$data@456");
+    }
+
+    @Test
+    public void testIsDataTable()
+    {
+        assertTrue(DeltaLakeTableName.isDataTable("abc"));
+        assertTrue(DeltaLakeTableName.isDataTable("abc$data"));
+
+        assertFalse(DeltaLakeTableName.isDataTable("abc$history"));
+        assertFalse(DeltaLakeTableName.isDataTable("abc$invalid"));
+    }
+
+    @Test
+    public void testTableNameFrom()
+    {
+        assertEquals(DeltaLakeTableName.tableNameFrom("abc"), "abc");
+        assertEquals(DeltaLakeTableName.tableNameFrom("abc$data"), "abc");
+        assertEquals(DeltaLakeTableName.tableNameFrom("abc$history"), "abc");
+        assertEquals(DeltaLakeTableName.tableNameFrom("abc$invalid"), "abc");
+    }
+
+    @Test
+    public void testTableTypeFrom()
+    {
+        assertEquals(DeltaLakeTableName.tableTypeFrom("abc"), Optional.of(DATA));
+        assertEquals(DeltaLakeTableName.tableTypeFrom("abc$data"), Optional.of(DATA));
+        assertEquals(DeltaLakeTableName.tableTypeFrom("abc$history"), Optional.of(HISTORY));
+
+        assertEquals(DeltaLakeTableName.tableTypeFrom("abc$invalid"), Optional.empty());
+    }
+
+    @Test
+    public void testGetTableNameWithType()
+    {
+        assertEquals(new DeltaLakeTableName("abc", DATA).getTableNameWithType(), "abc$data");
+        assertEquals(new DeltaLakeTableName("abc", HISTORY).getTableNameWithType(), "abc$history");
+    }
+
+    private static void assertInvalid(String inputName, String message)
+    {
+        assertTrinoExceptionThrownBy(() -> DeltaLakeTableName.from(inputName))
+                .hasErrorCode(NOT_SUPPORTED)
+                .hasMessage(message);
+    }
+
+    private static void assertFrom(String inputName, String tableName, DeltaLakeTableType tableType)
+    {
+        DeltaLakeTableName name = DeltaLakeTableName.from(inputName);
+        assertEquals(name.getTableName(), tableName);
+        assertEquals(name.getTableType(), tableType);
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
@@ -315,13 +315,13 @@ public class TestTransactionLogAccess
                     ImmutableSet.of(
                             new CommitInfoEntry(0, 1579190200860L, "671960514434781", "michal.slizak@starburstdata.com", "WRITE",
                                     ImmutableMap.of("mode", "Append", "partitionBy", "[\"age\"]"), null, new CommitInfoEntry.Notebook("3040849856940931"),
-                                    "0116-154224-guppy476", 10L, "WriteSerializable", true),
+                                    "0116-154224-guppy476", 10L, "WriteSerializable", Optional.of(true)),
                             new CommitInfoEntry(0, 1579190206644L, "671960514434781", "michal.slizak@starburstdata.com", "WRITE",
                                     ImmutableMap.of("mode", "Append", "partitionBy", "[\"age\"]"), null, new CommitInfoEntry.Notebook("3040849856940931"),
-                                    "0116-154224-guppy476", 11L, "WriteSerializable", true),
+                                    "0116-154224-guppy476", 11L, "WriteSerializable", Optional.of(true)),
                             new CommitInfoEntry(0, 1579190210571L, "671960514434781", "michal.slizak@starburstdata.com", "WRITE",
                                     ImmutableMap.of("mode", "Append", "partitionBy", "[\"age\"]"), null, new CommitInfoEntry.Notebook("3040849856940931"),
-                                    "0116-154224-guppy476", 12L, "WriteSerializable", true)));
+                                    "0116-154224-guppy476", 12L, "WriteSerializable", Optional.of(true))));
         }
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
@@ -313,13 +313,13 @@ public class TestTransactionLogAccess
             assertEquals(
                     entrySet,
                     ImmutableSet.of(
-                            new CommitInfoEntry(0, 1579190200860L, "671960514434781", "michal.slizak@starburstdata.com", "WRITE",
+                            new CommitInfoEntry(11, 1579190200860L, "671960514434781", "michal.slizak@starburstdata.com", "WRITE",
                                     ImmutableMap.of("mode", "Append", "partitionBy", "[\"age\"]"), null, new CommitInfoEntry.Notebook("3040849856940931"),
                                     "0116-154224-guppy476", 10L, "WriteSerializable", Optional.of(true)),
-                            new CommitInfoEntry(0, 1579190206644L, "671960514434781", "michal.slizak@starburstdata.com", "WRITE",
+                            new CommitInfoEntry(12, 1579190206644L, "671960514434781", "michal.slizak@starburstdata.com", "WRITE",
                                     ImmutableMap.of("mode", "Append", "partitionBy", "[\"age\"]"), null, new CommitInfoEntry.Notebook("3040849856940931"),
                                     "0116-154224-guppy476", 11L, "WriteSerializable", Optional.of(true)),
-                            new CommitInfoEntry(0, 1579190210571L, "671960514434781", "michal.slizak@starburstdata.com", "WRITE",
+                            new CommitInfoEntry(13, 1579190210571L, "671960514434781", "michal.slizak@starburstdata.com", "WRITE",
                                     ImmutableMap.of("mode", "Append", "partitionBy", "[\"age\"]"), null, new CommitInfoEntry.Notebook("3040849856940931"),
                                     "0116-154224-guppy476", 12L, "WriteSerializable", Optional.of(true))));
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Provide the ability to query the history of changes performed on a Delta Lake table.

The documentation from https://docs.databricks.com/delta/history.html `DESCRIBE HISTORY` command was used as reference.

Same as in case of Iceberg tables, the history content can be retrieved by doing the query:

```
SELECT * from "table_name$history";
```

Fixes #15683



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Add `$history` system table which can be queried to inspect Delta Lake table history. ({issue}`15683`)
```
