### PR TITLE
Check each commit code style

### DIFF
--- a/.github/actions/compile-commit/action.yml
+++ b/.github/actions/compile-commit/action.yml
@@ -28,7 +28,10 @@ runs:
         # For building with Maven we need MAVEN_OPTS to equal MAVEN_INSTALL_OPTS
         export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
         $RETRY $MAVEN dependency:go-offline
-        $MAVEN package ${MAVEN_COMPILE_COMMITS} ${MAVEN_GIB}
+        $MAVEN package \
+          ${MAVEN_COMPILE_COMMITS} `# defaults, kept in sync with ci.yml` \
+          -Dair.check.skip-all=false -Dair.check.skip-basic=true -Dair.check.skip-extended=true -Dair.check.skip-checkstyle=false \
+          ${MAVEN_GIB}
     - name: Clean local Maven repo
       # Avoid creating a cache entry because this job doesn't download all dependencies
       if: steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
It's not uncommon that checkstyle fixups are associated with not the right commit. A person reviewing commit-by-commit may notice them, and face the dilemma whether to comment on the nit, or ignore. Have the CI check alleviate the dilemma, by preventing such situations.
