### PR TITLE
Upgrade jgrapht library to the latest version

### DIFF
--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/policy/TestPhasedExecutionSchedule.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/policy/TestPhasedExecutionSchedule.java
@@ -34,7 +34,7 @@ import io.trino.spi.type.TypeOperators;
 import io.trino.sql.planner.PlanFragment;
 import io.trino.sql.planner.plan.PlanFragmentId;
 import io.trino.sql.planner.plan.PlanNodeId;
-import org.jgrapht.DirectedGraph;
+import org.jgrapht.Graph;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -82,7 +82,7 @@ public class TestPhasedExecutionSchedule
         assertThat(schedule.getSortedFragments()).containsExactly(buildFragment.getId(), probeFragment.getId(), joinFragment.getId());
 
         // single dependency between build and probe stages
-        DirectedGraph<PlanFragmentId, FragmentsEdge> dependencies = schedule.getFragmentDependency();
+        Graph<PlanFragmentId, FragmentsEdge> dependencies = schedule.getFragmentDependency();
         assertThat(dependencies.edgeSet()).containsExactlyInAnyOrder(new FragmentsEdge(buildFragment.getId(), probeFragment.getId()));
 
         // build and join stage should start immediately
@@ -120,7 +120,7 @@ public class TestPhasedExecutionSchedule
         assertThat(schedule.getSortedFragments()).containsExactly(buildFragment.getId(), joinSourceFragment.getId());
 
         // single dependency between build and join stages
-        DirectedGraph<PlanFragmentId, FragmentsEdge> dependencies = schedule.getFragmentDependency();
+        Graph<PlanFragmentId, FragmentsEdge> dependencies = schedule.getFragmentDependency();
         assertThat(dependencies.edgeSet()).containsExactlyInAnyOrder(new FragmentsEdge(buildFragment.getId(), joinSourceFragment.getId()));
 
         // build stage should start immediately
@@ -149,7 +149,7 @@ public class TestPhasedExecutionSchedule
         assertThat(schedule.getSortedFragments()).containsExactly(buildFragment.getId(), sourceFragment.getId(), aggregationFragment.getId(), joinFragment.getId());
 
         // aggregation and source stage should start immediately, join stage should wait for build stage to complete
-        DirectedGraph<PlanFragmentId, FragmentsEdge> dependencies = schedule.getFragmentDependency();
+        Graph<PlanFragmentId, FragmentsEdge> dependencies = schedule.getFragmentDependency();
         assertThat(dependencies.edgeSet()).containsExactly(new FragmentsEdge(buildFragment.getId(), joinFragment.getId()));
         assertThat(getSchedulingFragments(schedule)).containsExactly(buildFragment.getId(), sourceFragment.getId(), aggregationFragment.getId());
     }
@@ -171,7 +171,7 @@ public class TestPhasedExecutionSchedule
         assertThat(schedule.getSortedFragments()).containsExactly(buildFragment.getId(), sourceFragment.getId(), aggregationFragment.getId(), joinFragment.getId());
 
         // aggregation and source stage should start immediately, join stage should wait for build stage to complete
-        DirectedGraph<PlanFragmentId, FragmentsEdge> dependencies = schedule.getFragmentDependency();
+        Graph<PlanFragmentId, FragmentsEdge> dependencies = schedule.getFragmentDependency();
         assertThat(dependencies.edgeSet()).containsExactly(new FragmentsEdge(buildFragment.getId(), joinFragment.getId()));
         assertThat(getSchedulingFragments(schedule)).containsExactly(buildFragment.getId(), sourceFragment.getId(), aggregationFragment.getId());
 
@@ -205,7 +205,7 @@ public class TestPhasedExecutionSchedule
                 broadcastBuildStage, partitionedBuildStage, probeStage, joinStage), dynamicFilterService);
 
         // join stage should start immediately because partitioned join forces that
-        DirectedGraph<PlanFragmentId, FragmentsEdge> dependencies = schedule.getFragmentDependency();
+        Graph<PlanFragmentId, FragmentsEdge> dependencies = schedule.getFragmentDependency();
         assertThat(dependencies.edgeSet()).containsExactlyInAnyOrder(
                 new FragmentsEdge(broadcastBuildFragment.getId(), probeFragment.getId()),
                 new FragmentsEdge(partitionedBuildFragment.getId(), probeFragment.getId()),
@@ -240,7 +240,7 @@ public class TestPhasedExecutionSchedule
                 nestedJoinBuildStage, nestedJoinProbeStage, nestedJoinStage, joinSourceStage), dynamicFilterService);
 
         // nestedJoinStage and nestedJoinProbeStage should start immediately
-        DirectedGraph<PlanFragmentId, FragmentsEdge> dependencies = schedule.getFragmentDependency();
+        Graph<PlanFragmentId, FragmentsEdge> dependencies = schedule.getFragmentDependency();
         assertThat(dependencies.edgeSet()).containsExactlyInAnyOrder(
                 new FragmentsEdge(nestedJoinBuildFragment.getId(), joinSourceFragment.getId()),
                 new FragmentsEdge(nestedJoinFragment.getId(), joinSourceFragment.getId()),

--- a/pom.xml
+++ b/pom.xml
@@ -1834,7 +1834,7 @@
             <dependency>
                 <groupId>org.jgrapht</groupId>
                 <artifactId>jgrapht-core</artifactId>
-                <version>0.9.0</version>
+                <version>1.5.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The jgrapht library is used by the implementations of the `ExecutionSchedule` interface in the trino-main module.
The trino project depends on a really old version of jgrapht. This PR updates jgrapht to the latest version. The library functionality remains unchanged, however there are some breaking changes to the API, which are addressed in this PR.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Notable change to jgrapht API: `StrongConnectivityInspector` is now an interface, it was a concrete class previously. The implementation `KosarajuStrongConnectivityInspector` has the same behavior as the older concrete class - https://github.com/jgrapht/jgrapht/pull/152

Fixes #15547 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
