### PR TITLE
Add missing synchronization

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/TDigestHistogram.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/TDigestHistogram.java
@@ -57,7 +57,7 @@ public class TDigestHistogram
     }
 
     @JsonProperty
-    public TDigest getDigest()
+    public synchronized TDigest getDigest()
     {
         return TDigest.copyOf(digest);
     }
@@ -65,14 +65,14 @@ public class TDigestHistogram
     @Override
     public TDigestHistogram mergeWith(TDigestHistogram other)
     {
-        TDigest result = TDigest.copyOf(digest);
+        TDigest result = getDigest();
         result.mergeWith(other.getDigest());
         return new TDigestHistogram(result);
     }
 
     @Override
     @JsonProperty
-    public long getTotal()
+    public synchronized long getTotal()
     {
         return (long) digest.getCount();
     }
@@ -146,7 +146,7 @@ public class TDigestHistogram
     }
 
     @Override
-    public double getPercentile(double percentile)
+    public synchronized double getPercentile(double percentile)
     {
         return digest.valueAt(percentile / 100.0);
     }


### PR DESCRIPTION
TDigest#valueAt can mutate digest state,
therefore all methods that access digest
should be synchronized.

* NO RELEASE NOTES *