### PR TITLE
Improve error message when trying to drop partitioned columns in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -1187,6 +1187,17 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testDropPartitionColumn()
+    {
+        String tableName = "test_drop_partition_column_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (id INTEGER, name VARCHAR, age INTEGER) WITH (partitioning = ARRAY['id', 'truncate(name, 5)', 'void(age)'])");
+        assertQueryFails("ALTER TABLE " + tableName + " DROP COLUMN id", "Cannot drop partition field: id");
+        assertQueryFails("ALTER TABLE " + tableName + " DROP COLUMN name", "Cannot drop partition field: name");
+        assertUpdate("ALTER TABLE " + tableName + " DROP COLUMN age");
+        dropTable(tableName);
+    }
+
+    @Test
     public void testShowStatsAfterAddColumn()
     {
         assertUpdate("CREATE TABLE test_show_stats_after_add_column (col0 INTEGER, col1 INTEGER, col2 INTEGER)");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Improve the error message while dropping the partitioned column **or** support dropping the partitioned column.

```sql
CREATE TABLE test (id INTEGER, name VARCHAR) WITH (partitioning = ARRAY['id', 'truncate(name, 5)']);

ALTER TABLE test DROP COLUMN id;
-- Failed to drop column: Cannot find source column for partition field: 1000: id: identity(1

ALTER TABLE test DROP COLUMN name;
-- Failed to drop column: Cannot find source column for partition field: 1001: name_trunc: truncate[5](2)
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
