### PR TITLE
Remove obsolete check in BigQuery connector

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorModule.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorModule.java
@@ -81,16 +81,11 @@ public class BigQueryConnectorModule
         }
 
         /**
-         * Apache Arrow requires reflective access to certain Java internals prohibited in Java 17.
+         * Apache Arrow requires reflective access to certain Java internals prohibited since Java 17.
          * Adds an error to the {@code binder} if required --add-opens is not passed to the JVM.
          */
         private static void verifyPackageAccessAllowed(Binder binder)
         {
-            if (Runtime.version().compareToIgnoreOptional(Runtime.Version.parse("17")) < 0) {
-                // No need to modify access before Java 17
-                return;
-            }
-
             // Match an --add-opens argument that opens a package to unnamed modules.
             // The first group is the opened package.
             Pattern argPattern = Pattern.compile(
@@ -108,7 +103,7 @@ public class BigQueryConnectorModule
 
             if (!openedModules.contains("java.base/java.nio")) {
                 binder.addError(
-                        "BigQuery connector requires additional JVM arguments to run on Java 17 when '" + EXPERIMENTAL_ARROW_SERIALIZATION_ENABLED + "' is enabled. " +
+                        "BigQuery connector requires additional JVM arguments to run when '" + EXPERIMENTAL_ARROW_SERIALIZATION_ENABLED + "' is enabled. " +
                                 "Please add '--add-opens=java.base/java.nio=ALL-UNNAMED' to the JVM configuration.");
             }
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Trino now requires a minimum of JDK 17 to run and this is verified in TrinoSystemRequirements already.