### PR TITLE
Fix failure when subquery contains time travel

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/tree/QueryPeriod.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/QueryPeriod.java
@@ -103,4 +103,14 @@ public class QueryPeriod
     {
         return "FOR " + rangeType.toString() + " AS OF " + end.get().toString();
     }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        if (!sameClass(this, other)) {
+            return false;
+        }
+
+        return rangeType.equals(((QueryPeriod) other).rangeType);
+    }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/QueryPeriod.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/QueryPeriod.java
@@ -51,12 +51,8 @@ public class QueryPeriod
     public List<Node> getChildren()
     {
         ImmutableList.Builder<Node> nodes = ImmutableList.builder();
-        if (start.isPresent()) {
-            nodes.add(start.get());
-        }
-        if (end.isPresent()) {
-            nodes.add(end.get());
-        }
+        start.ifPresent(nodes::add);
+        end.ifPresent(nodes::add);
         return nodes.build();
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fix failure when the subquery contains time travel. 
I added a test to only Iceberg because tests in the planner fails early due to unsupported time travel in tpch connector. 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Fix failure when a subquery contains time travel. ({issue}`15607`)
```
