### PR TITLE
Add stale tracking action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: Stale PR tracking
+
+on:
+  schedule:
+    - cron: '0 17 * * 1-5' # 9am UTC-8 on weekdays
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v7
+        with:
+          stale-pr-message: 'This pull request has gone a while without any activity. Tagging the Trino developer relations team: @bitsondatadev @colebow @mosabua'
+          days-before-pr-stale: 21
+          days-before-pr-close: 21
+          close-pr-message: 'Closing this pull request, as it has been stale for six weeks. Feel free to re-open at any time.'
+          stale-pr-label: 'stale'
+          exempt-pr-labels: 'no-stale'
+          start-date: '2023-01-01T00:00:00Z'


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This PR hooks into the [Close Stale Issues](https://github.com/marketplace/actions/close-stale-issues) action with some custom configuration to allow us to monitor & track staling PRs. A couple things to note:

* We'll need to add `stale` and `no-stale` (maybe `ignore-stale` would be better?) labels to the Trino project to support the bot.
* It will only run for PRs created this year, but we could remove that config option and extend this to the existing backlog once we're completely done manually sifting through it.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

The goal here is to make sure that PRs get the attention they need. The initial message will ping myself, @bitsondatadev, and @mosabua, and we'll be reviewing these mentions, triaging these PRs, working with the contributor who posted them, and finding maintainers/reviewers who can help move them forward and avoid having them be closed. If PRs fall off our radar or contributors never respond to us, then the action will eventually clean them up and close them for us.

I'm not entirely sure _exactly_ how the un-staling process works (does the action automatically remove the stale label? or does it just ignore it once their are updates?), so I'd like to see the bot in action and work with it a little bit before documenting it in DEVELOPMENT.md.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.