### PR TITLE
Add support for renaming column in Delta Lake

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
@@ -15,6 +15,7 @@ package io.trino.plugin.deltalake;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -330,6 +331,89 @@ public class TestDeltaLakeBasic
         Assertions.assertThat(droppedMetadata.getSchemaString())
                 .containsPattern("(delta\\.columnMapping\\.id.*?){5}")
                 .containsPattern("(delta\\.columnMapping\\.physicalName.*?){5}");
+    }
+
+    /**
+     * @see deltalake.column_mapping_mode_id
+     * @see deltalake.column_mapping_mode_name
+     */
+    @Test(dataProvider = "columnMappingModeDataProvider")
+    public void testRenameColumnWithColumnMappingMode(String columnMappingMode)
+            throws Exception
+    {
+        // The table contains 'x' column with column mapping mode
+        String tableName = "test_rename_column_" + randomNameSuffix();
+        Path tableLocation = Files.createTempFile(tableName, null);
+        copyDirectoryContents(new File(Resources.getResource("deltalake/column_mapping_mode_" + columnMappingMode).toURI()).toPath(), tableLocation);
+
+        assertUpdate("CALL system.register_table('%s', '%s', '%s')".formatted(getSession().getSchema().orElseThrow(), tableName, tableLocation.toUri()));
+        assertQueryReturnsEmptyResult("SELECT * FROM " + tableName);
+
+        assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN second_col row(a array(integer), b map(integer, integer), c row(field integer))");
+        MetadataEntry metadata = loadMetadataEntry(1, tableLocation);
+        assertThat(metadata.getConfiguration().get("delta.columnMapping.maxColumnId"))
+                .isEqualTo("6"); // +5 comes from second_col + second_col.a + second_col.b + second_col.c + second_col.c.field
+        assertThat(metadata.getSchemaString())
+                .containsPattern("(delta\\.columnMapping\\.id.*?){6}")
+                .containsPattern("(delta\\.columnMapping\\.physicalName.*?){6}");
+
+        JsonNode schema = OBJECT_MAPPER.readTree(metadata.getSchemaString());
+        List<JsonNode> fields = ImmutableList.copyOf(schema.get("fields").elements());
+        assertThat(fields).hasSize(2);
+        JsonNode integerColumn = fields.get(0);
+        JsonNode nestedColumn = fields.get(1);
+        List<JsonNode> rowFields = ImmutableList.copyOf(nestedColumn.get("type").get("fields").elements());
+        assertThat(rowFields).hasSize(3);
+
+        // Rename 'second_col' column and verify that nested metadata are same except for 'name' field and the table configuration are preserved
+        assertUpdate("ALTER TABLE " + tableName + " RENAME COLUMN second_col TO renamed_col");
+
+        MetadataEntry renamedMetadata = loadMetadataEntry(2, tableLocation);
+        JsonNode renamedSchema = OBJECT_MAPPER.readTree(renamedMetadata.getSchemaString());
+        List<JsonNode> renamedFields = ImmutableList.copyOf(renamedSchema.get("fields").elements());
+        assertThat(renamedFields).hasSize(2);
+        assertThat(renamedFields.get(0)).isEqualTo(integerColumn);
+        assertThat(renamedFields.get(1)).isNotEqualTo(nestedColumn);
+        JsonNode renamedColumn = ((ObjectNode) nestedColumn).put("name", "renamed_col");
+        assertThat(renamedFields.get(1)).isEqualTo(renamedColumn);
+
+        assertThat(renamedMetadata.getConfiguration())
+                .isEqualTo(metadata.getConfiguration());
+        assertThat(renamedMetadata.getSchemaString())
+                .containsPattern("(delta\\.columnMapping\\.id.*?){6}")
+                .containsPattern("(delta\\.columnMapping\\.physicalName.*?){6}");
+    }
+
+    /**
+     * @see deltalake.column_mapping_mode_id
+     * @see deltalake.column_mapping_mode_name
+     */
+    @Test(dataProvider = "columnMappingModeDataProvider")
+    public void testWriterAfterRenameColumnWithColumnMappingMode(String columnMappingMode)
+            throws Exception
+    {
+        String tableName = "test_writer_after_rename_column_" + randomNameSuffix();
+        Path tableLocation = Files.createTempFile(tableName, null);
+        copyDirectoryContents(new File(Resources.getResource("deltalake/column_mapping_mode_" + columnMappingMode).toURI()).toPath(), tableLocation);
+
+        assertUpdate("CALL system.register_table('%s', '%s', '%s')".formatted(getSession().getSchema().orElseThrow(), tableName, tableLocation.toUri()));
+        assertQueryReturnsEmptyResult("SELECT * FROM " + tableName);
+
+        assertUpdate("INSERT INTO " + tableName + " VALUES 1", 1);
+        assertUpdate("ALTER TABLE " + tableName + " RENAME COLUMN x to new_x");
+        assertQuery("SELECT * FROM " + tableName, "VALUES 1");
+
+        assertUpdate("UPDATE " + tableName + " SET new_x = 2", 1);
+        assertQuery("SELECT * FROM " + tableName, "VALUES 2");
+
+        assertUpdate("MERGE INTO " + tableName + " USING (VALUES 42) t(dummy) ON false " +
+                " WHEN NOT MATCHED THEN INSERT VALUES (3)", 1);
+        assertQuery("SELECT * FROM " + tableName, "VALUES 2, 3");
+
+        assertUpdate("DELETE FROM " + tableName + " WHERE new_x = 2", 1);
+        assertQuery("SELECT * FROM " + tableName, "VALUES 3");
+
+        assertUpdate("DROP TABLE " + tableName);
     }
 
     @DataProvider

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
@@ -174,52 +174,52 @@ public class TestDeltaLakeBasic
 
         assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN second_col row(a array(integer), b map(integer, integer), c row(field integer))");
         MetadataEntry metadata = loadMetadataEntry(1, tableLocation);
-        Assertions.assertThat(metadata.getConfiguration().get("delta.columnMapping.maxColumnId"))
+        assertThat(metadata.getConfiguration().get("delta.columnMapping.maxColumnId"))
                 .isEqualTo("6"); // +5 comes from second_col + second_col.a + second_col.b + second_col.c + second_col.c.field
 
         JsonNode schema = OBJECT_MAPPER.readTree(metadata.getSchemaString());
         List<JsonNode> fields = ImmutableList.copyOf(schema.get("fields").elements());
-        Assertions.assertThat(fields).hasSize(2);
+        assertThat(fields).hasSize(2);
         JsonNode columnX = fields.get(0);
         JsonNode columnY = fields.get(1);
 
         List<JsonNode> rowFields = ImmutableList.copyOf(columnY.get("type").get("fields").elements());
-        Assertions.assertThat(rowFields).hasSize(3);
+        assertThat(rowFields).hasSize(3);
         JsonNode nestedArray = rowFields.get(0);
         JsonNode nestedMap = rowFields.get(1);
         JsonNode nestedRow = rowFields.get(2);
 
         // Verify delta.columnMapping.id and delta.columnMapping.physicalName values
-        Assertions.assertThat(columnX.get("metadata").get("delta.columnMapping.id").asInt()).isEqualTo(1);
-        Assertions.assertThat(columnX.get("metadata").get("delta.columnMapping.physicalName").asText()).containsPattern(PHYSICAL_COLUMN_NAME_PATTERN);
-        Assertions.assertThat(columnY.get("metadata").get("delta.columnMapping.id").asInt()).isEqualTo(6);
-        Assertions.assertThat(columnY.get("metadata").get("delta.columnMapping.physicalName").asText()).containsPattern(PHYSICAL_COLUMN_NAME_PATTERN);
+        assertThat(columnX.get("metadata").get("delta.columnMapping.id").asInt()).isEqualTo(1);
+        assertThat(columnX.get("metadata").get("delta.columnMapping.physicalName").asText()).containsPattern(PHYSICAL_COLUMN_NAME_PATTERN);
+        assertThat(columnY.get("metadata").get("delta.columnMapping.id").asInt()).isEqualTo(6);
+        assertThat(columnY.get("metadata").get("delta.columnMapping.physicalName").asText()).containsPattern(PHYSICAL_COLUMN_NAME_PATTERN);
 
-        Assertions.assertThat(nestedArray.get("metadata").get("delta.columnMapping.id").asInt()).isEqualTo(2);
-        Assertions.assertThat(nestedArray.get("metadata").get("delta.columnMapping.physicalName").asText()).containsPattern(PHYSICAL_COLUMN_NAME_PATTERN);
+        assertThat(nestedArray.get("metadata").get("delta.columnMapping.id").asInt()).isEqualTo(2);
+        assertThat(nestedArray.get("metadata").get("delta.columnMapping.physicalName").asText()).containsPattern(PHYSICAL_COLUMN_NAME_PATTERN);
 
-        Assertions.assertThat(nestedMap.get("metadata").get("delta.columnMapping.id").asInt()).isEqualTo(3);
-        Assertions.assertThat(nestedMap.get("metadata").get("delta.columnMapping.physicalName").asText()).containsPattern(PHYSICAL_COLUMN_NAME_PATTERN);
+        assertThat(nestedMap.get("metadata").get("delta.columnMapping.id").asInt()).isEqualTo(3);
+        assertThat(nestedMap.get("metadata").get("delta.columnMapping.physicalName").asText()).containsPattern(PHYSICAL_COLUMN_NAME_PATTERN);
 
-        Assertions.assertThat(nestedRow.get("metadata").get("delta.columnMapping.id").asInt()).isEqualTo(5);
-        Assertions.assertThat(nestedRow.get("metadata").get("delta.columnMapping.physicalName").asText()).containsPattern(PHYSICAL_COLUMN_NAME_PATTERN);
-        Assertions.assertThat(getOnlyElement(nestedRow.get("type").get("fields").elements()).get("metadata").get("delta.columnMapping.id").asInt()).isEqualTo(4);
-        Assertions.assertThat(getOnlyElement(nestedRow.get("type").get("fields").elements()).get("metadata").get("delta.columnMapping.physicalName").asText()).containsPattern(PHYSICAL_COLUMN_NAME_PATTERN);
+        assertThat(nestedRow.get("metadata").get("delta.columnMapping.id").asInt()).isEqualTo(5);
+        assertThat(nestedRow.get("metadata").get("delta.columnMapping.physicalName").asText()).containsPattern(PHYSICAL_COLUMN_NAME_PATTERN);
+        assertThat(getOnlyElement(nestedRow.get("type").get("fields").elements()).get("metadata").get("delta.columnMapping.id").asInt()).isEqualTo(4);
+        assertThat(getOnlyElement(nestedRow.get("type").get("fields").elements()).get("metadata").get("delta.columnMapping.physicalName").asText()).containsPattern(PHYSICAL_COLUMN_NAME_PATTERN);
 
         // Repeat adding a new column and verify the existing fields are preserved
         assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN third_col row(a array(integer), b map(integer, integer), c row(field integer))");
         MetadataEntry thirdMetadata = loadMetadataEntry(2, tableLocation);
         JsonNode latestSchema = OBJECT_MAPPER.readTree(thirdMetadata.getSchemaString());
         List<JsonNode> latestFields = ImmutableList.copyOf(latestSchema.get("fields").elements());
-        Assertions.assertThat(latestFields).hasSize(3);
+        assertThat(latestFields).hasSize(3);
         JsonNode latestColumnX = latestFields.get(0);
         JsonNode latestColumnY = latestFields.get(1);
-        Assertions.assertThat(latestColumnX).isEqualTo(columnX);
-        Assertions.assertThat(latestColumnY).isEqualTo(columnY);
+        assertThat(latestColumnX).isEqualTo(columnX);
+        assertThat(latestColumnY).isEqualTo(columnY);
 
-        Assertions.assertThat(thirdMetadata.getConfiguration())
+        assertThat(thirdMetadata.getConfiguration())
                 .containsEntry("delta.columnMapping.maxColumnId", "11");
-        Assertions.assertThat(thirdMetadata.getSchemaString())
+        assertThat(thirdMetadata.getSchemaString())
                 .containsPattern("(delta\\.columnMapping\\.id.*?){11}")
                 .containsPattern("(delta\\.columnMapping\\.physicalName.*?){11}");
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -150,7 +150,6 @@ public class TestDeltaLakeConnectorTest
                 return false;
 
             case SUPPORTS_DROP_FIELD:
-            case SUPPORTS_RENAME_COLUMN:
             case SUPPORTS_SET_COLUMN_TYPE:
                 return false;
 
@@ -359,6 +358,33 @@ public class TestDeltaLakeConnectorTest
         // There are some tests in in io.trino.tests.product.deltalake.TestDeltaLakeColumnMappingMode
         assertThatThrownBy(super::testDropAndAddColumnWithSameName)
                 .hasMessageContaining("Cannot drop column from table using column mapping mode NONE");
+    }
+
+    @Override
+    public void testRenameColumn()
+    {
+        // Override because the connector doesn't support renaming columns with 'none' column mapping
+        // There are some tests in in io.trino.tests.product.deltalake.TestDeltaLakeColumnMappingMode
+        assertThatThrownBy(super::testRenameColumn)
+                .hasMessageContaining("Cannot rename column in table using column mapping mode NONE");
+    }
+
+    @Override
+    public void testAlterTableRenameColumnToLongName()
+    {
+        // Override because the connector doesn't support renaming columns with 'none' column mapping
+        // There are some tests in in io.trino.tests.product.deltalake.TestDeltaLakeColumnMappingMode
+        assertThatThrownBy(super::testAlterTableRenameColumnToLongName)
+                .hasMessageContaining("Cannot rename column in table using column mapping mode NONE");
+    }
+
+    @Override
+    public void testRenameColumnName(String columnName)
+    {
+        // Override because the connector doesn't support renaming columns with 'none' column mapping
+        // There are some tests in in io.trino.tests.product.deltalake.TestDeltaLakeColumnMappingMode
+        assertThatThrownBy(() -> super.testRenameColumnName(columnName))
+                .hasMessageContaining("Cannot rename column in table using column mapping mode NONE");
     }
 
     @Override
@@ -903,6 +929,17 @@ public class TestDeltaLakeConnectorTest
             assertUpdate("ALTER TABLE " + table.getName() + " SET PROPERTIES change_data_feed_enabled = false");
             assertUpdate("ALTER TABLE " + table.getName() + " ADD COLUMN " + columnName + " int");
             assertTableColumnNames(table.getName(), "col", columnName);
+        }
+    }
+
+    @Test(dataProvider = "changeDataFeedColumnNamesDataProvider")
+    public void testUnsupportedRenameColumnWithChangeDataFeed(String columnName)
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_rename_column", "(col int) WITH (change_data_feed_enabled = true)")) {
+            assertQueryFails(
+                    "ALTER TABLE " + table.getName() + " RENAME COLUMN col TO " + columnName,
+                    "Cannot rename column when change data feed is enabled");
+            assertTableColumnNames(table.getName(), "col");
         }
     }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/trinodb/trino/issues/12638
Fixes #13538

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Add support for renaming columns. ({issue}`15821 `)
```
