### PR TITLE
Describe session properties from config

### DIFF
--- a/lib/trino-plugin-toolkit/pom.xml
+++ b/lib/trino-plugin-toolkit/pom.xml
@@ -125,6 +125,12 @@
         </dependency>
 
         <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.12.13</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.gaul</groupId>
             <artifactId>modernizer-maven-annotations</artifactId>
         </dependency>

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/session/PropertyMetadataUtil.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/session/PropertyMetadataUtil.java
@@ -13,13 +13,44 @@
  */
 package io.trino.plugin.base.session;
 
+import com.google.common.base.Functions;
+import com.google.common.primitives.Primitives;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.spi.session.PropertyMetadata;
+import io.trino.spi.type.Type;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.implementation.MethodDelegation;
+import net.bytebuddy.implementation.bind.annotation.AllArguments;
+import net.bytebuddy.implementation.bind.annotation.Origin;
+import net.bytebuddy.implementation.bind.annotation.RuntimeType;
+import net.bytebuddy.matcher.ElementMatchers;
 
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
+import static com.google.common.base.Defaults.defaultValue;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.collect.MoreCollectors.onlyElement;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
 
 public final class PropertyMetadataUtil
 {
@@ -67,5 +98,155 @@ public final class PropertyMetadataUtil
                     return value;
                 },
                 Duration::toString);
+    }
+
+    public static PropertyBuilder property(String name)
+    {
+        return new PropertyBuilder(name);
+    }
+
+    public static class PropertyBuilder
+    {
+        private final String name;
+        private String description;
+        private Type sqlType;
+        private Class<?> javaType;
+        private @Nullable Object defaultValue;
+        private boolean hidden;
+
+        private PropertyBuilder(String name)
+        {
+            this.name = requireNonNull(name, "name is null");
+        }
+
+        @CanIgnoreReturnValue
+        public <C, T> PropertyBuilder fromConfig(C config, Function<C, T> getterMethodReference)
+        {
+            Class<?> configClass = config.getClass();
+            Method getter = findMethodByReference(configClass, configInstance -> {
+                //noinspection unchecked
+                T ignored = getterMethodReference.apply((C) configInstance);
+            });
+            description = findConfigDescriptionByGetter(configClass, getter)
+                    .orElseThrow(() -> new IllegalArgumentException("Config associated with %s.%s has no description".formatted(configClass.getName(), getter.getName())));
+            // Session properties are never primitives, as they are accessed with generic `ConnectorSession.getProperty(String, Class)`
+            javaType = Primitives.wrap(getter.getReturnType());
+            defaultValue = getterMethodReference.apply(config);
+
+            if (javaType == Boolean.class) {
+                sqlType = BOOLEAN;
+            }
+            if (javaType == Integer.class) {
+                sqlType = INTEGER;
+            }
+            if (javaType == Long.class) {
+                sqlType = BIGINT;
+            }
+            if (javaType == String.class) {
+                sqlType = VARCHAR;
+            }
+
+            return this;
+        }
+
+        @CanIgnoreReturnValue
+        public PropertyBuilder hidden()
+        {
+            hidden = true;
+            return this;
+        }
+
+        public PropertyMetadata<?> build()
+        {
+            Function<Object, Object> decoder = Functions.identity();
+            Function<Object, Object> encoder = Functions.identity();
+
+            //noinspection unchecked,rawtypes
+            return new PropertyMetadata(
+                    name,
+                    description,
+                    sqlType,
+                    javaType,
+                    defaultValue,
+                    hidden,
+                    decoder,
+                    encoder);
+        }
+    }
+
+    private static <C> Method findMethodByReference(Class<C> clazz, Consumer<C> methodReference)
+    {
+        List<Method> calledMethods = new ArrayList<>(1);
+        try (DynamicType.Unloaded<C> interceptingClass = new ByteBuddy()
+                .subclass(clazz)
+                .method(ElementMatchers.any())
+                .intercept(MethodDelegation.to(new TrackCallsInterceptor(calledMethods::add)))
+                .make()) {
+            C interceptingConfigInstance = interceptingClass
+                    .load(selectivelyChildFirstClassLoader(interceptingClass.getTypeDescription().getName(), clazz.getClassLoader()))
+                    .getLoaded()
+                    .getConstructor()
+                    .newInstance();
+            methodReference.accept(interceptingConfigInstance);
+            return getOnlyElement(calledMethods);
+        }
+        catch (ReflectiveOperationException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Child-first classloader for generated class, to avoid leak in ClassLoader.parallelLockMap within parent class loader.
+     */
+    private static ClassLoader selectivelyChildFirstClassLoader(String forClassName, ClassLoader parent)
+    {
+        requireNonNull(forClassName, "forClassName is null");
+        return new URLClassLoader(new URL[0], parent)
+        {
+            @Override
+            protected Class<?> loadClass(String name, boolean resolve)
+                    throws ClassNotFoundException
+            {
+                if (name.equals(forClassName)) {
+                    return findClass(name);
+                }
+                return super.loadClass(name, resolve);
+            }
+        };
+    }
+
+    public static class TrackCallsInterceptor
+    {
+        private final Consumer<Method> report;
+
+        public TrackCallsInterceptor(Consumer<Method> report)
+        {
+            this.report = requireNonNull(report, "report is null");
+        }
+
+        @RuntimeType
+        @SuppressWarnings("unused")
+        public Object intercept(@Origin Method method, @AllArguments Object[] allArguments)
+        {
+            report.accept(method);
+            return defaultValue(method.getReturnType());
+        }
+    }
+
+    private static Optional<String> findConfigDescriptionByGetter(Class<?> clazz, Method getter)
+    {
+        String name = getter.getName();
+        if (!name.startsWith("is") && !name.startsWith("get")) {
+            throw new IllegalArgumentException("Not getter method: " + name);
+        }
+        String setterName = name.replaceFirst("^(is|get)", "set");
+
+        Method setter = Stream.of(clazz.getMethods())
+                .filter(method -> method.getName().equals(setterName))
+                .filter(method -> method.isAnnotationPresent(Config.class))
+                .collect(onlyElement());
+
+        return Optional.ofNullable(setter.getAnnotation(ConfigDescription.class))
+                .map(ConfigDescription::value);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -45,7 +45,6 @@ public class IcebergConfig
     public static final int FORMAT_VERSION_SUPPORT_MIN = 1;
     public static final int FORMAT_VERSION_SUPPORT_MAX = 2;
     public static final String EXTENDED_STATISTICS_CONFIG = "iceberg.extended-statistics.enabled";
-    public static final String EXTENDED_STATISTICS_DESCRIPTION = "Enable collection (ANALYZE) and use of extended statistics.";
     public static final String EXPIRE_SNAPSHOTS_MIN_RETENTION = "iceberg.expire_snapshots.min-retention";
     public static final String REMOVE_ORPHAN_FILES_MIN_RETENTION = "iceberg.remove_orphan_files.min-retention";
 
@@ -194,7 +193,7 @@ public class IcebergConfig
     }
 
     @Config(EXTENDED_STATISTICS_CONFIG)
-    @ConfigDescription(EXTENDED_STATISTICS_DESCRIPTION)
+    @ConfigDescription("Enable collection (ANALYZE) and use of extended statistics.")
     public IcebergConfig setExtendedStatisticsEnabled(boolean extendedStatisticsEnabled)
     {
         this.extendedStatisticsEnabled = extendedStatisticsEnabled;

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -36,7 +36,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.plugin.base.session.PropertyMetadataUtil.dataSizeProperty;
 import static io.trino.plugin.base.session.PropertyMetadataUtil.durationProperty;
-import static io.trino.plugin.iceberg.IcebergConfig.EXTENDED_STATISTICS_DESCRIPTION;
+import static io.trino.plugin.base.session.PropertyMetadataUtil.property;
 import static io.trino.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static io.trino.spi.session.PropertyMetadata.booleanProperty;
 import static io.trino.spi.session.PropertyMetadata.doubleProperty;
@@ -234,11 +234,9 @@ public final class IcebergSessionProperties
                         "Expose table statistics",
                         icebergConfig.isTableStatisticsEnabled(),
                         false))
-                .add(booleanProperty(
-                        EXTENDED_STATISTICS_ENABLED,
-                        EXTENDED_STATISTICS_DESCRIPTION,
-                        icebergConfig.isExtendedStatisticsEnabled(),
-                        false))
+                .add(property(EXTENDED_STATISTICS_ENABLED)
+                        .fromConfig(icebergConfig, IcebergConfig::isExtendedStatisticsEnabled)
+                        .build())
                 .add(booleanProperty(
                         PROJECTION_PUSHDOWN_ENABLED,
                         "Read only required fields from a struct",


### PR DESCRIPTION
More often than not, a session property have a corresponding config property and their description it same, or should be same but is unintentionally different. This commit introduces a helper to define session properties based on config values, syncing their descriptions. It also removes type-related boilerplate for configs where types can be trivially inferred from config types.
