### PR TITLE
Increase memory requirement for tasks failed due to worker crash

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/ErrorCodes.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/ErrorCodes.java
@@ -18,6 +18,10 @@ import io.trino.spi.ErrorCode;
 import static io.trino.spi.StandardErrorCode.CLUSTER_OUT_OF_MEMORY;
 import static io.trino.spi.StandardErrorCode.EXCEEDED_GLOBAL_MEMORY_LIMIT;
 import static io.trino.spi.StandardErrorCode.EXCEEDED_LOCAL_MEMORY_LIMIT;
+import static io.trino.spi.StandardErrorCode.REMOTE_HOST_GONE;
+import static io.trino.spi.StandardErrorCode.REMOTE_TASK_ERROR;
+import static io.trino.spi.StandardErrorCode.REMOTE_TASK_MISMATCH;
+import static io.trino.spi.StandardErrorCode.TOO_MANY_REQUESTS_FAILED;
 
 public final class ErrorCodes
 {
@@ -28,5 +32,13 @@ public final class ErrorCodes
         return EXCEEDED_LOCAL_MEMORY_LIMIT.toErrorCode().equals(errorCode)
                 || EXCEEDED_GLOBAL_MEMORY_LIMIT.toErrorCode().equals(errorCode)
                 || CLUSTER_OUT_OF_MEMORY.toErrorCode().equals(errorCode);
+    }
+
+    public static boolean isWorkerCrashAssociatedError(ErrorCode errorCode)
+    {
+        return TOO_MANY_REQUESTS_FAILED.toErrorCode().equals(errorCode)
+                || REMOTE_HOST_GONE.toErrorCode().equals(errorCode)
+                || REMOTE_TASK_MISMATCH.toErrorCode().equals(errorCode)
+                || REMOTE_TASK_ERROR.toErrorCode().equals(errorCode);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
@@ -45,6 +45,8 @@ public class MemoryManagerConfig
     private DataSize faultTolerantExecutionTaskRuntimeMemoryEstimationOverhead = DataSize.of(1, GIGABYTE);
     private LowMemoryQueryKillerPolicy lowMemoryQueryKillerPolicy = LowMemoryQueryKillerPolicy.TOTAL_RESERVATION_ON_BLOCKED_NODES;
     private LowMemoryTaskKillerPolicy lowMemoryTaskKillerPolicy = LowMemoryTaskKillerPolicy.TOTAL_RESERVATION_ON_BLOCKED_NODES;
+    private boolean faultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled = true;
+
     /**
      * default value is overwritten for fault tolerant execution in {@link #applyFaultTolerantExecutionDefaults()}}
      */
@@ -187,6 +189,19 @@ public class MemoryManagerConfig
         checkArgument(faultTolerantExecutionTaskMemoryEstimationQuantile >= 0.0 && faultTolerantExecutionTaskMemoryEstimationQuantile <= 1.0,
                 "fault-tolerant-execution-task-memory-estimation-quantile must not be in [0.0, 1.0] range");
         this.faultTolerantExecutionTaskMemoryEstimationQuantile = faultTolerantExecutionTaskMemoryEstimationQuantile;
+        return this;
+    }
+
+    public boolean isFaultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled()
+    {
+        return faultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled;
+    }
+
+    @Config("fault-tolerant-execution.memory-requirement-increase-on-worker-crash-enabled")
+    @ConfigDescription("Increase memory requirement for tasks failed due to a suspected worker crash")
+    public MemoryManagerConfig setFaultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled(boolean faultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled)
+    {
+        this.faultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled = faultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled;
         return this;
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestBinPackingNodeAllocator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestBinPackingNodeAllocator.java
@@ -101,6 +101,7 @@ public class TestBinPackingNodeAllocator
                 nodeManager,
                 () -> workerMemoryInfos,
                 false,
+                false,
                 Duration.of(1, MINUTES),
                 taskRuntimeMemoryEstimationOverhead,
                 ticker);

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestExponentialGrowthPartitionMemoryEstimator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestExponentialGrowthPartitionMemoryEstimator.java
@@ -51,6 +51,7 @@ public class TestExponentialGrowthPartitionMemoryEstimator
                 nodeManager,
                 () -> ImmutableMap.of(new InternalNode("a-node", URI.create("local://blah"), NodeVersion.UNKNOWN, false).getNodeIdentifier(), Optional.of(buildWorkerMemoryInfo(DataSize.ofBytes(0)))),
                 false,
+                true,
                 Duration.of(1, MINUTES),
                 DataSize.ofBytes(0),
                 Ticker.systemTicker());
@@ -77,6 +78,14 @@ public class TestExponentialGrowthPartitionMemoryEstimator
                         new MemoryRequirements(DataSize.of(50, MEGABYTE)),
                         DataSize.of(10, MEGABYTE),
                         StandardErrorCode.CLUSTER_OUT_OF_MEMORY.toErrorCode()))
+                .isEqualTo(new MemoryRequirements(DataSize.of(150, MEGABYTE)));
+
+        assertThat(
+                estimator.getNextRetryMemoryRequirements(
+                        session,
+                        new MemoryRequirements(DataSize.of(50, MEGABYTE)),
+                        DataSize.of(10, MEGABYTE),
+                        StandardErrorCode.TOO_MANY_REQUESTS_FAILED.toErrorCode()))
                 .isEqualTo(new MemoryRequirements(DataSize.of(150, MEGABYTE)));
 
         assertThat(

--- a/core/trino-main/src/test/java/io/trino/memory/TestMemoryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestMemoryManagerConfig.java
@@ -45,7 +45,8 @@ public class TestMemoryManagerConfig
                 .setFaultTolerantExecutionTaskMemory(DataSize.of(5, GIGABYTE))
                 .setFaultTolerantExecutionTaskRuntimeMemoryEstimationOverhead(DataSize.of(1, GIGABYTE))
                 .setFaultTolerantExecutionTaskMemoryGrowthFactor(3.0)
-                .setFaultTolerantExecutionTaskMemoryEstimationQuantile(0.9));
+                .setFaultTolerantExecutionTaskMemoryEstimationQuantile(0.9)
+                .setFaultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled(true));
     }
 
     @Test
@@ -62,6 +63,7 @@ public class TestMemoryManagerConfig
                 .put("fault-tolerant-execution-task-runtime-memory-estimation-overhead", "300MB")
                 .put("fault-tolerant-execution-task-memory-growth-factor", "17.3")
                 .put("fault-tolerant-execution-task-memory-estimation-quantile", "0.7")
+                .put("fault-tolerant-execution.memory-requirement-increase-on-worker-crash-enabled", "false")
                 .buildOrThrow();
 
         MemoryManagerConfig expected = new MemoryManagerConfig()
@@ -74,7 +76,8 @@ public class TestMemoryManagerConfig
                 .setFaultTolerantExecutionTaskMemory(DataSize.of(2, GIGABYTE))
                 .setFaultTolerantExecutionTaskRuntimeMemoryEstimationOverhead(DataSize.of(300, MEGABYTE))
                 .setFaultTolerantExecutionTaskMemoryGrowthFactor(17.3)
-                .setFaultTolerantExecutionTaskMemoryEstimationQuantile(0.7);
+                .setFaultTolerantExecutionTaskMemoryEstimationQuantile(0.7)
+                .setFaultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled(false);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
When a task fails due to a suspected worker crash this may indicate (with a high likelihood) a potential memory accounting problem. Increasing memory requirement would essentially decrease overall cluster load allowing those problematic tasks to finish with a higher chance.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

When a task fails due to a suspected worker crash this may indicate
(with a high likelihood) a potential memory accounting problem.
Increasing memory requirement would essentially decrease overall cluster
load allowing those problematic tasks to finish with a higher chance.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
