### PR TITLE
Disallow legacy UPDATE/DELETE on Hive ACID tables

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
@@ -52,6 +52,7 @@ import java.util.stream.Stream;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.hive.HiveMetadata.LEGACY_ACID_UPDATE_DELETE_MESSAGE;
 import static io.trino.plugin.hive.HiveMetadata.MODIFYING_NON_TRANSACTIONAL_TABLE_MESSAGE;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
@@ -75,6 +76,7 @@ import static java.util.Locale.ENGLISH;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toUnmodifiableList;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -2016,6 +2018,121 @@ public class TestHiveTransactionalTable
             assertEquals(sizeOnHiveWithWhere, sizeOnTrinoWithWhere);
             assertEquals(sizeOnTrinoWithWhere, sizeOnTrinoWithoutWhere);
             assertTrue(sizeBeforeDeletion > sizeOnTrinoWithoutWhere);
+        });
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL)
+    public void testLegacyDeleteDisallowedOnAcidTables()
+    {
+        if (getHiveVersionMajor() < 3) {
+            throw new SkipException("Hive transactional tables are supported with Hive version 3 or above");
+        }
+        onTrino().executeQuery("SET SESSION legacy_update_delete_implementation = true");
+        withTemporaryTable("legacy_delete_disallow", true, true, NONE, table -> {
+            onTrino().executeQuery("CREATE TABLE %s WITH (transactional=true, partitioned_by=ARRAY['regionkey']) AS SELECT nationkey, regionkey FROM tpch.tiny.nation".formatted(table));
+            assertThat(onTrino().executeQuery("SELECT COUNT(1) FROM " + table)).containsOnly(row(25));
+
+            // metadata delete
+            assertThatThrownBy(() -> onTrino().executeQuery("DELETE FROM %s WHERE regionkey = 1".formatted(table)))
+                    .hasStackTraceContaining(LEGACY_ACID_UPDATE_DELETE_MESSAGE.formatted("DELETE"));
+
+            // row-by-row delete
+            assertThatThrownBy(() -> onTrino().executeQuery("DELETE FROM %s WHERE nationkey %% 2 = 0".formatted(table)))
+                    .hasStackTraceContaining(LEGACY_ACID_UPDATE_DELETE_MESSAGE.formatted("DELETE"));
+        });
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL)
+    public void testLegacyUpdateDisallowedOnAcidTables()
+    {
+        if (getHiveVersionMajor() < 3) {
+            throw new SkipException("Hive transactional tables are supported with Hive version 3 or above");
+        }
+        onTrino().executeQuery("SET SESSION legacy_update_delete_implementation = true");
+        withTemporaryTable("legacy_update_disallow", true, true, NONE, table -> {
+            onTrino().executeQuery("CREATE TABLE %s WITH (transactional=true, partitioned_by=ARRAY['regionkey']) AS SELECT nationkey, comment, regionkey FROM tpch.tiny.nation".formatted(table));
+            assertThat(onTrino().executeQuery("SELECT COUNT(1) FROM " + table)).containsOnly(row(25));
+
+            // entire partition update
+            assertThatThrownBy(() -> onTrino().executeQuery("UPDATE %s SET comment = 'updated' WHERE regionkey = 1".formatted(table)))
+                    .hasStackTraceContaining(LEGACY_ACID_UPDATE_DELETE_MESSAGE.formatted("UPDATE"));
+
+            // row-by-row update
+            assertThatThrownBy(() -> onTrino().executeQuery("UPDATE %s SET comment = 'updated' WHERE nationkey %% 2 = 0".formatted(table)))
+                    .hasStackTraceContaining(LEGACY_ACID_UPDATE_DELETE_MESSAGE.formatted("UPDATE"));
+        });
+    }
+
+    /**
+     * Test for https://github.com/trinodb/trino/issues/12731
+     */
+    @Test(groups = HIVE_TRANSACTIONAL)
+    public void testLargePartitionedDelete()
+    {
+        if (getHiveVersionMajor() < 3) {
+            throw new SkipException("Hive transactional tables are supported with Hive version 3 or above");
+        }
+        withTemporaryTable("large_delete_" + "stage1", false, false, NONE, tableStage1 -> {
+            onTrino().executeQuery("CREATE TABLE %s AS SELECT a, b, 20220101 AS d FROM UNNEST(SEQUENCE(1, 9001), SEQUENCE(1, 9001)) AS t(a, b)".formatted(tableStage1));
+            withTemporaryTable("large_delete_" + "stage2", false, false, NONE, tableStage2 -> {
+                onTrino().executeQuery("CREATE TABLE %s AS SELECT a, b, 20220101 AS d FROM UNNEST(SEQUENCE(1, 100), SEQUENCE(1, 100)) AS t(a, b)".formatted(tableStage2));
+                withTemporaryTable("large_delete_" + "new", true, true, NONE, tableNew -> {
+                    onTrino().executeQuery("""
+                            CREATE TABLE %s WITH (transactional=true, partitioned_by=ARRAY['d'])
+                            AS (SELECT stage1.a as a, stage1.b as b, stage1.d AS d FROM %s stage1, %s stage2 WHERE stage1.d = stage2.d)
+                            """.formatted(tableNew, tableStage1, tableStage2));
+                    verifySelectForTrinoAndHive("SELECT count(1) FROM %s WHERE d IS NOT NULL".formatted(tableNew), row(900100));
+                    onTrino().executeQuery("DELETE FROM %s WHERE d = 20220101".formatted(tableNew));
+
+                    // Verify no rows
+                    verifySelectForTrinoAndHive("SELECT count(1) FROM %s WHERE d IS NOT NULL".formatted(tableNew), row(0));
+
+                    onTrino().executeQuery("INSERT INTO %s SELECT stage1.a AS a, stage1.b AS b, stage1.d AS d FROM %s stage1, %s stage2 WHERE stage1.d = stage2.d".formatted(tableNew, tableStage1, tableStage2));
+
+                    verifySelectForTrinoAndHive("SELECT count(1) FROM %s WHERE d IS NOT NULL".formatted(tableNew), row(900100));
+                    onTrino().executeQuery("DELETE FROM %s WHERE d = 20220101".formatted(tableNew));
+
+                    // Verify no rows
+                    verifySelectForTrinoAndHive("SELECT count(1) FROM %s WHERE d IS NOT NULL".formatted(tableNew), row(0));
+                });
+            });
+        });
+    }
+
+    /**
+     * Test for https://github.com/trinodb/trino/issues/12731
+     */
+    @Test(groups = HIVE_TRANSACTIONAL)
+    public void testLargePartitionedUpdate()
+    {
+        if (getHiveVersionMajor() < 3) {
+            throw new SkipException("Hive transactional tables are supported with Hive version 3 or above");
+        }
+        withTemporaryTable("large_update_" + "stage1", false, false, NONE, tableStage1 -> {
+            onTrino().executeQuery("CREATE TABLE %s AS SELECT a, b, 20220101 AS d FROM UNNEST(SEQUENCE(1, 9001), SEQUENCE(1, 9001)) AS t(a, b)".formatted(tableStage1));
+            withTemporaryTable("large_update_" + "stage2", false, false, NONE, tableStage2 -> {
+                onTrino().executeQuery("CREATE TABLE %s AS SELECT a, b, 20220101 AS d FROM UNNEST(SEQUENCE(1, 100), SEQUENCE(1, 100)) AS t(a, b)".formatted(tableStage2));
+                withTemporaryTable("large_update_" + "new", true, true, NONE, tableNew -> {
+                    onTrino().executeQuery("""
+                            CREATE TABLE %s WITH (transactional=true, partitioned_by=ARRAY['d'])
+                            AS (SELECT stage1.a as a, stage1.b as b, stage1.d AS d FROM %s stage1, %s stage2 WHERE stage1.d = stage2.d)
+                            """.formatted(tableNew, tableStage1, tableStage2));
+                    verifySelectForTrinoAndHive("SELECT count(1) FROM %s WHERE d IS NOT NULL".formatted(tableNew), row(900100));
+                    onTrino().executeQuery("UPDATE %s SET a = 0 WHERE d = 20220101".formatted(tableNew));
+
+                    // Verify all rows updated
+                    verifySelectForTrinoAndHive("SELECT count(1) FROM %s WHERE a = 0".formatted(tableNew), row(900100));
+                    verifySelectForTrinoAndHive("SELECT count(1) FROM %s WHERE d IS NOT NULL".formatted(tableNew), row(900100));
+
+                    onTrino().executeQuery("INSERT INTO %s SELECT stage1.a AS a, stage1.b AS b, stage1.d AS d FROM %s stage1, %s stage2 WHERE stage1.d = stage2.d".formatted(tableNew, tableStage1, tableStage2));
+
+                    verifySelectForTrinoAndHive("SELECT count(1) FROM %s WHERE d IS NOT NULL".formatted(tableNew), row(1800200));
+                    onTrino().executeQuery("UPDATE %s SET a = 0 WHERE d = 20220101".formatted(tableNew));
+
+                    // Verify all matching rows updated
+                    verifySelectForTrinoAndHive("SELECT count(1) FROM %s WHERE a = 0".formatted(tableNew), row(1800200));
+                });
+            });
         });
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

UDPATE/DELETE on Hive ACID transactional tables when using the non-MERGE
implementation can lead to correctness issues as shown by the tests
added to TestHiveTransactionalTable.

To prevent these issues we now disallow UPDATE/DELETE on Hive ACID
tables when using the legacy implementation (by setting
`deprecated.legacy-update-delete-implementation` to true).

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This adds test coverage and fix for https://github.com/trinodb/trino/issues/12731

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

```markdown
# Hive

* Disallow UPDATE/DELETE on Hive ACID transactional tables to prevent correctness
  issues when `deprecated.legacy-update-delete-implementation` is set to true.
```