### PR TITLE
Add table function for generating Iceberg CDC records

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergColumnHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergColumnHandle.java
@@ -43,6 +43,15 @@ public class IcebergColumnHandle
     public static final int TRINO_MERGE_PARTITION_SPEC_ID = Integer.MIN_VALUE + 2;
     public static final int TRINO_MERGE_PARTITION_DATA = Integer.MIN_VALUE + 3;
 
+    public static final String DATA_CHANGE_TYPE_NAME = "_change_type";
+    public static final int DATA_CHANGE_TYPE_ID = Integer.MIN_VALUE + 5;
+    public static final String DATA_CHANGE_VERSION_NAME = "_change_version_id";
+    public static final int DATA_CHANGE_VERSION_ID = Integer.MIN_VALUE + 6;
+    public static final String DATA_CHANGE_TIMESTAMP_NAME = "_change_timestamp";
+    public static final int DATA_CHANGE_TIMESTAMP_ID = Integer.MIN_VALUE + 7;
+    public static final String DATA_CHANGE_ORDINAL_NAME = "_change_ordinal";
+    public static final int DATA_CHANGE_ORDINAL_ID = Integer.MIN_VALUE + 8;
+
     private final ColumnIdentity baseColumnIdentity;
     private final Type baseType;
     // The list of field ids to indicate the projected part of the top-level column represented by baseColumnIdentity

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnector.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnector.java
@@ -32,6 +32,8 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.TableProcedureMetadata;
+import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.function.table.ConnectorTableFunction;
 import io.trino.spi.procedure.Procedure;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.transaction.IsolationLevel;
@@ -66,6 +68,8 @@ public class IcebergConnector
     private final Optional<ConnectorAccessControl> accessControl;
     private final Set<Procedure> procedures;
     private final Set<TableProcedureMetadata> tableProcedures;
+    private final Set<ConnectorTableFunction> tableFunctions;
+    private final FunctionProvider functionProvider;
 
     public IcebergConnector(
             Injector injector,
@@ -82,7 +86,9 @@ public class IcebergConnector
             List<PropertyMetadata<?>> analyzeProperties,
             Optional<ConnectorAccessControl> accessControl,
             Set<Procedure> procedures,
-            Set<TableProcedureMetadata> tableProcedures)
+            Set<TableProcedureMetadata> tableProcedures,
+            Set<ConnectorTableFunction> tableFunctions,
+            FunctionProvider functionProvider)
     {
         this.injector = requireNonNull(injector, "injector is null");
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
@@ -101,6 +107,8 @@ public class IcebergConnector
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.procedures = ImmutableSet.copyOf(requireNonNull(procedures, "procedures is null"));
         this.tableProcedures = ImmutableSet.copyOf(requireNonNull(tableProcedures, "tableProcedures is null"));
+        this.tableFunctions = ImmutableSet.copyOf(requireNonNull(tableFunctions, "tableFunctions is null"));
+        this.functionProvider = requireNonNull(functionProvider, "functionProvider is null");
     }
 
     @Override
@@ -152,6 +160,18 @@ public class IcebergConnector
     public Set<TableProcedureMetadata> getTableProcedures()
     {
         return tableProcedures;
+    }
+
+    @Override
+    public Set<ConnectorTableFunction> getTableFunctions()
+    {
+        return tableFunctions;
+    }
+
+    @Override
+    public Optional<FunctionProvider> getFunctionProvider()
+    {
+        return Optional.of(functionProvider);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
@@ -26,6 +26,9 @@ import io.trino.plugin.hive.orc.OrcReaderConfig;
 import io.trino.plugin.hive.orc.OrcWriterConfig;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.plugin.hive.parquet.ParquetWriterConfig;
+import io.trino.plugin.iceberg.functions.IcebergFunctionProvider;
+import io.trino.plugin.iceberg.functions.tablechanges.TableChangesFunctionProcessorProvider;
+import io.trino.plugin.iceberg.functions.tablechanges.TableChangesFunctionProvider;
 import io.trino.plugin.iceberg.procedure.DropExtendedStatsTableProcedure;
 import io.trino.plugin.iceberg.procedure.ExpireSnapshotsTableProcedure;
 import io.trino.plugin.iceberg.procedure.OptimizeTableProcedure;
@@ -37,6 +40,8 @@ import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.TableProcedureMetadata;
+import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.function.table.ConnectorTableFunction;
 import io.trino.spi.procedure.Procedure;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
@@ -65,6 +70,7 @@ public class IcebergModule
                 .setDefault().toInstance(true);
         binder.bind(ConnectorSplitManager.class).to(IcebergSplitManager.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, ConnectorPageSourceProvider.class).setDefault().to(IcebergPageSourceProvider.class).in(Scopes.SINGLETON);
+        binder.bind(IcebergPageSourceProvider.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorPageSinkProvider.class).to(IcebergPageSinkProvider.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorNodePartitioningProvider.class).to(IcebergNodePartitioningProvider.class).in(Scopes.SINGLETON);
 
@@ -95,5 +101,9 @@ public class IcebergModule
         tableProcedures.addBinding().toProvider(DropExtendedStatsTableProcedure.class).in(Scopes.SINGLETON);
         tableProcedures.addBinding().toProvider(ExpireSnapshotsTableProcedure.class).in(Scopes.SINGLETON);
         tableProcedures.addBinding().toProvider(RemoveOrphanFilesTableProcedure.class).in(Scopes.SINGLETON);
+
+        newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(TableChangesFunctionProvider.class).in(Scopes.SINGLETON);
+        binder.bind(FunctionProvider.class).to(IcebergFunctionProvider.class).in(Scopes.SINGLETON);
+        binder.bind(TableChangesFunctionProcessorProvider.class).in(Scopes.SINGLETON);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -231,21 +231,52 @@ public class IcebergPageSourceProvider
             DynamicFilter dynamicFilter)
     {
         IcebergSplit split = (IcebergSplit) connectorSplit;
-        IcebergTableHandle table = (IcebergTableHandle) connectorTable;
-
         List<IcebergColumnHandle> icebergColumns = columns.stream()
                 .map(IcebergColumnHandle.class::cast)
                 .collect(toImmutableList());
-
-        Schema tableSchema = SchemaParser.fromJson(table.getTableSchemaJson());
-
-        Set<IcebergColumnHandle> deleteFilterRequiredColumns = requiredColumnsForDeletes(tableSchema, split.getDeletes());
-
-        PartitionSpec partitionSpec = PartitionSpecParser.fromJson(tableSchema, split.getPartitionSpecJson());
+        IcebergTableHandle tableHandle = (IcebergTableHandle) connectorTable;
+        Schema schema = SchemaParser.fromJson(tableHandle.getTableSchemaJson());
+        PartitionSpec partitionSpec = PartitionSpecParser.fromJson(schema, split.getPartitionSpecJson());
         org.apache.iceberg.types.Type[] partitionColumnTypes = partitionSpec.fields().stream()
-                .map(field -> field.transform().getResultType(tableSchema.findType(field.sourceId())))
+                .map(field -> field.transform().getResultType(schema.findType(field.sourceId())))
                 .toArray(org.apache.iceberg.types.Type[]::new);
-        PartitionData partitionData = PartitionData.fromJson(split.getPartitionDataJson(), partitionColumnTypes);
+
+        return createPageSource(
+                session,
+                icebergColumns,
+                schema,
+                partitionSpec,
+                PartitionData.fromJson(split.getPartitionDataJson(), partitionColumnTypes),
+                split.getDeletes(),
+                dynamicFilter,
+                tableHandle.getUnenforcedPredicate(),
+                split.getPath(),
+                split.getStart(),
+                split.getLength(),
+                split.getFileSize(),
+                split.getPartitionDataJson(),
+                split.getFileFormat(),
+                tableHandle.getNameMappingJson().map(NameMappingParser::fromJson));
+    }
+
+    public ConnectorPageSource createPageSource(
+            ConnectorSession session,
+            List<IcebergColumnHandle> icebergColumns,
+            Schema tableSchema,
+            PartitionSpec partitionSpec,
+            PartitionData partitionData,
+            List<DeleteFile> deletes,
+            DynamicFilter dynamicFilter,
+            TupleDomain<IcebergColumnHandle> unenforcedPredicate,
+            String path,
+            long start,
+            long length,
+            long fileSize,
+            String partitionDataJson,
+            IcebergFileFormat fileFormat,
+            Optional<NameMapping> nameMapping)
+    {
+        Set<IcebergColumnHandle> deleteFilterRequiredColumns = requiredColumnsForDeletes(tableSchema, deletes);
         Map<Integer, Optional<String>> partitionKeys = getPartitionKeys(partitionData, partitionSpec);
 
         List<IcebergColumnHandle> requiredColumns = new ArrayList<>(icebergColumns);
@@ -282,7 +313,7 @@ public class IcebergPageSourceProvider
                     }
                 });
 
-        TupleDomain<IcebergColumnHandle> effectivePredicate = table.getUnenforcedPredicate()
+        TupleDomain<IcebergColumnHandle> effectivePredicate = unenforcedPredicate
                 .intersect(dynamicFilter.getCurrentPredicate().transformKeys(IcebergColumnHandle.class::cast))
                 .simplify(ICEBERG_DOMAIN_COMPACTION_THRESHOLD);
         if (effectivePredicate.isNone()) {
@@ -291,21 +322,21 @@ public class IcebergPageSourceProvider
 
         TrinoFileSystem fileSystem = fileSystemFactory.create(session);
         TrinoInputFile inputfile = isUseFileSizeFromMetadata(session)
-                ? fileSystem.newInputFile(Location.of(split.getPath()), split.getFileSize())
-                : fileSystem.newInputFile(Location.of(split.getPath()));
+                ? fileSystem.newInputFile(Location.of(path), fileSize)
+                : fileSystem.newInputFile(Location.of(path));
 
         ReaderPageSourceWithRowPositions readerPageSourceWithRowPositions = createDataPageSource(
                 session,
                 inputfile,
-                split.getStart(),
-                split.getLength(),
+                start,
+                length,
                 partitionSpec.specId(),
-                split.getPartitionDataJson(),
-                split.getFileFormat(),
-                SchemaParser.fromJson(table.getTableSchemaJson()),
+                partitionDataJson,
+                fileFormat,
+                tableSchema,
                 requiredColumns,
                 effectivePredicate,
-                table.getNameMappingJson().map(NameMappingParser::fromJson),
+                nameMapping,
                 partitionKeys);
         ReaderPageSource dataPageSource = readerPageSourceWithRowPositions.getReaderPageSource();
 
@@ -324,8 +355,8 @@ public class IcebergPageSourceProvider
             List<DeleteFilter> deleteFilters = readDeletes(
                     session,
                     tableSchema,
-                    split.getPath(),
-                    split.getDeletes(),
+                    path,
+                    deletes,
                     readerPageSourceWithRowPositions.getStartRowPosition(),
                     readerPageSourceWithRowPositions.getEndRowPosition());
             return deleteFilters.stream()

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/InternalIcebergConnectorFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/InternalIcebergConnectorFactory.java
@@ -52,6 +52,8 @@ import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.TableProcedureMetadata;
+import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.function.table.ConnectorTableFunction;
 import io.trino.spi.procedure.Procedure;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.type.TypeManager;
@@ -126,6 +128,8 @@ public final class InternalIcebergConnectorFactory
             IcebergAnalyzeProperties icebergAnalyzeProperties = injector.getInstance(IcebergAnalyzeProperties.class);
             Set<Procedure> procedures = injector.getInstance(Key.get(new TypeLiteral<Set<Procedure>>() {}));
             Set<TableProcedureMetadata> tableProcedures = injector.getInstance(Key.get(new TypeLiteral<Set<TableProcedureMetadata>>() {}));
+            Set<ConnectorTableFunction> tableFunctions = injector.getInstance(Key.get(new TypeLiteral<Set<ConnectorTableFunction>>() {}));
+            FunctionProvider functionProvider = injector.getInstance(FunctionProvider.class);
             Optional<ConnectorAccessControl> accessControl = injector.getInstance(Key.get(new TypeLiteral<Optional<ConnectorAccessControl>>() {}));
             // Materialized view should allow configuring all the supported iceberg table properties for the storage table
             List<PropertyMetadata<?>> materializedViewProperties = Stream.of(icebergTableProperties.getTableProperties(), materializedViewAdditionalProperties.getMaterializedViewProperties())
@@ -147,7 +151,9 @@ public final class InternalIcebergConnectorFactory
                     icebergAnalyzeProperties.getAnalyzeProperties(),
                     accessControl,
                     procedures,
-                    tableProcedures);
+                    tableProcedures,
+                    tableFunctions,
+                    functionProvider);
         }
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/IcebergFunctionProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/IcebergFunctionProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.functions;
+
+import com.google.inject.Inject;
+import io.trino.plugin.iceberg.functions.tablechanges.TableChangesFunctionHandle;
+import io.trino.plugin.iceberg.functions.tablechanges.TableChangesFunctionProcessorProvider;
+import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.function.table.ConnectorTableFunctionHandle;
+import io.trino.spi.function.table.TableFunctionProcessorProvider;
+
+import static java.util.Objects.requireNonNull;
+
+public class IcebergFunctionProvider
+        implements FunctionProvider
+{
+    private final TableChangesFunctionProcessorProvider tableChangesFunctionProcessorProvider;
+
+    @Inject
+    public IcebergFunctionProvider(TableChangesFunctionProcessorProvider tableChangesFunctionProcessorProvider)
+    {
+        this.tableChangesFunctionProcessorProvider = requireNonNull(tableChangesFunctionProcessorProvider, "tableChangesFunctionProcessorProvider is null");
+    }
+
+    @Override
+    public TableFunctionProcessorProvider getTableFunctionProcessorProvider(ConnectorTableFunctionHandle functionHandle)
+    {
+        if (functionHandle instanceof TableChangesFunctionHandle) {
+            return tableChangesFunctionProcessorProvider;
+        }
+
+        throw new UnsupportedOperationException("Unsupported function: " + functionHandle);
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunction.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunction.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.functions.tablechanges;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.airlift.slice.Slice;
+import io.trino.plugin.iceberg.ColumnIdentity;
+import io.trino.plugin.iceberg.IcebergColumnHandle;
+import io.trino.plugin.iceberg.IcebergUtil;
+import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorAccessControl;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.function.table.AbstractConnectorTableFunction;
+import io.trino.spi.function.table.Argument;
+import io.trino.spi.function.table.Descriptor;
+import io.trino.spi.function.table.ScalarArgument;
+import io.trino.spi.function.table.ScalarArgumentSpecification;
+import io.trino.spi.function.table.TableFunctionAnalysis;
+import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.VarcharType;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.plugin.iceberg.ColumnIdentity.TypeCategory.PRIMITIVE;
+import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_ORDINAL_ID;
+import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_ORDINAL_NAME;
+import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_TIMESTAMP_ID;
+import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_TIMESTAMP_NAME;
+import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_TYPE_ID;
+import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_TYPE_NAME;
+import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_VERSION_ID;
+import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_VERSION_NAME;
+import static io.trino.plugin.iceberg.TypeConverter.toTrinoType;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.function.table.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static java.util.Objects.requireNonNull;
+
+public class TableChangesFunction
+        extends AbstractConnectorTableFunction
+{
+    private static final String FUNCTION_NAME = "table_changes";
+    private static final String SCHEMA_VAR_NAME = "SCHEMA";
+    private static final String TABLE_VAR_NAME = "TABLE";
+    private static final String START_SNAPSHOT_VAR_NAME = "START_SNAPSHOT_ID";
+    private static final String END_SNAPSHOT_VAR_NAME = "END_SNAPSHOT_ID";
+
+    private final TrinoCatalogFactory trinoCatalogFactory;
+    private final TypeManager typeManager;
+
+    @Inject
+    public TableChangesFunction(TrinoCatalogFactory trinoCatalogFactory, TypeManager typeManager)
+    {
+        super(
+                "system",
+                FUNCTION_NAME,
+                ImmutableList.of(
+                        ScalarArgumentSpecification.builder()
+                                .name(SCHEMA_VAR_NAME)
+                                .type(VarcharType.createUnboundedVarcharType())
+                                .build(),
+                        ScalarArgumentSpecification.builder()
+                                .name(TABLE_VAR_NAME)
+                                .type(VarcharType.createUnboundedVarcharType())
+                                .build(),
+                        ScalarArgumentSpecification.builder()
+                                .name(START_SNAPSHOT_VAR_NAME)
+                                .type(BIGINT)
+                                .build(),
+                        ScalarArgumentSpecification.builder()
+                                .name(END_SNAPSHOT_VAR_NAME)
+                                .type(BIGINT)
+                                .build()),
+                GENERIC_TABLE);
+
+        this.trinoCatalogFactory = requireNonNull(trinoCatalogFactory, "trinoCatalogFactory is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+    }
+
+    @Override
+    public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments, ConnectorAccessControl accessControl)
+    {
+        String schema = ((Slice) checkNonNull(((ScalarArgument) arguments.get(SCHEMA_VAR_NAME)).getValue())).toStringUtf8();
+        String table = ((Slice) checkNonNull(((ScalarArgument) arguments.get(TABLE_VAR_NAME)).getValue())).toStringUtf8();
+        long startSnapshotId = (long) checkNonNull(((ScalarArgument) arguments.get(START_SNAPSHOT_VAR_NAME)).getValue());
+        long endSnapshotId = (long) checkNonNull(((ScalarArgument) arguments.get(END_SNAPSHOT_VAR_NAME)).getValue());
+
+        SchemaTableName schemaTableName = new SchemaTableName(schema, table);
+        Table icebergTable = trinoCatalogFactory.create(session.getIdentity())
+                .loadTable(session, schemaTableName);
+
+        checkSnapshotExists(icebergTable, startSnapshotId);
+        checkSnapshotExists(icebergTable, endSnapshotId);
+
+        ImmutableList.Builder<Descriptor.Field> columns = ImmutableList.builder();
+        Schema tableSchema = icebergTable.schemas().get(icebergTable.snapshot(endSnapshotId).schemaId());
+        tableSchema.columns().stream()
+                .map(column -> new Descriptor.Field(column.name(), Optional.of(toTrinoType(column.type(), typeManager))))
+                .forEach(columns::add);
+
+        columns.add(new Descriptor.Field(DATA_CHANGE_TYPE_NAME, Optional.of(VarcharType.createUnboundedVarcharType())));
+        columns.add(new Descriptor.Field(DATA_CHANGE_VERSION_NAME, Optional.of(BIGINT)));
+        columns.add(new Descriptor.Field(DATA_CHANGE_TIMESTAMP_NAME, Optional.of(TIMESTAMP_TZ_MILLIS)));
+        columns.add(new Descriptor.Field(DATA_CHANGE_ORDINAL_NAME, Optional.of(INTEGER)));
+
+        ImmutableList.Builder<IcebergColumnHandle> columnHandlesBuilder = ImmutableList.builder();
+        IcebergUtil.getColumns(tableSchema, typeManager).forEach(columnHandlesBuilder::add);
+        columnHandlesBuilder.add(new IcebergColumnHandle(
+                new ColumnIdentity(DATA_CHANGE_TYPE_ID, DATA_CHANGE_TYPE_NAME, PRIMITIVE, ImmutableList.of()),
+                VarcharType.createUnboundedVarcharType(),
+                ImmutableList.of(),
+                VarcharType.createUnboundedVarcharType(),
+                Optional.empty()));
+        columnHandlesBuilder.add(new IcebergColumnHandle(
+                new ColumnIdentity(DATA_CHANGE_VERSION_ID, DATA_CHANGE_VERSION_NAME, PRIMITIVE, ImmutableList.of()),
+                BIGINT,
+                ImmutableList.of(),
+                BIGINT,
+                Optional.empty()));
+        columnHandlesBuilder.add(new IcebergColumnHandle(
+                new ColumnIdentity(DATA_CHANGE_TIMESTAMP_ID, DATA_CHANGE_TIMESTAMP_NAME, PRIMITIVE, ImmutableList.of()),
+                TIMESTAMP_TZ_MILLIS,
+                ImmutableList.of(),
+                TIMESTAMP_TZ_MILLIS,
+                Optional.empty()));
+        columnHandlesBuilder.add(new IcebergColumnHandle(
+                new ColumnIdentity(DATA_CHANGE_ORDINAL_ID, DATA_CHANGE_ORDINAL_NAME, PRIMITIVE, ImmutableList.of()),
+                INTEGER,
+                ImmutableList.of(),
+                INTEGER,
+                Optional.empty()));
+        List<IcebergColumnHandle> columnHandles = columnHandlesBuilder.build();
+
+        accessControl.checkCanSelectFromColumns(null, schemaTableName, columnHandles.stream()
+                .map(IcebergColumnHandle::getName)
+                .collect(toImmutableSet()));
+
+        return TableFunctionAnalysis.builder()
+                .returnedType(new Descriptor(columns.build()))
+                .handle(new TableChangesFunctionHandle(
+                        schemaTableName,
+                        SchemaParser.toJson(tableSchema),
+                        columnHandles,
+                        Optional.ofNullable(icebergTable.properties().get(TableProperties.DEFAULT_NAME_MAPPING)),
+                        startSnapshotId,
+                        endSnapshotId))
+                .build();
+    }
+
+    private static Object checkNonNull(Object argumentValue)
+    {
+        if (argumentValue == null) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, FUNCTION_NAME + " arguments may not be null");
+        }
+        return argumentValue;
+    }
+
+    private static void checkSnapshotExists(Table icebergTable, long snapshotId)
+    {
+        if (icebergTable.snapshot(snapshotId) == null) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Snapshot not found in Iceberg table history: " + snapshotId);
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionHandle.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.functions.tablechanges;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.iceberg.IcebergColumnHandle;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.function.table.ConnectorTableFunctionHandle;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record TableChangesFunctionHandle(
+        SchemaTableName schemaTableName,
+        String tableSchemaJson,
+        List<IcebergColumnHandle> columns,
+        Optional<String> nameMappingJson,
+        long startSnapshotId,
+        long endSnapshotId) implements ConnectorTableFunctionHandle
+{
+    public TableChangesFunctionHandle
+    {
+        requireNonNull(schemaTableName, "schemaTableName is null");
+        requireNonNull(tableSchemaJson, "tableSchemaJson is null");
+        columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
+        requireNonNull(nameMappingJson, "nameMappingJson is null");
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.functions.tablechanges;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.iceberg.IcebergColumnHandle;
+import io.trino.plugin.iceberg.IcebergPageSourceProvider;
+import io.trino.plugin.iceberg.PartitionData;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.function.table.TableFunctionProcessorState;
+import io.trino.spi.function.table.TableFunctionSplitProcessor;
+import io.trino.spi.predicate.TupleDomain;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.mapping.NameMappingParser;
+
+import java.util.Optional;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_ORDINAL_ID;
+import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_TIMESTAMP_ID;
+import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_TYPE_ID;
+import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_VERSION_ID;
+import static io.trino.spi.function.table.TableFunctionProcessorState.Finished.FINISHED;
+import static io.trino.spi.function.table.TableFunctionProcessorState.Processed.produced;
+import static io.trino.spi.predicate.Utils.nativeValueToBlock;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static java.util.Objects.requireNonNull;
+
+public class TableChangesFunctionProcessor
+        implements TableFunctionSplitProcessor
+{
+    private static final Page EMPTY_PAGE = new Page(0);
+
+    private final ConnectorPageSource pageSource;
+    private final int[] delegateColumnMap;
+    private final Optional<Integer> changeTypeIndex;
+    private final Block changeTypeValue;
+    private final Optional<Integer> changeVersionIndex;
+    private final Block changeVersionValue;
+    private final Optional<Integer> changeTimestampIndex;
+    private final Block changeTimestampValue;
+    private final Optional<Integer> changeOrdinalIndex;
+    private final Block changeOrdinalValue;
+
+    public TableChangesFunctionProcessor(
+            ConnectorSession session,
+            TableChangesFunctionHandle functionHandle,
+            TableChangesSplit split,
+            IcebergPageSourceProvider icebergPageSourceProvider)
+    {
+        requireNonNull(session, "session is null");
+        requireNonNull(functionHandle, "functionHandle is null");
+        requireNonNull(split, "split is null");
+        requireNonNull(icebergPageSourceProvider, "icebergPageSourceProvider is null");
+
+        Schema tableSchema = SchemaParser.fromJson(functionHandle.tableSchemaJson());
+        PartitionSpec partitionSpec = PartitionSpecParser.fromJson(tableSchema, split.partitionSpecJson());
+        org.apache.iceberg.types.Type[] partitionColumnTypes = partitionSpec.fields().stream()
+                .map(field -> field.transform().getResultType(tableSchema.findType(field.sourceId())))
+                .toArray(org.apache.iceberg.types.Type[]::new);
+
+        int delegateColumnIndex = 0;
+        int[] delegateColumnMap = new int[functionHandle.columns().size()];
+        Optional<Integer> changeTypeIndex = Optional.empty();
+        Optional<Integer> changeVersionIndex = Optional.empty();
+        Optional<Integer> changeTimestampIndex = Optional.empty();
+        Optional<Integer> changeOrdinalIndex = Optional.empty();
+        for (int columnIndex = 0; columnIndex < functionHandle.columns().size(); columnIndex++) {
+            IcebergColumnHandle column = functionHandle.columns().get(columnIndex);
+            if (column.getId() == DATA_CHANGE_TYPE_ID) {
+                changeTypeIndex = Optional.of(columnIndex);
+                delegateColumnMap[columnIndex] = -1;
+            }
+            else if (column.getId() == DATA_CHANGE_VERSION_ID) {
+                changeVersionIndex = Optional.of(columnIndex);
+                delegateColumnMap[columnIndex] = -1;
+            }
+            else if (column.getId() == DATA_CHANGE_TIMESTAMP_ID) {
+                changeTimestampIndex = Optional.of(columnIndex);
+                delegateColumnMap[columnIndex] = -1;
+            }
+            else if (column.getId() == DATA_CHANGE_ORDINAL_ID) {
+                changeOrdinalIndex = Optional.of(columnIndex);
+                delegateColumnMap[columnIndex] = -1;
+            }
+            else {
+                delegateColumnMap[columnIndex] = delegateColumnIndex;
+                delegateColumnIndex++;
+            }
+        }
+
+        this.pageSource = icebergPageSourceProvider.createPageSource(
+                session,
+                functionHandle.columns(),
+                tableSchema,
+                partitionSpec,
+                PartitionData.fromJson(split.partitionDataJson(), partitionColumnTypes),
+                ImmutableList.of(),
+                DynamicFilter.EMPTY,
+                TupleDomain.all(),
+                split.path(),
+                split.start(),
+                split.length(),
+                split.fileSize(),
+                split.partitionDataJson(),
+                split.fileFormat(),
+                functionHandle.nameMappingJson().map(NameMappingParser::fromJson));
+        this.delegateColumnMap = delegateColumnMap;
+
+        this.changeTypeIndex = changeTypeIndex;
+        this.changeTypeValue = nativeValueToBlock(createUnboundedVarcharType(), utf8Slice(split.changeType().getTableValue()));
+
+        this.changeVersionIndex = changeVersionIndex;
+        this.changeVersionValue = nativeValueToBlock(BIGINT, split.snapshotId());
+
+        this.changeTimestampIndex = changeTimestampIndex;
+        this.changeTimestampValue = nativeValueToBlock(TIMESTAMP_TZ_MILLIS, split.snapshotTimestamp());
+
+        this.changeOrdinalIndex = changeOrdinalIndex;
+        this.changeOrdinalValue = nativeValueToBlock(INTEGER, (long) split.changeOrdinal());
+    }
+
+    @Override
+    public TableFunctionProcessorState process()
+    {
+        if (pageSource.isFinished()) {
+            return FINISHED;
+        }
+
+        Page dataPage = pageSource.getNextPage();
+        if (dataPage == null) {
+            return TableFunctionProcessorState.Processed.produced(EMPTY_PAGE);
+        }
+
+        Block[] blocks = new Block[delegateColumnMap.length];
+        for (int targetChannel = 0; targetChannel < delegateColumnMap.length; targetChannel++) {
+            int delegateIndex = delegateColumnMap[targetChannel];
+            if (delegateIndex != -1) {
+                blocks[targetChannel] = dataPage.getBlock(delegateIndex);
+            }
+        }
+
+        changeTypeIndex.ifPresent(columnChannel ->
+                blocks[columnChannel] = RunLengthEncodedBlock.create(changeTypeValue, dataPage.getPositionCount()));
+        changeVersionIndex.ifPresent(columnChannel ->
+                blocks[columnChannel] = RunLengthEncodedBlock.create(changeVersionValue, dataPage.getPositionCount()));
+        changeTimestampIndex.ifPresent(columnChannel ->
+                blocks[columnChannel] = RunLengthEncodedBlock.create(changeTimestampValue, dataPage.getPositionCount()));
+        changeOrdinalIndex.ifPresent(columnChannel ->
+                blocks[columnChannel] = RunLengthEncodedBlock.create(changeOrdinalValue, dataPage.getPositionCount()));
+
+        return produced(new Page(dataPage.getPositionCount(), blocks));
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessorProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessorProvider.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.functions.tablechanges;
+
+import com.google.inject.Inject;
+import io.trino.plugin.iceberg.IcebergPageSourceProvider;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.function.table.ConnectorTableFunctionHandle;
+import io.trino.spi.function.table.TableFunctionProcessorProvider;
+import io.trino.spi.function.table.TableFunctionSplitProcessor;
+
+import static java.util.Objects.requireNonNull;
+
+public class TableChangesFunctionProcessorProvider
+        implements TableFunctionProcessorProvider
+{
+    private final IcebergPageSourceProvider icebergPageSourceProvider;
+
+    @Inject
+    public TableChangesFunctionProcessorProvider(IcebergPageSourceProvider icebergPageSourceProvider)
+    {
+        this.icebergPageSourceProvider = requireNonNull(icebergPageSourceProvider, "icebergPageSourceProvider is null");
+    }
+
+    @Override
+    public TableFunctionSplitProcessor getSplitProcessor(
+            ConnectorSession session,
+            ConnectorTableFunctionHandle handle,
+            ConnectorSplit split)
+    {
+        return new TableChangesFunctionProcessor(
+                session,
+                (TableChangesFunctionHandle) handle,
+                (TableChangesSplit) split,
+                icebergPageSourceProvider);
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.functions.tablechanges;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorTableFunction;
+import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
+import io.trino.spi.function.table.ConnectorTableFunction;
+import io.trino.spi.type.TypeManager;
+
+import static java.util.Objects.requireNonNull;
+
+public class TableChangesFunctionProvider
+        implements Provider<ConnectorTableFunction>
+{
+    private final TrinoCatalogFactory trinoCatalogFactory;
+    private final TypeManager typeManager;
+
+    @Inject
+    public TableChangesFunctionProvider(TrinoCatalogFactory trinoCatalogFactory, TypeManager typeManager)
+    {
+        this.trinoCatalogFactory = requireNonNull(trinoCatalogFactory, "trinoCatalogFactory is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+    }
+
+    @Override
+    public ConnectorTableFunction get()
+    {
+        return new ClassLoaderSafeConnectorTableFunction(
+                new TableChangesFunction(trinoCatalogFactory, typeManager),
+                getClass().getClassLoader());
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesSplit.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.functions.tablechanges;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.SizeOf;
+import io.trino.plugin.iceberg.IcebergFileFormat;
+import io.trino.spi.HostAddress;
+import io.trino.spi.SplitWeight;
+import io.trino.spi.connector.ConnectorSplit;
+
+import java.util.List;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static java.util.Objects.requireNonNull;
+
+public record TableChangesSplit(
+        ChangeType changeType,
+        long snapshotId,
+        long snapshotTimestamp,
+        int changeOrdinal,
+        String path,
+        long start,
+        long length,
+        long fileSize,
+        long fileRecordCount,
+        IcebergFileFormat fileFormat,
+        List<HostAddress> addresses,
+        String partitionSpecJson,
+        String partitionDataJson,
+        SplitWeight splitWeight) implements ConnectorSplit
+{
+    private static final int INSTANCE_SIZE = SizeOf.instanceSize(TableChangesSplit.class);
+
+    public TableChangesSplit
+    {
+        requireNonNull(changeType, "changeType is null");
+        requireNonNull(path, "path is null");
+        requireNonNull(fileFormat, "fileFormat is null");
+        addresses = ImmutableList.copyOf(requireNonNull(addresses, "addresses is null"));
+        requireNonNull(partitionSpecJson, "partitionSpecJson is null");
+        requireNonNull(partitionDataJson, "partitionDataJson is null");
+        requireNonNull(splitWeight, "splitWeight is null");
+    }
+
+    @Override
+    public boolean isRemotelyAccessible()
+    {
+        return true;
+    }
+
+    @Override
+    public List<HostAddress> getAddresses()
+    {
+        return addresses;
+    }
+
+    @Override
+    public SplitWeight getSplitWeight()
+    {
+        return splitWeight;
+    }
+
+    @Override
+    public Object getInfo()
+    {
+        return ImmutableMap.builder()
+                .put("path", path)
+                .put("start", start)
+                .put("length", length)
+                .buildOrThrow();
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE
+                + estimatedSizeOf(path)
+                + estimatedSizeOf(addresses, HostAddress::getRetainedSizeInBytes)
+                + estimatedSizeOf(partitionSpecJson)
+                + estimatedSizeOf(partitionDataJson)
+                + splitWeight.getRetainedSizeInBytes();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .addValue(path)
+                .add("start", start)
+                .add("length", length)
+                .add("records", fileRecordCount)
+                .toString();
+    }
+
+    public enum ChangeType {
+        ADDED_FILE("insert"),
+        DELETED_FILE("delete"),
+        POSITIONAL_DELETE("delete");
+
+        private final String tableValue;
+
+        ChangeType(String tableValue)
+        {
+            this.tableValue = tableValue;
+        }
+
+        public String getTableValue()
+        {
+            return tableValue;
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesSplitSource.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.functions.tablechanges;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Closer;
+import io.trino.plugin.iceberg.IcebergFileFormat;
+import io.trino.plugin.iceberg.PartitionData;
+import io.trino.spi.SplitWeight;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorSplitSource;
+import io.trino.spi.type.DateTimeEncoding;
+import org.apache.iceberg.AddedRowsScanTask;
+import org.apache.iceberg.ChangelogScanTask;
+import org.apache.iceberg.DeletedDataFileScanTask;
+import org.apache.iceberg.IncrementalChangelogScan;
+import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.SplittableScanTask;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static com.google.common.collect.Iterators.singletonIterator;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
+import static java.util.Collections.emptyIterator;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+public class TableChangesSplitSource
+        implements ConnectorSplitSource
+{
+    private final Table icebergTable;
+    private final IncrementalChangelogScan tableScan;
+    private final long targetSplitSize;
+    private final Closer closer = Closer.create();
+
+    private CloseableIterable<ChangelogScanTask> changelogScanIterable;
+    private CloseableIterator<ChangelogScanTask> changelogScanIterator;
+    private Iterator<? extends ChangelogScanTask> fileTasksIterator = emptyIterator();
+
+    public TableChangesSplitSource(
+            Table icebergTable,
+            IncrementalChangelogScan tableScan)
+    {
+        this.icebergTable = requireNonNull(icebergTable, "table is null");
+        this.tableScan = requireNonNull(tableScan, "tableScan is null");
+        this.targetSplitSize = tableScan.targetSplitSize();
+    }
+
+    @Override
+    public CompletableFuture<ConnectorSplitBatch> getNextBatch(int maxSize)
+    {
+        if (changelogScanIterable == null) {
+            try {
+                this.changelogScanIterable = closer.register(tableScan.planFiles());
+                this.changelogScanIterator = closer.register(changelogScanIterable.iterator());
+            }
+            catch (UnsupportedOperationException e) {
+                throw new TrinoException(NOT_SUPPORTED, "Table uses features which are not yet supported by the table_changes function", e);
+            }
+        }
+
+        List<ConnectorSplit> splits = new ArrayList<>(maxSize);
+        while (splits.size() < maxSize && (fileTasksIterator.hasNext() || changelogScanIterator.hasNext())) {
+            if (!fileTasksIterator.hasNext()) {
+                ChangelogScanTask wholeFileTask = changelogScanIterator.next();
+                fileTasksIterator = splitIfPossible(wholeFileTask, targetSplitSize);
+                continue;
+            }
+
+            ChangelogScanTask next = fileTasksIterator.next();
+            splits.add(toIcebergSplit(next));
+        }
+        return completedFuture(new ConnectorSplitBatch(splits, isFinished()));
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return changelogScanIterator != null && !changelogScanIterator.hasNext();
+    }
+
+    @Override
+    public void close()
+    {
+        try {
+            closer.close();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Iterator<? extends ChangelogScanTask> splitIfPossible(ChangelogScanTask wholeFileScan, long targetSplitSize)
+    {
+        if (wholeFileScan instanceof AddedRowsScanTask) {
+            return ((SplittableScanTask<AddedRowsScanTask>) wholeFileScan).split(targetSplitSize).iterator();
+        }
+
+        if (wholeFileScan instanceof DeletedDataFileScanTask) {
+            return ((SplittableScanTask<DeletedDataFileScanTask>) wholeFileScan).split(targetSplitSize).iterator();
+        }
+
+        return singletonIterator(wholeFileScan);
+    }
+
+    private ConnectorSplit toIcebergSplit(ChangelogScanTask task)
+    {
+        // TODO: Support DeletedRowsScanTask (requires https://github.com/apache/iceberg/pull/6182)
+        if (task instanceof AddedRowsScanTask) {
+            return toSplit((AddedRowsScanTask) task);
+        }
+        else if (task instanceof DeletedDataFileScanTask) {
+            return toSplit((DeletedDataFileScanTask) task);
+        }
+        else {
+            throw new TrinoException(NOT_SUPPORTED, "ChangelogScanTask type is not supported:" + task);
+        }
+    }
+
+    private TableChangesSplit toSplit(AddedRowsScanTask task)
+    {
+        return new TableChangesSplit(
+                TableChangesSplit.ChangeType.ADDED_FILE,
+                task.commitSnapshotId(),
+                DateTimeEncoding.packDateTimeWithZone(icebergTable.snapshot(task.commitSnapshotId()).timestampMillis(), UTC_KEY),
+                task.changeOrdinal(),
+                task.file().path().toString(),
+                task.start(),
+                task.length(),
+                task.file().fileSizeInBytes(),
+                task.file().recordCount(),
+                IcebergFileFormat.fromIceberg(task.file().format()),
+                ImmutableList.of(),
+                PartitionSpecParser.toJson(task.spec()),
+                PartitionData.toJson(task.file().partition()),
+                SplitWeight.standard());
+    }
+
+    private TableChangesSplit toSplit(DeletedDataFileScanTask task)
+    {
+        return new TableChangesSplit(
+                TableChangesSplit.ChangeType.DELETED_FILE,
+                task.commitSnapshotId(),
+                DateTimeEncoding.packDateTimeWithZone(icebergTable.snapshot(task.commitSnapshotId()).timestampMillis(), UTC_KEY),
+                task.changeOrdinal(),
+                task.file().path().toString(),
+                task.start(),
+                task.length(),
+                task.file().fileSizeInBytes(),
+                task.file().recordCount(),
+                IcebergFileFormat.fromIceberg(task.file().format()),
+                ImmutableList.of(),
+                PartitionSpecParser.toJson(task.spec()),
+                PartitionData.toJson(task.file().partition()),
+                SplitWeight.standard());
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -657,7 +657,7 @@ public abstract class BaseIcebergConnectorSmokeTest
 
             assertQuery(
                     "SELECT nationkey, name, _change_type, _change_version_id, to_iso8601(_change_timestamp), _change_ordinal " +
-                            "FROM TABLE(system.table_changes('tpch', '%s', %s, %s))".formatted(table.getName(), initialSnapshot, snapshotAfterInsert),
+                            "FROM TABLE(system.table_changes(CURRENT_SCHEMA, '%s', %s, %s))".formatted(table.getName(), initialSnapshot, snapshotAfterInsert),
                     "SELECT nationkey, name, 'insert', %s, '%s', 0 FROM nation".formatted(snapshotAfterInsert, snapshotAfterInsertTime));
 
             assertUpdate("DELETE FROM " + table.getName(), 25);
@@ -666,12 +666,12 @@ public abstract class BaseIcebergConnectorSmokeTest
 
             assertQuery(
                     "SELECT nationkey, name, _change_type, _change_version_id, to_iso8601(_change_timestamp), _change_ordinal " +
-                            "FROM TABLE(system.table_changes('tpch', '%s', %s, %s))".formatted(table.getName(), snapshotAfterInsert, snapshotAfterDelete),
+                            "FROM TABLE(system.table_changes(CURRENT_SCHEMA, '%s', %s, %s))".formatted(table.getName(), snapshotAfterInsert, snapshotAfterDelete),
                     "SELECT nationkey, name, 'delete', %s, '%s', 0 FROM nation".formatted(snapshotAfterDelete, snapshotAfterDeleteTime));
 
             assertQuery(
                     "SELECT nationkey, name, _change_type, _change_version_id, to_iso8601(_change_timestamp), _change_ordinal " +
-                            "FROM TABLE(system.table_changes('tpch', '%s', %s, %s))".formatted(table.getName(), initialSnapshot, snapshotAfterDelete),
+                            "FROM TABLE(system.table_changes(CURRENT_SCHEMA, '%s', %s, %s))".formatted(table.getName(), initialSnapshot, snapshotAfterDelete),
                     "SELECT nationkey, name, 'insert', %s, '%s', 0 FROM nation UNION SELECT nationkey, name, 'delete', %s, '%s', 1 FROM nation".formatted(
                             snapshotAfterInsert, snapshotAfterInsertTime, snapshotAfterDelete, snapshotAfterDeleteTime));
         }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
 import io.trino.Session;
 import io.trino.filesystem.FileIterator;
@@ -30,6 +31,7 @@ import org.apache.iceberg.io.FileIO;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CyclicBarrier;
@@ -47,6 +49,7 @@ import static io.trino.testing.TestingAccessControlManager.privilege;
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -639,6 +642,71 @@ public abstract class BaseIcebergConnectorSmokeTest
     }
 
     protected abstract boolean isFileSorted(Location path, String sortColumnName);
+
+    @Test
+    public void testTableChangesFunction()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_table_changes_function_",
+                "AS SELECT nationkey, name FROM tpch.tiny.nation WITH NO DATA")) {
+            long initialSnapshot = getMostRecentSnapshotId(table.getName());
+            assertUpdate("INSERT INTO " + table.getName() + " SELECT nationkey, name FROM nation", 25);
+            long snapshotAfterInsert = getMostRecentSnapshotId(table.getName());
+            String snapshotAfterInsertTime = getSnapshotTime(table.getName(), snapshotAfterInsert).format(ISO_INSTANT);
+
+            assertQuery(
+                    "SELECT nationkey, name, _change_type, _change_version_id, to_iso8601(_change_timestamp), _change_ordinal " +
+                            "FROM TABLE(system.table_changes('tpch', '%s', %s, %s))".formatted(table.getName(), initialSnapshot, snapshotAfterInsert),
+                    "SELECT nationkey, name, 'insert', %s, '%s', 0 FROM nation".formatted(snapshotAfterInsert, snapshotAfterInsertTime));
+
+            assertUpdate("DELETE FROM " + table.getName(), 25);
+            long snapshotAfterDelete = getMostRecentSnapshotId(table.getName());
+            String snapshotAfterDeleteTime = getSnapshotTime(table.getName(), snapshotAfterDelete).format(ISO_INSTANT);
+
+            assertQuery(
+                    "SELECT nationkey, name, _change_type, _change_version_id, to_iso8601(_change_timestamp), _change_ordinal " +
+                            "FROM TABLE(system.table_changes('tpch', '%s', %s, %s))".formatted(table.getName(), snapshotAfterInsert, snapshotAfterDelete),
+                    "SELECT nationkey, name, 'delete', %s, '%s', 0 FROM nation".formatted(snapshotAfterDelete, snapshotAfterDeleteTime));
+
+            assertQuery(
+                    "SELECT nationkey, name, _change_type, _change_version_id, to_iso8601(_change_timestamp), _change_ordinal " +
+                            "FROM TABLE(system.table_changes('tpch', '%s', %s, %s))".formatted(table.getName(), initialSnapshot, snapshotAfterDelete),
+                    "SELECT nationkey, name, 'insert', %s, '%s', 0 FROM nation UNION SELECT nationkey, name, 'delete', %s, '%s', 1 FROM nation".formatted(
+                            snapshotAfterInsert, snapshotAfterInsertTime, snapshotAfterDelete, snapshotAfterDeleteTime));
+        }
+    }
+
+    @Test
+    public void testRowLevelDeletesWithTableChangesFunction()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_row_level_deletes_with_table_changes_function_",
+                "AS SELECT nationkey, regionkey, name FROM tpch.tiny.nation WITH NO DATA")) {
+            assertUpdate("INSERT INTO " + table.getName() + " SELECT nationkey, regionkey, name FROM nation", 25);
+            long snapshotAfterInsert = getMostRecentSnapshotId(table.getName());
+
+            assertUpdate("DELETE FROM " + table.getName() + " WHERE regionkey = 2", 5);
+            long snapshotAfterDelete = getMostRecentSnapshotId(table.getName());
+
+            assertQueryFails(
+                    "SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA, '%s', %s, %s))".formatted(table.getName(), snapshotAfterInsert, snapshotAfterDelete),
+                    "Table uses features which are not yet supported by the table_changes function");
+        }
+    }
+
+    private long getMostRecentSnapshotId(String tableName)
+    {
+        return (long) Iterables.getOnlyElement(getQueryRunner().execute(format("SELECT snapshot_id FROM \"%s$snapshots\" ORDER BY committed_at DESC LIMIT 1", tableName))
+                .getOnlyColumnAsSet());
+    }
+
+    private ZonedDateTime getSnapshotTime(String tableName, long snapshotId)
+    {
+        return (ZonedDateTime) Iterables.getOnlyElement(getQueryRunner().execute(format("SELECT committed_at FROM \"%s$snapshots\" WHERE snapshot_id = %s", tableName, snapshotId))
+                .getOnlyColumnAsSet());
+    }
 
     private String getTableLocation(String tableName)
     {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -6918,6 +6918,56 @@ public abstract class BaseIcebergConnectorTest
         assertUpdate("DROP TABLE " + tableName);
     }
 
+    @Test
+    public void testTableChangesFunctionAfterSchemaChange()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_table_changes_function_",
+                "AS SELECT nationkey, name FROM tpch.tiny.nation WITH NO DATA")) {
+            long initialSnapshot = getCurrentSnapshotId(table.getName());
+            assertUpdate("INSERT INTO " + table.getName() + " SELECT nationkey, name FROM nation WHERE nationkey < 5", 5);
+            long snapshotAfterInsert = getCurrentSnapshotId(table.getName());
+
+            assertUpdate("ALTER TABLE " + table.getName() + " DROP COLUMN name");
+            assertUpdate("INSERT INTO " + table.getName() + " SELECT nationkey FROM nation WHERE nationkey >= 5 AND nationkey < 10", 5);
+            long snapshotAfterDropColumn = getCurrentSnapshotId(table.getName());
+
+            assertUpdate("ALTER TABLE " + table.getName() + " ADD COLUMN comment VARCHAR");
+            assertUpdate("INSERT INTO " + table.getName() + " SELECT nationkey, comment FROM nation WHERE nationkey >= 10 AND nationkey < 15", 5);
+            long snapshotAfterAddColumn = getCurrentSnapshotId(table.getName());
+
+            assertUpdate("ALTER TABLE " + table.getName() + " ADD COLUMN name VARCHAR");
+            assertUpdate("INSERT INTO " + table.getName() + " SELECT nationkey, comment, name FROM nation WHERE nationkey >= 15", 10);
+            long snapshotAfterReaddingNameColumn = getCurrentSnapshotId(table.getName());
+
+            assertQuery(
+                    "SELECT nationkey, name, _change_type, _change_version_id, _change_ordinal " +
+                            "FROM TABLE(system.table_changes('tpch', '%s', %s, %s))".formatted(table.getName(), initialSnapshot, snapshotAfterInsert),
+                    "SELECT nationkey, name, 'insert', %s, 0 FROM nation WHERE nationkey < 5".formatted(snapshotAfterInsert));
+
+            assertQuery(
+                    "SELECT nationkey, _change_type, _change_version_id, _change_ordinal " +
+                            "FROM TABLE(system.table_changes('tpch', '%s', %s, %s))".formatted(table.getName(), initialSnapshot, snapshotAfterDropColumn),
+                    "SELECT nationkey, 'insert', %s, 0 FROM nation WHERE nationkey < 5 UNION SELECT nationkey, 'insert', %s, 1 FROM nation WHERE nationkey >= 5 AND nationkey < 10 ".formatted(snapshotAfterInsert, snapshotAfterDropColumn));
+
+            assertQuery(
+                    "SELECT nationkey, comment, _change_type, _change_version_id, _change_ordinal " +
+                            "FROM TABLE(system.table_changes('tpch', '%s', %s, %s))".formatted(table.getName(), initialSnapshot, snapshotAfterAddColumn),
+                    ("SELECT nationkey, NULL, 'insert', %s, 0 FROM nation WHERE nationkey < 5 " +
+                            "UNION SELECT nationkey, NULL, 'insert', %s, 1 FROM nation WHERE nationkey >= 5 AND nationkey < 10 " +
+                            "UNION SELECT nationkey, comment, 'insert', %s, 2 FROM nation WHERE nationkey >= 10 AND nationkey < 15").formatted(snapshotAfterInsert, snapshotAfterDropColumn, snapshotAfterAddColumn));
+
+            assertQuery(
+                    "SELECT nationkey, comment, name, _change_type, _change_version_id, _change_ordinal " +
+                            "FROM TABLE(system.table_changes('tpch', '%s', %s, %s))".formatted(table.getName(), initialSnapshot, snapshotAfterReaddingNameColumn),
+                    ("SELECT nationkey, NULL, NULL, 'insert', %s, 0 FROM nation WHERE nationkey < 5 " +
+                            "UNION SELECT nationkey, NULL, NULL, 'insert', %s, 1 FROM nation WHERE nationkey >= 5 AND nationkey < 10 " +
+                            "UNION SELECT nationkey, comment, NULL, 'insert', %s, 2 FROM nation WHERE nationkey >= 10 AND nationkey < 15" +
+                            "UNION SELECT nationkey, comment, name, 'insert', %s, 3 FROM nation WHERE nationkey >= 15").formatted(snapshotAfterInsert, snapshotAfterDropColumn, snapshotAfterAddColumn, snapshotAfterReaddingNameColumn));
+        }
+    }
+
     @Override
     protected void verifyTableNameLengthFailurePermissible(Throwable e)
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Adds a table function which, given a range of snapshot ids, will produce a table of the rows inserted and deleted between those two snapshots.

Currently only supports metadata deletes, not merge-on-read positional or equality deletes.

A document comparing the Iceberg and Delta Lake CDC implementations and how I think we should reconcile the differences is [here](https://docs.google.com/document/d/1e71DP0b9-NCecEqizgf22gJcGzOocnn2vGEZ_RTWmc4/edit?usp=sharing).

## Additional context and related issues

Support for positional and equality deletes depends on: https://github.com/apache/iceberg/pull/6182

## Release notes

This is still a draft

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
