### PR TITLE
Allow specifying exact desired split count in TPC-DS connector

### DIFF
--- a/plugin/trino-tpcds/pom.xml
+++ b/plugin/trino-tpcds/pom.xml
@@ -28,6 +28,16 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
@@ -40,6 +50,21 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
 
         <dependency>

--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsConfig.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsConfig.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.tpcds;
 
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
 
 import javax.validation.constraints.Min;
 
@@ -21,6 +22,7 @@ public class TpcdsConfig
 {
     private int splitsPerNode = Runtime.getRuntime().availableProcessors();
     private boolean withNoSexism;
+    private Integer splitCount;
 
     @Min(1)
     public int getSplitsPerNode()
@@ -44,6 +46,20 @@ public class TpcdsConfig
     public TpcdsConfig setWithNoSexism(boolean withNoSexism)
     {
         this.withNoSexism = withNoSexism;
+        return this;
+    }
+
+    @Min(1)
+    public Integer getSplitCount()
+    {
+        return splitCount;
+    }
+
+    @Config("tpcds.split-count")
+    @ConfigDescription("Number of split to be created. If not specified the number of splits is computed as 'tpcds.splits-per-node * <number of active nodes>'")
+    public TpcdsConfig setSplitCount(Integer splitCount)
+    {
+        this.splitCount = splitCount;
         return this;
     }
 }

--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsConfig.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.tpcds;
+
+import io.airlift.configuration.Config;
+
+import javax.validation.constraints.Min;
+
+public class TpcdsConfig
+{
+    private int splitsPerNode = Runtime.getRuntime().availableProcessors();
+    private boolean withNoSexism;
+
+    @Min(1)
+    public int getSplitsPerNode()
+    {
+        return splitsPerNode;
+    }
+
+    @Config("tpcds.splits-per-node")
+    public TpcdsConfig setSplitsPerNode(int splitsPerNode)
+    {
+        this.splitsPerNode = splitsPerNode;
+        return this;
+    }
+
+    public boolean isWithNoSexism()
+    {
+        return withNoSexism;
+    }
+
+    @Config("tpcds.with-no-sexism")
+    public TpcdsConfig setWithNoSexism(boolean withNoSexism)
+    {
+        this.withNoSexism = withNoSexism;
+        return this;
+    }
+}

--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsConnector.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsConnector.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.tpcds;
+
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorNodePartitioningProvider;
+import io.trino.spi.connector.ConnectorRecordSetProvider;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.transaction.IsolationLevel;
+
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class TpcdsConnector
+        implements Connector
+{
+    private final TpcdsMetadata metadata;
+    private final TpcdsSplitManager splitManager;
+    private final TpcdsRecordSetProvider recordSetProvider;
+    private final TpcdsNodePartitioningProvider nodePartitioningProvider;
+
+    @Inject
+    public TpcdsConnector(
+            TpcdsMetadata metadata,
+            TpcdsSplitManager splitManager,
+            TpcdsRecordSetProvider recordSetProvider,
+            TpcdsNodePartitioningProvider nodePartitioningProvider)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.splitManager = requireNonNull(splitManager, "splitManager is null");
+        this.recordSetProvider = requireNonNull(recordSetProvider, "recordSetProvider is null");
+        this.nodePartitioningProvider = requireNonNull(nodePartitioningProvider, "nodePartitioningProvider is null");
+    }
+
+    @Override
+    public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit)
+    {
+        return TpcdsTransactionHandle.INSTANCE;
+    }
+
+    @Override
+    public ConnectorMetadata getMetadata(ConnectorSession session, ConnectorTransactionHandle transactionHandle)
+    {
+        return metadata;
+    }
+
+    @Override
+    public ConnectorSplitManager getSplitManager()
+    {
+        return splitManager;
+    }
+
+    @Override
+    public ConnectorRecordSetProvider getRecordSetProvider()
+    {
+        return recordSetProvider;
+    }
+
+    @Override
+    public ConnectorNodePartitioningProvider getNodePartitioningProvider()
+    {
+        return nodePartitioningProvider;
+    }
+}

--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsConnector.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsConnector.java
@@ -20,9 +20,12 @@ import io.trino.spi.connector.ConnectorRecordSetProvider;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.transaction.IsolationLevel;
 
 import javax.inject.Inject;
+
+import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
@@ -33,18 +36,21 @@ public class TpcdsConnector
     private final TpcdsSplitManager splitManager;
     private final TpcdsRecordSetProvider recordSetProvider;
     private final TpcdsNodePartitioningProvider nodePartitioningProvider;
+    private final TpcdsSessionProperties sessionProperties;
 
     @Inject
     public TpcdsConnector(
             TpcdsMetadata metadata,
             TpcdsSplitManager splitManager,
             TpcdsRecordSetProvider recordSetProvider,
-            TpcdsNodePartitioningProvider nodePartitioningProvider)
+            TpcdsNodePartitioningProvider nodePartitioningProvider,
+            TpcdsSessionProperties sessionProperties)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.recordSetProvider = requireNonNull(recordSetProvider, "recordSetProvider is null");
         this.nodePartitioningProvider = requireNonNull(nodePartitioningProvider, "nodePartitioningProvider is null");
+        this.sessionProperties = requireNonNull(sessionProperties, "sessionProperties is null");
     }
 
     @Override
@@ -75,5 +81,11 @@ public class TpcdsConnector
     public ConnectorNodePartitioningProvider getNodePartitioningProvider()
     {
         return nodePartitioningProvider;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties.getSessionProperties();
     }
 }

--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsConnectorFactory.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsConnectorFactory.java
@@ -13,42 +13,19 @@
  */
 package io.trino.plugin.tpcds;
 
-import io.trino.spi.NodeManager;
+import com.google.inject.Injector;
+import io.airlift.bootstrap.Bootstrap;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
-import io.trino.spi.connector.ConnectorMetadata;
-import io.trino.spi.connector.ConnectorNodePartitioningProvider;
-import io.trino.spi.connector.ConnectorRecordSetProvider;
-import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.connector.ConnectorSplitManager;
-import io.trino.spi.connector.ConnectorTransactionHandle;
-import io.trino.spi.transaction.IsolationLevel;
 
 import java.util.Map;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.base.Preconditions.checkState;
 import static io.trino.plugin.base.Versions.checkSpiVersion;
-import static java.lang.Boolean.parseBoolean;
-import static java.lang.Integer.parseInt;
 
 public class TpcdsConnectorFactory
         implements ConnectorFactory
 {
-    private final int defaultSplitsPerNode;
-
-    public TpcdsConnectorFactory()
-    {
-        this(Runtime.getRuntime().availableProcessors());
-    }
-
-    public TpcdsConnectorFactory(int defaultSplitsPerNode)
-    {
-        checkState(defaultSplitsPerNode > 0, "default splits per node is negative");
-        this.defaultSplitsPerNode = defaultSplitsPerNode;
-    }
-
     @Override
     public String getName()
     {
@@ -60,54 +37,13 @@ public class TpcdsConnectorFactory
     {
         checkSpiVersion(context, this);
 
-        int splitsPerNode = getSplitsPerNode(config);
-        NodeManager nodeManager = context.getNodeManager();
-        return new Connector()
-        {
-            @Override
-            public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit)
-            {
-                return TpcdsTransactionHandle.INSTANCE;
-            }
+        Bootstrap app = new Bootstrap(new TpcdsModule(context.getNodeManager()));
 
-            @Override
-            public ConnectorMetadata getMetadata(ConnectorSession session, ConnectorTransactionHandle transactionHandle)
-            {
-                return new TpcdsMetadata();
-            }
+        Injector injector = app
+                .doNotInitializeLogging()
+                .setRequiredConfigurationProperties(config)
+                .initialize();
 
-            @Override
-            public ConnectorSplitManager getSplitManager()
-            {
-                return new TpcdsSplitManager(nodeManager, splitsPerNode, isWithNoSexism(config));
-            }
-
-            @Override
-            public ConnectorRecordSetProvider getRecordSetProvider()
-            {
-                return new TpcdsRecordSetProvider();
-            }
-
-            @Override
-            public ConnectorNodePartitioningProvider getNodePartitioningProvider()
-            {
-                return new TpcdsNodePartitioningProvider(nodeManager, splitsPerNode);
-            }
-        };
-    }
-
-    private int getSplitsPerNode(Map<String, String> properties)
-    {
-        try {
-            return parseInt(firstNonNull(properties.get("tpcds.splits-per-node"), String.valueOf(defaultSplitsPerNode)));
-        }
-        catch (NumberFormatException e) {
-            throw new IllegalArgumentException("Invalid property tpcds.splits-per-node");
-        }
-    }
-
-    private boolean isWithNoSexism(Map<String, String> properties)
-    {
-        return parseBoolean(firstNonNull(properties.get("tpcds.with-no-sexism"), String.valueOf(false)));
+        return injector.getInstance(TpcdsConnector.class);
     }
 }

--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsModule.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsModule.java
@@ -36,6 +36,7 @@ public class TpcdsModule
     {
         configBinder(binder).bindConfig(TpcdsConfig.class);
         binder.bind(NodeManager.class).toInstance(nodeManager);
+        binder.bind(TpcdsSessionProperties.class).in(Scopes.SINGLETON);
         binder.bind(TpcdsMetadata.class).in(Scopes.SINGLETON);
         binder.bind(TpcdsSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(TpcdsRecordSetProvider.class).in(Scopes.SINGLETON);

--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsModule.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsModule.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.tpcds;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import io.trino.spi.NodeManager;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static java.util.Objects.requireNonNull;
+
+public class TpcdsModule
+        implements Module
+{
+    private final NodeManager nodeManager;
+
+    public TpcdsModule(NodeManager nodeManager)
+    {
+        this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
+    }
+
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(TpcdsConfig.class);
+        binder.bind(NodeManager.class).toInstance(nodeManager);
+        binder.bind(TpcdsMetadata.class).in(Scopes.SINGLETON);
+        binder.bind(TpcdsSplitManager.class).in(Scopes.SINGLETON);
+        binder.bind(TpcdsRecordSetProvider.class).in(Scopes.SINGLETON);
+        binder.bind(TpcdsNodePartitioningProvider.class).in(Scopes.SINGLETON);
+        binder.bind(TpcdsConnector.class).in(Scopes.SINGLETON);
+    }
+}

--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsNodePartitioningProvider.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsNodePartitioningProvider.java
@@ -25,6 +25,8 @@ import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.type.Type;
 
+import javax.inject.Inject;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -42,6 +44,14 @@ public class TpcdsNodePartitioningProvider
 {
     private final NodeManager nodeManager;
     private final int splitsPerNode;
+
+    @Inject
+    public TpcdsNodePartitioningProvider(NodeManager nodeManager, TpcdsConfig config)
+    {
+        this(
+                nodeManager,
+                requireNonNull(config, "config is null").getSplitsPerNode());
+    }
 
     public TpcdsNodePartitioningProvider(NodeManager nodeManager, int splitsPerNode)
     {

--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsNodePartitioningProvider.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsNodePartitioningProvider.java
@@ -34,7 +34,7 @@ import java.util.function.ToIntFunction;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.trino.plugin.tpcds.TpcdsSessionProperties.getSplitsPerNode;
+import static io.trino.plugin.tpcds.TpcdsSplitManager.getSplitCount;
 import static io.trino.spi.connector.ConnectorBucketNodeMap.createBucketNodeMap;
 import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
@@ -59,12 +59,10 @@ public class TpcdsNodePartitioningProvider
         List<Node> sortedNodes = nodes.stream()
                 .sorted(comparing(node -> node.getHostAndPort().toString()))
                 .collect(toImmutableList());
-        int splitsPerNode = getSplitsPerNode(session);
+        int splitCount = getSplitCount(session, nodes.size());
         ImmutableList.Builder<Node> bucketToNode = ImmutableList.builder();
-        for (Node node : sortedNodes) {
-            for (int i = 0; i < splitsPerNode; i++) {
-                bucketToNode.add(node);
-            }
+        for (int i = 0; i < splitCount; i++) {
+            bucketToNode.add(sortedNodes.get(i % nodes.size()));
         }
         return Optional.of(createBucketNodeMap(bucketToNode.build()));
     }

--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsSessionProperties.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsSessionProperties.java
@@ -20,6 +20,7 @@ import io.trino.spi.session.PropertyMetadata;
 import javax.inject.Inject;
 
 import java.util.List;
+import java.util.OptionalInt;
 
 import static io.trino.spi.session.PropertyMetadata.booleanProperty;
 import static io.trino.spi.session.PropertyMetadata.integerProperty;
@@ -28,6 +29,7 @@ public final class TpcdsSessionProperties
 {
     private static final String SPLITS_PER_NODE = "splits_per_node";
     private static final String WITH_NO_SEXISM = "with_no_sexism";
+    private static final String SPLIT_COUNT = "split_count";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -44,6 +46,11 @@ public final class TpcdsSessionProperties
                         WITH_NO_SEXISM,
                         "With no sexism",
                         config.isWithNoSexism(),
+                        false),
+                integerProperty(
+                        SPLIT_COUNT,
+                        "Number of split to be created. If not specified the number of splits is computed as 'splits_per_node * <number of active nodes>'",
+                        config.getSplitCount(),
                         false));
     }
 
@@ -60,5 +67,11 @@ public final class TpcdsSessionProperties
     public static boolean isWithNoSexism(ConnectorSession session)
     {
         return session.getProperty(WITH_NO_SEXISM, Boolean.class);
+    }
+
+    public static OptionalInt getSplitCount(ConnectorSession session)
+    {
+        Integer value = session.getProperty(SPLIT_COUNT, Integer.class);
+        return value == null ? OptionalInt.empty() : OptionalInt.of(value);
     }
 }

--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsSessionProperties.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsSessionProperties.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.tpcds;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.session.PropertyMetadata;
+
+import javax.inject.Inject;
+
+import java.util.List;
+
+import static io.trino.spi.session.PropertyMetadata.booleanProperty;
+import static io.trino.spi.session.PropertyMetadata.integerProperty;
+
+public final class TpcdsSessionProperties
+{
+    private static final String SPLITS_PER_NODE = "splits_per_node";
+    private static final String WITH_NO_SEXISM = "with_no_sexism";
+
+    private final List<PropertyMetadata<?>> sessionProperties;
+
+    @Inject
+    public TpcdsSessionProperties(TpcdsConfig config)
+    {
+        sessionProperties = ImmutableList.of(
+                integerProperty(
+                        SPLITS_PER_NODE,
+                        "Number of splits created for each worker node",
+                        config.getSplitsPerNode(),
+                        false),
+                booleanProperty(
+                        WITH_NO_SEXISM,
+                        "With no sexism",
+                        config.isWithNoSexism(),
+                        false));
+    }
+
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties;
+    }
+
+    public static int getSplitsPerNode(ConnectorSession session)
+    {
+        return session.getProperty(SPLITS_PER_NODE, Integer.class);
+    }
+
+    public static boolean isWithNoSexism(ConnectorSession session)
+    {
+        return session.getProperty(WITH_NO_SEXISM, Boolean.class);
+    }
+}

--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsSplitManager.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsSplitManager.java
@@ -82,6 +82,7 @@ public class TpcdsSplitManager
 
     public static int getSplitCount(ConnectorSession session, int nodeCount)
     {
-        return getSplitsPerNode(session) * nodeCount;
+        return TpcdsSessionProperties.getSplitCount(session)
+                .orElseGet(() -> getSplitsPerNode(session) * nodeCount);
     }
 }

--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsSplitManager.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsSplitManager.java
@@ -26,6 +26,8 @@ import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.FixedSplitSource;
 
+import javax.inject.Inject;
+
 import java.util.List;
 import java.util.Set;
 
@@ -41,6 +43,15 @@ public class TpcdsSplitManager
     private final NodeManager nodeManager;
     private final int splitsPerNode;
     private final boolean noSexism;
+
+    @Inject
+    public TpcdsSplitManager(NodeManager nodeManager, TpcdsConfig config)
+    {
+        this(
+                nodeManager,
+                requireNonNull(config, "config is null").getSplitsPerNode(),
+                config.isWithNoSexism());
+    }
 
     public TpcdsSplitManager(NodeManager nodeManager, int splitsPerNode, boolean noSexism)
     {

--- a/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TestTpcdsConfig.java
+++ b/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TestTpcdsConfig.java
@@ -29,7 +29,8 @@ public class TestTpcdsConfig
     {
         assertRecordedDefaults(recordDefaults(TpcdsConfig.class)
                 .setSplitsPerNode(Runtime.getRuntime().availableProcessors())
-                .setWithNoSexism(false));
+                .setWithNoSexism(false)
+                .setSplitCount(null));
     }
 
     @Test
@@ -38,11 +39,13 @@ public class TestTpcdsConfig
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("tpcds.splits-per-node", "123")
                 .put("tpcds.with-no-sexism", "true")
+                .put("tpcds.split-count", "22")
                 .buildOrThrow();
 
         TpcdsConfig expected = new TpcdsConfig()
                 .setSplitsPerNode(123)
-                .setWithNoSexism(true);
+                .setWithNoSexism(true)
+                .setSplitCount(22);
         assertFullMapping(properties, expected);
     }
 }

--- a/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TestTpcdsConfig.java
+++ b/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TestTpcdsConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.tpcds;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestTpcdsConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(TpcdsConfig.class)
+                .setSplitsPerNode(Runtime.getRuntime().availableProcessors())
+                .setWithNoSexism(false));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("tpcds.splits-per-node", "123")
+                .put("tpcds.with-no-sexism", "true")
+                .buildOrThrow();
+
+        TpcdsConfig expected = new TpcdsConfig()
+                .setSplitsPerNode(123)
+                .setWithNoSexism(true);
+        assertFullMapping(properties, expected);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Some tables (such as store_returns, store_sales) change the number of
rows based on the number of splits generated. While it is unclear
whether this is expected behavior (as the same is observed in the
reference implementation from TPC) for now it was decided to allow
specifying the number of splits explicitly to allow generating
deterministic data sets.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
