### PR TITLE
Trino CLI: support --extra-header parameter

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -55,6 +55,7 @@ import static io.trino.client.uri.PropertyName.CLIENT_TAGS;
 import static io.trino.client.uri.PropertyName.EXTERNAL_AUTHENTICATION;
 import static io.trino.client.uri.PropertyName.EXTERNAL_AUTHENTICATION_REDIRECT_HANDLERS;
 import static io.trino.client.uri.PropertyName.EXTRA_CREDENTIALS;
+import static io.trino.client.uri.PropertyName.EXTRA_HEADERS;
 import static io.trino.client.uri.PropertyName.HTTP_PROXY;
 import static io.trino.client.uri.PropertyName.KERBEROS_CONFIG_PATH;
 import static io.trino.client.uri.PropertyName.KERBEROS_CREDENTIAL_CACHE_PATH;
@@ -193,6 +194,10 @@ public class ClientOptions
     @Option(names = "--client-tags", paramLabel = "<tags>", description = "Client tags")
     public Optional<String> clientTags;
 
+    @PropertyMapping(EXTRA_HEADERS)
+    @Option(names = "--extra-header", paramLabel = "<header>", description = "Extra HTTP header to attach to Trino queries (property can be used multiple times; format is key=value)")
+    public final List<ExtraHeader> extraHeaders = new ArrayList<>();
+
     @PropertyMapping(TRACE_TOKEN)
     @Option(names = "--trace-token", paramLabel = "<token>", description = "Trace token")
     public Optional<String> traceToken;
@@ -321,6 +326,7 @@ public class ClientOptions
                 .source(source.orElse("trino-cli"))
                 .traceToken(traceToken)
                 .clientTags(parseClientTags(clientTags.orElse("")))
+                .extraHeaders(toExtraHeaders(extraHeaders))
                 .clientInfo(clientInfo.orElse(null))
                 .catalog(uri.getCatalog().orElse(catalog.orElse(null)))
                 .schema(uri.getSchema().orElse(schema.orElse(null)))
@@ -405,6 +411,9 @@ public class ClientOptions
         source.ifPresent(builder::setSource);
         clientInfo.ifPresent(builder::setClientInfo);
         clientTags.ifPresent(builder::setClientTags);
+        if (!extraHeaders.isEmpty()) {
+            builder.setExtraHeaders(toExtraHeaders(extraHeaders));
+        }
         traceToken.ifPresent(builder::setTraceToken);
         socksProxy.ifPresent(builder::setSocksProxy);
         httpProxy.ifPresent(builder::setHttpProxy);
@@ -474,6 +483,15 @@ public class ClientOptions
     {
         Splitter splitter = Splitter.on(',').trimResults().omitEmptyStrings();
         return ImmutableSet.copyOf(splitter.split(nullToEmpty(clientTagsString)));
+    }
+
+    public static Map<String, String> toExtraHeaders(List<ExtraHeader> extraHeaders)
+    {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        for (ExtraHeader extraHeader : extraHeaders) {
+            builder.put(extraHeader.getHeader(), extraHeader.getValue());
+        }
+        return builder.buildOrThrow();
     }
 
     public static Map<String, String> toProperties(List<ClientSessionProperty> sessionProperties)
@@ -567,6 +585,58 @@ public class ClientOptions
         public int hashCode()
         {
             return Objects.hash(resource, estimate);
+        }
+    }
+
+    public static final class ExtraHeader
+    {
+        private final String header;
+        private final String value;
+
+        public ExtraHeader(String headerAndValue)
+        {
+            List<String> nameValue = NAME_VALUE_SPLITTER.splitToList(headerAndValue);
+            checkArgument(nameValue.size() == 2, "Header and value: %s", headerAndValue);
+
+            this.header = nameValue.get(0);
+            this.value = nameValue.get(1);
+            checkArgument(!header.isEmpty(), "Header name is empty");
+            checkArgument(!value.isEmpty(), "Header value is empty");
+        }
+
+        public ExtraHeader(String header, String value)
+        {
+            this.header = header;
+            this.value = value;
+        }
+
+        public String getHeader()
+        {
+            return header;
+        }
+
+        public String getValue()
+        {
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ExtraHeader other = (ExtraHeader) o;
+            return Objects.equals(header, other.header) && Objects.equals(value, other.value);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(header, value);
         }
     }
 

--- a/client/trino-cli/src/main/java/io/trino/cli/Trino.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Trino.java
@@ -18,6 +18,7 @@ import io.airlift.units.Duration;
 import io.trino.cli.ClientOptions.ClientExtraCredential;
 import io.trino.cli.ClientOptions.ClientResourceEstimate;
 import io.trino.cli.ClientOptions.ClientSessionProperty;
+import io.trino.cli.ClientOptions.ExtraHeader;
 import org.jline.utils.AttributedStringBuilder;
 import org.jline.utils.AttributedStyle;
 import picocli.CommandLine;
@@ -54,6 +55,7 @@ public final class Trino
                 .registerConverter(ClientResourceEstimate.class, ClientResourceEstimate::new)
                 .registerConverter(ClientSessionProperty.class, ClientSessionProperty::new)
                 .registerConverter(ClientExtraCredential.class, ClientExtraCredential::new)
+                .registerConverter(ExtraHeader.class, ExtraHeader::new)
                 .registerConverter(HostAndPort.class, HostAndPort::fromString)
                 .registerConverter(Duration.class, Duration::valueOf)
                 .setExecutionExceptionHandler((e, cmd, parseResult) -> {

--- a/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
@@ -216,6 +216,16 @@ public class TestClientOptions
     }
 
     @Test
+    public void testExtraHeaders()
+    {
+        Console console = createConsole("--extra-header", "X-Trino-Routing-Group=foo", "--extra-header", "x-foo=bar");
+        ClientOptions options = console.clientOptions;
+        assertEquals(options.extraHeaders, ImmutableList.of(
+                new ClientOptions.ExtraHeader("X-Trino-Routing-Group", "foo"),
+                new ClientOptions.ExtraHeader("x-foo", "bar")));
+    }
+
+    @Test
     public void testSessionProperties()
     {
         Console console = createConsole("--session", "system=system-value", "--session", "catalog.name=catalog-property");

--- a/client/trino-client/src/main/java/io/trino/client/ClientSession.java
+++ b/client/trino-client/src/main/java/io/trino/client/ClientSession.java
@@ -46,6 +46,7 @@ public class ClientSession
     private final ZoneId timeZone;
     private final Locale locale;
     private final Map<String, String> resourceEstimates;
+    private final Map<String, String> extraHeaders;
     private final Map<String, String> properties;
     private final Map<String, String> preparedStatements;
     private final Map<String, ClientSelectedRole> roles;
@@ -78,6 +79,7 @@ public class ClientSession
             String source,
             Optional<String> traceToken,
             Set<String> clientTags,
+            Map<String, String> extraHeaders,
             String clientInfo,
             Optional<String> catalog,
             Optional<String> schema,
@@ -99,6 +101,7 @@ public class ClientSession
         this.source = source;
         this.traceToken = requireNonNull(traceToken, "traceToken is null");
         this.clientTags = ImmutableSet.copyOf(requireNonNull(clientTags, "clientTags is null"));
+        this.extraHeaders = ImmutableMap.copyOf(requireNonNull(extraHeaders, "extraHeaders is null"));
         this.clientInfo = clientInfo;
         this.catalog = catalog;
         this.schema = schema;
@@ -171,6 +174,11 @@ public class ClientSession
     public Set<String> getClientTags()
     {
         return clientTags;
+    }
+
+    public Map<String, String> getExtraHeaders()
+    {
+        return extraHeaders;
     }
 
     public String getClientInfo()
@@ -259,6 +267,7 @@ public class ClientSession
                 .add("principal", principal)
                 .add("user", user)
                 .add("clientTags", clientTags)
+                .add("extraHeaders", extraHeaders)
                 .add("clientInfo", clientInfo)
                 .add("catalog", catalog)
                 .add("schema", schema)
@@ -280,6 +289,7 @@ public class ClientSession
         private String source;
         private Optional<String> traceToken = Optional.empty();
         private Set<String> clientTags = ImmutableSet.of();
+        private Map<String, String> extraHeaders = ImmutableMap.of();
         private String clientInfo;
         private String catalog;
         private String schema;
@@ -306,6 +316,7 @@ public class ClientSession
             source = clientSession.getSource();
             traceToken = clientSession.getTraceToken();
             clientTags = clientSession.getClientTags();
+            extraHeaders = clientSession.getExtraHeaders();
             clientInfo = clientSession.getClientInfo();
             catalog = clientSession.getCatalog().orElse(null);
             schema = clientSession.getSchema().orElse(null);
@@ -355,6 +366,12 @@ public class ClientSession
         public Builder clientTags(Set<String> clientTags)
         {
             this.clientTags = clientTags;
+            return this;
+        }
+
+        public Builder extraHeaders(Map<String, String> extraHeaders)
+        {
+            this.extraHeaders = extraHeaders;
             return this;
         }
 
@@ -451,6 +468,7 @@ public class ClientSession
                     source,
                     traceToken,
                     clientTags,
+                    extraHeaders,
                     clientInfo,
                     Optional.ofNullable(catalog),
                     Optional.ofNullable(schema),

--- a/client/trino-client/src/main/java/io/trino/client/OkHttpUtil.java
+++ b/client/trino-client/src/main/java/io/trino/client/OkHttpUtil.java
@@ -52,6 +52,7 @@ import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -96,6 +97,17 @@ public final class OkHttpUtil
         return chain -> chain.proceed(chain.request().newBuilder()
                 .addHeader(AUTHORIZATION, "Bearer " + accessToken)
                 .build());
+    }
+
+    public static Interceptor extraHeaders(Map<String, String> extraHeaders)
+    {
+        requireNonNull(extraHeaders, "extraHeaders is null");
+
+        return chain -> {
+            okhttp3.Request.Builder builder = chain.request().newBuilder();
+            extraHeaders.forEach((k, v) -> builder.addHeader(k, v));
+            return chain.proceed(builder.build());
+        };
     }
 
     public static void setupTimeouts(OkHttpClient.Builder clientBuilder, int timeout, TimeUnit unit)

--- a/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
@@ -91,6 +91,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<String, Map<String, String>> EXTRA_CREDENTIALS = new ExtraCredentials();
     public static final ConnectionProperty<String, String> CLIENT_INFO = new ClientInfo();
     public static final ConnectionProperty<String, String> CLIENT_TAGS = new ClientTags();
+    public static final ConnectionProperty<String, Map<String, String>> EXTRA_HEADERS = new ExtraHeaders();
     public static final ConnectionProperty<String, String> TRACE_TOKEN = new TraceToken();
     public static final ConnectionProperty<String, Map<String, String>> SESSION_PROPERTIES = new SessionProperties();
     public static final ConnectionProperty<String, String> SOURCE = new Source();
@@ -131,6 +132,7 @@ final class ConnectionProperties
             .add(EXTRA_CREDENTIALS)
             .add(CLIENT_INFO)
             .add(CLIENT_TAGS)
+            .add(EXTRA_HEADERS)
             .add(TRACE_TOKEN)
             .add(SESSION_PROPERTIES)
             .add(SOURCE)
@@ -633,6 +635,22 @@ final class ConnectionProperties
         public static Map<String, String> parseExtraCredentials(String extraCredentialString)
         {
             return new MapPropertyParser(PropertyName.EXTRA_CREDENTIALS.toString()).parse(extraCredentialString);
+        }
+    }
+
+    private static class ExtraHeaders
+            extends AbstractConnectionProperty<String, Map<String, String>>
+    {
+        public ExtraHeaders()
+        {
+            super(PropertyName.EXTRA_HEADERS, NOT_REQUIRED, ALLOWED, ExtraHeaders::parseExtraHeaders);
+        }
+
+        // Extra credentials consists of a list of credential name value pairs.
+        // E.g., `jdbc:trino://example.net:8080/?extraHeaders=abc:xyz;foo:bar` will create credentials `abc=xyz` and `foo=bar`
+        public static Map<String, String> parseExtraHeaders(String extraHeadersString)
+        {
+            return new MapPropertyParser(PropertyName.EXTRA_CREDENTIALS.toString()).parse(extraHeadersString);
         }
     }
 

--- a/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
@@ -58,6 +58,7 @@ public enum PropertyName
     EXTRA_CREDENTIALS("extraCredentials"),
     CLIENT_INFO("clientInfo"),
     CLIENT_TAGS("clientTags"),
+    EXTRA_HEADERS("extraHeaders"),
     TRACE_TOKEN("traceToken"),
     SESSION_PROPERTIES("sessionProperties"),
     SOURCE("source"),

--- a/docs/src/main/sphinx/client/cli.md
+++ b/docs/src/main/sphinx/client/cli.md
@@ -155,6 +155,9 @@ mode:
   * - ``--editing-mode``
     - Sets key bindings in the CLI to be compatible with VI or
       EMACS editors. Defaults to ``EMACS``.
+  * - ``--extra-header``
+    - Arbitrary headers to attach to HTTP requests made by the CLI. Property can be
+      used multiple times with the format ``header=value``.
   * - ``--http-proxy``
     - Configures the URL of the HTTP proxy to connect to Trino.
   * - ``--history-file``


### PR DESCRIPTION
## Description

Adds an --extra-header flag to the Trino CLI to allow for passing arbitrary HTTP headers to Trino requests.

## Additional context and related issues

This can be useful for all sort of header-y things, including passing the `X-Trino-Routing-Group` header for the presto-gateway, or adding specific values needed by other fanciful architectures. :)

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Add a `--extra-header` argument to the trino-cli to support sending arbitrary HTTP headers to Trino 
```