### PR TITLE
Make NestedLoopOutputIterator sealed

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/join/NestedLoopJoinOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/NestedLoopJoinOperator.java
@@ -279,7 +279,8 @@ public class NestedLoopJoinOperator
     // bi-morphic parent class for the two implementations allowed. Adding a third implementation will make getOutput megamorphic and
     // should be avoided
     @VisibleForTesting
-    abstract static class NestedLoopOutputIterator
+    abstract static sealed class NestedLoopOutputIterator
+            permits PageRepeatingIterator, NestedLoopPageBuilder
     {
         public abstract boolean hasNext();
 


### PR DESCRIPTION
## Description
Minor change that adds `sealed` / `permits` modifiers to `NestedLoopJoinOperator.NestedLoopOutputIterator` to enforce the bi-morphic constraint that was previously only described by an inline comment added before migrating to JDK17.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
