### PR TITLE
Add support for Iceberg catalog warehouse property in REST

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -95,6 +95,9 @@ Property Name                                        Description
 ``iceberg.rest-catalog.uri``                   REST server API endpoint URI (required).
                                                Example: ``http://iceberg-with-rest:8181``
 
+``iceberg.rest-catalog.warehouse``             Warehouse identifier/location for the catalog (optional).
+                                               Example: ``s3://my_bucket/warehouse_location``
+
 ``iceberg.rest-catalog.security``              The type of security to use (default: ``NONE``).  ``OAUTH2``
                                                requires either a ``token`` or ``credential``.
                                                Example: ``OAUTH2``

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogConfig.java
@@ -19,6 +19,7 @@ import io.airlift.configuration.ConfigDescription;
 import javax.validation.constraints.NotNull;
 
 import java.net.URI;
+import java.util.Optional;
 
 public class IcebergRestCatalogConfig
 {
@@ -35,6 +36,7 @@ public class IcebergRestCatalogConfig
     }
 
     private URI restUri;
+    private Optional<String> warehouse = Optional.empty();
     private Security security = Security.NONE;
     private SessionType sessionType = SessionType.NONE;
 
@@ -79,6 +81,19 @@ public class IcebergRestCatalogConfig
     public IcebergRestCatalogConfig setSessionType(SessionType sessionType)
     {
         this.sessionType = sessionType;
+        return this;
+    }
+
+    public Optional<String> getWarehouse()
+    {
+        return warehouse;
+    }
+
+    @Config("iceberg.rest-catalog.warehouse")
+    @ConfigDescription("The warehouse location/identifier to use with the REST catalog server")
+    public IcebergRestCatalogConfig setWarehouse(String warehouse)
+    {
+        this.warehouse = Optional.ofNullable(warehouse);
         return this;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
@@ -29,6 +29,7 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.inject.Inject;
 
 import java.net.URI;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -38,6 +39,7 @@ public class TrinoIcebergRestCatalogFactory
     private final CatalogName catalogName;
     private final String trinoVersion;
     private final URI serverUri;
+    private final Optional<String> warehouse;
     private final SessionType sessionType;
     private final SecurityProperties securityProperties;
     private final boolean uniqueTableLocation;
@@ -57,6 +59,7 @@ public class TrinoIcebergRestCatalogFactory
         this.trinoVersion = requireNonNull(nodeVersion, "nodeVersion is null").toString();
         requireNonNull(restConfig, "restConfig is null");
         this.serverUri = restConfig.getBaseUri();
+        this.warehouse = restConfig.getWarehouse();
         this.sessionType = restConfig.getSessionType();
         this.securityProperties = requireNonNull(securityProperties, "securityProperties is null");
         requireNonNull(icebergConfig, "icebergConfig is null");
@@ -71,6 +74,7 @@ public class TrinoIcebergRestCatalogFactory
         if (icebergCatalog == null) {
             ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
             properties.put(CatalogProperties.URI, serverUri.toString());
+            warehouse.ifPresent(location -> properties.put(CatalogProperties.WAREHOUSE_LOCATION, location));
             properties.put("trino-version", trinoVersion);
             properties.putAll(securityProperties.get());
             RESTSessionCatalog icebergCatalogInstance = new RESTSessionCatalog();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogConfig.java
@@ -29,6 +29,7 @@ public class TestIcebergRestCatalogConfig
     {
         assertRecordedDefaults(recordDefaults(IcebergRestCatalogConfig.class)
                 .setBaseUri(null)
+                .setWarehouse(null)
                 .setSessionType(IcebergRestCatalogConfig.SessionType.NONE)
                 .setSecurity(IcebergRestCatalogConfig.Security.NONE));
     }
@@ -38,12 +39,14 @@ public class TestIcebergRestCatalogConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("iceberg.rest-catalog.uri", "http://localhost:1234")
+                .put("iceberg.rest-catalog.warehouse", "test_warehouse_identifier")
                 .put("iceberg.rest-catalog.security", "OAUTH2")
                 .put("iceberg.rest-catalog.session", "USER")
                 .buildOrThrow();
 
         IcebergRestCatalogConfig expected = new IcebergRestCatalogConfig()
                 .setBaseUri("http://localhost:1234")
+                .setWarehouse("test_warehouse_identifier")
                 .setSessionType(IcebergRestCatalogConfig.SessionType.USER)
                 .setSecurity(IcebergRestCatalogConfig.Security.OAUTH2);
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This PR adds support for configuring the `warehouse` [catalog property](https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/CatalogProperties.java#L29) for the REST Catalog which is part of the [REST Spec](https://github.com/apache/iceberg/blob/master/open-api/rest-catalog-open-api.yaml#L88).

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

N/A

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
