### PR TITLE
Fix failure to read nullable time(6) columns

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcWriteValidation.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcWriteValidation.java
@@ -41,6 +41,7 @@ import io.trino.orc.metadata.statistics.StatisticsHasher;
 import io.trino.orc.metadata.statistics.StringStatistics;
 import io.trino.orc.metadata.statistics.StringStatisticsBuilder;
 import io.trino.orc.metadata.statistics.StripeStatistics;
+import io.trino.orc.metadata.statistics.TimeMicrosStatisticsBuilder;
 import io.trino.orc.metadata.statistics.TimestampStatisticsBuilder;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
@@ -93,6 +94,7 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeType.TIME_MICROS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_NANOS;
@@ -625,6 +627,11 @@ public class OrcWriteValidation
             }
             else if (VARBINARY.equals(type) || UUID.equals(type)) {
                 statisticsBuilder = new BinaryStatisticsBuilder();
+                fieldExtractor = ignored -> ImmutableList.of();
+                fieldBuilders = ImmutableList.of();
+            }
+            else if (TIME_MICROS.equals(type)) {
+                statisticsBuilder = new TimeMicrosStatisticsBuilder(new NoOpBloomFilterBuilder());
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();
             }

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/TimeMicrosStatisticsBuilder.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/TimeMicrosStatisticsBuilder.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.orc.metadata.statistics;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.type.Type;
+
+import java.util.Optional;
+
+import static io.trino.orc.metadata.statistics.IntegerStatistics.INTEGER_VALUE_BYTES;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+import static java.lang.Math.addExact;
+import static java.util.Objects.requireNonNull;
+
+public class TimeMicrosStatisticsBuilder
+        implements LongValueStatisticsBuilder
+{
+    private long nonNullValueCount;
+    private long minimum = Long.MAX_VALUE;
+    private long maximum = Long.MIN_VALUE;
+    private long sum;
+    private boolean overflow;
+
+    private final BloomFilterBuilder bloomFilterBuilder;
+
+    public TimeMicrosStatisticsBuilder(BloomFilterBuilder bloomFilterBuilder)
+    {
+        this.bloomFilterBuilder = requireNonNull(bloomFilterBuilder, "bloomFilterBuilder is null");
+    }
+
+    @Override
+    public long getValueFromBlock(Type type, Block block, int position)
+    {
+        return type.getLong(block, position) / PICOSECONDS_PER_MICROSECOND;
+    }
+
+    @Override
+    public void addValue(long value)
+    {
+        nonNullValueCount++;
+
+        minimum = Math.min(value, minimum);
+        maximum = Math.max(value, maximum);
+
+        if (!overflow) {
+            try {
+                sum = addExact(sum, value);
+            }
+            catch (ArithmeticException e) {
+                overflow = true;
+            }
+        }
+        bloomFilterBuilder.addLong(value);
+    }
+
+    private Optional<IntegerStatistics> buildIntegerStatistics()
+    {
+        if (nonNullValueCount == 0) {
+            return Optional.empty();
+        }
+        return Optional.of(new IntegerStatistics(minimum, maximum, overflow ? null : sum));
+    }
+
+    @Override
+    public ColumnStatistics buildColumnStatistics()
+    {
+        Optional<IntegerStatistics> integerStatistics = buildIntegerStatistics();
+        return new ColumnStatistics(
+                nonNullValueCount,
+                integerStatistics.map(s -> INTEGER_VALUE_BYTES).orElse(0L),
+                null,
+                integerStatistics.orElse(null),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                bloomFilterBuilder.buildBloomFilter());
+    }
+}

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/ColumnReaders.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/ColumnReaders.java
@@ -33,6 +33,7 @@ import static io.trino.spi.type.TimeType.TIME_MICROS;
 public final class ColumnReaders
 {
     public static final String ICEBERG_BINARY_TYPE = "iceberg.binary-type";
+    public static final String ICEBERG_LONG_TYPE = "iceberg.long-type";
 
     private ColumnReaders() {}
 
@@ -47,7 +48,7 @@ public final class ColumnReaders
     {
         if (type instanceof TimeType) {
             if (!type.equals(TIME_MICROS) || column.getColumnType() != LONG ||
-                    !"TIME".equals(column.getAttributes().get("iceberg.long-type"))) {
+                    !"TIME".equals(column.getAttributes().get(ICEBERG_LONG_TYPE))) {
                 throw invalidStreamType(column, type);
             }
             return new TimeColumnReader(type, column, memoryContext.newLocalMemoryContext(ColumnReaders.class.getSimpleName()));

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/LongColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/LongColumnReader.java
@@ -188,6 +188,9 @@ public class LongColumnReader
         if (type instanceof BigintType) {
             return longReadNullBlock(isNull, nonNullCount);
         }
+        if (type instanceof TimeType) {
+            return longReadNullBlock(isNull, nonNullCount);
+        }
         if (type instanceof IntegerType || type instanceof DateType) {
             return intReadNullBlock(isNull, nonNullCount);
         }
@@ -209,6 +212,7 @@ public class LongColumnReader
 
         dataStream.next(longNonNullValueTemp, nonNullCount);
 
+        maybeTransformValues(longNonNullValueTemp, nonNullCount);
         long[] result = unpackLongNulls(longNonNullValueTemp, isNull);
 
         return new LongArrayBlock(nextBatchSize, Optional.of(isNull), result);

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/ColumnWriters.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/ColumnWriters.java
@@ -33,6 +33,7 @@ import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.orc.metadata.OrcType.OrcTypeKind.LONG;
+import static io.trino.orc.reader.ColumnReaders.ICEBERG_LONG_TYPE;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
@@ -55,7 +56,7 @@ public final class ColumnWriters
         if (type instanceof TimeType timeType) {
             checkArgument(timeType.getPrecision() == 6, "%s not supported for ORC writer", type);
             checkArgument(orcType.getOrcTypeKind() == LONG, "wrong ORC type %s for type %s", orcType, type);
-            checkArgument("TIME".equals(orcType.getAttributes().get("iceberg.long-type")), "wrong attributes %s for type %s", orcType.getAttributes(), type);
+            checkArgument("TIME".equals(orcType.getAttributes().get(ICEBERG_LONG_TYPE)), "wrong attributes %s for type %s", orcType.getAttributes(), type);
             return new TimeColumnWriter(columnId, type, compression, bufferSize, () -> new IntegerStatisticsBuilder(bloomFilterBuilder.get()));
         }
         switch (orcType.getOrcTypeKind()) {

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/ColumnWriters.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/ColumnWriters.java
@@ -25,6 +25,7 @@ import io.trino.orc.metadata.statistics.DateStatisticsBuilder;
 import io.trino.orc.metadata.statistics.DoubleStatisticsBuilder;
 import io.trino.orc.metadata.statistics.IntegerStatisticsBuilder;
 import io.trino.orc.metadata.statistics.StringStatisticsBuilder;
+import io.trino.orc.metadata.statistics.TimeMicrosStatisticsBuilder;
 import io.trino.orc.metadata.statistics.TimestampStatisticsBuilder;
 import io.trino.spi.type.TimeType;
 import io.trino.spi.type.Type;
@@ -57,7 +58,7 @@ public final class ColumnWriters
             checkArgument(timeType.getPrecision() == 6, "%s not supported for ORC writer", type);
             checkArgument(orcType.getOrcTypeKind() == LONG, "wrong ORC type %s for type %s", orcType, type);
             checkArgument("TIME".equals(orcType.getAttributes().get(ICEBERG_LONG_TYPE)), "wrong attributes %s for type %s", orcType.getAttributes(), type);
-            return new TimeColumnWriter(columnId, type, compression, bufferSize, () -> new IntegerStatisticsBuilder(bloomFilterBuilder.get()));
+            return new TimeColumnWriter(columnId, type, compression, bufferSize, () -> new TimeMicrosStatisticsBuilder(bloomFilterBuilder.get()));
         }
         switch (orcType.getOrcTypeKind()) {
             case BOOLEAN:

--- a/lib/trino-orc/src/test/java/io/trino/orc/AbstractTestOrcReader.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/AbstractTestOrcReader.java
@@ -23,6 +23,7 @@ import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.SqlDate;
 import io.trino.spi.type.SqlDecimal;
+import io.trino.spi.type.SqlTime;
 import io.trino.spi.type.SqlTimestamp;
 import io.trino.spi.type.SqlTimestampWithTimeZone;
 import io.trino.spi.type.SqlVarbinary;
@@ -53,6 +54,7 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeType.TIME_MICROS;
 import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
@@ -314,6 +316,25 @@ public abstract class AbstractTestOrcReader
                 .buildOrThrow();
         map.forEach((expected, value) -> assertEquals(value.toString(), expected));
         tester.testRoundTrip(TIMESTAMP_MILLIS, newArrayList(limit(cycle(map.values()), 30_000)));
+    }
+
+    @Test
+    public void testTimeMicros()
+            throws Exception
+    {
+        Map<String, SqlTime> map = ImmutableMap.<String, SqlTime>builder()
+                .put("00:00:00.000000", SqlTime.newInstance(6, 0L))
+                .put("12:05:19.257000", SqlTime.newInstance(6, 43519257000000000L))
+                .put("17:37:07.638000", SqlTime.newInstance(6, 63427638000000000L))
+                .put("05:17:37.346000", SqlTime.newInstance(6, 19057346000000000L))
+                .put("06:09:00.988000", SqlTime.newInstance(6, 22140988000000000L))
+                .put("13:31:34.185000", SqlTime.newInstance(6, 48694185000000000L))
+                .put("01:09:07.185000", SqlTime.newInstance(6, 4147185000000000L))
+                .put("20:43:39.822000", SqlTime.newInstance(6, 74619822000000000L))
+                .put("23:59:59.999000", SqlTime.newInstance(6, 86399999000000000L))
+                .buildOrThrow();
+        map.forEach((expected, value) -> assertEquals(value.toString(), expected));
+        tester.testRoundTrip(TIME_MICROS, newArrayList(limit(cycle(map.values()), 30_000)));
     }
 
     @Test

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestingOrcPredicate.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestingOrcPredicate.java
@@ -29,6 +29,7 @@ import io.trino.spi.type.MapType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.SqlDate;
 import io.trino.spi.type.SqlDecimal;
+import io.trino.spi.type.SqlTime;
 import io.trino.spi.type.SqlTimestamp;
 import io.trino.spi.type.SqlTimestampWithTimeZone;
 import io.trino.spi.type.Type;
@@ -51,6 +52,7 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeType.TIME_MICROS;
 import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
@@ -58,6 +60,7 @@ import static io.trino.spi.type.TimestampType.TIMESTAMP_NANOS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_NANOS;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.UuidType.UUID;
 import static java.util.stream.Collectors.toList;
@@ -103,6 +106,9 @@ public final class TestingOrcPredicate
             return new DecimalOrcPredicate(expectedValues);
         }
 
+        if (TIME_MICROS.equals(type)) {
+            return new LongOrcPredicate(false, transform(expectedValues, value -> ((SqlTime) value).getPicos() / PICOSECONDS_PER_MICROSECOND));
+        }
         if (TIMESTAMP_MILLIS.equals(type)) {
             return new LongOrcPredicate(false, transform(expectedValues, value -> ((SqlTimestamp) value).getMillis()));
         }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMinioOrcConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMinioOrcConnectorTest.java
@@ -135,6 +135,23 @@ public class TestIcebergMinioOrcConnectorTest
         }
     }
 
+    @Test
+    public void testTimeType()
+    {
+        // Regression test for https://github.com/trinodb/trino/issues/15603
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_time", "(col time(6))")) {
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (TIME '13:30:00'), (TIME '14:30:00'), (NULL)", 3);
+            assertQuery("SELECT * FROM " + table.getName(), "VALUES '13:30:00', '14:30:00', NULL");
+            assertQuery(
+                    "SHOW STATS FOR " + table.getName(),
+                    """
+                            VALUES
+                            ('col', null, 2.0, 0.33333333333, null, null, null),
+                            (null, null, null, null, 3, null, null)
+                            """);
+        }
+    }
+
     @Override
     public void testDropAmbiguousRowFieldCaseSensitivity()
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fixes #15603 


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes issue where ORC files containing nullable Iceberg TIME columns could throw an exception when being read.  Also fixed an error in the ORC file validator where time columns did not validate correctly in order to add appropriate tests for the Time type.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Fix Iceberg query failure when reading ORC files with nullable `time` columns. ({issue}`15606`)
```
