### PR TITLE
Add table function to execute stored procedure in MySQL & SQLServer

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
@@ -29,6 +29,7 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
 import io.trino.spi.type.Type;
 
+import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -211,6 +212,13 @@ public class DefaultQueryBuilder
         }
 
         return statement;
+    }
+
+    @Override
+    public CallableStatement callProcedure(JdbcClient client, ConnectorSession session, Connection connection, ProcedureQuery procedureQuery)
+            throws SQLException
+    {
+        return connection.prepareCall(procedureQuery.getQuery());
     }
 
     protected String formatJoinCondition(JdbcClient client, String leftRelationAlias, String rightRelationAlias, JdbcJoinCondition condition)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -91,6 +91,12 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
+    public JdbcTableHandle getTableHandle(ConnectorSession session, ProcedureQuery procedureQuery)
+    {
+        return delegate().getTableHandle(session, procedureQuery);
+    }
+
+    @Override
     public List<JdbcColumnHandle> getColumns(ConnectorSession session, JdbcTableHandle tableHandle)
     {
         return delegate().getColumns(session, tableHandle);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
@@ -57,6 +57,8 @@ public interface JdbcClient
 
     JdbcTableHandle getTableHandle(ConnectorSession session, PreparedQuery preparedQuery);
 
+    JdbcTableHandle getTableHandle(ConnectorSession session, ProcedureQuery procedureQuery);
+
     List<JdbcColumnHandle> getColumns(ConnectorSession session, JdbcTableHandle tableHandle);
 
     Optional<ColumnMapping> toColumnMapping(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadata.java
@@ -21,5 +21,7 @@ public interface JdbcMetadata
 {
     JdbcTableHandle getTableHandle(ConnectorSession session, PreparedQuery preparedQuery);
 
+    JdbcTableHandle getTableHandle(ConnectorSession session, ProcedureQuery procedureQuery);
+
     void rollback();
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcProcedureRelationHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcProcedureRelationHandle.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class JdbcProcedureRelationHandle
+        extends JdbcRelationHandle
+{
+    private final ProcedureQuery procedure;
+
+    @JsonCreator
+    public JdbcProcedureRelationHandle(ProcedureQuery procedureQuery)
+    {
+        this.procedure = requireNonNull(procedureQuery, "procedureQuery is null");
+    }
+
+    @JsonProperty
+    public ProcedureQuery getProcedureQuery()
+    {
+        return procedure;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("Procedure[%s]", procedure.getQuery());
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRelationHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRelationHandle.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonSubTypes({
         @JsonSubTypes.Type(value = JdbcNamedRelationHandle.class, name = "named"),
         @JsonSubTypes.Type(value = JdbcQueryRelationHandle.class, name = "query"),
+        @JsonSubTypes.Type(value = JdbcProcedureRelationHandle.class, name = "procedure"),
 })
 public abstract class JdbcRelationHandle
 {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcTableHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcTableHandle.java
@@ -213,6 +213,12 @@ public final class JdbcTableHandle
     }
 
     @JsonIgnore
+    public boolean isProcedure()
+    {
+        return relationHandle instanceof JdbcProcedureRelationHandle;
+    }
+
+    @JsonIgnore
     public boolean isNamedRelation()
     {
         return relationHandle instanceof JdbcNamedRelationHandle;

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ProcedureQuery.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ProcedureQuery.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public final class ProcedureQuery
+{
+    private final String query;
+
+    @JsonCreator
+    public ProcedureQuery(@JsonProperty String query)
+    {
+        this.query = requireNonNull(query, "query is null");
+    }
+
+    @JsonProperty
+    public String getQuery()
+    {
+        return query;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProcedureQuery that = (ProcedureQuery) o;
+        return query.equals(that.query);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(query);
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
@@ -18,6 +18,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.JoinType;
 import io.trino.spi.predicate.TupleDomain;
 
+import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -62,5 +63,12 @@ public interface QueryBuilder
             ConnectorSession session,
             Connection connection,
             PreparedQuery preparedQuery)
+            throws SQLException;
+
+    CallableStatement callProcedure(
+            JdbcClient client,
+            ConnectorSession session,
+            Connection connection,
+            ProcedureQuery procedureQuery)
             throws SQLException;
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/JdbcClientStats.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/JdbcClientStats.java
@@ -45,6 +45,7 @@ public final class JdbcClientStats
     private final JdbcApiStats getSplits = new JdbcApiStats();
     private final JdbcApiStats getTableHandle = new JdbcApiStats();
     private final JdbcApiStats getTableHandleForQuery = new JdbcApiStats();
+    private final JdbcApiStats getTableHandleForProcedure = new JdbcApiStats();
     private final JdbcApiStats getTableNames = new JdbcApiStats();
     private final JdbcApiStats getTableStatistics = new JdbcApiStats();
     private final JdbcApiStats renameColumn = new JdbcApiStats();
@@ -249,6 +250,13 @@ public final class JdbcClientStats
     public JdbcApiStats getGetTableHandleForQuery()
     {
         return getTableHandleForQuery;
+    }
+
+    @Managed
+    @Nested
+    public JdbcApiStats getGetTableHandleForProcedure()
+    {
+        return getTableHandleForProcedure;
     }
 
     @Managed

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -24,6 +24,7 @@ import io.trino.plugin.jdbc.JdbcSplit;
 import io.trino.plugin.jdbc.JdbcTableHandle;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
 import io.trino.plugin.jdbc.PreparedQuery;
+import io.trino.plugin.jdbc.ProcedureQuery;
 import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.plugin.jdbc.WriteFunction;
 import io.trino.plugin.jdbc.WriteMapping;
@@ -108,6 +109,12 @@ public final class StatisticsAwareJdbcClient
     public JdbcTableHandle getTableHandle(ConnectorSession session, PreparedQuery preparedQuery)
     {
         return stats.getGetTableHandleForQuery().wrap(() -> delegate().getTableHandle(session, preparedQuery));
+    }
+
+    @Override
+    public JdbcTableHandle getTableHandle(ConnectorSession session, ProcedureQuery procedureQuery)
+    {
+        return stats.getGetTableHandleForProcedure().wrap(() -> delegate().getTableHandle(session, procedureQuery));
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ptf/Procedure.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ptf/Procedure.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.ptf;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airlift.slice.Slice;
+import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorTableFunction;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcMetadata;
+import io.trino.plugin.jdbc.JdbcTableHandle;
+import io.trino.plugin.jdbc.JdbcTransactionManager;
+import io.trino.plugin.jdbc.ProcedureQuery;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.ptf.AbstractConnectorTableFunction;
+import io.trino.spi.ptf.Argument;
+import io.trino.spi.ptf.ConnectorTableFunction;
+import io.trino.spi.ptf.ConnectorTableFunctionHandle;
+import io.trino.spi.ptf.Descriptor;
+import io.trino.spi.ptf.Descriptor.Field;
+import io.trino.spi.ptf.ScalarArgument;
+import io.trino.spi.ptf.ScalarArgumentSpecification;
+import io.trino.spi.ptf.TableFunctionAnalysis;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.spi.ptf.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public class Procedure
+        implements Provider<ConnectorTableFunction>
+{
+    public static final String SCHEMA_NAME = "system";
+    public static final String NAME = "procedure";
+
+    private final JdbcTransactionManager transactionManager;
+
+    @Inject
+    public Procedure(JdbcTransactionManager transactionManager)
+    {
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+    }
+
+    @Override
+    public ConnectorTableFunction get()
+    {
+        return new ClassLoaderSafeConnectorTableFunction(new ProcedureFunction(transactionManager), getClass().getClassLoader());
+    }
+
+    public static class ProcedureFunction
+            extends AbstractConnectorTableFunction
+    {
+        private final JdbcTransactionManager transactionManager;
+
+        public ProcedureFunction(JdbcTransactionManager transactionManager)
+        {
+            super(
+                    SCHEMA_NAME,
+                    NAME,
+                    List.of(ScalarArgumentSpecification.builder()
+                            .name("QUERY")
+                            .type(VARCHAR)
+                            .build()),
+                    GENERIC_TABLE);
+            this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        }
+
+        @Override
+        public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
+        {
+            ScalarArgument argument = (ScalarArgument) getOnlyElement(arguments.values());
+            String query = ((Slice) argument.getValue()).toStringUtf8();
+
+            JdbcMetadata metadata = transactionManager.getMetadata(transaction);
+            JdbcTableHandle tableHandle = metadata.getTableHandle(session, new ProcedureQuery(query));
+            List<JdbcColumnHandle> columns = tableHandle.getColumns().orElseThrow(() -> new IllegalStateException("Handle doesn't have columns info"));
+            Descriptor returnedType = new Descriptor(columns.stream()
+                    .map(column -> new Field(column.getColumnName(), Optional.of(column.getColumnType())))
+                    .collect(toImmutableList()));
+
+            ProcedureFunctionHandle handle = new ProcedureFunctionHandle(tableHandle);
+
+            return TableFunctionAnalysis.builder()
+                    .returnedType(returnedType)
+                    .handle(handle)
+                    .build();
+        }
+    }
+
+    public static class ProcedureFunctionHandle
+            implements ConnectorTableFunctionHandle
+    {
+        private final JdbcTableHandle tableHandle;
+
+        @JsonCreator
+        public ProcedureFunctionHandle(@JsonProperty("tableHandle") JdbcTableHandle tableHandle)
+        {
+            this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
+        }
+
+        @JsonProperty
+        public ConnectorTableHandle getTableHandle()
+        {
+            return tableHandle;
+        }
+    }
+}

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestProcedure.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestProcedure.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import io.trino.testing.sql.SqlExecutor;
+import io.trino.testing.sql.TemporaryRelation;
+
+import static java.util.Objects.requireNonNull;
+
+public class TestProcedure
+        implements TemporaryRelation
+{
+    protected final SqlExecutor sqlExecutor;
+    protected final String name;
+
+    public TestProcedure(SqlExecutor sqlExecutor, String name, String createProcedureTemplate)
+    {
+        this.sqlExecutor = sqlExecutor;
+        this.name = requireNonNull(name, "name is null");
+        sqlExecutor.execute(createProcedureTemplate.formatted(name));
+    }
+
+    @Override
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public void close()
+    {
+        sqlExecutor.execute("DROP PROCEDURE " + name);
+    }
+}

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClientModule.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClientModule.java
@@ -28,6 +28,7 @@ import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcJoinPushdownSupportModule;
 import io.trino.plugin.jdbc.JdbcStatisticsConfig;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
+import io.trino.plugin.jdbc.ptf.Procedure;
 import io.trino.plugin.jdbc.ptf.Query;
 import io.trino.spi.ptf.ConnectorTableFunction;
 
@@ -50,6 +51,7 @@ public class MySqlClientModule
         install(new DecimalModule());
         install(new JdbcJoinPushdownSupportModule());
         newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Query.class).in(Scopes.SINGLETON);
+        newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Procedure.class).in(Scopes.SINGLETON);
     }
 
     @Provides

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClientModule.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClientModule.java
@@ -29,6 +29,7 @@ import io.trino.plugin.jdbc.JdbcJoinPushdownSupportModule;
 import io.trino.plugin.jdbc.JdbcStatisticsConfig;
 import io.trino.plugin.jdbc.MaxDomainCompactionThreshold;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
+import io.trino.plugin.jdbc.ptf.Procedure;
 import io.trino.plugin.jdbc.ptf.Query;
 import io.trino.spi.ptf.ConnectorTableFunction;
 
@@ -52,6 +53,7 @@ public class SqlServerClientModule
         bindSessionPropertiesProvider(binder, SqlServerSessionProperties.class);
         newOptionalBinder(binder, Key.get(int.class, MaxDomainCompactionThreshold.class)).setBinding().toInstance(SQL_SERVER_MAX_LIST_EXPRESSIONS);
         newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Query.class).in(Scopes.SINGLETON);
+        newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Procedure.class).in(Scopes.SINGLETON);
         install(new JdbcJoinPushdownSupportModule());
     }
 

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
@@ -19,9 +19,11 @@ import io.trino.Session;
 import io.trino.plugin.jdbc.BaseJdbcConnectorTest;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcTableHandle;
+import io.trino.plugin.jdbc.TestProcedure;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.TestTable;
@@ -585,6 +587,62 @@ public abstract class BaseSqlServerConnectorTest
     protected void verifyColumnNameLengthFailurePermissible(Throwable e)
     {
         assertThat(e).hasMessageMatching("Column name must be shorter than or equal to '128' characters but got '129': '.*'");
+    }
+
+    @Test
+    public void testSelectFromProcedureFunction()
+    {
+        try (TestProcedure testProcedure = simpleProcedure("SELECT 1 as first_column")) {
+            assertQuery(
+                    format("SELECT * FROM TABLE(system.procedure(query => 'EXEC %s')) ".formatted(testProcedure.getName()), getSession().getSchema().orElseThrow()),
+                    "VALUES 1");
+        }
+    }
+
+    @Test
+    public void testFilterPushdownRestrictedForProcedureFunction()
+    {
+        try (TestProcedure testProcedure = simpleProcedure("SELECT * FROM nation")) {
+            assertThat(query(format("SELECT name FROM TABLE(system.procedure(query => 'EXEC %s')) WHERE nationkey = 0".formatted(testProcedure.getName()))))
+                    .isNotFullyPushedDown(FilterNode.class)
+                    .skippingTypesCheck()
+                    .matches("VALUES 'ALGERIA'");
+        }
+    }
+
+    @Test
+    public void testAggregationPushdownRestrictedForProcedureFunction()
+    {
+        try (TestProcedure testProcedure = simpleProcedure("SELECT * FROM nation")) {
+            assertThat(query(format("SELECT COUNT(*) FROM TABLE(system.procedure(query => 'EXEC %s'))".formatted(testProcedure.getName()))))
+                    .isNotFullyPushedDown(AggregationNode.class)
+                    .matches("VALUES BIGINT '25'");
+        }
+    }
+
+    @Test
+    public void testJoinPushdownRestrictedForProcedureFunction()
+    {
+        try (TestProcedure testProcedure = simpleProcedure("SELECT * FROM nation")) {
+            assertThat(query(
+                    joinPushdownEnabled(getSession()),
+                    format("SELECT nationkey FROM TABLE(system.procedure(query => 'EXEC %s')) INNER JOIN nation USING (nationkey) ORDER BY 1 LIMIT 1".formatted(testProcedure.getName()))))
+                    .joinIsNotFullyPushedDown()
+                    .matches("VALUES BIGINT '0'");
+        }
+    }
+
+    private TestProcedure simpleProcedure(String baseQuery)
+    {
+        String procedureName = getSession().getSchema().orElseThrow() + ".procedure" + randomNameSuffix();
+        return new TestProcedure(
+                onRemoteDatabase(),
+                procedureName,
+                """
+                    CREATE PROCEDURE %s
+                    AS BEGIN
+                        %s;
+                    END""".formatted(procedureName, baseQuery));
     }
 
     private String getLongInClause(int start, int length)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

A dedicated table function which allows us to run stored procedures in MySQL and SQLServer. We can't use existing query table function - as it wraps with inside a query like `SELECT * FROM (CALL my_procedure()) o` -  so we are handing them via a different function.  All the pushdown are disabled for `TableHandle` resolved by this `TableFunction`. 

#### Limitation

- In case of stored procedures with multiple statement - we process the `ResultSet` only for the first statement. (Test to be added)
- Stored procedures with output variables are not supported.
- Input variables for the stored procedures are not parameterized(yet). 


#### Example 

```
SELECT * FROM TABLE(system.procedure(query => 'CALL my_new_procedure()')
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
