### PR TITLE
Simplify logical expressions using TupleDomain when possible

### DIFF
--- a/core/trino-main/src/main/java/io/trino/cost/FilterStatsCalculator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/FilterStatsCalculator.java
@@ -119,7 +119,7 @@ public class FilterStatsCalculator
         // TODO reuse io.trino.sql.planner.iterative.rule.SimplifyExpressions.rewrite
 
         Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(plannerContext, session, predicate, types);
-        ExpressionInterpreter interpreter = new ExpressionInterpreter(predicate, plannerContext, session, expressionTypes);
+        ExpressionInterpreter interpreter = new ExpressionInterpreter(predicate, plannerContext, session, expressionTypes, types);
         Object value = interpreter.optimize(NoOpSymbolResolver.INSTANCE);
 
         if (value == null) {

--- a/core/trino-main/src/main/java/io/trino/cost/ScalarStatsCalculator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/ScalarStatsCalculator.java
@@ -136,7 +136,7 @@ public class ScalarStatsCalculator
         protected SymbolStatsEstimate visitFunctionCall(FunctionCall node, Void context)
         {
             Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(plannerContext, session, node, types);
-            ExpressionInterpreter interpreter = new ExpressionInterpreter(node, plannerContext, session, expressionTypes);
+            ExpressionInterpreter interpreter = new ExpressionInterpreter(node, plannerContext, session, expressionTypes, types);
             Object value = interpreter.optimize(NoOpSymbolResolver.INSTANCE);
 
             if (value == null || value instanceof NullLiteral) {

--- a/core/trino-main/src/main/java/io/trino/sql/ExpressionUtils.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ExpressionUtils.java
@@ -304,7 +304,7 @@ public final class ExpressionUtils
     private static boolean constantExpressionEvaluatesSuccessfully(PlannerContext plannerContext, Session session, Expression constantExpression)
     {
         Map<NodeRef<Expression>, Type> types = getExpressionTypes(plannerContext, session, constantExpression, TypeProvider.empty());
-        ExpressionInterpreter interpreter = new ExpressionInterpreter(constantExpression, plannerContext, session, types);
+        ExpressionInterpreter interpreter = new ExpressionInterpreter(constantExpression, plannerContext, session, types, TypeProvider.empty());
         Object literalValue = interpreter.optimize(NoOpSymbolResolver.INSTANCE);
         return !(literalValue instanceof Expression);
     }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -2815,7 +2815,7 @@ class StatementAnalyzer
                 throw semanticException(TYPE_MISMATCH, samplePercentage, "Sample percentage should be a numeric expression");
             }
 
-            ExpressionInterpreter samplePercentageEval = new ExpressionInterpreter(samplePercentage, plannerContext, session, expressionTypes);
+            ExpressionInterpreter samplePercentageEval = new ExpressionInterpreter(samplePercentage, plannerContext, session, expressionTypes, TypeProvider.empty());
 
             Object samplePercentageObject = samplePercentageEval.optimize(symbol -> {
                 throw semanticException(EXPRESSION_NOT_CONSTANT, samplePercentage, "Sample percentage cannot contain column references");

--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -563,8 +563,8 @@ public final class DomainTranslator
          */
         private Optional<NormalizedSimpleComparison> toNormalizedSimpleComparison(Map<NodeRef<Expression>, Type> expressionTypes, ComparisonExpression comparison)
         {
-            Object left = new ExpressionInterpreter(comparison.getLeft(), plannerContext, session, expressionTypes).optimize(NoOpSymbolResolver.INSTANCE);
-            Object right = new ExpressionInterpreter(comparison.getRight(), plannerContext, session, expressionTypes).optimize(NoOpSymbolResolver.INSTANCE);
+            Object left = new ExpressionInterpreter(comparison.getLeft(), plannerContext, session, expressionTypes, types).optimize(NoOpSymbolResolver.INSTANCE);
+            Object right = new ExpressionInterpreter(comparison.getRight(), plannerContext, session, expressionTypes, types).optimize(NoOpSymbolResolver.INSTANCE);
 
             Type leftType = expressionTypes.get(NodeRef.of(comparison.getLeft()));
             Type rightType = expressionTypes.get(NodeRef.of(comparison.getRight()));
@@ -977,7 +977,7 @@ public final class DomainTranslator
             List<Expression> excludedExpressions = new ArrayList<>();
 
             for (Expression expression : valueList.getValues()) {
-                Object value = new ExpressionInterpreter(expression, plannerContext, session, expressionTypes)
+                Object value = new ExpressionInterpreter(expression, plannerContext, session, expressionTypes, types)
                         .optimize(NoOpSymbolResolver.INSTANCE);
                 if (value == null || value instanceof NullLiteral) {
                     if (!complement) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/EffectivePredicateExtractor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/EffectivePredicateExtractor.java
@@ -376,7 +376,7 @@ public class EffectivePredicateExtractor
                             nonDeterministic[i] = true;
                         }
                         else {
-                            ExpressionInterpreter interpreter = new ExpressionInterpreter(value, plannerContext, session, expressionTypes);
+                            ExpressionInterpreter interpreter = new ExpressionInterpreter(value, plannerContext, session, expressionTypes, types);
                             Object item = interpreter.optimize(NoOpSymbolResolver.INSTANCE);
                             if (item instanceof Expression) {
                                 return TRUE_LITERAL;
@@ -403,7 +403,7 @@ public class EffectivePredicateExtractor
                     if (!DeterminismEvaluator.isDeterministic(row, metadata)) {
                         return TRUE_LITERAL;
                     }
-                    ExpressionInterpreter interpreter = new ExpressionInterpreter(row, plannerContext, session, expressionTypes);
+                    ExpressionInterpreter interpreter = new ExpressionInterpreter(row, plannerContext, session, expressionTypes, types);
                     Object evaluated = interpreter.optimize(NoOpSymbolResolver.INSTANCE);
                     if (evaluated instanceof Expression) {
                         return TRUE_LITERAL;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LayoutConstraintEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LayoutConstraintEvaluator.java
@@ -38,7 +38,7 @@ public class LayoutConstraintEvaluator
     public LayoutConstraintEvaluator(PlannerContext plannerContext, TypeAnalyzer typeAnalyzer, Session session, TypeProvider types, Map<Symbol, ColumnHandle> assignments, Expression expression)
     {
         this.assignments = ImmutableMap.copyOf(requireNonNull(assignments, "assignments is null"));
-        evaluator = new ExpressionInterpreter(expression, plannerContext, session, typeAnalyzer.getTypes(session, types, expression));
+        evaluator = new ExpressionInterpreter(expression, plannerContext, session, typeAnalyzer.getTypes(session, types, expression), types);
         arguments = SymbolsExtractor.extractUnique(expression).stream()
                 .map(assignments::get)
                 .collect(toImmutableSet());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -2079,7 +2079,7 @@ public class LocalExecutionPlanner
                     Map<NodeRef<Expression>, Type> types = typeAnalyzer.getTypes(session, TypeProvider.empty(), row);
                     checkState(types.get(NodeRef.of(row)) instanceof RowType, "unexpected type of Values row: %s", types);
                     // evaluate the literal value
-                    Object result = new ExpressionInterpreter(row, plannerContext, session, types).evaluate();
+                    Object result = new ExpressionInterpreter(row, plannerContext, session, types, TypeProvider.empty()).evaluate();
                     for (int j = 0; j < outputTypes.size(); j++) {
                         // divide row into fields
                         writeNativeValue(outputTypes.get(j), pageBuilder.getBlockBuilder(j), readNativeValue(outputTypes.get(j), (SingleRowBlock) result, j));

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PreAggregateCaseAggregations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PreAggregateCaseAggregations.java
@@ -421,7 +421,7 @@ public class PreAggregateCaseAggregations
     private Object optimizeExpression(Expression expression, Context context)
     {
         Map<NodeRef<Expression>, Type> expressionTypes = typeAnalyzer.getTypes(context.getSession(), context.getSymbolAllocator().getTypes(), expression);
-        ExpressionInterpreter expressionInterpreter = new ExpressionInterpreter(expression, plannerContext, context.getSession(), expressionTypes);
+        ExpressionInterpreter expressionInterpreter = new ExpressionInterpreter(expression, plannerContext, context.getSession(), expressionTypes, context.getSymbolAllocator().getTypes());
         return expressionInterpreter.optimize(Symbol::toSymbolReference);
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationIntoTableScan.java
@@ -200,7 +200,7 @@ public class PushAggregationIntoTableScan
                     Map<NodeRef<Expression>, Type> translatedExpressionTypes = typeAnalyzer.getTypes(session, context.getSymbolAllocator().getTypes(), translated);
                     translated = literalEncoder.toExpression(
                             session,
-                            new ExpressionInterpreter(translated, plannerContext, session, translatedExpressionTypes)
+                            new ExpressionInterpreter(translated, plannerContext, session, translatedExpressionTypes, context.getSymbolAllocator().getTypes())
                                     .optimize(NoOpSymbolResolver.INSTANCE),
                             translatedExpressionTypes.get(NodeRef.of(translated)));
                     return translated;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
@@ -329,7 +329,7 @@ public class PushPredicateIntoTableScan
         verify(newTablePartitioning.equals(oldTablePartitioning), "Partitioning must not change after predicate is pushed down");
     }
 
-    private static SplitExpression splitExpression(PlannerContext plannerContext, Expression predicate)
+    public static SplitExpression splitExpression(PlannerContext plannerContext, Expression predicate)
     {
         Metadata metadata = plannerContext.getMetadata();
 
@@ -419,7 +419,7 @@ public class PushPredicateIntoTableScan
         return TupleDomain.withColumnDomains(enforcedDomainsBuilder.buildOrThrow());
     }
 
-    private static class SplitExpression
+    public static class SplitExpression
     {
         private final Expression dynamicFilter;
         private final Expression deterministicPredicate;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
@@ -288,7 +288,7 @@ public class PushPredicateIntoTableScan
             Map<NodeRef<Expression>, Type> translatedExpressionTypes = typeAnalyzer.getTypes(session, symbolAllocator.getTypes(), translatedExpression);
             translatedExpression = literalEncoder.toExpression(
                     session,
-                    new ExpressionInterpreter(translatedExpression, plannerContext, session, translatedExpressionTypes)
+                    new ExpressionInterpreter(translatedExpression, plannerContext, session, translatedExpressionTypes, symbolAllocator.getTypes())
                             .optimize(NoOpSymbolResolver.INSTANCE),
                     translatedExpressionTypes.get(NodeRef.of(translatedExpression)));
             remainingDecomposedPredicate = combineConjuncts(plannerContext.getMetadata(), translatedExpression, expressionTranslation.remainingExpression());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushProjectionIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushProjectionIntoTableScan.java
@@ -158,7 +158,7 @@ public class PushProjectionIntoTableScan
                     Map<NodeRef<Expression>, Type> translatedExpressionTypes = typeAnalyzer.getTypes(session, context.getSymbolAllocator().getTypes(), translated);
                     translated = literalEncoder.toExpression(
                             session,
-                            new ExpressionInterpreter(translated, plannerContext, session, translatedExpressionTypes)
+                            new ExpressionInterpreter(translated, plannerContext, session, translatedExpressionTypes, context.getSymbolAllocator().getTypes())
                                     .optimize(NoOpSymbolResolver.INSTANCE),
                             translatedExpressionTypes.get(NodeRef.of(translated)));
                     return translated;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyExpressions.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyExpressions.java
@@ -50,7 +50,7 @@ public class SimplifyExpressions
         expression = extractCommonPredicates(plannerContext.getMetadata(), expression);
         expression = normalizeOrExpression(expression);
         expressionTypes = typeAnalyzer.getTypes(session, symbolAllocator.getTypes(), expression);
-        ExpressionInterpreter interpreter = new ExpressionInterpreter(expression, plannerContext, session, expressionTypes);
+        ExpressionInterpreter interpreter = new ExpressionInterpreter(expression, plannerContext, session, expressionTypes, symbolAllocator.getTypes());
         Object optimized = interpreter.optimize(NoOpSymbolResolver.INSTANCE);
         return new LiteralEncoder(plannerContext).toExpression(session, optimized, expressionTypes.get(NodeRef.of(expression)));
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
@@ -179,7 +179,7 @@ public class UnwrapCastInComparison
                 return expression;
             }
 
-            Object right = new ExpressionInterpreter(expression.getRight(), plannerContext, session, typeAnalyzer.getTypes(session, types, expression.getRight()))
+            Object right = new ExpressionInterpreter(expression.getRight(), plannerContext, session, typeAnalyzer.getTypes(session, types, expression.getRight()), types)
                     .optimize(NoOpSymbolResolver.INSTANCE);
 
             ComparisonExpression.Operator operator = expression.getOperator();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapDateTruncInComparison.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapDateTruncInComparison.java
@@ -166,7 +166,7 @@ public class UnwrapDateTruncInComparison
             if (!(expressionTypes.get(NodeRef.of(unitExpression)) instanceof VarcharType) || !isEffectivelyLiteral(plannerContext, session, unitExpression)) {
                 return expression;
             }
-            Slice unitName = (Slice) new ExpressionInterpreter(unitExpression, plannerContext, session, expressionTypes)
+            Slice unitName = (Slice) new ExpressionInterpreter(unitExpression, plannerContext, session, expressionTypes, types)
                     .optimize(NoOpSymbolResolver.INSTANCE);
             if (unitName == null) {
                 return expression;
@@ -178,7 +178,7 @@ public class UnwrapDateTruncInComparison
             Type rightType = expressionTypes.get(NodeRef.of(expression.getRight()));
             verify(argumentType.equals(rightType), "Mismatched types: %s and %s", argumentType, rightType);
 
-            Object right = new ExpressionInterpreter(expression.getRight(), plannerContext, session, expressionTypes)
+            Object right = new ExpressionInterpreter(expression.getRight(), plannerContext, session, expressionTypes, types)
                     .optimize(NoOpSymbolResolver.INSTANCE);
 
             if (right == null || right instanceof NullLiteral) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
@@ -1216,7 +1216,7 @@ public class PredicatePushDown
         private Expression simplifyExpression(Expression expression)
         {
             Map<NodeRef<Expression>, Type> expressionTypes = typeAnalyzer.getTypes(session, symbolAllocator.getTypes(), expression);
-            ExpressionInterpreter optimizer = new ExpressionInterpreter(expression, plannerContext, session, expressionTypes);
+            ExpressionInterpreter optimizer = new ExpressionInterpreter(expression, plannerContext, session, expressionTypes, symbolAllocator.getTypes());
             return literalEncoder.toExpression(session, optimizer.optimize(NoOpSymbolResolver.INSTANCE), expressionTypes.get(NodeRef.of(expression)));
         }
 
@@ -1231,7 +1231,7 @@ public class PredicatePushDown
         private Object nullInputEvaluator(Collection<Symbol> nullSymbols, Expression expression)
         {
             Map<NodeRef<Expression>, Type> expressionTypes = typeAnalyzer.getTypes(session, symbolAllocator.getTypes(), expression);
-            return new ExpressionInterpreter(expression, plannerContext, session, expressionTypes)
+            return new ExpressionInterpreter(expression, plannerContext, session, expressionTypes, symbolAllocator.getTypes())
                     .optimize(symbol -> nullSymbols.contains(symbol) ? null : symbol.toSymbolReference());
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
@@ -749,7 +749,7 @@ public final class PropertyDerivations
 
                 Map<NodeRef<Expression>, Type> expressionTypes = typeAnalyzer.getTypes(session, types, expression);
                 Type type = requireNonNull(expressionTypes.get(NodeRef.of(expression)));
-                ExpressionInterpreter optimizer = new ExpressionInterpreter(expression, plannerContext, session, expressionTypes);
+                ExpressionInterpreter optimizer = new ExpressionInterpreter(expression, plannerContext, session, expressionTypes, types);
                 // TODO:
                 // We want to use a symbol resolver that looks up in the constants from the input subplan
                 // to take advantage of constant-folding for complex expressions

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/FunctionAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/FunctionAssertions.java
@@ -767,7 +767,7 @@ public final class FunctionAssertions
     private Object interpret(Expression expression, Type expectedType, Session session)
     {
         Map<NodeRef<Expression>, Type> expressionTypes = getTypes(session, getPlannerContext(), INPUT_TYPES, expression);
-        ExpressionInterpreter evaluator = new ExpressionInterpreter(expression, runner.getPlannerContext(), session, expressionTypes);
+        ExpressionInterpreter evaluator = new ExpressionInterpreter(expression, runner.getPlannerContext(), session, expressionTypes, INPUT_TYPES);
 
         Object result = evaluator.evaluate(symbol -> {
             int position = 0;

--- a/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
@@ -1916,7 +1916,7 @@ public class TestExpressionInterpreter
     static Object optimize(Expression parsedExpression)
     {
         Map<NodeRef<Expression>, Type> expressionTypes = getTypes(TEST_SESSION, PLANNER_CONTEXT, SYMBOL_TYPES, parsedExpression);
-        ExpressionInterpreter interpreter = new ExpressionInterpreter(parsedExpression, PLANNER_CONTEXT, TEST_SESSION, expressionTypes);
+        ExpressionInterpreter interpreter = new ExpressionInterpreter(parsedExpression, PLANNER_CONTEXT, TEST_SESSION, expressionTypes, SYMBOL_TYPES);
         return interpreter.optimize(INPUTS);
     }
 
@@ -1964,7 +1964,7 @@ public class TestExpressionInterpreter
     private static Object evaluate(Expression expression)
     {
         Map<NodeRef<Expression>, Type> expressionTypes = getTypes(TEST_SESSION, PLANNER_CONTEXT, SYMBOL_TYPES, expression);
-        ExpressionInterpreter interpreter = new ExpressionInterpreter(expression, PLANNER_CONTEXT, TEST_SESSION, expressionTypes);
+        ExpressionInterpreter interpreter = new ExpressionInterpreter(expression, PLANNER_CONTEXT, TEST_SESSION, expressionTypes, SYMBOL_TYPES);
 
         return interpreter.evaluate(INPUTS);
     }

--- a/core/trino-main/src/test/java/io/trino/sql/TestSqlToRowExpressionTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestSqlToRowExpressionTranslator.java
@@ -100,7 +100,7 @@ public class TestSqlToRowExpressionTranslator
         // Testing simplified expressions is important, since simplification may create CASTs or function calls that cannot be simplified by the ExpressionOptimizer
 
         Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(expression);
-        ExpressionInterpreter interpreter = new ExpressionInterpreter(expression, PLANNER_CONTEXT, TEST_SESSION, expressionTypes);
+        ExpressionInterpreter interpreter = new ExpressionInterpreter(expression, PLANNER_CONTEXT, TEST_SESSION, expressionTypes, TypeProvider.empty());
         Object value = interpreter.optimize(NoOpSymbolResolver.INSTANCE);
         return literalEncoder.toExpression(TEST_SESSION, value, expressionTypes.get(NodeRef.of(expression)));
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLiteralEncoder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLiteralEncoder.java
@@ -302,7 +302,7 @@ public class TestLiteralEncoder
 
     private Object getExpressionValue(Expression expression)
     {
-        return new ExpressionInterpreter(expression, PLANNER_CONTEXT, TEST_SESSION, getExpressionTypes(expression)).evaluate();
+        return new ExpressionInterpreter(expression, PLANNER_CONTEXT, TEST_SESSION, getExpressionTypes(expression), TypeProvider.empty()).evaluate();
     }
 
     private Type getExpressionType(Expression expression)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Currently only filter conditions may benefit from simplification via TupleDomain merge inside `PushPredicateIntoTableScan`, e.g.
```
explain
select name
from part
where size > 1 and size > 2

 Output[columnNames = [name]]
 │   Layout: [name:varchar(55)]
 │   Estimates: {rows: 195918 (7.05MB), cpu: 0, memory: 0B, network: 0B}
 └─ ScanFilterProject[table = tpch:sf1:part, filterPredicate = ("size" > 2)]
        Layout: [name:varchar(55)]
        Estimates: {rows: 200000 (7.20MB), cpu: 8.15M, memory: 0B, network: 0B}/{rows: 195918 (7.05MB), cpu: 8.15M, memory: 0B, network: 0B}/{rows: 195918 (7.05MB), cpu: 7.05M, memory: 0B, network:
        size := tpch:size
        name := tpch:name
        tpch:container
            :: [[JUMBO BAG, WRAP PKG]]
        tpch:type
            :: [[ECONOMY ANODIZED BRASS, STANDARD POLISHED TIN]]
```
However, for most cases where an Expression can be present which contains multiple terms, they are just kept as is, e.g.
```
explain
select case when size > 1 and size > 2 then name end
from part;

 Output[columnNames = [_col0]]
 │   Layout: [expr:varchar(55)]
 │   Estimates: {rows: 200000 (10.49MB), cpu: 0, memory: 0B, network: 0B}
 │   _col0 := expr
 └─ ScanProject[table = tpch:sf1:part]
        Layout: [expr:varchar(55)]
        Estimates: {rows: 200000 (10.49MB), cpu: 8.15M, memory: 0B, network: 0B}/{rows: 200000 (10.49MB), cpu: 10.49M, memory: 0B, network: 0B}
        expr := (CASE WHEN (("size" > 1) AND ("size" > 2)) THEN "name" END)
        size := tpch:size
        name := tpch:name
        tpch:container
            :: [[JUMBO BAG, WRAP PKG]]
        tpch:type
            :: [[ECONOMY ANODIZED BRASS, STANDARD POLISHED TIN]]
```
The purpose of this PR is to use the similar logic to enable the simplification/merging of the logical terms so that the plan ends up with simpler expression evaluation. With the change, the same query generates a better plan:
```
 Output[columnNames = [_col0]]
 │   Layout: [expr:varchar(55)]
 │   Estimates: {rows: 200000 (10.49MB), cpu: 0, memory: 0B, network: 0B}
 │   _col0 := expr
 └─ ScanProject[table = tpch:sf1:part]
        Layout: [expr:varchar(55)]
        Estimates: {rows: 200000 (10.49MB), cpu: 8.15M, memory: 0B, network: 0B}/{rows: 200000 (10.49MB), cpu: 10.49M, memory: 0B, network: 0B}
        expr := (CASE WHEN ("size" > 2) THEN "name" END)
        size := tpch:size
        name := tpch:name
        tpch:container
            :: [[JUMBO BAG, WRAP PKG]]
        tpch:type
            :: [[ECONOMY ANODIZED BRASS, STANDARD POLISHED TIN]]
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
