### PR TITLE
Improve error message in Kafka connector when parsing recursive protobuf schemas

### DIFF
--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/protobuf/ProtobufUtils.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/protobuf/ProtobufUtils.java
@@ -72,8 +72,14 @@ public final class ProtobufUtils
     public static FileDescriptor getFileDescriptor(String protoFile)
             throws DescriptorValidationException
     {
+        return getFileDescriptor(Optional.empty(), protoFile);
+    }
+
+    public static FileDescriptor getFileDescriptor(Optional<String> fileName, String protoFile)
+            throws DescriptorValidationException
+    {
         ProtoFileElement protoFileElement = ProtoParser.Companion.parse(Location.get(""), protoFile);
-        return getFileDescriptor(Optional.empty(), protoFileElement);
+        return getFileDescriptor(fileName, protoFileElement);
     }
 
     public static FileDescriptor getFileDescriptor(Optional<String> fileName, ProtoFileElement protoFileElement)
@@ -84,7 +90,7 @@ public final class ProtobufUtils
         int index = 0;
         for (String importStatement : protoFileElement.getImports()) {
             try {
-                FileDescriptor fileDescriptor = getFileDescriptor(getProtoFile(importStatement));
+                FileDescriptor fileDescriptor = getFileDescriptor(Optional.of(importStatement), getProtoFile(importStatement));
                 fileDescriptor.getMessageTypes().stream()
                         .map(Descriptor::getFullName)
                         .forEach(definedMessages::add);

--- a/plugin/trino-kafka/pom.xml
+++ b/plugin/trino-kafka/pom.xml
@@ -339,6 +339,46 @@
                     </ignoredResourcePatterns>
                 </configuration>
             </plugin>
+            <!-- TODO: Instead of using this plugin to generate classes we should invoke the parser directly (https://github.com/trinodb/trino/issues/16039) -->
+            <plugin>
+                <groupId>com.github.os72</groupId>
+                <artifactId>protoc-jar-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-test-sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <protocVersion>${dep.protobuf.version}</protocVersion>
+                            <addSources>none</addSources>
+                            <inputDirectories>
+                                <include>src/test/resources/protobuf-sources</include>
+                            </inputDirectories>
+                            <outputDirectory>target/generated-test-sources/</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-test-sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${basedir}/target/generated-test-sources</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/protobuf/ProtobufSchemaParser.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/protobuf/ProtobufSchemaParser.java
@@ -13,6 +13,8 @@
  */
 package io.trino.plugin.kafka.encoder.protobuf;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
@@ -21,6 +23,7 @@ import io.trino.decoder.protobuf.ProtobufRowDecoder;
 import io.trino.plugin.kafka.KafkaTopicFieldDescription;
 import io.trino.plugin.kafka.KafkaTopicFieldGroup;
 import io.trino.plugin.kafka.schema.confluent.SchemaParser;
+import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.MapType;
@@ -30,9 +33,14 @@ import io.trino.spi.type.TypeManager;
 
 import javax.inject.Inject;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DoubleType.DOUBLE;
@@ -42,6 +50,7 @@ import static io.trino.spi.type.TimestampType.createTimestampType;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 
 public class ProtobufSchemaParser
         implements SchemaParser
@@ -66,7 +75,7 @@ public class ProtobufSchemaParser
                 protobufSchema.toDescriptor().getFields().stream()
                         .map(field -> new KafkaTopicFieldDescription(
                                 field.getName(),
-                                getType(field),
+                                getType(field, ImmutableList.of()),
                                 field.getName(),
                                 null,
                                 null,
@@ -75,7 +84,7 @@ public class ProtobufSchemaParser
                         .collect(toImmutableList()));
     }
 
-    private Type getType(FieldDescriptor fieldDescriptor)
+    private Type getType(FieldDescriptor fieldDescriptor, List<FieldAndType> processedMessages)
     {
         Type baseType = switch (fieldDescriptor.getJavaType()) {
             case BOOLEAN -> BOOLEAN;
@@ -85,31 +94,61 @@ public class ProtobufSchemaParser
             case DOUBLE -> DOUBLE;
             case BYTE_STRING -> VARBINARY;
             case STRING, ENUM -> createUnboundedVarcharType();
-            case MESSAGE -> getTypeForMessage(fieldDescriptor);
+            case MESSAGE -> getTypeForMessage(fieldDescriptor, processedMessages);
         };
 
-        // Protobuf does not support adding repeated label for map type but schema registry incorrecty adds it
+        // Protobuf does not support adding repeated label for map type but schema registry incorrectly adds it
         if (fieldDescriptor.isRepeated() && !fieldDescriptor.isMapField()) {
             return new ArrayType(baseType);
         }
         return baseType;
     }
 
-    private Type getTypeForMessage(FieldDescriptor fieldDescriptor)
+    private Type getTypeForMessage(FieldDescriptor fieldDescriptor, List<FieldAndType> processedMessages)
     {
         Descriptor descriptor = fieldDescriptor.getMessageType();
         if (descriptor.getFullName().equals(TIMESTAMP_TYPE_NAME)) {
             return createTimestampType(6);
         }
+
+        // We MUST check just the type names since same type can be present with different field names which is also recursive
+        Set<String> processedMessagesFullTypeNames = processedMessages.stream()
+                .map(FieldAndType::fullTypeName)
+                .collect(toImmutableSet());
+        if (processedMessagesFullTypeNames.contains(descriptor.getFullName())) {
+            throw new TrinoException(NOT_SUPPORTED, "Protobuf schema containing fields with self-reference are not supported because they cannot be mapped to a Trino type: %s"
+                    .formatted(Streams.concat(processedMessages.stream(), Stream.of(new FieldAndType(fieldDescriptor)))
+                            .map(FieldAndType::toString)
+                            .collect(joining(" > "))));
+        }
+        List<FieldAndType> newProcessedMessages = ImmutableList.<FieldAndType>builderWithExpectedSize(processedMessages.size() + 1)
+                .addAll(processedMessages)
+                .add(new FieldAndType(fieldDescriptor))
+                .build();
+
         if (fieldDescriptor.isMapField()) {
             return new MapType(
-                    getType(descriptor.findFieldByNumber(1)),
-                    getType(descriptor.findFieldByNumber(2)),
+                    getType(descriptor.findFieldByNumber(1), newProcessedMessages),
+                    getType(descriptor.findFieldByNumber(2), newProcessedMessages),
                     typeManager.getTypeOperators());
         }
         return RowType.from(
                 descriptor.getFields().stream()
-                        .map(field -> RowType.field(field.getName(), getType(field)))
+                        .map(field -> RowType.field(field.getName(), getType(field, newProcessedMessages)))
                         .collect(toImmutableList()));
+    }
+
+    public record FieldAndType(String fullFieldName, String fullTypeName)
+    {
+        public FieldAndType(FieldDescriptor fieldDescriptor)
+        {
+            this(fieldDescriptor.getFullName(), fieldDescriptor.getMessageType().getFullName());
+        }
+
+        @Override
+        public String toString()
+        {
+            return fullFieldName + ": " + fullTypeName;
+        }
     }
 }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/protobuf/ProtobufSchemaParser.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/protobuf/ProtobufSchemaParser.java
@@ -98,7 +98,7 @@ public class ProtobufSchemaParser
     private Type getTypeForMessage(FieldDescriptor fieldDescriptor)
     {
         Descriptor descriptor = fieldDescriptor.getMessageType();
-        if (fieldDescriptor.getMessageType().getFullName().equals(TIMESTAMP_TYPE_NAME)) {
+        if (descriptor.getFullName().equals(TIMESTAMP_TYPE_NAME)) {
             return createTimestampType(6);
         }
         if (fieldDescriptor.isMapField()) {
@@ -108,7 +108,7 @@ public class ProtobufSchemaParser
                     typeManager.getTypeOperators());
         }
         return RowType.from(
-                fieldDescriptor.getMessageType().getFields().stream()
+                descriptor.getFields().stream()
                         .map(field -> RowType.field(field.getName(), getType(field)))
                         .collect(toImmutableList()));
     }

--- a/plugin/trino-kafka/src/test/resources/protobuf-sources/unsupported_recursive.proto
+++ b/plugin/trino-kafka/src/test/resources/protobuf-sources/unsupported_recursive.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package io.trino.protobuf;
+
+option java_package = "io.trino.plugin.kafka.protobuf";
+option java_outer_classname = "UnsupportedRecursiveTypes";
+
+message schema {
+    RecursiveValue recursive_value_one = 1;
+}
+
+message RecursiveStruct {
+    map<string, RecursiveValue> fields = 1;
+}
+
+message RecursiveValue {
+    string string_value = 1;
+    RecursiveStruct struct_value = 2;
+    RecursiveListValue list_value = 3;
+}
+
+message RecursiveListValue {
+    repeated RecursiveValue values = 1;
+}

--- a/plugin/trino-kafka/src/test/resources/protobuf/structural_datatypes.proto
+++ b/plugin/trino-kafka/src/test/resources/protobuf/structural_datatypes.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+
+message schema {
+    repeated string list = 1;
+    map<string, string> map = 2;
+    enum Number {
+        ZERO = 0;
+        ONE = 1;
+        TWO = 2;
+    };
+    message Row {
+        string string_column = 1;
+        uint32 integer_column = 2;
+        uint64 long_column = 3;
+        double double_column = 4;
+        float float_column = 5;
+        bool boolean_column = 6;
+        Number number_column = 7;
+        google.protobuf.Timestamp timestamp_column = 8;
+        bytes bytes_column = 9;
+    };
+    Row row = 3;
+    message NestedRow {
+        repeated Row nested_list = 1;
+        map<string, Row> nested_map = 2;
+        Row row = 3;
+    };
+    NestedRow nested_row = 4;
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Kafka connector throws a StackOverflowError when the protobuf schema
includes self referenced object types.
To improve user experience the schema parsing now throws TrinoException
saying that the type is unsupported.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Improve error message in Kafka connector when parsing recursive protobuf schemas. ({issue}`issuenumber`)
```
