### PR TITLE
Add metric to measure requests duration of HttpPageBufferClient

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/TestDirectExchangeClient.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestDirectExchangeClient.java
@@ -173,6 +173,7 @@ public class TestDirectExchangeClient
 
         // client should have sent only 3 requests: one to get all pages, one to acknowledge and one to get the done signal
         assertStatus(status.getPageBufferClientStatuses().get(0), location, "closed", 3, 3, 3, "not scheduled");
+        assertEquals(status.getRequestDuration().getDigest().getCount(), 2.0);
 
         exchangeClient.close();
 


### PR DESCRIPTION
It adds the metric that measures distribution of requests duration sent by `HttpPageBufferClient`. It was found that it is very useful during investigation. Example of metric:

                 "requestDuration" : {
                    "@class" : "io.trino.plugin.base.metrics.TDigestHistogram",
                    "digest" : "AAAAAAAAAPA/AAAAAABQn0AAAAAAAABZQAAAAABgBSBBRAAAAAAAAAAAAPA/AAAAAAAA8D8AAAAAAADwPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADwPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADwPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADwPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADwPw8kWmFzIPE/AAAAAAAAAEAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAEAAAAAAAAAAQJOJjp9HYwBAflSXmLVQBkAAAAAAAAAIQAAAAAAAAAhAQRqkQRqkCUCV6nxySRMQQHwhOSXlhhNAaXLKm4AVGUCMA9mskrIhQLUSoGvY6ihA7IqcjXMJLkAKcUXV8qYzQBCGrIvLHT1ARWDCAj0zRkCxNfFQVk9RQFqY6MDxaVhAnhyE1M6oYECKjrKuk7ZoQPQShZFIWXpACO0ltJeskEAjFd6gGOKTQHbjwWniV5ZA7fWUUSR9mEDr5MHDOO2ZQPHw8PDwXJtADgJufTZ0nECqBaEA2WGdQE7FELLxDp5AanKzCiV1nkBt27Zt27SeQAAAAABA6p5A/////38Rn0AAAAAAgCOfQOqiiy66MJ9AAQAAAAA7n0DTJ33SJz2fQAAAAAAAQJ9AAAAAAIBAn0AAAAAAwESfQAAAAAAASJ9At23btm1Ln0AAAAAAAFCfQAAAAAAAUJ9AAAAAAABQn0AAAAAAAFCfQAAAAAAAUJ9AAAAAAABQn0AAAAAAAADwPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADwPwAAAAAAAPA/AAAAAAAAAEAAAAAAAAAIQAAAAAAAABBAAAAAAAAAFEAAAAAAAAAgQAAAAAAAACxAAAAAAAAANkAAAAAAAIBBQAAAAAAAADpAAAAAAAAAQUAAAAAAAMBRQAAAAAAAwFhAAAAAAAAgZkAAAAAAAOBuQAAAAAAAEHJAAAAAAACgakAAAAAAAJCGQAAAAAAAYIlAAAAAAAAMkUAAAAAAAFCeQAAAAAAASqlAAAAAAADWsUAAAAAAAEqzQAAAAAAAuMNAAAAAAABYzUAAAAAAAMbOQAAAAABA1t1AAAAAACAh40AAAAAAQPjjQAAAAAAAGOpAAAAAAICK70AAAAAAAITrQAAAAACANOpAAAAAAABv40AAAAAAAB3aQAAAAADAN9FAAAAAAAAZzEAAAAAAABDDQAAAAAAAWbRAAAAAAAAasEAAAAAAAEClQAAAAAAAIJ9AAAAAAABwmUAAAAAAADiQQAAAAAAAcINAAAAAAAAAdUAAAAAAAABwQAAAAAAAAGhAAAAAAAAAYEAAAAAAAABWQAAAAAAAAFBAAAAAAACARkAAAAAAAAA+QAAAAAAAADhAAAAAAAAAMEAAAAAAAAAiQAAAAAAAABxAAAAAAAAAEEAAAAAAAAAIQAAAAAAAAABAAAAAAAAAAEAAAAAAAADwPwAAAAAAAPA/",
                    "min" : 1.0,
                    "max" : 2004.0,
                    "p25" : 24.773767527925415,
                    "p50" : 72.38128466405055,
                    "p75" : 164.2206421966297,
                    "p90" : 1038.1338917985497,
                    "p95" : 1393.0669669598371,
                    "p99" : 1829.004132388759,
                    "total" : 524976,
                    "p01" : 3.0317586167615143,
                    "p05" : 6.812988317960782,
                    "p10" : 12.562557107902899
                  }
