### PR TITLE
Support gen_point type in Elasticsearch connector

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/DecoderDescriptor.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/DecoderDescriptor.java
@@ -20,6 +20,7 @@ import io.trino.plugin.elasticsearch.decoders.BigintDecoder;
 import io.trino.plugin.elasticsearch.decoders.BooleanDecoder;
 import io.trino.plugin.elasticsearch.decoders.Decoder;
 import io.trino.plugin.elasticsearch.decoders.DoubleDecoder;
+import io.trino.plugin.elasticsearch.decoders.GeopointDecoder;
 import io.trino.plugin.elasticsearch.decoders.IdColumnDecoder;
 import io.trino.plugin.elasticsearch.decoders.IntegerDecoder;
 import io.trino.plugin.elasticsearch.decoders.IpAddressDecoder;
@@ -47,6 +48,7 @@ import io.trino.plugin.elasticsearch.decoders.VarcharDecoder;
         @JsonSubTypes.Type(value = RealDecoder.Descriptor.class, name = "real"),
         @JsonSubTypes.Type(value = DoubleDecoder.Descriptor.class, name = "double"),
         @JsonSubTypes.Type(value = VarcharDecoder.Descriptor.class, name = "varchar"),
+        @JsonSubTypes.Type(value = GeopointDecoder.Descriptor.class, name = "varchar"),
         @JsonSubTypes.Type(value = VarbinaryDecoder.Descriptor.class, name = "varbinary"),
         @JsonSubTypes.Type(value = IpAddressDecoder.Descriptor.class, name = "ipAddress"),
         @JsonSubTypes.Type(value = RowDecoder.Descriptor.class, name = "row"),

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
@@ -32,6 +32,7 @@ import io.trino.plugin.elasticsearch.decoders.ArrayDecoder;
 import io.trino.plugin.elasticsearch.decoders.BigintDecoder;
 import io.trino.plugin.elasticsearch.decoders.BooleanDecoder;
 import io.trino.plugin.elasticsearch.decoders.DoubleDecoder;
+import io.trino.plugin.elasticsearch.decoders.GeopointDecoder;
 import io.trino.plugin.elasticsearch.decoders.IntegerDecoder;
 import io.trino.plugin.elasticsearch.decoders.IpAddressDecoder;
 import io.trino.plugin.elasticsearch.decoders.RawJsonDecoder;
@@ -308,6 +309,7 @@ public class ElasticsearchMetadata
                 case "double":
                 case "float":
                 case "keyword":
+                case "geo_point":
                     return true;
             }
         }
@@ -353,6 +355,8 @@ public class ElasticsearchMetadata
                 case "text":
                 case "keyword":
                     return new TypeAndDecoder(VARCHAR, new VarcharDecoder.Descriptor(path));
+                case "geo_point":
+                    return new TypeAndDecoder(VARCHAR, new GeopointDecoder.Descriptor(path));
                 case "ip":
                     return new TypeAndDecoder(ipAddressType, new IpAddressDecoder.Descriptor(path, ipAddressType));
                 case "boolean":

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/GeopointDecoder.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/GeopointDecoder.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.elasticsearch.decoders;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.airlift.slice.Slices;
+import io.trino.plugin.elasticsearch.DecoderDescriptor;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.BlockBuilder;
+import org.elasticsearch.search.SearchHit;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static io.trino.spi.StandardErrorCode.TYPE_MISMATCH;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class GeopointDecoder
+        implements Decoder
+{
+    private final String path;
+
+    public GeopointDecoder(String path)
+    {
+        this.path = requireNonNull(path, "path is null");
+    }
+
+    @Override
+    public void decode(SearchHit hit, Supplier<Object> getter, BlockBuilder output)
+    {
+        Object value = getter.get();
+        if (value == null) {
+            output.appendNull();
+        }
+        else if (value instanceof String) {
+            VARCHAR.writeSlice(output, Slices.utf8Slice(value.toString()));
+        }
+        else if (value instanceof ArrayList) {
+            List<Double> valueArrayList = new ArrayList<>();
+            for (Object o : (List<?>) value) {
+                valueArrayList.add(Double.class.cast(o));
+            }
+            String changeArrayValueToString = "" + valueArrayList.get(0) + "," + valueArrayList.get(1);
+            VARCHAR.writeSlice(output, Slices.utf8Slice(changeArrayValueToString.toString()));
+        }
+        else if (value instanceof Object) {
+            ObjectMapper oMapper = new ObjectMapper();
+            Map<String, Object> mapValue = oMapper.convertValue(value, Map.class);
+            String changeObjectValueToString = "" + mapValue.get("lat") + "," + mapValue.get("lon");
+            VARCHAR.writeSlice(output, Slices.utf8Slice(changeObjectValueToString.toString()));
+        }
+        else {
+            throw new TrinoException(TYPE_MISMATCH, format("Unsupported representation for field '%s' of type VARCHAR: %s [%s]", path, value, value.getClass().getSimpleName()));
+        }
+    }
+
+    public static class Descriptor
+            implements DecoderDescriptor
+    {
+        private final String path;
+
+        @JsonCreator
+        public Descriptor(String path)
+        {
+            this.path = path;
+        }
+
+        @JsonProperty
+        public String getPath()
+        {
+            return path;
+        }
+
+        @Override
+        public Decoder createDecoder()
+        {
+            return new GeopointDecoder(path);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
When we query the geo_point type data in Elasticsearch, an error "Column 'latlon' cannot be resolved" will be reported, and "latlon" is  geo_point type data. It indicates that the query geo_point type data is not supported.
In trino-elasticsearch, it is found that there is no query that supports geo_point type data. We have added the function of geo_point type query in Elasticsearch.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
