### PR TITLE
Fix redundant backquote from HTTP client documentation

### DIFF
--- a/docs/src/main/sphinx/admin/properties-http-client.rst
+++ b/docs/src/main/sphinx/admin/properties-http-client.rst
@@ -149,7 +149,7 @@ Request logging
 * **Type:** :ref:`prop-type-boolean`
 * **Default value:** ``true``
 
-Enable log file compression. The client uses the ``.gz``` format for log files.
+Enable log file compression. The client uses the ``.gz`` format for log files.
 
 ``http-client.log.enabled``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description

Fix redundant backquote from HTTP client documentation

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
