### PR TITLE
Rename Iceberg JDBC catalog config class

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcCatalogConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcCatalogConfig.java
@@ -19,7 +19,7 @@ import io.airlift.configuration.ConfigSecuritySensitive;
 
 import javax.validation.constraints.NotEmpty;
 
-public class IcebergJdbcConfig
+public class IcebergJdbcCatalogConfig
 {
     private String connectionUrl;
     private String catalogName;
@@ -33,7 +33,7 @@ public class IcebergJdbcConfig
     @Config("iceberg.jdbc-catalog.connection-url")
     @ConfigDescription("The URI to connect to the JDBC server")
     @ConfigSecuritySensitive
-    public IcebergJdbcConfig setConnectionUrl(String connectionUrl)
+    public IcebergJdbcCatalogConfig setConnectionUrl(String connectionUrl)
     {
         this.connectionUrl = connectionUrl;
         return this;
@@ -47,7 +47,7 @@ public class IcebergJdbcConfig
 
     @Config("iceberg.jdbc-catalog.catalog-name")
     @ConfigDescription("Iceberg JDBC metastore catalog name")
-    public IcebergJdbcConfig setCatalogName(String catalogName)
+    public IcebergJdbcCatalogConfig setCatalogName(String catalogName)
     {
         this.catalogName = catalogName;
         return this;
@@ -61,7 +61,7 @@ public class IcebergJdbcConfig
 
     @Config("iceberg.jdbc-catalog.default-warehouse-dir")
     @ConfigDescription("The default warehouse directory to use for JDBC")
-    public IcebergJdbcConfig setDefaultWarehouseDir(String defaultWarehouseDir)
+    public IcebergJdbcCatalogConfig setDefaultWarehouseDir(String defaultWarehouseDir)
     {
         this.defaultWarehouseDir = defaultWarehouseDir;
         return this;

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcCatalogModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcCatalogModule.java
@@ -30,7 +30,7 @@ public class IcebergJdbcCatalogModule
     @Override
     protected void setup(Binder binder)
     {
-        configBinder(binder).bindConfig(IcebergJdbcConfig.class);
+        configBinder(binder).bindConfig(IcebergJdbcCatalogConfig.class);
         binder.bind(IcebergTableOperationsProvider.class).to(IcebergJdbcTableOperationsProvider.class).in(Scopes.SINGLETON);
         newExporter(binder).export(IcebergTableOperationsProvider.class).withGeneratedName();
         binder.bind(TrinoCatalogFactory.class).to(TrinoJdbcCatalogFactory.class).in(Scopes.SINGLETON);
@@ -40,7 +40,7 @@ public class IcebergJdbcCatalogModule
 
     @Provides
     @Singleton
-    public static IcebergJdbcClient createIcebergJdbcClient(IcebergJdbcConfig config)
+    public static IcebergJdbcClient createIcebergJdbcClient(IcebergJdbcCatalogConfig config)
     {
         return new IcebergJdbcClient(
                 new IcebergJdbcConnectionFactory(config.getConnectionUrl()),

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalogFactory.java
@@ -52,7 +52,7 @@ public class TrinoJdbcCatalogFactory
             TypeManager typeManager,
             IcebergTableOperationsProvider tableOperationsProvider,
             TrinoFileSystemFactory fileSystemFactory,
-            IcebergJdbcConfig jdbcConfig,
+            IcebergJdbcCatalogConfig jdbcConfig,
             IcebergConfig icebergConfig)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConfig.java
@@ -22,12 +22,12 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertFullMappin
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 
-public class TestIcebergIcebergJdbcConfig
+public class TestIcebergJdbcCatalogConfig
 {
     @Test
     public void testDefaults()
     {
-        assertRecordedDefaults(recordDefaults(IcebergJdbcConfig.class)
+        assertRecordedDefaults(recordDefaults(IcebergJdbcCatalogConfig.class)
                 .setConnectionUrl(null)
                 .setCatalogName(null)
                 .setDefaultWarehouseDir(null));
@@ -42,7 +42,7 @@ public class TestIcebergIcebergJdbcConfig
                 .put("iceberg.jdbc-catalog.default-warehouse-dir", "s3://bucket")
                 .buildOrThrow();
 
-        IcebergJdbcConfig expected = new IcebergJdbcConfig()
+        IcebergJdbcCatalogConfig expected = new IcebergJdbcCatalogConfig()
                 .setConnectionUrl("jdbc:postgresql://localhost:5432/test")
                 .setCatalogName("test")
                 .setDefaultWarehouseDir("s3://bucket");


### PR DESCRIPTION
Catalog config classes follow `IcebergXxxCatalogConfig` naming pattern. This also fixes test class name, was a bit off.
