### PR TITLE
Fix incorrect input columns passed to table function

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1604,7 +1604,7 @@ class StatementAnalyzer
                 // the scope is recorded, because table arguments are already analyzed
                 Scope inputScope = analysis.getScope(tableArgumentsByName.get(name).getRelation());
                 columns.stream()
-                        .filter(column -> column < 0 || column >= inputScope.getRelationType().getAllFieldCount()) // hidden columns can be required as well as visible columns
+                        .filter(column -> column < 0 || column >= inputScope.getRelationType().getVisibleFieldCount())
                         .findFirst()
                         .ifPresent(column -> {
                             throw new TrinoException(FUNCTION_IMPLEMENTATION_ERROR, format("Invalid index: %s of required column from table argument %s", column, name));

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -6645,11 +6645,13 @@ public class TestAnalyzer
                 .hasErrorCode(FUNCTION_IMPLEMENTATION_ERROR)
                 .hasMessage("Invalid index: 1 of required column from table argument INPUT");
 
-        // table s1.t5 has two columns. The second column is hidden. Table function can require a hidden column.
-        analyze("""
+        // table s1.t5 has two columns. The second column is hidden. Table function cannot require a hidden column.
+        assertFails("""
                 SELECT * FROM TABLE(system.required_columns_function(
                     input => TABLE(s1.t5)))
-                """);
+                """)
+                .hasErrorCode(FUNCTION_IMPLEMENTATION_ERROR)
+                .hasMessage("Invalid index: 1 of required column from table argument INPUT");
     }
 
     @BeforeClass


### PR DESCRIPTION
During analysis, a table function declares required input columns by choosing indexes from visible columns list.
Before this change, the function got columns with those indexes from the input relation type. It was not correct, because the hidden input columns were not taken into account. After this change, the required column indexes are remapped to skip hidden columns.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.

Table arguments are not yet supported.

( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
