### PR TITLE
Continue commits checks when one fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
     needs: check-commits
     if: github.event_name == 'pull_request' && needs.check-commits.outputs.matrix != ''
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.check-commits.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
For a PR that has several commits, it makes sense to check all of them. The idea is the same as we do in testing tasks.

Fixes "cancellation" part of https://github.com/trinodb/trino/issues/15793