### PR TITLE
Trino CLI: support X-Trino-Routing-Group header

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -121,6 +121,9 @@ public class ClientOptions
     @Option(names = "--client-tags", paramLabel = "<tags>", description = "Client tags")
     public String clientTags;
 
+    @Option(names = "--routing-group", paramLabel = "<routingGroup>", description = "Routing group")
+    public String routingGroup;
+
     @Option(names = "--trace-token", paramLabel = "<token>", description = "Trace token")
     public String traceToken;
 
@@ -225,6 +228,7 @@ public class ClientOptions
                 .source(source)
                 .traceToken(Optional.ofNullable(traceToken))
                 .clientTags(parseClientTags(nullToEmpty(clientTags)))
+                .routingGroup(Optional.ofNullable(routingGroup))
                 .clientInfo(clientInfo)
                 .catalog(catalog)
                 .schema(schema)

--- a/client/trino-client/src/main/java/io/trino/client/ClientSession.java
+++ b/client/trino-client/src/main/java/io/trino/client/ClientSession.java
@@ -39,6 +39,7 @@ public class ClientSession
     private final String source;
     private final Optional<String> traceToken;
     private final Set<String> clientTags;
+    private final Optional<String> routingGroup;
     private final String clientInfo;
     private final String catalog;
     private final String schema;
@@ -78,6 +79,7 @@ public class ClientSession
             String source,
             Optional<String> traceToken,
             Set<String> clientTags,
+            Optional<String> routingGroup,
             String clientInfo,
             String catalog,
             String schema,
@@ -99,6 +101,7 @@ public class ClientSession
         this.source = source;
         this.traceToken = requireNonNull(traceToken, "traceToken is null");
         this.clientTags = ImmutableSet.copyOf(requireNonNull(clientTags, "clientTags is null"));
+        this.routingGroup = requireNonNull(routingGroup, "routingGroup is null");
         this.clientInfo = clientInfo;
         this.catalog = catalog;
         this.schema = schema;
@@ -171,6 +174,11 @@ public class ClientSession
     public Set<String> getClientTags()
     {
         return clientTags;
+    }
+
+    public Optional<String> getRoutingGroup()
+    {
+        return routingGroup;
     }
 
     public String getClientInfo()
@@ -260,6 +268,7 @@ public class ClientSession
                 .add("user", user)
                 .add("clientTags", clientTags)
                 .add("clientInfo", clientInfo)
+                .add("routingGroup", routingGroup)
                 .add("catalog", catalog)
                 .add("schema", schema)
                 .add("path", path)
@@ -280,6 +289,7 @@ public class ClientSession
         private String source;
         private Optional<String> traceToken = Optional.empty();
         private Set<String> clientTags = ImmutableSet.of();
+        private Optional<String> routingGroup = Optional.empty();
         private String clientInfo;
         private String catalog;
         private String schema;
@@ -355,6 +365,12 @@ public class ClientSession
         public Builder clientTags(Set<String> clientTags)
         {
             this.clientTags = clientTags;
+            return this;
+        }
+
+        public Builder routingGroup(Optional<String> routingGroup)
+        {
+            this.routingGroup = routingGroup;
             return this;
         }
 
@@ -451,6 +467,7 @@ public class ClientSession
                     source,
                     traceToken,
                     clientTags,
+                    routingGroup,
                     clientInfo,
                     catalog,
                     schema,

--- a/client/trino-client/src/main/java/io/trino/client/ProtocolHeaders.java
+++ b/client/trino-client/src/main/java/io/trino/client/ProtocolHeaders.java
@@ -98,6 +98,11 @@ public final class ProtocolHeaders
         return prefix + "Role";
     }
 
+    public String requestRoutingGroup()
+    {
+        return prefix + "Routing-Group";
+    }
+
     public String requestPreparedStatement()
     {
         return prefix + "Prepared-Statement";

--- a/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
+++ b/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
@@ -80,6 +80,7 @@ class StatementClientV1
     private final AtomicReference<String> setCatalog = new AtomicReference<>();
     private final AtomicReference<String> setSchema = new AtomicReference<>();
     private final AtomicReference<String> setPath = new AtomicReference<>();
+    private final AtomicReference<String> setRoutingGroup = new AtomicReference<>();
     private final Map<String, String> setSessionProperties = new ConcurrentHashMap<>();
     private final Set<String> resetSessionProperties = Sets.newConcurrentHashSet();
     private final Map<String, ClientSelectedRole> setRoles = new ConcurrentHashMap<>();
@@ -140,6 +141,8 @@ class StatementClientV1
         if (session.getSource() != null) {
             builder.addHeader(TRINO_HEADERS.requestSource(), session.getSource());
         }
+
+        session.getRoutingGroup().ifPresent(group -> builder.addHeader(TRINO_HEADERS.requestRoutingGroup(), group));
 
         session.getTraceToken().ifPresent(token -> builder.addHeader(TRINO_HEADERS.requestTraceToken(), token));
 


### PR DESCRIPTION
## Description

Hey folks!

I've started using Trino + [Lyft's `presto-gateway`](https://github.com/lyft/presto-gateway), which seems to be a popular combo.

`presto-gateway` has a feature to group one-or-more Trino clusters as a single "routing group". You can have several routing roups per gateway. It turns presto-gateway into a powerful piece of software, transparently redirecting between several Trino clusters with potentially varying performance, catalogs, etc. All great stuff!

To distinguish which routing group to send queries to, presto-gateway uses the `X-Trino-Routing-Group` header. This is great for programmatic access, but it makes it impossible to use this feature from our beloved `trino-cli`.

This PR adds a new optional argument to the trino-cli, `--routing-group`, which, when set, sets the corresponding HTTP header when sending queries.

This enables using `trino-cli` with the presto-gateway's routing group functionality. 👍 

## Additional context and related issues

This being my first PR for Trino, I might have missed things / not done stuff the right way - please let me know what I should fix/improve etc.

In particular, I haven't written documentation for this new option. Should I? (I'd be happy to!)

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* Add a `--routing-group` argument to the trino-cli to support routing in the presto-gateway
```