### PR TITLE
Handle interruption in RetryDriver and TaskRunner

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/executor/TaskExecutor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/TaskExecutor.java
@@ -561,6 +561,15 @@ public class TaskExecutor
                         }
                         splitFinished(split);
                     }
+                    finally {
+                        // Clear the interrupted flag on the current thread, driver cancellation may have triggered an interrupt
+                        if (Thread.interrupted()) {
+                            if (closed) {
+                                // reset interrupted flag if closed before interrupt
+                                Thread.currentThread().interrupt();
+                            }
+                        }
+                    }
                 }
             }
             finally {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/RetryDriver.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/RetryDriver.java
@@ -130,6 +130,11 @@ public class RetryDriver
                 return callable.call();
             }
             catch (Exception e) {
+                // Immediately stop retry attempts once an interrupt has been received
+                if (e instanceof InterruptedException || Thread.currentThread().isInterrupted()) {
+                    addSuppressed(e, suppressedExceptions);
+                    throw e;
+                }
                 for (Class<? extends Exception> clazz : stopOnExceptions) {
                     if (clazz.isInstance(e)) {
                         addSuppressed(e, suppressedExceptions);


### PR DESCRIPTION
## Description
This PR includes two changes to Thread interrupt handling:
1. In `trino-hive`, modify `RetryDriver` to stop attempting retries if `InterruptedException` is caught or the current thread is interrupted and immediately throw the current exception. Otherwise, `RetryDriver` might interfere with drivers terminating in a timely manner after tasks are terminated via a cancel, failure, or abort.
2. In `trino-main`, check and clear thread interrupt status at the end of processing a split in `TaskRunner` before looping back to start processing a new split. Otherwise, a split that is interrupted (eg: because the task was cancelled) would leave the thread interrupted flag set which would cause the `TaskRunner` to stop processing and unnecessarily submit a new instance from which could cause additional threads to be created in the cached thread pool executor.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
