### PR TITLE
Fix handling of unknown stats in ScalarStatsCalculator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/cost/ScalarStatsCalculator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/ScalarStatsCalculator.java
@@ -224,6 +224,9 @@ public class ScalarStatsCalculator
             requireNonNull(node, "node is null");
             SymbolStatsEstimate left = process(node.getLeft());
             SymbolStatsEstimate right = process(node.getRight());
+            if (left.isUnknown() || right.isUnknown()) {
+                return SymbolStatsEstimate.unknown();
+            }
 
             SymbolStatsEstimate.Builder result = SymbolStatsEstimate.builder()
                     .setAverageRowSize(Math.max(left.getAverageRowSize(), right.getAverageRowSize()))

--- a/core/trino-main/src/test/java/io/trino/cost/TestScalarStatsCalculator.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestScalarStatsCalculator.java
@@ -318,6 +318,7 @@ public class TestScalarStatsCalculator
                         .setNullsFraction(0.2)
                         .setAverageRowSize(2.0)
                         .build())
+                .addSymbolStatistics(new Symbol("unknown"), SymbolStatsEstimate.unknown())
                 .setOutputRowCount(10)
                 .build();
 
@@ -327,6 +328,11 @@ public class TestScalarStatsCalculator
                 .highValue(15.0)
                 .nullsFraction(0.28)
                 .averageRowSize(2.0);
+
+        assertCalculate(expression("x + unknown"), relationStats)
+                .isEqualTo(SymbolStatsEstimate.unknown());
+        assertCalculate(expression("unknown + unknown"), relationStats)
+                .isEqualTo(SymbolStatsEstimate.unknown());
 
         assertCalculate(expression("x - y"), relationStats)
                 .distinctValuesCount(10.0)


### PR DESCRIPTION
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
In visitArithmeticBinary we can set the high and low value to NaN for unknown input stats. 
This gets treated as an empty range by SymbolStatsEstimate constructor with 1.0 nullsFraction. 
This can result in 0 row count estimate with a filter that selects non-null values.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/15605

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix planner estimates for queries with filters on columns without statistics. ({issue}`15642`)
```
