### PR TITLE
Use exact math for timestamp calculations

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/type/ShortTimestampEncoder.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/type/ShortTimestampEncoder.java
@@ -22,6 +22,8 @@ import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
 import static io.trino.spi.type.Timestamps.MILLISECONDS_PER_SECOND;
 import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.Timestamps.round;
+import static java.lang.Math.addExact;
+import static java.lang.Math.multiplyExact;
 
 class ShortTimestampEncoder
         extends AbstractTrinoTimestampEncoder<Long>
@@ -43,12 +45,12 @@ class ShortTimestampEncoder
     {
         long micros;
         if (timeZone != DateTimeZone.UTC) {
-            micros = timeZone.convertUTCToLocal(decodedTimestamp.epochSeconds() * MILLISECONDS_PER_SECOND) * MICROSECONDS_PER_MILLISECOND;
+            micros = multiplyExact(timeZone.convertUTCToLocal(multiplyExact(decodedTimestamp.epochSeconds(), MILLISECONDS_PER_SECOND)), MICROSECONDS_PER_MILLISECOND);
         }
         else {
-            micros = decodedTimestamp.epochSeconds() * MICROSECONDS_PER_SECOND;
+            micros = multiplyExact(decodedTimestamp.epochSeconds(), MICROSECONDS_PER_SECOND);
         }
         int nanosOfSecond = (int) round(decodedTimestamp.nanosOfSecond(), 9 - type.getPrecision());
-        return micros + nanosOfSecond / NANOSECONDS_PER_MICROSECOND;
+        return addExact(micros, nanosOfSecond / NANOSECONDS_PER_MICROSECOND);
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/type/TrinoTimestampEncoderFactory.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/type/TrinoTimestampEncoderFactory.java
@@ -19,6 +19,7 @@ import org.joda.time.DateTimeZone;
 
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+import static java.lang.Math.addExact;
 import static java.lang.Math.multiplyExact;
 import static java.util.Objects.requireNonNull;
 
@@ -41,7 +42,7 @@ public final class TrinoTimestampEncoderFactory
     static LongTimestamp longTimestamp(long epochSecond, long fractionInPicos)
     {
         return new LongTimestamp(
-                multiplyExact(epochSecond, MICROSECONDS_PER_SECOND) + fractionInPicos / PICOSECONDS_PER_MICROSECOND,
+                addExact(multiplyExact(epochSecond, MICROSECONDS_PER_SECOND), fractionInPicos / PICOSECONDS_PER_MICROSECOND),
                 (int) (fractionInPicos % PICOSECONDS_PER_MICROSECOND));
     }
 }


### PR DESCRIPTION
## Description
The current TimestampEncoders performs some operations with overflow.  I do not know if this this problem is visible in the current code base, but it makes using the encoder library error prone.

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
