### PR TITLE
Fix case insensitive matching when dropping MongoDB schema 

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -198,7 +198,7 @@ public class MongoSession
 
     public void dropSchema(String schemaName)
     {
-        client.getDatabase(schemaName).drop();
+        client.getDatabase(toRemoteSchemaName(schemaName)).drop();
     }
 
     public Set<String> getAllTables(String schema)

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoCaseInsensitiveMapping.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoCaseInsensitiveMapping.java
@@ -76,6 +76,9 @@ public class TestMongoCaseInsensitiveMapping
 
         assertQuery("SELECT value FROM testcase.testinsensitive WHERE name = 'def'", "SELECT 2");
         assertUpdate("DROP TABLE testcase.testinsensitive");
+
+        assertUpdate("DROP SCHEMA testcase");
+        assertQueryReturnsEmptyResult("SHOW SCHEMAS IN mongodb LIKE 'testcase'");
     }
 
     @Test

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoCaseInsensitiveMapping.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoCaseInsensitiveMapping.java
@@ -76,6 +76,7 @@ public class TestMongoCaseInsensitiveMapping
 
         assertQuery("SELECT value FROM testcase.testinsensitive WHERE name = 'def'", "SELECT 2");
         assertUpdate("DROP TABLE testcase.testinsensitive");
+        assertQueryReturnsEmptyResult("SHOW TABLES IN testcase");
 
         assertUpdate("DROP SCHEMA testcase");
         assertQueryReturnsEmptyResult("SHOW SCHEMAS IN mongodb LIKE 'testcase'");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fixes #15716

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# MongoDB
* Fix bug when dropping schemas and `mongodb.case-insensitive-name-matching` is enabled.
  Previously, the statement succeeded, but the schema wasn't dropped. ({issue}`15716`)
```
