### PR TITLE
Pass full row type of input table to table function

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1819,7 +1819,7 @@ class StatementAnalyzer
                 analysisBuilder.withName(relationName);
             }
 
-            argumentBuilder.rowType(RowType.from(argumentScope.getRelationType().getVisibleFields().stream()
+            argumentBuilder.rowType(RowType.from(argumentScope.getRelationType().getAllFields().stream()
                     .map(field -> new RowType.Field(field.getName(), field.getType()))
                     .collect(toImmutableList())));
 


### PR DESCRIPTION
Before this change, only visible columns were passed to table function during analysis. Now, both visible and hidden columns are passed so that the function can require and use any input column.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.

Table arguments are not yet supported.

( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

