### PR TITLE
Fix killing threads in Matcher

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/TestRowPatternMatching.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestRowPatternMatching.java
@@ -1548,4 +1548,18 @@ public class TestRowPatternMatching
                 """))
                 .matches("VALUES 1");
     }
+
+    @Test
+    public void testKillThread()
+    {
+        assertThat(assertions.query("""
+                SELECT *
+                FROM (VALUES 1, 2, 3, 4, 5)
+                  MATCH_RECOGNIZE (
+                      MEASURES 'foo' AS foo
+                      PATTERN ((Y?){2,})
+                      DEFINE Y AS true)
+                """))
+                .matches("VALUES 'foo'");
+    }
 }


### PR DESCRIPTION
Before this change, killing threads in the Matcher was incorrectly implemented. When a thread was killed, it still persisted in the `threadsAtInstructions` structure. However, all other thread's data was cleared, so accessing the thread caused failure.

The simplest solution would be to remove the thread from the `threadsAtInstructions` structure while killing the thread. However, that would be a costly operation, because there might be multiple entries for the thread across the structure. Additionally, by removing the thread eagerly, we would miss the opportunity to early kill other threads, equivalent to the removed thread.

The chosen solution is to delay killing threads until the end of the iteration of the main loop of the matching algorithm. Instead of killed, the invalidated threads are recorded as `threadsToKill`. The downside to this solution is higher memory consumption during the iteration. The advantages include more efficient thread pruning and easy maintenance of the `threadsAtInstructions` structure (it is reset after the iteration).

fixes https://github.com/trinodb/trino/issues/15461

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# General
* Fix potential failure in row pattern matching. ({issue}`15461`)
```
