### PR TITLE
Correct exception type when table exists while creating a view

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -2605,7 +2605,7 @@ public class HiveMetadata
         Optional<Table> existing = metastore.getTable(viewName.getSchemaName(), viewName.getTableName());
         if (existing.isPresent()) {
             if (!replace || !isPrestoView(existing.get())) {
-                throw new ViewAlreadyExistsException(viewName);
+                throw new TableAlreadyExistsException(viewName);
             }
 
             metastore.replaceTable(viewName.getSchemaName(), viewName.getTableName(), table, principalPrivileges);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TrinoViewHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TrinoViewHiveMetastore.java
@@ -87,7 +87,7 @@ public final class TrinoViewHiveMetastore
         Optional<io.trino.plugin.hive.metastore.Table> existing = metastore.getTable(schemaViewName.getSchemaName(), schemaViewName.getTableName());
         if (existing.isPresent()) {
             if (!replace || !isPrestoView(existing.get())) {
-                throw new ViewAlreadyExistsException(schemaViewName);
+                throw new TableAlreadyExistsException(schemaViewName);
             }
 
             metastore.replaceTable(schemaViewName.getSchemaName(), schemaViewName.getTableName(), table, principalPrivileges);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -3925,6 +3925,9 @@ public abstract class AbstractTestHive
             doCreateView(temporaryCreateView, false);
             fail("create existing should fail");
         }
+        catch (TableAlreadyExistsException e) {
+            assertEquals(e.getTableName(), temporaryCreateView);
+        }
         catch (ViewAlreadyExistsException e) {
             assertEquals(e.getViewName(), temporaryCreateView);
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
`ViewAlreadyExistsException` exception is misleading when a table exists while creating a view. Changing it to `TableAlreadyExistsException`.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
