### PR TITLE
Add aggregation pushdown support for count using Iceberg Metrics

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -41,6 +41,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
             <optional>true</optional>
@@ -140,6 +146,11 @@
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-hive-formats</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-matching</artifactId>
         </dependency>
 
         <dependency>

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergColumnHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergColumnHandle.java
@@ -32,6 +32,7 @@ import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.plugin.iceberg.IcebergMetadataColumn.FILE_MODIFIED_TIME;
 import static io.trino.plugin.iceberg.IcebergMetadataColumn.FILE_PATH;
+import static io.trino.plugin.iceberg.aggregation.AggregateExpression.COUNT_AGGREGATE_COLUMN_ID;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.MetadataColumns.IS_DELETED;
 import static org.apache.iceberg.MetadataColumns.ROW_POSITION;
@@ -298,5 +299,10 @@ public class IcebergColumnHandle
     public boolean isPathColumn()
     {
         return getColumnIdentity().getId() == FILE_PATH.getId();
+    }
+
+    public boolean isAggregateColumn()
+    {
+        return getColumnIdentity().getId() == COUNT_AGGREGATE_COLUMN_ID;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -79,6 +79,7 @@ public class IcebergConfig
     private boolean sortedWritingEnabled = true;
     private boolean queryPartitionFilterRequired;
     private int splitManagerThreads = Runtime.getRuntime().availableProcessors() * 2;
+    private boolean aggregationPushdownEnabled;
 
     public CatalogType getCatalogType()
     {
@@ -434,5 +435,17 @@ public class IcebergConfig
     public boolean isStorageSchemaSetWhenHidingIsEnabled()
     {
         return hideMaterializedViewStorageTable && materializedViewsStorageSchema.isPresent();
+    }
+
+    public boolean isAggregationPushdownEnabled()
+    {
+        return aggregationPushdownEnabled;
+    }
+
+    @Config("iceberg.aggregation-pushdown.enabled")
+    public IcebergConfig setAggregationPushdownEnabled(boolean aggregationPushdownEnabled)
+    {
+        this.aggregationPushdownEnabled = aggregationPushdownEnabled;
+        return this;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -97,6 +97,7 @@ public final class IcebergSessionProperties
     private static final String MERGE_MANIFESTS_ON_WRITE = "merge_manifests_on_write";
     private static final String SORTED_WRITING_ENABLED = "sorted_writing_enabled";
     private static final String QUERY_PARTITION_FILTER_REQUIRED = "query_partition_filter_required";
+    public static final String AGGREGATION_PUSHDOWN_ENABLED = "aggregation_pushdown_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -348,6 +349,11 @@ public final class IcebergSessionProperties
                         "Require filter on partition column",
                         icebergConfig.isQueryPartitionFilterRequired(),
                         false))
+                .add(booleanProperty(
+                        AGGREGATION_PUSHDOWN_ENABLED,
+                        "Enable Aggregation Pushdown",
+                        icebergConfig.isAggregationPushdownEnabled(),
+                        false))
                 .build();
     }
 
@@ -567,5 +573,10 @@ public final class IcebergSessionProperties
     public static boolean isQueryPartitionFilterRequired(ConnectorSession session)
     {
         return session.getProperty(QUERY_PARTITION_FILTER_REQUIRED, Boolean.class);
+    }
+
+    public static boolean isAggregationPushdownEnabled(ConnectorSession session)
+    {
+        return session.getProperty(AGGREGATION_PUSHDOWN_ENABLED, Boolean.class);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/aggregation/AggregateExpression.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/aggregation/AggregateExpression.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.aggregation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.iceberg.ColumnIdentity;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.trino.plugin.iceberg.IcebergMetadataColumn.FILE_MODIFIED_TIME;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class AggregateExpression
+{
+    private final String function;
+    private final String argument;
+    // did not find a cleaner way to find an id for aggregate's synthetic column,
+    // Trino maintains FILE_MODIFIED_TIME as one of the synthetic metadata column.
+    // which is Integer.MAX_VALUE - 1001, so using FILE_MODIFIED_TIME - 1001 to have some buffer.
+    public static final Integer COUNT_AGGREGATE_COLUMN_ID = FILE_MODIFIED_TIME.getId() - 1001;
+
+    @JsonCreator
+    public AggregateExpression(@JsonProperty String function, @JsonProperty String argument)
+    {
+        this.function = requireNonNull(function, "function is null");
+        this.argument = requireNonNull(argument, "argument is null");
+    }
+
+    @JsonProperty
+    public String getFunction()
+    {
+        return function;
+    }
+
+    @JsonProperty
+    public String getArgument()
+    {
+        return argument;
+    }
+
+    public ColumnIdentity toColumnIdentity(Integer columnId)
+    {
+        return new ColumnIdentity(columnId, format("%s(%s)", function, argument), ColumnIdentity.TypeCategory.PRIMITIVE, ImmutableList.of());
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof AggregateExpression)) {
+            return false;
+        }
+        AggregateExpression that = (AggregateExpression) other;
+        return that.function.equals(function) &&
+                that.argument.equals(argument);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(function, argument);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("function", function)
+                .add("argument", argument)
+                .toString();
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/aggregation/AggregateIcebergSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/aggregation/AggregateIcebergSplit.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.aggregation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.iceberg.IcebergSplit;
+import io.trino.spi.HostAddress;
+import io.trino.spi.connector.ConnectorSplit;
+
+import java.util.List;
+import java.util.OptionalLong;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.instanceSize;
+import static io.airlift.slice.SizeOf.sizeOf;
+
+public class AggregateIcebergSplit
+        implements ConnectorSplit
+{
+    private static final int INSTANCE_SIZE = instanceSize(IcebergSplit.class);
+    private final List<HostAddress> addresses;
+    private final long totalCount;
+
+    @JsonCreator
+    public AggregateIcebergSplit(
+            @JsonProperty("addresses") List<HostAddress> addresses,
+            @JsonProperty("totalCount") long totalCount)
+    {
+        this.addresses = addresses;
+        this.totalCount = totalCount;
+    }
+
+    @JsonProperty
+    public long getTotalCount()
+    {
+        return totalCount;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + sizeOf(OptionalLong.of(totalCount));
+    }
+
+    @Override
+
+    public boolean isRemotelyAccessible()
+    {
+        return true;
+    }
+
+    @JsonProperty
+    @Override
+    public List<HostAddress> getAddresses()
+    {
+        return addresses;
+    }
+
+    @Override
+    public Object getInfo()
+    {
+        return ImmutableMap.builder()
+                .put("totalCount", totalCount)
+                .buildOrThrow();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .addValue(totalCount)
+                .toString();
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/aggregation/AggregatePageSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/aggregation/AggregatePageSource.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.aggregation;
+
+import io.trino.plugin.iceberg.IcebergColumnHandle;
+import io.trino.plugin.iceberg.util.PageListBuilder;
+import io.trino.spi.Page;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.metrics.Metrics;
+import io.trino.spi.type.Type;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.stream.Collectors.toList;
+
+public class AggregatePageSource
+        implements ConnectorPageSource
+{
+    private final List<Type> columnTypes;
+    private long readTimeNanos;
+    private Iterator<Page> pages;
+    private final long recordCount;
+
+    public AggregatePageSource(List<IcebergColumnHandle> columnHandles, long recordCount)
+    {
+        // _pos columns are not required.
+        this.columnTypes = columnHandles.stream().filter(columnHandle -> !columnHandle.isRowPositionColumn()).map(ch -> ch.getType()).collect(toList());
+        this.recordCount = recordCount;
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return 0;
+    }
+
+    /**
+     * Gets the number of input rows processed by this page source so far.
+     * By default, the positions count of the page returned from getNextPage
+     * is used to calculate the number of input rows.
+     */
+    @Override
+    public OptionalLong getCompletedPositions()
+    {
+        return ConnectorPageSource.super.getCompletedPositions();
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return readTimeNanos;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return pages != null && !pages.hasNext();
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        if (pages != null && pages.hasNext()) {
+            return pages.next();
+        }
+
+        long start = System.nanoTime();
+        PageListBuilder pageListBuilder = new PageListBuilder(columnTypes);
+
+        pageListBuilder.beginRow();
+        pageListBuilder.appendBigint(recordCount);
+        pageListBuilder.endRow();
+
+        this.readTimeNanos += System.nanoTime() - start;
+        this.pages = pageListBuilder.build().iterator();
+        return pages.next();
+    }
+
+    /**
+     * Get the total memory that needs to be reserved in the memory pool.
+     * This memory should include any buffers, etc. that are used for reading data.
+     *
+     * @return the memory used so far in table read
+     */
+    @Override
+    public long getMemoryUsage()
+    {
+        return 0;
+    }
+
+    @Override
+    public void close()
+    {
+    }
+
+    /**
+     * Returns a future that will be completed when the page source becomes
+     * unblocked.  If the page source is not blocked, this method should return
+     * {@code NOT_BLOCKED}.
+     */
+    @Override
+    public CompletableFuture<?> isBlocked()
+    {
+        return ConnectorPageSource.super.isBlocked();
+    }
+
+    /**
+     * Returns the connector's metrics, mapping a metric ID to its latest value.
+     * Each call must return an immutable snapshot of available metrics.
+     * Same ID metrics are merged across all tasks and exposed via OperatorStats.
+     * This method can be called after the page source is closed.
+     */
+    @Override
+    public Metrics getMetrics()
+    {
+        return ConnectorPageSource.super.getMetrics();
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/aggregation/AggregateSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/aggregation/AggregateSplitSource.java
@@ -1,0 +1,489 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.aggregation;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Closer;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.plugin.iceberg.IcebergColumnHandle;
+import io.trino.plugin.iceberg.IcebergFileSystemFactory;
+import io.trino.plugin.iceberg.IcebergTableHandle;
+import io.trino.plugin.iceberg.util.DataFileWithDeleteFiles;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorSplitSource;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.NullableValue;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.TypeManager;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.TableScanUtil;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Suppliers.memoize;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Sets.intersection;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.iceberg.ExpressionConverter.toIcebergExpression;
+import static io.trino.plugin.iceberg.IcebergColumnHandle.fileModifiedTimeColumnHandle;
+import static io.trino.plugin.iceberg.IcebergColumnHandle.pathColumnHandle;
+import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
+import static io.trino.plugin.iceberg.IcebergMetadataColumn.isMetadataColumnId;
+import static io.trino.plugin.iceberg.IcebergSplitManager.ICEBERG_DOMAIN_COMPACTION_THRESHOLD;
+import static io.trino.plugin.iceberg.IcebergTypes.convertIcebergValueToTrino;
+import static io.trino.plugin.iceberg.IcebergUtil.deserializePartitionValue;
+import static io.trino.plugin.iceberg.IcebergUtil.getColumnHandle;
+import static io.trino.plugin.iceberg.IcebergUtil.getPartitionKeys;
+import static io.trino.plugin.iceberg.IcebergUtil.primitiveFieldTypes;
+import static io.trino.plugin.iceberg.TypeConverter.toIcebergType;
+import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
+import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.iceberg.types.Conversions.fromByteBuffer;
+
+public class AggregateSplitSource
+        implements ConnectorSplitSource
+{
+    private static final ConnectorSplitBatch EMPTY_BATCH = new ConnectorSplitBatch(ImmutableList.of(), false);
+    private static final ConnectorSplitBatch NO_MORE_SPLITS_BATCH = new ConnectorSplitBatch(ImmutableList.of(), true);
+
+    private final IcebergFileSystemFactory fileSystemFactory;
+    protected final ConnectorSession session;
+    protected final IcebergTableHandle tableHandle;
+    protected final TableScan tableScan;
+    protected final Optional<Long> maxScannedFileSizeInBytes;
+    protected final Map<Integer, Type.PrimitiveType> fieldIdToType;
+    protected final DynamicFilter dynamicFilter;
+    protected final long dynamicFilteringWaitTimeoutMillis;
+    protected final Stopwatch dynamicFilterWaitStopwatch;
+    protected final Constraint constraint;
+    protected final TypeManager typeManager;
+    protected final Closer closer = Closer.create();
+    protected final double minimumAssignedSplitWeight;
+    protected final TupleDomain<IcebergColumnHandle> dataColumnPredicate;
+    protected final Domain pathDomain;
+    protected final Domain fileModifiedTimeDomain;
+
+    private CloseableIterable<FileScanTask> fileScanTaskIterable;
+    private CloseableIterator<FileScanTask> fileScanTaskIterator;
+    protected TupleDomain<IcebergColumnHandle> pushedDownDynamicFilterPredicate;
+
+    protected final boolean recordScannedFiles;
+    private final ImmutableSet.Builder<DataFileWithDeleteFiles> scannedFiles = ImmutableSet.builder();
+
+    private final Map<String, String> fileIoProperties;
+
+    public AggregateSplitSource(
+            IcebergFileSystemFactory fileSystemFactory,
+            ConnectorSession session,
+            IcebergTableHandle tableHandle,
+            Map<String, String> fileIoProperties,
+            TableScan tableScan,
+            Optional<DataSize> maxScannedFileSize,
+            DynamicFilter dynamicFilter,
+            Duration dynamicFilteringWaitTimeout,
+            Constraint constraint,
+            TypeManager typeManager,
+            boolean recordScannedFiles,
+            double minimumAssignedSplitWeight)
+    {
+        this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
+        this.session = requireNonNull(session, "session is null");
+        this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
+        this.fileIoProperties = fileIoProperties;
+        this.tableScan = requireNonNull(tableScan, "tableScan is null");
+        this.maxScannedFileSizeInBytes = maxScannedFileSize.map(DataSize::toBytes);
+        this.fieldIdToType = primitiveFieldTypes(tableScan.schema());
+        this.dynamicFilter = requireNonNull(dynamicFilter, "dynamicFilter is null");
+        this.dynamicFilteringWaitTimeoutMillis = dynamicFilteringWaitTimeout.toMillis();
+        this.dynamicFilterWaitStopwatch = Stopwatch.createStarted();
+        this.constraint = requireNonNull(constraint, "constraint is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.recordScannedFiles = recordScannedFiles;
+        this.minimumAssignedSplitWeight = minimumAssignedSplitWeight;
+        this.dataColumnPredicate = tableHandle.getEnforcedPredicate().filter((column, domain) -> !isMetadataColumnId(column.getId()));
+        this.pathDomain = getPathDomain(tableHandle.getEnforcedPredicate());
+        this.fileModifiedTimeDomain = getFileModifiedTimePathDomain(tableHandle.getEnforcedPredicate());
+    }
+
+    @Override
+    public CompletableFuture<ConnectorSplitBatch> getNextBatch(int maxSize)
+    {
+        long timeLeft = dynamicFilteringWaitTimeoutMillis - dynamicFilterWaitStopwatch.elapsed(MILLISECONDS);
+        if (dynamicFilter.isAwaitable() && timeLeft > 0) {
+            return dynamicFilter.isBlocked()
+                    .thenApply(ignored -> EMPTY_BATCH)
+                    .completeOnTimeout(EMPTY_BATCH, timeLeft, MILLISECONDS);
+        }
+
+        long recordCount = 0L;
+        Set<String> uniqueFileName = new HashSet<>();
+
+        if (fileScanTaskIterable == null) {
+            // Used to avoid duplicating work if the Dynamic Filter was already pushed down to the Iceberg API
+            boolean dynamicFilterIsComplete = dynamicFilter.isComplete();
+            this.pushedDownDynamicFilterPredicate = dynamicFilter.getCurrentPredicate().transformKeys(IcebergColumnHandle.class::cast);
+            TupleDomain<IcebergColumnHandle> fullPredicate = tableHandle.getUnenforcedPredicate()
+                    .intersect(pushedDownDynamicFilterPredicate);
+            // TODO: (https://github.com/trinodb/trino/issues/9743): Consider removing TupleDomain#simplify
+            TupleDomain<IcebergColumnHandle> simplifiedPredicate = fullPredicate.simplify(ICEBERG_DOMAIN_COMPACTION_THRESHOLD);
+            boolean usedSimplifiedPredicate = !simplifiedPredicate.equals(fullPredicate);
+            if (usedSimplifiedPredicate) {
+                // Pushed down predicate was simplified, always evaluate it against individual splits
+                this.pushedDownDynamicFilterPredicate = TupleDomain.all();
+            }
+
+            TupleDomain<IcebergColumnHandle> effectivePredicate = dataColumnPredicate
+                    .intersect(simplifiedPredicate);
+
+            if (effectivePredicate.isNone()) {
+                finish();
+                return completedFuture(NO_MORE_SPLITS_BATCH);
+            }
+
+            Expression filterExpression = toIcebergExpression(effectivePredicate);
+            // If the Dynamic Filter will be evaluated against each file, stats are required. Otherwise, skip them.
+            boolean requiresColumnStats = usedSimplifiedPredicate || !dynamicFilterIsComplete;
+            TableScan scan = tableScan.filter(filterExpression);
+            if (requiresColumnStats) {
+                scan = scan.includeColumnStats();
+            }
+            this.fileScanTaskIterable = TableScanUtil.splitFiles(scan.planFiles(), tableScan.targetSplitSize());
+            closer.register(fileScanTaskIterable);
+            this.fileScanTaskIterator = fileScanTaskIterable.iterator();
+            closer.register(fileScanTaskIterator);
+            // TODO: Remove when NPE check has been released: https://github.com/trinodb/trino/issues/15372
+            isFinished();
+        }
+
+        TupleDomain<IcebergColumnHandle> dynamicFilterPredicate = dynamicFilter.getCurrentPredicate()
+                .transformKeys(IcebergColumnHandle.class::cast);
+        if (dynamicFilterPredicate.isNone()) {
+            finish();
+            return completedFuture(NO_MORE_SPLITS_BATCH);
+        }
+
+        // Note: not using the maxSize of the batch, as we need to calculate the aggregates in single threaded.
+        // When we will implement it in distributed way which might need the Engine to support Top level aggregation.
+        // As right now if connector handles aggregation pushdown, Engine does not handle the aggregate function.
+        ImmutableList.Builder<ConnectorSplit> splits = ImmutableList.builder();
+        while (fileScanTaskIterator.hasNext()) {
+            FileScanTask scanTask = fileScanTaskIterator.next();
+
+            if (!uniqueFileName.add(scanTask.file().path().toString())) {
+                // duplicate file entry, mostly because of the file size and Iceberg's internal default file-size=128 MB
+                // so do not need to process this entry, as this data file's metadata is already being used.
+                continue;
+            }
+
+            if (scanTask.deletes().isEmpty() &&
+                    maxScannedFileSizeInBytes.isPresent() &&
+                    scanTask.file().fileSizeInBytes() > maxScannedFileSizeInBytes.get()) {
+                continue;
+            }
+
+            if (!pathDomain.includesNullableValue(utf8Slice(scanTask.file().path().toString()))) {
+                continue;
+            }
+            if (!fileModifiedTimeDomain.isAll()) {
+                long fileModifiedTime = getModificationTime(scanTask.file().path().toString());
+                if (!fileModifiedTimeDomain.includesNullableValue(packDateTimeWithZone(fileModifiedTime, UTC_KEY))) {
+                    continue;
+                }
+            }
+
+            Schema fileSchema = scanTask.spec().schema();
+            Map<Integer, Optional<String>> partitionKeys = getPartitionKeys(scanTask);
+
+            Set<IcebergColumnHandle> identityPartitionColumns = partitionKeys.keySet().stream()
+                    .map(fieldId -> getColumnHandle(fileSchema.findField(fieldId), typeManager))
+                    .collect(toImmutableSet());
+
+            Supplier<Map<ColumnHandle, NullableValue>> partitionValues = memoize(() -> {
+                Map<ColumnHandle, NullableValue> bindings = new HashMap<>();
+                for (IcebergColumnHandle partitionColumn : identityPartitionColumns) {
+                    Object partitionValue = deserializePartitionValue(
+                            partitionColumn.getType(),
+                            partitionKeys.get(partitionColumn.getId()).orElse(null),
+                            partitionColumn.getName());
+                    NullableValue bindingValue = new NullableValue(partitionColumn.getType(), partitionValue);
+                    bindings.put(partitionColumn, bindingValue);
+                }
+                return bindings;
+            });
+
+            if (!dynamicFilterPredicate.isAll() && !dynamicFilterPredicate.equals(pushedDownDynamicFilterPredicate)) {
+                if (!partitionMatchesPredicate(
+                        identityPartitionColumns,
+                        partitionValues,
+                        dynamicFilterPredicate)) {
+                    continue;
+                }
+                if (!fileMatchesPredicate(
+                        fieldIdToType,
+                        dynamicFilterPredicate,
+                        scanTask.file().lowerBounds(),
+                        scanTask.file().upperBounds(),
+                        scanTask.file().nullValueCounts())) {
+                    continue;
+                }
+            }
+            if (!partitionMatchesConstraint(identityPartitionColumns, partitionValues, constraint)) {
+                continue;
+            }
+
+            if (recordScannedFiles) {
+                // Positional and Equality deletes can only be cleaned up if the whole table has been optimized.
+                // Equality deletes may apply to many files, and position deletes may be grouped together. This makes it difficult to know if they are obsolete.
+                List<org.apache.iceberg.DeleteFile> fullyAppliedDeletes = tableHandle.getEnforcedPredicate().isAll() ? scanTask.deletes() : ImmutableList.of();
+                scannedFiles.add(new DataFileWithDeleteFiles(scanTask.file(), fullyAppliedDeletes));
+            }
+
+            recordCount = recordCount + scanTask.file().recordCount() - getDeletedFilesCount(scanTask);
+        }
+
+        if (recordCount >= 0) {
+            AggregateIcebergSplit icebergSplit = toIcebergSplit(recordCount);
+            splits.add(icebergSplit);
+        }
+
+        return completedFuture(new ConnectorSplitBatch(splits.build(), isFinished()));
+    }
+
+    private long getModificationTime(String path)
+    {
+        try {
+            TrinoInputFile inputFile = fileSystemFactory.create(session.getIdentity(), fileIoProperties).newInputFile(Location.of(path));
+            return inputFile.lastModified().toEpochMilli();
+        }
+        catch (IOException e) {
+            throw new TrinoException(ICEBERG_FILESYSTEM_ERROR, "Failed to get file modification time: " + path, e);
+        }
+    }
+
+    private void finish()
+    {
+        close();
+        this.fileScanTaskIterable = CloseableIterable.empty();
+        this.fileScanTaskIterator = CloseableIterator.empty();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return fileScanTaskIterator != null && !fileScanTaskIterator.hasNext();
+    }
+
+    @Override
+    public Optional<List<Object>> getTableExecuteSplitsInfo()
+    {
+        checkState(isFinished(), "Split source must be finished before TableExecuteSplitsInfo is read");
+        if (!recordScannedFiles) {
+            return Optional.empty();
+        }
+        return Optional.of(ImmutableList.copyOf(scannedFiles.build()));
+    }
+
+    @Override
+    public void close()
+    {
+        try {
+            closer.close();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @VisibleForTesting
+    static boolean fileMatchesPredicate(
+            Map<Integer, Type.PrimitiveType> primitiveTypeForFieldId,
+            TupleDomain<IcebergColumnHandle> dynamicFilterPredicate,
+            @Nullable Map<Integer, ByteBuffer> lowerBounds,
+            @Nullable Map<Integer, ByteBuffer> upperBounds,
+            @Nullable Map<Integer, Long> nullValueCounts)
+    {
+        if (dynamicFilterPredicate.isNone()) {
+            return false;
+        }
+        Map<IcebergColumnHandle, Domain> domains = dynamicFilterPredicate.getDomains().orElseThrow();
+
+        for (Map.Entry<IcebergColumnHandle, Domain> domainEntry : domains.entrySet()) {
+            IcebergColumnHandle column = domainEntry.getKey();
+            Domain domain = domainEntry.getValue();
+
+            int fieldId = column.getId();
+            boolean mayContainNulls;
+            if (nullValueCounts == null) {
+                mayContainNulls = true;
+            }
+            else {
+                Long nullValueCount = nullValueCounts.get(fieldId);
+                mayContainNulls = nullValueCount == null || nullValueCount > 0;
+            }
+            Type type = primitiveTypeForFieldId.get(fieldId);
+            Domain statisticsDomain = domainForStatistics(
+                    column,
+                    lowerBounds == null ? null : fromByteBuffer(type, lowerBounds.get(fieldId)),
+                    upperBounds == null ? null : fromByteBuffer(type, upperBounds.get(fieldId)),
+                    mayContainNulls);
+            if (!domain.overlaps(statisticsDomain)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static Domain domainForStatistics(
+            IcebergColumnHandle columnHandle,
+            @Nullable Object lowerBound,
+            @Nullable Object upperBound,
+            boolean mayContainNulls)
+    {
+        io.trino.spi.type.Type type = columnHandle.getType();
+        Type icebergType = toIcebergType(type, columnHandle.getColumnIdentity());
+        if (lowerBound == null && upperBound == null) {
+            return Domain.create(ValueSet.all(type), mayContainNulls);
+        }
+
+        Range statisticsRange;
+        if (lowerBound != null && upperBound != null) {
+            statisticsRange = Range.range(
+                    type,
+                    convertIcebergValueToTrino(icebergType, lowerBound),
+                    true,
+                    convertIcebergValueToTrino(icebergType, upperBound),
+                    true);
+        }
+        else if (upperBound != null) {
+            statisticsRange = Range.lessThanOrEqual(type, convertIcebergValueToTrino(icebergType, upperBound));
+        }
+        else {
+            statisticsRange = Range.greaterThanOrEqual(type, convertIcebergValueToTrino(icebergType, lowerBound));
+        }
+        return Domain.create(ValueSet.ofRanges(statisticsRange), mayContainNulls);
+    }
+
+    static boolean partitionMatchesConstraint(
+            Set<IcebergColumnHandle> identityPartitionColumns,
+            Supplier<Map<ColumnHandle, NullableValue>> partitionValues,
+            Constraint constraint)
+    {
+        // We use Constraint just to pass functional predicate here from DistributedExecutionPlanner
+        verify(constraint.getSummary().isAll());
+
+        if (constraint.predicate().isEmpty() ||
+                intersection(constraint.getPredicateColumns().orElseThrow(), identityPartitionColumns).isEmpty()) {
+            return true;
+        }
+        return constraint.predicate().get().test(partitionValues.get());
+    }
+
+    @VisibleForTesting
+    static boolean partitionMatchesPredicate(
+            Set<IcebergColumnHandle> identityPartitionColumns,
+            Supplier<Map<ColumnHandle, NullableValue>> partitionValues,
+            TupleDomain<IcebergColumnHandle> dynamicFilterPredicate)
+    {
+        if (dynamicFilterPredicate.isNone()) {
+            return false;
+        }
+        Map<IcebergColumnHandle, Domain> domains = dynamicFilterPredicate.getDomains().orElseThrow();
+
+        for (IcebergColumnHandle partitionColumn : identityPartitionColumns) {
+            Domain allowedDomain = domains.get(partitionColumn);
+            if (allowedDomain != null) {
+                if (!allowedDomain.includesNullableValue(partitionValues.get().get(partitionColumn).getValue())) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private AggregateIcebergSplit toIcebergSplit(long totalCount)
+    {
+        return new AggregateIcebergSplit(
+                ImmutableList.of(),
+                totalCount);
+    }
+
+    private static Domain getPathDomain(TupleDomain<IcebergColumnHandle> effectivePredicate)
+    {
+        IcebergColumnHandle pathColumn = pathColumnHandle();
+        Domain domain = effectivePredicate.getDomains().orElseThrow(() -> new IllegalArgumentException("Unexpected NONE tuple domain"))
+                .get(pathColumn);
+        if (domain == null) {
+            return Domain.all(pathColumn.getType());
+        }
+        return domain;
+    }
+
+    private static Domain getFileModifiedTimePathDomain(TupleDomain<IcebergColumnHandle> effectivePredicate)
+    {
+        IcebergColumnHandle fileModifiedTimeColumn = fileModifiedTimeColumnHandle();
+        Domain domain = effectivePredicate.getDomains().orElseThrow(() -> new IllegalArgumentException("Unexpected NONE tuple domain"))
+                .get(fileModifiedTimeColumn);
+        if (domain == null) {
+            return Domain.all(fileModifiedTimeColumn.getType());
+        }
+        return domain;
+    }
+
+    private static long getDeletedFilesCount(FileScanTask fileScanTask)
+    {
+        AtomicLong deletedCount = new AtomicLong();
+        fileScanTask.deletes().stream().forEach(deleteFile -> {
+            deletedCount.getAndAdd(deleteFile.recordCount());
+        });
+
+        return deletedCount.longValue();
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/aggregation/ImplementCountAll.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/aggregation/ImplementCountAll.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.aggregation;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.aggregation.AggregateFunctionRule;
+import io.trino.spi.connector.AggregateFunction;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.plugin.base.aggregation.AggregateFunctionPatterns.arguments;
+import static io.trino.plugin.base.aggregation.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.aggregation.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.aggregation.AggregateFunctionPatterns.outputType;
+import static io.trino.spi.type.BigintType.BIGINT;
+
+public class ImplementCountAll
+        implements AggregateFunctionRule<AggregateExpression, Void>
+{
+    @Override
+    public Pattern<AggregateFunction> getPattern()
+    {
+        return basicAggregation()
+                .with(functionName().equalTo("count"))
+                .with(arguments().equalTo(List.of()))
+                .with(outputType().equalTo(BIGINT));
+    }
+
+    @Override
+    public Optional<AggregateExpression> rewrite(AggregateFunction aggregateFunction, Captures captures, RewriteContext<Void> context)
+    {
+        return Optional.of(new AggregateExpression("count", "*"));
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -67,7 +67,8 @@ public class TestIcebergConfig
                 .setRegisterTableProcedureEnabled(false)
                 .setSortedWritingEnabled(true)
                 .setQueryPartitionFilterRequired(false)
-                .setSplitManagerThreads(Runtime.getRuntime().availableProcessors() * 2));
+                .setSplitManagerThreads(Runtime.getRuntime().availableProcessors() * 2)
+                .setAggregationPushdownEnabled(false));
     }
 
     @Test
@@ -99,6 +100,7 @@ public class TestIcebergConfig
                 .put("iceberg.sorted-writing-enabled", "false")
                 .put("iceberg.query-partition-filter-required", "true")
                 .put("iceberg.split-manager-threads", "42")
+                .put("iceberg.aggregation-pushdown.enabled", "true")
                 .buildOrThrow();
 
         IcebergConfig expected = new IcebergConfig()
@@ -126,7 +128,8 @@ public class TestIcebergConfig
                 .setRegisterTableProcedureEnabled(true)
                 .setSortedWritingEnabled(false)
                 .setQueryPartitionFilterRequired(true)
-                .setSplitManagerThreads(42);
+                .setSplitManagerThreads(42)
+                .setAggregationPushdownEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -1772,7 +1772,7 @@ public class TestIcebergSparkCompatibility
 
         List<Row> expected = ImmutableList.of(row(11, 12), row(12, 12));
 
-        onTrino().executeQuery("SET SESSION iceberg.aggregation_pushdown_enabled = 'true'");
+        onTrino().executeQuery("SET SESSION iceberg.aggregation_pushdown_enabled = true");
 
         assertThat(onTrino().executeQuery("SELECT * FROM " + trinoTableName)).containsOnly(expected);
         assertThat(onSpark().executeQuery("SELECT * FROM " + sparkTableName)).containsOnly(expected);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Iceberg maintains metrics of the data files in the Iceberg metadata. So, we can utilize these metrics to optimize the simple aggregate queries.
To achieve this, Query Engine needs to support aggregation pushdown at the connector layer. Trino connector framework supports aggregation pushdown but Iceberg and Hive connectors have not implemented it. Aggregation Pushdown.
If Iceberg connector can support it then we can use the Iceberg metrics to give some of the answers like count, min, and max with the partition filters. Currently, in Iceberg and Hive connectors, aggregations are handled at the engine level.
Important points
This is a single-threaded implementation and generates a single split to populate the page/data for the result.
We might be able to implement it in a distributed manner If an engine can support handling aggregation at the top level while handing the aggregation pushdown. Like how the engine handles count(*) by summing the result/count it gets from different workers.
This implementation will also not handle the situation where the count is not present for some files/partitions so that some metrics can be used partially, and for some data still, the metrics will be read from the actual data files.
My understanding is, that this would require the following feature to be done: https://github.com/trinodb/trino/issues/13534
It can handle positional delete but not equality-based deletes.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

`ConnectorMetadata.applyAggregation(....) ` can result into projected column per aggregate function, if it needs to pushed down

`applyAggregation` is called by the QueryEngine in and latter on in the flow, it calls the `ConnectorSplitManager` to generate the splits.

`IcebergSplitManager` creates the `IcebergSplitSource` now it can create `AggregateSplitSource` as well.

`AggregateSplitSource` (like IcebergSplitSource) apply the partition filter and get the dataFiles needed, and then use the metrics. Now it can create AggregationSplit with the calculated count/metrics.

`IcebergPageSourceProvider.createPageSource` gets the split, now here if aggregation pushdown is used then create the `AggregatePageSource` based on the `count/min/max` available in the split.

This feature is controlled by session level flag `aggregation_pushdown_enabled`

Following type of queries can be benefitted 

```
SELECT count(*) FROM tbl ;

SELECT count(*) FROM tbl WHERE part_col = 'foo' ;

SELECT count(*) FROM tbl WHERE part_date =DATE  '2023-01-10' ;
SELECT count(*) FROM tbl WHERE part_date BETWEEN DATE  '2023-01-10'  AND DATE  '2023-01-15' ;

```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`15745`)
```

For https://github.com/trinodb/trino/issues/10974