### PR TITLE
Use authentication error message from response body

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/JsonResponse.java
+++ b/client/trino-client/src/main/java/io/trino/client/JsonResponse.java
@@ -36,7 +36,6 @@ import static java.util.Objects.requireNonNull;
 public final class JsonResponse<T>
 {
     private final int statusCode;
-    private final String statusMessage;
     private final Headers headers;
     @Nullable
     private final String responseBody;
@@ -44,10 +43,9 @@ public final class JsonResponse<T>
     private final T value;
     private final IllegalArgumentException exception;
 
-    private JsonResponse(int statusCode, String statusMessage, Headers headers, String responseBody)
+    private JsonResponse(int statusCode, Headers headers, String responseBody)
     {
         this.statusCode = statusCode;
-        this.statusMessage = statusMessage;
         this.headers = requireNonNull(headers, "headers is null");
         this.responseBody = requireNonNull(responseBody, "responseBody is null");
 
@@ -56,10 +54,9 @@ public final class JsonResponse<T>
         this.exception = null;
     }
 
-    private JsonResponse(int statusCode, String statusMessage, Headers headers, @Nullable String responseBody, @Nullable T value, @Nullable IllegalArgumentException exception)
+    private JsonResponse(int statusCode, Headers headers, @Nullable String responseBody, @Nullable T value, @Nullable IllegalArgumentException exception)
     {
         this.statusCode = statusCode;
-        this.statusMessage = statusMessage;
         this.headers = requireNonNull(headers, "headers is null");
         this.responseBody = responseBody;
         this.value = value;
@@ -70,11 +67,6 @@ public final class JsonResponse<T>
     public int getStatusCode()
     {
         return statusCode;
-    }
-
-    public String getStatusMessage()
-    {
-        return statusMessage;
     }
 
     public Headers getHeaders()
@@ -111,7 +103,6 @@ public final class JsonResponse<T>
     {
         return toStringHelper(this)
                 .add("statusCode", statusCode)
-                .add("statusMessage", statusMessage)
                 .add("headers", headers.toMultimap())
                 .add("hasValue", hasValue)
                 .add("value", value)
@@ -158,9 +149,9 @@ public final class JsonResponse<T>
                     }
                     exception = new IllegalArgumentException(message, e);
                 }
-                return new JsonResponse<>(response.code(), response.message(), response.headers(), body, value, exception);
+                return new JsonResponse<>(response.code(), response.headers(), body, value, exception);
             }
-            return new JsonResponse<>(response.code(), response.message(), response.headers(), responseBody.string());
+            return new JsonResponse<>(response.code(), response.headers(), responseBody.string());
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
+++ b/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
@@ -448,7 +448,7 @@ class StatementClientV1
         if (!response.hasValue()) {
             if (response.getStatusCode() == HTTP_UNAUTHORIZED) {
                 return new ClientException("Authentication failed" +
-                        Optional.ofNullable(response.getStatusMessage())
+                        response.getResponseBody()
                                 .map(message -> ": " + message)
                                 .orElse(""));
             }

--- a/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
@@ -294,7 +294,8 @@ public class TestResourceSecurity
                     .headers(Headers.of("Authorization", Credentials.basic(TEST_USER_LOGIN, "wrong_password")))
                     .build();
             try (Response response = client.newCall(request).execute()) {
-                assertThat(response.message()).isEqualTo("Access Denied: Invalid credentials | Access Denied: Invalid credentials2");
+                assertThat(requireNonNull(response.body()).string())
+                        .isEqualTo("Access Denied: Invalid credentials | Access Denied: Invalid credentials2");
             }
         }
     }


### PR DESCRIPTION
## Description

All versions of Trino (since c0bcc9bbcde2d4850ddf81ca962b5d7c16b1e109) send the error message in the response body. The reason phrase does not exist in HTTP/2.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# CLI
* Improve authentication error messages when accessing the server over HTTP/2. ({issue}`15720`)

# JDBC driver
* Improve authentication error messages when accessing the server over HTTP/2. ({issue}`15720`)
```
