### PR TITLE
Check `rollback_to_snapshot` accuracy when it does not do any changes

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -1112,6 +1112,11 @@ public abstract class BaseIcebergConnectorTest
 
         assertUpdate("INSERT INTO test_rollback (col0, col1) VALUES (123, CAST(987 AS BIGINT))", 1);
         long afterFirstInsertId = getCurrentSnapshotId("test_rollback");
+        assertQuery("SELECT * FROM test_rollback ORDER BY col0", "VALUES (123, CAST(987 AS BIGINT))");
+
+        // Check that rollback_to_snapshot can be executed also when it does not do any changes
+        assertUpdate(format("CALL system.rollback_to_snapshot('tpch', 'test_rollback', %s)", afterFirstInsertId));
+        assertQuery("SELECT * FROM test_rollback ORDER BY col0", "VALUES (123, CAST(987 AS BIGINT))");
 
         assertUpdate("INSERT INTO test_rollback (col0, col1) VALUES (456, CAST(654 AS BIGINT))", 1);
         assertQuery("SELECT * FROM test_rollback ORDER BY col0", "VALUES (123, CAST(987 AS BIGINT)), (456, CAST(654 AS BIGINT))");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

When performing `rollback_to_snapshot` procedure calls with the latest snapshot of the table as parameter, the operation used to fail in Trino `403` while it depended on Iceberg `1.0.0`:

```
Caused by: java.lang.IllegalStateException: Cannot commit transaction: last operation has not committed
    at org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkState(Preconditions.java:502)
    at org.apache.iceberg.BaseTransaction.commitTransaction(BaseTransaction.java:252)
    at org.apache.iceberg.SnapshotManager.commit(SnapshotManager.java:158)
    at io.trino.plugin.iceberg.RollbackToSnapshotProcedure.rollbackToSnapshot(RollbackToSnapshotProcedure.java:80)
````

With Iceberg `1.1.0` the problem was fixed in  https://github.com/apache/iceberg/pull/5536 .

This extra check is a regression test for future Iceberg library releases.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
