### PR TITLE
Account for DF limits per channel in DynamicFilterSourceOperator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/DynamicFilterSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DynamicFilterSourceOperator.java
@@ -44,6 +44,7 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.TypeUtils.isFloatingPointNaN;
 import static io.trino.spi.type.TypeUtils.readNativeValue;
 import static java.lang.String.format;
+import static java.util.Arrays.stream;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 
@@ -179,24 +180,12 @@ public class DynamicFilterSourceOperator
     private boolean finished;
     private Page current;
     private final DynamicFilterSourceConsumer dynamicPredicateConsumer;
-    private final int maxDistinctValues;
-    private final long maxFilterSizeInBytes;
 
     private final List<Channel> channels;
-    private final List<Integer> minMaxChannels;
-    private final List<BlockPositionComparison> minMaxComparisons;
-
-    // May be dropped if the predicate becomes too large.
-    @Nullable
-    private BlockBuilder[] blockBuilders;
-    @Nullable
-    private TypedSet[] valueSets;
+    private final ChannelFilter[] channelFilters;
 
     private int minMaxCollectionLimit;
-    @Nullable
-    private Block[] minValues;
-    @Nullable
-    private Block[] maxValues;
+    private boolean isDomainCollectionComplete;
 
     private DynamicFilterSourceOperator(
             OperatorContext context,
@@ -209,40 +198,21 @@ public class DynamicFilterSourceOperator
             BlockTypeOperators blockTypeOperators)
     {
         this.context = requireNonNull(context, "context is null");
-        this.maxDistinctValues = maxDistinctValues;
-        this.maxFilterSizeInBytes = maxFilterSize.toBytes();
-
+        this.minMaxCollectionLimit = minMaxCollectionLimit;
         this.dynamicPredicateConsumer = requireNonNull(dynamicPredicateConsumer, "dynamicPredicateConsumer is null");
         this.channels = requireNonNull(channels, "channels is null");
+        this.channelFilters = new ChannelFilter[channels.size()];
 
-        this.blockBuilders = new BlockBuilder[channels.size()];
-        this.valueSets = new TypedSet[channels.size()];
-        ImmutableList.Builder<Integer> minMaxChannelsBuilder = ImmutableList.builder();
-        ImmutableList.Builder<BlockPositionComparison> minMaxComparisonsBuilder = ImmutableList.builder();
         for (int channelIndex = 0; channelIndex < channels.size(); ++channelIndex) {
-            Type type = channels.get(channelIndex).type;
-            // Skipping DOUBLE and REAL in collectMinMaxValues to avoid dealing with NaN values
-            if (minMaxCollectionLimit > 0 && type.isOrderable() && type != DOUBLE && type != REAL) {
-                minMaxChannelsBuilder.add(channelIndex);
-                minMaxComparisonsBuilder.add(blockTypeOperators.getComparisonUnorderedLastOperator(type));
-            }
-            this.blockBuilders[channelIndex] = type.createBlockBuilder(null, EXPECTED_BLOCK_BUILDER_SIZE);
-            this.valueSets[channelIndex] = createUnboundedEqualityTypedSet(
-                    type,
-                    blockTypeOperators.getEqualOperator(type),
-                    blockTypeOperators.getHashCodeOperator(type),
-                    blockBuilders[channelIndex],
-                    EXPECTED_BLOCK_BUILDER_SIZE,
-                    format("DynamicFilterSourceOperator_%s_%d", planNodeId, channelIndex));
+            channelFilters[channelIndex] = new ChannelFilter(
+                    blockTypeOperators,
+                    minMaxCollectionLimit > 0,
+                    planNodeId,
+                    maxDistinctValues,
+                    maxFilterSize.toBytes(),
+                    this::finishDomainCollectionIfNecessary,
+                    channels.get(channelIndex));
         }
-
-        this.minMaxCollectionLimit = minMaxCollectionLimit;
-        this.minMaxChannels = minMaxChannelsBuilder.build();
-        if (!minMaxChannels.isEmpty()) {
-            this.minValues = new Block[minMaxChannels.size()];
-            this.maxValues = new Block[minMaxChannels.size()];
-        }
-        this.minMaxComparisons = minMaxComparisonsBuilder.build();
     }
 
     @Override
@@ -262,123 +232,25 @@ public class DynamicFilterSourceOperator
     {
         verify(!finished, "DynamicFilterSourceOperator: addInput() may not be called after finish()");
         current = page;
-        if (valueSets == null) {
-            if (minValues == null) {
-                // there are too many rows to collect min/max range
-                return;
-            }
-            minMaxCollectionLimit -= page.getPositionCount();
-            if (minMaxCollectionLimit < 0) {
-                handleMinMaxCollectionLimitExceeded();
-                return;
-            }
-            // the predicate became too large, record only min and max values for each orderable channel
-            for (int i = 0; i < minMaxChannels.size(); i++) {
-                Integer channelIndex = minMaxChannels.get(i);
-                BlockPositionComparison comparison = minMaxComparisons.get(i);
-                Block block = page.getBlock(channels.get(channelIndex).index);
-                updateMinMaxValues(block, i, comparison);
-            }
+
+        if (isDomainCollectionComplete) {
             return;
         }
-        minMaxCollectionLimit -= page.getPositionCount();
-        // TODO: we should account for the memory used for collecting build-side values using MemoryContext
-        long filterSizeInBytes = 0;
-        int filterMaxDistinctValues = 0;
+
+        if (minMaxCollectionLimit >= 0) {
+            minMaxCollectionLimit -= page.getPositionCount();
+            if (minMaxCollectionLimit < 0) {
+                for (int channelIndex = 0; channelIndex < channels.size(); channelIndex++) {
+                    channelFilters[channelIndex].disableMinMax();
+                }
+                finishDomainCollectionIfNecessary();
+            }
+        }
+
         // Collect only the columns which are relevant for the JOIN.
         for (int channelIndex = 0; channelIndex < channels.size(); ++channelIndex) {
             Block block = page.getBlock(channels.get(channelIndex).index);
-            TypedSet valueSet = valueSets[channelIndex];
-            for (int position = 0; position < block.getPositionCount(); ++position) {
-                valueSet.add(block, position);
-            }
-            filterSizeInBytes += valueSet.getRetainedSizeInBytes();
-            filterMaxDistinctValues = Math.max(filterMaxDistinctValues, valueSet.size());
-        }
-        if (filterMaxDistinctValues > maxDistinctValues || filterSizeInBytes > maxFilterSizeInBytes) {
-            // The whole filter (summed over all columns) exceeds maxFilterSizeInBytes or a column contains too many distinct values
-            handleTooLargePredicate();
-        }
-    }
-
-    private void handleTooLargePredicate()
-    {
-        // The resulting predicate is too large
-        if (minMaxChannels.isEmpty()) {
-            // allow all probe-side values to be read.
-            dynamicPredicateConsumer.addPartition(TupleDomain.all());
-        }
-        else {
-            if (minMaxCollectionLimit < 0) {
-                handleMinMaxCollectionLimitExceeded();
-            }
-            else {
-                // convert to min/max per column for orderable types
-                for (int i = 0; i < minMaxChannels.size(); i++) {
-                    Integer channelIndex = minMaxChannels.get(i);
-                    BlockPositionComparison comparison = minMaxComparisons.get(i);
-                    Block block = blockBuilders[channelIndex].build();
-                    updateMinMaxValues(block, i, comparison);
-                }
-            }
-        }
-        // Drop references to collected values.
-        valueSets = null;
-        blockBuilders = null;
-    }
-
-    private void handleMinMaxCollectionLimitExceeded()
-    {
-        // allow all probe-side values to be read.
-        dynamicPredicateConsumer.addPartition(TupleDomain.all());
-        // Drop references to collected values.
-        minValues = null;
-        maxValues = null;
-    }
-
-    private void updateMinMaxValues(Block block, int channelIndex, BlockPositionComparison comparison)
-    {
-        checkState(minValues != null && maxValues != null);
-        int minValuePosition = -1;
-        int maxValuePosition = -1;
-
-        for (int position = 0; position < block.getPositionCount(); ++position) {
-            if (block.isNull(position)) {
-                continue;
-            }
-            if (minValuePosition == -1) {
-                // First non-null value
-                minValuePosition = position;
-                maxValuePosition = position;
-                continue;
-            }
-            if (comparison.compare(block, position, block, minValuePosition) < 0) {
-                minValuePosition = position;
-            }
-            else if (comparison.compare(block, position, block, maxValuePosition) > 0) {
-                maxValuePosition = position;
-            }
-        }
-
-        if (minValuePosition == -1) {
-            // all block values are nulls
-            return;
-        }
-        if (minValues[channelIndex] == null) {
-            // First Page with non-null value for this block
-            minValues[channelIndex] = block.getSingleValueBlock(minValuePosition);
-            maxValues[channelIndex] = block.getSingleValueBlock(maxValuePosition);
-            return;
-        }
-        // Compare with min/max values from previous Pages
-        Block currentMin = minValues[channelIndex];
-        Block currentMax = maxValues[channelIndex];
-
-        if (comparison.compare(block, minValuePosition, currentMin, 0) < 0) {
-            minValues[channelIndex] = block.getSingleValueBlock(minValuePosition);
-        }
-        if (comparison.compare(block, maxValuePosition, currentMax, 0) > 0) {
-            maxValues[channelIndex] = block.getSingleValueBlock(maxValuePosition);
+            channelFilters[channelIndex].process(block);
         }
     }
 
@@ -398,66 +270,38 @@ public class DynamicFilterSourceOperator
             return;
         }
         finished = true;
-        ImmutableMap.Builder<DynamicFilterId, Domain> domainsBuilder = ImmutableMap.builder();
-        if (valueSets == null) {
-            if (minValues == null) {
-                // there were too many rows to collect min/max range
-                // dynamicPredicateConsumer was notified with 'all' in handleTooLargePredicate if there are no orderable types,
-                // else it was notified with 'all' in handleMinMaxCollectionLimitExceeded
-                return;
-            }
-            // valueSets became too large, create TupleDomain from min/max values
-            for (int i = 0; i < minMaxChannels.size(); i++) {
-                Integer channelIndex = minMaxChannels.get(i);
-                Type type = channels.get(channelIndex).type;
-                if (minValues[i] == null) {
-                    // all values were null
-                    domainsBuilder.put(channels.get(channelIndex).filterId, Domain.none(type));
-                    continue;
-                }
-                Object min = blockToNativeValue(type, minValues[i]);
-                Object max = blockToNativeValue(type, maxValues[i]);
-                Domain domain = Domain.create(
-                        ValueSet.ofRanges(range(type, min, true, max, true)),
-                        false);
-                domainsBuilder.put(channels.get(channelIndex).filterId, domain);
-            }
-            minValues = null;
-            maxValues = null;
-            dynamicPredicateConsumer.addPartition(TupleDomain.withColumnDomains(domainsBuilder.buildOrThrow()));
+        if (isDomainCollectionComplete) {
+            // dynamicPredicateConsumer was already notified with 'all'
             return;
         }
+
+        ImmutableMap.Builder<DynamicFilterId, Domain> domainsBuilder = ImmutableMap.builder();
         for (int channelIndex = 0; channelIndex < channels.size(); ++channelIndex) {
-            Block block = blockBuilders[channelIndex].build();
-            Type type = channels.get(channelIndex).type;
-            domainsBuilder.put(channels.get(channelIndex).filterId, convertToDomain(type, block));
+            DynamicFilterId filterId = channels.get(channelIndex).filterId;
+            domainsBuilder.put(filterId, channelFilters[channelIndex].getDomain());
         }
-        valueSets = null;
-        blockBuilders = null;
         dynamicPredicateConsumer.addPartition(TupleDomain.withColumnDomains(domainsBuilder.buildOrThrow()));
-    }
-
-    private Domain convertToDomain(Type type, Block block)
-    {
-        ImmutableList.Builder<Object> values = ImmutableList.builder();
-        for (int position = 0; position < block.getPositionCount(); ++position) {
-            Object value = readNativeValue(type, block, position);
-            if (value != null) {
-                // join doesn't match rows with NaN values.
-                if (!isFloatingPointNaN(type, value)) {
-                    values.add(value);
-                }
-            }
-        }
-
-        // Inner and right join doesn't match rows with null key column values.
-        return Domain.create(ValueSet.copyOf(type, values.build()), false);
     }
 
     @Override
     public boolean isFinished()
     {
         return current == null && finished;
+    }
+
+    private void finishDomainCollectionIfNecessary()
+    {
+        if (!isDomainCollectionComplete && stream(channelFilters).allMatch(channel -> channel.state == ChannelState.NONE)) {
+            // allow all probe-side values to be read.
+            dynamicPredicateConsumer.addPartition(TupleDomain.all());
+            isDomainCollectionComplete = true;
+        }
+    }
+
+    private static boolean isMinMaxPossible(Type type)
+    {
+        // Skipping DOUBLE and REAL in collectMinMaxValues to avoid dealing with NaN values
+        return type.isOrderable() && type != DOUBLE && type != REAL;
     }
 
     private static class PassthroughDynamicFilterSourceOperator
@@ -514,5 +358,182 @@ public class DynamicFilterSourceOperator
         {
             return current == null && finished;
         }
+    }
+
+    private static class ChannelFilter
+    {
+        private final Type type;
+        private final int maxDistinctValues;
+        private final long maxFilterSizeInBytes;
+        private final Runnable notifyStateChange;
+
+        private ChannelState state;
+        private boolean collectMinMax;
+        // May be dropped if the predicate becomes too large.
+        @Nullable
+        private BlockBuilder blockBuilder;
+        @Nullable
+        private TypedSet valueSet;
+        @Nullable
+        private Block minValues;
+        @Nullable
+        private Block maxValues;
+        @Nullable
+        private BlockPositionComparison minMaxComparison;
+
+        private ChannelFilter(
+                BlockTypeOperators blockTypeOperators,
+                boolean minMaxEnabled,
+                PlanNodeId planNodeId,
+                int maxDistinctValues,
+                long maxFilterSizeInBytes,
+                Runnable notifyStateChange,
+                Channel channel)
+        {
+            this.maxDistinctValues = maxDistinctValues;
+            this.maxFilterSizeInBytes = maxFilterSizeInBytes;
+            this.notifyStateChange = requireNonNull(notifyStateChange, "notifyStateChange is null");
+            type = channel.type;
+            state = ChannelState.SET;
+            collectMinMax = minMaxEnabled && isMinMaxPossible(type);
+            if (collectMinMax) {
+                minMaxComparison = blockTypeOperators.getComparisonUnorderedLastOperator(type);
+            }
+            blockBuilder = type.createBlockBuilder(null, EXPECTED_BLOCK_BUILDER_SIZE);
+            valueSet = createUnboundedEqualityTypedSet(
+                    type,
+                    blockTypeOperators.getEqualOperator(type),
+                    blockTypeOperators.getHashCodeOperator(type),
+                    blockBuilder,
+                    EXPECTED_BLOCK_BUILDER_SIZE,
+                    format("DynamicFilterSourceOperator_%s_%d", planNodeId, channel.index));
+        }
+
+        private void process(Block block)
+        {
+            // TODO: we should account for the memory used for collecting build-side values using MemoryContext
+            switch (state) {
+                case SET:
+                    for (int position = 0; position < block.getPositionCount(); ++position) {
+                        valueSet.add(block, position);
+                    }
+                    if (valueSet.size() > maxDistinctValues || valueSet.getRetainedSizeInBytes() > maxFilterSizeInBytes) {
+                        if (collectMinMax) {
+                            state = ChannelState.MIN_MAX;
+                            updateMinMaxValues(blockBuilder.build(), minMaxComparison);
+                        }
+                        else {
+                            state = ChannelState.NONE;
+                            notifyStateChange.run();
+                        }
+                        valueSet = null;
+                        blockBuilder = null;
+                    }
+                    break;
+                case MIN_MAX:
+                    updateMinMaxValues(block, minMaxComparison);
+                    break;
+                case NONE:
+                    break;
+            }
+        }
+
+        private Domain getDomain()
+        {
+            return switch (state) {
+                case SET -> convertToDomain();
+                case MIN_MAX -> {
+                    if (minValues == null) {
+                        // all values were null
+                        yield Domain.none(type);
+                    }
+                    Object min = blockToNativeValue(type, minValues);
+                    Object max = blockToNativeValue(type, maxValues);
+                    yield Domain.create(ValueSet.ofRanges(range(type, min, true, max, true)), false);
+                }
+                case NONE -> Domain.all(type);
+            };
+        }
+
+        private void disableMinMax()
+        {
+            collectMinMax = false;
+            if (state == ChannelState.MIN_MAX) {
+                state = ChannelState.NONE;
+            }
+            // Drop references to collected values.
+            minValues = null;
+            maxValues = null;
+        }
+
+        private Domain convertToDomain()
+        {
+            Block block = blockBuilder.build();
+            ImmutableList.Builder<Object> values = ImmutableList.builder();
+            for (int position = 0; position < block.getPositionCount(); ++position) {
+                Object value = readNativeValue(type, block, position);
+                if (value != null) {
+                    // join doesn't match rows with NaN values.
+                    if (!isFloatingPointNaN(type, value)) {
+                        values.add(value);
+                    }
+                }
+            }
+
+            // Inner and right join doesn't match rows with null key column values.
+            return Domain.create(ValueSet.copyOf(type, values.build()), false);
+        }
+
+        private void updateMinMaxValues(Block block, BlockPositionComparison comparison)
+        {
+            int minValuePosition = -1;
+            int maxValuePosition = -1;
+
+            for (int position = 0; position < block.getPositionCount(); ++position) {
+                if (block.isNull(position)) {
+                    continue;
+                }
+                if (minValuePosition == -1) {
+                    // First non-null value
+                    minValuePosition = position;
+                    maxValuePosition = position;
+                    continue;
+                }
+                if (comparison.compare(block, position, block, minValuePosition) < 0) {
+                    minValuePosition = position;
+                }
+                else if (comparison.compare(block, position, block, maxValuePosition) > 0) {
+                    maxValuePosition = position;
+                }
+            }
+
+            if (minValuePosition == -1) {
+                // all block values are nulls
+                return;
+            }
+            if (minValues == null) {
+                // First Page with non-null value for this block
+                minValues = block.getSingleValueBlock(minValuePosition);
+                maxValues = block.getSingleValueBlock(maxValuePosition);
+                return;
+            }
+            // Compare with min/max values from previous Pages
+            Block currentMin = minValues;
+            Block currentMax = maxValues;
+
+            if (comparison.compare(block, minValuePosition, currentMin, 0) < 0) {
+                minValues = block.getSingleValueBlock(minValuePosition);
+            }
+            if (comparison.compare(block, maxValuePosition, currentMax, 0) > 0) {
+                maxValues = block.getSingleValueBlock(maxValuePosition);
+            }
+        }
+    }
+
+    private enum ChannelState
+    {
+        SET,
+        MIN_MAX,
+        NONE,
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/TestDynamicFilterSourceOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestDynamicFilterSourceOperator.java
@@ -440,7 +440,7 @@ public class TestDynamicFilterSourceOperator
     }
 
     @Test
-    public void testMultipleColumnsCollectMinMaxRangeWhenTooManyDistinctValues()
+    public void testMultipleColumnsBothSetAndRangeWhenTooManyDistinctValues()
     {
         int maxDistinctValues = 100;
         Page largePage = new Page(
@@ -452,9 +452,26 @@ public class TestDynamicFilterSourceOperator
                 TupleDomain.withColumnDomains(ImmutableMap.of(
                         new DynamicFilterId("0"), Domain.create(ValueSet.ofRanges(
                                 range(BIGINT, 0L, true, 100L, true)), false),
+                        new DynamicFilterId("1"), Domain.singleValue(COLOR, 100L),
                         new DynamicFilterId("2"), Domain.create(ValueSet.ofRanges(
                                 equal(BIGINT, 200L)), false))));
         assertDynamicFilters(maxDistinctValues, ImmutableList.of(BIGINT, COLOR, BIGINT), ImmutableList.of(largePage), expectedTupleDomains);
+    }
+
+    @Test
+    public void testMultipleColumnsSingleSetWithNoRangeWhenTooManyDistinctValues()
+    {
+        int maxDistinctValues = 100;
+        Page largePage = new Page(
+                createLongSequenceBlock(0, 101),
+                createColorRepeatBlock(100, 101),
+                createLongRepeatBlock(200, 101));
+
+        List<TupleDomain<DynamicFilterId>> expectedTupleDomains = ImmutableList.of(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        new DynamicFilterId("1"), Domain.singleValue(COLOR, 100L),
+                        new DynamicFilterId("2"), Domain.singleValue(BIGINT, 200L))));
+        assertDynamicFilters(maxDistinctValues, DataSize.of(10, KILOBYTE), 100, ImmutableList.of(BIGINT, COLOR, BIGINT), ImmutableList.of(largePage), expectedTupleDomains);
     }
 
     @Test

--- a/testing/trino-tests/src/test/java/io/trino/execution/AbstractTestCoordinatorDynamicFiltering.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/AbstractTestCoordinatorDynamicFiltering.java
@@ -152,7 +152,9 @@ public abstract class AbstractTestCoordinatorDynamicFiltering
                         "JOIN tpch.tiny.lineitem l2 ON l1.orderkey = l2.orderkey AND l1.suppkey = l2.suppkey " +
                         "WHERE l2.suppkey BETWEEN 1 AND 10",
                 Set.of(ORDERKEY_HANDLE, SUPP_KEY_HANDLE),
-                TupleDomain.all());
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        SUPP_KEY_HANDLE,
+                        multipleValues(BIGINT, LongStream.rangeClosed(1L, 10L).boxed().collect(toImmutableList())))));
     }
 
     @Test(timeOut = 30_000, dataProvider = "testJoinDistributionType")

--- a/testing/trino-tests/src/test/java/io/trino/execution/AbstractTestCoordinatorDynamicFiltering.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/AbstractTestCoordinatorDynamicFiltering.java
@@ -143,6 +143,19 @@ public abstract class AbstractTestCoordinatorDynamicFiltering
     }
 
     @Test(timeOut = 30_000, dataProvider = "testJoinDistributionType")
+    public void testMultiColumnJoinWithDifferentCardinalitiesInBuildSide(JoinDistributionType joinDistributionType, boolean coordinatorDynamicFiltersDistribution)
+    {
+        // orderkey has high cardinality, suppkey has low cardinality due to filter
+        assertQueryDynamicFilters(
+                noJoinReordering(joinDistributionType, coordinatorDynamicFiltersDistribution),
+                "SELECT * FROM lineitem l1 " +
+                        "JOIN tpch.tiny.lineitem l2 ON l1.orderkey = l2.orderkey AND l1.suppkey = l2.suppkey " +
+                        "WHERE l2.suppkey BETWEEN 1 AND 10",
+                Set.of(ORDERKEY_HANDLE, SUPP_KEY_HANDLE),
+                TupleDomain.all());
+    }
+
+    @Test(timeOut = 30_000, dataProvider = "testJoinDistributionType")
     public void testJoinWithSelectiveBuildSide(JoinDistributionType joinDistributionType, boolean coordinatorDynamicFiltersDistribution)
     {
         assertQueryDynamicFilters(


### PR DESCRIPTION
## Description
Up to this point, when dynamic filter went beyond the threshold all channels fall back to the min/max range predicate. Now the biggest channel falls back, while the rest continue to be gathered as a set of values. This way if a single channel is too big, it won't prevent other, smaller ones to be used as a dynamic filter.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/14797

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Improve performance of queries with selective joins. ({issue}`15569`)
```
