### PR TITLE
Add metric to measure requests duration of HttpPageBufferClient

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/DirectExchangeClientStatus.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DirectExchangeClientStatus.java
@@ -16,6 +16,8 @@ package io.trino.operator;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import io.airlift.stats.TDigest;
+import io.trino.plugin.base.metrics.TDigestHistogram;
 import io.trino.spi.Mergeable;
 
 import java.util.List;
@@ -35,6 +37,7 @@ public class DirectExchangeClientStatus
     private final long spilledBytes;
     private final boolean noMoreLocations;
     private final List<PageBufferClientStatus> pageBufferClientStatuses;
+    private final TDigestHistogram requestsDuration;
 
     @JsonCreator
     public DirectExchangeClientStatus(
@@ -46,7 +49,8 @@ public class DirectExchangeClientStatus
             @JsonProperty("spilledPages") int spilledPages,
             @JsonProperty("spilledBytes") long spilledBytes,
             @JsonProperty("noMoreLocations") boolean noMoreLocations,
-            @JsonProperty("pageBufferClientStatuses") List<PageBufferClientStatus> pageBufferClientStatuses)
+            @JsonProperty("pageBufferClientStatuses") List<PageBufferClientStatus> pageBufferClientStatuses,
+            @JsonProperty("requestsDurationInMilliseconds") TDigestHistogram requestsDuration)
     {
         this.bufferedBytes = bufferedBytes;
         this.maxBufferedBytes = maxBufferedBytes;
@@ -57,6 +61,7 @@ public class DirectExchangeClientStatus
         this.spilledBytes = spilledBytes;
         this.noMoreLocations = noMoreLocations;
         this.pageBufferClientStatuses = ImmutableList.copyOf(requireNonNull(pageBufferClientStatuses, "pageBufferClientStatuses is null"));
+        this.requestsDuration = requireNonNull(requestsDuration, "requestsDuration is null");
     }
 
     @JsonProperty
@@ -113,6 +118,12 @@ public class DirectExchangeClientStatus
         return pageBufferClientStatuses;
     }
 
+    @JsonProperty
+    public synchronized TDigestHistogram getRequestsDuration()
+    {
+        return new TDigestHistogram(TDigest.copyOf(requestsDuration.getDigest()));
+    }
+
     @Override
     public boolean isFinal()
     {
@@ -132,6 +143,7 @@ public class DirectExchangeClientStatus
                 .add("spilledBytes", spilledBytes)
                 .add("noMoreLocations", noMoreLocations)
                 .add("pageBufferClientStatuses", pageBufferClientStatuses)
+                .add("requestsDuration", requestsDuration)
                 .toString();
     }
 
@@ -147,7 +159,8 @@ public class DirectExchangeClientStatus
                 spilledPages + other.spilledPages,
                 spilledBytes + other.spilledBytes,
                 noMoreLocations && other.noMoreLocations, // if at least one has some locations, mergee has some too
-                ImmutableList.of()); // pageBufferClientStatuses may be long, so we don't want to combine the lists
+                ImmutableList.of(), // pageBufferClientStatuses may be long, so we don't want to combine the lists
+                getRequestsDuration().mergeWith(other.getRequestsDuration()));
     }
 
     private static long mergeAvgs(long value1, long count1, long value2, long count2)

--- a/core/trino-main/src/main/java/io/trino/operator/PageBufferClientStatus.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PageBufferClientStatus.java
@@ -15,6 +15,8 @@ package io.trino.operator;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airlift.stats.TDigest;
+import io.trino.plugin.base.metrics.TDigestHistogram;
 import org.joda.time.DateTime;
 
 import java.net.URI;
@@ -39,6 +41,7 @@ public class PageBufferClientStatus
     private final int requestsFailed;
     private final int requestsSucceeded;
     private final String httpRequestState;
+    private final TDigestHistogram requestsDuration;
 
     @JsonCreator
     public PageBufferClientStatus(@JsonProperty("uri") URI uri,
@@ -52,7 +55,8 @@ public class PageBufferClientStatus
             @JsonProperty("requestsCompleted") int requestsCompleted,
             @JsonProperty("requestsFailed") int requestsFailed,
             @JsonProperty("requestsSucceeded") int requestsSucceeded,
-            @JsonProperty("httpRequestState") String httpRequestState)
+            @JsonProperty("httpRequestState") String httpRequestState,
+            @JsonProperty("requestsDurationInMilliseconds") TDigestHistogram requestsDuration)
     {
         this.uri = uri;
         this.state = state;
@@ -66,6 +70,7 @@ public class PageBufferClientStatus
         this.requestsFailed = requestsFailed;
         this.requestsSucceeded = requestsSucceeded;
         this.httpRequestState = httpRequestState;
+        this.requestsDuration = requireNonNull(requestsDuration, "requestsDuration is null");
     }
 
     @JsonProperty
@@ -138,6 +143,12 @@ public class PageBufferClientStatus
     public String getHttpRequestState()
     {
         return httpRequestState;
+    }
+
+    @JsonProperty
+    public synchronized TDigestHistogram getRequestsDuration()
+    {
+        return new TDigestHistogram(TDigest.copyOf(requestsDuration.getDigest()));
     }
 
     @Override


### PR DESCRIPTION
It adds the metric that measures distribution of requests duration sent by `HttpPageBufferClient`. It was found that it is very useful during investigation. Example of metric:

                 "requestsDurationInMilliseconds" : {
                    "@class" : "io.trino.plugin.base.metrics.TDigestHistogram",
                    "digest" : "AAAAAAAAAPA/AAAAAABQn0AAAAAAAABZQAAAAABgBSBBRAAAAAAAAAAAAPA/AAAAAAAA8D8AAAAAAADwPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADwPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADwPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADwPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADwPw8kWmFzIPE/AAAAAAAAAEAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAEAAAAAAAAAAQJOJjp9HYwBAflSXmLVQBkAAAAAAAAAIQAAAAAAAAAhAQRqkQRqkCUCV6nxySRMQQHwhOSXlhhNAaXLKm4AVGUCMA9mskrIhQLUSoGvY6ihA7IqcjXMJLkAKcUXV8qYzQBCGrIvLHT1ARWDCAj0zRkCxNfFQVk9RQFqY6MDxaVhAnhyE1M6oYECKjrKuk7ZoQPQShZFIWXpACO0ltJeskEAjFd6gGOKTQHbjwWniV5ZA7fWUUSR9mEDr5MHDOO2ZQPHw8PDwXJtADgJufTZ0nECqBaEA2WGdQE7FELLxDp5AanKzCiV1nkBt27Zt27SeQAAAAABA6p5A/////38Rn0AAAAAAgCOfQOqiiy66MJ9AAQAAAAA7n0DTJ33SJz2fQAAAAAAAQJ9AAAAAAIBAn0AAAAAAwESfQAAAAAAASJ9At23btm1Ln0AAAAAAAFCfQAAAAAAAUJ9AAAAAAABQn0AAAAAAAFCfQAAAAAAAUJ9AAAAAAABQn0AAAAAAAADwPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADwPwAAAAAAAPA/AAAAAAAAAEAAAAAAAAAIQAAAAAAAABBAAAAAAAAAFEAAAAAAAAAgQAAAAAAAACxAAAAAAAAANkAAAAAAAIBBQAAAAAAAADpAAAAAAAAAQUAAAAAAAMBRQAAAAAAAwFhAAAAAAAAgZkAAAAAAAOBuQAAAAAAAEHJAAAAAAACgakAAAAAAAJCGQAAAAAAAYIlAAAAAAAAMkUAAAAAAAFCeQAAAAAAASqlAAAAAAADWsUAAAAAAAEqzQAAAAAAAuMNAAAAAAABYzUAAAAAAAMbOQAAAAABA1t1AAAAAACAh40AAAAAAQPjjQAAAAAAAGOpAAAAAAICK70AAAAAAAITrQAAAAACANOpAAAAAAABv40AAAAAAAB3aQAAAAADAN9FAAAAAAAAZzEAAAAAAABDDQAAAAAAAWbRAAAAAAAAasEAAAAAAAEClQAAAAAAAIJ9AAAAAAABwmUAAAAAAADiQQAAAAAAAcINAAAAAAAAAdUAAAAAAAABwQAAAAAAAAGhAAAAAAAAAYEAAAAAAAABWQAAAAAAAAFBAAAAAAACARkAAAAAAAAA+QAAAAAAAADhAAAAAAAAAMEAAAAAAAAAiQAAAAAAAABxAAAAAAAAAEEAAAAAAAAAIQAAAAAAAAABAAAAAAAAAAEAAAAAAAADwPwAAAAAAAPA/",
                    "min" : 1.0,
                    "max" : 2004.0,
                    "p25" : 24.773767527925415,
                    "p50" : 72.38128466405055,
                    "p75" : 164.2206421966297,
                    "p90" : 1038.1338917985497,
                    "p95" : 1393.0669669598371,
                    "p99" : 1829.004132388759,
                    "total" : 524976,
                    "p01" : 3.0317586167615143,
                    "p05" : 6.812988317960782,
                    "p10" : 12.562557107902899
                  }

P.S. Still waiting for throughput benchmarks result