### PR TITLE
Use only PositionsAppender buffers in PagePartitioner

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/output/BytePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/BytePositionsAppender.java
@@ -117,6 +117,23 @@ public class BytePositionsAppender
     }
 
     @Override
+    public void append(int sourcePosition, Block source)
+    {
+        ensureCapacity(positionCount + 1);
+        if (source.isNull(sourcePosition)) {
+            valueIsNull[positionCount] = true;
+            hasNullValue = true;
+        }
+        else {
+            values[positionCount] = source.getByte(sourcePosition, 0);
+            hasNonNullValue = true;
+        }
+        positionCount++;
+
+        updateSize(1);
+    }
+
+    @Override
     public Block build()
     {
         Block result;

--- a/core/trino-main/src/main/java/io/trino/operator/output/Int128PositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/Int128PositionsAppender.java
@@ -130,6 +130,25 @@ public class Int128PositionsAppender
     }
 
     @Override
+    public void append(int sourcePosition, Block source)
+    {
+        ensureCapacity(positionCount + 1);
+        if (source.isNull(sourcePosition)) {
+            valueIsNull[positionCount] = true;
+            hasNullValue = true;
+        }
+        else {
+            int positionIndex = positionCount * 2;
+            values[positionIndex] = source.getLong(sourcePosition, 0);
+            values[positionIndex + 1] = source.getLong(sourcePosition, SIZE_OF_LONG);
+            hasNonNullValue = true;
+        }
+        positionCount++;
+
+        updateSize(1);
+    }
+
+    @Override
     public Block build()
     {
         Block result;

--- a/core/trino-main/src/main/java/io/trino/operator/output/Int96PositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/Int96PositionsAppender.java
@@ -125,6 +125,25 @@ public class Int96PositionsAppender
     }
 
     @Override
+    public void append(int sourcePosition, Block source)
+    {
+        ensureCapacity(positionCount + 1);
+        if (source.isNull(sourcePosition)) {
+            valueIsNull[positionCount] = true;
+            hasNullValue = true;
+        }
+        else {
+            high[positionCount] = source.getLong(sourcePosition, 0);
+            low[positionCount] = source.getInt(sourcePosition, SIZE_OF_LONG);
+
+            hasNonNullValue = true;
+        }
+        positionCount++;
+
+        updateSize(1);
+    }
+
+    @Override
     public Block build()
     {
         Block result;

--- a/core/trino-main/src/main/java/io/trino/operator/output/IntPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/IntPositionsAppender.java
@@ -117,6 +117,23 @@ public class IntPositionsAppender
     }
 
     @Override
+    public void append(int sourcePosition, Block source)
+    {
+        ensureCapacity(positionCount + 1);
+        if (source.isNull(sourcePosition)) {
+            valueIsNull[positionCount] = true;
+            hasNullValue = true;
+        }
+        else {
+            values[positionCount] = source.getInt(sourcePosition, 0);
+            hasNonNullValue = true;
+        }
+        positionCount++;
+
+        updateSize(1);
+    }
+
+    @Override
     public Block build()
     {
         Block result;

--- a/core/trino-main/src/main/java/io/trino/operator/output/LongPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/LongPositionsAppender.java
@@ -117,6 +117,23 @@ public class LongPositionsAppender
     }
 
     @Override
+    public void append(int sourcePosition, Block source)
+    {
+        ensureCapacity(positionCount + 1);
+        if (source.isNull(sourcePosition)) {
+            valueIsNull[positionCount] = true;
+            hasNullValue = true;
+        }
+        else {
+            values[positionCount] = source.getLong(sourcePosition, 0);
+            hasNonNullValue = true;
+        }
+        positionCount++;
+
+        updateSize(1);
+    }
+
+    @Override
     public Block build()
     {
         Block result;

--- a/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppender.java
@@ -28,6 +28,15 @@ public interface PositionsAppender
     void appendRle(Block value, int rlePositionCount);
 
     /**
+     * Appends single position. The implementation must be conceptually equal to
+     * {@code append(IntArrayList.wrap(new int[] {position}), source)} but may be optimized.
+     * Caller should avoid using this method if {@link #append(IntArrayList, Block)} can be used
+     * as appending positions one by one can be significantly slower and may not support features
+     * like pushing RLE through the appender.
+     */
+    void append(int position, Block source);
+
+    /**
      * Creates the block from the appender data.
      * After this, appender is reset to the initial state, and it is ready to build a new block.
      */

--- a/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderPageBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderPageBuilder.java
@@ -61,6 +61,16 @@ public class PositionsAppenderPageBuilder
         }
     }
 
+    public void appendToOutputPartition(Page page, int position)
+    {
+        declarePositions(1);
+
+        for (int channel = 0; channel < channelAppenders.length; channel++) {
+            Block block = page.getBlock(channel);
+            channelAppenders[channel].append(position, block);
+        }
+    }
+
     public long getRetainedSizeInBytes()
     {
         // We use a foreach loop instead of streams

--- a/core/trino-main/src/main/java/io/trino/operator/output/RleAwarePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/RleAwarePositionsAppender.java
@@ -91,6 +91,13 @@ public class RleAwarePositionsAppender
     }
 
     @Override
+    public void append(int position, Block value)
+    {
+        switchToFlat();
+        delegate.append(position, value);
+    }
+
+    @Override
     public Block build()
     {
         Block result;

--- a/core/trino-main/src/main/java/io/trino/operator/output/ShortPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/ShortPositionsAppender.java
@@ -117,6 +117,23 @@ public class ShortPositionsAppender
     }
 
     @Override
+    public void append(int sourcePosition, Block source)
+    {
+        ensureCapacity(positionCount + 1);
+        if (source.isNull(sourcePosition)) {
+            valueIsNull[positionCount] = true;
+            hasNullValue = true;
+        }
+        else {
+            values[positionCount] = source.getShort(sourcePosition, 0);
+            hasNonNullValue = true;
+        }
+        positionCount++;
+
+        updateSize(1);
+    }
+
+    @Override
     public Block build()
     {
         Block result;

--- a/core/trino-main/src/main/java/io/trino/operator/output/SlicePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/SlicePositionsAppender.java
@@ -141,6 +141,35 @@ public class SlicePositionsAppender
     }
 
     @Override
+    public void append(int position, Block source)
+    {
+        ensurePositionCapacity(positionCount + 1);
+        if (source.isNull(position)) {
+            valueIsNull[positionCount] = true;
+            offsets[positionCount + 1] = getCurrentOffset();
+            positionCount++;
+
+            hasNullValue = true;
+            updateSize(1, 0);
+        }
+        else {
+            hasNonNullValue = true;
+            int currentOffset = getCurrentOffset();
+            int sliceLength = source.getSliceLength(position);
+            Slice slice = source.getSlice(position, 0, sliceLength);
+
+            ensureExtraBytesCapacity(sliceLength);
+
+            slice.getBytes(0, bytes, currentOffset, sliceLength);
+
+            offsets[positionCount + 1] = currentOffset + sliceLength;
+
+            positionCount++;
+            updateSize(1, sliceLength);
+        }
+    }
+
+    @Override
     public Block build()
     {
         Block result;

--- a/core/trino-main/src/main/java/io/trino/operator/output/TypedPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/TypedPositionsAppender.java
@@ -61,6 +61,12 @@ class TypedPositionsAppender
     }
 
     @Override
+    public void append(int position, Block source)
+    {
+        type.appendTo(source, position, blockBuilder);
+    }
+
+    @Override
     public Block build()
     {
         Block result = blockBuilder.build();

--- a/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
@@ -64,6 +64,20 @@ public class UnnestingPositionsAppender
     }
 
     @Override
+    public void append(int position, Block source)
+    {
+        if (source instanceof RunLengthEncodedBlock runLengthEncodedBlock) {
+            delegate.append(0, runLengthEncodedBlock.getValue());
+        }
+        else if (source instanceof DictionaryBlock dictionaryBlock) {
+            delegate.append(dictionaryBlock.getId(position), dictionaryBlock.getDictionary());
+        }
+        else {
+            delegate.append(position, source);
+        }
+    }
+
+    @Override
     public Block build()
     {
         return delegate.build();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
The row-based approach in `PagePartitioner` is faster than the columnar one when the number of positions in a page is smaller than the partition count.
For this reason, we currently maintain two buffers in PagePartitioner, one for a columnar approach and one for row-based.
This has the downside of possibly doubling the amount of memory we use to buffer the outgoing pages before there are flushed to the `OutputBuffer`.
This change switches to only `PositionsAppender` buffers without much performance impact by adding efficient single position append in `PositionsAppender` implementations.

# Full JMH benchmark results
The average difference is around 0 but there are a few cases with some degradation, usually 5-10% but also some with higher, mostly for the extreme 10 positions per page case.
In general, I think this looks good.

| Benchmark                                  | channelCount | enableCompression | nullRate | partitionCount | positionCount | type                                                    | block builders | positions appender | positions appender % |
| ------------------------------------------ | ------------ | ----------------- | -------- | -------------- | ------------- | ------------------------------------------------------- | -------------- | ------------------ | -------------------- |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | BIGINT                                                  | 182.312        | 207.154            | 13.62609154          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | BIGINT_PARTITION_CHANNEL_SKEWED                         | 190.239        | 174.304            | \-8.376305595        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | DICTIONARY_BIGINT                                       | 191.49         | 174.605            | \-8.81769283         |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | RLE_BIGINT                                              | 129.364        | 118.183            | \-8.643053709        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | BIGINT_PARTITION_CHANNEL_20_PERCENT                     | 129.217        | 118.739            | \-8.108840168        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | BIGINT_PARTITION_CHANNEL_DICTIONARY_20_PERCENT          | 127.113        | 135.859            | 6.880492161          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | BIGINT_PARTITION_CHANNEL_DICTIONARY_50_PERCENT          | 127.721        | 135.904            | 6.406933864          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | BIGINT_PARTITION_CHANNEL_DICTIONARY_80_PERCENT          | 127.69         | 136.217            | 6.677891769          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | BIGINT_PARTITION_CHANNEL_DICTIONARY_100_PERCENT         | 127.799        | 137.165            | 7.328695843          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | BIGINT_PARTITION_CHANNEL_DICTIONARY_100_PERCENT_MINUS_1 | 127.701        | 135.939            | 6.451006648          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | BIGINT_PARTITION_CHANNEL_RLE                            | 197.128        | 204.823            | 3.903555051          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | BIGINT_PARTITION_CHANNEL_RLE_NULL                       | 34.921         | 35.598             | 1.93866155           |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | LONG_DECIMAL                                            | 223.834        | 215.947            | \-3.523593377        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | DICTIONARY_LONG_DECIMAL                                 | 237.942        | 213.815            | \-10.13986602        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | INTEGER                                                 | 228.359        | 214.568            | \-6.039175158        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | DICTIONARY_INTEGER                                      | 239.533        | 207.268            | \-13.4699603         |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | SMALLINT                                                | 222.603        | 275.655            | 23.8325629           |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | DICTIONARY_SMALLINT                                     | 236.022        | 209.71             | \-11.14811331        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | BOOLEAN                                                 | 235.265        | 208.124            | \-11.53635262        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | DICTIONARY_BOOLEAN                                      | 234.626        | 214.347            | \-8.643117131        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | VARCHAR                                                 | 245.767        | 227.642            | \-7.374871321        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | DICTIONARY_VARCHAR                                      | 246.313        | 280.227            | 13.7686602           |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | ARRAY_BIGINT                                            | 81.324         | 76.833             | \-5.522355024        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | ARRAY_VARCHAR                                           | 88.141         | 87.426             | \-0.811200236        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | ARRAY_ARRAY_BIGINT                                      | 90.659         | 86.527             | \-4.557738338        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | MAP_BIGINT_BIGINT                                       | 98.706         | 92.928             | \-5.853747493        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | MAP_BIGINT_MAP_BIGINT_BIGINT                            | 123.565        | 123.26             | \-0.2468336503       |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | ROW_BIGINT_BIGINT                                       | 91.72          | 78.931             | \-13.94352377        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | ROW_ARRAY_BIGINT_ARRAY_BIGINT                           | 90.06          | 77.113             | \-14.37597157        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 10            | ROW_RLE_BIGINT_BIGINT                                   | 90.708         | 78.093             | \-13.90726287        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | BIGINT                                                  | 190.264        | 205.982            | 8.261152924          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | BIGINT_PARTITION_CHANNEL_SKEWED                         | 194.858        | 175.507            | \-9.930821419        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | DICTIONARY_BIGINT                                       | 201.051        | 175.463            | \-12.72711899        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | RLE_BIGINT                                              | 129.922        | 118.425            | \-8.849155647        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | BIGINT_PARTITION_CHANNEL_20_PERCENT                     | 131.221        | 119.427            | \-8.987890658        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | BIGINT_PARTITION_CHANNEL_DICTIONARY_20_PERCENT          | 128.339        | 136.144            | 6.081549646          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | BIGINT_PARTITION_CHANNEL_DICTIONARY_50_PERCENT          | 127.682        | 125.617            | \-1.617299228        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | BIGINT_PARTITION_CHANNEL_DICTIONARY_80_PERCENT          | 131.504        | 136.498            | 3.797603115          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | BIGINT_PARTITION_CHANNEL_DICTIONARY_100_PERCENT         | 129.246        | 136.383            | 5.522027761          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | BIGINT_PARTITION_CHANNEL_DICTIONARY_100_PERCENT_MINUS_1 | 132.674        | 136.128            | 2.603373683          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | BIGINT_PARTITION_CHANNEL_RLE                            | 185.12         | 204.049            | 10.22525929          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | BIGINT_PARTITION_CHANNEL_RLE_NULL                       | 35.067         | 35.65              | 1.662531725          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | LONG_DECIMAL                                            | 222.741        | 214.29             | \-3.794092691        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | DICTIONARY_LONG_DECIMAL                                 | 241.466        | 222.747            | \-7.752230128        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | INTEGER                                                 | 224.968        | 340.913            | 51.53844102          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | DICTIONARY_INTEGER                                      | 239.345        | 206.618            | \-13.67356744        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | SMALLINT                                                | 226.603        | 216.01             | \-4.674695392        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | DICTIONARY_SMALLINT                                     | 235.358        | 274.928            | 16.81268536          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | BOOLEAN                                                 | 235.643        | 210.027            | \-10.8706815         |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | DICTIONARY_BOOLEAN                                      | 238.641        | 215.12             | \-9.856227555        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | VARCHAR                                                 | 246.731        | 283.798            | 15.02324394          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | DICTIONARY_VARCHAR                                      | 250.19         | 288.195            | 15.19045525          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | ARRAY_BIGINT                                            | 80.993         | 77.699             | \-4.067018137        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | ARRAY_VARCHAR                                           | 88.32          | 87.941             | \-0.4291213768       |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | ARRAY_ARRAY_BIGINT                                      | 90.449         | 84.941             | \-6.089619565        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | MAP_BIGINT_BIGINT                                       | 94.715         | 92.964             | \-1.848704007        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | MAP_BIGINT_MAP_BIGINT_BIGINT                            | 125.226        | 121.082            | \-3.309216936        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | ROW_BIGINT_BIGINT                                       | 89.611         | 77.268             | \-13.77397864        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | ROW_ARRAY_BIGINT_ARRAY_BIGINT                           | 88.592         | 74.446             | \-15.96758172        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 10            | ROW_RLE_BIGINT_BIGINT                                   | 90.605         | 76.743             | \-15.29937641        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | BIGINT                                                  | 249.056        | 268.652            | 7.868109983          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | BIGINT_PARTITION_CHANNEL_SKEWED                         | 228.509        | 235.725            | 3.157862491          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | DICTIONARY_BIGINT                                       | 255.337        | 257.49             | 0.8431993796         |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | RLE_BIGINT                                              | 150.126        | 152.206            | 1.385502844          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | BIGINT_PARTITION_CHANNEL_20_PERCENT                     | 144.324        | 152.122            | 5.403120756          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | BIGINT_PARTITION_CHANNEL_DICTIONARY_20_PERCENT          | 144.843        | 130.307            | \-10.03569382        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | BIGINT_PARTITION_CHANNEL_DICTIONARY_50_PERCENT          | 145.99         | 130.432            | \-10.65689431        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | BIGINT_PARTITION_CHANNEL_DICTIONARY_80_PERCENT          | 144.912        | 130.946            | \-9.637573148        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | BIGINT_PARTITION_CHANNEL_DICTIONARY_100_PERCENT         | 145.107        | 130.688            | \-9.936805254        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | BIGINT_PARTITION_CHANNEL_DICTIONARY_100_PERCENT_MINUS_1 | 145.961        | 130.301            | \-10.72889333        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | BIGINT_PARTITION_CHANNEL_RLE                            | 215.54         | 193.268            | \-10.33311682        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | BIGINT_PARTITION_CHANNEL_RLE_NULL                       | 35.27          | 34.776             | \-1.40062376         |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | LONG_DECIMAL                                            | 272.604        | 274.069            | 0.5374095758         |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | DICTIONARY_LONG_DECIMAL                                 | 276.616        | 327.015            | 18.21984267          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | INTEGER                                                 | 262.314        | 333.119            | 26.99245942          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | DICTIONARY_INTEGER                                      | 275.191        | 324.438            | 17.89557071          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | SMALLINT                                                | 262.655        | 332.23             | 26.48912071          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | DICTIONARY_SMALLINT                                     | 271.349        | 325.73             | 20.04098043          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | BOOLEAN                                                 | 255.41         | 304.325            | 19.15156024          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | DICTIONARY_BOOLEAN                                      | 258.889        | 237.207            | \-8.375017865        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | VARCHAR                                                 | 287.784        | 400.346            | 39.1133628           |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | DICTIONARY_VARCHAR                                      | 297.616        | 396.297            | 33.15715553          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | ARRAY_BIGINT                                            | 97.689         | 96.754             | \-0.9571190206       |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | ARRAY_VARCHAR                                           | 116.391        | 114.196            | \-1.885884647        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | ARRAY_ARRAY_BIGINT                                      | 143.715        | 143.506            | \-0.1454267126       |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | MAP_BIGINT_BIGINT                                       | 123.914        | 112.92             | \-8.872282389        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | MAP_BIGINT_MAP_BIGINT_BIGINT                            | 262.598        | 258.763            | \-1.460407162        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | ROW_BIGINT_BIGINT                                       | 114.948        | 111.065            | \-3.378049205        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | ROW_ARRAY_BIGINT_ARRAY_BIGINT                           | 143.777        | 115.56             | \-19.6255312         |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 100           | ROW_RLE_BIGINT_BIGINT                                   | 113.346        | 102.147            | \-9.880366312        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | BIGINT                                                  | 244.005        | 253.1              | 3.727382636          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | BIGINT_PARTITION_CHANNEL_SKEWED                         | 223.82         | 235.492            | 5.214904834          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | DICTIONARY_BIGINT                                       | 240.863        | 247.756            | 2.861792803          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | RLE_BIGINT                                              | 148.781        | 153.046            | 2.866629476          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | BIGINT_PARTITION_CHANNEL_20_PERCENT                     | 144.654        | 154.929            | 7.103156498          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | BIGINT_PARTITION_CHANNEL_DICTIONARY_20_PERCENT          | 150.838        | 133.701            | \-11.36119545        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | BIGINT_PARTITION_CHANNEL_DICTIONARY_50_PERCENT          | 150.101        | 133.645            | \-10.96328472        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | BIGINT_PARTITION_CHANNEL_DICTIONARY_80_PERCENT          | 150.57         | 133.461            | \-11.36282128        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | BIGINT_PARTITION_CHANNEL_DICTIONARY_100_PERCENT         | 148.885        | 133.17             | \-10.55512644        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | BIGINT_PARTITION_CHANNEL_DICTIONARY_100_PERCENT_MINUS_1 | 148.653        | 133.563            | \-10.15115739        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | BIGINT_PARTITION_CHANNEL_RLE                            | 231.79         | 198.46             | \-14.37939514        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | BIGINT_PARTITION_CHANNEL_RLE_NULL                       | 35.179         | 35.75              | 1.623127434          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | LONG_DECIMAL                                            | 276.652        | 271.166            | \-1.982996689        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | DICTIONARY_LONG_DECIMAL                                 | 277.456        | 320.939            | 15.67203448          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | INTEGER                                                 | 270.324        | 332.615            | 23.04308903          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | DICTIONARY_INTEGER                                      | 270.643        | 323.759            | 19.62585398          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | SMALLINT                                                | 270.5          | 272.35             | 0.6839186691         |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | DICTIONARY_SMALLINT                                     | 268.258        | 259.417            | \-3.295707863        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | BOOLEAN                                                 | 256.842        | 247.662            | \-3.574181793        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | DICTIONARY_BOOLEAN                                      | 258.998        | 240.372            | \-7.191561325        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | VARCHAR                                                 | 285.986        | 330.757            | 15.65496213          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | DICTIONARY_VARCHAR                                      | 296.022        | 267.563            | \-9.613812487        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | ARRAY_BIGINT                                            | 99.835         | 93.913             | \-5.931787449        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | ARRAY_VARCHAR                                           | 114.054        | 109.772            | \-3.754361969        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | ARRAY_ARRAY_BIGINT                                      | 133.399        | 130.876            | \-1.891318526        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | MAP_BIGINT_BIGINT                                       | 135.477        | 128.107            | \-5.440037792        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | MAP_BIGINT_MAP_BIGINT_BIGINT                            | 246.843        | 233.242            | \-5.509980028        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | ROW_BIGINT_BIGINT                                       | 109.447        | 99.386             | \-9.192577229        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | ROW_ARRAY_BIGINT_ARRAY_BIGINT                           | 132.309        | 108.426            | \-18.05092624        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 100           | ROW_RLE_BIGINT_BIGINT                                   | 110.996        | 121.596            | 9.54989369           |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | BIGINT                                                  | 504.754        | 533.664            | 5.727542526          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | BIGINT_PARTITION_CHANNEL_SKEWED                         | 355.624        | 349.748            | \-1.652306931        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | DICTIONARY_BIGINT                                       | 473.799        | 467.333            | \-1.364713729        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | RLE_BIGINT                                              | 231.899        | 225.19             | \-2.893069828        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | BIGINT_PARTITION_CHANNEL_20_PERCENT                     | 234.003        | 223.491            | \-4.492250099        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | BIGINT_PARTITION_CHANNEL_DICTIONARY_20_PERCENT          | 239.283        | 232.567            | \-2.806718405        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | BIGINT_PARTITION_CHANNEL_DICTIONARY_50_PERCENT          | 245.222        | 232.09             | \-5.355147581        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | BIGINT_PARTITION_CHANNEL_DICTIONARY_80_PERCENT          | 243.142        | 232.678            | \-4.303657945        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | BIGINT_PARTITION_CHANNEL_DICTIONARY_100_PERCENT         | 237.663        | 232.599            | \-2.13074816         |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | BIGINT_PARTITION_CHANNEL_DICTIONARY_100_PERCENT_MINUS_1 | 242.097        | 232.352            | \-4.025246079        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | BIGINT_PARTITION_CHANNEL_RLE                            | 375.255        | 358.041            | \-4.587280649        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | BIGINT_PARTITION_CHANNEL_RLE_NULL                       | 36.365         | 36.252             | \-0.3107383473       |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | LONG_DECIMAL                                            | 563.829        | 640.743            | 13.64136999          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | DICTIONARY_LONG_DECIMAL                                 | 528.288        | 580.853            | 9.950065116          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | INTEGER                                                 | 513.889        | 538.427            | 4.77496113           |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | DICTIONARY_INTEGER                                      | 468.459        | 476.843            | 1.789697711          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | SMALLINT                                                | 483.436        | 534.134            | 10.48701379          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | DICTIONARY_SMALLINT                                     | 469.974        | 469.258            | \-0.1523488533       |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | BOOLEAN                                                 | 373.087        | 430.655            | 15.43018116          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | DICTIONARY_BOOLEAN                                      | 386.527        | 356.547            | \-7.756249887        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | VARCHAR                                                 | 495.41         | 491.003            | \-0.8895662179       |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | DICTIONARY_VARCHAR                                      | 540.81         | 551.418            | 1.961502191          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | ARRAY_BIGINT                                            | 193.989        | 184.011            | \-5.143590616        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | ARRAY_VARCHAR                                           | 239.832        | 218.629            | \-8.840771874        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | ARRAY_ARRAY_BIGINT                                      | 424.341        | 421.2              | \-0.7402065791       |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | MAP_BIGINT_BIGINT                                       | 235.701        | 251.054            | 6.513761079          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | MAP_BIGINT_MAP_BIGINT_BIGINT                            | 978.102        | 1047.243           | 7.068894655          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | ROW_BIGINT_BIGINT                                       | 225.319        | 207.418            | \-7.94473613         |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | ROW_ARRAY_BIGINT_ARRAY_BIGINT                           | 401.4          | 297.736            | \-25.82561036        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 500           | ROW_RLE_BIGINT_BIGINT                                   | 224.891        | 210.686            | \-6.316393275        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | BIGINT                                                  | 466.485        | 498.466            | 6.85574027           |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | BIGINT_PARTITION_CHANNEL_SKEWED                         | 374.742        | 375.166            | 0.1131445101         |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | DICTIONARY_BIGINT                                       | 454.283        | 444.73             | \-2.1028742          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | RLE_BIGINT                                              | 235.002        | 225.093            | \-4.216559859        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | BIGINT_PARTITION_CHANNEL_20_PERCENT                     | 237.472        | 238.393            | 0.3878351974         |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | BIGINT_PARTITION_CHANNEL_DICTIONARY_20_PERCENT          | 257.835        | 248.475            | \-3.630228635        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | BIGINT_PARTITION_CHANNEL_DICTIONARY_50_PERCENT          | 257.237        | 248.147            | \-3.533706271        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | BIGINT_PARTITION_CHANNEL_DICTIONARY_80_PERCENT          | 254.059        | 248.266            | \-2.280179014        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | BIGINT_PARTITION_CHANNEL_DICTIONARY_100_PERCENT         | 258.625        | 253.224            | \-2.088351861        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | BIGINT_PARTITION_CHANNEL_DICTIONARY_100_PERCENT_MINUS_1 | 256.21         | 248.055            | \-3.182935873        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | BIGINT_PARTITION_CHANNEL_RLE                            | 395.724        | 384.135            | \-2.928556266        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | BIGINT_PARTITION_CHANNEL_RLE_NULL                       | 37.331         | 36.553             | \-2.084058825        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | LONG_DECIMAL                                            | 529.648        | 551.969            | 4.214308371          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | DICTIONARY_LONG_DECIMAL                                 | 510.352        | 481.778            | \-5.598880772        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | INTEGER                                                 | 487.499        | 573.419            | 17.62465154          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | DICTIONARY_INTEGER                                      | 470.604        | 466.106            | \-0.9557929809       |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | SMALLINT                                                | 473.794        | 570.945            | 20.50490297          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | DICTIONARY_SMALLINT                                     | 457.439        | 457.791            | 0.07695015073        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | BOOLEAN                                                 | 379.735        | 437.976            | 15.33727468          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | DICTIONARY_BOOLEAN                                      | 396.667        | 485.919            | 22.50048529          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | VARCHAR                                                 | 484.638        | 480.668            | \-0.8191681214       |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | DICTIONARY_VARCHAR                                      | 526.881        | 464.71             | \-11.79981818        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | ARRAY_BIGINT                                            | 180.563        | 178.973            | \-0.8805790777       |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | ARRAY_VARCHAR                                           | 224.718        | 209.545            | \-6.752018085        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | ARRAY_ARRAY_BIGINT                                      | 348.152        | 368.908            | 5.961763827          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | MAP_BIGINT_BIGINT                                       | 329.771        | 358.214            | 8.625076189          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | MAP_BIGINT_MAP_BIGINT_BIGINT                            | 887.531        | 836.803            | \-5.715631341        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | ROW_BIGINT_BIGINT                                       | 197.2          | 190.73             | \-3.280933063        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | ROW_ARRAY_BIGINT_ARRAY_BIGINT                           | 322.973        | 262.428            | \-18.74614906        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 500           | ROW_RLE_BIGINT_BIGINT                                   | 202.498        | 188.794            | \-6.767474247        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | BIGINT                                                  | 871.807        | 857.326            | \-1.661032774        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | BIGINT_PARTITION_CHANNEL_SKEWED                         | 499.548        | 500.546            | 0.1997806017         |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | DICTIONARY_BIGINT                                       | 813.513        | 752.115            | \-7.547267223        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | RLE_BIGINT                                              | 337.33         | 313.388            | \-7.097500963        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | BIGINT_PARTITION_CHANNEL_20_PERCENT                     | 330.071        | 313.933            | \-4.889251101        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | BIGINT_PARTITION_CHANNEL_DICTIONARY_20_PERCENT          | 355.914        | 330.209            | \-7.222250319        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | BIGINT_PARTITION_CHANNEL_DICTIONARY_50_PERCENT          | 354.916        | 330.822            | \-6.788648582        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | BIGINT_PARTITION_CHANNEL_DICTIONARY_80_PERCENT          | 351.37         | 330.774            | \-5.861627344        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | BIGINT_PARTITION_CHANNEL_DICTIONARY_100_PERCENT         | 354.045        | 332.32             | \-6.136225621        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | BIGINT_PARTITION_CHANNEL_DICTIONARY_100_PERCENT_MINUS_1 | 354.143        | 331.221            | \-6.472526635        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | BIGINT_PARTITION_CHANNEL_RLE                            | 555.984        | 516.024            | \-7.187257187        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | BIGINT_PARTITION_CHANNEL_RLE_NULL                       | 36.426         | 36.906             | 1.317740076          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | LONG_DECIMAL                                            | 992.992        | 1229.432           | 23.81086655          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | DICTIONARY_LONG_DECIMAL                                 | 904.475        | 895.945            | \-0.943088532        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | INTEGER                                                 | 874.089        | 929.719            | 6.364340473          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | DICTIONARY_INTEGER                                      | 769.626        | 829.14             | 7.732846863          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | SMALLINT                                                | 840.492        | 939.53             | 11.78333643          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | DICTIONARY_SMALLINT                                     | 778.801        | 838.003            | 7.601685154          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | BOOLEAN                                                 | 528.479        | 596.772            | 12.922557            |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | DICTIONARY_BOOLEAN                                      | 549.003        | 512.283            | \-6.688488041        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | VARCHAR                                                 | 756.891        | 836.333            | 10.49583097          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | DICTIONARY_VARCHAR                                      | 840.673        | 756.28             | \-10.03874277        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | ARRAY_BIGINT                                            | 324.752        | 307.182            | \-5.410282308        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | ARRAY_VARCHAR                                           | 401.253        | 366.851            | \-8.573643063        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | ARRAY_ARRAY_BIGINT                                      | 813.592        | 819.497            | 0.725793764          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | MAP_BIGINT_BIGINT                                       | 368.911        | 416.225            | 12.82531559          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | MAP_BIGINT_MAP_BIGINT_BIGINT                            | 1883.627       | 2124.77            | 12.80205688          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | ROW_BIGINT_BIGINT                                       | 377.387        | 371.528            | \-1.552517707        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | ROW_ARRAY_BIGINT_ARRAY_BIGINT                           | 780.866        | 554.442            | \-28.99652437        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1000          | ROW_RLE_BIGINT_BIGINT                                   | 368.406        | 364.834            | \-0.9695824715       |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | BIGINT                                                  | 756.216        | 804.314            | 6.360352069          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | BIGINT_PARTITION_CHANNEL_SKEWED                         | 542.593        | 542.042            | \-0.1015494118       |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | DICTIONARY_BIGINT                                       | 764.909        | 732.242            | \-4.270704097        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | RLE_BIGINT                                              | 339.949        | 312.862            | \-7.9679599          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | BIGINT_PARTITION_CHANNEL_20_PERCENT                     | 343.559        | 342.92             | \-0.1859942543       |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | BIGINT_PARTITION_CHANNEL_DICTIONARY_20_PERCENT          | 380.676        | 362.164            | \-4.862928054        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | BIGINT_PARTITION_CHANNEL_DICTIONARY_50_PERCENT          | 384.257        | 360.817            | \-6.100084058        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | BIGINT_PARTITION_CHANNEL_DICTIONARY_80_PERCENT          | 381.713        | 365.67             | \-4.202895893        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | BIGINT_PARTITION_CHANNEL_DICTIONARY_100_PERCENT         | 381.528        | 366.4              | \-3.965108721        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | BIGINT_PARTITION_CHANNEL_DICTIONARY_100_PERCENT_MINUS_1 | 378.902        | 366.164            | \-3.361819151        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | BIGINT_PARTITION_CHANNEL_RLE                            | 597.907        | 558.834            | \-6.534962795        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | BIGINT_PARTITION_CHANNEL_RLE_NULL                       | 36.73          | 36.381             | \-0.9501769671       |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | LONG_DECIMAL                                            | 884.682        | 1018.802           | 15.16024967          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | DICTIONARY_LONG_DECIMAL                                 | 871.143        | 813.292            | \-6.640815572        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | INTEGER                                                 | 778.543        | 928.249            | 19.2289957           |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | DICTIONARY_INTEGER                                      | 754.71         | 763.298            | 1.137920526          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | SMALLINT                                                | 769.511        | 821.144            | 6.709845603          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | DICTIONARY_SMALLINT                                     | 732.686        | 838.848            | 14.48942658          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | BOOLEAN                                                 | 536.52         | 659.579            | 22.93651681          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | DICTIONARY_BOOLEAN                                      | 561.025        | 520.193            | \-7.278107036        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | VARCHAR                                                 | 723.859        | 741.002            | 2.368278905          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | DICTIONARY_VARCHAR                                      | 823.108        | 721.36             | \-12.36143981        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | ARRAY_BIGINT                                            | 293.32         | 314.005            | 7.052025092          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | ARRAY_VARCHAR                                           | 366.453        | 343.018            | \-6.39509023         |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | ARRAY_ARRAY_BIGINT                                      | 659.081        | 707.797            | 7.391504231          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | MAP_BIGINT_BIGINT                                       | 612.861        | 699.638            | 14.15932813          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | MAP_BIGINT_MAP_BIGINT_BIGINT                            | 1717.969       | 1649.071           | \-4.01043325         |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | ROW_BIGINT_BIGINT                                       | 314.146        | 322.234            | 2.574599072          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | ROW_ARRAY_BIGINT_ARRAY_BIGINT                           | 565.506        | 512.998            | \-9.28513579         |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1000          | ROW_RLE_BIGINT_BIGINT                                   | 323.544        | 315.997            | \-2.332603912        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | BIGINT                                                  | 1534.192       | 1427.813           | \-6.933877898        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | BIGINT_PARTITION_CHANNEL_SKEWED                         | 901.72         | 789.187            | \-12.47981635        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | DICTIONARY_BIGINT                                       | 1462.034       | 1399.928           | \-4.247917627        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | RLE_BIGINT                                              | 556.227        | 491.827            | \-11.57800682        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | BIGINT_PARTITION_CHANNEL_20_PERCENT                     | 528.119        | 492.89             | \-6.670655667        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | BIGINT_PARTITION_CHANNEL_DICTIONARY_20_PERCENT          | 573.903        | 505.148            | \-11.98024753        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | BIGINT_PARTITION_CHANNEL_DICTIONARY_50_PERCENT          | 575.387        | 506.939            | \-11.89599348        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | BIGINT_PARTITION_CHANNEL_DICTIONARY_80_PERCENT          | 578.383        | 513.626            | \-11.19621427        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | BIGINT_PARTITION_CHANNEL_DICTIONARY_100_PERCENT         | 579.917        | 511.043            | \-11.87652716        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | BIGINT_PARTITION_CHANNEL_DICTIONARY_100_PERCENT_MINUS_1 | 583.163        | 507.162            | \-13.03254836        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | BIGINT_PARTITION_CHANNEL_RLE                            | 920.003        | 823.613            | \-10.47713975        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | BIGINT_PARTITION_CHANNEL_RLE_NULL                       | 37.728         | 37.429             | \-0.7925148431       |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | LONG_DECIMAL                                            | 1815.523       | 1865.961           | 2.778152632          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | DICTIONARY_LONG_DECIMAL                                 | 1706.47        | 1644.192           | \-3.649522113        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | INTEGER                                                 | 1454.693       | 1564.915           | 7.576993909          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | DICTIONARY_INTEGER                                      | 1429.272       | 1397.096           | \-2.251216004        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | SMALLINT                                                | 1487.671       | 1975.427           | 32.78655025          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | DICTIONARY_SMALLINT                                     | 1369.057       | 1730.997           | 26.43717537          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | BOOLEAN                                                 | 816.195        | 857.471            | 5.057124829          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | DICTIONARY_BOOLEAN                                      | 864.457        | 858.1              | \-0.7353749232       |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | VARCHAR                                                 | 1263.677       | 1412.11            | 11.74611867          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | DICTIONARY_VARCHAR                                      | 1465.827       | 1307.074           | \-10.83026851        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | ARRAY_BIGINT                                            | 571.645        | 597.818            | 4.578540878          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | ARRAY_VARCHAR                                           | 710.664        | 648.216            | \-8.787274999        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | ARRAY_ARRAY_BIGINT                                      | 1644.464       | 1786.091           | 8.612350286          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | MAP_BIGINT_BIGINT                                       | 673.833        | 742.194            | 10.1450953           |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | MAP_BIGINT_MAP_BIGINT_BIGINT                            | 4082.986       | 4446.061           | 8.892389051          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | ROW_BIGINT_BIGINT                                       | 677.604        | 687.913            | 1.521390074          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | ROW_ARRAY_BIGINT_ARRAY_BIGINT                           | 1539.424       | 1093.887           | \-28.94179901        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0        | 1000           | 1999          | ROW_RLE_BIGINT_BIGINT                                   | 687.878        | 669.877            | \-2.61688846         |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | BIGINT                                                  | 1387.761       | 1432.536           | 3.226420111          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | BIGINT_PARTITION_CHANNEL_SKEWED                         | 914.682        | 905.75             | \-0.9765142421       |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | DICTIONARY_BIGINT                                       | 1405.78        | 1306.071           | \-7.092788345        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | RLE_BIGINT                                              | 555.77         | 493.135            | \-11.2699498         |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | BIGINT_PARTITION_CHANNEL_20_PERCENT                     | 561.999        | 543.693            | \-3.25730117         |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | BIGINT_PARTITION_CHANNEL_DICTIONARY_20_PERCENT          | 629.795        | 575.163            | \-8.674568709        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | BIGINT_PARTITION_CHANNEL_DICTIONARY_50_PERCENT          | 632.358        | 581.001            | \-8.121507121        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | BIGINT_PARTITION_CHANNEL_DICTIONARY_80_PERCENT          | 629.222        | 582.943            | \-7.354955803        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | BIGINT_PARTITION_CHANNEL_DICTIONARY_100_PERCENT         | 636.797        | 574.454            | \-9.790090092        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | BIGINT_PARTITION_CHANNEL_DICTIONARY_100_PERCENT_MINUS_1 | 631.514        | 580.039            | \-8.151046533        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | BIGINT_PARTITION_CHANNEL_RLE                            | 1034.551       | 942.158            | \-8.930734203        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | BIGINT_PARTITION_CHANNEL_RLE_NULL                       | 38.817         | 39.318             | 1.290671613          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | LONG_DECIMAL                                            | 1678.192       | 1852.106           | 10.36317656          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | DICTIONARY_LONG_DECIMAL                                 | 1636.54        | 1594.16            | \-2.589609787        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | INTEGER                                                 | 1436.157       | 1478.29            | 2.933732176          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | DICTIONARY_INTEGER                                      | 1361.017       | 1393.353           | 2.375870397          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | SMALLINT                                                | 1415.255       | 1568.885           | 10.85528756          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | DICTIONARY_SMALLINT                                     | 1327.129       | 1363.571           | 2.745927487          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | BOOLEAN                                                 | 843.265        | 928.38             | 10.0935056           |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | DICTIONARY_BOOLEAN                                      | 909.346        | 880.08             | \-3.218356929        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | VARCHAR                                                 | 1217.512       | 1284.184           | 5.476085657          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | DICTIONARY_VARCHAR                                      | 1439.251       | 1241.999           | \-13.70518415        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | ARRAY_BIGINT                                            | 539.071        | 548.953            | 1.833153703          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | ARRAY_VARCHAR                                           | 640.053        | 617.058            | \-3.592671232        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | ARRAY_ARRAY_BIGINT                                      | 1407.441       | 1513.087           | 7.506247154          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | MAP_BIGINT_BIGINT                                       | 1218.065       | 1353.054           | 11.08224931          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | MAP_BIGINT_MAP_BIGINT_BIGINT                            | 3507.44        | 3266.532           | \-6.868485277        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | ROW_BIGINT_BIGINT                                       | 563.22         | 596.885            | 5.977238024          |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | ROW_ARRAY_BIGINT_ARRAY_BIGINT                           | 1209.435       | 988.623            | \-18.25745079        |
| BenchmarkPartitionedOutputOperator.addPage | 1            | FALSE             | 0.2      | 1000           | 1999          | ROW_RLE_BIGINT_BIGINT                                   | 563.511        | 583.779            | 3.596735467          |

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
