### PR TITLE
Mark filter() function as deterministic

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayFilterFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayFilterFunction.java
@@ -25,7 +25,7 @@ import io.trino.spi.type.Type;
 import static java.lang.Boolean.TRUE;
 
 @Description("Return array containing elements that match the given predicate")
-@ScalarFunction(value = "filter", deterministic = false)
+@ScalarFunction(value = "filter")
 public final class ArrayFilterFunction
 {
     private ArrayFilterFunction() {}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Mark `filter()` function as deterministic function to enable more optimization opportunities such as predicate pushdown through projection.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes [#15604 ](https://github.com/trinodb/trino/issues/15604)

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(O) Release notes are required, with the following suggested text: Mark `filter()` function as deterministic function to enable more optimization opportunities such as predicate pushdown through projection
