### PR TITLE
Compare with true literal appropriately

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -2481,7 +2481,7 @@ public class LocalExecutionPlanner
         private Optional<Expression> removeExpressionFromFilter(Expression filter, Expression expression)
         {
             Expression updatedJoinFilter = replaceExpression(filter, ImmutableMap.of(expression, TRUE_LITERAL));
-            return updatedJoinFilter == TRUE_LITERAL ? Optional.empty() : Optional.of(updatedJoinFilter);
+            return updatedJoinFilter.equals(TRUE_LITERAL) ? Optional.empty() : Optional.of(updatedJoinFilter);
         }
 
         private SpatialPredicate spatialTest(FunctionCall functionCall, boolean probeFirst, Optional<ComparisonExpression.Operator> comparisonOperator)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
@@ -542,7 +542,7 @@ public class PredicatePushDown
             }
 
             Optional<Expression> newJoinFilter = Optional.of(combineConjuncts(metadata, joinFilter));
-            if (newJoinFilter.get() == TRUE_LITERAL) {
+            if (newJoinFilter.get().equals(TRUE_LITERAL)) {
                 newJoinFilter = Optional.empty();
             }
 


### PR DESCRIPTION
There is no assumption that `TRUE_LITERAL` and `FALSE_LITERAL` are the only instances of the `BooleanLiteral` class.
