### PR TITLE
Fix check-commits task names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: rm -rf ~/.m2/repository/io/trino/trino-*
 
-  check-commits:
+  check-commits-dispatcher:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     outputs:
@@ -101,12 +101,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # checkout all commits to be able to determine merge base
-      - name: Check Commits
+      - name: Block illegal commits
         uses: trinodb/github-actions/block-commits@c2991972560c5219d9ae5fb68c0c9d687ffcdd10
         with:
           action-merge: fail
           action-fixup: none
-      - name: Set matrix
+      - name: Set matrix (dispatch commit checks)
         id: set-matrix
         run: |
           # The output from rev-list ends with a newline, so we have to filter out index -1 in jq since it's an empty string
@@ -125,13 +125,13 @@ jobs:
           echo "Commit matrix: $(jq '.' commit-matrix.json)"
           echo "matrix=$(jq -c '.' commit-matrix.json)" >> $GITHUB_OUTPUT
 
-  check-commits-dispatcher:
+  check-commit:
     runs-on: ubuntu-latest
-    needs: check-commits
-    if: github.event_name == 'pull_request' && needs.check-commits.outputs.matrix != ''
+    needs: check-commits-dispatcher
+    if: github.event_name == 'pull_request' && needs.check-commits-dispatcher.outputs.matrix != ''
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.check-commits.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.check-commits-dispatcher.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Usually "a dispatcher" is the entity defining tasks to be done rather
than the entity doing an individual task.

The change has the additional benefit that the matrix task checking
individual commits has a shorter name, so the matrix parameter is
slightly more visible in the GitHub actions UI.