### PR TITLE
Quote column name when setting column comment in BigQuery

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -538,7 +538,7 @@ public class BigQueryMetadata
                 quote(remoteTableName.getProjectId()),
                 quote(remoteTableName.getDatasetName()),
                 quote(remoteTableName.getTableName()),
-                column.getName());
+                quote(column.getName()));
         client.executeUpdate(QueryJobConfiguration.newBuilder(sql)
                 .setQuery(sql)
                 .addPositionalParameter(QueryParameterValue.string(newComment.orElse(null)))

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
@@ -181,6 +181,12 @@ public abstract class BaseOracleConnectorTest
         assertThat((String) computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue()).doesNotContain("COMMENT 'new comment'");
     }
 
+    @Override
+    public void testCommentColumnName(String columnName)
+    {
+        throw new SkipException("The test is covered in TestOraclePoolRemarksReportingConnectorSmokeTest");
+    }
+
     /**
      * See {@link TestOraclePoolRemarksReportingConnectorSmokeTest#testCommentColumnSpecialCharacter(String comment)}
      */

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOraclePoolRemarksReportingConnectorSmokeTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOraclePoolRemarksReportingConnectorSmokeTest.java
@@ -24,10 +24,12 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 
+import static com.google.common.base.Throwables.getStackTraceAsString;
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_PASS;
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_USER;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
@@ -108,6 +110,80 @@ public class TestOraclePoolRemarksReportingConnectorSmokeTest
     {
         requireNonNull(value, "value is null");
         return "'" + value.replace("'", "''") + "'";
+    }
+
+    // This method is copied from BaseConnectorTest because oracle.remarks-reporting.enabled config property needs to be enabled
+    @Test(dataProvider = "testColumnNameDataProvider")
+    public void testCommentColumnName(String columnName)
+    {
+        if (!requiresDelimiting(columnName)) {
+            testCommentColumnName(columnName, false);
+        }
+        testCommentColumnName(columnName, true);
+    }
+
+    private void testCommentColumnName(String columnName, boolean delimited)
+    {
+        String nameInSql = toColumnNameInSql(columnName, delimited);
+
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_comment_column", "(" + nameInSql + " integer)")) {
+            assertUpdate("COMMENT ON COLUMN " + table.getName() + "." + nameInSql + " IS 'test comment'");
+            assertThat(getColumnComment(table.getName(), columnName.replace("'", "''").toLowerCase(ENGLISH))).isEqualTo("test comment");
+        }
+        catch (RuntimeException e) {
+            if (getStackTraceAsString(e).contains("CREATE TABLE") &&
+                    (columnName.equals("a\"quote") || columnName.equals("\"STATS_MIXED_QUOTED_UPPER\"") || columnName.equals("\"stats_mixed_quoted_lower\"") || columnName.equals("\"stats_mixed_QuoTeD_miXED\""))) {
+                return;
+            }
+            throw e;
+        }
+    }
+
+    @DataProvider
+    public Object[][] testColumnNameDataProvider()
+    {
+        return new Object[][] {
+                {"STATS_MIXED_UNQUOTED_UPPER"},
+                {"stats_mixed_unquoted_lower"},
+                {"stats_mixed_uNQuoTeD_miXED"},
+                {"\"STATS_MIXED_QUOTED_UPPER\""},
+                {"\"stats_mixed_quoted_lower\""},
+                {"\"stats_mixed_QuoTeD_miXED\""},
+                {"lowercase"},
+                {"UPPERCASE"},
+                {"MixedCase"},
+                {"an_underscore"},
+                {"a-hyphen-minus"}, // ASCII '-' is HYPHEN-MINUS in Unicode
+                {"a space"},
+                {"atrailingspace "},
+                {" aleadingspace"},
+                {"a.dot"},
+                {"a,comma"},
+                {"a:colon"},
+                {"a;semicolon"},
+                {"an@at"},
+                {"a\"quote"},
+                {"an'apostrophe"},
+                {"a`backtick`"},
+                {"a/slash`"},
+                {"a\\backslash`"},
+                {"adigit0"},
+                {"0startwithdigit"}
+        };
+    }
+
+    private static String toColumnNameInSql(String columnName, boolean delimited)
+    {
+        String nameInSql = columnName;
+        if (delimited) {
+            nameInSql = "\"" + columnName.replace("\"", "\"\"") + "\"";
+        }
+        return nameInSql;
+    }
+
+    private static boolean requiresDelimiting(String identifierName)
+    {
+        return !identifierName.matches("[a-zA-Z][a-zA-Z0-9_]*");
     }
 
     protected String getColumnComment(String tableName, String columnName)


### PR DESCRIPTION
## Description

Quote column name when setting column comment in BigQuery. 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
