### PR TITLE
Download more dependencies to decrease the chance of network errors

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -10,6 +10,7 @@ be found in the [docs module](../docs).
 * [Code style](#code-style)
 * [Additional IDE configuration](#additional-ide-configuration)
 * [Building the Web UI](#building-the-web-ui)
+* [CI pipeline](#ci-pipeline)
 
 ## Commits and pull requests
 
@@ -259,3 +260,17 @@ Once it is time to release, the release process is kicked off. A code freeze is
 announced on the Trino Slack in the #releases channel, and then a maintainer
 utilizes the [release scripts](https://github.com/trinodb/release-scripts) to
 update Trino to the next version.
+
+## CI pipeline
+
+### Maven offline mode
+
+The CI pipeline runs most Maven commands in offline mode to avoid dependency on Maven Central.
+
+Before calling Maven a job should execute the `./.github/actions/setup` compound action to
+download all the dependencies it will require. 
+
+It uses two complementary tools to detect and download Maven dependencies, 
+but some plugin dependencies are not expressed in the tree hierarchy.
+
+These dynamic dependencies must be listed as `<DynamicDependency>` entries in the root `pom.xml`.

--- a/.github/actions/compile-commit/action.yml
+++ b/.github/actions/compile-commit/action.yml
@@ -17,7 +17,7 @@ runs:
         # It's important that these values are NOT passed as parameters, because then their values would always be taken from PR HEAD
         # -------
         # allow overriding Maven command
-        MAVEN="./mvnw"
+        MAVEN="./mvnw --offline"
         # maven.wagon.rto is in millis, defaults to 30m
         MAVEN_INSTALL_OPTS="-Xmx3G -XX:+ExitOnOutOfMemoryError -Dmaven.wagon.rto=60000"
         MAVEN_COMPILE_COMMITS="-B --strict-checksums --quiet -T C1 -DskipTests -Dmaven.source.skip=true -Dair.check.skip-all=true -Dmaven.javadoc.skip=true --no-snapshot-updates --no-transfer-progress -pl !:trino-server-rpm"

--- a/.github/actions/compile-commit/action.yml
+++ b/.github/actions/compile-commit/action.yml
@@ -27,7 +27,7 @@ runs:
 
         # For building with Maven we need MAVEN_OPTS to equal MAVEN_INSTALL_OPTS
         export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-        $RETRY $MAVEN dependency:go-offline
+        ./.github/bin/download-maven-dependencies.sh
         $MAVEN package \
           ${MAVEN_COMPILE_COMMITS} `# defaults, kept in sync with ci.yml` \
           -Dair.check.skip-all=false -Dair.check.skip-basic=true -Dair.check.skip-extended=true -Dair.check.skip-checkstyle=false \

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -44,6 +44,9 @@ runs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
+      - name: Fetch any missing dependencies
+        shell: bash
+        run: ./.github/bin/download-maven-dependencies.sh
       - name: Configure Problem Matchers
         if: ${{ inputs.java-version != '' }}
         shell: bash

--- a/.github/bin/download-maven-dependencies.sh
+++ b/.github/bin/download-maven-dependencies.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+RETRY=".github/bin/retry"
+
+# Run download tools without any profiles to use active-by-default profiles
+$RETRY $MAVEN -B dependency:go-offline
+$RETRY $MAVEN -B de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+
+# Downloading dependencies is used to populate the maven cache shared between PRs, so PR-specific GIB state needs to be ignored
+
+# Enable common profiles to make sure their plugin dependencies are downloaded as well
+# GIB should be disabled even though it's profile is active, to make sure it doesn't skip any submodules
+$RETRY $MAVEN -B -P ci,errorprone-compiler ${MAVEN_GIB} -Dgib.disable dependency:go-offline
+$RETRY $MAVEN -B -P ci,errorprone-compiler ${MAVEN_GIB} -Dgib.disable de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+
+# TODO: Remove next step once https://github.com/qaware/go-offline-maven-plugin/issues/28 is fixed
+# trino-pinot overrides some common dependency versions, focus on it to make sure those overrides are downloaded as well
+$RETRY $MAVEN -B -P ci,errorprone-compiler ${MAVEN_GIB} -Dgib.disable de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -pl ':trino-pinot'

--- a/.github/bin/download-maven-dependencies.sh
+++ b/.github/bin/download-maven-dependencies.sh
@@ -3,18 +3,19 @@
 set -exuo pipefail
 
 RETRY=".github/bin/retry"
+MAVEN_ONLINE="${MAVEN//--offline/}"
 
 # Run download tools without any profiles to use active-by-default profiles
-$RETRY $MAVEN -B dependency:go-offline
-$RETRY $MAVEN -B de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+$RETRY $MAVEN_ONLINE -B dependency:go-offline
+$RETRY $MAVEN_ONLINE -B de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
 
 # Downloading dependencies is used to populate the maven cache shared between PRs, so PR-specific GIB state needs to be ignored
 
 # Enable common profiles to make sure their plugin dependencies are downloaded as well
 # GIB should be disabled even though it's profile is active, to make sure it doesn't skip any submodules
-$RETRY $MAVEN -B -P ci,errorprone-compiler ${MAVEN_GIB} -Dgib.disable dependency:go-offline
-$RETRY $MAVEN -B -P ci,errorprone-compiler ${MAVEN_GIB} -Dgib.disable de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+$RETRY $MAVEN_ONLINE -B -P ci,errorprone-compiler ${MAVEN_GIB} -Dgib.disable dependency:go-offline
+$RETRY $MAVEN_ONLINE -B -P ci,errorprone-compiler ${MAVEN_GIB} -Dgib.disable de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
 
 # TODO: Remove next step once https://github.com/qaware/go-offline-maven-plugin/issues/28 is fixed
 # trino-pinot overrides some common dependency versions, focus on it to make sure those overrides are downloaded as well
-$RETRY $MAVEN -B -P ci,errorprone-compiler ${MAVEN_GIB} -Dgib.disable de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -pl ':trino-pinot'
+$RETRY $MAVEN_ONLINE -B -P ci,errorprone-compiler ${MAVEN_GIB} -Dgib.disable de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -pl ':trino-pinot'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   # An envar that signals to tests we are executing in the CI environment
   CONTINUOUS_INTEGRATION: true
   # allow overriding Maven command
-  MAVEN: ./mvnw
+  MAVEN: ./mvnw --offline
   # maven.wagon.rto is in millis, defaults to 30m
   MAVEN_OPTS: "-Xmx512M -XX:+ExitOnOutOfMemoryError -Dmaven.wagon.rto=60000"
   MAVEN_INSTALL_OPTS: "-Xmx3G -XX:+ExitOnOutOfMemoryError -Dmaven.wagon.rto=60000"
@@ -69,8 +69,6 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           java-version: ${{ matrix.java-version }}
-      - name: Download all Trino dependencies to make sure cache is complete
-        run: ./.github/bin/download-maven-dependencies.sh
       - name: Maven Checks
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,7 @@ jobs:
         with:
           java-version: ${{ matrix.java-version }}
       - name: Download all Trino dependencies to make sure cache is complete
-        run: |
-          $RETRY $MAVEN dependency:go-offline
+        run: ./.github/bin/download-maven-dependencies.sh
       - name: Maven Checks
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -498,8 +498,6 @@ jobs:
                 github.event.client_payload.pull_request.head.sha == github.event.client_payload.slash_command.args.named.sha &&
                 format('refs/pull/{0}/head', github.event.client_payload.pull_request.number) || '' }}
       - uses: ./.github/actions/setup
-        with:
-          cache: false
       - name: Maven validate
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ env:
   MAVEN_COMPILE_COMMITS: "-B --strict-checksums --quiet -T C1 -DskipTests -Dmaven.source.skip=true -Dair.check.skip-all=true -Dmaven.javadoc.skip=true --no-snapshot-updates --no-transfer-progress -pl '!:trino-server-rpm'"
   MAVEN_GIB: "-P gib -Dgib.referenceBranch=refs/remotes/origin/${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.event.repository.default_branch }}"
   MAVEN_TEST: "-B --strict-checksums -Dmaven.source.skip=true -Dair.check.skip-all --fail-at-end -P gib -Dgib.referenceBranch=refs/remotes/origin/${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.event.repository.default_branch }}"
-  RETRY: .github/bin/retry
   # Testcontainers kills image pulls if they don't make progress for > 30s and retries for 2m before failing. This means
   # that if an image doesn't download all it's layers within ~2m then any other concurrent pull will be killed because
   # the Docker daemon only downloads 3 layers concurrently which prevents the other pull from making any progress.
@@ -157,12 +156,12 @@ jobs:
       - name: Maven Package
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          $RETRY $MAVEN clean package ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -pl '!:trino-docs,!:trino-server,!:trino-server-rpm'
+          $MAVEN clean package ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -pl '!:trino-docs,!:trino-server,!:trino-server-rpm'
       - name: Error Prone Checks
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           # Run Error Prone on one module with a retry to ensure all runtime dependencies are fetched
-          $RETRY $MAVEN ${MAVEN_TEST} -T C1 clean verify -DskipTests -P gib,errorprone-compiler -am -pl ':trino-spi'
+          $MAVEN ${MAVEN_TEST} -T C1 clean verify -DskipTests -P gib,errorprone-compiler -am -pl ':trino-spi'
           # The main Error Prone run
           $MAVEN ${MAVEN_TEST} -T C1 clean verify -DskipTests -P gib,errorprone-compiler \
             -pl '!:trino-docs,!:trino-server,!:trino-server-rpm'
@@ -202,7 +201,7 @@ jobs:
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          $RETRY $MAVEN clean install ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -Dgib.logImpactedTo=gib-impacted.log -pl '!:trino-docs,!:trino-server,!:trino-server-rpm'
+          $MAVEN clean install ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -Dgib.logImpactedTo=gib-impacted.log -pl '!:trino-docs,!:trino-server,!:trino-server-rpm'
       - name: Test old JDBC vs current server
         run: |
           if [ ! -f gib-impacted.log ] || grep -q testing/trino-test-jdbc-compatibility-old-driver gib-impacted.log; then
@@ -271,7 +270,7 @@ jobs:
       - name: Install Hive Module
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          $RETRY $MAVEN clean install ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -Dgib.logImpactedTo=gib-impacted.log -am -pl :trino-hive-hadoop2
+          $MAVEN clean install ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -Dgib.logImpactedTo=gib-impacted.log -am -pl :trino-hive-hadoop2
       - name: Run Hive Tests
         run: |
           source plugin/trino-hive-hadoop2/conf/hive-tests-${{ matrix.config }}.sh &&
@@ -416,7 +415,7 @@ jobs:
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          $RETRY $MAVEN clean install ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -pl '!:trino-docs,!:trino-server,!:trino-server-rpm'
+          $MAVEN clean install ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -pl '!:trino-docs,!:trino-server,!:trino-server-rpm'
       - name: Maven Tests
         run: |
           $MAVEN test ${MAVEN_TEST} -pl '
@@ -499,7 +498,7 @@ jobs:
       - name: Maven validate
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          $RETRY $MAVEN validate ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -Dgib.logImpactedTo=gib-impacted.log -P disable-check-spi-dependencies -pl '!:trino-docs'
+          $MAVEN validate ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -Dgib.logImpactedTo=gib-impacted.log -P disable-check-spi-dependencies -pl '!:trino-docs'
       - name: Set matrix
         id: set-matrix
         run: |
@@ -588,7 +587,7 @@ jobs:
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          $RETRY $MAVEN clean install ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -am -pl "${{ matrix.modules }}"
+          $MAVEN clean install ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -am -pl "${{ matrix.modules }}"
       - name: Maven Tests
         if: >-
           matrix.modules != 'plugin/trino-singlestore'
@@ -754,7 +753,7 @@ jobs:
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          $RETRY $MAVEN clean install ${MAVEN_FAST_INSTALL} -pl '!:trino-docs,!:trino-server-rpm'
+          $MAVEN clean install ${MAVEN_FAST_INSTALL} -pl '!:trino-docs,!:trino-server-rpm'
       - name: Map impacted plugins to features
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -217,6 +217,33 @@
                                         <match>@java.lang.Deprecated(*) ^*;</match>
                                     </old>
                                 </item>
+                                <!-- Revapi tries to compare any API with its previous version -->
+                                <!-- If it can't download the old version, if falls back to comparing with an empty file -->
+                                <!-- This can lead to errors which are not shown in daily development where local Maven cache has the old version -->
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>class io.airlift.slice.BasicSliceInput</new>
+                                    <justification>Trino SPI depends on Airlift</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>class io.airlift.slice.Slice</new>
+                                    <justification>Trino SPI depends on Airlift</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>class io.airlift.slice.SliceInput</new>
+                                    <justification>Trino SPI depends on Airlift</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>class io.airlift.slice.SliceOutput</new>
+                                    <justification>Trino SPI depends on Airlift</justification>
+                                </item>
                                 <!-- Backwards incompatible changes since the previous release -->
                                 <!-- Any exclusions below can be deleted after each release -->
                             </differences>

--- a/pom.xml
+++ b/pom.xml
@@ -2114,6 +2114,110 @@
                         </exceptions>
                     </configuration>
                 </plugin>
+
+                <plugin>
+                    <groupId>de.qaware.maven</groupId>
+                    <artifactId>go-offline-maven-plugin</artifactId>
+                    <version>1.2.8</version>
+                    <configuration>
+                        <dynamicDependencies>
+                            <DynamicDependency>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-javadoc-plugin</artifactId>
+                                <version>3.2.0</version>
+                                <repositoryType>PLUGIN</repositoryType>
+                            </DynamicDependency>
+                            <DynamicDependency>
+                                <groupId>org.apache.yetus</groupId>
+                                <artifactId>audience-annotations</artifactId>
+                                <version>0.8.0</version>
+                                <repositoryType>PLUGIN</repositoryType>
+                            </DynamicDependency>
+                            <DynamicDependency>
+                                <groupId>io.airlift.drift</groupId>
+                                <artifactId>drift-javadoc</artifactId>
+                                <version>${dep.drift.version}</version>
+                                <repositoryType>PLUGIN</repositoryType>
+                            </DynamicDependency>
+                            <DynamicDependency>
+                                <groupId>com.google.errorprone</groupId>
+                                <artifactId>error_prone_core</artifactId>
+                                <version>${dep.errorprone.version}</version>
+                                <repositoryType>MAIN</repositoryType>
+                            </DynamicDependency>
+                            <DynamicDependency>
+                                <groupId>org.junit.jupiter</groupId>
+                                <artifactId>junit-jupiter-engine</artifactId>
+                                <version>5.3.2</version> <!-- legacy version which Surefire seems to need for some reason -->
+                                <type>pom</type>
+                                <repositoryType>MAIN</repositoryType>
+                            </DynamicDependency>
+                            <DynamicDependency>
+                                <groupId>org.junit.jupiter</groupId>
+                                <artifactId>junit-jupiter-params</artifactId>
+                                <version>5.3.2</version> <!-- legacy version which Surefire seems to need for some reason -->
+                                <type>pom</type>
+                                <repositoryType>MAIN</repositoryType>
+                            </DynamicDependency>
+                            <DynamicDependency>
+                                <groupId>org.mockito</groupId>
+                                <artifactId>mockito-core</artifactId>
+                                <version>2.28.2</version> <!-- legacy version which Surefire seems to need for some reason -->
+                                <type>pom</type>
+                                <repositoryType>MAIN</repositoryType>
+                            </DynamicDependency>
+                            <DynamicDependency>
+                                <groupId>org.powermock</groupId>
+                                <artifactId>powermock-reflect</artifactId>
+                                <version>2.0.5</version> <!-- legacy version which Surefire seems to need for some reason -->
+                                <type>pom</type>
+                                <repositoryType>MAIN</repositoryType>
+                            </DynamicDependency>
+                            <DynamicDependency>
+                                <groupId>junit</groupId>
+                                <artifactId>junit</artifactId>
+                                <version>4.13</version> <!-- legacy version which Surefire seems to need for some reason -->
+                                <type>pom</type>
+                                <repositoryType>MAIN</repositoryType>
+                            </DynamicDependency>
+                            <DynamicDependency>
+                                <groupId>org.testng</groupId>
+                                <artifactId>testng</artifactId>
+                                <version>5.10</version> <!-- legacy version which Surefire seems to need for some reason -->
+                                <type>pom</type>
+                                <repositoryType>MAIN</repositoryType>
+                            </DynamicDependency>
+                            <DynamicDependency>
+                                <groupId>org.assertj</groupId>
+                                <artifactId>assertj-core</artifactId>
+                                <version>3.9.1</version> <!-- legacy version which Surefire seems to need for some reason -->
+                                <type>pom</type>
+                                <repositoryType>MAIN</repositoryType>
+                            </DynamicDependency>
+                            <DynamicDependency>
+                                <groupId>org.hamcrest</groupId>
+                                <artifactId>hamcrest-library</artifactId>
+                                <version>1.3</version> <!-- legacy version which Surefire seems to need for some reason -->
+                                <type>pom</type>
+                                <repositoryType>MAIN</repositoryType>
+                            </DynamicDependency>
+                            <DynamicDependency>
+                                <groupId>org.easytesting</groupId>
+                                <artifactId>fest-assert</artifactId>
+                                <version>1.4</version> <!-- legacy version which Surefire seems to need for some reason -->
+                                <type>pom</type>
+                                <repositoryType>MAIN</repositoryType>
+                            </DynamicDependency>
+                            <DynamicDependency>
+                                <groupId>org.apache.maven.surefire</groupId>
+                                <artifactId>surefire-testng</artifactId>
+                                <version>2.22.2</version> <!-- legacy version which Surefire seems to need for some reason -->
+                                <type>jar</type>
+                                <repositoryType>MAIN</repositoryType>
+                            </DynamicDependency>
+                        </dynamicDependencies>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

A call to `dependency:go-offline` was recently added to download all dependencies into the local Maven cache.
Unfortunately it turns out the goal has some problems with multi-module projects, and Maven will still attempt to download any missing artifacts during build.

The purpose of this PR is to improve this situation by caching MORE dependencies, as every cached artifact decreases the chance of a Maven Central download failure breaking Maven builds. 

Downloading ALL dependencies is NOT a requirement, although it would be ideal.

Other jobs will now depend the `maven-checks` job as they now need to unpack the cache artifact left by it.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

CI workers sometimes fail to download dependencies in the middle of a build.
A workaround was proposed to download as many dependencies as possible at the start of CI pipeline, cache them for other jobs, to limit the use of Maven Central afterwards.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
