### PR TITLE
Fix insert into BigQuery tables

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -538,10 +538,6 @@ public class BigQueryMetadata
         String projectId = table.asPlainTable().getRemoteTableName().getProjectId();
         String schemaName = table.asPlainTable().getRemoteTableName().getDatasetName();
 
-        if (!schemaExists(session, schemaName)) {
-            throw new SchemaNotFoundException(schemaName);
-        }
-
         String temporaryTableName = generateTemporaryTableName();
         createTable(client, projectId, schemaName, temporaryTableName, tempFields.build(), Optional.empty());
 


### PR DESCRIPTION
Recent change which added FTE support broke insert flow for tables in schemas which used mixec case. This came from the fact that `schemaExists` method is used with `datasetName`, while it expects Trino schema name which is always lowercased.

The whole schemaExists check can be removed as schema existence was checked before `beginInsert` was called when table handle was resolved.

## Additional context and related issues

https://github.com/trinodb/trino/pull/15620 - PR which introduced a regression

## Release notes

Release notes should not be requried as this fixes a regression which was not released yet.
