### PR TITLE
Remove deprecated checkCanCreateSchema

### DIFF
--- a/core/trino-main/src/main/java/io/trino/security/InjectedConnectorAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/InjectedConnectorAccessControl.java
@@ -14,7 +14,6 @@
 package io.trino.security;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.CatalogSchemaName;
@@ -58,13 +57,6 @@ public class InjectedConnectorAccessControl
     {
         checkArgument(context == null, "context must be null");
         accessControl.checkCanCreateSchema(securityContext, getCatalogSchemaName(schemaName), properties);
-    }
-
-    @Override
-    public void checkCanCreateSchema(ConnectorSecurityContext context, String schemaName)
-    {
-        checkArgument(context == null, "context must be null");
-        accessControl.checkCanCreateSchema(securityContext, getCatalogSchemaName(schemaName), ImmutableMap.of());
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorAccessControl.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorAccessControl.java
@@ -100,17 +100,6 @@ public interface ConnectorAccessControl
     }
 
     /**
-     * Check if identity is allowed to create the specified schema.
-     *
-     * @throws io.trino.spi.security.AccessDeniedException if not allowed
-     */
-    @Deprecated
-    default void checkCanCreateSchema(ConnectorSecurityContext context, String schemaName)
-    {
-        denyCreateSchema(schemaName);
-    }
-
-    /**
      * Check if identity is allowed to drop the specified schema.
      *
      * @throws io.trino.spi.security.AccessDeniedException if not allowed

--- a/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
@@ -265,17 +265,6 @@ public interface SystemAccessControl
     }
 
     /**
-     * Check if identity is allowed to create the specified schema in a catalog.
-     *
-     * @throws AccessDeniedException if not allowed
-     */
-    @Deprecated
-    default void checkCanCreateSchema(SystemSecurityContext context, CatalogSchemaName schema)
-    {
-        denyCreateSchema(schema.toString());
-    }
-
-    /**
      * Check if identity is allowed to drop the specified schema in a catalog.
      *
      * @throws AccessDeniedException if not allowed

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
@@ -55,14 +55,6 @@ public class ClassLoaderSafeConnectorAccessControl
     }
 
     @Override
-    public void checkCanCreateSchema(ConnectorSecurityContext context, String schemaName)
-    {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanCreateSchema(context, schemaName);
-        }
-    }
-
-    @Override
     public void checkCanDropSchema(ConnectorSecurityContext context, String schemaName)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllAccessControl.java
@@ -38,11 +38,6 @@ public class AllowAllAccessControl
     }
 
     @Override
-    public void checkCanCreateSchema(ConnectorSecurityContext context, String schemaName)
-    {
-    }
-
-    @Override
     public void checkCanDropSchema(ConnectorSecurityContext context, String schemaName)
     {
     }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllSystemAccessControl.java
@@ -142,11 +142,6 @@ public class AllowAllSystemAccessControl
     }
 
     @Override
-    public void checkCanCreateSchema(SystemSecurityContext context, CatalogSchemaName schema)
-    {
-    }
-
-    @Override
     public void checkCanDropSchema(SystemSecurityContext context, CatalogSchemaName schema)
     {
     }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
@@ -140,12 +140,6 @@ public class FileBasedAccessControl
     @Override
     public void checkCanCreateSchema(ConnectorSecurityContext context, String schemaName, Map<String, Object> properties)
     {
-        checkCanCreateSchema(context, schemaName);
-    }
-
-    @Override
-    public void checkCanCreateSchema(ConnectorSecurityContext context, String schemaName)
-    {
         if (!isSchemaOwner(context, schemaName)) {
             denyCreateSchema(schemaName);
         }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
@@ -386,12 +386,6 @@ public class FileBasedSystemAccessControl
     @Override
     public void checkCanCreateSchema(SystemSecurityContext context, CatalogSchemaName schema, Map<String, Object> properties)
     {
-        checkCanCreateSchema(context, schema);
-    }
-
-    @Override
-    public void checkCanCreateSchema(SystemSecurityContext context, CatalogSchemaName schema)
-    {
         if (!isSchemaOwner(context, schema)) {
             denyCreateSchema(schema.toString());
         }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingConnectorAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingConnectorAccessControl.java
@@ -56,12 +56,6 @@ public abstract class ForwardingConnectorAccessControl
     }
 
     @Override
-    public void checkCanCreateSchema(ConnectorSecurityContext context, String schemaName)
-    {
-        delegate().checkCanCreateSchema(context, schemaName);
-    }
-
-    @Override
     public void checkCanDropSchema(ConnectorSecurityContext context, String schemaName)
     {
         delegate().checkCanDropSchema(context, schemaName);

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingSystemAccessControl.java
@@ -146,12 +146,6 @@ public abstract class ForwardingSystemAccessControl
     }
 
     @Override
-    public void checkCanCreateSchema(SystemSecurityContext context, CatalogSchemaName schema)
-    {
-        delegate().checkCanCreateSchema(context, schema);
-    }
-
-    @Override
     public void checkCanDropSchema(SystemSecurityContext context, CatalogSchemaName schema)
     {
         delegate().checkCanDropSchema(context, schema);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/LegacyAccessControl.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/LegacyAccessControl.java
@@ -76,11 +76,6 @@ public class LegacyAccessControl
     }
 
     @Override
-    public void checkCanCreateSchema(ConnectorSecurityContext context, String schemaName)
-    {
-    }
-
-    @Override
     public void checkCanDropSchema(ConnectorSecurityContext context, String schemaName)
     {
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
@@ -132,12 +132,6 @@ public class SqlStandardAccessControl
     @Override
     public void checkCanCreateSchema(ConnectorSecurityContext context, String schemaName, Map<String, Object> properties)
     {
-        checkCanCreateSchema(context, schemaName);
-    }
-
-    @Override
-    public void checkCanCreateSchema(ConnectorSecurityContext context, String schemaName)
-    {
         if (!isAdmin(context)) {
             denyCreateSchema(schemaName);
         }


### PR DESCRIPTION
Retaining the deprecated method was not sufficient for maintaining compatibility, because the new method did not delegate to the old one. Thus, if an implementor kept implementing only the old method, the CREATE SCHEMA would get denied, irrespective of the implemented logic. Removing the deprecated method makes the incompatibility clearer, as it fails at the compilation time.

Follows https://github.com/trinodb/trino/pull/15153#discussion_r1062617378