### PR TITLE
Remove redundant if condition

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ApplyPreferredTableExecutePartitioning.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ApplyPreferredTableExecutePartitioning.java
@@ -61,11 +61,6 @@ public class ApplyPreferredTableExecutePartitioning
             return enable(node);
         }
         int minimumNumberOfPartitions = getPreferredWritePartitioningMinNumberOfPartitions(context.getSession());
-        if (minimumNumberOfPartitions <= 1) {
-            // Force 'preferred write partitioning' even if stats are missing or broken
-            return enable(node);
-        }
-
         double expectedNumberOfPartitions = getRowsCount(
                 context.getStatsProvider().getStats(node.getSource()),
                 node.getPreferredPartitioningScheme().get().getPartitioning().getColumns());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ApplyPreferredTableWriterPartitioning.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ApplyPreferredTableWriterPartitioning.java
@@ -67,11 +67,6 @@ public class ApplyPreferredTableWriterPartitioning
         }
 
         int minimumNumberOfPartitions = getPreferredWritePartitioningMinNumberOfPartitions(context.getSession());
-        if (minimumNumberOfPartitions <= 1) {
-            // Force 'preferred write partitioning' even if stats are missing or broken
-            return enable(node);
-        }
-
         double expectedNumberOfPartitions = getRowsCount(
                 context.getStatsProvider().getStats(node.getSource()),
                 node.getPreferredPartitioningScheme().get().getPartitioning().getColumns());


### PR DESCRIPTION
Currently, preferred write/execute will
be chosen when stats are broken or missing.
Hence, extra if condition is no longer needed

NO RELEASE NOTES
