### PR TITLE
Remove redundant variable in docs conf.py

### DIFF
--- a/docs/src/main/sphinx/conf.py
+++ b/docs/src/main/sphinx/conf.py
@@ -85,7 +85,6 @@ master_doc = 'index'
 project = u'Trino'
 
 version = get_version()
-release = version
 
 exclude_patterns = ['_build']
 
@@ -95,7 +94,7 @@ default_role = 'backquote'
 
 rst_epilog = """
 .. |trino_server_release| replace:: ``trino-server-{release}``
-""".replace('{release}', release)
+""".replace('{release}', version)
 
 # Any replace that is inside of a code block should be added here
 # https://stackoverflow.com/questions/8821511/substitutions-inside-sphinx-code-blocks-arent-replaced
@@ -111,7 +110,7 @@ html_theme = 'sphinx_material'
 
 html_static_path = ['static']
 
-html_title = '%s %s Documentation' % (project, release)
+html_title = '%s %s Documentation' % (project, version)
 
 html_logo = 'images/trino.svg'
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Don't think we need two variables storing the same value. 😛 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Going to be trying to add a banner to alert users that they're on a past version of the docs, bumped into this and figured it was a light lift to fix first.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: