### PR TITLE
Fix result when complex type contains user defined type in Cassandra

### DIFF
--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraTypeManager.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraTypeManager.java
@@ -472,8 +472,9 @@ public class CassandraTypeManager
             case INET:
             case VARINT:
             case TUPLE:
-            case UDT:
                 return quoteStringLiteralForJson(cassandraValue.toString());
+            case UDT:
+                return quoteStringLiteralForJson(((UdtValue) cassandraValue).getFormattedContents());
 
             case BLOB:
             case CUSTOM:


### PR DESCRIPTION
## Description

Fixes #15771

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Cassandra
* Fix incorrect results when Cassandra `list`, `map` and `set` types contain user defined types. ({issue}`15771`)
```
