### PR TITLE
Apply sanitization checks only for entity specified in comment-format

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/logging/FormatBasedRemoteQueryModifier.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/logging/FormatBasedRemoteQueryModifier.java
@@ -43,7 +43,9 @@ public class FormatBasedRemoteQueryModifier
     {
         String message = commentFormat;
         for (PredefinedValue predefinedValue : PredefinedValue.values()) {
-            message = message.replaceAll(predefinedValue.getMatchCase(), predefinedValue.value(session));
+            if (message.contains(predefinedValue.getPredefinedValueCode())) {
+                message = message.replaceAll(predefinedValue.getMatchCase(), predefinedValue.value(session));
+            }
         }
         return query + " /*" + message + "*/";
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Previously the sanitization checks were applied for source and trace token even if they are not specified in the `query.comment-format` - now we are applying them if configured.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
https://github.com/trinodb/trino/pull/15691
https://github.com/trinodb/trino/pull/14500

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
