### PR TITLE
Avoid updating Ubuntu Docker image in PR builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,10 @@ jobs:
       - uses: docker/setup-qemu-action@v2
         with:
           platforms: arm64,ppc64le
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v2
       - name: Test Docker Image
         run: core/docker/build.sh -c
       - name: Remove Trino from local Maven repo to avoid caching it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           platforms: arm64,ppc64le
       - name: Test Docker Image
-        run: core/docker/build.sh
+        run: core/docker/build.sh -c
       - name: Remove Trino from local Maven repo to avoid caching it
         # Avoid caching artifacts built in this job, cache should only include dependencies
         if: steps.cache.outputs.cache-hit != 'true'

--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -11,37 +11,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM eclipse-temurin:17-jdk AS builder
-
-RUN \
-    set -xeu && \
-    echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
-    echo 'Acquire::http::Timeout "15";' > /etc/apt/apt.conf.d/80-timeouts && \
-    apt-get update -q && \
-    apt-get install -y -q git gcc make && \
-    git clone https://github.com/airlift/jvmkill /tmp/jvmkill && \
-    make -C /tmp/jvmkill
-
-FROM eclipse-temurin:17-jdk
-
-RUN \
-    set -xeu && \
-    echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
-    echo 'Acquire::http::Timeout "15";' > /etc/apt/apt.conf.d/80-timeouts && \
-    apt-get update -q && \
-    apt-get install -y -q less python3 curl && \
-    rm -rf /var/lib/apt/lists/* && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
-    groupadd trino --gid 1000 && \
-    useradd trino --uid 1000 --gid 1000 --create-home && \
-    mkdir -p /usr/lib/trino /data/trino && \
-    chown -R "trino:trino" /usr/lib/trino /data/trino
+ARG TRINO_VERSION
+FROM trino-base:${TRINO_VERSION}-${TARGETARCH}
 
 ARG TRINO_VERSION
 COPY trino-cli-${TRINO_VERSION}-executable.jar /usr/bin/trino
 COPY --chown=trino:trino trino-server-${TRINO_VERSION} /usr/lib/trino
 COPY --chown=trino:trino default/etc /etc/trino
-COPY --chown=trino:trino --from=builder /tmp/jvmkill/libjvmkill.so /usr/lib/trino/bin
 
 EXPOSE 8080
 USER trino:trino

--- a/core/docker/base.Dockerfile
+++ b/core/docker/base.Dockerfile
@@ -1,0 +1,40 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+FROM eclipse-temurin:17-jdk AS builder
+
+RUN \
+    set -xeu && \
+    echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
+    echo 'Acquire::http::Timeout "15";' > /etc/apt/apt.conf.d/80-timeouts && \
+    apt-get update -q && \
+    apt-get install -y -q git gcc make && \
+    git clone https://github.com/airlift/jvmkill /tmp/jvmkill && \
+    make -C /tmp/jvmkill
+
+FROM eclipse-temurin:17-jdk
+
+RUN \
+    set -xeu && \
+    echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
+    echo 'Acquire::http::Timeout "15";' > /etc/apt/apt.conf.d/80-timeouts && \
+    apt-get update -q && \
+    apt-get install -y -q less python3 curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
+    groupadd trino --gid 1000 && \
+    useradd trino --uid 1000 --gid 1000 --create-home && \
+    mkdir -p /usr/lib/trino /data/trino && \
+    chown -R "trino:trino" /usr/lib/trino /data/trino
+
+COPY --chown=trino:trino --from=builder /tmp/jvmkill/libjvmkill.so /usr/lib/trino/bin/libjvmkill.so

--- a/core/docker/build.sh
+++ b/core/docker/build.sh
@@ -8,7 +8,7 @@ Usage: $0 [-h] [-a <ARCHITECTURES>] [-r <VERSION>] [-c]
 Builds the Trino Docker image
 
 -h       Display help
--a       Build the specified comma-separated architectures, defaults to amd64,arm64
+-a       Build the specified comma-separated architectures, defaults to: amd64,arm64,ppc64le
 -r       Build the specified Trino release version, downloads all required artifacts
 -c       Use trinodb/trino:latest as additional Docker build cache
 EOF


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Some issues with stability of Ubuntu repositories have surfaced lately. 
Our Dockerfile tries to update packages in the base Ubuntu image, and when that fails, the entire `maven-checks` job fails.

We can use a build cache to avoid running these updates.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/trinodb/trino/pull/15807#issuecomment-1403381201
https://github.com/trinodb/trino/actions/runs/4004028582/jobs/6872683430

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
