### PR TITLE
Fix failure when analyzing table with no snapshots

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1653,6 +1653,7 @@ public class IcebergMetadata
 
             transaction.commitTransaction();
             transaction = null;
+            return;
         }
         long snapshotId = handle.getSnapshotId().orElseThrow();
 


### PR DESCRIPTION
There was a return missing. This case is hard to test, since both Trino & Spark create an initial empty snapshot, when creating a table.
