### PR TITLE
Fix failure with dynamic pattern in LIKE

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -1060,7 +1060,8 @@ public final class DomainTranslator
 
             Symbol symbol = Symbol.from(value);
 
-            if (!(typeAnalyzer.getType(session, types, patternArgument) instanceof LikePatternType)) {
+            if (!(typeAnalyzer.getType(session, types, patternArgument) instanceof LikePatternType) ||
+                    !SymbolsExtractor.extractAll(patternArgument).isEmpty()) {
                 // dynamic pattern or escape
                 return Optional.empty();
             }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestLikeFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestLikeFunctions.java
@@ -329,4 +329,29 @@ public class TestLikeFunctions
         assertEquals(unescapeLiteralLikePattern(utf8Slice("a##bc#_"), Optional.of(utf8Slice("#"))), utf8Slice("a#bc_"));
         assertEquals(unescapeLiteralLikePattern(utf8Slice("a###_bc"), Optional.of(utf8Slice("#"))), utf8Slice("a#_bc"));
     }
+
+    @Test
+    public void testLikeWithDynamicPattern()
+    {
+        assertThat(assertions.query("""
+                SELECT value FROM (
+                    VALUES
+                        ('a', 'a'),
+                        ('b', 'a'),
+                        ('c', '%')) t(value, pattern)
+                WHERE value LIKE pattern
+                """))
+                .matches("VALUES 'a', 'c'");
+
+        assertThat(assertions.query("""
+                SELECT value FROM (
+                    VALUES
+                        ('a%b', 'aX%b', 'X'),
+                        ('a0b', 'aX%b', 'X'),
+                        ('b_', 'aY_', 'Y'),
+                        ('c%', 'cZ%', 'Z')) t(value, pattern, esc)
+                WHERE value LIKE pattern ESCAPE esc
+                """))
+                .matches("VALUES 'a%b', 'c%'");
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/15629

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix failure when `WHERE` or `JOIN` clauses contain `LIKE` expression with non-constant pattern or escape. ({issue}`15629`)
```
