### PR TITLE
Update code using Map-of-Map

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
@@ -414,11 +414,7 @@ public final class TupleDomain<T>
             if (!domain.isNone()) {
                 for (Map.Entry<T, Domain> entry : domain.getDomains().get().entrySet()) {
                     if (commonColumns.contains(entry.getKey())) {
-                        List<Domain> domainForColumn = domainsByColumn.get(entry.getKey());
-                        if (domainForColumn == null) {
-                            domainForColumn = new ArrayList<>();
-                            domainsByColumn.put(entry.getKey(), domainForColumn);
-                        }
+                        List<Domain> domainForColumn = domainsByColumn.computeIfAbsent(entry.getKey(), ignored -> new ArrayList<>());
                         domainForColumn.add(entry.getValue());
                     }
                 }

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/serializers/LexicoderRowSerializer.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/serializers/LexicoderRowSerializer.java
@@ -13,6 +13,8 @@
  */
 package io.trino.plugin.accumulo.serializers;
 
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
 import io.airlift.slice.Slice;
 import io.trino.plugin.accumulo.Types;
 import io.trino.spi.TrinoException;
@@ -63,7 +65,7 @@ public class LexicoderRowSerializer
     private static final Map<Type, ListLexicoder<?>> LIST_LEXICODERS = new HashMap<>();
     private static final Map<Type, MapLexicoder<?, ?>> MAP_LEXICODERS = new HashMap<>();
 
-    private final Map<String, Map<String, String>> familyQualifierColumnMap = new HashMap<>();
+    private final Table<String, String, String> familyQualifierColumnMap = HashBasedTable.create();
     private final Map<String, byte[]> columnValues = new HashMap<>();
     private final Text rowId = new Text();
     private final Text family = new Text();
@@ -106,13 +108,7 @@ public class LexicoderRowSerializer
     public void setMapping(String name, String family, String qualifier)
     {
         columnValues.put(name, null);
-        Map<String, String> qualifierToNameMap = familyQualifierColumnMap.get(family);
-        if (qualifierToNameMap == null) {
-            qualifierToNameMap = new HashMap<>();
-            familyQualifierColumnMap.put(family, qualifierToNameMap);
-        }
-
-        qualifierToNameMap.put(qualifier, name);
+        familyQualifierColumnMap.put(family, qualifier, name);
     }
 
     @Override
@@ -141,7 +137,7 @@ public class LexicoderRowSerializer
         }
 
         value.set(entry.getValue().get());
-        columnValues.put(familyQualifierColumnMap.get(family.toString()).get(qualifier.toString()), value.copyBytes());
+        columnValues.put(familyQualifierColumnMap.get(family.toString(), qualifier.toString()), value.copyBytes());
     }
 
     @Override

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/serializers/StringRowSerializer.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/serializers/StringRowSerializer.java
@@ -13,6 +13,8 @@
  */
 package io.trino.plugin.accumulo.serializers;
 
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
 import io.airlift.slice.Slice;
 import io.trino.plugin.accumulo.Types;
 import io.trino.spi.TrinoException;
@@ -51,7 +53,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class StringRowSerializer
         implements AccumuloRowSerializer
 {
-    private final Map<String, Map<String, String>> familyQualifierColumnMap = new HashMap<>();
+    private final Table<String, String, String> familyQualifierColumnMap = HashBasedTable.create();
     private final Map<String, Object> columnValues = new HashMap<>();
     private final Text rowId = new Text();
     private final Text family = new Text();
@@ -77,13 +79,7 @@ public class StringRowSerializer
     public void setMapping(String name, String family, String qualifier)
     {
         columnValues.put(name, null);
-        Map<String, String> qualifierColumnMap = familyQualifierColumnMap.get(family);
-        if (qualifierColumnMap == null) {
-            qualifierColumnMap = new HashMap<>();
-            familyQualifierColumnMap.put(family, qualifierColumnMap);
-        }
-
-        qualifierColumnMap.put(qualifier, name);
+        familyQualifierColumnMap.put(family, qualifier, name);
     }
 
     @Override
@@ -112,7 +108,7 @@ public class StringRowSerializer
         }
 
         value.set(entry.getValue().get());
-        columnValues.put(familyQualifierColumnMap.get(family.toString()).get(qualifier.toString()), value.toString());
+        columnValues.put(familyQualifierColumnMap.get(family.toString(), qualifier.toString()), value.toString());
     }
 
     @Override


### PR DESCRIPTION
Guava's `Table` is a good class solving two-level hashing well. For SPI we cannot avoid Map-of-Map, but we can at least use `Map.computeIfAbsent` to make the code more readable.
