### PR TITLE
Remove test timeouts from connector tests

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -1733,7 +1733,7 @@ public abstract class BaseJdbcConnectorTest
         return new Object[][] {{BROADCAST}, {PARTITIONED}};
     }
 
-    @Test(timeOut = 60_000, dataProvider = "fixedJoinDistributionTypes")
+    @Test(dataProvider = "fixedJoinDistributionTypes")
     public void testDynamicFiltering(JoinDistributionType joinDistributionType)
     {
         skipTestUnless(hasBehavior(SUPPORTS_DYNAMIC_FILTER_PUSHDOWN));
@@ -1742,7 +1742,7 @@ public abstract class BaseJdbcConnectorTest
                 joinDistributionType);
     }
 
-    @Test(timeOut = 60_000)
+    @Test
     public void testDynamicFilteringWithAggregationGroupingColumn()
     {
         skipTestUnless(hasBehavior(SUPPORTS_DYNAMIC_FILTER_PUSHDOWN));
@@ -1752,7 +1752,7 @@ public abstract class BaseJdbcConnectorTest
                 PARTITIONED);
     }
 
-    @Test(timeOut = 60_000)
+    @Test
     public void testDynamicFilteringWithAggregationAggregateColumn()
     {
         skipTestUnless(hasBehavior(SUPPORTS_DYNAMIC_FILTER_PUSHDOWN));
@@ -1768,7 +1768,7 @@ public abstract class BaseJdbcConnectorTest
                 isAggregationPushedDown);
     }
 
-    @Test(timeOut = 60_000)
+    @Test
     public void testDynamicFilteringWithAggregationGroupingSet()
     {
         skipTestUnless(hasBehavior(SUPPORTS_DYNAMIC_FILTER_PUSHDOWN));
@@ -1778,7 +1778,7 @@ public abstract class BaseJdbcConnectorTest
                         "ON a.orderkey = b.orderkey AND b.totalprice < 1000");
     }
 
-    @Test(timeOut = 60_000)
+    @Test
     public void testDynamicFilteringWithLimit()
     {
         skipTestUnless(hasBehavior(SUPPORTS_DYNAMIC_FILTER_PUSHDOWN));
@@ -1788,7 +1788,7 @@ public abstract class BaseJdbcConnectorTest
                         "ON a.orderkey = b.orderkey AND b.totalprice < 1000");
     }
 
-    @Test(timeOut = 60_000)
+    @Test
     public void testDynamicFilteringDomainCompactionThreshold()
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE_WITH_DATA));
@@ -1831,7 +1831,7 @@ public abstract class BaseJdbcConnectorTest
         assertUpdate("DROP TABLE " + tableName);
     }
 
-    @Test(timeOut = 60_000)
+    @Test
     public void testDynamicFilteringCaseInsensitiveDomainCompaction()
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE_WITH_DATA));

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -702,7 +702,7 @@ public abstract class BaseConnectorTest
     /**
      * Test interactions between optimizer (including CBO), scheduling and connector metadata APIs.
      */
-    @Test(timeOut = 300_000, dataProvider = "joinDistributionTypes")
+    @Test(dataProvider = "joinDistributionTypes")
     public void testJoinWithEmptySides(JoinDistributionType joinDistributionType)
     {
         Session session = noJoinReordering(joinDistributionType);


### PR DESCRIPTION
1. We use test timeouts as a safety measure only for tests that involve explicit concurrently. We do not use them in regular tests.
2. Connector tests are run against various different connectors, so different systems. Some connectors/systems are slower than others, so a timeout value may or may not be appropriate for them.
