### PR TITLE
Retry maven when building individual commits

### DIFF
--- a/.github/actions/compile-commit/action.yml
+++ b/.github/actions/compile-commit/action.yml
@@ -17,12 +17,12 @@ runs:
         # It's important that these values are NOT passed as parameters, because then their values would always be taken from PR HEAD
         # -------
         # allow overriding Maven command
-        export MAVEN="./mvnw"
+        MAVEN="./mvnw"
         # maven.wagon.rto is in millis, defaults to 30m
         export MAVEN_OPTS="-Xmx512M -XX:+ExitOnOutOfMemoryError -Dmaven.wagon.rto=60000"
-        export MAVEN_INSTALL_OPTS="-Xmx3G -XX:+ExitOnOutOfMemoryError -Dmaven.wagon.rto=60000"
-        export MAVEN_COMPILE_COMMITS="-B --strict-checksums --quiet -T C1 -DskipTests -Dmaven.source.skip=true -Dair.check.skip-all=true -Dmaven.javadoc.skip=true --no-snapshot-updates --no-transfer-progress -pl !:trino-server-rpm"
-        export MAVEN_GIB="-P gib -Dgib.referenceBranch=refs/remotes/origin/${{ inputs.base_ref }}"
+        MAVEN_INSTALL_OPTS="-Xmx3G -XX:+ExitOnOutOfMemoryError -Dmaven.wagon.rto=60000"
+        MAVEN_COMPILE_COMMITS="-B --strict-checksums --quiet -T C1 -DskipTests -Dmaven.source.skip=true -Dair.check.skip-all=true -Dmaven.javadoc.skip=true --no-snapshot-updates --no-transfer-progress -pl !:trino-server-rpm"
+        MAVEN_GIB="-P gib -Dgib.referenceBranch=refs/remotes/origin/${{ inputs.base_ref }}"
         # -------
         
         # For building with Maven we need MAVEN_OPTS to equal MAVEN_INSTALL_OPTS

--- a/.github/actions/compile-commit/action.yml
+++ b/.github/actions/compile-commit/action.yml
@@ -19,7 +19,6 @@ runs:
         # allow overriding Maven command
         MAVEN="./mvnw"
         # maven.wagon.rto is in millis, defaults to 30m
-        export MAVEN_OPTS="-Xmx512M -XX:+ExitOnOutOfMemoryError -Dmaven.wagon.rto=60000"
         MAVEN_INSTALL_OPTS="-Xmx3G -XX:+ExitOnOutOfMemoryError -Dmaven.wagon.rto=60000"
         MAVEN_COMPILE_COMMITS="-B --strict-checksums --quiet -T C1 -DskipTests -Dmaven.source.skip=true -Dair.check.skip-all=true -Dmaven.javadoc.skip=true --no-snapshot-updates --no-transfer-progress -pl !:trino-server-rpm"
         MAVEN_GIB="-P gib -Dgib.referenceBranch=refs/remotes/origin/${{ inputs.base_ref }}"

--- a/.github/actions/compile-commit/action.yml
+++ b/.github/actions/compile-commit/action.yml
@@ -22,10 +22,12 @@ runs:
         MAVEN_INSTALL_OPTS="-Xmx3G -XX:+ExitOnOutOfMemoryError -Dmaven.wagon.rto=60000"
         MAVEN_COMPILE_COMMITS="-B --strict-checksums --quiet -T C1 -DskipTests -Dmaven.source.skip=true -Dair.check.skip-all=true -Dmaven.javadoc.skip=true --no-snapshot-updates --no-transfer-progress -pl !:trino-server-rpm"
         MAVEN_GIB="-P gib -Dgib.referenceBranch=refs/remotes/origin/${{ inputs.base_ref }}"
+        RETRY: .github/bin/retry
         # -------
 
         # For building with Maven we need MAVEN_OPTS to equal MAVEN_INSTALL_OPTS
         export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
+        $RETRY $MAVEN dependency:go-offline
         $MAVEN package ${MAVEN_COMPILE_COMMITS} ${MAVEN_GIB}
     - name: Clean local Maven repo
       # Avoid creating a cache entry because this job doesn't download all dependencies

--- a/.github/actions/compile-commit/action.yml
+++ b/.github/actions/compile-commit/action.yml
@@ -12,7 +12,7 @@ runs:
       shell: bash
       run: |
         set -x
-        
+
         # The section below should always contain copies of env variables from .github/workflows/ci.yml to maintain both files in sync
         # It's important that these values are NOT passed as parameters, because then their values would always be taken from PR HEAD
         # -------
@@ -24,7 +24,7 @@ runs:
         MAVEN_COMPILE_COMMITS="-B --strict-checksums --quiet -T C1 -DskipTests -Dmaven.source.skip=true -Dair.check.skip-all=true -Dmaven.javadoc.skip=true --no-snapshot-updates --no-transfer-progress -pl !:trino-server-rpm"
         MAVEN_GIB="-P gib -Dgib.referenceBranch=refs/remotes/origin/${{ inputs.base_ref }}"
         # -------
-        
+
         # For building with Maven we need MAVEN_OPTS to equal MAVEN_INSTALL_OPTS
         export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
         $MAVEN package ${MAVEN_COMPILE_COMMITS} ${MAVEN_GIB}


### PR DESCRIPTION
Maven repositories communication (e.g. downloading dependencies from
Maven Central) has been observed to be unreliable and requires retries.