### PR TITLE
Cache metastore (table and partition) stats by default

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -739,7 +739,8 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public Optional<List<String>> getPartitionNamesByFilter(String databaseName,
+    public Optional<List<String>> getPartitionNamesByFilter(
+            String databaseName,
             String tableName,
             List<String> columnNames,
             TupleDomain<String> partitionKeysFilter)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastoreConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastoreConfig.java
@@ -26,6 +26,11 @@ import java.util.concurrent.TimeUnit;
 public class CachingHiveMetastoreConfig
 {
     private Duration metastoreCacheTtl = new Duration(0, TimeUnit.SECONDS);
+    // Use 5 mins for stats cache TTL by default. 5 mins will be sufficient to help
+    // significantly when there is high number of concurrent queries.
+    // 5 mins will also prevent stats from being stalled for a long time since
+    // time window where table data can be altered is limited.
+    private Duration statsCacheTtl = new Duration(5, TimeUnit.MINUTES);
     private Optional<Duration> metastoreRefreshInterval = Optional.empty();
     private long metastoreCacheMaximumSize = 10000;
     private int maxMetastoreRefreshThreads = 10;
@@ -41,6 +46,19 @@ public class CachingHiveMetastoreConfig
     public CachingHiveMetastoreConfig setMetastoreCacheTtl(Duration metastoreCacheTtl)
     {
         this.metastoreCacheTtl = metastoreCacheTtl;
+        return this;
+    }
+
+    @NotNull
+    public Duration getStatsCacheTtl()
+    {
+        return statsCacheTtl;
+    }
+
+    @Config("hive.metastore-stats-cache-ttl")
+    public CachingHiveMetastoreConfig setStatsCacheTtl(Duration statsCacheTtl)
+    {
+        this.statsCacheTtl = statsCacheTtl;
         return this;
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/SharedHiveMetastoreCache.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/SharedHiveMetastoreCache.java
@@ -78,12 +78,17 @@ public class SharedHiveMetastoreCache
         // Disable caching on workers, because there currently is no way to invalidate such a cache.
         // Note: while we could skip CachingHiveMetastoreModule altogether on workers, we retain it so that catalog
         // configuration can remain identical for all nodes, making cluster configuration easier.
-        enabled = nodeManager.getCurrentNode().isCoordinator() &&
-                config.getMetastoreCacheTtl().toMillis() > 0 &&
+        boolean metadataCacheEnabled = config.getMetastoreCacheTtl().toMillis() > 0;
+        boolean statsCacheEnabled = config.getStatsCacheTtl().toMillis() > 0;
+        enabled = (metadataCacheEnabled || statsCacheEnabled) &&
+                nodeManager.getCurrentNode().isCoordinator() &&
                 config.getMetastoreCacheMaximumSize() > 0;
 
         cachingMetastoreBuilder = CachingHiveMetastore.builder()
+                .metadataCacheEnabled(metadataCacheEnabled)
+                .statsCacheEnabled(statsCacheEnabled)
                 .cacheTtl(config.getMetastoreCacheTtl())
+                .statsCacheTtl(config.getStatsCacheTtl())
                 .refreshInterval(config.getMetastoreRefreshInterval())
                 .maximumSize(config.getMetastoreCacheMaximumSize())
                 .partitionCacheEnabled(config.isPartitionCacheEnabled());

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -796,6 +796,8 @@ public abstract class AbstractTestHive
                         .hdfsEnvironment(hdfsEnvironment)
                         .build()))
                 .executor(executor)
+                .metadataCacheEnabled(true)
+                .statsCacheEnabled(true)
                 .cacheTtl(new Duration(1, MINUTES))
                 .refreshInterval(new Duration(15, SECONDS))
                 .maximumSize(10000)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreConfig.java
@@ -31,6 +31,7 @@ public class TestCachingHiveMetastoreConfig
     {
         assertRecordedDefaults(recordDefaults(CachingHiveMetastoreConfig.class)
                 .setMetastoreCacheTtl(new Duration(0, TimeUnit.SECONDS))
+                .setStatsCacheTtl(new Duration(5, TimeUnit.MINUTES))
                 .setMetastoreRefreshInterval(null)
                 .setMetastoreCacheMaximumSize(10000)
                 .setMaxMetastoreRefreshThreads(10)
@@ -42,6 +43,7 @@ public class TestCachingHiveMetastoreConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("hive.metastore-cache-ttl", "2h")
+                .put("hive.metastore-stats-cache-ttl", "10m")
                 .put("hive.metastore-refresh-interval", "30m")
                 .put("hive.metastore-cache-maximum-size", "5000")
                 .put("hive.metastore-refresh-max-threads", "2500")
@@ -50,6 +52,7 @@ public class TestCachingHiveMetastoreConfig
 
         CachingHiveMetastoreConfig expected = new CachingHiveMetastoreConfig()
                 .setMetastoreCacheTtl(new Duration(2, TimeUnit.HOURS))
+                .setStatsCacheTtl(new Duration(10, TimeUnit.MINUTES))
                 .setMetastoreRefreshInterval(new Duration(30, TimeUnit.MINUTES))
                 .setMetastoreCacheMaximumSize(5000)
                 .setMaxMetastoreRefreshThreads(2500)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/IcebergHiveMetastoreCatalogModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/IcebergHiveMetastoreCatalogModule.java
@@ -17,13 +17,19 @@ import com.google.inject.Binder;
 import com.google.inject.Key;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.units.Duration;
 import io.trino.plugin.hive.HideDeltaLakeTables;
 import io.trino.plugin.hive.metastore.DecoratedHiveMetastoreModule;
+import io.trino.plugin.hive.metastore.cache.CachingHiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreModule;
 import io.trino.plugin.hive.metastore.thrift.TranslateHiveViews;
 import io.trino.plugin.iceberg.catalog.IcebergTableOperationsProvider;
 import io.trino.plugin.iceberg.catalog.MetastoreValidator;
 import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
+
+import java.util.concurrent.TimeUnit;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class IcebergHiveMetastoreCatalogModule
         extends AbstractConfigurationAwareModule
@@ -40,5 +46,10 @@ public class IcebergHiveMetastoreCatalogModule
         binder.bind(Key.get(boolean.class, TranslateHiveViews.class)).toInstance(false);
         binder.bind(Key.get(boolean.class, HideDeltaLakeTables.class)).toInstance(HIDE_DELTA_LAKE_TABLES_IN_ICEBERG);
         install(new DecoratedHiveMetastoreModule());
+
+        configBinder(binder).bindConfigDefaults(CachingHiveMetastoreConfig.class, config -> {
+            // ensure caching metastore wrapper isn't created, as it's not leveraged by Iceberg
+            config.setStatsCacheTtl(new Duration(0, TimeUnit.SECONDS));
+        });
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/file/TestingIcebergFileMetastoreCatalogModule.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/file/TestingIcebergFileMetastoreCatalogModule.java
@@ -16,14 +16,19 @@ package io.trino.plugin.iceberg.catalog.file;
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.units.Duration;
 import io.trino.plugin.hive.metastore.DecoratedHiveMetastoreModule;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
 import io.trino.plugin.hive.metastore.RawHiveMetastoreFactory;
+import io.trino.plugin.hive.metastore.cache.CachingHiveMetastoreConfig;
 import io.trino.plugin.iceberg.catalog.IcebergTableOperationsProvider;
 import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
 import io.trino.plugin.iceberg.catalog.hms.TrinoHiveCatalogFactory;
 
+import java.util.concurrent.TimeUnit;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
 import static java.util.Objects.requireNonNull;
 
 public class TestingIcebergFileMetastoreCatalogModule
@@ -43,5 +48,10 @@ public class TestingIcebergFileMetastoreCatalogModule
         install(new DecoratedHiveMetastoreModule());
         binder.bind(IcebergTableOperationsProvider.class).to(FileMetastoreTableOperationsProvider.class).in(Scopes.SINGLETON);
         binder.bind(TrinoCatalogFactory.class).to(TrinoHiveCatalogFactory.class).in(Scopes.SINGLETON);
+
+        configBinder(binder).bindConfigDefaults(CachingHiveMetastoreConfig.class, config -> {
+            // ensure caching metastore wrapper isn't created, as it's not leveraged by Iceberg
+            config.setStatsCacheTtl(new Duration(0, TimeUnit.SECONDS));
+        });
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestExternalHiveTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestExternalHiveTable.java
@@ -71,6 +71,7 @@ public class TestExternalHiveTable
                 row(null, null, null, null, 5.0, null, null));
 
         onHive().executeQuery("ANALYZE TABLE " + EXTERNAL_TABLE_NAME + " PARTITION (p_regionkey) COMPUTE STATISTICS FOR COLUMNS");
+        onTrino().executeQuery("CALL system.flush_metadata_cache()");
         assertThat(onTrino().executeQuery("SHOW STATS FOR " + EXTERNAL_TABLE_NAME)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", 38.0, 5.0, 0.0, null, null, null),

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTableStatistics.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTableStatistics.java
@@ -200,6 +200,7 @@ public class TestHiveTableStatistics
         // basic analysis
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS");
+        onTrino().executeQuery("CALL system.flush_metadata_cache()");
 
         assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("n_nationkey", null, null, null, null, null, null),
@@ -211,6 +212,7 @@ public class TestHiveTableStatistics
         // column analysis
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS FOR COLUMNS");
+        onTrino().executeQuery("CALL system.flush_metadata_cache()");
 
         assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("n_nationkey", null, anyOf(19., 25.), 0.0, null, "0", "24"),
@@ -249,6 +251,7 @@ public class TestHiveTableStatistics
         // basic analysis for single partition
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey = \"1\") COMPUTE STATISTICS");
+        onTrino().executeQuery("CALL system.flush_metadata_cache()");
 
         assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
@@ -274,6 +277,7 @@ public class TestHiveTableStatistics
         // basic analysis for all partitions
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey) COMPUTE STATISTICS");
+        onTrino().executeQuery("CALL system.flush_metadata_cache()");
 
         assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
@@ -299,6 +303,7 @@ public class TestHiveTableStatistics
         // column analysis for single partition
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey = \"1\") COMPUTE STATISTICS FOR COLUMNS");
+        onTrino().executeQuery("CALL system.flush_metadata_cache()");
 
         assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
@@ -324,6 +329,7 @@ public class TestHiveTableStatistics
         // column analysis for all partitions
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey) COMPUTE STATISTICS FOR COLUMNS");
+        onTrino().executeQuery("CALL system.flush_metadata_cache()");
 
         assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
@@ -376,6 +382,7 @@ public class TestHiveTableStatistics
         // basic analysis for single partition
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey = \"AMERICA\") COMPUTE STATISTICS");
+        onTrino().executeQuery("CALL system.flush_metadata_cache()");
 
         assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
@@ -401,6 +408,7 @@ public class TestHiveTableStatistics
         // basic analysis for all partitions
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey) COMPUTE STATISTICS");
+        onTrino().executeQuery("CALL system.flush_metadata_cache()");
 
         assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
@@ -426,6 +434,7 @@ public class TestHiveTableStatistics
         // column analysis for single partition
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey = \"AMERICA\") COMPUTE STATISTICS FOR COLUMNS");
+        onTrino().executeQuery("CALL system.flush_metadata_cache()");
 
         assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
@@ -451,6 +460,7 @@ public class TestHiveTableStatistics
         // column analysis for all partitions
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey) COMPUTE STATISTICS FOR COLUMNS");
+        onTrino().executeQuery("CALL system.flush_metadata_cache()");
 
         assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
@@ -502,6 +512,7 @@ public class TestHiveTableStatistics
                 row(null, null, null, null, 2.0, null, null));
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS FOR COLUMNS");
+        onTrino().executeQuery("CALL system.flush_metadata_cache()");
 
         // SHOW STATS FORMAT: column_name, data_size, distinct_values_count, nulls_fraction, row_count
         assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
@@ -550,6 +561,7 @@ public class TestHiveTableStatistics
                 row(null, null, null, null, 0.0, null, null));
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS FOR COLUMNS");
+        onTrino().executeQuery("CALL system.flush_metadata_cache()");
 
         assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
                 row("c_tinyint", 0.0, 0.0, 1.0, null, null, null),
@@ -598,6 +610,7 @@ public class TestHiveTableStatistics
                 row(null, null, null, null, 1.0, null, null));
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS FOR COLUMNS");
+        onTrino().executeQuery("CALL system.flush_metadata_cache()");
 
         assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
                 row("c_tinyint", 0.0, 0.0, 1.0, null, null, null),
@@ -633,6 +646,7 @@ public class TestHiveTableStatistics
                 row(null, null, null, null, 2.0, null, null));
 
         onHive().executeQuery("ANALYZE TABLE " + tableName + " COMPUTE STATISTICS");
+        onTrino().executeQuery("CALL system.flush_metadata_cache()");
 
         assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableName)).containsOnly(
                 row("c_string", null, null, null, null, null, null),
@@ -640,6 +654,7 @@ public class TestHiveTableStatistics
                 row(null, null, null, null, 2.0, null, null));
 
         onHive().executeQuery("ANALYZE TABLE " + tableName + " COMPUTE STATISTICS FOR COLUMNS");
+        onTrino().executeQuery("CALL system.flush_metadata_cache()");
         assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableName)).containsOnly(
                 row("c_string", 4.0, 1.0, 0.0, null, null, null),
                 row("c_int", null, 2.0, 0.0, null, "1", "2"),
@@ -1413,6 +1428,7 @@ public class TestHiveTableStatistics
             onTrino().executeQuery(format("ANALYZE %s WITH (partitions = ARRAY[ARRAY['1']])", tableName));
             onHive().executeQuery(format("ANALYZE TABLE %s PARTITION (p = \"2\") COMPUTE STATISTICS", tableName));
             onHive().executeQuery(format("ANALYZE TABLE %s PARTITION (p = \"2\") COMPUTE STATISTICS FOR COLUMNS", tableName));
+            onTrino().executeQuery("CALL system.flush_metadata_cache()");
 
             // we can get stats for individual partitions
             assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(


### PR DESCRIPTION
    Split caching into metadata and stats cache. Stats
    pulling puts significant pressure on metastore. However,
    stats don't have to be always up to date in order
    to get good query plance. Therefore, stats can
    be cached by default.

RELEASE NOTES:
```
Hive/Delta
* Reduce query latency by caching partition and table statistics by default. {}
```