### PR TITLE
Update H2 to 2.1.214

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -176,9 +176,9 @@ public abstract class BaseJdbcConnectorTest
         String schema = getSession().getSchema().orElseThrow();
         try (TestTable table = new TestTable(onRemoteDatabase(), schema + ".char_trailing_space", "(x char(10))", List.of("'test'"))) {
             String tableName = table.getName();
-            assertQuery("SELECT * FROM " + tableName + " WHERE x = char 'test'", "VALUES 'test'");
-            assertQuery("SELECT * FROM " + tableName + " WHERE x = char 'test  '", "VALUES 'test'");
-            assertQuery("SELECT * FROM " + tableName + " WHERE x = char 'test        '", "VALUES 'test'");
+            assertQuery("SELECT * FROM " + tableName + " WHERE x = char 'test'", "VALUES 'test      '");
+            assertQuery("SELECT * FROM " + tableName + " WHERE x = char 'test  '", "VALUES 'test      '");
+            assertQuery("SELECT * FROM " + tableName + " WHERE x = char 'test        '", "VALUES 'test      '");
             assertQueryReturnsEmptyResult("SELECT * FROM " + tableName + " WHERE x = char ' test'");
         }
     }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcMetadata.java
@@ -365,7 +365,7 @@ public class TestDefaultJdbcMetadata
     }
 
     @Test
-    public void tesMultiGroupKeyPredicatePushdown()
+    public void testMultiGroupKeyPredicatePushdown()
     {
         ConnectorSession session = TestingConnectorSession.builder()
                 .setPropertyMetadata(new JdbcMetadataSessionProperties(new JdbcMetadataConfig().setAggregationPushdownEnabled(true), Optional.empty()).getSessionProperties())

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
@@ -54,6 +54,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.LongStream;
 
+import static com.google.common.base.Strings.padEnd;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.testing.Assertions.assertContains;
@@ -397,7 +398,12 @@ public class TestDefaultJdbcQueryBuilder
                     builder.add((String) resultSet.getObject("col_11"));
                 }
             }
-            assertEquals(builder.build(), ImmutableSet.of("test_str_700", "test_str_701", "test_str_180", "test_str_196"));
+
+            assertThat(builder.build()).containsOnly(
+                    padEnd("test_str_180", 128, ' '),
+                    padEnd("test_str_700", 128, ' '),
+                    padEnd("test_str_701", 128, ' '),
+                    padEnd("test_str_196", 128, ' '));
 
             assertContains(preparedStatement.toString(), "\"col_11\" >= ?");
             assertContains(preparedStatement.toString(), "\"col_11\" < ?");

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcCachingConnectorSmokeTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcCachingConnectorSmokeTest.java
@@ -108,8 +108,8 @@ public class TestJdbcCachingConnectorSmokeTest
 
         // H2 stores unquoted names as uppercase. So this query should fail
         assertThatThrownBy(() -> h2SqlExecutor.execute("SELECT * FROM tpch.\"cached_name\""))
-                .hasRootCauseMessage("Table \"cached_name\" not found; SQL statement:\n" +
-                        "SELECT * FROM tpch.\"cached_name\" [42102-200]");
+                .hasRootCauseMessage("Table \"cached_name\" not found (candidates are: \"CACHED_NAME\"); SQL statement:\n" +
+                        "SELECT * FROM tpch.\"cached_name\" [42103-214]");
         // H2 stores unquoted names as uppercase. So this query should succeed
         h2SqlExecutor.execute("SELECT * FROM tpch.\"CACHED_NAME\"");
 

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectorTest.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Properties;
 
 import static io.trino.plugin.jdbc.H2QueryRunner.createH2QueryRunner;
@@ -281,17 +282,6 @@ public class TestJdbcConnectorTest
     }
 
     @Override
-    protected Optional<SetColumnTypeSetup> filterSetColumnTypesDataProvider(SetColumnTypeSetup setup)
-    {
-        if (setup.sourceColumnType().equals("char(20)") && setup.newColumnType().equals("varchar")) {
-            // H2 trims trailing spaces
-            return Optional.of(setup.withNewValueLiteral("rtrim(%s)".formatted(setup.newValueLiteral())));
-        }
-
-        return Optional.of(setup);
-    }
-
-    @Override
     protected JdbcSqlExecutor onRemoteDatabase()
     {
         return new JdbcSqlExecutor(properties.get("connection-url"), new Properties());
@@ -302,5 +292,41 @@ public class TestJdbcConnectorTest
         return Session.builder(getSession())
                 .setCatalogSessionProperty("jdbc", UNSUPPORTED_TYPE_HANDLING, unsupportedTypeHandling.name())
                 .build();
+    }
+
+    @Override
+    protected void verifyColumnNameLengthFailurePermissible(Throwable e)
+    {
+        assertThat(e).hasMessageMatching("(?s)(.*The name that starts with .* is too long\\..*)");
+    }
+
+    @Override
+    protected void verifySchemaNameLengthFailurePermissible(Throwable e)
+    {
+        assertThat(e).hasMessageMatching("(?s)(.*The name that starts with .* is too long\\..*)");
+    }
+
+    @Override
+    protected void verifyTableNameLengthFailurePermissible(Throwable e)
+    {
+        assertThat(e).hasMessageMatching("(?s)(.*The name that starts with .* is too long\\..*)");
+    }
+
+    @Override
+    protected OptionalInt maxColumnNameLength()
+    {
+        return OptionalInt.of(256);
+    }
+
+    @Override
+    protected OptionalInt maxSchemaNameLength()
+    {
+        return OptionalInt.of(256);
+    }
+
+    @Override
+    protected OptionalInt maxTableNameLength()
+    {
+        return OptionalInt.of(256);
     }
 }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingDatabase.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingDatabase.java
@@ -42,7 +42,7 @@ final class TestingDatabase
             throws SQLException
     {
         databaseName = "TEST" + System.nanoTime() + ThreadLocalRandom.current().nextLong();
-        String connectionUrl = "jdbc:h2:mem:" + databaseName;
+        String connectionUrl = "jdbc:h2:mem:" + databaseName + ";NON_KEYWORDS=KEY,VALUE"; // key and value are reserved keywords in H2 2.x
         jdbcClient = new TestingH2JdbcClient(
                 new BaseJdbcConfig(),
                 new DriverConnectionFactory(new Driver(), connectionUrl, new Properties(), new EmptyCredentialProvider()));

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcClient.java
@@ -62,6 +62,7 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.timeColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.timestampColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.tinyintColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.tinyintWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.varcharColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
 import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.getUnsupportedTypeHandling;
 import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
@@ -75,6 +76,7 @@ import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimeType.TIME_MILLIS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 
 class TestingH2JdbcClient
         extends BaseJdbcClient
@@ -82,6 +84,7 @@ class TestingH2JdbcClient
     private static final Logger log = Logger.get(TestingH2JdbcClient.class);
 
     private static final JdbcTypeHandle BIGINT_TYPE_HANDLE = new JdbcTypeHandle(Types.BIGINT, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+    private static final int MAXIMUM_VARCHAR_LENGTH = 1_000_000_000;
 
     public TestingH2JdbcClient(BaseJdbcConfig config, ConnectionFactory connectionFactory)
     {
@@ -163,7 +166,8 @@ class TestingH2JdbcClient
             case Types.BIGINT:
                 return Optional.of(bigintColumnMapping());
 
-            case Types.REAL:
+            // both types as both are used by H2 JDBC driver
+            case Types.FLOAT, Types.REAL:
                 return Optional.of(realColumnMapping());
 
             case Types.DOUBLE:
@@ -173,6 +177,10 @@ class TestingH2JdbcClient
                 return Optional.of(defaultCharColumnMapping(typeHandle.getRequiredColumnSize(), true));
 
             case Types.VARCHAR:
+                // varchar columns get created as varchar(max_length) in H2
+                if (typeHandle.getRequiredColumnSize() == MAXIMUM_VARCHAR_LENGTH) {
+                    return Optional.of(varcharColumnMapping(createUnboundedVarcharType(), true));
+                }
                 return Optional.of(defaultVarcharColumnMapping(typeHandle.getRequiredColumnSize(), true));
 
             case Types.DATE:

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -5004,16 +5004,18 @@ public abstract class BaseHiveConnectorTest
 
             assertQuery(
                     "SELECT a, a <= 'bbc' FROM test_table_with_char",
-                    "VALUES (cast('aaa' as char(20)), true), " +
-                            "(cast('bbb' as char(20)), true), " +
-                            "(cast('bbc' as char(20)), true), " +
-                            "(cast('bbd' as char(20)), false)");
+                    "VALUES " +
+                            "('aaa                 ', true), " +
+                            "('bbb                 ', true), " +
+                            "('bbc                 ', true), " +
+                            "('bbd                 ', false)");
 
             assertQuery(
                     "SELECT a FROM test_table_with_char WHERE a <= 'bbc'",
-                    "VALUES cast('aaa' as char(20)), " +
-                            "cast('bbb' as char(20)), " +
-                            "cast('bbc' as char(20))");
+                    "VALUES " +
+                            "'aaa                 ', " +
+                            "'bbb                 ', " +
+                            "'bbc                 '");
         }
         finally {
             assertUpdate("DROP TABLE test_table_with_char");
@@ -6029,7 +6031,7 @@ public abstract class BaseHiveConnectorTest
         try {
             assertQuery(
                     "SELECT * FROM test_table_with_char_rc WHERE char_column = 'khaki  '",
-                    "VALUES (CAST('khaki' AS CHAR(7)))");
+                    "VALUES ('khaki  ')");
         }
         finally {
             assertUpdate("DROP TABLE test_table_with_char_rc");

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
@@ -586,7 +586,7 @@ public class TestMongoConnectorTest
                 "VALUES (11, 11), (14, 11), (11, 15), (12, 15), (12, 11), (14, 15), (13, 13)");
 
         // Group by ObjectId (IS DISTINCT FROM)
-        assertQuery("SELECT array_agg(i ORDER BY i) FROM " + inlineTable + " GROUP BY one", "VALUES ((10, 15)), ((11, 12, 14)), ((13))");
+        assertQuery("SELECT array_agg(i ORDER BY i) FROM " + inlineTable + " GROUP BY one", "VALUES (ARRAY[10, 15]), (ARRAY[11, 12, 14]), (ARRAY[13])");
         assertQuery("SELECT i FROM " + inlineTable + " GROUP BY one, i", "VALUES 10, 11, 12, 13, 14, 15");
 
         // Group by Row(ObjectId) (ID DISTINCT FROM in @OperatorDependency)

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
@@ -56,7 +56,7 @@ public class TestDbResourceGroupConfigurationManager
 
     static H2DaoProvider setup(String prefix)
     {
-        DbResourceGroupConfig config = new DbResourceGroupConfig().setConfigDbUrl("jdbc:h2:mem:test_" + prefix + System.nanoTime() + ThreadLocalRandom.current().nextLong());
+        DbResourceGroupConfig config = new DbResourceGroupConfig().setConfigDbUrl("jdbc:h2:mem:test_" + prefix + System.nanoTime() + ThreadLocalRandom.current().nextLong() + ";NON_KEYWORDS=KEY,VALUE");
         return new H2DaoProvider(config);
     }
 

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestResourceGroupsDao.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestResourceGroupsDao.java
@@ -63,7 +63,7 @@ public class TestResourceGroupsDao
 
     static H2ResourceGroupsDao setup(String prefix)
     {
-        DbResourceGroupConfig config = new DbResourceGroupConfig().setConfigDbUrl("jdbc:h2:mem:test_" + prefix + System.nanoTime() + ThreadLocalRandom.current().nextLong());
+        DbResourceGroupConfig config = new DbResourceGroupConfig().setConfigDbUrl("jdbc:h2:mem:test_" + prefix + System.nanoTime() + ThreadLocalRandom.current().nextLong() + ";NON_KEYWORDS=KEY,VALUE"); // key and value are reserved keywords in H2 2.x
         return new H2DaoProvider(config).get();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1238,7 +1238,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>1.4.200</version>
+                <version>2.1.214</version>
             </dependency>
 
             <dependency>

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestAggregations.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestAggregations.java
@@ -1327,14 +1327,14 @@ public abstract class AbstractTestAggregations
                         "WHERE orderkey IN (1, 2, 3, 4, 5) " +
                         "GROUP BY GROUPING SETS ((), (orderpriority), (orderpriority, custkey))",
                 "VALUES " +
-                        "(NULL, NULL , ('F', 'O', 'O'))," +
-                        "('5-LOW', NULL , ('F', 'O'))," +
-                        "('1-URGENT', NULL , ('O'))," +
+                        "(NULL, NULL , ARRAY['F', 'O', 'O'])," +
+                        "('5-LOW', NULL , ARRAY['F', 'O'])," +
+                        "('1-URGENT', NULL, ARRAY['O'])," +
                         "('5-LOW', 370 , NULL)," +
-                        "('5-LOW', 1234, ('F'))," +
-                        "('5-LOW', 1369, ('O'))," +
+                        "('5-LOW', 1234, ARRAY['F'])," +
+                        "('5-LOW', 1369, ARRAY['O'])," +
                         "('5-LOW', 445 , NULL)," +
-                        "('1-URGENT', 781 , ('O'))");
+                        "('1-URGENT', 781 , ARRAY['O'])");
     }
 
     @Test

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -387,13 +387,14 @@ public abstract class AbstractTestEngineOnlyQueries
     public void testVarcharCharComparison()
     {
         // with implicit coercions
-        assertQuery("SELECT * FROM (VALUES" +
+        assertThat(query("SELECT * FROM (VALUES" +
                 "   CAST(NULL AS varchar(3)), " +
                 "   CAST('' AS varchar(3))," +
                 "   CAST(' ' AS varchar(3)), " +
                 "   CAST('  ' AS varchar(3)), " +
                 "   CAST('   ' AS varchar(3))) t(x) " +
-                "WHERE x = CAST('  ' AS char(2))");
+                "WHERE x = CAST('  ' AS char(2))"))
+                .matches("VALUES '', ' ', '  ', '   '");
 
         // with explicit casts
         assertQuery("SELECT * FROM (VALUES" +

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -371,7 +371,9 @@ public abstract class AbstractTestEngineOnlyQueries
         assertQuery("SELECT * FROM (VALUES" +
                 "   CAST(NULL AS char(3)), " +
                 "   CAST('   ' AS char(3))) t(x) " +
-                "WHERE x = CAST('  ' AS varchar(2))");
+                "WHERE x = CAST('  ' AS varchar(2))",
+                // H2 returns '' on CAST char(3) to varchar(2)
+                "SELECT '   '");
 
         // with explicit casts
         assertQuery(

--- a/testing/trino-testing/src/main/java/io/trino/testing/H2QueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/H2QueryRunner.java
@@ -102,11 +102,11 @@ public class H2QueryRunner
         handle.execute("CREATE TABLE orders (\n" +
                 "  orderkey BIGINT PRIMARY KEY,\n" +
                 "  custkey BIGINT NOT NULL,\n" +
-                "  orderstatus CHAR(1) NOT NULL,\n" +
+                "  orderstatus VARCHAR(1) NOT NULL,\n" +
                 "  totalprice DOUBLE NOT NULL,\n" +
                 "  orderdate DATE NOT NULL,\n" +
-                "  orderpriority CHAR(15) NOT NULL,\n" +
-                "  clerk CHAR(15) NOT NULL,\n" +
+                "  orderpriority VARCHAR(15) NOT NULL,\n" +
+                "  clerk VARCHAR(15) NOT NULL,\n" +
                 "  shippriority INTEGER NOT NULL,\n" +
                 "  comment VARCHAR(79) NOT NULL\n" +
                 ")");

--- a/testing/trino-testing/src/main/java/io/trino/testing/H2QueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/H2QueryRunner.java
@@ -66,7 +66,6 @@ import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.plugin.tpch.TpchRecordSet.createTpchRecordSet;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
-import static io.trino.spi.type.Chars.padSpaces;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -96,7 +95,7 @@ public class H2QueryRunner
 
     public H2QueryRunner()
     {
-        handle = Jdbi.open("jdbc:h2:mem:test" + System.nanoTime() + ThreadLocalRandom.current().nextLong());
+        handle = Jdbi.open("jdbc:h2:mem:test" + System.nanoTime() + ThreadLocalRandom.current().nextLong() + ";NON_KEYWORDS=KEY,VALUE"); // key and value are reserved keywords in H2 2.x
         TpchMetadata tpchMetadata = new TpchMetadata();
 
         handle.execute("CREATE TABLE orders (\n" +
@@ -281,22 +280,13 @@ public class H2QueryRunner
                         row.add(jsonParse(utf8Slice(stringValue)).toStringUtf8());
                     }
                 }
-                else if (type instanceof VarcharType) {
+                else if (type instanceof VarcharType || type instanceof CharType) {
                     String stringValue = resultSet.getString(i);
                     if (resultSet.wasNull()) {
                         row.add(null);
                     }
                     else {
                         row.add(stringValue);
-                    }
-                }
-                else if (type instanceof CharType charType) {
-                    String stringValue = resultSet.getString(i);
-                    if (resultSet.wasNull()) {
-                        row.add(null);
-                    }
-                    else {
-                        row.add(padSpaces(stringValue, charType));
                     }
                 }
                 else if (VARBINARY.equals(type)) {

--- a/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/H2TestUtil.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/H2TestUtil.java
@@ -102,7 +102,7 @@ final class H2TestUtil
 
     public static String getDbConfigUrl()
     {
-        return "jdbc:h2:mem:test_" + Math.abs(new Random().nextLong());
+        return "jdbc:h2:mem:test_" + Math.abs(new Random().nextLong()) + ";NON_KEYWORDS=KEY,VALUE"; // key and value are reserved keywords in H2 2.x
     }
 
     public static H2ResourceGroupsDao getDao(String url)

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestLocalQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestLocalQueries.java
@@ -91,12 +91,12 @@ public class TestLocalQueries
     @Test
     public void testDecimal()
     {
-        assertQuery("SELECT DECIMAL '1.0'", "SELECT CAST('1.0' AS DECIMAL)");
-        assertQuery("SELECT DECIMAL '1.'", "SELECT CAST('1.0' AS DECIMAL)");
-        assertQuery("SELECT DECIMAL '0.1'", "SELECT CAST('0.1' AS DECIMAL)");
-        assertQuery("SELECT 1.0", "SELECT CAST('1.0' AS DECIMAL)");
-        assertQuery("SELECT 1.", "SELECT CAST('1.0' AS DECIMAL)");
-        assertQuery("SELECT 0.1", "SELECT CAST('0.1' AS DECIMAL)");
+        assertQuery("SELECT DECIMAL '1.0'", "SELECT CAST('1.0' AS DECIMAL(10, 1))");
+        assertQuery("SELECT DECIMAL '1.'", "SELECT CAST('1.0' AS DECIMAL(10, 1))");
+        assertQuery("SELECT DECIMAL '0.1'", "SELECT CAST('0.1' AS DECIMAL(10, 1))");
+        assertQuery("SELECT 1.0");
+        assertQuery("SELECT 1.");
+        assertQuery("SELECT 0.1");
     }
 
     @Test


### PR DESCRIPTION
Update H2 to 2.1.214

There are couple of significant changes to the H2 semantics:

- "key" and "value" are restricted keywords in H2 2.x as per: http://www.h2database.com/html/advanced.html#keywords
- maximum length of identifier (schema, table, colum name) is now 256: http://www.h2database.com/html/grammar.html#name
- maximum length of a varchar/char types is 1_000_000_000: http://www.h2database.com/html/datatypes.html#character_varying_type
- decimal(p, s) without scale is decimal(p, 0): http://www.h2database.com/html/datatypes.html#numeric_type
- arrays with mixed types elements are not longer supported: http://www.h2database.com/html/migration-to-v2.html

This version update solves also two critical CVEs:

- https://www.cvedetails.com/cve/CVE-2022-23221/
- https://www.cvedetails.com/cve/CVE-2021-42392/

NO RELEASE NOTES needed.
