### PR TITLE
Improve HiveUtils name escaping

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestHiveUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestHiveUtil.java
@@ -129,6 +129,7 @@ public class TestHiveUtil
         assertUnescapePathName("", "");
         assertUnescapePathName("x", "x");
         assertUnescapePathName("abc", "abc");
+        assertUnescapePathName("abc%", "abc%");
         assertUnescapePathName("%", "%");
         assertUnescapePathName("%41", "A");
         assertUnescapePathName("%41%x", "A%x");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Avoids creating unnecessary String copies when attempting to escape and unescape path name parts that have no special characters in them. Also avoids the unnecessary overhead of using String.format when unescaping is necessary and pre-computes the `CharMatcher` (which results in a faster, 16 byte bitset).

Similar code was contributed to Hive in [HIVE-26685](https://issues.apache.org/jira/browse/HIVE-26685) (pull request: https://github.com/apache/hive/pull/3721), but was further improved here for Trino to use `java.util.HexFormat` which is not available in JDK8.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
