### PR TITLE
Allow pinning certain partitioning strategy to save memory

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
@@ -65,6 +65,7 @@ public class TaskManagerConfig
     private DataSize sinkMaxBroadcastBufferSize = DataSize.of(200, Unit.MEGABYTE);
     private DataSize maxPagePartitioningBufferSize = DataSize.of(32, Unit.MEGABYTE);
     private int pagePartitioningBufferPoolSize = 8;
+    private PagePartitioningStrategy pagePartitioningStrategy = PagePartitioningStrategy.MOST_EFFICIENT_PER_PAGE;
 
     private Duration clientTimeout = new Duration(2, TimeUnit.MINUTES);
     private Duration infoMaxAge = new Duration(15, TimeUnit.MINUTES);
@@ -393,6 +394,19 @@ public class TaskManagerConfig
         return this;
     }
 
+    @NotNull
+    public PagePartitioningStrategy getPagePartitioningStrategy()
+    {
+        return pagePartitioningStrategy;
+    }
+
+    @Config("driver.page-partitioning-strategy")
+    public TaskManagerConfig setPagePartitioningStrategy(PagePartitioningStrategy pagePartitioningStrategy)
+    {
+        this.pagePartitioningStrategy = pagePartitioningStrategy;
+        return this;
+    }
+
     @MinDuration("5s")
     @NotNull
     public Duration getClientTimeout()
@@ -602,5 +616,14 @@ public class TaskManagerConfig
     public void applyFaultTolerantExecutionDefaults()
     {
         taskConcurrency = 8;
+    }
+
+    public enum PagePartitioningStrategy
+    {
+        MOST_EFFICIENT_FOR_FIRST_PAGE,
+        MOST_EFFICIENT_PER_PAGE,
+        COLUMNAR,
+        ROW_WISE,
+        /**/;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/output/PartitionedOutputOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PartitionedOutputOperator.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.slice.Slice;
 import io.airlift.units.DataSize;
+import io.trino.execution.TaskManagerConfig.PagePartitioningStrategy;
 import io.trino.execution.buffer.OutputBuffer;
 import io.trino.execution.buffer.PagesSerdeFactory;
 import io.trino.memory.context.AggregatedMemoryContext;
@@ -60,6 +61,7 @@ public class PartitionedOutputOperator
         private final Optional<Slice> exchangeEncryptionKey;
         private final AggregatedMemoryContext memoryContext;
         private final int pagePartitionerPoolSize;
+        private final PagePartitioningStrategy partitioningStrategy;
 
         public PartitionedOutputFactory(
                 PartitionFunction partitionFunction,
@@ -72,7 +74,8 @@ public class PartitionedOutputOperator
                 PositionsAppenderFactory positionsAppenderFactory,
                 Optional<Slice> exchangeEncryptionKey,
                 AggregatedMemoryContext memoryContext,
-                int pagePartitionerPoolSize)
+                int pagePartitionerPoolSize,
+                PagePartitioningStrategy partitioningStrategy)
         {
             this.partitionFunction = requireNonNull(partitionFunction, "partitionFunction is null");
             this.partitionChannels = requireNonNull(partitionChannels, "partitionChannels is null");
@@ -85,6 +88,7 @@ public class PartitionedOutputOperator
             this.exchangeEncryptionKey = requireNonNull(exchangeEncryptionKey, "exchangeEncryptionKey is null");
             this.memoryContext = requireNonNull(memoryContext, "memoryContext is null");
             this.pagePartitionerPoolSize = pagePartitionerPoolSize;
+            this.partitioningStrategy = requireNonNull(partitioningStrategy, "partitioningStrategy is null");
         }
 
         @Override
@@ -111,7 +115,8 @@ public class PartitionedOutputOperator
                     positionsAppenderFactory,
                     exchangeEncryptionKey,
                     memoryContext,
-                    pagePartitionerPoolSize);
+                    pagePartitionerPoolSize,
+                    partitioningStrategy);
         }
     }
 
@@ -135,6 +140,7 @@ public class PartitionedOutputOperator
         private final AggregatedMemoryContext memoryContext;
         private final int pagePartitionerPoolSize;
         private final PagePartitionerPool pagePartitionerPool;
+        private final PagePartitioningStrategy partitioningStrategy;
 
         public PartitionedOutputOperatorFactory(
                 int operatorId,
@@ -152,7 +158,8 @@ public class PartitionedOutputOperator
                 PositionsAppenderFactory positionsAppenderFactory,
                 Optional<Slice> exchangeEncryptionKey,
                 AggregatedMemoryContext memoryContext,
-                int pagePartitionerPoolSize)
+                int pagePartitionerPoolSize,
+                PagePartitioningStrategy partitioningStrategy)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
@@ -170,6 +177,7 @@ public class PartitionedOutputOperator
             this.exchangeEncryptionKey = requireNonNull(exchangeEncryptionKey, "exchangeEncryptionKey is null");
             this.memoryContext = requireNonNull(memoryContext, "memoryContext is null");
             this.pagePartitionerPoolSize = pagePartitionerPoolSize;
+            this.partitioningStrategy = requireNonNull(partitioningStrategy, "partitioningStrategy is null");
             this.pagePartitionerPool = new PagePartitionerPool(
                     pagePartitionerPoolSize,
                     () -> new PagePartitioner(
@@ -184,7 +192,8 @@ public class PartitionedOutputOperator
                             maxMemory,
                             positionsAppenderFactory,
                             exchangeEncryptionKey,
-                            memoryContext));
+                            memoryContext,
+                            partitioningStrategy));
         }
 
         @Override
@@ -223,7 +232,8 @@ public class PartitionedOutputOperator
                     positionsAppenderFactory,
                     exchangeEncryptionKey,
                     memoryContext,
-                    pagePartitionerPoolSize);
+                    pagePartitionerPoolSize,
+                    partitioningStrategy);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -40,6 +40,7 @@ import io.trino.execution.StageId;
 import io.trino.execution.TableExecuteContextManager;
 import io.trino.execution.TaskId;
 import io.trino.execution.TaskManagerConfig;
+import io.trino.execution.TaskManagerConfig.PagePartitioningStrategy;
 import io.trino.execution.buffer.OutputBuffer;
 import io.trino.execution.buffer.PagesSerdeFactory;
 import io.trino.index.IndexManager;
@@ -391,6 +392,7 @@ public class LocalExecutionPlanner
     private final IndexJoinLookupStats indexJoinLookupStats;
     private final DataSize maxPartialAggregationMemorySize;
     private final DataSize maxPagePartitioningBufferSize;
+    private final PagePartitioningStrategy pagePartitioningStrategy;
     private final DataSize maxLocalExchangeBufferSize;
     private final SpillerFactory spillerFactory;
     private final SingleStreamSpillerFactory singleStreamSpillerFactory;
@@ -475,6 +477,7 @@ public class LocalExecutionPlanner
         this.partitioningSpillerFactory = requireNonNull(partitioningSpillerFactory, "partitioningSpillerFactory is null");
         this.maxPartialAggregationMemorySize = taskManagerConfig.getMaxPartialAggregationMemoryUsage();
         this.maxPagePartitioningBufferSize = taskManagerConfig.getMaxPagePartitioningBufferSize();
+        this.pagePartitioningStrategy = taskManagerConfig.getPagePartitioningStrategy();
         this.maxLocalExchangeBufferSize = taskManagerConfig.getMaxLocalExchangeBufferSize();
         this.pagesIndexFactory = requireNonNull(pagesIndexFactory, "pagesIndexFactory is null");
         this.joinCompiler = requireNonNull(joinCompiler, "joinCompiler is null");
@@ -584,7 +587,8 @@ public class LocalExecutionPlanner
                         positionsAppenderFactory,
                         taskContext.getSession().getExchangeEncryptionKey(),
                         taskContext.newAggregateMemoryContext(),
-                        getPagePartitioningBufferPoolSize(taskContext.getSession())));
+                        getPagePartitioningBufferPoolSize(taskContext.getSession()),
+                        pagePartitioningStrategy));
     }
 
     public LocalExecutionPlan plan(

--- a/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
@@ -26,6 +26,8 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertFullMappin
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.airlift.units.DataSize.Unit;
+import static io.trino.execution.TaskManagerConfig.PagePartitioningStrategy.COLUMNAR;
+import static io.trino.execution.TaskManagerConfig.PagePartitioningStrategy.MOST_EFFICIENT_PER_PAGE;
 import static io.trino.util.MachineInfo.getAvailablePhysicalProcessorCount;
 import static it.unimi.dsi.fastutil.HashCommon.nextPowerOfTwo;
 import static java.lang.Math.max;
@@ -61,6 +63,7 @@ public class TestTaskManagerConfig
                 .setSinkMaxBroadcastBufferSize(DataSize.of(200, Unit.MEGABYTE))
                 .setMaxPagePartitioningBufferSize(DataSize.of(32, Unit.MEGABYTE))
                 .setPagePartitioningBufferPoolSize(8)
+                .setPagePartitioningStrategy(MOST_EFFICIENT_PER_PAGE)
                 .setScaleWritersEnabled(true)
                 .setScaleWritersMaxWriterCount(DEFAULT_SCALE_WRITERS_MAX_WRITER_COUNT)
                 .setWriterCount(1)
@@ -105,6 +108,7 @@ public class TestTaskManagerConfig
                 .put("sink.max-broadcast-buffer-size", "128MB")
                 .put("driver.max-page-partitioning-buffer-size", "40MB")
                 .put("driver.page-partitioning-buffer-pool-size", "0")
+                .put("driver.page-partitioning-strategy", "COLUMNAR")
                 .put("task.scale-writers.enabled", "false")
                 .put("task.scale-writers.max-writer-count", Integer.toString(maxWriterCount))
                 .put("task.writer-count", "4")
@@ -144,6 +148,7 @@ public class TestTaskManagerConfig
                 .setSinkMaxBroadcastBufferSize(DataSize.of(128, Unit.MEGABYTE))
                 .setMaxPagePartitioningBufferSize(DataSize.of(40, Unit.MEGABYTE))
                 .setPagePartitioningBufferPoolSize(0)
+                .setPagePartitioningStrategy(COLUMNAR)
                 .setScaleWritersEnabled(false)
                 .setScaleWritersMaxWriterCount(maxWriterCount)
                 .setWriterCount(4)

--- a/core/trino-main/src/test/java/io/trino/operator/output/BenchmarkPartitionedOutputOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/BenchmarkPartitionedOutputOperator.java
@@ -90,6 +90,7 @@ import static io.trino.block.BlockAssertions.createLongsBlock;
 import static io.trino.block.BlockAssertions.createRandomBlockForType;
 import static io.trino.block.BlockAssertions.createRandomLongsBlock;
 import static io.trino.block.BlockAssertions.createRepeatedValuesBlock;
+import static io.trino.execution.TaskManagerConfig.PagePartitioningStrategy.MOST_EFFICIENT_PER_PAGE;
 import static io.trino.execution.buffer.PipelinedOutputBuffers.BufferType.PARTITIONED;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.operator.output.BenchmarkPartitionedOutputOperator.BenchmarkData.TestType;
@@ -467,7 +468,8 @@ public class BenchmarkPartitionedOutputOperator
                     POSITIONS_APPENDER_FACTORY,
                     Optional.empty(),
                     newSimpleAggregatedMemoryContext(),
-                    0);
+                    0,
+                    MOST_EFFICIENT_PER_PAGE);
             return (PartitionedOutputOperator) operatorFactory
                     .createOutputOperator(0, new PlanNodeId("plan-node-0"), types, Function.identity(), serdeFactory)
                     .createOperator(createDriverContext());

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPagePartitionerPool.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPagePartitionerPool.java
@@ -53,6 +53,7 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.Threads.threadsNamed;
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.block.BlockAssertions.createLongsBlock;
+import static io.trino.execution.TaskManagerConfig.PagePartitioningStrategy.MOST_EFFICIENT_PER_PAGE;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
@@ -100,7 +101,8 @@ public class TestPagePartitionerPool
                 new PositionsAppenderFactory(new BlockTypeOperators()),
                 Optional.empty(),
                 memoryContext,
-                2);
+                2,
+                MOST_EFFICIENT_PER_PAGE);
 
         assertEquals(memoryContext.getBytes(), 0);
         // first split, too small for a flush


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

When the number of output partitions is high (e.g.: 1000+) it might be
necessary to increase the buffer size (driver.max-page-partitioning-buffer-size)
from the default value of 32MB to a higher value (e.g.: 64 - 256MB) to
avoid small page problem.

Having the partitioning strategy being chosen dynamically for every page
may effectively double the memory used for buffering resulting in
significantly higher memory utilization for the purpose of partitioning.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
