### PR TITLE
Skip 404 in Trino compatibility tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         id: set-matrix
         run: |
           # The output from rev-list ends with a newline, so we have to filter out index -1 in jq since it's an empty string
-          export JQ_PIPELINE='split("\n") | .[0:-1] | map({base_ref: "${{ github.event.pull_request.base.ref }}", commit: .}) | select(length > 0) | {include: .}'
+          JQ_PIPELINE='split("\n") | .[0:-1] | map({base_ref: "${{ github.event.pull_request.base.ref }}", commit: .}) | select(length > 0) | {include: .}'
 
           # Make sure the PR branch contains the compile-commit composite job
           if git merge-base --is-ancestor $( git rev-list HEAD -- .github/actions/compile-commit/action.yml | tail -n 1 ) ${{ github.event.pull_request.head.sha }}

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteCompatibility.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteCompatibility.java
@@ -77,6 +77,10 @@ public class SuiteCompatibility
             ImmutableList.Builder<String> testedTrinoVersions = ImmutableList.builder();
             int testVersion = currentVersion - 1; // always test last release version
             for (int i = 0; i < NUMBER_OF_TESTED_VERSIONS; i++) {
+                if (testVersion == 404) {
+                    // 404 release was skipped.
+                    testVersion--;
+                }
                 if (testVersion < FIRST_TRINO_VERSION) {
                     break;
                 }

--- a/testing/trino-test-jdbc-compatibility-old-driver/bin/run_tests.sh
+++ b/testing/trino-test-jdbc-compatibility-old-driver/bin/run_tests.sh
@@ -16,11 +16,17 @@ version_step=5
 
 echo "Current version: ${current_version}"
 
+if (( previous_released_version == 404 )); then
+    # 404 was skipped
+    previous_released_version=403
+fi
+
 (( previous_released_version >= first_tested_version )) || exit 0
 
 echo "Testing every ${version_step}. version between ${first_tested_version} and ${previous_released_version}"
 
-tested_versions=$(seq "${first_tested_version}" ${version_step} "${previous_released_version}")
+# 404 was skipped
+tested_versions=$(seq "${first_tested_version}" ${version_step} "${previous_released_version}" | grep -vx 404)
 
 if (( (previous_released_version - first_tested_version) % version_step != 0 )); then
     tested_versions="${tested_versions} ${previous_released_version}"

--- a/testing/trino-test-jdbc-compatibility-old-server/src/test/java/io/trino/TestJdbcResultSetCompatibilityOldServer.java
+++ b/testing/trino-test-jdbc-compatibility-old-server/src/test/java/io/trino/TestJdbcResultSetCompatibilityOldServer.java
@@ -71,6 +71,10 @@ public class TestJdbcResultSetCompatibilityOldServer
             ImmutableList.Builder<String> testedTrinoVersions = ImmutableList.builder();
             int testVersion = currentVersion - 1; // last release version
             for (int i = 0; i < NUMBER_OF_TESTED_VERSIONS; i++) {
+                if (testVersion == 404) {
+                    // 404 release was skipped.
+                    testVersion--;
+                }
                 if (testVersion < FIRST_VERSION) {
                     break;
                 }


### PR DESCRIPTION
This version has not been released.  Currently (when working on 406 SNAPSHOT) the ci does not failV, because we test with some granularity, and 404 isn't getting picked up for the test, but would fail after a release or two.
