### PR TITLE
Fix reading parquet column indexes without nulls count

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
@@ -67,7 +67,6 @@ import static io.trino.parquet.ParquetTimestampUtils.decodeInt96Timestamp;
 import static io.trino.parquet.ParquetTypeUtils.getShortDecimalValue;
 import static io.trino.parquet.predicate.PredicateUtils.isStatisticsOverflow;
 import static io.trino.plugin.base.type.TrinoTimestampEncoderFactory.createTimestampEncoder;
-import static io.trino.spi.predicate.TupleDomain.extractDiscreteValues;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
@@ -501,7 +501,8 @@ public class TupleDomainParquetPredicate
 
         List<ByteBuffer> maxValues = columnIndex.getMaxValues();
         List<ByteBuffer> minValues = columnIndex.getMinValues();
-        List<Long> nullCounts = columnIndex.getNullCounts();
+        // Null counts is optional in the format, see org.apache.parquet.internal.column.columnindex.ColumnIndexBuilder for reference
+        Optional<List<Long>> nullCounts = Optional.ofNullable(columnIndex.getNullCounts());
         List<Boolean> nullPages = columnIndex.getNullPages();
 
         String columnName = descriptor.getPrimitiveType().getName();
@@ -512,13 +513,15 @@ public class TupleDomainParquetPredicate
             return Domain.all(type);
         }
 
-        long totalNullCount = nullCounts.stream()
-                .mapToLong(value -> value)
-                .sum();
-        boolean hasNullValue = totalNullCount > 0;
-
-        if (hasNullValue && totalNullCount == columnValuesCount) {
-            return Domain.onlyNull(type);
+        boolean hasNullValue = true;
+        if (nullCounts.isPresent()) {
+            long totalNullCount = nullCounts.orElseThrow().stream()
+                    .mapToLong(value -> value)
+                    .sum();
+            if (totalNullCount == columnValuesCount) {
+                return Domain.onlyNull(type);
+            }
+            hasNullValue = totalNullCount > 0;
         }
 
         try {
@@ -603,16 +606,17 @@ public class TupleDomainParquetPredicate
     private static boolean isCorruptedColumnIndex(
             List<ByteBuffer> minValues,
             List<ByteBuffer> maxValues,
-            List<Long> nullCounts,
+            Optional<List<Long>> nullCounts,
             List<Boolean> nullPages)
     {
-        if (maxValues == null || minValues == null || nullCounts == null || nullPages == null) {
+        if (maxValues == null || minValues == null || nullPages == null) {
             return true;
         }
 
-        return maxValues.size() != minValues.size()
-                || maxValues.size() != nullPages.size()
-                || maxValues.size() != nullCounts.size();
+        int pageCount = nullPages.size();
+        return (nullCounts.isPresent() && nullCounts.get().size() != pageCount)
+                || minValues.size() != pageCount
+                || maxValues.size() != pageCount;
     }
 
     public static long asLong(Object value)

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
@@ -712,6 +712,27 @@ public class TestTupleDomainParquetPredicate
                         true));
     }
 
+    @Test
+    public void testColumnIndexWithNoNullsCount()
+            throws Exception
+    {
+        ColumnIndex columnIndex = ColumnIndexBuilder.build(
+                Types.required(INT64).named("test_int64"),
+                BoundaryOrder.UNORDERED,
+                asList(false, false, false),
+                null,
+                toByteBufferList(2L, 4L, 9L),
+                toByteBufferList(3L, 15L, 10L));
+        ColumnDescriptor column = new ColumnDescriptor(new String[] {"path"}, Types.optional(INT64).named("Test column"), 0, 0);
+        assertThat(getDomain(BIGINT, 200, columnIndex, new ParquetDataSourceId("test"), column, UTC))
+                .isEqualTo(Domain.create(
+                        ValueSet.ofRanges(
+                                range(BIGINT, 2L, true, 3L, true),
+                                range(BIGINT, 4L, true, 15L, true),
+                                range(BIGINT, 9L, true, 10L, true)),
+                        true));
+    }
+
     private ColumnDescriptor createColumnDescriptor(PrimitiveTypeName typeName, String columnName)
     {
         return new ColumnDescriptor(new String[]{}, new PrimitiveType(REQUIRED, typeName, columnName), 0, 0);


### PR DESCRIPTION
## Description

Nulls count may be absent for the column index in the file.
This case is now handled instead of failing the query.

## Additional context and related issues
E.g. failure
```
io.trino.spi.TrinoException: Corrupted statistics for column "name" in Parquet file "data.parquet". Corrupted column index: [Boudary order: UNORDERED
                      null count  min                                       max                                     
page-0                    <none>                                                                                    
page-1                    <none>  @colors/colors                            zlib-devel                              
page-2                    <none>  iconv-lite                                range-parser                            
page-3                    <none>  adduser                                   zlib1g                                  
]
	at io.trino.plugin.hive.parquet.ParquetPageSourceFactory.createPageSource(ParquetPageSourceFactory.java:278)
	at io.trino.plugin.hive.parquet.ParquetPageSourceFactory.createPageSource(ParquetPageSourceFactory.java:164)
```
It's a regression from changes in release 361
https://github.com/trinodb/trino/pull/7349/files#diff-ad2cef297ca9a945f4efa17ad1e9b36ec97c06578a87eb3b3afaf66eb89c4f16R438

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Hudi, Iceberg, Delta
* Fix query failure due to missing nulls counts in parquet column indexes. ({issue}`15706`)
```
