### PR TITLE
Fix inconsistent pageSinkId column naming

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -713,7 +713,7 @@ public abstract class BaseJdbcClient
                     columnTypes.build(),
                     Optional.of(jdbcColumnTypes.build()),
                     Optional.of(remoteTemporaryTableName),
-                    pageSinkIdColumn.map(ColumnMetadata::getName));
+                    pageSinkIdColumn.map(column -> identifierMapping.toRemoteColumnName(connection, column.getName())));
         }
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fix inconsistent `pageSinkId` column naming causing problems with case-sensitive databases where lower case is not the default.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Example: `EXPLAIN ANALYZE` would fail due to unrecognised column name (only on source systems where uppercase is the default, like Snowflake).
```json
INSERT INTO "TMP_SEP_CICD_TEST_MHPT0EER6T"."TEST_SCHEMA_2"."TMP_TRINO_D4C971E39EE3431C86C9E2515A8D059F" ("NATIONKEY", "NAME", "REGIONKEY", "COMMENT", "trino_page_sink_id") VALUES (?,?,?,?, ?)
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
