### PR TITLE
Fix issues due to mask aliasing

### DIFF
--- a/core/trino-main/src/main/java/io/trino/security/AccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControl.java
@@ -566,8 +566,8 @@ public interface AccessControl
         return ImmutableList.of();
     }
 
-    default List<ViewExpression> getColumnMasks(SecurityContext context, QualifiedObjectName tableName, String columnName, Type type)
+    default Optional<ViewExpression> getColumnMask(SecurityContext context, QualifiedObjectName tableName, String columnName, Type type)
     {
-        return ImmutableList.of();
+        return Optional.empty();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
@@ -72,6 +72,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.configuration.ConfigurationLoader.loadPropertiesFrom;
+import static io.trino.spi.StandardErrorCode.INVALID_COLUMN_MASK;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.SERVER_STARTING_UP;
 import static java.lang.String.format;
@@ -1248,26 +1249,30 @@ public class AccessControlManager
     }
 
     @Override
-    public List<ViewExpression> getColumnMasks(SecurityContext context, QualifiedObjectName tableName, String columnName, Type type)
+    public Optional<ViewExpression> getColumnMask(SecurityContext context, QualifiedObjectName tableName, String columnName, Type type)
     {
         requireNonNull(context, "context is null");
         requireNonNull(tableName, "tableName is null");
 
         ImmutableList.Builder<ViewExpression> masks = ImmutableList.builder();
 
-        // connector-provided masks take precedence over global masks
         ConnectorAccessControl connectorAccessControl = getConnectorAccessControl(context.getTransactionId(), tableName.getCatalogName());
         if (connectorAccessControl != null) {
-            connectorAccessControl.getColumnMasks(toConnectorSecurityContext(tableName.getCatalogName(), context), tableName.asSchemaTableName(), columnName, type)
-                    .forEach(masks::add);
+            connectorAccessControl.getColumnMask(toConnectorSecurityContext(tableName.getCatalogName(), context), tableName.asSchemaTableName(), columnName, type)
+                    .ifPresent(masks::add);
         }
 
         for (SystemAccessControl systemAccessControl : getSystemAccessControls()) {
-            systemAccessControl.getColumnMasks(context.toSystemSecurityContext(), tableName.asCatalogSchemaTableName(), columnName, type)
-                    .forEach(masks::add);
+            systemAccessControl.getColumnMask(context.toSystemSecurityContext(), tableName.asCatalogSchemaTableName(), columnName, type)
+                    .ifPresent(masks::add);
         }
 
-        return masks.build();
+        List<ViewExpression> allMasks = masks.build();
+        if (allMasks.size() > 1) {
+            throw new TrinoException(INVALID_COLUMN_MASK, format("Column must have a single mask: %s", columnName));
+        }
+
+        return allMasks.stream().findFirst();
     }
 
     private ConnectorAccessControl getConnectorAccessControl(TransactionId transactionId, String catalogName)

--- a/core/trino-main/src/main/java/io/trino/security/ForwardingAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/ForwardingAccessControl.java
@@ -486,8 +486,8 @@ public abstract class ForwardingAccessControl
     }
 
     @Override
-    public List<ViewExpression> getColumnMasks(SecurityContext context, QualifiedObjectName tableName, String columnName, Type type)
+    public Optional<ViewExpression> getColumnMask(SecurityContext context, QualifiedObjectName tableName, String columnName, Type type)
     {
-        return delegate().getColumnMasks(context, tableName, columnName, type);
+        return delegate().getColumnMask(context, tableName, columnName, type);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/security/InjectedConnectorAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/InjectedConnectorAccessControl.java
@@ -492,13 +492,19 @@ public class InjectedConnectorAccessControl
     }
 
     @Override
-    public List<ViewExpression> getColumnMasks(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
+    public Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
     {
         checkArgument(context == null, "context must be null");
-        if (accessControl.getColumnMasks(securityContext, new QualifiedObjectName(catalogName, tableName.getSchemaName(), tableName.getTableName()), columnName, type).isEmpty()) {
-            return ImmutableList.of();
+        if (accessControl.getColumnMask(securityContext, new QualifiedObjectName(catalogName, tableName.getSchemaName(), tableName.getTableName()), columnName, type).isEmpty()) {
+            return Optional.empty();
         }
         throw new TrinoException(NOT_SUPPORTED, "Column masking not supported");
+    }
+
+    @Override
+    public List<ViewExpression> getColumnMasks(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
+    {
+        throw new UnsupportedOperationException();
     }
 
     private QualifiedObjectName getQualifiedObjectName(SchemaTableName schemaTableName)

--- a/core/trino-main/src/main/java/io/trino/security/ViewAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/ViewAccessControl.java
@@ -22,6 +22,7 @@ import io.trino.spi.security.ViewExpression;
 import io.trino.spi.type.Type;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Verify.verify;
@@ -92,9 +93,9 @@ public class ViewAccessControl
     }
 
     @Override
-    public List<ViewExpression> getColumnMasks(SecurityContext context, QualifiedObjectName tableName, String columnName, Type type)
+    public Optional<ViewExpression> getColumnMask(SecurityContext context, QualifiedObjectName tableName, String columnName, Type type)
     {
-        return delegate.getColumnMasks(context, tableName, columnName, type);
+        return delegate.getColumnMask(context, tableName, columnName, type);
     }
 
     private static void wrapAccessDeniedException(Runnable runnable)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
@@ -293,7 +293,7 @@ class RelationPlanner
 
     private RelationPlan addColumnMasks(Table table, RelationPlan plan)
     {
-        Map<String, List<Expression>> columnMasks = analysis.getColumnMasks(table);
+        Map<String, Expression> columnMasks = analysis.getColumnMasks(table);
 
         // A Table can represent a WITH query, which can have anonymous fields. On the other hand,
         // it can't have masks. The loop below expects fields to have proper names, so bail out
@@ -308,7 +308,8 @@ class RelationPlanner
         for (int i = 0; i < plan.getDescriptor().getAllFieldCount(); i++) {
             Field field = plan.getDescriptor().getFieldByIndex(i);
 
-            for (Expression mask : columnMasks.getOrDefault(field.getName().orElseThrow(), ImmutableList.of())) {
+            Expression mask = columnMasks.get(field.getName().orElseThrow());
+            if (mask != null) {
                 planBuilder = subqueryPlanner.handleSubqueries(planBuilder, mask, analysis.getSubqueries(mask));
 
                 Map<Symbol, Expression> assignments = new LinkedHashMap<>();

--- a/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
@@ -135,7 +135,7 @@ public class TestingAccessControlManager
 
     private final Set<TestingPrivilege> denyPrivileges = new HashSet<>();
     private final Map<RowFilterKey, List<ViewExpression>> rowFilters = new HashMap<>();
-    private final Map<ColumnMaskKey, List<ViewExpression>> columnMasks = new HashMap<>();
+    private final Map<ColumnMaskKey, ViewExpression> columnMasks = new HashMap<>();
     private Predicate<String> deniedCatalogs = s -> true;
     private Predicate<String> deniedSchemas = s -> true;
     private Predicate<SchemaTableName> deniedTables = s -> true;
@@ -175,8 +175,7 @@ public class TestingAccessControlManager
 
     public void columnMask(QualifiedObjectName table, String column, String identity, ViewExpression mask)
     {
-        columnMasks.computeIfAbsent(new ColumnMaskKey(identity, table, column), key -> new ArrayList<>())
-                .add(mask);
+        columnMasks.put(new ColumnMaskKey(identity, table, column), mask);
     }
 
     public void reset()
@@ -746,13 +745,13 @@ public class TestingAccessControlManager
     }
 
     @Override
-    public List<ViewExpression> getColumnMasks(SecurityContext context, QualifiedObjectName tableName, String column, Type type)
+    public Optional<ViewExpression> getColumnMask(SecurityContext context, QualifiedObjectName tableName, String column, Type type)
     {
-        List<ViewExpression> viewExpressions = columnMasks.get(new ColumnMaskKey(context.getIdentity().getUser(), tableName, column));
-        if (viewExpressions != null) {
-            return viewExpressions;
+        ViewExpression mask = columnMasks.get(new ColumnMaskKey(context.getIdentity().getUser(), tableName, column));
+        if (mask != null) {
+            return Optional.of(mask);
         }
-        return super.getColumnMasks(context, tableName, column, type);
+        return super.getColumnMask(context, tableName, column, type);
     }
 
     private boolean shouldDenyPrivilege(String actorName, String entityName, TestingPrivilegeType verb)

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorAccessControl.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorAccessControl.java
@@ -130,11 +130,15 @@ class MockConnectorAccessControl
     }
 
     @Override
+    public Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
+    {
+        return Optional.ofNullable(columnMasks.apply(tableName, columnName));
+    }
+
+    @Override
     public List<ViewExpression> getColumnMasks(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
     {
-        return Optional.ofNullable(columnMasks.apply(tableName, columnName))
-                .map(ImmutableList::of)
-                .orElseGet(ImmutableList::of);
+        throw new UnsupportedOperationException();
     }
 
     public void grantSchemaPrivileges(String schemaName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)

--- a/core/trino-main/src/test/java/io/trino/security/TestAccessControlManager.java
+++ b/core/trino-main/src/test/java/io/trino/security/TestAccessControlManager.java
@@ -58,7 +58,6 @@ import java.util.Set;
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.spi.function.FunctionKind.TABLE;
 import static io.trino.spi.security.AccessDeniedException.denySelectTable;
-import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.testing.TestingEventListenerManager.emptyEventListenerManager;
 import static io.trino.testing.TestingHandles.TEST_CATALOG_NAME;
 import static io.trino.transaction.InMemoryTransactionManager.createTestTransactionManager;
@@ -258,17 +257,6 @@ public class TestAccessControlManager
                 {
                 }
             })));
-
-            transaction(transactionManager, accessControlManager)
-                    .execute(transactionId -> {
-                        List<ViewExpression> masks = accessControlManager.getColumnMasks(
-                                context(transactionId),
-                                new QualifiedObjectName(TEST_CATALOG_NAME, "schema", "table"),
-                                "column",
-                                BIGINT);
-                        assertEquals(masks.get(0).getExpression(), "connector mask");
-                        assertEquals(masks.get(1).getExpression(), "system mask");
-                    });
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
@@ -197,25 +197,6 @@ public class TestColumnMask
     }
 
     @Test
-    public void testMultipleMasksOnSameColumn()
-    {
-        accessControl.reset();
-        accessControl.columnMask(
-                new QualifiedObjectName(LOCAL_CATALOG, "tiny", "orders"),
-                "custkey",
-                USER,
-                new ViewExpression(USER, Optional.empty(), Optional.empty(), "-custkey"));
-
-        accessControl.columnMask(
-                new QualifiedObjectName(LOCAL_CATALOG, "tiny", "orders"),
-                "custkey",
-                USER,
-                new ViewExpression(USER, Optional.empty(), Optional.empty(), "custkey * 2"));
-
-        assertThat(assertions.query("SELECT custkey FROM orders WHERE orderkey = 1")).matches("VALUES BIGINT '-740'");
-    }
-
-    @Test
     public void testMultipleMasksOnDifferentColumns()
     {
         accessControl.reset();
@@ -613,22 +594,6 @@ public class TestColumnMask
                 "orderkey",
                 USER,
                 new ViewExpression(USER, Optional.of(LOCAL_CATALOG), Optional.of("tiny"), "orderkey + 1"));
-        assertThat(assertions.query("SELECT count(*) FROM orders JOIN orders USING (orderkey)")).matches("VALUES BIGINT '15000'");
-
-        // multiple masks
-        accessControl.reset();
-        accessControl.columnMask(
-                new QualifiedObjectName(LOCAL_CATALOG, "tiny", "orders"),
-                "orderkey",
-                USER,
-                new ViewExpression(USER, Optional.empty(), Optional.empty(), "-orderkey"));
-
-        accessControl.columnMask(
-                new QualifiedObjectName(LOCAL_CATALOG, "tiny", "orders"),
-                "orderkey",
-                USER,
-                new ViewExpression(USER, Optional.empty(), Optional.empty(), "orderkey * 2"));
-
         assertThat(assertions.query("SELECT count(*) FROM orders JOIN orders USING (orderkey)")).matches("VALUES BIGINT '15000'");
     }
 

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -233,6 +233,20 @@
                                     <newVisibility>package</newVisibility>
                                     <justification>It was not accessible outside of SPI anyway</justification>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeChanged</code>
+                                    <old>parameter void io.trino.spi.eventlistener.ColumnInfo::&lt;init&gt;(java.lang.String, ===java.util.List&lt;java.lang.String&gt;===)</old>
+                                    <new>parameter void io.trino.spi.eventlistener.ColumnInfo::&lt;init&gt;(java.lang.String, ===java.util.Optional&lt;java.lang.String&gt;===)</new>
+                                    <parameterIndex>1</parameterIndex>
+                                    <justification>Removing support for multiple masks on a given column, as they are error prone</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method java.util.List&lt;java.lang.String&gt; io.trino.spi.eventlistener.ColumnInfo::getMasks()</old>
+                                    <justification>Removing support for multiple masks on a given column, as they are error prone</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorAccessControl.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorAccessControl.java
@@ -659,13 +659,24 @@ public interface ConnectorAccessControl
     }
 
     /**
-     * Get column masks associated with the given table, column and identity.
+     * Get column mask associated with the given table, column and identity.
      * <p>
-     * Each mask must be a scalar SQL expression of a type coercible to the type of the column being masked. The expression
+     * The mask must be a scalar SQL expression of a type coercible to the type of the column being masked. The expression
      * must be written in terms of columns in the table.
      *
-     * @return the list of masks, or empty list if not applicable
+     * @return the mask if present, or empty if not applicable
      */
+    default Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
+    {
+        List<ViewExpression> masks = getColumnMasks(context, tableName, columnName, type);
+        if (masks.size() > 1) {
+            throw new UnsupportedOperationException("Multiple masks on a single column are no longer supported");
+        }
+
+        return masks.stream().findFirst();
+    }
+
+    @Deprecated
     default List<ViewExpression> getColumnMasks(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
     {
         return emptyList();

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ColumnInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ColumnInfo.java
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.Unstable;
 
-import java.util.List;
+import java.util.Optional;
 
 /**
  * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
@@ -25,14 +25,14 @@ import java.util.List;
 public class ColumnInfo
 {
     private final String column;
-    private final List<String> masks;
+    private final Optional<String> mask;
 
     @JsonCreator
     @Unstable
-    public ColumnInfo(String column, List<String> masks)
+    public ColumnInfo(String column, Optional<String> mask)
     {
         this.column = column;
-        this.masks = masks;
+        this.mask = mask;
     }
 
     @JsonProperty
@@ -42,8 +42,8 @@ public class ColumnInfo
     }
 
     @JsonProperty
-    public List<String> getMasks()
+    public Optional<String> getMask()
     {
-        return masks;
+        return mask;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
@@ -877,11 +877,22 @@ public interface SystemAccessControl
     /**
      * Get column masks associated with the given table, column and identity.
      * <p>
-     * Each mask must be a scalar SQL expression of a type coercible to the type of the column being masked. The expression
+     * The mask must be a scalar SQL expression of a type coercible to the type of the column being masked. The expression
      * must be written in terms of columns in the table.
      *
-     * @return the list of masks, or empty list if not applicable
+     * @return the mask if present, or empty if not applicable
      */
+    default Optional<ViewExpression> getColumnMask(SystemSecurityContext context, CatalogSchemaTableName tableName, String columnName, Type type)
+    {
+        List<ViewExpression> masks = getColumnMasks(context, tableName, columnName, type);
+        if (masks.size() > 1) {
+            throw new UnsupportedOperationException("Multiple masks on a single column are no longer supported");
+        }
+
+        return masks.stream().findFirst();
+    }
+
+    @Deprecated
     default List<ViewExpression> getColumnMasks(SystemSecurityContext context, CatalogSchemaTableName tableName, String columnName, Type type)
     {
         return List.of();

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
@@ -535,6 +535,14 @@ public class ClassLoaderSafeConnectorAccessControl
     }
 
     @Override
+    public Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getColumnMask(context, tableName, columnName, type);
+        }
+    }
+
+    @Override
     public List<ViewExpression> getColumnMasks(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllAccessControl.java
@@ -345,6 +345,12 @@ public class AllowAllAccessControl
     }
 
     @Override
+    public Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
+    {
+        return Optional.empty();
+    }
+
+    @Override
     public List<ViewExpression> getColumnMasks(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
     {
         return ImmutableList.of();

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllSystemAccessControl.java
@@ -462,6 +462,12 @@ public class AllowAllSystemAccessControl
     }
 
     @Override
+    public Optional<ViewExpression> getColumnMask(SystemSecurityContext context, CatalogSchemaTableName tableName, String columnName, Type type)
+    {
+        return Optional.empty();
+    }
+
+    @Override
     public List<ViewExpression> getColumnMasks(SystemSecurityContext context, CatalogSchemaTableName tableName, String columnName, Type type)
     {
         return emptyList();

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingConnectorAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingConnectorAccessControl.java
@@ -418,6 +418,12 @@ public abstract class ForwardingConnectorAccessControl
     }
 
     @Override
+    public Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
+    {
+        return delegate().getColumnMask(context, tableName, columnName, type);
+    }
+
+    @Override
     public List<ViewExpression> getColumnMasks(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
     {
         return delegate().getColumnMasks(context, tableName, columnName, type);

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingSystemAccessControl.java
@@ -512,6 +512,12 @@ public abstract class ForwardingSystemAccessControl
     }
 
     @Override
+    public Optional<ViewExpression> getColumnMask(SystemSecurityContext context, CatalogSchemaTableName tableName, String columnName, Type type)
+    {
+        return delegate().getColumnMask(context, tableName, columnName, type);
+    }
+
+    @Override
     public List<ViewExpression> getColumnMasks(SystemSecurityContext context, CatalogSchemaTableName tableName, String columnName, Type type)
     {
         return delegate().getColumnMasks(context, tableName, columnName, type);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/LegacyAccessControl.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/LegacyAccessControl.java
@@ -422,6 +422,12 @@ public class LegacyAccessControl
     }
 
     @Override
+    public Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
+    {
+        return Optional.empty();
+    }
+
+    @Override
     public List<ViewExpression> getColumnMasks(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
     {
         return ImmutableList.of();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
@@ -632,6 +632,12 @@ public class SqlStandardAccessControl
     }
 
     @Override
+    public Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
+    {
+        return Optional.empty();
+    }
+
+    @Override
     public List<ViewExpression> getColumnMasks(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
     {
         return ImmutableList.of();

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -353,7 +353,7 @@ public class TestEventListenerBasic
 
         ColumnInfo column = table.getColumns().get(0);
         assertEquals(column.getColumn(), "linenumber");
-        assertTrue(column.getMasks().isEmpty());
+        assertTrue(column.getMask().isEmpty());
 
         List<RoutineInfo> routines = event.getMetadata().getRoutines();
         assertEquals(tables.size(), 1);
@@ -385,7 +385,7 @@ public class TestEventListenerBasic
 
         ColumnInfo column = table.getColumns().get(0);
         assertThat(column.getColumn()).isEqualTo("nationkey");
-        assertThat(column.getMasks()).isEmpty();
+        assertThat(column.getMask()).isEmpty();
 
         table = tables.get(1);
         assertThat(table.getCatalog()).isEqualTo("mock");
@@ -398,7 +398,7 @@ public class TestEventListenerBasic
 
         column = table.getColumns().get(0);
         assertThat(column.getColumn()).isEqualTo("test_column");
-        assertThat(column.getMasks()).isEmpty();
+        assertThat(column.getMask()).isEmpty();
     }
 
     @Test
@@ -422,7 +422,7 @@ public class TestEventListenerBasic
 
         ColumnInfo column = table.getColumns().get(0);
         assertThat(column.getColumn()).isEqualTo("nationkey");
-        assertThat(column.getMasks()).isEmpty();
+        assertThat(column.getMask()).isEmpty();
 
         table = tables.get(1);
         assertThat(table.getCatalog()).isEqualTo("mock");
@@ -435,7 +435,7 @@ public class TestEventListenerBasic
 
         column = table.getColumns().get(0);
         assertThat(column.getColumn()).isEqualTo("test_column");
-        assertThat(column.getMasks()).isEmpty();
+        assertThat(column.getMask()).isEmpty();
     }
 
     @Test
@@ -522,7 +522,7 @@ public class TestEventListenerBasic
 
         ColumnInfo column = table.getColumns().get(0);
         assertThat(column.getColumn()).isEqualTo("name");
-        assertThat(column.getMasks()).isEmpty();
+        assertThat(column.getMask()).isEmpty();
 
         table = tables.get(1);
         assertThat(table.getCatalog()).isEqualTo("mock");
@@ -535,7 +535,7 @@ public class TestEventListenerBasic
 
         column = table.getColumns().get(0);
         assertThat(column.getColumn()).isEqualTo("test_varchar");
-        assertThat(column.getMasks()).isEmpty();
+        assertThat(column.getMask()).isEmpty();
     }
 
     @Test
@@ -570,7 +570,7 @@ public class TestEventListenerBasic
 
         ColumnInfo column = table.getColumns().get(0);
         assertThat(column.getColumn()).isEqualTo("orderkey");
-        assertThat(column.getMasks()).isEmpty();
+        assertThat(column.getMask()).isEmpty();
 
         table = tables.get(1);
         assertThat(table.getCatalog()).isEqualTo("mock");
@@ -583,11 +583,11 @@ public class TestEventListenerBasic
 
         column = table.getColumns().get(0);
         assertThat(column.getColumn()).isEqualTo("test_varchar");
-        assertThat(column.getMasks()).hasSize(1);
+        assertThat(column.getMask()).isPresent();
 
         column = table.getColumns().get(1);
         assertThat(column.getColumn()).isEqualTo("test_bigint");
-        assertThat(column.getMasks()).isEmpty();
+        assertThat(column.getMask()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Fix aliasing of fields in mask expressions

This causes two problems:
* Masks can inadvertently refer to columns that appear earlier
      in the list of columns as the projection is planned. This
      causes the mask expression to see the masked value of other columns
      instead of the underlying value
* A possible bug in other optimizers causes mask expressions to be
      lost when the result of a such an expression is of type ROW
      and there's a dereference of a field downstream


Fixes #15659

Relates to #14420

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Section
* TBD
```
