### PR TITLE
Support reading float as double in ORC and Parquet for Iceberg type change

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/FloatColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/FloatColumnReader.java
@@ -17,6 +17,8 @@ import io.trino.parquet.PrimitiveField;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
 
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.RealType.REAL;
 import static java.lang.Float.floatToRawIntBits;
 
 public class FloatColumnReader
@@ -30,6 +32,14 @@ public class FloatColumnReader
     @Override
     protected void readValue(BlockBuilder blockBuilder, Type type)
     {
-        type.writeLong(blockBuilder, floatToRawIntBits(valuesReader.readFloat()));
+        if (type == REAL) {
+            type.writeLong(blockBuilder, floatToRawIntBits(valuesReader.readFloat()));
+        }
+        else if (type == DOUBLE) {
+            type.writeDouble(blockBuilder, valuesReader.readFloat());
+        }
+        else {
+            throw new VerifyError("Unsupported type " + type);
+        }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fixes #15650

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Fix failure when reading columns whose type was changed from `float` to `double` by other query engines. ({issue}`15650`)
```
