### PR TITLE
[WIP]: Fix drop void partition column in iceberg connector

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -1186,6 +1186,16 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void tesInsertAfterDropVoidPartitionColumn()
+    {
+        String tableName = "test_drop_partition_column_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (id INTEGER, name VARCHAR) WITH (partitioning = ARRAY['id', 'void(name)'])");
+        assertUpdate("ALTER TABLE " + tableName + " DROP COLUMN name");
+        assertUpdate("INSERT INTO " + tableName + " VALUES (1)", 1);
+        dropTable(tableName);
+    }
+
+    @Test
     public void testSchemaEvolution()
     {
         assertUpdate("CREATE TABLE test_schema_evolution_drop_end (col0 INTEGER, col1 INTEGER, col2 INTEGER)");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
`IcebergMetadata#dropColumn` does not remove the partition column from the current partition spec. which causes the failure when trying to select/insert/update on the table.

Partial fixes https://github.com/trinodb/trino/issues/15738

This PR depends on https://github.com/trinodb/trino/issues/15729 to get fixed completely.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(X) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
