### PR TITLE
Add CatalogHandle to ConnectorContext

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorContextInstance.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorContextInstance.java
@@ -17,6 +17,7 @@ import io.trino.spi.NodeManager;
 import io.trino.spi.PageIndexerFactory;
 import io.trino.spi.PageSorter;
 import io.trino.spi.VersionEmbedder;
+import io.trino.spi.connector.CatalogHandle;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.MetadataProvider;
 import io.trino.spi.type.TypeManager;
@@ -38,8 +39,10 @@ public class ConnectorContextInstance
     private final PageIndexerFactory pageIndexerFactory;
     private final Supplier<ClassLoader> duplicatePluginClassLoaderFactory;
     private final AtomicBoolean pluginClassLoaderDuplicated = new AtomicBoolean();
+    private final CatalogHandle catalogHandle;
 
     public ConnectorContextInstance(
+            CatalogHandle catalogHandle,
             NodeManager nodeManager,
             VersionEmbedder versionEmbedder,
             TypeManager typeManager,
@@ -55,6 +58,13 @@ public class ConnectorContextInstance
         this.pageSorter = requireNonNull(pageSorter, "pageSorter is null");
         this.pageIndexerFactory = requireNonNull(pageIndexerFactory, "pageIndexerFactory is null");
         this.duplicatePluginClassLoaderFactory = requireNonNull(duplicatePluginClassLoaderFactory, "duplicatePluginClassLoaderFactory is null");
+        this.catalogHandle = requireNonNull(catalogHandle, "catalogHandle is null");
+    }
+
+    @Override
+    public CatalogHandle getCatalogHandle()
+    {
+        return catalogHandle;
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogFactory.java
+++ b/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogFactory.java
@@ -190,6 +190,7 @@ public class DefaultCatalogFactory
             Map<String, String> properties)
     {
         ConnectorContext context = new ConnectorContextInstance(
+                catalogHandle,
                 new ConnectorAwareNodeManager(nodeManager, nodeInfo.getEnvironment(), catalogHandle, schedulerIncludeCoordinator),
                 versionEmbedder,
                 typeManager,

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorContext.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorContext.java
@@ -21,6 +21,11 @@ import io.trino.spi.type.TypeManager;
 
 public interface ConnectorContext
 {
+    default CatalogHandle getCatalogHandle()
+    {
+        throw new UnsupportedOperationException();
+    }
+
     default NodeManager getNodeManager()
     {
         throw new UnsupportedOperationException();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Add CatalogHandle to ConnectorContext.

This makes the catalog handle available to the connector factory when creating a new connector instance


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
This builds upon the PR to add CatalogHandle to the SPI: https://github.com/trinodb/trino/pull/15425


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

