### PR TITLE
Add parallelism to FailureRecovery tests

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcFailureRecoveryTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcFailureRecoveryTest.java
@@ -31,14 +31,14 @@ public abstract class BaseJdbcFailureRecoveryTest
     }
 
     @Override
-    public void testAnalyzeTable()
+    protected void testAnalyzeTable()
     {
         assertThatThrownBy(super::testAnalyzeTable).hasMessageMatching("This connector does not support analyze");
         throw new SkipException("skipped");
     }
 
     @Override
-    public void testDelete()
+    protected void testDelete()
     {
         // This simple delete on JDBC ends up as a very simple, single-fragment, coordinator-only plan,
         // which has no ability to recover from errors. This test simply verifies that's still the case.
@@ -53,14 +53,14 @@ public abstract class BaseJdbcFailureRecoveryTest
     }
 
     @Override
-    public void testDeleteWithSubquery()
+    protected void testDeleteWithSubquery()
     {
         assertThatThrownBy(super::testDeleteWithSubquery).hasMessageContaining(MODIFYING_ROWS_MESSAGE);
         throw new SkipException("skipped");
     }
 
     @Override
-    public void testRefreshMaterializedView()
+    protected void testRefreshMaterializedView()
     {
         assertThatThrownBy(super::testRefreshMaterializedView)
                 .hasMessageContaining("This connector does not support creating materialized views");
@@ -68,21 +68,21 @@ public abstract class BaseJdbcFailureRecoveryTest
     }
 
     @Override
-    public void testUpdate()
+    protected void testUpdate()
     {
         assertThatThrownBy(super::testUpdate).hasMessageContaining(MODIFYING_ROWS_MESSAGE);
         throw new SkipException("skipped");
     }
 
     @Override
-    public void testUpdateWithSubquery()
+    protected void testUpdateWithSubquery()
     {
         assertThatThrownBy(super::testUpdateWithSubquery).hasMessageContaining(MODIFYING_ROWS_MESSAGE);
         throw new SkipException("skipped");
     }
 
     @Override
-    public void testMerge()
+    protected void testMerge()
     {
         assertThatThrownBy(super::testMerge).hasMessageContaining(MODIFYING_ROWS_MESSAGE);
         throw new SkipException("skipped");

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoFailureRecoveryTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoFailureRecoveryTest.java
@@ -56,35 +56,35 @@ public abstract class BaseMongoFailureRecoveryTest
     }
 
     @Override
-    public void testAnalyzeTable()
+    protected void testAnalyzeTable()
     {
         assertThatThrownBy(super::testAnalyzeTable).hasMessageMatching("This connector does not support analyze");
         throw new SkipException("skipped");
     }
 
     @Override
-    public void testDelete()
+    protected void testDelete()
     {
         assertThatThrownBy(super::testDeleteWithSubquery).hasMessageContaining("This connector does not support modifying table rows");
         throw new SkipException("skipped");
     }
 
     @Override
-    public void testDeleteWithSubquery()
+    protected void testDeleteWithSubquery()
     {
         assertThatThrownBy(super::testDeleteWithSubquery).hasMessageContaining("This connector does not support modifying table rows");
         throw new SkipException("skipped");
     }
 
     @Override
-    public void testMerge()
+    protected void testMerge()
     {
         assertThatThrownBy(super::testMerge).hasMessageContaining("This connector does not support modifying table rows");
         throw new SkipException("skipped");
     }
 
     @Override
-    public void testRefreshMaterializedView()
+    protected void testRefreshMaterializedView()
     {
         assertThatThrownBy(super::testRefreshMaterializedView)
                 .hasMessageContaining("This connector does not support creating materialized views");
@@ -92,14 +92,14 @@ public abstract class BaseMongoFailureRecoveryTest
     }
 
     @Override
-    public void testUpdate()
+    protected void testUpdate()
     {
         assertThatThrownBy(super::testUpdate).hasMessageContaining("This connector does not support modifying table rows");
         throw new SkipException("skipped");
     }
 
     @Override
-    public void testUpdateWithSubquery()
+    protected void testUpdateWithSubquery()
     {
         assertThatThrownBy(super::testUpdateWithSubquery).hasMessageContaining("This connector does not support modifying table rows");
         throw new SkipException("skipped");

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/Listeners.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/Listeners.java
@@ -13,8 +13,11 @@
  */
 package io.trino.testng.services;
 
+import com.google.common.base.Joiner;
 import com.google.errorprone.annotations.FormatMethod;
+import org.testng.ITestClass;
 import org.testng.ITestNGListener;
+import org.testng.ITestResult;
 
 import static java.lang.String.format;
 
@@ -36,5 +39,25 @@ final class Listeners
         // TestNG may or may not propagate listener's exception as test execution exception.
         // Therefore, instead of throwing, we terminate the JVM.
         System.exit(1);
+    }
+
+    public static String formatTestName(ITestClass testClass)
+    {
+        return testClass.getName();
+    }
+
+    public static String formatTestName(ITestResult testCase)
+    {
+        // See LogTestDurationListener.getName
+        return format("%s.%s%s", testCase.getTestClass().getName(), testCase.getName(), formatTestParameters(testCase));
+    }
+
+    private static String formatTestParameters(ITestResult testCase)
+    {
+        Object[] parameters = testCase.getParameters();
+        if (parameters == null || parameters.length == 0) {
+            return "";
+        }
+        return format(" [%s]", Joiner.on(", ").useForNull("null").join(parameters));
     }
 }

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/LogTestDurationListener.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/LogTestDurationListener.java
@@ -40,6 +40,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.getStackTraceAsString;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.units.Duration.nanosSince;
+import static io.trino.testng.services.Listeners.formatTestName;
 import static io.trino.testng.services.Listeners.reportListenerFailure;
 import static java.lang.String.format;
 import static java.lang.management.ManagementFactory.getThreadMXBean;
@@ -176,7 +177,7 @@ public class LogTestDurationListener
         }
 
         try {
-            beginTest(getName(testClass));
+            beginTest(formatTestName(testClass));
         }
         catch (RuntimeException | Error e) {
             reportListenerFailure(LogTestDurationListener.class, "onBeforeClass: \n%s", getStackTraceAsString(e));
@@ -191,7 +192,7 @@ public class LogTestDurationListener
         }
 
         try {
-            String name = getName(testClass);
+            String name = formatTestName(testClass);
             Duration duration = endTest(name);
             if (duration.compareTo(CLASS_LOGGING_THRESHOLD) > 0) {
                 LOG.warn("Tests from %s took %s", name, duration);
@@ -210,7 +211,7 @@ public class LogTestDurationListener
         }
 
         try {
-            beginTest(getName(method));
+            beginTest(formatTestName(testResult));
         }
         catch (RuntimeException | Error e) {
             reportListenerFailure(LogTestDurationListener.class, "beforeInvocation: \n%s", getStackTraceAsString(e));
@@ -225,7 +226,7 @@ public class LogTestDurationListener
         }
 
         try {
-            String name = getName(method);
+            String name = formatTestName(testResult);
             Duration duration = endTest(name);
             if (duration.compareTo(SINGLE_TEST_LOGGING_THRESHOLD) > 0) {
                 LOG.info("Test %s took %s", name, duration);
@@ -251,16 +252,5 @@ public class LogTestDurationListener
         Long startTime = started.remove(name);
         checkState(startTime != null, "There is no start record for test: %s", name);
         return nanosSince(startTime);
-    }
-
-    private static String getName(ITestClass testClass)
-    {
-        return testClass.getName();
-    }
-
-    private static String getName(IInvokedMethod method)
-    {
-        // See ProgressLoggingListener.formatTestName
-        return format("%s.%s", method.getTestMethod().getTestClass().getName(), method.getTestMethod().getMethodName());
     }
 }

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/ProgressLoggingListener.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/ProgressLoggingListener.java
@@ -13,7 +13,6 @@
  */
 package io.trino.testng.services;
 
-import com.google.common.base.Joiner;
 import io.airlift.log.Logger;
 import org.testng.IClassListener;
 import org.testng.IInvokedMethod;
@@ -26,6 +25,7 @@ import org.testng.ITestResult;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
+import static io.trino.testng.services.Listeners.formatTestName;
 import static java.lang.String.format;
 
 public class ProgressLoggingListener
@@ -127,7 +127,7 @@ public class ProgressLoggingListener
             return;
         }
 
-        LOGGER.info("[BEFORE CLASS] %s", getName(testClass));
+        LOGGER.info("[BEFORE CLASS] %s", formatTestName(testClass));
     }
 
     @Override
@@ -137,22 +137,7 @@ public class ProgressLoggingListener
             return;
         }
 
-        LOGGER.info("[AFTER CLASS] %s", getName(testClass));
-    }
-
-    private String formatTestName(ITestResult testCase)
-    {
-        // See LogTestDurationListener.getName
-        return format("%s.%s%s", testCase.getTestClass().getName(), testCase.getName(), formatTestParameters(testCase));
-    }
-
-    private String formatTestParameters(ITestResult testCase)
-    {
-        Object[] parameters = testCase.getParameters();
-        if (parameters == null || parameters.length == 0) {
-            return "";
-        }
-        return format(" [%s]", Joiner.on(", ").useForNull("null").join(parameters));
+        LOGGER.info("[AFTER CLASS] %s", formatTestName(testClass));
     }
 
     private static String formatDuration(ITestResult testCase)
@@ -174,10 +159,5 @@ public class ProgressLoggingListener
     private static BigDecimal durationInSeconds(long millis)
     {
         return (new BigDecimal(millis)).divide(new BigDecimal(1000), 1, RoundingMode.HALF_UP);
-    }
-
-    private static String getName(ITestClass testClass)
-    {
-        return testClass.getName();
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This parallelizes the test methods for all FailureRecovery tests. As far as @arhimondr and I could tell, the only other way to do this is using the TestNG XML descriptor, designating the class with `parallel="methods"`, but since we do not use that XML descriptor, this appears to be the only available option. These tests can take upwards of 20, 30, even 50 minutes for some connectors. This suite of tests benefitted greatly from parallelism.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

The primary goal here is to speed up FailureRecoveryTests, improving the iteration cycle time, and preventing CI timeouts. I observed a roughly 40-50% improvement (depending on the connector) with this change.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
