### PR TITLE
BigQuery FTE

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
@@ -49,6 +49,7 @@ depending on the desired :ref:`retry policy <fte-retry-policy>`.
   * Fault tolerant execution of :ref:`write operations <sql-write-operations>`
     is supported by the following connectors:
 
+    * :doc:`/connector/bigquery`
     * :doc:`/connector/delta-lake`
     * :doc:`/connector/hive`
     * :doc:`/connector/iceberg`

--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -297,6 +297,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-exchange-filesystem</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
             <scope>test</scope>
 
@@ -430,6 +436,7 @@
                                 <exclude>**/TestBigQueryMetadata.java</exclude>
                                 <exclude>**/TestBigQueryInstanceCleaner.java</exclude>
                                 <exclude>**/TestBigQueryCaseInsensitiveMapping.java</exclude>
+                                <exclude>**/TestBigQuery*FailureRecoveryTest.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -455,6 +462,7 @@
                                 <include>**/TestBigQueryTypeMapping.java</include>
                                 <include>**/TestBigQueryMetadata.java</include>
                                 <include>**/TestBigQueryInstanceCleaner.java</include>
+                                <include>**/TestBigQuery*FailureRecoveryTest.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryInsertTableHandle.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryInsertTableHandle.java
@@ -30,17 +30,23 @@ public class BigQueryInsertTableHandle
     private final RemoteTableName remoteTableName;
     private final List<String> columnNames;
     private final List<Type> columnTypes;
+    private final String temporaryTableName;
+    private final String pageSinkIdColumnName;
 
     @JsonCreator
     public BigQueryInsertTableHandle(
             @JsonProperty("remoteTableName") RemoteTableName remoteTableName,
             @JsonProperty("columnNames") List<String> columnNames,
-            @JsonProperty("columnTypes") List<Type> columnTypes)
+            @JsonProperty("columnTypes") List<Type> columnTypes,
+            @JsonProperty("temporaryTableName") String temporaryTableName,
+            @JsonProperty("pageSinkIdColumnName") String pageSinkIdColumnName)
     {
         this.remoteTableName = requireNonNull(remoteTableName, "remoteTableName is null");
         this.columnNames = ImmutableList.copyOf(requireNonNull(columnNames, "columnNames is null"));
         this.columnTypes = ImmutableList.copyOf(requireNonNull(columnTypes, "columnTypes is null"));
         checkArgument(columnNames.size() == columnTypes.size(), "columnNames and columnTypes must have the same size");
+        this.temporaryTableName = requireNonNull(temporaryTableName, "temporaryTableName is null");
+        this.pageSinkIdColumnName = requireNonNull(pageSinkIdColumnName, "pageSinkIdColumnName is null");
     }
 
     @JsonProperty
@@ -59,5 +65,22 @@ public class BigQueryInsertTableHandle
     public List<Type> getColumnTypes()
     {
         return columnTypes;
+    }
+
+    @JsonProperty
+    public String getTemporaryTableName()
+    {
+        return temporaryTableName;
+    }
+
+    public RemoteTableName getTemporaryRemoteTableName()
+    {
+        return new RemoteTableName(remoteTableName.getProjectId(), remoteTableName.getDatasetName(), temporaryTableName);
+    }
+
+    @JsonProperty
+    public String getPageSinkIdColumnName()
+    {
+        return pageSinkIdColumnName;
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPageSinkProvider.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPageSinkProvider.java
@@ -23,6 +23,8 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 
 import javax.inject.Inject;
 
+import java.util.Optional;
+
 import static java.util.Objects.requireNonNull;
 
 public class BigQueryPageSinkProvider
@@ -40,13 +42,27 @@ public class BigQueryPageSinkProvider
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle, ConnectorPageSinkId pageSinkId)
     {
         BigQueryOutputTableHandle handle = (BigQueryOutputTableHandle) outputTableHandle;
-        return new BigQueryPageSink(clientFactory.createBigQueryClient(session), handle.getRemoteTableName(), handle.getColumnNames(), handle.getColumnTypes());
+        return new BigQueryPageSink(
+                clientFactory.createBigQueryClient(session),
+                handle.getRemoteTableName(),
+                handle.getColumnNames(),
+                handle.getColumnTypes(),
+                pageSinkId,
+                handle.getTemporaryTableName(),
+                handle.getPageSinkIdColumnName());
     }
 
     @Override
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle, ConnectorPageSinkId pageSinkId)
     {
         BigQueryInsertTableHandle handle = (BigQueryInsertTableHandle) insertTableHandle;
-        return new BigQueryPageSink(clientFactory.createBigQueryClient(session), handle.getRemoteTableName(), handle.getColumnNames(), handle.getColumnTypes());
+        return new BigQueryPageSink(
+                clientFactory.createBigQueryClient(session),
+                handle.getRemoteTableName(),
+                handle.getColumnNames(),
+                handle.getColumnTypes(),
+                pageSinkId,
+                Optional.of(handle.getTemporaryTableName()),
+                Optional.of(handle.getPageSinkIdColumnName()));
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryUtil.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryUtil.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import static com.google.cloud.bigquery.TableDefinition.Type.TABLE;
 import static com.google.cloud.http.BaseHttpServiceException.UNKNOWN_CODE;
 import static com.google.common.base.Throwables.getCausalChain;
+import static java.lang.String.format;
 
 public final class BigQueryUtil
 {
@@ -81,5 +82,10 @@ public final class BigQueryUtil
     public static String quote(String name)
     {
         return QUOTE + name.replace(QUOTE, ESCAPED_QUOTE) + QUOTE;
+    }
+
+    public static String quoted(RemoteTableName table)
+    {
+        return format("%s.%s.%s", quote(table.getProjectId()), quote(table.getDatasetName()), quote(table.getTableName()));
     }
 }

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryFailureRecoveryTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryFailureRecoveryTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.operator.RetryPolicy;
+import io.trino.plugin.exchange.filesystem.FileSystemExchangePlugin;
+import io.trino.testing.BaseFailureRecoveryTest;
+import io.trino.testing.QueryRunner;
+import io.trino.tpch.TpchTable;
+import org.testng.SkipException;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class BaseBigQueryFailureRecoveryTest
+        extends BaseFailureRecoveryTest
+{
+    public BaseBigQueryFailureRecoveryTest(RetryPolicy retryPolicy)
+    {
+        super(retryPolicy);
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner(
+            List<TpchTable<?>> requiredTpchTables,
+            Map<String, String> configProperties,
+            Map<String, String> coordinatorProperties)
+            throws Exception
+    {
+        return BigQueryQueryRunner.createQueryRunner(
+                configProperties,
+                coordinatorProperties,
+                ImmutableMap.of(),
+                requiredTpchTables,
+                runner -> {
+                    runner.installPlugin(new FileSystemExchangePlugin());
+                    runner.loadExchangeManager("filesystem", ImmutableMap.<String, String>builder()
+                            .put("exchange.base-directories", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager")
+                            .buildOrThrow());
+                });
+    }
+
+    @Override
+    protected boolean areWriteRetriesSupported()
+    {
+        return true;
+    }
+
+    @Override
+    protected void testAnalyzeTable()
+    {
+        assertThatThrownBy(super::testAnalyzeTable).hasMessageMatching("This connector does not support analyze");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    protected void testDelete()
+    {
+        assertThatThrownBy(super::testDeleteWithSubquery).hasMessageContaining("This connector does not support modifying table rows");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    protected void testDeleteWithSubquery()
+    {
+        assertThatThrownBy(super::testDeleteWithSubquery).hasMessageContaining("This connector does not support modifying table rows");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    protected void testMerge()
+    {
+        assertThatThrownBy(super::testMerge).hasMessageContaining("This connector does not support modifying table rows");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    protected void testRefreshMaterializedView()
+    {
+        assertThatThrownBy(super::testRefreshMaterializedView)
+                .hasMessageContaining("This connector does not support creating materialized views");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    protected void testUpdate()
+    {
+        assertThatThrownBy(super::testUpdate).hasMessageContaining("This connector does not support modifying table rows");
+        throw new SkipException("skipped");
+    }
+
+    @Override
+    protected void testUpdateWithSubquery()
+    {
+        assertThatThrownBy(super::testUpdateWithSubquery).hasMessageContaining("This connector does not support modifying table rows");
+        throw new SkipException("skipped");
+    }
+}

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
@@ -30,6 +30,7 @@ import io.airlift.log.Logger;
 import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.SqlExecutor;
 import io.trino.tpch.TpchTable;
 import org.intellij.lang.annotations.Language;
@@ -42,6 +43,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static com.google.cloud.bigquery.BigQuery.DatasetDeleteOption.deleteContents;
 import static com.google.cloud.bigquery.BigQuery.DatasetListOption.labelFilter;
@@ -66,10 +68,23 @@ public final class BigQueryQueryRunner
             Iterable<TpchTable<?>> tables)
             throws Exception
     {
+        return createQueryRunner(extraProperties, ImmutableMap.of(), connectorProperties, tables, runner -> {});
+    }
+
+    public static DistributedQueryRunner createQueryRunner(
+            Map<String, String> extraProperties,
+            Map<String, String> coordinatorProperties,
+            Map<String, String> connectorProperties,
+            Iterable<TpchTable<?>> tables,
+            Consumer<QueryRunner> moreSetup)
+            throws Exception
+    {
         DistributedQueryRunner queryRunner = null;
         try {
             queryRunner = DistributedQueryRunner.builder(createSession())
                     .setExtraProperties(extraProperties)
+                    .setCoordinatorProperties(coordinatorProperties)
+                    .setAdditionalSetup(moreSetup)
                     .build();
 
             queryRunner.installPlugin(new TpchPlugin());

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryQueryFailureRecoveryTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryQueryFailureRecoveryTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import io.trino.operator.RetryPolicy;
+
+public class TestBigQueryQueryFailureRecoveryTest
+        extends BaseBigQueryFailureRecoveryTest
+{
+    public TestBigQueryQueryFailureRecoveryTest()
+    {
+        super(RetryPolicy.QUERY);
+    }
+}

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryTaskFailureRecoveryTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryTaskFailureRecoveryTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import io.trino.operator.RetryPolicy;
+
+public class TestBigQueryTaskFailureRecoveryTest
+        extends BaseBigQueryFailureRecoveryTest
+{
+    public TestBigQueryTaskFailureRecoveryTest()
+    {
+        super(RetryPolicy.TASK);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This PR introduces FTE for BigQuery.

This differs slightly from previous FTE PRs in that the FailureRecoveryTests are executed within the `-Pcloud-tests`, rather than a separate profile like the others. This _may_  cause problems by running up against the 1 hour time limit, in which case, we'll have to separate the FailureRecoveryTests from cloud-tests.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(X) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
