### PR TITLE
Allow hyphen as a valid value for sanitization checks

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/logging/FormatBasedRemoteQueryModifier.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/logging/FormatBasedRemoteQueryModifier.java
@@ -81,7 +81,7 @@ public class FormatBasedRemoteQueryModifier
     private static class SanitizedValuesProvider
             implements Function<ConnectorSession, String>
     {
-        private static final Predicate<String> VALIDATION_MATCHER = Pattern.compile("^[\\w_]*$").asMatchPredicate();
+        private static final Predicate<String> VALIDATION_MATCHER = Pattern.compile("^[\\w_-]*$").asMatchPredicate();
         private final Function<ConnectorSession, String> valueProvider;
         private final String name;
 
@@ -98,7 +98,7 @@ public class FormatBasedRemoteQueryModifier
             if (VALIDATION_MATCHER.test(value)) {
                 return value;
             }
-            throw new TrinoException(JDBC_NON_TRANSIENT_ERROR, format("Passed value %s as %s does not meet security criteria. It can contain only letters, digits and underscores", value, name));
+            throw new TrinoException(JDBC_NON_TRANSIENT_ERROR, format("Passed value %s as %s does not meet security criteria. It can contain only letters, digits, underscores and hyphens", value, name));
         }
     }
 }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/logging/TestFormatBasedRemoteQueryModifier.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/logging/TestFormatBasedRemoteQueryModifier.java
@@ -16,6 +16,7 @@ package io.trino.plugin.jdbc.logging;
 import io.trino.spi.TrinoException;
 import io.trino.spi.security.ConnectorIdentity;
 import io.trino.testing.TestingConnectorSession;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -79,7 +80,7 @@ public class TestFormatBasedRemoteQueryModifier
 
         assertThatThrownBy(() -> modifier.apply(connectorSession, "SELECT * from USERS"))
                 .isInstanceOf(TrinoException.class)
-                .hasMessage("Passed value */; DROP TABLE TABLE_A; /* as $TRACE_TOKEN does not meet security criteria. It can contain only letters, digits and underscores");
+                .hasMessage("Passed value */; DROP TABLE TABLE_A; /* as $TRACE_TOKEN does not meet security criteria. It can contain only letters, digits, underscores and hyphens");
     }
 
     @Test
@@ -95,15 +96,16 @@ public class TestFormatBasedRemoteQueryModifier
 
         assertThatThrownBy(() -> modifier.apply(connectorSession, "SELECT * from USERS"))
                 .isInstanceOf(TrinoException.class)
-                .hasMessage("Passed value */; DROP TABLE TABLE_A; /* as $SOURCE does not meet security criteria. It can contain only letters, digits and underscores");
+                .hasMessage("Passed value */; DROP TABLE TABLE_A; /* as $SOURCE does not meet security criteria. It can contain only letters, digits, underscores and hyphens");
     }
 
-    @Test
-    public void testFormatWithEmptyValues()
+    @Test(dataProvider = "validValues")
+    public void testFormatWithValidValues(String value)
     {
         TestingConnectorSession connectorSession = TestingConnectorSession.builder()
                 .setIdentity(ConnectorIdentity.ofUser("Alice"))
-                .setSource("")
+                .setSource(value)
+                .setTraceToken(value)
                 .build();
 
         FormatBasedRemoteQueryModifier modifier = createRemoteQueryModifier("source=$SOURCE ttoken=$TRACE_TOKEN");
@@ -111,7 +113,24 @@ public class TestFormatBasedRemoteQueryModifier
         String modifiedQuery = modifier.apply(connectorSession, "SELECT * FROM USERS");
 
         assertThat(modifiedQuery)
-                .isEqualTo("SELECT * FROM USERS /*source= ttoken=*/");
+                .isEqualTo("SELECT * FROM USERS /*source=%1$s ttoken=%1$s*/".formatted(value));
+    }
+
+    @DataProvider
+    public Object[][] validValues()
+    {
+        return new Object[][] {
+                {"trino"},
+                {"123"},
+                {"1t2r3i4n0"},
+                {"trino-cli"},
+                {"trino_cli"},
+                {"trino-cli_123"},
+                {"123_trino-cli"},
+                {"123-trino_cli"},
+                {"-trino-cli"},
+                {"_trino_cli"}
+        };
     }
 
     private static FormatBasedRemoteQueryModifier createRemoteQueryModifier(String commentFormat)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Previously only letters, digits and underscores are considered as a valid values for source and trace token to be tracked in query comment for jdbc based connectors. This PR adds hyphen to the list of valid values.  

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
https://github.com/trinodb/trino/pull/14500



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
```
