### PR TITLE
Disable hadoop MemoryManager in hive parquet writer

### DIFF
--- a/plugin/trino-hive/src/main/java/org/apache/parquet/hadoop/DisabledMemoryManager.java
+++ b/plugin/trino-hive/src/main/java/org/apache/parquet/hadoop/DisabledMemoryManager.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.parquet.hadoop;
+
+public final class DisabledMemoryManager
+        extends MemoryManager
+{
+    public DisabledMemoryManager()
+    {
+        super(0.95f, 1024 * 1024);
+    }
+
+    @Override
+    synchronized void addWriter(InternalParquetRecordWriter<?> writer, Long allocation)
+    {
+    }
+
+    @Override
+    synchronized void removeWriter(InternalParquetRecordWriter<?> writer)
+    {
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
@@ -39,7 +39,7 @@ import io.trino.plugin.hive.orc.OrcWriterConfig;
 import io.trino.plugin.hive.parquet.write.MapKeyValuesSchemaConverter;
 import io.trino.plugin.hive.parquet.write.SingleLevelArrayMapKeyValuesSchemaConverter;
 import io.trino.plugin.hive.parquet.write.SingleLevelArraySchemaConverter;
-import io.trino.plugin.hive.parquet.write.TestMapredParquetOutputFormat;
+import io.trino.plugin.hive.parquet.write.TestingMapredParquetOutputFormat;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.TrinoException;
@@ -628,7 +628,7 @@ public class ParquetTester
             DateTimeZone dateTimeZone)
             throws Exception
     {
-        RecordWriter recordWriter = new TestMapredParquetOutputFormat(parquetSchema, singleLevelArray, dateTimeZone)
+        RecordWriter recordWriter = new TestingMapredParquetOutputFormat(parquetSchema, singleLevelArray, dateTimeZone)
                 .getHiveRecordWriter(
                         jobConf,
                         new Path(outputFile.toURI()),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetDecimalScaling.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetDecimalScaling.java
@@ -17,7 +17,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import io.trino.Session;
 import io.trino.plugin.hive.HiveQueryRunner;
-import io.trino.plugin.hive.parquet.write.TestMapredParquetOutputFormat;
+import io.trino.plugin.hive.parquet.write.TestingMapredParquetOutputFormat;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.QueryRunner;
@@ -473,7 +473,7 @@ public class TestParquetDecimalScaling
         jobConf.setEnum(WRITER_VERSION, writerVersion);
 
         try {
-            FileSinkOperator.RecordWriter recordWriter = new TestMapredParquetOutputFormat(Optional.of(parquetSchema), true, DateTimeZone.getDefault())
+            FileSinkOperator.RecordWriter recordWriter = new TestingMapredParquetOutputFormat(Optional.of(parquetSchema), true, DateTimeZone.getDefault())
                     .getHiveRecordWriter(
                             jobConf,
                             path,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/TestingMapredParquetOutputFormat.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/TestingMapredParquetOutputFormat.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.Properties;
 
+import static io.trino.plugin.hive.parquet.ParquetRecordWriter.replaceHadoopParquetMemoryManager;
 import static java.util.Objects.requireNonNull;
 
 /*
@@ -40,6 +41,12 @@ import static java.util.Objects.requireNonNull;
 public class TestingMapredParquetOutputFormat
         extends MapredParquetOutputFormat
 {
+    static {
+        //  The tests using this class don't use io.trino.plugin.hive.parquet.ParquetRecordWriter for writing parquet files with old writer.
+        //  Therefore, we need to replace the hadoop parquet memory manager here explicitly.
+        replaceHadoopParquetMemoryManager();
+    }
+
     private final Optional<MessageType> schema;
 
     public TestingMapredParquetOutputFormat(Optional<MessageType> schema, boolean singleLevelArray, DateTimeZone dateTimeZone)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/TestingMapredParquetOutputFormat.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/TestingMapredParquetOutputFormat.java
@@ -37,12 +37,12 @@ import static java.util.Objects.requireNonNull;
   we also want to test the cases were the backing type is INT32/INT64, which requires
   a custom Parquet schema.
 */
-public class TestMapredParquetOutputFormat
+public class TestingMapredParquetOutputFormat
         extends MapredParquetOutputFormat
 {
     private final Optional<MessageType> schema;
 
-    public TestMapredParquetOutputFormat(Optional<MessageType> schema, boolean singleLevelArray, DateTimeZone dateTimeZone)
+    public TestingMapredParquetOutputFormat(Optional<MessageType> schema, boolean singleLevelArray, DateTimeZone dateTimeZone)
     {
         super(new ParquetOutputFormat<>(new TestDataWritableWriteSupport(singleLevelArray, dateTimeZone)));
         this.schema = requireNonNull(schema, "schema is null");


### PR DESCRIPTION
## Description
Disable hadoop MemoryManager in hive parquet writer
to prevent it from making decisions about resizing row groups 
based on global context about active writers and JVM max heap size.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/13633

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
