### PR TITLE
Fix query failure for outer join with DFs in fault tolerant execution

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestJoinQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestJoinQueries.java
@@ -2252,6 +2252,23 @@ public abstract class AbstractTestJoinQueries
                 "WITH small_part AS (SELECT * FROM part WHERE name = 'a') SELECT lineitem.orderkey FROM small_part RIGHT JOIN lineitem ON  small_part.partkey = lineitem.partkey");
     }
 
+    @Test(timeOut = 30_000)
+    public void testRightJoinWithOuterJoinInLookupSource()
+    {
+        assertQuery(
+                noJoinReordering(),
+                "SELECT * FROM nation n1 " +
+                        "RIGHT JOIN " +
+                        "(SELECT n.nationkey FROM (SELECT * FROM lineitem WHERE suppkey BETWEEN 20 and 30) l LEFT JOIN nation n on l.suppkey = n.nationkey) n2" +
+                        " ON n1.nationkey = n2.nationkey + 1");
+        assertQuery(
+                noJoinReordering(),
+                "SELECT * FROM nation n1 " +
+                        "RIGHT JOIN " +
+                        "(SELECT n.nationkey FROM (SELECT * FROM lineitem WHERE suppkey BETWEEN 20 and 30) l RIGHT JOIN nation n on l.suppkey = n.nationkey) n2 " +
+                        "ON n1.nationkey = n2.nationkey + 1");
+    }
+
     @Test
     public void testEquijoinOnDifferentTypesWithFilter()
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In FTE for a query shape like below, DynamicFilterSourceFactory may need to be duplicated by LocalExecutionPlanner#addLookupOuterDrivers
```
    RightJoin[criteria = ("orderkey" = "orderkey_0"), hash = [$hashvalue, $hashvalue_17], distribution = PARTITIONED]
    │   Layout: [orderkey:bigint]
    │   Distribution: PARTITIONED
    ├─ RemoteSource[sourceFragmentIds = [1]]
    │      Layout: [orderkey:bigint, $hashvalue:bigint]
    └─ LocalExchange[partitioning = HASH, hashColumn = [$hashvalue_17], arguments = ["orderkey_0"]]
       │   Layout: [orderkey_0:bigint, $hashvalue_17:bigint]
       └─ RemoteSource[sourceFragmentIds = [2]]
              Layout: [orderkey_0:bigint, $hashvalue_18:bigint]

Fragment 2 [HASH]
    Output layout: [orderkey_0, $hashvalue_24]
    Output partitioning: HASH [orderkey_0][$hashvalue_24]
    DynamicFilterSource[dynamicFilterAssignments = {orderkey_0 -> #df_426}]
    │   Layout: [orderkey_0:bigint, $hashvalue_24:bigint]
    └─ Project[]
       │   Layout: [orderkey_0:bigint, $hashvalue_24:bigint]
       │   $hashvalue_24 := combine_hash(bigint '0', COALESCE("$operator$hash_code"("orderkey_0"), 0))
       └─ RightJoin[criteria = ("orderkey_0" = "nationkey"), hash = [$hashvalue_19, $hashvalue_21], distribution = PARTITIONED]
          │   Layout: [orderkey_0:bigint]
          │   Estimates: {rows: ? (?), cpu: ?, memory: ?, network: 0B}
          │   Distribution: PARTITIONED
          ├─ RemoteSource[sourceFragmentIds = [3]]
          │      Layout: [orderkey_0:bigint, $hashvalue_19:bigint]
          └─ LocalExchange[partitioning = SINGLE]
             │   Layout: [nationkey:bigint, $hashvalue_21:bigint]
             └─ RemoteSource[sourceFragmentIds = [4]]
                    Layout: [nationkey:bigint, $hashvalue_22:bigint]
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/15596

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix query failure for outer joins in fault tolerant execution. ({issue}`15608`)
```
