### PR TITLE
Randomize table names in MongoDB tests

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -116,7 +116,7 @@ import static java.util.stream.Collectors.toSet;
 public class MongoSession
 {
     private static final Logger log = Logger.get(MongoSession.class);
-    private static final List<String> SYSTEM_TABLES = Arrays.asList("system.indexes", "system.users", "system.version");
+    private static final List<String> SYSTEM_TABLES = Arrays.asList("system.indexes", "system.users", "system.version", "system.views");
 
     private static final String TABLE_NAME_KEY = "table";
     private static final String COMMENT_KEY = "comment";

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
@@ -149,15 +149,16 @@ public class TestMongoConnectorTest
     @Test(dataProvider = "guessFieldTypesProvider")
     public void testGuessFieldTypes(String mongoValue, String trinoValue)
     {
+        String tableName = "test_guess_field_type_" + randomNameSuffix();
         Document document = Document.parse(format("{\"test\":%s}", mongoValue));
 
-        assertUpdate("DROP TABLE IF EXISTS test.test_guess_field_type");
-        client.getDatabase("test").getCollection("test_guess_field_type").insertOne(document);
+        assertUpdate("DROP TABLE IF EXISTS test." + tableName);
+        client.getDatabase("test").getCollection(tableName).insertOne(document);
 
-        assertThat(query("SELECT test FROM test.test_guess_field_type"))
+        assertThat(query("SELECT test FROM test." + tableName))
                 .matches("SELECT " + trinoValue);
 
-        assertUpdate("DROP TABLE test.test_guess_field_type");
+        assertUpdate("DROP TABLE test." + tableName);
     }
 
     @DataProvider
@@ -182,9 +183,10 @@ public class TestMongoConnectorTest
     @Test
     public void createTableWithEveryType()
     {
-        String query = "" +
-                "CREATE TABLE test_types_table AS " +
-                "SELECT" +
+        String tableName = "test_types_table_" + randomNameSuffix();
+        String query = "CREATE TABLE " +
+                tableName +
+                " AS SELECT" +
                 " 'foo' _varchar" +
                 ", cast('bar' as varbinary) _varbinary" +
                 ", cast(1 as bigint) _bigint" +
@@ -198,7 +200,7 @@ public class TestMongoConnectorTest
 
         assertUpdate(query, 1);
 
-        MaterializedResult results = getQueryRunner().execute(getSession(), "SELECT * FROM test_types_table").toTestTypes();
+        MaterializedResult results = getQueryRunner().execute(getSession(), "SELECT * FROM " + tableName).toTestTypes();
         assertEquals(results.getRowCount(), 1);
         MaterializedRow row = results.getMaterializedRows().get(0);
         assertEquals(row.getField(0), "foo");
@@ -210,16 +212,17 @@ public class TestMongoConnectorTest
         assertEquals(row.getField(6), LocalDateTime.of(1980, 5, 7, 11, 22, 33, 456_000_000));
         assertEquals(row.getField(8), "{\"name\":\"alice\"}");
         assertEquals(row.getField(9), new BigDecimal("12.30000"));
-        assertUpdate("DROP TABLE test_types_table");
+        assertUpdate("DROP TABLE " + tableName);
 
-        assertFalse(getQueryRunner().tableExists(getSession(), "test_types_table"));
+        assertFalse(getQueryRunner().tableExists(getSession(), tableName));
     }
 
     @Test
     public void testInsertWithEveryType()
     {
-        String createSql = "" +
-                "CREATE TABLE test_insert_types_table " +
+        String tableName = "test_insert_types_table_" + randomNameSuffix();
+        String createSql = "CREATE TABLE " +
+                tableName +
                 "(" +
                 "  vc varchar" +
                 ", vb varbinary" +
@@ -233,9 +236,9 @@ public class TestMongoConnectorTest
                 ")";
         getQueryRunner().execute(getSession(), createSql);
 
-        String insertSql = "" +
-                "INSERT INTO test_insert_types_table " +
-                "SELECT" +
+        String insertSql = "INSERT INTO " +
+                tableName +
+                " SELECT" +
                 " 'foo' _varchar" +
                 ", cast('bar' as varbinary) _varbinary" +
                 ", cast(1 as bigint) _bigint" +
@@ -247,7 +250,7 @@ public class TestMongoConnectorTest
                 ", JSON '{\"name\":\"alice\"}' _json";
         getQueryRunner().execute(getSession(), insertSql);
 
-        MaterializedResult results = getQueryRunner().execute(getSession(), "SELECT * FROM test_insert_types_table").toTestTypes();
+        MaterializedResult results = getQueryRunner().execute(getSession(), "SELECT * FROM " + tableName).toTestTypes();
         assertEquals(results.getRowCount(), 1);
         MaterializedRow row = results.getMaterializedRows().get(0);
         assertEquals(row.getField(0), "foo");
@@ -258,8 +261,8 @@ public class TestMongoConnectorTest
         assertEquals(row.getField(5), LocalDate.of(1980, 5, 7));
         assertEquals(row.getField(6), LocalDateTime.of(1980, 5, 7, 11, 22, 33, 456_000_000));
         assertEquals(row.getField(8), "{\"name\":\"alice\"}");
-        assertUpdate("DROP TABLE test_insert_types_table");
-        assertFalse(getQueryRunner().tableExists(getSession(), "test_insert_types_table"));
+        assertUpdate("DROP TABLE " + tableName);
+        assertFalse(getQueryRunner().tableExists(getSession(), tableName));
     }
 
     @Override
@@ -327,16 +330,17 @@ public class TestMongoConnectorTest
     @Test
     public void testJson()
     {
-        assertUpdate("CREATE TABLE test_json (id INT, col JSON)");
+        String tableName = "test_json_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (id INT, col JSON)");
 
-        assertUpdate("INSERT INTO test_json VALUES (1, JSON '{\"name\":\"alice\"}')", 1);
-        assertQuery("SELECT json_extract_scalar(col, '$.name') FROM test_json WHERE id = 1", "SELECT 'alice'");
+        assertUpdate("INSERT INTO " + tableName + " VALUES (1, JSON '{\"name\":\"alice\"}')", 1);
+        assertQuery("SELECT json_extract_scalar(col, '$.name') FROM " + tableName + " WHERE id = 1", "SELECT 'alice'");
 
-        assertUpdate("INSERT INTO test_json VALUES (2, JSON '{\"numbers\":[1, 2, 3]}')", 1);
-        assertQuery("SELECT json_extract(col, '$.numbers[0]') FROM test_json WHERE id = 2", "SELECT 1");
+        assertUpdate("INSERT INTO " + tableName + " VALUES (2, JSON '{\"numbers\":[1, 2, 3]}')", 1);
+        assertQuery("SELECT json_extract(col, '$.numbers[0]') FROM " + tableName + " WHERE id = 2", "SELECT 1");
 
-        assertUpdate("INSERT INTO test_json VALUES (3, NULL)", 1);
-        assertQuery("SELECT col FROM test_json WHERE id = 3", "SELECT NULL");
+        assertUpdate("INSERT INTO " + tableName + " VALUES (3, NULL)", 1);
+        assertQuery("SELECT col FROM " + tableName + " WHERE id = 3", "SELECT NULL");
 
         assertQueryFails(
                 "CREATE TABLE test_json_scalar AS SELECT JSON '1' AS col",
@@ -346,55 +350,76 @@ public class TestMongoConnectorTest
                 "CREATE TABLE test_json_array AS SELECT JSON '[\"a\", \"b\", \"c\"]' AS col",
                 "Can't convert json to MongoDB Document.*");
 
-        assertUpdate("DROP TABLE test_json");
+        assertUpdate("DROP TABLE " + tableName);
     }
 
     @Test
     public void testArrays()
     {
-        assertUpdate("CREATE TABLE tmp_array1 AS SELECT ARRAY[1, 2, NULL] AS col", 1);
-        assertQuery("SELECT col[2] FROM tmp_array1", "SELECT 2");
-        assertQuery("SELECT col[3] FROM tmp_array1", "SELECT NULL");
+        String arrayIntegerTable = "test_array_integer" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + arrayIntegerTable + " AS SELECT ARRAY[1, 2, NULL] AS col", 1);
+        assertQuery("SELECT col[2] FROM " + arrayIntegerTable, "SELECT 2");
+        assertQuery("SELECT col[3] FROM " + arrayIntegerTable, "SELECT NULL");
+        assertUpdate("DROP TABLE " + arrayIntegerTable);
 
-        assertUpdate("CREATE TABLE tmp_array2 AS SELECT ARRAY[1.0E0, 2.5E0, 3.5E0] AS col", 1);
-        assertQuery("SELECT col[2] FROM tmp_array2", "SELECT 2.5");
+        String arrayDoubleTable = "test_array_double" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + arrayDoubleTable + " AS SELECT ARRAY[1.0E0, 2.5E0, 3.5E0] AS col", 1);
+        assertQuery("SELECT col[2] FROM " + arrayDoubleTable, "SELECT 2.5");
+        assertUpdate("DROP TABLE " + arrayDoubleTable);
 
-        assertUpdate("CREATE TABLE tmp_array3 AS SELECT ARRAY['puppies', 'kittens', NULL] AS col", 1);
-        assertQuery("SELECT col[2] FROM tmp_array3", "SELECT 'kittens'");
-        assertQuery("SELECT col[3] FROM tmp_array3", "SELECT NULL");
+        String arrayVarcharTable = "test_array_varchar" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + arrayVarcharTable + " AS SELECT ARRAY['puppies', 'kittens', NULL] AS col", 1);
+        assertQuery("SELECT col[2] FROM " + arrayVarcharTable, "SELECT 'kittens'");
+        assertQuery("SELECT col[3] FROM " + arrayVarcharTable, "SELECT NULL");
+        assertUpdate("DROP TABLE " + arrayVarcharTable);
 
-        assertUpdate("CREATE TABLE tmp_array4 AS SELECT ARRAY[TRUE, NULL] AS col", 1);
-        assertQuery("SELECT col[1] FROM tmp_array4", "SELECT TRUE");
-        assertQuery("SELECT col[2] FROM tmp_array4", "SELECT NULL");
+        String arrayBooleanTable = "test_array_boolean" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + arrayBooleanTable + " AS SELECT ARRAY[TRUE, NULL] AS col", 1);
+        assertQuery("SELECT col[1] FROM " + arrayBooleanTable, "SELECT TRUE");
+        assertQuery("SELECT col[2] FROM " + arrayBooleanTable, "SELECT NULL");
+        assertUpdate("DROP TABLE " + arrayBooleanTable);
 
-        assertUpdate("CREATE TABLE tmp_array5 AS SELECT ARRAY[ARRAY[1, 2], NULL, ARRAY[3, 4]] AS col", 1);
-        assertQuery("SELECT col[1][2] FROM tmp_array5", "SELECT 2");
+        String nestedArrayIntegerTable = "test_nested_array_integer" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + nestedArrayIntegerTable + " AS SELECT ARRAY[ARRAY[1, 2], NULL, ARRAY[3, 4]] AS col", 1);
+        assertQuery("SELECT col[1][2] FROM " + nestedArrayIntegerTable, "SELECT 2");
+        assertUpdate("DROP TABLE " + nestedArrayIntegerTable);
 
-        assertUpdate("CREATE TABLE tmp_array6 AS SELECT ARRAY[ARRAY['\"hi\"'], NULL, ARRAY['puppies']] AS col", 1);
-        assertQuery("SELECT col[1][1] FROM tmp_array6", "SELECT '\"hi\"'");
-        assertQuery("SELECT col[3][1] FROM tmp_array6", "SELECT 'puppies'");
+        String nestedArrayVarcharTable = "test_nested_array_varchar" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + nestedArrayVarcharTable + " AS SELECT ARRAY[ARRAY['\"hi\"'], NULL, ARRAY['puppies']] AS col", 1);
+        assertQuery("SELECT col[1][1] FROM " + nestedArrayVarcharTable, "SELECT '\"hi\"'");
+        assertQuery("SELECT col[3][1] FROM " + nestedArrayVarcharTable, "SELECT 'puppies'");
+        assertUpdate("DROP TABLE " + nestedArrayVarcharTable);
     }
 
     @Test
     public void testTemporalArrays()
     {
-        assertUpdate("CREATE TABLE tmp_array7 AS SELECT ARRAY[DATE '2014-09-30'] AS col", 1);
-        assertOneNotNullResult("SELECT col[1] FROM tmp_array7");
-        assertUpdate("CREATE TABLE tmp_array8 AS SELECT ARRAY[TIMESTAMP '2001-08-22 03:04:05.321'] AS col", 1);
-        assertOneNotNullResult("SELECT col[1] FROM tmp_array8");
+        String dateArrayTable = "test_array_date" + randomNameSuffix();
+        String timestampArrayTable = "test_array_timestamp" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + dateArrayTable + " AS SELECT ARRAY[DATE '2014-09-30'] AS col", 1);
+        assertOneNotNullResult("SELECT col[1] FROM " + dateArrayTable);
+        assertUpdate("DROP TABLE " + dateArrayTable);
+
+        assertUpdate("CREATE TABLE " + timestampArrayTable + " AS SELECT ARRAY[TIMESTAMP '2001-08-22 03:04:05.321'] AS col", 1);
+        assertOneNotNullResult("SELECT col[1] FROM " + timestampArrayTable);
+        assertUpdate("DROP TABLE " + timestampArrayTable);
     }
 
     @Test
     public void testSkipUnknownTypes()
     {
+        String unknownFieldTable = "test_unknown_field" + randomNameSuffix();
         Document document1 = new Document("col", Document.parse("{\"key1\": \"value1\", \"key2\": null}"));
-        client.getDatabase("test").getCollection("tmp_guess_schema1").insertOne(document1);
-        assertQuery("SHOW COLUMNS FROM test.tmp_guess_schema1", "SELECT 'col', 'row(key1 varchar)', '', ''");
-        assertQuery("SELECT col.key1 FROM test.tmp_guess_schema1", "SELECT 'value1'");
+        client.getDatabase("test").getCollection(unknownFieldTable).insertOne(document1);
+        assertQuery("SHOW COLUMNS FROM test." + unknownFieldTable, "SELECT 'col', 'row(key1 varchar)', '', ''");
+        assertQuery("SELECT col.key1 FROM test." + unknownFieldTable, "SELECT 'value1'");
+        assertUpdate("DROP TABLE test." + unknownFieldTable);
 
+        String allUnknownFieldTable = "test_all_unknown_field" + randomNameSuffix();
         Document document2 = new Document("col", new Document("key1", null));
-        client.getDatabase("test").getCollection("tmp_guess_schema2").insertOne(document2);
-        assertQueryReturnsEmptyResult("SHOW COLUMNS FROM test.tmp_guess_schema2");
+        client.getDatabase("test").getCollection(allUnknownFieldTable).insertOne(document2);
+        assertQueryReturnsEmptyResult("SHOW COLUMNS FROM test." + allUnknownFieldTable);
+        assertUpdate("DROP TABLE test." + allUnknownFieldTable);
     }
 
     @Test(dataProvider = "dbRefProvider")
@@ -405,16 +430,18 @@ public class TestMongoConnectorTest
         DBRef dbRef = new DBRef("test", "creators", objectId);
         document.append("creator", dbRef);
 
-        assertUpdate("DROP TABLE IF EXISTS test.test_dbref");
-        client.getDatabase("test").getCollection("test_dbref").insertOne(document);
+        String tableName = "test_dbref_" + randomNameSuffix();
 
-        assertThat(query("SELECT creator.databaseName, creator.collectionName, creator.id FROM test.test_dbref"))
+        assertUpdate("DROP TABLE IF EXISTS test." + tableName);
+        client.getDatabase("test").getCollection(tableName).insertOne(document);
+
+        assertThat(query("SELECT creator.databaseName, creator.collectionName, creator.id FROM test." + tableName))
                 .matches("SELECT varchar 'test', varchar 'creators', " + expectedValue);
         assertQuery(
-                "SELECT typeof(creator) FROM test.test_dbref",
+                "SELECT typeof(creator) FROM test." + tableName,
                 "SELECT 'row(databaseName varchar, collectionName varchar, id " + expectedType + ")'");
 
-        assertUpdate("DROP TABLE test.test_dbref");
+        assertUpdate("DROP TABLE test." + tableName);
     }
 
     @DataProvider
@@ -435,60 +462,86 @@ public class TestMongoConnectorTest
     @Test
     public void testMaps()
     {
-        assertUpdate("CREATE TABLE tmp_map1 AS SELECT MAP(ARRAY[0,1], ARRAY[2,NULL]) AS col", 1);
-        assertQuery("SELECT col[0] FROM tmp_map1", "SELECT 2");
-        assertQuery("SELECT col[1] FROM tmp_map1", "SELECT NULL");
+        String mapIntegerTable = "test_map_integer" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + mapIntegerTable + " AS SELECT MAP(ARRAY[0,1], ARRAY[2,NULL]) AS col", 1);
+        assertQuery("SELECT col[0] FROM " + mapIntegerTable, "SELECT 2");
+        assertQuery("SELECT col[1] FROM " + mapIntegerTable, "SELECT NULL");
+        assertUpdate("DROP TABLE " + mapIntegerTable);
 
-        assertUpdate("CREATE TABLE tmp_map2 AS SELECT MAP(ARRAY[1.0E0], ARRAY[2.5E0]) AS col", 1);
-        assertQuery("SELECT col[1.0] FROM tmp_map2", "SELECT 2.5");
+        String mapDoubleTable = "test_map_double" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + mapDoubleTable + " AS SELECT MAP(ARRAY[1.0E0], ARRAY[2.5E0]) AS col", 1);
+        assertQuery("SELECT col[1.0] FROM " + mapDoubleTable, "SELECT 2.5");
+        assertUpdate("DROP TABLE " + mapDoubleTable);
 
-        assertUpdate("CREATE TABLE tmp_map3 AS SELECT MAP(ARRAY['puppies'], ARRAY['kittens']) AS col", 1);
-        assertQuery("SELECT col['puppies'] FROM tmp_map3", "SELECT 'kittens'");
+        String mapVarcharTable = "test_map_varchar" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + mapVarcharTable + " AS SELECT MAP(ARRAY['puppies'], ARRAY['kittens']) AS col", 1);
+        assertQuery("SELECT col['puppies'] FROM " + mapVarcharTable, "SELECT 'kittens'");
+        assertUpdate("DROP TABLE " + mapVarcharTable);
 
-        assertUpdate("CREATE TABLE tmp_map4 AS SELECT MAP(ARRAY[TRUE], ARRAY[FALSE]) AS col", "SELECT 1");
-        assertQuery("SELECT col[TRUE] FROM tmp_map4", "SELECT FALSE");
+        String mapBooleanTable = "test_map_boolean" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + mapBooleanTable + " AS SELECT MAP(ARRAY[TRUE], ARRAY[FALSE]) AS col", "SELECT 1");
+        assertQuery("SELECT col[TRUE] FROM " + mapBooleanTable, "SELECT FALSE");
+        assertUpdate("DROP TABLE " + mapBooleanTable);
 
-        assertUpdate("CREATE TABLE tmp_map5 AS SELECT MAP(ARRAY[1.0E0], ARRAY[ARRAY[1, 2]]) AS col", 1);
-        assertQuery("SELECT col[1.0][2] FROM tmp_map5", "SELECT 2");
+        String mapDoubleNestedTable = "test_map_double_nested" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + mapDoubleNestedTable + " AS SELECT MAP(ARRAY[1.0E0], ARRAY[ARRAY[1, 2]]) AS col", 1);
+        assertQuery("SELECT col[1.0][2] FROM " + mapDoubleNestedTable, "SELECT 2");
+        assertUpdate("DROP TABLE " + mapDoubleNestedTable);
 
-        assertUpdate("CREATE TABLE tmp_map6 AS SELECT MAP(ARRAY[DATE '2014-09-30'], ARRAY[DATE '2014-09-29']) AS col", 1);
-        assertOneNotNullResult("SELECT col[DATE '2014-09-30'] FROM tmp_map6");
-        assertUpdate("CREATE TABLE tmp_map7 AS SELECT MAP(ARRAY[TIMESTAMP '2001-08-22 03:04:05.321'], ARRAY[TIMESTAMP '2001-08-22 03:04:05.321']) AS col", 1);
-        assertOneNotNullResult("SELECT col[TIMESTAMP '2001-08-22 03:04:05.321'] FROM tmp_map7");
+        String mapDateTable = "test_map_date" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + mapDateTable + " AS SELECT MAP(ARRAY[DATE '2014-09-30'], ARRAY[DATE '2014-09-29']) AS col", 1);
+        assertOneNotNullResult("SELECT col[DATE '2014-09-30'] FROM " + mapDateTable);
+        assertUpdate("DROP TABLE " + mapDateTable);
 
-        assertUpdate("CREATE TABLE test.tmp_map8 (col MAP<VARCHAR, VARCHAR>)");
-        client.getDatabase("test").getCollection("tmp_map8").insertOne(new Document(
+        String mapTimestampTable = "test_map_timestamp" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + mapTimestampTable + " AS SELECT MAP(ARRAY[TIMESTAMP '2001-08-22 03:04:05.321'], ARRAY[TIMESTAMP '2001-08-22 03:04:05.321']) AS col", 1);
+        assertOneNotNullResult("SELECT col[TIMESTAMP '2001-08-22 03:04:05.321'] FROM " + mapTimestampTable);
+        assertUpdate("DROP TABLE " + mapTimestampTable);
+
+        String mapTable = "test_map" + randomNameSuffix();
+        assertUpdate("CREATE TABLE test." + mapTable + " (col MAP<VARCHAR, VARCHAR>)");
+        client.getDatabase("test").getCollection(mapTable).insertOne(new Document(
                 ImmutableMap.of("col", new Document(ImmutableMap.of("key1", "value1", "key2", "value2")))));
-        assertQuery("SELECT col['key1'] FROM test.tmp_map8", "SELECT 'value1'");
+        assertQuery("SELECT col['key1'] FROM test." + mapTable, "SELECT 'value1'");
+        assertUpdate("DROP TABLE test." + mapTable);
 
-        assertUpdate("CREATE TABLE test.tmp_map9 (col VARCHAR)");
-        client.getDatabase("test").getCollection("tmp_map9").insertOne(new Document(
+        String simpleMapToVarcharTable = "test_simple_map_to_varchar" + randomNameSuffix();
+        assertUpdate("CREATE TABLE test." + simpleMapToVarcharTable + " (col VARCHAR)");
+        client.getDatabase("test").getCollection(simpleMapToVarcharTable).insertOne(new Document(
                 ImmutableMap.of("col", new Document(ImmutableMap.of("key1", "value1", "key2", "value2")))));
-        assertQuery("SELECT col FROM test.tmp_map9", "SELECT '{\"key1\": \"value1\", \"key2\": \"value2\"}'");
+        assertQuery("SELECT col FROM test." + simpleMapToVarcharTable, "SELECT '{\"key1\": \"value1\", \"key2\": \"value2\"}'");
+        assertUpdate("DROP TABLE test." + simpleMapToVarcharTable);
 
-        assertUpdate("CREATE TABLE test.tmp_map10 (col VARCHAR)");
-        client.getDatabase("test").getCollection("tmp_map10").insertOne(new Document(
+        String listMapToVarcharTable = "test_list_map_to_varchar" + randomNameSuffix();
+        assertUpdate("CREATE TABLE test." + listMapToVarcharTable + " (col VARCHAR)");
+        client.getDatabase("test").getCollection(listMapToVarcharTable).insertOne(new Document(
                 ImmutableMap.of("col", ImmutableList.of(new Document(ImmutableMap.of("key1", "value1", "key2", "value2")),
                         new Document(ImmutableMap.of("key3", "value3", "key4", "value4"))))));
-        assertQuery("SELECT col FROM test.tmp_map10", "SELECT '[{\"key1\": \"value1\", \"key2\": \"value2\"}, {\"key3\": \"value3\", \"key4\": \"value4\"}]'");
+        assertQuery("SELECT col FROM test." + listMapToVarcharTable, "SELECT '[{\"key1\": \"value1\", \"key2\": \"value2\"}, {\"key3\": \"value3\", \"key4\": \"value4\"}]'");
+        assertUpdate("DROP TABLE test." + listMapToVarcharTable);
 
-        assertUpdate("CREATE TABLE test.tmp_map11 (col VARCHAR)");
-        client.getDatabase("test").getCollection("tmp_map11").insertOne(new Document(
+        String integerToVarcharTable = "test_integer_to_varchar" + randomNameSuffix();
+        assertUpdate("CREATE TABLE test." + integerToVarcharTable + " (col VARCHAR)");
+        client.getDatabase("test").getCollection(integerToVarcharTable).insertOne(new Document(
                 ImmutableMap.of("col", 10)));
-        assertQuery("SELECT col FROM test.tmp_map11", "SELECT '10'");
+        assertQuery("SELECT col FROM test." + integerToVarcharTable, "SELECT '10'");
+        assertUpdate("DROP TABLE test." + integerToVarcharTable);
 
-        assertUpdate("CREATE TABLE test.tmp_map12 (col VARCHAR)");
-        client.getDatabase("test").getCollection("tmp_map12").insertOne(new Document(
+        String arrayToVarcharTable = "test_array_to_varchar" + randomNameSuffix();
+        assertUpdate("CREATE TABLE test." + arrayToVarcharTable + " (col VARCHAR)");
+        client.getDatabase("test").getCollection(arrayToVarcharTable).insertOne(new Document(
                 ImmutableMap.of("col", Arrays.asList(10, null, 11))));
-        assertQuery("SELECT col FROM test.tmp_map12", "SELECT '[10, null, 11]'");
+        assertQuery("SELECT col FROM test." + arrayToVarcharTable, "SELECT '[10, null, 11]'");
+        assertUpdate("DROP TABLE test." + arrayToVarcharTable);
     }
 
     @Test
     public void testCollectionNameContainsDots()
     {
-        assertUpdate("CREATE TABLE \"tmp.dot1\" AS SELECT 'foo' _varchar", 1);
-        assertQuery("SELECT _varchar FROM \"tmp.dot1\"", "SELECT 'foo'");
-        assertUpdate("DROP TABLE \"tmp.dot1\"");
+        String tableName = "test.dot1_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE \"" + tableName + "\" AS SELECT 'foo' _varchar", 1);
+        assertQuery("SELECT _varchar FROM \"" + tableName + "\"", "SELECT 'foo'");
+        assertUpdate("DROP TABLE \"" + tableName + "\"");
     }
 
     @Test
@@ -503,12 +556,13 @@ public class TestMongoConnectorTest
                 " (15, NULL, ObjectId('ffffffffffffffffffffffff'))";
         String inlineTable = format("(%s) AS t(i, one, two)", values);
 
-        assertUpdate("DROP TABLE IF EXISTS tmp_objectid");
-        assertUpdate("CREATE TABLE tmp_objectid AS SELECT * FROM " + inlineTable, 6);
+        String tableName = "test_objectid_" + randomNameSuffix();
+        assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM " + inlineTable, 6);
 
         // IS NULL
         assertQuery("SELECT i FROM " + inlineTable + " WHERE one IS NULL", "VALUES 10, 15");
-        assertQuery("SELECT i FROM tmp_objectid WHERE one IS NULL", "SELECT 0 WHERE false"); // NULL gets replaced with new unique ObjectId in MongoPageSink, this affects other test cases
+        assertQuery("SELECT i FROM " + tableName + " WHERE one IS NULL", "SELECT 0 WHERE false"); // NULL gets replaced with new unique ObjectId in MongoPageSink, this affects other test cases
 
         // CAST AS varchar
         assertQuery(
@@ -516,15 +570,15 @@ public class TestMongoConnectorTest
                 "VALUES (10, NULL), (11, 'ffffffffffffffffffffffff'), (12, 'ffffffffffffffffffffffff'), (13, '000000000000000000000000')");
 
         // EQUAL
-        assertQuery("SELECT i FROM tmp_objectid WHERE one = two", "VALUES 11, 13");
-        assertQuery("SELECT i FROM tmp_objectid WHERE one = ObjectId('ffffffffffffffffffffffff')", "VALUES 11, 12, 14");
+        assertQuery("SELECT i FROM " + tableName + " WHERE one = two", "VALUES 11, 13");
+        assertQuery("SELECT i FROM " + tableName + " WHERE one = ObjectId('ffffffffffffffffffffffff')", "VALUES 11, 12, 14");
 
         // IS DISTINCT FROM
         assertQuery("SELECT i FROM " + inlineTable + " WHERE one IS DISTINCT FROM two", "VALUES 12, 14, 15");
         assertQuery("SELECT i FROM " + inlineTable + " WHERE one IS NOT DISTINCT FROM two", "VALUES 10, 11, 13");
 
-        assertQuery("SELECT i FROM tmp_objectid WHERE one IS DISTINCT FROM two", "VALUES 10, 12, 14, 15");
-        assertQuery("SELECT i FROM tmp_objectid WHERE one IS NOT DISTINCT FROM two", "VALUES 11, 13");
+        assertQuery("SELECT i FROM " + tableName + " WHERE one IS DISTINCT FROM two", "VALUES 10, 12, 14, 15");
+        assertQuery("SELECT i FROM " + tableName + " WHERE one IS NOT DISTINCT FROM two", "VALUES 11, 13");
 
         // Join on ObjectId
         assertQuery(
@@ -543,47 +597,51 @@ public class TestMongoConnectorTest
                 "SELECT r.x, CAST(r.one AS varchar), count(*) FROM (SELECT CAST(row(one, i / 3 * 3) AS row(one ObjectId, x bigint)) r FROM " + inlineTable + ") GROUP BY r",
                 "VALUES (9, NULL, 1), (9, 'ffffffffffffffffffffffff', 1), (12, 'ffffffffffffffffffffffff', 2), (12, '000000000000000000000000', 1), (15, NULL, 1)");
 
-        assertUpdate("DROP TABLE tmp_objectid");
+        assertUpdate("DROP TABLE " + tableName);
     }
 
     @Test
     public void testSelectView()
     {
-        assertUpdate("CREATE TABLE test.view_base AS SELECT 'foo' _varchar", 1);
-        client.getDatabase("test").createView("test_view", "view_base", ImmutableList.of());
-        assertQuery("SELECT * FROM test.view_base", "SELECT 'foo'");
-        assertUpdate("DROP TABLE test.test_view");
-        assertUpdate("DROP TABLE test.view_base");
+        String tableName = "test_view_base_" + randomNameSuffix();
+        String viewName = "test_view_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE test." + tableName + " AS SELECT 'foo' _varchar", 1);
+        client.getDatabase("test").createView(viewName, tableName, ImmutableList.of());
+        assertQuery("SELECT * FROM test." + viewName, "SELECT 'foo'");
+        assertUpdate("DROP TABLE test." + viewName);
+        assertUpdate("DROP TABLE test." + tableName);
     }
 
     @Test
     public void testBooleanPredicates()
     {
-        assertUpdate("CREATE TABLE boolean_predicates(id integer, value boolean)");
-        assertUpdate("INSERT INTO boolean_predicates VALUES(1, true)", 1);
-        assertUpdate("INSERT INTO boolean_predicates VALUES(2, false)", 1);
+        String tableName = "test_boolean_predicates_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + "(id integer, value boolean)");
+        assertUpdate("INSERT INTO " + tableName + " VALUES(1, true)", 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES(2, false)", 1);
 
-        assertQuery("SELECT id FROM boolean_predicates WHERE value = true", "VALUES 1");
-        assertQuery("SELECT id FROM boolean_predicates WHERE value = false", "VALUES 2");
+        assertQuery("SELECT id FROM " + tableName + " WHERE value = true", "VALUES 1");
+        assertQuery("SELECT id FROM " + tableName + " WHERE value = false", "VALUES 2");
 
-        assertUpdate("DROP TABLE boolean_predicates");
+        assertUpdate("DROP TABLE " + tableName);
     }
 
     @Test
     public void testNullPredicates()
     {
-        assertUpdate("CREATE TABLE test.null_predicates(name varchar, value integer)");
+        String tableName = "test_null_predicates_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE test." + tableName + "(name varchar, value integer)");
 
-        MongoCollection<Document> collection = client.getDatabase("test").getCollection("null_predicates");
+        MongoCollection<Document> collection = client.getDatabase("test").getCollection(tableName);
         collection.insertOne(new Document(ImmutableMap.of("name", "abc", "value", 1)));
         collection.insertOne(new Document(ImmutableMap.of("name", "abcd")));
         collection.insertOne(new Document(Document.parse("{\"name\": \"abcde\", \"value\": null}")));
 
-        assertQuery("SELECT count(*) FROM test.null_predicates WHERE value IS NULL OR rand() = 42", "SELECT 2");
-        assertQuery("SELECT count(*) FROM test.null_predicates WHERE value IS NULL", "SELECT 2");
-        assertQuery("SELECT count(*) FROM test.null_predicates WHERE value IS NOT NULL", "SELECT 1");
+        assertQuery("SELECT count(*) FROM test." + tableName + " WHERE value IS NULL OR rand() = 42", "SELECT 2");
+        assertQuery("SELECT count(*) FROM test." + tableName + " WHERE value IS NULL", "SELECT 2");
+        assertQuery("SELECT count(*) FROM test." + tableName + " WHERE value IS NOT NULL", "SELECT 1");
 
-        assertUpdate("DROP TABLE test.null_predicates");
+        assertUpdate("DROP TABLE test." + tableName);
     }
 
     @Test
@@ -609,7 +667,7 @@ public class TestMongoConnectorTest
                 .insertMany(ImmutableList.of(new Document("text", "e"), new Document("text", "é")));
 
         assertQuery("SELECT * FROM test." + tableName + " WHERE text = 'e'", "VALUES 'e'");
-        client.getDatabase("test").getCollection(tableName).drop();
+        assertUpdate("DROP TABLE test." + tableName);
     }
 
     @Test
@@ -622,7 +680,7 @@ public class TestMongoConnectorTest
                 .insertMany(ImmutableList.of(new Document("text", "abc"), new Document("text", "ABC")));
 
         assertQuery("SELECT * FROM test." + tableName + " WHERE text > 'ABC'", "VALUES 'abc'");
-        client.getDatabase("test").getCollection(tableName).drop();
+        assertUpdate("DROP TABLE test." + tableName);
     }
 
     @Test
@@ -635,7 +693,7 @@ public class TestMongoConnectorTest
                 .insertMany(ImmutableList.of(new Document("number", "-10"), new Document("number", "-2.1"), new Document("number", "1")));
 
         assertQuery("SELECT * FROM test." + tableName + " WHERE number > '-2.1'", "VALUES '1'");
-        client.getDatabase("test").getCollection(tableName).drop();
+        assertUpdate("DROP TABLE test." + tableName);
     }
 
     @Override
@@ -666,6 +724,7 @@ public class TestMongoConnectorTest
 
         assertThat(query("SELECT array_field FROM TABLE(mongodb.system.query(database => 'tpch', collection => '" + tableName + "', filter => '{ \"array_field.1\": \"one\" }'))"))
                 .matches("VALUES CAST(ARRAY['zero', 'one', 'two'] AS array(varchar))");
+        assertUpdate("DROP TABLE " + tableName);
     }
 
     @Test
@@ -679,6 +738,7 @@ public class TestMongoConnectorTest
         assertQuery(
                 "SELECT row_field.first.second FROM TABLE(mongodb.system.query(database => 'tpch', collection => '" + tableName + "', filter => '{ \"row_field.first.second\": 1 }'))",
                 "VALUES 1");
+        assertUpdate("DROP TABLE " + tableName);
     }
 
     @Test
@@ -729,6 +789,7 @@ public class TestMongoConnectorTest
         assertQuery(
                 "SELECT * FROM TABLE(mongodb.system.query(database => 'test', collection => '" + tableName + "', filter => '{\"TestColumn\": 1}'))",
                 "VALUES 1");
+        assertUpdate("DROP TABLE test." + tableName);
     }
 
     @Test

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
@@ -846,6 +846,15 @@ public class TestMongoConnectorTest
         assertThat(getQueryRunner().execute("SHOW TABLES FROM mongodb.huge_schema").getRowCount()).isEqualTo(10_000);
     }
 
+    @Test
+    public void testSystemSchemas()
+    {
+        // Ensures that system schemas are inaccessible
+        assertQueryReturnsEmptyResult("SHOW SCHEMAS IN mongodb LIKE 'admin'");
+        assertQueryReturnsEmptyResult("SHOW SCHEMAS IN mongodb LIKE 'config'");
+        assertQueryReturnsEmptyResult("SHOW SCHEMAS IN mongodb LIKE 'local'");
+    }
+
     @Override
     protected OptionalInt maxSchemaNameLength()
     {

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -2582,6 +2582,7 @@ public abstract class BaseConnectorTest
         assertThatThrownBy(() -> assertUpdate("ALTER TABLE " + sourceTableName + " RENAME TO " + invalidTargetTableName))
                 .satisfies(this::verifyTableNameLengthFailurePermissible);
         assertFalse(getQueryRunner().tableExists(getSession(), invalidTargetTableName));
+        assertUpdate("DROP TABLE " + sourceTableName);
     }
 
     protected OptionalInt maxTableNameLength()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

- Clean up those tests resources after test execution
- Randomize the resource names of the created mongo test resources
- system.views is not queryable collection hence included in the system tables to be filtered before returning the available collection in the database
- System database to be filtered before returning the list of available databases

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.

