### PR TITLE
Test failure message when executing `register_table` procedure in Iceberg REST and JDBC catalogs

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
@@ -186,7 +186,7 @@ public class TrinoJdbcCatalog
     @Override
     public void registerTable(ConnectorSession session, SchemaTableName tableName, String tableLocation, String metadataLocation)
     {
-        jdbcCatalog.registerTable(TableIdentifier.of(tableName.getSchemaName(), tableName.getTableName()), metadataLocation);
+        throw new TrinoException(NOT_SUPPORTED, "registerTable is not supported for Iceberg JDBC catalogs");
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConnectorSmokeTest.java
@@ -54,6 +54,7 @@ public class TestIcebergJdbcCatalogConnectorSmokeTest
                                 .put("iceberg.catalog.type", "jdbc")
                                 .put("iceberg.jdbc-catalog.connection-url", server.getJdbcUrl())
                                 .put("iceberg.jdbc-catalog.catalog-name", "tpch")
+                                .put("iceberg.register-table-procedure.enabled", "true")
                                 .buildOrThrow())
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .build();
@@ -97,42 +98,35 @@ public class TestIcebergJdbcCatalogConnectorSmokeTest
     public void testRegisterTableWithTableLocation()
     {
         assertThatThrownBy(super::testRegisterTableWithTableLocation)
-                .hasMessageContaining("register_table procedure is disabled");
+                .hasMessageContaining("registerTable is not supported for Iceberg JDBC catalogs");
     }
 
     @Override
     public void testRegisterTableWithComments()
     {
         assertThatThrownBy(super::testRegisterTableWithComments)
-                .hasMessageContaining("register_table procedure is disabled");
+                .hasMessageContaining("registerTable is not supported for Iceberg JDBC catalogs");
     }
 
     @Override
     public void testRegisterTableWithShowCreateTable()
     {
         assertThatThrownBy(super::testRegisterTableWithShowCreateTable)
-                .hasMessageContaining("register_table procedure is disabled");
+                .hasMessageContaining("registerTable is not supported for Iceberg JDBC catalogs");
     }
 
     @Override
     public void testRegisterTableWithReInsert()
     {
         assertThatThrownBy(super::testRegisterTableWithReInsert)
-                .hasMessageContaining("register_table procedure is disabled");
-    }
-
-    @Override
-    public void testRegisterTableWithDroppedTable()
-    {
-        assertThatThrownBy(super::testRegisterTableWithDroppedTable)
-                .hasMessageContaining("register_table procedure is disabled");
+                .hasMessageContaining("registerTable is not supported for Iceberg JDBC catalogs");
     }
 
     @Override
     public void testRegisterTableWithDifferentTableName()
     {
         assertThatThrownBy(super::testRegisterTableWithDifferentTableName)
-                .hasMessageContaining("register_table procedure is disabled");
+                .hasMessageContaining("registerTable is not supported for Iceberg JDBC catalogs");
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogConnectorSmokeTest.java
@@ -76,6 +76,7 @@ public class TestIcebergRestCatalogConnectorSmokeTest
                                 .put("iceberg.file-format", format.name())
                                 .put("iceberg.catalog.type", "rest")
                                 .put("iceberg.rest-catalog.uri", testServer.getBaseUrl().toString())
+                                .put("iceberg.register-table-procedure.enabled", "true")
                                 .buildOrThrow())
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .build();
@@ -119,42 +120,35 @@ public class TestIcebergRestCatalogConnectorSmokeTest
     public void testRegisterTableWithTableLocation()
     {
         assertThatThrownBy(super::testRegisterTableWithTableLocation)
-                .hasMessageContaining("register_table procedure is disabled");
+                .hasMessageContaining("registerTable is not supported for Iceberg REST catalog");
     }
 
     @Override
     public void testRegisterTableWithComments()
     {
         assertThatThrownBy(super::testRegisterTableWithComments)
-                .hasMessageContaining("register_table procedure is disabled");
+                .hasMessageContaining("registerTable is not supported for Iceberg REST catalog");
     }
 
     @Override
     public void testRegisterTableWithShowCreateTable()
     {
         assertThatThrownBy(super::testRegisterTableWithShowCreateTable)
-                .hasMessageContaining("register_table procedure is disabled");
+                .hasMessageContaining("registerTable is not supported for Iceberg REST catalog");
     }
 
     @Override
     public void testRegisterTableWithReInsert()
     {
         assertThatThrownBy(super::testRegisterTableWithReInsert)
-                .hasMessageContaining("register_table procedure is disabled");
-    }
-
-    @Override
-    public void testRegisterTableWithDroppedTable()
-    {
-        assertThatThrownBy(super::testRegisterTableWithDroppedTable)
-                .hasMessageContaining("register_table procedure is disabled");
+                .hasMessageContaining("registerTable is not supported for Iceberg REST catalog");
     }
 
     @Override
     public void testRegisterTableWithDifferentTableName()
     {
         assertThatThrownBy(super::testRegisterTableWithDifferentTableName)
-                .hasMessageContaining("register_table procedure is disabled");
+                .hasMessageContaining("registerTable is not supported for Iceberg REST catalog");
     }
 
     @Override


### PR DESCRIPTION
## Description

Test failure message when executing `register_table` procedure in Iceberg REST and JDBC catalogs

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
