### PR TITLE
Support sheet table function for google sheets connector

### DIFF
--- a/docs/src/main/sphinx/connector/googlesheets.rst
+++ b/docs/src/main/sphinx/connector/googlesheets.rst
@@ -68,8 +68,8 @@ containing the following columns in this order:
 
 * Table Name
 * Sheet ID
-* Owner
-* Notes
+* Owner (optional)
+* Notes (optional)
 
 See this `example sheet <https://docs.google.com/spreadsheets/d/1Es4HhWALUQjoa-bQh4a8B5HROz7dpGMfq_HbfoaW5LM>`_
 as a reference.
@@ -89,9 +89,13 @@ address of the service account.
 
 The sheet needs to be mapped to a Trino table name. Specify a table name
 (column A) and the sheet ID (column B) in the metadata sheet. To refer
-to a specific tab in the sheet, add the tab name after the sheet ID, separated
-with ``#``. If tab name is not provided, connector loads only 10,000 rows by default from
+to a specific range in the sheet, add the range after the sheet ID, separated
+with ``#``. If a range is not provided, the connector loads only 10,000 rows by default from
 the first tab in the sheet.
+
+The first row of the provided sheet range is used as the header and will determine the column
+names of the Trino table.
+For more details on sheet range syntax see the `google sheets docs <https://developers.google.com/sheets/api/guides/concepts>`_.
 
 API usage limits
 ----------------
@@ -133,3 +137,33 @@ SQL support
 The connector provides :ref:`globally available <sql-globally-available>` and
 :ref:`read operation <sql-read-operations>` statements to access data and
 metadata in Google Sheets.
+
+Table functions
+---------------
+
+The connector provides specific :doc:`table functions </functions/table>` to
+access Google Sheets.
+
+.. _google-sheets-sheet-function:
+
+``sheet(id, range) -> table``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``sheet`` function allows you to query a Google Sheet directly without
+specifying it as a named table in the metadata sheet.
+
+For example, for a catalog named 'example'::
+
+    SELECT *
+    FROM
+      TABLE(example.system.sheet(
+          id => 'googleSheetIdHere'));
+
+A sheet range or named range can be provided as an optional ``range`` argument.
+The default sheet range is ``$1:$10000`` if one is not provided::
+
+    SELECT *
+    FROM
+      TABLE(example.system.sheet(
+          id => 'googleSheetIdHere',
+          range => 'TabName!A1:B4'));

--- a/plugin/trino-google-sheets/pom.xml
+++ b/plugin/trino-google-sheets/pom.xml
@@ -184,6 +184,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.eclipse.jetty.toolchain</groupId>
             <artifactId>jetty-servlet-api</artifactId>
             <scope>test</scope>

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetNotFoundException.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetNotFoundException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.google.sheets;
+
+import io.trino.spi.connector.NotFoundException;
+
+import static java.lang.String.format;
+
+public class SheetNotFoundException
+        extends NotFoundException
+{
+    public SheetNotFoundException(String sheetExpression)
+    {
+        super(format("Sheet '%s' not found", sheetExpression));
+    }
+}

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsClient.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsClient.java
@@ -75,7 +75,7 @@ public class SheetsClient
     private final NonEvictableLoadingCache<String, Optional<String>> tableSheetMappingCache;
     private final NonEvictableLoadingCache<String, List<List<Object>>> sheetDataCache;
 
-    private final String metadataSheetId;
+    private final Optional<String> metadataSheetId;
 
     private final Sheets sheetsService;
 
@@ -160,9 +160,12 @@ public class SheetsClient
 
     public Set<String> getTableNames()
     {
+        if (metadataSheetId.isEmpty()) {
+            return ImmutableSet.of();
+        }
         ImmutableSet.Builder<String> tables = ImmutableSet.builder();
         try {
-            List<List<Object>> tableMetadata = sheetDataCache.getUnchecked(metadataSheetId);
+            List<List<Object>> tableMetadata = sheetDataCache.getUnchecked(metadataSheetId.get());
             for (int i = 1; i < tableMetadata.size(); i++) {
                 if (tableMetadata.get(i).size() > 0) {
                     tables.add(String.valueOf(tableMetadata.get(i).get(0)));
@@ -218,8 +221,11 @@ public class SheetsClient
 
     private Map<String, Optional<String>> getAllTableSheetExpressionMapping()
     {
+        if (metadataSheetId.isEmpty()) {
+            return ImmutableMap.of();
+        }
         ImmutableMap.Builder<String, Optional<String>> tableSheetMap = ImmutableMap.builder();
-        List<List<Object>> data = readAllValuesFromSheetExpression(metadataSheetId);
+        List<List<Object>> data = readAllValuesFromSheetExpression(metadataSheetId.get());
         // first line is assumed to be sheet header
         for (int i = 1; i < data.size(); i++) {
             if (data.get(i).size() >= 2) {

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsClient.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsClient.java
@@ -134,7 +134,7 @@ public class SheetsClient
                 columns.add(new SheetsColumn(columnValue, VarcharType.VARCHAR));
             }
             List<List<String>> dataValues = values.subList(1, values.size()); // removing header info
-            return Optional.of(new SheetsTable(tableName, columns.build(), dataValues));
+            return Optional.of(new SheetsTable(columns.build(), dataValues));
         }
         return Optional.empty();
     }

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsClient.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsClient.java
@@ -278,7 +278,11 @@ public class SheetsClient
                 defaultRange = tableOptions[1];
             }
             log.debug("Accessing sheet id [%s] with range [%s]", sheetId, defaultRange);
-            return sheetsService.spreadsheets().values().get(sheetId, defaultRange).execute().getValues();
+            List<List<Object>> values = sheetsService.spreadsheets().values().get(sheetId, defaultRange).execute().getValues();
+            if (values == null) {
+                throw new TrinoException(SHEETS_TABLE_LOAD_ERROR, "No non-empty cells found in sheet: " + sheetExpression);
+            }
+            return values;
         }
         catch (IOException e) {
             // TODO: improve error to a {Table|Sheet}NotFoundException

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsConfig.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsConfig.java
@@ -32,7 +32,7 @@ public class SheetsConfig
 {
     private Optional<String> credentialsFilePath = Optional.empty();
     private Optional<String> credentialsKey = Optional.empty();
-    private String metadataSheetId;
+    private Optional<String> metadataSheetId = Optional.empty();
     private int sheetsDataMaxCacheSize = 1000;
     private Duration sheetsDataExpireAfterWrite = new Duration(5, TimeUnit.MINUTES);
     private Duration readTimeout = new Duration(20, TimeUnit.SECONDS); // 20s is the default timeout of com.google.api.client.http.HttpRequest
@@ -74,7 +74,7 @@ public class SheetsConfig
     }
 
     @NotNull
-    public String getMetadataSheetId()
+    public Optional<String> getMetadataSheetId()
     {
         return metadataSheetId;
     }
@@ -84,7 +84,7 @@ public class SheetsConfig
     @ConfigDescription("Metadata sheet id containing table sheet mapping")
     public SheetsConfig setMetadataSheetId(String metadataSheetId)
     {
-        this.metadataSheetId = metadataSheetId;
+        this.metadataSheetId = Optional.ofNullable(metadataSheetId);
         return this;
     }
 

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsConnector.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsConnector.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.google.sheets;
 
+import com.google.common.collect.ImmutableSet;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorMetadata;
@@ -20,9 +21,12 @@ import io.trino.spi.connector.ConnectorRecordSetProvider;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.ptf.ConnectorTableFunction;
 import io.trino.spi.transaction.IsolationLevel;
 
 import javax.inject.Inject;
+
+import java.util.Set;
 
 import static io.trino.plugin.google.sheets.SheetsTransactionHandle.INSTANCE;
 import static java.util.Objects.requireNonNull;
@@ -34,18 +38,21 @@ public class SheetsConnector
     private final SheetsMetadata metadata;
     private final SheetsSplitManager splitManager;
     private final SheetsRecordSetProvider recordSetProvider;
+    private final Set<ConnectorTableFunction> connectorTableFunctions;
 
     @Inject
     public SheetsConnector(
             LifeCycleManager lifeCycleManager,
             SheetsMetadata metadata,
             SheetsSplitManager splitManager,
-            SheetsRecordSetProvider recordSetProvider)
+            SheetsRecordSetProvider recordSetProvider,
+            Set<ConnectorTableFunction> connectorTableFunctions)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.recordSetProvider = requireNonNull(recordSetProvider, "recordSetProvider is null");
+        this.connectorTableFunctions = ImmutableSet.copyOf(requireNonNull(connectorTableFunctions, "connectorTableFunctions is null"));
     }
 
     @Override
@@ -70,6 +77,12 @@ public class SheetsConnector
     public ConnectorRecordSetProvider getRecordSetProvider()
     {
         return recordSetProvider;
+    }
+
+    @Override
+    public Set<ConnectorTableFunction> getTableFunctions()
+    {
+        return connectorTableFunctions;
     }
 
     @Override

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsConnectorTableHandle.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsConnectorTableHandle.java
@@ -14,9 +14,22 @@
 package io.trino.plugin.google.sheets;
 
 import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.NotFoundException;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.TableNotFoundException;
 
 public sealed interface SheetsConnectorTableHandle
         extends ConnectorTableHandle
-        permits SheetsNamedTableHandle
+        permits SheetsNamedTableHandle, SheetsSheetTableHandle
 {
+    static NotFoundException tableNotFound(SheetsConnectorTableHandle tableHandle)
+    {
+        if (tableHandle instanceof SheetsNamedTableHandle sheetsNamedTableHandle) {
+            return new TableNotFoundException(new SchemaTableName(sheetsNamedTableHandle.getSchemaName(), sheetsNamedTableHandle.getTableName()));
+        }
+        if (tableHandle instanceof SheetsSheetTableHandle sheetsSheetTableHandle) {
+            return new SheetNotFoundException(sheetsSheetTableHandle.getSheetExpression());
+        }
+        throw new IllegalStateException("Found unexpected table handle type " + tableHandle);
+    }
 }

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsConnectorTableHandle.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsConnectorTableHandle.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.google.sheets;
+
+import io.trino.spi.connector.ConnectorTableHandle;
+
+public sealed interface SheetsConnectorTableHandle
+        extends ConnectorTableHandle
+        permits SheetsNamedTableHandle
+{
+}

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsMetadata.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsMetadata.java
@@ -61,7 +61,7 @@ public class SheetsMetadata
     }
 
     @Override
-    public SheetsTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
+    public SheetsNamedTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
     {
         requireNonNull(tableName, "tableName is null");
         if (!listSchemaNames(session).contains(tableName.getSchemaName())) {
@@ -73,13 +73,13 @@ public class SheetsMetadata
             return null;
         }
 
-        return new SheetsTableHandle(tableName.getSchemaName(), tableName.getTableName());
+        return new SheetsNamedTableHandle(tableName.getSchemaName(), tableName.getTableName());
     }
 
     @Override
     public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
     {
-        SheetsTableHandle tableHandle = (SheetsTableHandle) table;
+        SheetsNamedTableHandle tableHandle = (SheetsNamedTableHandle) table;
         return getTableMetadata(tableHandle.toSchemaTableName())
                 .orElseThrow(() -> new TrinoException(SHEETS_UNKNOWN_TABLE_ERROR, "Metadata not found for table " + tableHandle.getTableName()));
     }
@@ -87,7 +87,7 @@ public class SheetsMetadata
     @Override
     public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        SheetsTableHandle sheetsTableHandle = (SheetsTableHandle) tableHandle;
+        SheetsNamedTableHandle sheetsTableHandle = (SheetsNamedTableHandle) tableHandle;
         SheetsTable table = sheetsClient.getTable(sheetsTableHandle.getTableName())
                 .orElseThrow(() -> new TableNotFoundException(sheetsTableHandle.toSchemaTableName()));
 

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsMetadata.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsMetadata.java
@@ -18,13 +18,16 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorTableSchema;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
-import io.trino.spi.connector.TableNotFoundException;
+import io.trino.spi.connector.TableFunctionApplicationResult;
+import io.trino.spi.ptf.ConnectorTableFunctionHandle;
 
 import javax.inject.Inject;
 
@@ -34,7 +37,9 @@ import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.plugin.google.sheets.SheetsConnectorTableHandle.tableNotFound;
 import static io.trino.plugin.google.sheets.SheetsErrorCode.SHEETS_UNKNOWN_TABLE_ERROR;
+import static io.trino.plugin.google.sheets.ptf.Sheet.SheetFunctionHandle;
 import static java.util.Objects.requireNonNull;
 
 public class SheetsMetadata
@@ -79,17 +84,18 @@ public class SheetsMetadata
     @Override
     public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
     {
-        SheetsNamedTableHandle tableHandle = (SheetsNamedTableHandle) table;
-        return getTableMetadata(tableHandle.toSchemaTableName())
-                .orElseThrow(() -> new TrinoException(SHEETS_UNKNOWN_TABLE_ERROR, "Metadata not found for table " + tableHandle.getTableName()));
+        SheetsConnectorTableHandle tableHandle = (SheetsConnectorTableHandle) table;
+        SheetsTable sheetsTable = sheetsClient.getTable(tableHandle)
+                .orElseThrow(() -> new TrinoException(SHEETS_UNKNOWN_TABLE_ERROR, "Metadata not found for table " + tableNotFound(tableHandle)));
+        return new ConnectorTableMetadata(getSchemaTableName(tableHandle), sheetsTable.getColumnsMetadata());
     }
 
     @Override
     public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        SheetsNamedTableHandle sheetsTableHandle = (SheetsNamedTableHandle) tableHandle;
-        SheetsTable table = sheetsClient.getTable(sheetsTableHandle.getTableName())
-                .orElseThrow(() -> new TableNotFoundException(sheetsTableHandle.toSchemaTableName()));
+        SheetsConnectorTableHandle sheetsTableHandle = (SheetsConnectorTableHandle) tableHandle;
+        SheetsTable table = sheetsClient.getTable(sheetsTableHandle)
+                .orElseThrow(() -> tableNotFound(sheetsTableHandle));
 
         ImmutableMap.Builder<String, ColumnHandle> columnHandles = ImmutableMap.builder();
         int index = 0;
@@ -144,5 +150,35 @@ public class SheetsMetadata
     public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
     {
         return ((SheetsColumnHandle) columnHandle).getColumnMetadata();
+    }
+
+    @Override
+    public Optional<TableFunctionApplicationResult<ConnectorTableHandle>> applyTableFunction(ConnectorSession session, ConnectorTableFunctionHandle handle)
+    {
+        if (!(handle instanceof SheetFunctionHandle)) {
+            return Optional.empty();
+        }
+
+        ConnectorTableHandle tableHandle = ((SheetFunctionHandle) handle).getTableHandle();
+        ConnectorTableSchema tableSchema = getTableSchema(session, tableHandle);
+        Map<String, ColumnHandle> columnHandlesByName = getColumnHandles(session, tableHandle);
+        List<ColumnHandle> columnHandles = tableSchema.getColumns().stream()
+                .map(ColumnSchema::getName)
+                .map(columnHandlesByName::get)
+                .collect(toImmutableList());
+
+        return Optional.of(new TableFunctionApplicationResult<>(tableHandle, columnHandles));
+    }
+
+    private static SchemaTableName getSchemaTableName(SheetsConnectorTableHandle handle)
+    {
+        if (handle instanceof SheetsNamedTableHandle namedTableHandle) {
+            return new SchemaTableName(namedTableHandle.getSchemaName(), namedTableHandle.getTableName());
+        }
+        if (handle instanceof SheetsSheetTableHandle) {
+            // TODO (https://github.com/trinodb/trino/issues/6694) SchemaTableName should not be required for synthetic ConnectorTableHandle
+            return new SchemaTableName("_generated", "_generated");
+        }
+        throw new IllegalStateException("Found unexpected table handle type " + handle);
     }
 }

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsModule.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsModule.java
@@ -16,7 +16,10 @@ package io.trino.plugin.google.sheets;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
+import io.trino.plugin.google.sheets.ptf.Sheet;
+import io.trino.spi.ptf.ConnectorTableFunction;
 
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.json.JsonCodec.listJsonCodec;
 import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
@@ -36,5 +39,7 @@ public class SheetsModule
         configBinder(binder).bindConfig(SheetsConfig.class);
 
         jsonCodecBinder(binder).bindMapJsonCodec(String.class, listJsonCodec(SheetsTable.class));
+
+        newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Sheet.class).in(Scopes.SINGLETON);
     }
 }

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsNamedTableHandle.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsNamedTableHandle.java
@@ -48,11 +48,6 @@ public final class SheetsNamedTableHandle
         return schemaTableName.getTableName();
     }
 
-    public SchemaTableName toSchemaTableName()
-    {
-        return schemaTableName;
-    }
-
     @Override
     public int hashCode()
     {

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsNamedTableHandle.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsNamedTableHandle.java
@@ -15,20 +15,19 @@ package io.trino.plugin.google.sheets;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.SchemaTableName;
 
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
-public final class SheetsTableHandle
-        implements ConnectorTableHandle
+public final class SheetsNamedTableHandle
+        implements SheetsConnectorTableHandle
 {
     private final SchemaTableName schemaTableName;
 
     @JsonCreator
-    public SheetsTableHandle(
+    public SheetsNamedTableHandle(
             @JsonProperty("schemaName") String schemaName,
             @JsonProperty("tableName") String tableName)
     {
@@ -70,7 +69,7 @@ public final class SheetsTableHandle
             return false;
         }
 
-        SheetsTableHandle other = (SheetsTableHandle) obj;
+        SheetsNamedTableHandle other = (SheetsNamedTableHandle) obj;
         return Objects.equals(this.schemaTableName, other.schemaTableName);
     }
 

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsSheetTableHandle.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsSheetTableHandle.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.google.sheets;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static io.trino.plugin.google.sheets.SheetsClient.RANGE_SEPARATOR;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public final class SheetsSheetTableHandle
+        implements SheetsConnectorTableHandle
+{
+    private final String sheetId;
+    private final String sheetRange;
+
+    @JsonCreator
+    public SheetsSheetTableHandle(
+            @JsonProperty("sheetId") String sheetId,
+            @JsonProperty("sheetRange") String sheetRange)
+    {
+        this.sheetId = requireNonNull(sheetId, "sheetId is null");
+        this.sheetRange = requireNonNull(sheetRange, "sheetRange is null");
+    }
+
+    @JsonProperty
+    public String getSheetId()
+    {
+        return sheetId;
+    }
+
+    @JsonProperty
+    public String getSheetRange()
+    {
+        return sheetRange;
+    }
+
+    @JsonIgnore
+    public String getSheetExpression()
+    {
+        return "%s%s%s".formatted(sheetId, RANGE_SEPARATOR, sheetRange);
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("Sheet[sheetId=%s, sheetRange=%s]", sheetId, sheetRange);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SheetsSheetTableHandle that = (SheetsSheetTableHandle) o;
+        return sheetId.equals(that.sheetId) && sheetRange.equals(that.sheetRange);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(sheetId, sheetRange);
+    }
+}

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsSplit.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsSplit.java
@@ -22,9 +22,11 @@ import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
 
 import java.util.List;
+import java.util.Optional;
 
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
 import static io.airlift.slice.SizeOf.instanceSize;
+import static io.airlift.slice.SizeOf.sizeOf;
 import static java.util.Objects.requireNonNull;
 
 public class SheetsSplit
@@ -32,33 +34,42 @@ public class SheetsSplit
 {
     private static final int INSTANCE_SIZE = instanceSize(SheetsSplit.class);
 
-    private final String schemaName;
-    private final String tableName;
+    private final Optional<String> schemaName;
+    private final Optional<String> tableName;
+    private final Optional<String> sheetExpression;
     private final List<List<String>> values;
     private final List<HostAddress> hostAddresses;
 
     @JsonCreator
     public SheetsSplit(
-            @JsonProperty("schemaName") String schemaName,
-            @JsonProperty("tableName") String tableName,
+            @JsonProperty("schemaName") Optional<String> schemaName,
+            @JsonProperty("tableName") Optional<String> tableName,
+            @JsonProperty("sheetExpression") Optional<String> sheetExpression,
             @JsonProperty("values") List<List<String>> values)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
+        this.sheetExpression = requireNonNull(sheetExpression, "sheetExpression is null");
         this.values = requireNonNull(values, "values is null");
         this.hostAddresses = ImmutableList.of();
     }
 
     @JsonProperty
-    public String getSchemaName()
+    public Optional<String> getSchemaName()
     {
         return schemaName;
     }
 
     @JsonProperty
-    public String getTableName()
+    public Optional<String> getTableName()
     {
         return tableName;
+    }
+
+    @JsonProperty
+    public Optional<String> getSheetExpression()
+    {
+        return sheetExpression;
     }
 
     @JsonProperty
@@ -82,19 +93,21 @@ public class SheetsSplit
     @Override
     public Object getInfo()
     {
-        return ImmutableMap.builder()
-                .put("schemaName", schemaName)
-                .put("tableName", tableName)
-                .put("hostAddresses", hostAddresses)
-                .buildOrThrow();
+        ImmutableMap.Builder<Object, Object> builder = ImmutableMap.builder()
+                .put("hostAddresses", hostAddresses);
+        schemaName.ifPresent(name -> builder.put("schemaName", name));
+        tableName.ifPresent(name -> builder.put("tableName", name));
+        sheetExpression.ifPresent(expression -> builder.put("sheetExpression", expression));
+        return builder.buildOrThrow();
     }
 
     @Override
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE
-                + estimatedSizeOf(schemaName)
-                + estimatedSizeOf(tableName)
+                + sizeOf(schemaName, SizeOf::estimatedSizeOf)
+                + sizeOf(tableName, SizeOf::estimatedSizeOf)
+                + sizeOf(sheetExpression, SizeOf::estimatedSizeOf)
                 + estimatedSizeOf(values, value -> estimatedSizeOf(value, SizeOf::estimatedSizeOf))
                 + estimatedSizeOf(hostAddresses, HostAddress::getRetainedSizeInBytes);
     }

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsSplitManager.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsSplitManager.java
@@ -51,7 +51,7 @@ public class SheetsSplitManager
             DynamicFilter dynamicFilter,
             Constraint constraint)
     {
-        SheetsTableHandle tableHandle = (SheetsTableHandle) connectorTableHandle;
+        SheetsNamedTableHandle tableHandle = (SheetsNamedTableHandle) connectorTableHandle;
         SheetsTable table = sheetsClient.getTable(tableHandle.getTableName())
                 // this can happen if table is removed during a query
                 .orElseThrow(() -> new TableNotFoundException(tableHandle.toSchemaTableName()));

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsSplitManager.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsSplitManager.java
@@ -22,14 +22,15 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.FixedSplitSource;
-import io.trino.spi.connector.TableNotFoundException;
 
 import javax.inject.Inject;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
+import static io.trino.plugin.google.sheets.SheetsConnectorTableHandle.tableNotFound;
 import static java.util.Objects.requireNonNull;
 
 public class SheetsSplitManager
@@ -51,14 +52,35 @@ public class SheetsSplitManager
             DynamicFilter dynamicFilter,
             Constraint constraint)
     {
-        SheetsNamedTableHandle tableHandle = (SheetsNamedTableHandle) connectorTableHandle;
-        SheetsTable table = sheetsClient.getTable(tableHandle.getTableName())
+        SheetsConnectorTableHandle tableHandle = (SheetsConnectorTableHandle) connectorTableHandle;
+        SheetsTable table = sheetsClient.getTable(tableHandle)
                 // this can happen if table is removed during a query
-                .orElseThrow(() -> new TableNotFoundException(tableHandle.toSchemaTableName()));
+                .orElseThrow(() -> tableNotFound(tableHandle));
 
         List<ConnectorSplit> splits = new ArrayList<>();
-        splits.add(new SheetsSplit(tableHandle.getSchemaName(), tableHandle.getTableName(), table.getValues()));
+        splits.add(sheetsSplitFromTableHandle(tableHandle, table.getValues()));
         Collections.shuffle(splits);
         return new FixedSplitSource(splits);
+    }
+
+    private static SheetsSplit sheetsSplitFromTableHandle(
+            SheetsConnectorTableHandle tableHandle,
+            List<List<String>> values)
+    {
+        if (tableHandle instanceof SheetsNamedTableHandle namedTableHandle) {
+            return new SheetsSplit(
+                    Optional.of(namedTableHandle.getSchemaName()),
+                    Optional.of(namedTableHandle.getTableName()),
+                    Optional.empty(),
+                    values);
+        }
+        if (tableHandle instanceof SheetsSheetTableHandle sheetTableHandle) {
+            return new SheetsSplit(
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.of(sheetTableHandle.getSheetExpression()),
+                    values);
+        }
+        throw new IllegalStateException("Found unexpected table handle type " + tableHandle);
     }
 }

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsTable.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsTable.java
@@ -20,8 +20,6 @@ import io.trino.spi.connector.ColumnMetadata;
 
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Objects.requireNonNull;
 
 public class SheetsTable
@@ -31,11 +29,9 @@ public class SheetsTable
 
     @JsonCreator
     public SheetsTable(
-            @JsonProperty("name") String name,
             @JsonProperty("columns") List<SheetsColumn> columns,
             @JsonProperty("values") List<List<String>> values)
     {
-        checkArgument(!isNullOrEmpty(name), "name is null or is empty");
         requireNonNull(columns, "columns is null");
 
         ImmutableList.Builder<ColumnMetadata> columnsMetadata = ImmutableList.builder();

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/ptf/Sheet.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/ptf/Sheet.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.google.sheets.ptf;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.airlift.slice.Slice;
+import io.trino.plugin.google.sheets.SheetsClient;
+import io.trino.plugin.google.sheets.SheetsColumnHandle;
+import io.trino.plugin.google.sheets.SheetsConnectorTableHandle;
+import io.trino.plugin.google.sheets.SheetsMetadata;
+import io.trino.plugin.google.sheets.SheetsSheetTableHandle;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.ptf.AbstractConnectorTableFunction;
+import io.trino.spi.ptf.Argument;
+import io.trino.spi.ptf.ConnectorTableFunction;
+import io.trino.spi.ptf.ConnectorTableFunctionHandle;
+import io.trino.spi.ptf.Descriptor;
+import io.trino.spi.ptf.ScalarArgument;
+import io.trino.spi.ptf.ScalarArgumentSpecification;
+import io.trino.spi.ptf.TableFunctionAnalysis;
+
+import javax.inject.Provider;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.google.sheets.SheetsClient.DEFAULT_RANGE;
+import static io.trino.plugin.google.sheets.SheetsClient.RANGE_SEPARATOR;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.ptf.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public class Sheet
+        implements Provider<ConnectorTableFunction>
+{
+    public static final String SCHEMA_NAME = "system";
+    public static final String NAME = "sheet";
+    public static final String ID_ARGUMENT = "ID";
+    public static final String RANGE_ARGUMENT = "RANGE";
+
+    private final SheetsMetadata metadata;
+
+    @Inject
+    public Sheet(SheetsClient client)
+    {
+        this.metadata = new SheetsMetadata(requireNonNull(client, "client is null"));
+    }
+
+    @Override
+    public ConnectorTableFunction get()
+    {
+        return new SheetFunction(metadata);
+    }
+
+    public static class SheetFunction
+            extends AbstractConnectorTableFunction
+    {
+        private final SheetsMetadata metadata;
+
+        public SheetFunction(SheetsMetadata metadata)
+        {
+            super(
+                    SCHEMA_NAME,
+                    NAME,
+                    ImmutableList.of(
+                            ScalarArgumentSpecification.builder()
+                                    .name(ID_ARGUMENT)
+                                    .type(VARCHAR)
+                                    .build(),
+                            ScalarArgumentSpecification.builder()
+                                    .name(RANGE_ARGUMENT)
+                                    .type(VARCHAR)
+                                    .defaultValue(utf8Slice(DEFAULT_RANGE))
+                                    .build()),
+                    GENERIC_TABLE);
+            this.metadata = requireNonNull(metadata, "metadata is null");
+        }
+
+        @Override
+        public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
+        {
+            String sheetId = ((Slice) ((ScalarArgument) arguments.get(ID_ARGUMENT)).getValue()).toStringUtf8();
+            validateSheetId(sheetId);
+            String rangeArgument = ((Slice) ((ScalarArgument) arguments.get(RANGE_ARGUMENT)).getValue()).toStringUtf8();
+
+            SheetsConnectorTableHandle tableHandle = new SheetsSheetTableHandle(sheetId, rangeArgument);
+            SheetFunctionHandle handle = new SheetFunctionHandle(tableHandle);
+
+            List<Descriptor.Field> fields = metadata.getColumnHandles(session, tableHandle).entrySet().stream()
+                    .map(entry -> new Descriptor.Field(
+                            entry.getKey(),
+                            Optional.of(((SheetsColumnHandle) (entry.getValue())).getColumnType())))
+                    .collect(toImmutableList());
+
+            Descriptor returnedType = new Descriptor(fields);
+
+            return TableFunctionAnalysis.builder()
+                    .returnedType(returnedType)
+                    .handle(handle)
+                    .build();
+        }
+    }
+
+    private static void validateSheetId(String sheetId)
+    {
+        // Sheet ids cannot contain "#", if a "#" is present it is because a range is present
+        // Ranges should be provided through the range argument
+        // https://developers.google.com/sheets/api/guides/concepts
+        if (sheetId.contains(RANGE_SEPARATOR)) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Google sheet ID %s cannot contain '#'. Provide a range through the 'range' argument.".formatted(sheetId));
+        }
+    }
+
+    public static class SheetFunctionHandle
+            implements ConnectorTableFunctionHandle
+    {
+        private final SheetsConnectorTableHandle tableHandle;
+
+        @JsonCreator
+        public SheetFunctionHandle(@JsonProperty("tableHandle") SheetsConnectorTableHandle tableHandle)
+        {
+            this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
+        }
+
+        @JsonProperty
+        public ConnectorTableHandle getTableHandle()
+        {
+            return tableHandle;
+        }
+    }
+}

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/SheetsQueryRunner.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/SheetsQueryRunner.java
@@ -45,7 +45,6 @@ public class SheetsQueryRunner
             // note: additional copy via ImmutableList so that if fails on nulls
             connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));
             connectorProperties.putIfAbsent("gsheets.credentials-path", getTestCredentialsPath());
-            connectorProperties.putIfAbsent("gsheets.metadata-sheet-id", TEST_METADATA_SHEET_ID);
             connectorProperties.putIfAbsent("gsheets.max-data-cache-size", "1000");
             connectorProperties.putIfAbsent("gsheets.data-cache-ttl", "5m");
 
@@ -75,7 +74,7 @@ public class SheetsQueryRunner
 
         DistributedQueryRunner queryRunner = createSheetsQueryRunner(
                 ImmutableMap.of("http-server.http.port", "8080"),
-                ImmutableMap.of());
+                ImmutableMap.of("gsheets.metadata-sheet-id", TEST_METADATA_SHEET_ID));
 
         Logger log = Logger.get(SheetsQueryRunner.class);
         log.info("======== SERVER STARTED ========");

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestGoogleSheets.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestGoogleSheets.java
@@ -20,6 +20,7 @@ import org.testng.annotations.Test;
 
 import static io.trino.plugin.google.sheets.SheetsQueryRunner.createSheetsQueryRunner;
 import static io.trino.plugin.google.sheets.TestSheetsPlugin.DATA_SHEET_ID;
+import static io.trino.plugin.google.sheets.TestSheetsPlugin.TEST_METADATA_SHEET_ID;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 
@@ -30,7 +31,11 @@ public class TestGoogleSheets
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createSheetsQueryRunner(ImmutableMap.of(), ImmutableMap.of("gsheets.read-timeout", "1m"));
+        return createSheetsQueryRunner(
+                ImmutableMap.of(),
+                ImmutableMap.of(
+                        "gsheets.read-timeout", "1m",
+                        "gsheets.metadata-sheet-id", TEST_METADATA_SHEET_ID));
     }
 
     @Test

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestGoogleSheets.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestGoogleSheets.java
@@ -19,6 +19,8 @@ import io.trino.testing.QueryRunner;
 import org.testng.annotations.Test;
 
 import static io.trino.plugin.google.sheets.SheetsQueryRunner.createSheetsQueryRunner;
+import static io.trino.plugin.google.sheets.TestSheetsPlugin.DATA_SHEET_ID;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 
 public class TestGoogleSheets
@@ -77,5 +79,113 @@ public class TestGoogleSheets
     {
         assertQuery("desc table_with_duplicate_and_missing_column_names", "SELECT * FROM (VALUES('a','varchar','','')," +
                 " ('column_1','varchar','',''), ('column_2','varchar','',''), ('c','varchar','',''))");
+    }
+
+    @Test
+    public void testSheetQuerySimple()
+    {
+        assertQuery(
+                "SELECT * FROM TABLE(gsheets.system.sheet(id => '%s'))".formatted(DATA_SHEET_ID),
+                "VALUES " +
+                        "('1', 'one')," +
+                        "('2', 'two')," +
+                        "('3', 'three')," +
+                        "('4', 'four')," +
+                        "('5', 'five')");
+    }
+
+    @Test
+    public void testSheetQueryFilter()
+    {
+        assertQuery(
+                "SELECT * FROM TABLE(gsheets.system.sheet(id => '%s'))".formatted(DATA_SHEET_ID) +
+                "WHERE number = '1' and text = 'one'",
+                "VALUES " +
+                        "('1', 'one')");
+    }
+
+    @Test
+    public void testSheetQueryWithSheet()
+    {
+        assertQuery(
+                "SELECT * FROM TABLE(gsheets.system.sheet(id => '%s', range => '%s'))".formatted(DATA_SHEET_ID, "number_text"),
+                "VALUES " +
+                        "('1', 'one')," +
+                        "('2', 'two')," +
+                        "('3', 'three')," +
+                        "('4', 'four')," +
+                        "('5', 'five')");
+    }
+
+    @Test
+    public void testSheetQueryWithSheetAndRangeWithoutHeader()
+    {
+        // The range skips the header row, the first row of the range is treated as a header
+        assertQuery(
+                "SELECT * FROM TABLE(gsheets.system.sheet(id => '%s', range => '%s'))".formatted(DATA_SHEET_ID, "number_text!A2:B6") +
+                        "WHERE \"1\" = \"1\" and \"one\" = \"one\"",
+                "VALUES " +
+                        "('2', 'two')," +
+                        "('3', 'three')," +
+                        "('4', 'four')," +
+                        "('5', 'five')");
+    }
+
+    @Test
+    public void testSheetQueryWithSheetAndRowRange()
+    {
+        assertQuery(
+                "SELECT * FROM TABLE(gsheets.system.sheet(id => '%s', range => '%s'))".formatted(DATA_SHEET_ID, "number_text!A1:B4") +
+                        "WHERE number = number and text = text",
+                "VALUES " +
+                        "('1', 'one')," +
+                        "('2', 'two')," +
+                        "('3', 'three')");
+    }
+
+    @Test
+    public void testSheetQueryWithSheetAndColumnRange()
+    {
+        assertQuery(
+                "SELECT * FROM TABLE(gsheets.system.sheet(id => '%s', range => '%s'))".formatted(DATA_SHEET_ID, "number_text!A1:A6") +
+                "WHERE number = number",
+                "VALUES " +
+                        "('1')," +
+                        "('2')," +
+                        "('3')," +
+                        "('4')," +
+                        "('5')");
+    }
+
+    @Test
+    public void testSheetQueryWithSheetAndRowAndColumnRange()
+    {
+        assertQuery(
+                "SELECT * FROM TABLE(gsheets.system.sheet(id => '%s', range => '%s'))".formatted(DATA_SHEET_ID, "number_text!B3:B5") +
+                "WHERE \"two\" = \"two\"",
+                "VALUES " +
+                        "('three')," +
+                        "('four')");
+    }
+
+    @Test
+    public void testSheetQueryWithSheetRangeInIdFails()
+    {
+        // Sheet ids with "#" are explicitly forbidden since "#" is the sheet separator
+        assertThatThrownBy(() -> query(
+                "SELECT * FROM TABLE(gsheets.system.sheet(id => '%s#%s'))".formatted(DATA_SHEET_ID, "number_text")))
+                .hasMessageContaining("Google sheet ID %s cannot contain '#'. Provide a range through the 'range' argument.".formatted(DATA_SHEET_ID + "#number_text"));
+
+        // Attempting to put a sheet range in the id fails since the sheet id is invalid
+        assertThatThrownBy(() -> query(
+                "SELECT * FROM TABLE(gsheets.system.sheet(id => '%s%s'))".formatted(DATA_SHEET_ID, "number_text")))
+                .hasMessageContaining("Failed reading data from sheet: %snumber_text#$1:$10000".formatted(DATA_SHEET_ID));
+    }
+
+    @Test
+    public void testSheetQueryWithInvalidSheetId()
+    {
+        assertThatThrownBy(() -> query("SELECT * FROM TABLE(gsheets.system.sheet(id => 'DOESNOTEXIST'))"))
+                .hasMessageContaining("Failed reading data from sheet: DOESNOTEXIST");
     }
 }

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestGoogleSheets.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestGoogleSheets.java
@@ -188,6 +188,18 @@ public class TestGoogleSheets
     }
 
     @Test
+    public void testSheetQueryWithNoDataInRangeFails()
+    {
+        assertThatThrownBy(() -> query(
+                "SELECT * FROM TABLE(gsheets.system.sheet(id => '%s', range => '%s'))".formatted(DATA_SHEET_ID, "number_text!D1:D1")))
+                .hasMessageContaining("No non-empty cells found in sheet: %s#number_text!D1:D1".formatted(DATA_SHEET_ID));
+
+        assertThatThrownBy(() -> query(
+                "SELECT * FROM TABLE(gsheets.system.sheet(id => '%s', range => '%s'))".formatted(DATA_SHEET_ID, "number_text!D12:E13")))
+                .hasMessageContaining("No non-empty cells found in sheet: %s#number_text!D12:E13".formatted(DATA_SHEET_ID));
+    }
+
+    @Test
     public void testSheetQueryWithInvalidSheetId()
     {
         assertThatThrownBy(() -> query("SELECT * FROM TABLE(gsheets.system.sheet(id => 'DOESNOTEXIST'))"))

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestGoogleSheetsWithoutMetadataSheetId.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestGoogleSheetsWithoutMetadataSheetId.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.google.sheets;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.Test;
+
+import static io.trino.plugin.google.sheets.SheetsQueryRunner.createSheetsQueryRunner;
+import static io.trino.plugin.google.sheets.TestSheetsPlugin.DATA_SHEET_ID;
+
+public class TestGoogleSheetsWithoutMetadataSheetId
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return createSheetsQueryRunner(ImmutableMap.of(), ImmutableMap.of("gsheets.read-timeout", "1m"));
+    }
+
+    @Test
+    public void testSheetQuerySimple()
+    {
+        assertQuery(
+                "SELECT * FROM TABLE(gsheets.system.sheet(id => '%s'))".formatted(DATA_SHEET_ID),
+                "VALUES " +
+                        "('1', 'one')," +
+                        "('2', 'two')," +
+                        "('3', 'three')," +
+                        "('4', 'four')," +
+                        "('5', 'five')");
+    }
+}

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestSheetsConfig.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestSheetsConfig.java
@@ -72,7 +72,7 @@ public class TestSheetsConfig
 
         assertEquals(config.getCredentialsKey(), Optional.empty());
         assertEquals(config.getCredentialsFilePath(), Optional.of(credentialsFile.toString()));
-        assertEquals(config.getMetadataSheetId(), "foo_bar_sheet_id#Sheet1");
+        assertEquals(config.getMetadataSheetId(), Optional.of("foo_bar_sheet_id#Sheet1"));
         assertEquals(config.getSheetsDataMaxCacheSize(), 2000);
         assertEquals(config.getSheetsDataExpireAfterWrite(), Duration.valueOf("10m"));
         assertEquals(config.getReadTimeout(), Duration.valueOf("1m"));
@@ -94,7 +94,7 @@ public class TestSheetsConfig
 
         assertEquals(config.getCredentialsKey(), Optional.of(BASE_64_ENCODED_TEST_KEY));
         assertEquals(config.getCredentialsFilePath(), Optional.empty());
-        assertEquals(config.getMetadataSheetId(), "foo_bar_sheet_id#Sheet1");
+        assertEquals(config.getMetadataSheetId(), Optional.of("foo_bar_sheet_id#Sheet1"));
         assertEquals(config.getSheetsDataMaxCacheSize(), 2000);
         assertEquals(config.getSheetsDataExpireAfterWrite(), Duration.valueOf("10m"));
         assertEquals(config.getReadTimeout(), Duration.valueOf("1m"));

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestSheetsConnectorTableHandle.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestSheetsConnectorTableHandle.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.google.sheets;
+
+import io.airlift.json.JsonCodec;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestSheetsConnectorTableHandle
+{
+    private final JsonCodec<SheetsNamedTableHandle> namedCodec = JsonCodec.jsonCodec(SheetsNamedTableHandle.class);
+
+    @Test
+    public void testRoundTripWithNamedTable()
+    {
+        SheetsNamedTableHandle expected = new SheetsNamedTableHandle("schema", "table");
+
+        String json = namedCodec.toJson(expected);
+        SheetsNamedTableHandle actual = namedCodec.fromJson(json);
+
+        assertEquals(actual, expected);
+    }
+}

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestSheetsConnectorTableHandle.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestSheetsConnectorTableHandle.java
@@ -21,6 +21,7 @@ import static org.testng.Assert.assertEquals;
 public class TestSheetsConnectorTableHandle
 {
     private final JsonCodec<SheetsNamedTableHandle> namedCodec = JsonCodec.jsonCodec(SheetsNamedTableHandle.class);
+    private final JsonCodec<SheetsSheetTableHandle> sheetCodec = JsonCodec.jsonCodec(SheetsSheetTableHandle.class);
 
     @Test
     public void testRoundTripWithNamedTable()
@@ -29,6 +30,17 @@ public class TestSheetsConnectorTableHandle
 
         String json = namedCodec.toJson(expected);
         SheetsNamedTableHandle actual = namedCodec.fromJson(json);
+
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testRoundTripWithSheetTable()
+    {
+        SheetsSheetTableHandle expected = new SheetsSheetTableHandle("sheetID", "$1:$10000");
+
+        String json = sheetCodec.toJson(expected);
+        SheetsSheetTableHandle actual = sheetCodec.fromJson(json);
 
         assertEquals(actual, expected);
     }

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestSheetsPlugin.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestSheetsPlugin.java
@@ -34,6 +34,7 @@ import static org.testng.Assert.assertNotNull;
 public class TestSheetsPlugin
 {
     static final String TEST_METADATA_SHEET_ID = "1Es4HhWALUQjoa-bQh4a8B5HROz7dpGMfq_HbfoaW5LM#Tables";
+    static final String DATA_SHEET_ID = "1S625j2oTptRepg6Yci68fCYE1269tdoSjljNOmTgQ3U";
 
     static String getTestCredentialsPath()
             throws Exception


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Supports `sheet` table function for the google sheets connector. 

Allows querying google sheets directly by id instead of requiring a metadata sheet mapping. 

Also makes the `gsheets.metadata-sheet-id` config optional since the sheet table function makes it no longer strictly required.  


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
N/A


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Google Sheets
* Add `sheet` table function to the connector. ({issue}`12502`)
```
