### PR TITLE
Optimize decoders for DELTA_BINARY_PACKED parquet encoding

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderUtils.java
@@ -83,6 +83,71 @@ public final class ParquetReaderUtils
         return value | inputByte << 28;
     }
 
+    public static long readUleb128Long(SimpleSliceInputStream input)
+    {
+        byte[] inputBytes = input.getByteArray();
+        int offset = input.getByteArrayOffset();
+        // Manual loop unrolling shows improvements in BenchmarkReadUleb128Long
+        long inputByte = inputBytes[offset];
+        long value = inputByte & 0x7F;
+        if ((inputByte & 0x80) == 0) {
+            input.skip(1);
+            return value;
+        }
+        inputByte = inputBytes[offset + 1];
+        value |= (inputByte & 0x7F) << 7;
+        if ((inputByte & 0x80) == 0) {
+            input.skip(2);
+            return value;
+        }
+        inputByte = inputBytes[offset + 2];
+        value |= (inputByte & 0x7F) << 14;
+        if ((inputByte & 0x80) == 0) {
+            input.skip(3);
+            return value;
+        }
+        inputByte = inputBytes[offset + 3];
+        value |= (inputByte & 0x7F) << 21;
+        if ((inputByte & 0x80) == 0) {
+            input.skip(4);
+            return value;
+        }
+        inputByte = inputBytes[offset + 4];
+        value |= (inputByte & 0x7F) << 28;
+        if ((inputByte & 0x80) == 0) {
+            input.skip(5);
+            return value;
+        }
+        inputByte = inputBytes[offset + 5];
+        value |= (inputByte & 0x7F) << 35;
+        if ((inputByte & 0x80) == 0) {
+            input.skip(6);
+            return value;
+        }
+        inputByte = inputBytes[offset + 6];
+        value |= (inputByte & 0x7F) << 42;
+        if ((inputByte & 0x80) == 0) {
+            input.skip(7);
+            return value;
+        }
+        inputByte = inputBytes[offset + 7];
+        value |= (inputByte & 0x7F) << 49;
+        if ((inputByte & 0x80) == 0) {
+            input.skip(8);
+            return value;
+        }
+        inputByte = inputBytes[offset + 8];
+        value |= (inputByte & 0x7F) << 56;
+        if ((inputByte & 0x80) == 0) {
+            input.skip(9);
+            return value;
+        }
+        inputByte = inputBytes[offset + 9];
+        verify((inputByte & 0x80) == 0, "ULEB128 variable-width long should not be longer than 10 bytes");
+        input.skip(10);
+        return value | inputByte << 63;
+    }
+
     public static int readFixedWidthInt(SimpleSliceInputStream input, int bytesWidth)
     {
         return switch (bytesWidth) {
@@ -96,6 +161,27 @@ public final class ParquetReaderUtils
             case 4 -> input.readInt();
             default -> throw new IllegalArgumentException(format("Encountered bytesWidth (%d) that requires more than 4 bytes", bytesWidth));
         };
+    }
+
+    /**
+     * For storing signed values (not the deltas themselves) in DELTA_BINARY_PACKED encoding, zigzag encoding
+     * (<a href="https://developers.google.com/protocol-buffers/docs/encoding#signed-integers">...</a>)
+     * is used to map negative values to positive ones and then apply ULEB128 on the result.
+     */
+    public static long zigzagDecode(long value)
+    {
+        return (value >>> 1) ^ -(value & 1);
+    }
+
+    /**
+     * Returns the result of arguments division rounded up.
+     * <p>
+     * Works only for positive numbers.
+     * The sum of dividend and divisor cannot exceed Integer.MAX_VALUE
+     */
+    public static int ceilDiv(int dividend, int divisor)
+    {
+        return (dividend + divisor - 1) / divisor;
     }
 
     /**

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
@@ -143,7 +143,7 @@ public final class ColumnReaderFactory
                     throw unsupportedException(type, field);
                 }
                 if (primitiveType == INT32) {
-                    return new FlatColumnReader<>(field, ValueDecoders::getIntToLongDecoder, LONG_ADAPTER, memoryContext);
+                    return new FlatColumnReader<>(field, TransformingValueDecoders::getInt32ToLongDecoder, LONG_ADAPTER, memoryContext);
                 }
                 if (primitiveType == INT64) {
                     return new FlatColumnReader<>(field, ValueDecoders::getLongDecoder, LONG_ADAPTER, memoryContext);
@@ -218,7 +218,7 @@ public final class ColumnReaderFactory
                 if (decimalType.getScale() == 0 && decimalType.getPrecision() >= MAX_INT_DIGITS
                         && primitiveType == INT32
                         && isIntegerAnnotation(annotation)) {
-                    return new FlatColumnReader<>(field, ValueDecoders::getIntToLongDecoder, LONG_ADAPTER, memoryContext);
+                    return new FlatColumnReader<>(field, TransformingValueDecoders::getInt32ToLongDecoder, LONG_ADAPTER, memoryContext);
                 }
                 if (!(annotation instanceof DecimalLogicalTypeAnnotation decimalAnnotation)) {
                     throw unsupportedException(type, field);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/SimpleSliceInputStream.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/SimpleSliceInputStream.java
@@ -77,6 +77,12 @@ public final class SimpleSliceInputStream
         return bytes;
     }
 
+    public void readBytes(byte[] output, int outputOffset, int length)
+    {
+        slice.getBytes(offset, output, outputOffset, length);
+        offset += length;
+    }
+
     public void readBytes(Slice destination, int destinationIndex, int length)
     {
         slice.getBytes(offset, destination, destinationIndex, length);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ApacheParquetValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ApacheParquetValueDecoders.java
@@ -38,7 +38,6 @@ import java.nio.ByteOrder;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.parquet.ParquetReaderUtils.castToByte;
-import static io.trino.parquet.ParquetReaderUtils.toShortExact;
 import static io.trino.parquet.ParquetTimestampUtils.decodeInt96Timestamp;
 import static io.trino.parquet.ParquetTypeUtils.checkBytesFitInShortDecimal;
 import static io.trino.parquet.ParquetTypeUtils.getShortDecimalValue;
@@ -53,37 +52,6 @@ import static org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalType
 public class ApacheParquetValueDecoders
 {
     private ApacheParquetValueDecoders() {}
-
-    public static final class ShortApacheParquetValueDecoder
-            implements ValueDecoder<short[]>
-    {
-        private final ValuesReader delegate;
-
-        public ShortApacheParquetValueDecoder(ValuesReader delegate)
-        {
-            this.delegate = requireNonNull(delegate, "delegate is null");
-        }
-
-        @Override
-        public void init(SimpleSliceInputStream input)
-        {
-            initialize(input, delegate);
-        }
-
-        @Override
-        public void read(short[] values, int offset, int length)
-        {
-            for (int i = offset; i < offset + length; i++) {
-                values[i] = toShortExact(delegate.readInteger());
-            }
-        }
-
-        @Override
-        public void skip(int n)
-        {
-            delegate.skip(n);
-        }
-    }
 
     public static final class IntToLongApacheParquetValueDecoder
             implements ValueDecoder<long[]>

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ApacheParquetValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ApacheParquetValueDecoders.java
@@ -38,7 +38,6 @@ import java.nio.ByteOrder;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.parquet.ParquetReaderUtils.castToByte;
-import static io.trino.parquet.ParquetReaderUtils.toByteExact;
 import static io.trino.parquet.ParquetReaderUtils.toShortExact;
 import static io.trino.parquet.ParquetTimestampUtils.decodeInt96Timestamp;
 import static io.trino.parquet.ParquetTypeUtils.checkBytesFitInShortDecimal;
@@ -76,37 +75,6 @@ public class ApacheParquetValueDecoders
         {
             for (int i = offset; i < offset + length; i++) {
                 values[i] = toShortExact(delegate.readInteger());
-            }
-        }
-
-        @Override
-        public void skip(int n)
-        {
-            delegate.skip(n);
-        }
-    }
-
-    public static final class ByteApacheParquetValueDecoder
-            implements ValueDecoder<byte[]>
-    {
-        private final ValuesReader delegate;
-
-        public ByteApacheParquetValueDecoder(ValuesReader delegate)
-        {
-            this.delegate = requireNonNull(delegate, "delegate is null");
-        }
-
-        @Override
-        public void init(SimpleSliceInputStream input)
-        {
-            initialize(input, delegate);
-        }
-
-        @Override
-        public void read(byte[] values, int offset, int length)
-        {
-            for (int i = offset; i < offset + length; i++) {
-                values[i] = toByteExact(delegate.readInteger());
             }
         }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ApacheParquetValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ApacheParquetValueDecoders.java
@@ -53,37 +53,6 @@ public class ApacheParquetValueDecoders
 {
     private ApacheParquetValueDecoders() {}
 
-    public static final class IntToLongApacheParquetValueDecoder
-            implements ValueDecoder<long[]>
-    {
-        private final ValuesReader delegate;
-
-        public IntToLongApacheParquetValueDecoder(ValuesReader delegate)
-        {
-            this.delegate = requireNonNull(delegate, "delegate is null");
-        }
-
-        @Override
-        public void init(SimpleSliceInputStream input)
-        {
-            initialize(input, delegate);
-        }
-
-        @Override
-        public void read(long[] values, int offset, int length)
-        {
-            for (int i = offset; i < offset + length; i++) {
-                values[i] = delegate.readInteger();
-            }
-        }
-
-        @Override
-        public void skip(int n)
-        {
-            delegate.skip(n);
-        }
-    }
-
     public static final class BooleanApacheParquetValueDecoder
             implements ValueDecoder<byte[]>
     {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ApacheParquetValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ApacheParquetValueDecoders.java
@@ -55,37 +55,6 @@ public class ApacheParquetValueDecoders
 {
     private ApacheParquetValueDecoders() {}
 
-    public static final class IntApacheParquetValueDecoder
-            implements ValueDecoder<int[]>
-    {
-        private final ValuesReader delegate;
-
-        public IntApacheParquetValueDecoder(ValuesReader delegate)
-        {
-            this.delegate = requireNonNull(delegate, "delegate is null");
-        }
-
-        @Override
-        public void init(SimpleSliceInputStream input)
-        {
-            initialize(input, delegate);
-        }
-
-        @Override
-        public void read(int[] values, int offset, int length)
-        {
-            for (int i = offset; i < offset + length; i++) {
-                values[i] = delegate.readInteger();
-            }
-        }
-
-        @Override
-        public void skip(int n)
-        {
-            delegate.skip(n);
-        }
-    }
-
     public static final class ShortApacheParquetValueDecoder
             implements ValueDecoder<short[]>
     {
@@ -169,37 +138,6 @@ public class ApacheParquetValueDecoders
         {
             for (int i = offset; i < offset + length; i++) {
                 values[i] = delegate.readInteger();
-            }
-        }
-
-        @Override
-        public void skip(int n)
-        {
-            delegate.skip(n);
-        }
-    }
-
-    public static final class LongApacheParquetValueDecoder
-            implements ValueDecoder<long[]>
-    {
-        private final ValuesReader delegate;
-
-        public LongApacheParquetValueDecoder(ValuesReader delegate)
-        {
-            this.delegate = requireNonNull(delegate, "delegate is null");
-        }
-
-        @Override
-        public void init(SimpleSliceInputStream input)
-        {
-            initialize(input, delegate);
-        }
-
-        @Override
-        public void read(long[] values, int offset, int length)
-        {
-            for (int i = offset; i < offset + length; i++) {
-                values[i] = delegate.readLong();
             }
         }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ByteBitUnpacker.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ByteBitUnpacker.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.trino.parquet.reader.SimpleSliceInputStream;
+
+public interface ByteBitUnpacker
+{
+    /**
+     * @param length must be a multiple of 32
+     */
+    void unpack(byte[] output, int outputOffset, SimpleSliceInputStream input, int length);
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ByteBitUnpackers.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ByteBitUnpackers.java
@@ -1,0 +1,492 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.trino.parquet.reader.SimpleSliceInputStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public final class ByteBitUnpackers
+{
+    private static final ByteBitUnpacker[] UNPACKERS = {
+            new Unpacker1(),
+            new Unpacker2(),
+            new Unpacker3(),
+            new Unpacker4(),
+            new Unpacker5(),
+            new Unpacker6(),
+            new Unpacker7(),
+            new Unpacker8(),
+            new Unpacker9()};
+
+    // Byte unpacker also exists for the out-of-range 9 value.
+    // This unpacker truncates the most significant bit of the resulted numbers.
+    // This is due to the fact that deltas may require more than 8 bits to be stored.
+    // E.g. Values -100, 100, -100 are stored as deltas 200, -200 which is a span of 400,
+    // far exceeding the 8-byte capabilities.
+    // However, since the Trino type is Tinyint we have a certainty
+    // that the resulting value fits into 8-byte number and the most significant
+    // delta bit, when being '1' would cause positive overflow. Knowing that the value
+    // fits into 8-bit value we can assume that there has been negative overflow
+    // previously and the result is correct
+    // Example:
+    // Values: -100, 100, -100
+    // First value: -100
+    // Deltas: 200, -200
+    // Minimum delta: -200
+    // Normalized deltas: 400 , 0
+    // Calculating first value: -100 + -200 (negative overflow) + 400 (positive overflow) = 100
+    // Calculating first value without first bit: -100 + -200 + 144 (truncated) = -156
+    // And finally the resulting value truncation: (byte) -156 == 100
+    public static ByteBitUnpacker getByteBitUnpacker(int bitWidth)
+    {
+        checkArgument(bitWidth > 0 && bitWidth <= 9, "bitWidth %s should be in the range 1-9", bitWidth);
+        return UNPACKERS[bitWidth - 1];
+    }
+
+    private ByteBitUnpackers()
+    {
+    }
+
+    private static final class Unpacker1
+            implements ByteBitUnpacker
+    {
+        @Override
+        public void unpack(byte[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(byte[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            int v0 = input.readInt();
+            output[outputOffset] = (byte) (v0 & 0b1L);
+            output[outputOffset + 1] = (byte) ((v0 >>> 1) & 0b1L);
+            output[outputOffset + 2] = (byte) ((v0 >>> 2) & 0b1L);
+            output[outputOffset + 3] = (byte) ((v0 >>> 3) & 0b1L);
+            output[outputOffset + 4] = (byte) ((v0 >>> 4) & 0b1L);
+            output[outputOffset + 5] = (byte) ((v0 >>> 5) & 0b1L);
+            output[outputOffset + 6] = (byte) ((v0 >>> 6) & 0b1L);
+            output[outputOffset + 7] = (byte) ((v0 >>> 7) & 0b1L);
+            output[outputOffset + 8] = (byte) ((v0 >>> 8) & 0b1L);
+            output[outputOffset + 9] = (byte) ((v0 >>> 9) & 0b1L);
+            output[outputOffset + 10] = (byte) ((v0 >>> 10) & 0b1L);
+            output[outputOffset + 11] = (byte) ((v0 >>> 11) & 0b1L);
+            output[outputOffset + 12] = (byte) ((v0 >>> 12) & 0b1L);
+            output[outputOffset + 13] = (byte) ((v0 >>> 13) & 0b1L);
+            output[outputOffset + 14] = (byte) ((v0 >>> 14) & 0b1L);
+            output[outputOffset + 15] = (byte) ((v0 >>> 15) & 0b1L);
+            output[outputOffset + 16] = (byte) ((v0 >>> 16) & 0b1L);
+            output[outputOffset + 17] = (byte) ((v0 >>> 17) & 0b1L);
+            output[outputOffset + 18] = (byte) ((v0 >>> 18) & 0b1L);
+            output[outputOffset + 19] = (byte) ((v0 >>> 19) & 0b1L);
+            output[outputOffset + 20] = (byte) ((v0 >>> 20) & 0b1L);
+            output[outputOffset + 21] = (byte) ((v0 >>> 21) & 0b1L);
+            output[outputOffset + 22] = (byte) ((v0 >>> 22) & 0b1L);
+            output[outputOffset + 23] = (byte) ((v0 >>> 23) & 0b1L);
+            output[outputOffset + 24] = (byte) ((v0 >>> 24) & 0b1L);
+            output[outputOffset + 25] = (byte) ((v0 >>> 25) & 0b1L);
+            output[outputOffset + 26] = (byte) ((v0 >>> 26) & 0b1L);
+            output[outputOffset + 27] = (byte) ((v0 >>> 27) & 0b1L);
+            output[outputOffset + 28] = (byte) ((v0 >>> 28) & 0b1L);
+            output[outputOffset + 29] = (byte) ((v0 >>> 29) & 0b1L);
+            output[outputOffset + 30] = (byte) ((v0 >>> 30) & 0b1L);
+            output[outputOffset + 31] = (byte) ((v0 >>> 31) & 0b1L);
+        }
+    }
+
+    private static final class Unpacker2
+            implements ByteBitUnpacker
+    {
+        @Override
+        public void unpack(byte[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(byte[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            output[outputOffset] = (byte) (v0 & 0b11L);
+            output[outputOffset + 1] = (byte) ((v0 >>> 2) & 0b11L);
+            output[outputOffset + 2] = (byte) ((v0 >>> 4) & 0b11L);
+            output[outputOffset + 3] = (byte) ((v0 >>> 6) & 0b11L);
+            output[outputOffset + 4] = (byte) ((v0 >>> 8) & 0b11L);
+            output[outputOffset + 5] = (byte) ((v0 >>> 10) & 0b11L);
+            output[outputOffset + 6] = (byte) ((v0 >>> 12) & 0b11L);
+            output[outputOffset + 7] = (byte) ((v0 >>> 14) & 0b11L);
+            output[outputOffset + 8] = (byte) ((v0 >>> 16) & 0b11L);
+            output[outputOffset + 9] = (byte) ((v0 >>> 18) & 0b11L);
+            output[outputOffset + 10] = (byte) ((v0 >>> 20) & 0b11L);
+            output[outputOffset + 11] = (byte) ((v0 >>> 22) & 0b11L);
+            output[outputOffset + 12] = (byte) ((v0 >>> 24) & 0b11L);
+            output[outputOffset + 13] = (byte) ((v0 >>> 26) & 0b11L);
+            output[outputOffset + 14] = (byte) ((v0 >>> 28) & 0b11L);
+            output[outputOffset + 15] = (byte) ((v0 >>> 30) & 0b11L);
+            output[outputOffset + 16] = (byte) ((v0 >>> 32) & 0b11L);
+            output[outputOffset + 17] = (byte) ((v0 >>> 34) & 0b11L);
+            output[outputOffset + 18] = (byte) ((v0 >>> 36) & 0b11L);
+            output[outputOffset + 19] = (byte) ((v0 >>> 38) & 0b11L);
+            output[outputOffset + 20] = (byte) ((v0 >>> 40) & 0b11L);
+            output[outputOffset + 21] = (byte) ((v0 >>> 42) & 0b11L);
+            output[outputOffset + 22] = (byte) ((v0 >>> 44) & 0b11L);
+            output[outputOffset + 23] = (byte) ((v0 >>> 46) & 0b11L);
+            output[outputOffset + 24] = (byte) ((v0 >>> 48) & 0b11L);
+            output[outputOffset + 25] = (byte) ((v0 >>> 50) & 0b11L);
+            output[outputOffset + 26] = (byte) ((v0 >>> 52) & 0b11L);
+            output[outputOffset + 27] = (byte) ((v0 >>> 54) & 0b11L);
+            output[outputOffset + 28] = (byte) ((v0 >>> 56) & 0b11L);
+            output[outputOffset + 29] = (byte) ((v0 >>> 58) & 0b11L);
+            output[outputOffset + 30] = (byte) ((v0 >>> 60) & 0b11L);
+            output[outputOffset + 31] = (byte) ((v0 >>> 62) & 0b11L);
+        }
+    }
+
+    private static final class Unpacker3
+            implements ByteBitUnpacker
+    {
+        @Override
+        public void unpack(byte[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(byte[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            int v1 = input.readInt();
+            output[outputOffset] = (byte) (v0 & 0b111L);
+            output[outputOffset + 1] = (byte) ((v0 >>> 3) & 0b111L);
+            output[outputOffset + 2] = (byte) ((v0 >>> 6) & 0b111L);
+            output[outputOffset + 3] = (byte) ((v0 >>> 9) & 0b111L);
+            output[outputOffset + 4] = (byte) ((v0 >>> 12) & 0b111L);
+            output[outputOffset + 5] = (byte) ((v0 >>> 15) & 0b111L);
+            output[outputOffset + 6] = (byte) ((v0 >>> 18) & 0b111L);
+            output[outputOffset + 7] = (byte) ((v0 >>> 21) & 0b111L);
+            output[outputOffset + 8] = (byte) ((v0 >>> 24) & 0b111L);
+            output[outputOffset + 9] = (byte) ((v0 >>> 27) & 0b111L);
+            output[outputOffset + 10] = (byte) ((v0 >>> 30) & 0b111L);
+            output[outputOffset + 11] = (byte) ((v0 >>> 33) & 0b111L);
+            output[outputOffset + 12] = (byte) ((v0 >>> 36) & 0b111L);
+            output[outputOffset + 13] = (byte) ((v0 >>> 39) & 0b111L);
+            output[outputOffset + 14] = (byte) ((v0 >>> 42) & 0b111L);
+            output[outputOffset + 15] = (byte) ((v0 >>> 45) & 0b111L);
+            output[outputOffset + 16] = (byte) ((v0 >>> 48) & 0b111L);
+            output[outputOffset + 17] = (byte) ((v0 >>> 51) & 0b111L);
+            output[outputOffset + 18] = (byte) ((v0 >>> 54) & 0b111L);
+            output[outputOffset + 19] = (byte) ((v0 >>> 57) & 0b111L);
+            output[outputOffset + 20] = (byte) ((v0 >>> 60) & 0b111L);
+            output[outputOffset + 21] = (byte) (((v0 >>> 63) & 0b1L) | ((v1 & 0b11L) << 1));
+            output[outputOffset + 22] = (byte) ((v1 >>> 2) & 0b111L);
+            output[outputOffset + 23] = (byte) ((v1 >>> 5) & 0b111L);
+            output[outputOffset + 24] = (byte) ((v1 >>> 8) & 0b111L);
+            output[outputOffset + 25] = (byte) ((v1 >>> 11) & 0b111L);
+            output[outputOffset + 26] = (byte) ((v1 >>> 14) & 0b111L);
+            output[outputOffset + 27] = (byte) ((v1 >>> 17) & 0b111L);
+            output[outputOffset + 28] = (byte) ((v1 >>> 20) & 0b111L);
+            output[outputOffset + 29] = (byte) ((v1 >>> 23) & 0b111L);
+            output[outputOffset + 30] = (byte) ((v1 >>> 26) & 0b111L);
+            output[outputOffset + 31] = (byte) ((v1 >>> 29) & 0b111L);
+        }
+    }
+
+    private static final class Unpacker4
+            implements ByteBitUnpacker
+    {
+        @Override
+        public void unpack(byte[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(byte[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            output[outputOffset] = (byte) (v0 & 0b1111L);
+            output[outputOffset + 1] = (byte) ((v0 >>> 4) & 0b1111L);
+            output[outputOffset + 2] = (byte) ((v0 >>> 8) & 0b1111L);
+            output[outputOffset + 3] = (byte) ((v0 >>> 12) & 0b1111L);
+            output[outputOffset + 4] = (byte) ((v0 >>> 16) & 0b1111L);
+            output[outputOffset + 5] = (byte) ((v0 >>> 20) & 0b1111L);
+            output[outputOffset + 6] = (byte) ((v0 >>> 24) & 0b1111L);
+            output[outputOffset + 7] = (byte) ((v0 >>> 28) & 0b1111L);
+            output[outputOffset + 8] = (byte) ((v0 >>> 32) & 0b1111L);
+            output[outputOffset + 9] = (byte) ((v0 >>> 36) & 0b1111L);
+            output[outputOffset + 10] = (byte) ((v0 >>> 40) & 0b1111L);
+            output[outputOffset + 11] = (byte) ((v0 >>> 44) & 0b1111L);
+            output[outputOffset + 12] = (byte) ((v0 >>> 48) & 0b1111L);
+            output[outputOffset + 13] = (byte) ((v0 >>> 52) & 0b1111L);
+            output[outputOffset + 14] = (byte) ((v0 >>> 56) & 0b1111L);
+            output[outputOffset + 15] = (byte) ((v0 >>> 60) & 0b1111L);
+            output[outputOffset + 16] = (byte) (v1 & 0b1111L);
+            output[outputOffset + 17] = (byte) ((v1 >>> 4) & 0b1111L);
+            output[outputOffset + 18] = (byte) ((v1 >>> 8) & 0b1111L);
+            output[outputOffset + 19] = (byte) ((v1 >>> 12) & 0b1111L);
+            output[outputOffset + 20] = (byte) ((v1 >>> 16) & 0b1111L);
+            output[outputOffset + 21] = (byte) ((v1 >>> 20) & 0b1111L);
+            output[outputOffset + 22] = (byte) ((v1 >>> 24) & 0b1111L);
+            output[outputOffset + 23] = (byte) ((v1 >>> 28) & 0b1111L);
+            output[outputOffset + 24] = (byte) ((v1 >>> 32) & 0b1111L);
+            output[outputOffset + 25] = (byte) ((v1 >>> 36) & 0b1111L);
+            output[outputOffset + 26] = (byte) ((v1 >>> 40) & 0b1111L);
+            output[outputOffset + 27] = (byte) ((v1 >>> 44) & 0b1111L);
+            output[outputOffset + 28] = (byte) ((v1 >>> 48) & 0b1111L);
+            output[outputOffset + 29] = (byte) ((v1 >>> 52) & 0b1111L);
+            output[outputOffset + 30] = (byte) ((v1 >>> 56) & 0b1111L);
+            output[outputOffset + 31] = (byte) ((v1 >>> 60) & 0b1111L);
+        }
+    }
+
+    private static final class Unpacker5
+            implements ByteBitUnpacker
+    {
+        @Override
+        public void unpack(byte[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(byte[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            int v2 = input.readInt();
+            output[outputOffset] = (byte) (v0 & 0b11111L);
+            output[outputOffset + 1] = (byte) ((v0 >>> 5) & 0b11111L);
+            output[outputOffset + 2] = (byte) ((v0 >>> 10) & 0b11111L);
+            output[outputOffset + 3] = (byte) ((v0 >>> 15) & 0b11111L);
+            output[outputOffset + 4] = (byte) ((v0 >>> 20) & 0b11111L);
+            output[outputOffset + 5] = (byte) ((v0 >>> 25) & 0b11111L);
+            output[outputOffset + 6] = (byte) ((v0 >>> 30) & 0b11111L);
+            output[outputOffset + 7] = (byte) ((v0 >>> 35) & 0b11111L);
+            output[outputOffset + 8] = (byte) ((v0 >>> 40) & 0b11111L);
+            output[outputOffset + 9] = (byte) ((v0 >>> 45) & 0b11111L);
+            output[outputOffset + 10] = (byte) ((v0 >>> 50) & 0b11111L);
+            output[outputOffset + 11] = (byte) ((v0 >>> 55) & 0b11111L);
+            output[outputOffset + 12] = (byte) (((v0 >>> 60) & 0b1111L) | ((v1 & 0b1L) << 4));
+            output[outputOffset + 13] = (byte) ((v1 >>> 1) & 0b11111L);
+            output[outputOffset + 14] = (byte) ((v1 >>> 6) & 0b11111L);
+            output[outputOffset + 15] = (byte) ((v1 >>> 11) & 0b11111L);
+            output[outputOffset + 16] = (byte) ((v1 >>> 16) & 0b11111L);
+            output[outputOffset + 17] = (byte) ((v1 >>> 21) & 0b11111L);
+            output[outputOffset + 18] = (byte) ((v1 >>> 26) & 0b11111L);
+            output[outputOffset + 19] = (byte) ((v1 >>> 31) & 0b11111L);
+            output[outputOffset + 20] = (byte) ((v1 >>> 36) & 0b11111L);
+            output[outputOffset + 21] = (byte) ((v1 >>> 41) & 0b11111L);
+            output[outputOffset + 22] = (byte) ((v1 >>> 46) & 0b11111L);
+            output[outputOffset + 23] = (byte) ((v1 >>> 51) & 0b11111L);
+            output[outputOffset + 24] = (byte) ((v1 >>> 56) & 0b11111L);
+            output[outputOffset + 25] = (byte) (((v1 >>> 61) & 0b111L) | ((v2 & 0b11L) << 3));
+            output[outputOffset + 26] = (byte) ((v2 >>> 2) & 0b11111L);
+            output[outputOffset + 27] = (byte) ((v2 >>> 7) & 0b11111L);
+            output[outputOffset + 28] = (byte) ((v2 >>> 12) & 0b11111L);
+            output[outputOffset + 29] = (byte) ((v2 >>> 17) & 0b11111L);
+            output[outputOffset + 30] = (byte) ((v2 >>> 22) & 0b11111L);
+            output[outputOffset + 31] = (byte) ((v2 >>> 27) & 0b11111L);
+        }
+    }
+
+    private static final class Unpacker6
+            implements ByteBitUnpacker
+    {
+        @Override
+        public void unpack(byte[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(byte[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            output[outputOffset] = (byte) (v0 & 0b111111L);
+            output[outputOffset + 1] = (byte) ((v0 >>> 6) & 0b111111L);
+            output[outputOffset + 2] = (byte) ((v0 >>> 12) & 0b111111L);
+            output[outputOffset + 3] = (byte) ((v0 >>> 18) & 0b111111L);
+            output[outputOffset + 4] = (byte) ((v0 >>> 24) & 0b111111L);
+            output[outputOffset + 5] = (byte) ((v0 >>> 30) & 0b111111L);
+            output[outputOffset + 6] = (byte) ((v0 >>> 36) & 0b111111L);
+            output[outputOffset + 7] = (byte) ((v0 >>> 42) & 0b111111L);
+            output[outputOffset + 8] = (byte) ((v0 >>> 48) & 0b111111L);
+            output[outputOffset + 9] = (byte) ((v0 >>> 54) & 0b111111L);
+            output[outputOffset + 10] = (byte) (((v0 >>> 60) & 0b1111L) | ((v1 & 0b11L) << 4));
+            output[outputOffset + 11] = (byte) ((v1 >>> 2) & 0b111111L);
+            output[outputOffset + 12] = (byte) ((v1 >>> 8) & 0b111111L);
+            output[outputOffset + 13] = (byte) ((v1 >>> 14) & 0b111111L);
+            output[outputOffset + 14] = (byte) ((v1 >>> 20) & 0b111111L);
+            output[outputOffset + 15] = (byte) ((v1 >>> 26) & 0b111111L);
+            output[outputOffset + 16] = (byte) ((v1 >>> 32) & 0b111111L);
+            output[outputOffset + 17] = (byte) ((v1 >>> 38) & 0b111111L);
+            output[outputOffset + 18] = (byte) ((v1 >>> 44) & 0b111111L);
+            output[outputOffset + 19] = (byte) ((v1 >>> 50) & 0b111111L);
+            output[outputOffset + 20] = (byte) ((v1 >>> 56) & 0b111111L);
+            output[outputOffset + 21] = (byte) (((v1 >>> 62) & 0b11L) | ((v2 & 0b1111L) << 2));
+            output[outputOffset + 22] = (byte) ((v2 >>> 4) & 0b111111L);
+            output[outputOffset + 23] = (byte) ((v2 >>> 10) & 0b111111L);
+            output[outputOffset + 24] = (byte) ((v2 >>> 16) & 0b111111L);
+            output[outputOffset + 25] = (byte) ((v2 >>> 22) & 0b111111L);
+            output[outputOffset + 26] = (byte) ((v2 >>> 28) & 0b111111L);
+            output[outputOffset + 27] = (byte) ((v2 >>> 34) & 0b111111L);
+            output[outputOffset + 28] = (byte) ((v2 >>> 40) & 0b111111L);
+            output[outputOffset + 29] = (byte) ((v2 >>> 46) & 0b111111L);
+            output[outputOffset + 30] = (byte) ((v2 >>> 52) & 0b111111L);
+            output[outputOffset + 31] = (byte) ((v2 >>> 58) & 0b111111L);
+        }
+    }
+
+    private static final class Unpacker7
+            implements ByteBitUnpacker
+    {
+        @Override
+        public void unpack(byte[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(byte[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            int v3 = input.readInt();
+            output[outputOffset] = (byte) (v0 & 0b1111111L);
+            output[outputOffset + 1] = (byte) ((v0 >>> 7) & 0b1111111L);
+            output[outputOffset + 2] = (byte) ((v0 >>> 14) & 0b1111111L);
+            output[outputOffset + 3] = (byte) ((v0 >>> 21) & 0b1111111L);
+            output[outputOffset + 4] = (byte) ((v0 >>> 28) & 0b1111111L);
+            output[outputOffset + 5] = (byte) ((v0 >>> 35) & 0b1111111L);
+            output[outputOffset + 6] = (byte) ((v0 >>> 42) & 0b1111111L);
+            output[outputOffset + 7] = (byte) ((v0 >>> 49) & 0b1111111L);
+            output[outputOffset + 8] = (byte) ((v0 >>> 56) & 0b1111111L);
+            output[outputOffset + 9] = (byte) (((v0 >>> 63) & 0b1L) | ((v1 & 0b111111L) << 1));
+            output[outputOffset + 10] = (byte) ((v1 >>> 6) & 0b1111111L);
+            output[outputOffset + 11] = (byte) ((v1 >>> 13) & 0b1111111L);
+            output[outputOffset + 12] = (byte) ((v1 >>> 20) & 0b1111111L);
+            output[outputOffset + 13] = (byte) ((v1 >>> 27) & 0b1111111L);
+            output[outputOffset + 14] = (byte) ((v1 >>> 34) & 0b1111111L);
+            output[outputOffset + 15] = (byte) ((v1 >>> 41) & 0b1111111L);
+            output[outputOffset + 16] = (byte) ((v1 >>> 48) & 0b1111111L);
+            output[outputOffset + 17] = (byte) ((v1 >>> 55) & 0b1111111L);
+            output[outputOffset + 18] = (byte) (((v1 >>> 62) & 0b11L) | ((v2 & 0b11111L) << 2));
+            output[outputOffset + 19] = (byte) ((v2 >>> 5) & 0b1111111L);
+            output[outputOffset + 20] = (byte) ((v2 >>> 12) & 0b1111111L);
+            output[outputOffset + 21] = (byte) ((v2 >>> 19) & 0b1111111L);
+            output[outputOffset + 22] = (byte) ((v2 >>> 26) & 0b1111111L);
+            output[outputOffset + 23] = (byte) ((v2 >>> 33) & 0b1111111L);
+            output[outputOffset + 24] = (byte) ((v2 >>> 40) & 0b1111111L);
+            output[outputOffset + 25] = (byte) ((v2 >>> 47) & 0b1111111L);
+            output[outputOffset + 26] = (byte) ((v2 >>> 54) & 0b1111111L);
+            output[outputOffset + 27] = (byte) (((v2 >>> 61) & 0b111L) | ((v3 & 0b1111L) << 3));
+            output[outputOffset + 28] = (byte) ((v3 >>> 4) & 0b1111111L);
+            output[outputOffset + 29] = (byte) ((v3 >>> 11) & 0b1111111L);
+            output[outputOffset + 30] = (byte) ((v3 >>> 18) & 0b1111111L);
+            output[outputOffset + 31] = (byte) ((v3 >>> 25) & 0b1111111L);
+        }
+    }
+
+    private static final class Unpacker8
+            implements ByteBitUnpacker
+    {
+        @Override
+        public void unpack(byte[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            input.readBytes(output, outputOffset, length);
+        }
+    }
+
+    private static final class Unpacker9
+            implements ByteBitUnpacker
+    {
+        @Override
+        public void unpack(byte[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(byte[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            int v4 = input.readInt();
+            output[outputOffset] = (byte) v0;
+            output[outputOffset + 1] = (byte) ((v0 >>> 9) & 0b111111111L);
+            output[outputOffset + 2] = (byte) ((v0 >>> 18) & 0b111111111L);
+            output[outputOffset + 3] = (byte) ((v0 >>> 27) & 0b111111111L);
+            output[outputOffset + 4] = (byte) ((v0 >>> 36) & 0b111111111L);
+            output[outputOffset + 5] = (byte) ((v0 >>> 45) & 0b111111111L);
+            output[outputOffset + 6] = (byte) ((v0 >>> 54) & 0b111111111L);
+            output[outputOffset + 7] = (byte) ((v0 >>> 63) | ((v1 & 0b11111111L) << 1));
+            output[outputOffset + 8] = (byte) ((v1 >>> 8) & 0b111111111L);
+            output[outputOffset + 9] = (byte) ((v1 >>> 17) & 0b111111111L);
+            output[outputOffset + 10] = (byte) ((v1 >>> 26) & 0b111111111L);
+            output[outputOffset + 11] = (byte) ((v1 >>> 35) & 0b111111111L);
+            output[outputOffset + 12] = (byte) ((v1 >>> 44) & 0b111111111L);
+            output[outputOffset + 13] = (byte) ((v1 >>> 53) & 0b111111111L);
+            output[outputOffset + 14] = (byte) ((v1 >>> 62) | ((v2 & 0b1111111L) << 2));
+            output[outputOffset + 15] = (byte) ((v2 >>> 7) & 0b111111111L);
+            output[outputOffset + 16] = (byte) ((v2 >>> 16) & 0b111111111L);
+            output[outputOffset + 17] = (byte) ((v2 >>> 25) & 0b111111111L);
+            output[outputOffset + 18] = (byte) ((v2 >>> 34) & 0b111111111L);
+            output[outputOffset + 19] = (byte) ((v2 >>> 43) & 0b111111111L);
+            output[outputOffset + 20] = (byte) ((v2 >>> 52) & 0b111111111L);
+            output[outputOffset + 21] = (byte) ((v2 >>> 61) | ((v3 & 0b111111L) << 3));
+            output[outputOffset + 22] = (byte) ((v3 >>> 6) & 0b111111111L);
+            output[outputOffset + 23] = (byte) ((v3 >>> 15) & 0b111111111L);
+            output[outputOffset + 24] = (byte) ((v3 >>> 24) & 0b111111111L);
+            output[outputOffset + 25] = (byte) ((v3 >>> 33) & 0b111111111L);
+            output[outputOffset + 26] = (byte) ((v3 >>> 42) & 0b111111111L);
+            output[outputOffset + 27] = (byte) ((v3 >>> 51) & 0b111111111L);
+            output[outputOffset + 28] = (byte) ((v3 >>> 60) | ((v4 & 0b11111L) << 4));
+            output[outputOffset + 29] = (byte) ((v4 >>> 5) & 0b111111111L);
+            output[outputOffset + 30] = (byte) ((v4 >>> 14) & 0b111111111L);
+            output[outputOffset + 31] = (byte) ((v4 >>> 23) & 0b111111111L);
+        }
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/DeltaBinaryPackedDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/DeltaBinaryPackedDecoders.java
@@ -66,6 +66,35 @@ public final class DeltaBinaryPackedDecoders
         }
     }
 
+    public static class DeltaBinaryPackedShortDecoder
+            extends DeltaBinaryPackedDecoder<short[]>
+    {
+        @Override
+        protected short[] createMiniBlockBuffer(int size)
+        {
+            return new short[size];
+        }
+
+        @Override
+        protected void setValue(short[] values, int offset, long value)
+        {
+            values[offset] = (short) value;
+        }
+
+        @Override
+        public void read(short[] values, int offset, int length)
+        {
+            readInternal(values, offset, length);
+        }
+
+        @Override
+        protected long unpack(short[] output, int outputOffset, int length, SimpleSliceInputStream input, long minDelta, byte bitWidth)
+        {
+            DeltaPackingUtils.unpackDelta(output, outputOffset, length, input, minDelta, bitWidth);
+            return output[outputOffset + length - 1];
+        }
+    }
+
     public static class DeltaBinaryPackedIntDecoder
             extends DeltaBinaryPackedDecoder<int[]>
     {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/DeltaBinaryPackedDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/DeltaBinaryPackedDecoders.java
@@ -37,6 +37,35 @@ public final class DeltaBinaryPackedDecoders
 
     private DeltaBinaryPackedDecoders() {}
 
+    public static class DeltaBinaryPackedByteDecoder
+            extends DeltaBinaryPackedDecoder<byte[]>
+    {
+        @Override
+        protected byte[] createMiniBlockBuffer(int size)
+        {
+            return new byte[size];
+        }
+
+        @Override
+        protected void setValue(byte[] values, int offset, long value)
+        {
+            values[offset] = (byte) value;
+        }
+
+        @Override
+        public void read(byte[] values, int offset, int length)
+        {
+            readInternal(values, offset, length);
+        }
+
+        @Override
+        protected long unpack(byte[] output, int outputOffset, int length, SimpleSliceInputStream input, long minDelta, byte bitWidth)
+        {
+            DeltaPackingUtils.unpackDelta(output, outputOffset, length, input, minDelta, bitWidth);
+            return output[outputOffset + length - 1];
+        }
+    }
+
     public static class DeltaBinaryPackedIntDecoder
             extends DeltaBinaryPackedDecoder<int[]>
     {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/DeltaBinaryPackedDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/DeltaBinaryPackedDecoders.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.trino.parquet.reader.SimpleSliceInputStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.parquet.ParquetReaderUtils.ceilDiv;
+import static io.trino.parquet.ParquetReaderUtils.readUleb128Int;
+import static io.trino.parquet.ParquetReaderUtils.readUleb128Long;
+import static io.trino.parquet.ParquetReaderUtils.zigzagDecode;
+import static java.lang.Math.min;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Implementation of the encoding described in
+ * <a href="https://github.com/apache/parquet-format/blob/master/Encodings.md#delta-encoding-delta_binary_packed--5">...</a>
+ */
+public final class DeltaBinaryPackedDecoders
+{
+    // Block size is a multiple of 128
+    // Mini-block size is a multiple of 32
+    // Mini-block count per block is typically equal to 4
+    private static final int COMMON_MINI_BLOCKS_NUMBER = 4;
+    private static final int FIRST_VALUE = -1;
+
+    private DeltaBinaryPackedDecoders() {}
+
+    public static class DeltaBinaryPackedIntDecoder
+            extends DeltaBinaryPackedDecoder<int[]>
+    {
+        @Override
+        protected int[] createMiniBlockBuffer(int size)
+        {
+            return new int[size];
+        }
+
+        @Override
+        protected void setValue(int[] values, int offset, long value)
+        {
+            values[offset] = (int) value;
+        }
+
+        @Override
+        public void read(int[] values, int offset, int length)
+        {
+            readInternal(values, offset, length);
+        }
+
+        @Override
+        protected long unpack(int[] output, int outputOffset, int length, SimpleSliceInputStream input, long minDelta, byte bitWidth)
+        {
+            DeltaPackingUtils.unpackDelta(output, outputOffset, length, input, minDelta, bitWidth);
+            return output[outputOffset + length - 1];
+        }
+    }
+
+    public static class DeltaBinaryPackedLongDecoder
+            extends DeltaBinaryPackedDecoder<long[]>
+    {
+        @Override
+        protected long[] createMiniBlockBuffer(int size)
+        {
+            return new long[size];
+        }
+
+        @Override
+        protected void setValue(long[] values, int offset, long value)
+        {
+            values[offset] = value;
+        }
+
+        @Override
+        public void read(long[] values, int offset, int length)
+        {
+            readInternal(values, offset, length);
+        }
+
+        @Override
+        protected long unpack(long[] output, int outputOffset, int length, SimpleSliceInputStream input, long minDelta, byte bitWidth)
+        {
+            DeltaPackingUtils.unpackDelta(output, outputOffset, length, input, minDelta, bitWidth);
+            return output[outputOffset + length - 1];
+        }
+    }
+
+    private abstract static class DeltaBinaryPackedDecoder<ValuesType>
+            implements ValueDecoder<ValuesType>
+    {
+        private SimpleSliceInputStream input;
+
+        private int blockSize;
+        private int miniBlockSize;
+        // Last read value
+        private long previousValue;
+
+        private int miniBlocksInBlock;
+        private byte[] bitWidths;
+
+        private int alreadyReadInBlock;
+        private ValuesType blockValues;
+        private int valueCount;
+
+        private long blockMinDelta;
+        private int miniBlocksRemaining;
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            this.input = requireNonNull(input, "input is null");
+            alreadyReadInBlock = FIRST_VALUE;
+            readHeader();
+            blockValues = createMiniBlockBuffer(blockSize + 1); // First index is reserved for the last read value
+            bitWidths = new byte[miniBlocksInBlock];
+        }
+
+        protected abstract ValuesType createMiniBlockBuffer(int size);
+
+        protected abstract void setValue(ValuesType values, int offset, long value);
+
+        /**
+         * This method needs to do two things:
+         * <ul>
+         * <li>Set output[outputOffset-1] to 'previousValue'. This way the inner loops are consistent and can handle iterations in batches of 32.
+         * This is needed since some values might have been skipped</li>
+         * <li>Delegate unpacking to the corresponding static method from DeltaPackingUtils class</li>
+         * </ul>
+         *
+         * @return Last value read
+         */
+        protected abstract long unpack(ValuesType output, int outputOffset, int length, SimpleSliceInputStream input, long minDelta, byte bitWidth);
+
+        private void readHeader()
+        {
+            blockSize = readUleb128Int(input);
+            checkArgument(blockSize % 128 == 0, "Corrupted Parquet file: block size of the delta encoding needs to be a multiple of 128");
+            miniBlockSize = blockSize / readUleb128Int(input);
+            checkArgument(miniBlockSize % 32 == 0, "Corrupted Parquet file: mini block size of the delta encoding needs to be a multiple of 32");
+            valueCount = readUleb128Int(input);
+            miniBlocksRemaining = ceilDiv(valueCount - 1, miniBlockSize); // -1 as the first value is stored in a header
+            previousValue = zigzagDecode(readUleb128Long(input));
+            miniBlocksInBlock = blockSize / miniBlockSize;
+        }
+
+        @SuppressWarnings("SuspiciousSystemArraycopy")
+        public void readInternal(ValuesType values, int offset, int length)
+        {
+            // This condition will be true only for the first time and then continue to
+            // return false hopefully making branch prediction efficient
+            if (alreadyReadInBlock == FIRST_VALUE && length > 0) {
+                setValue(values, offset++, previousValue);
+                length--;
+                alreadyReadInBlock = 0;
+            }
+
+            if (alreadyReadInBlock != 0) { // Partially read block
+                int chunkSize = min(length, blockSize - alreadyReadInBlock);
+                // Leverage the fact that arrayCopy does not have array types specified
+                System.arraycopy(blockValues, alreadyReadInBlock + 1, values, offset, chunkSize);
+                markRead(chunkSize);
+
+                offset += chunkSize;
+                length -= chunkSize;
+            }
+
+            while (length > 0) {
+                readBlockHeader();
+
+                if (length <= blockSize) { // Read block partially
+                    setValue(blockValues, 0, previousValue);
+                    readBlock(blockValues, 1); // Write data to temporary buffer
+                    System.arraycopy(blockValues, 1, values, offset, length);
+                    markRead(length);
+                    length = 0;
+                }
+                else { // read full block
+                    if (offset == 0) {
+                        // Special case: The decoder is in the middle of the page but the output offset is 0. This prevents
+                        // us from leveraging output[offset-1] position to streamline the unpacking operation,
+                        // The solution is to use the temporary buffer.
+                        // This is a rare case that happens at most once every Trino page (~1MB or more)
+                        setValue(blockValues, 0, previousValue);
+                        readBlock(blockValues, 1); // Write data to temporary buffer
+                        System.arraycopy(blockValues, 1, values, offset, blockSize);
+                    }
+                    else {
+                        readBlock(values, offset); // Write data directly to output buffer
+                    }
+                    offset += blockSize;
+                    length -= blockSize;
+                }
+            }
+        }
+
+        public int getValueCount()
+        {
+            return valueCount;
+        }
+
+        private boolean areBitWidthTheSame()
+        {
+            if (miniBlocksInBlock == COMMON_MINI_BLOCKS_NUMBER) {
+                byte and = (byte) (bitWidths[0] & bitWidths[1] & bitWidths[2] & bitWidths[3]);
+                byte or = (byte) (bitWidths[0] | bitWidths[1] | bitWidths[2] | bitWidths[3]);
+                return and == or;
+            }
+            byte first = bitWidths[0];
+            boolean same = true;
+            for (int i = 1; i < miniBlocksInBlock; i++) {
+                same &= bitWidths[i] == first;
+            }
+            return same;
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            if (n == 0) {
+                return;
+            }
+            // This condition will be true only for the first time and then continue to
+            // return false hopefully making branch prediction efficient
+            if (alreadyReadInBlock == FIRST_VALUE) {
+                n--;
+                alreadyReadInBlock = 0;
+            }
+
+            if (alreadyReadInBlock != 0) { // Partially read mini block
+                int chunkSize = min(n, blockSize - alreadyReadInBlock);
+                markRead(chunkSize);
+                n -= chunkSize;
+            }
+
+            while (n > 0) {
+                readBlockHeader();
+                setValue(blockValues, 0, previousValue);
+                readBlock(blockValues, 1); // Write data to temporary buffer
+                int chunkSize = min(n, blockSize);
+                markRead(chunkSize);
+                n -= chunkSize;
+            }
+        }
+
+        /**
+         * @param chunkSize Needs to be less or equal to the number of values remaining in the current mini block
+         */
+        private void markRead(int chunkSize)
+        {
+            alreadyReadInBlock += chunkSize;
+            // Trick to skip conditional statement, does the same as:
+            // if ( alreadyReadInMiniBlock == miniBlockSize) { currentMiniBlock++; }
+            alreadyReadInBlock %= blockSize;
+        }
+
+        private void readBlock(ValuesType output, int outputOffset)
+        {
+            int miniBlocksToRead = Math.min(miniBlocksRemaining, miniBlocksInBlock);
+            if (miniBlocksToRead == miniBlocksInBlock && areBitWidthTheSame()) {
+                byte bitWidth = bitWidths[0];
+                previousValue = unpack(output, outputOffset, blockSize, input, blockMinDelta, bitWidth);
+            }
+            else {
+                for (int i = 0; i < miniBlocksToRead; i++) {
+                    byte bitWidth = bitWidths[i];
+                    previousValue = unpack(output, outputOffset, miniBlockSize, input, blockMinDelta, bitWidth);
+                    outputOffset += miniBlockSize;
+                }
+            }
+
+            miniBlocksRemaining -= miniBlocksToRead;
+        }
+
+        private void readBlockHeader()
+        {
+            blockMinDelta = zigzagDecode(readUleb128Long(input));
+            if (miniBlocksInBlock == COMMON_MINI_BLOCKS_NUMBER) {
+                int bitWidthsPacked = input.readInt();
+                bitWidths[0] = (byte) bitWidthsPacked;
+                bitWidths[1] = (byte) (bitWidthsPacked >> 8);
+                bitWidths[2] = (byte) (bitWidthsPacked >> 16);
+                bitWidths[3] = (byte) (bitWidthsPacked >> 24);
+            }
+            else {
+                input.readBytes(bitWidths, 0, miniBlocksInBlock);
+            }
+        }
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/DeltaPackingUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/DeltaPackingUtils.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.trino.parquet.reader.SimpleSliceInputStream;
+
+import java.util.Arrays;
+
+import static io.trino.parquet.reader.decoders.IntBitUnpackers.getIntBitUnpacker;
+import static io.trino.parquet.reader.decoders.LongBitUnpackers.getLongBitUnpacker;
+
+public final class DeltaPackingUtils
+{
+    private DeltaPackingUtils() {}
+
+    public static void unpackDelta(int[] output, int outputOffset, int length, SimpleSliceInputStream input, long minDelta, byte bitWidth)
+    {
+        if (bitWidth == 0) {
+            unpackEmpty(output, outputOffset, length, (int) minDelta);
+        }
+        else {
+            unpackInt(output, outputOffset, input, length, bitWidth, (int) minDelta);
+        }
+    }
+
+    public static void unpackDelta(long[] output, int outputOffset, int length, SimpleSliceInputStream input, long minDelta, byte bitWidth)
+    {
+        if (bitWidth == 0) {
+            unpackEmpty(output, outputOffset, length, minDelta);
+        }
+        else {
+            unpackLong(output, outputOffset, input, length, bitWidth, minDelta);
+        }
+    }
+
+    /**
+     * Fills output array with values that differ by a constant delta.
+     * With delta = 0 all values are the same and equal to the last written one
+     */
+    private static void unpackEmpty(int[] output, int outputOffset, int length, int delta)
+    {
+        if (delta == 0) { // Common case
+            Arrays.fill(output, outputOffset, outputOffset + length, output[outputOffset - 1]);
+        }
+        else {
+            Arrays.fill(output, outputOffset, outputOffset + length, delta);
+            for (int i = outputOffset; i < outputOffset + length; i += 32) {
+                output[i] += output[i - 1];
+                output[i + 1] += output[i];
+                output[i + 2] += output[i + 1];
+                output[i + 3] += output[i + 2];
+                output[i + 4] += output[i + 3];
+                output[i + 5] += output[i + 4];
+                output[i + 6] += output[i + 5];
+                output[i + 7] += output[i + 6];
+                output[i + 8] += output[i + 7];
+                output[i + 9] += output[i + 8];
+                output[i + 10] += output[i + 9];
+                output[i + 11] += output[i + 10];
+                output[i + 12] += output[i + 11];
+                output[i + 13] += output[i + 12];
+                output[i + 14] += output[i + 13];
+                output[i + 15] += output[i + 14];
+                output[i + 16] += output[i + 15];
+                output[i + 17] += output[i + 16];
+                output[i + 18] += output[i + 17];
+                output[i + 19] += output[i + 18];
+                output[i + 20] += output[i + 19];
+                output[i + 21] += output[i + 20];
+                output[i + 22] += output[i + 21];
+                output[i + 23] += output[i + 22];
+                output[i + 24] += output[i + 23];
+                output[i + 25] += output[i + 24];
+                output[i + 26] += output[i + 25];
+                output[i + 27] += output[i + 26];
+                output[i + 28] += output[i + 27];
+                output[i + 29] += output[i + 28];
+                output[i + 30] += output[i + 29];
+                output[i + 31] += output[i + 30];
+            }
+        }
+    }
+
+    /**
+     * Fills output array with values that differ by a constant delta.
+     * With delta = 0 all values are the same and equal to the last written one
+     */
+    private static void unpackEmpty(long[] output, int outputOffset, int length, long delta)
+    {
+        if (delta == 0) { // Common case
+            Arrays.fill(output, outputOffset, outputOffset + length, output[outputOffset - 1]);
+        }
+        else {
+            Arrays.fill(output, outputOffset, outputOffset + length, delta);
+            for (int i = outputOffset; i < outputOffset + length; i += 32) {
+                output[i] += output[i - 1];
+                output[i + 1] += output[i];
+                output[i + 2] += output[i + 1];
+                output[i + 3] += output[i + 2];
+                output[i + 4] += output[i + 3];
+                output[i + 5] += output[i + 4];
+                output[i + 6] += output[i + 5];
+                output[i + 7] += output[i + 6];
+                output[i + 8] += output[i + 7];
+                output[i + 9] += output[i + 8];
+                output[i + 10] += output[i + 9];
+                output[i + 11] += output[i + 10];
+                output[i + 12] += output[i + 11];
+                output[i + 13] += output[i + 12];
+                output[i + 14] += output[i + 13];
+                output[i + 15] += output[i + 14];
+                output[i + 16] += output[i + 15];
+                output[i + 17] += output[i + 16];
+                output[i + 18] += output[i + 17];
+                output[i + 19] += output[i + 18];
+                output[i + 20] += output[i + 19];
+                output[i + 21] += output[i + 20];
+                output[i + 22] += output[i + 21];
+                output[i + 23] += output[i + 22];
+                output[i + 24] += output[i + 23];
+                output[i + 25] += output[i + 24];
+                output[i + 26] += output[i + 25];
+                output[i + 27] += output[i + 26];
+                output[i + 28] += output[i + 27];
+                output[i + 29] += output[i + 28];
+                output[i + 30] += output[i + 29];
+                output[i + 31] += output[i + 30];
+            }
+        }
+    }
+
+    private static void unpackInt(int[] output, int outputOffset, SimpleSliceInputStream input, int length, byte bitWidth, int minDelta)
+    {
+        getIntBitUnpacker(bitWidth).unpack(output, outputOffset, input, length);
+        inPlacePrefixSum(output, outputOffset, length, minDelta);
+    }
+
+    private static void unpackLong(long[] output, int outputOffset, SimpleSliceInputStream input, int length, byte bitWidth, long minDelta)
+    {
+        getLongBitUnpacker(bitWidth).unpack(output, outputOffset, input, length);
+        inPlacePrefixSum(output, outputOffset, length, minDelta);
+    }
+
+    private static void inPlacePrefixSum(int[] output, int outputOffset, int length, int minDelta)
+    {
+        for (int i = outputOffset; i < outputOffset + length; i += 32) {
+            output[i] += output[i - 1] + minDelta;
+            output[i + 1] += output[i] + minDelta;
+            output[i + 2] += output[i + 1] + minDelta;
+            output[i + 3] += output[i + 2] + minDelta;
+            output[i + 4] += output[i + 3] + minDelta;
+            output[i + 5] += output[i + 4] + minDelta;
+            output[i + 6] += output[i + 5] + minDelta;
+            output[i + 7] += output[i + 6] + minDelta;
+            output[i + 8] += output[i + 7] + minDelta;
+            output[i + 9] += output[i + 8] + minDelta;
+            output[i + 10] += output[i + 9] + minDelta;
+            output[i + 11] += output[i + 10] + minDelta;
+            output[i + 12] += output[i + 11] + minDelta;
+            output[i + 13] += output[i + 12] + minDelta;
+            output[i + 14] += output[i + 13] + minDelta;
+            output[i + 15] += output[i + 14] + minDelta;
+            output[i + 16] += output[i + 15] + minDelta;
+            output[i + 17] += output[i + 16] + minDelta;
+            output[i + 18] += output[i + 17] + minDelta;
+            output[i + 19] += output[i + 18] + minDelta;
+            output[i + 20] += output[i + 19] + minDelta;
+            output[i + 21] += output[i + 20] + minDelta;
+            output[i + 22] += output[i + 21] + minDelta;
+            output[i + 23] += output[i + 22] + minDelta;
+            output[i + 24] += output[i + 23] + minDelta;
+            output[i + 25] += output[i + 24] + minDelta;
+            output[i + 26] += output[i + 25] + minDelta;
+            output[i + 27] += output[i + 26] + minDelta;
+            output[i + 28] += output[i + 27] + minDelta;
+            output[i + 29] += output[i + 28] + minDelta;
+            output[i + 30] += output[i + 29] + minDelta;
+            output[i + 31] += output[i + 30] + minDelta;
+        }
+    }
+
+    private static void inPlacePrefixSum(long[] output, int outputOffset, int length, long minDelta)
+    {
+        for (int i = outputOffset; i < outputOffset + length; i += 32) {
+            output[i] += output[i - 1] + minDelta;
+            output[i + 1] += output[i] + minDelta;
+            output[i + 2] += output[i + 1] + minDelta;
+            output[i + 3] += output[i + 2] + minDelta;
+            output[i + 4] += output[i + 3] + minDelta;
+            output[i + 5] += output[i + 4] + minDelta;
+            output[i + 6] += output[i + 5] + minDelta;
+            output[i + 7] += output[i + 6] + minDelta;
+            output[i + 8] += output[i + 7] + minDelta;
+            output[i + 9] += output[i + 8] + minDelta;
+            output[i + 10] += output[i + 9] + minDelta;
+            output[i + 11] += output[i + 10] + minDelta;
+            output[i + 12] += output[i + 11] + minDelta;
+            output[i + 13] += output[i + 12] + minDelta;
+            output[i + 14] += output[i + 13] + minDelta;
+            output[i + 15] += output[i + 14] + minDelta;
+            output[i + 16] += output[i + 15] + minDelta;
+            output[i + 17] += output[i + 16] + minDelta;
+            output[i + 18] += output[i + 17] + minDelta;
+            output[i + 19] += output[i + 18] + minDelta;
+            output[i + 20] += output[i + 19] + minDelta;
+            output[i + 21] += output[i + 20] + minDelta;
+            output[i + 22] += output[i + 21] + minDelta;
+            output[i + 23] += output[i + 22] + minDelta;
+            output[i + 24] += output[i + 23] + minDelta;
+            output[i + 25] += output[i + 24] + minDelta;
+            output[i + 26] += output[i + 25] + minDelta;
+            output[i + 27] += output[i + 26] + minDelta;
+            output[i + 28] += output[i + 27] + minDelta;
+            output[i + 29] += output[i + 28] + minDelta;
+            output[i + 30] += output[i + 29] + minDelta;
+            output[i + 31] += output[i + 30] + minDelta;
+        }
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/DeltaPackingUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/DeltaPackingUtils.java
@@ -13,18 +13,24 @@
  */
 package io.trino.parquet.reader.decoders;
 
+import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.parquet.reader.SimpleSliceInputStream;
 
 import java.util.Arrays;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.parquet.ParquetReaderUtils.toByteExact;
+import static io.trino.parquet.ParquetReaderUtils.toShortExact;
 import static io.trino.parquet.reader.decoders.ByteBitUnpackers.getByteBitUnpacker;
 import static io.trino.parquet.reader.decoders.IntBitUnpackers.getIntBitUnpacker;
 import static io.trino.parquet.reader.decoders.LongBitUnpackers.getLongBitUnpacker;
+import static io.trino.parquet.reader.decoders.ShortBitUnpackers.getShortBitUnpacker;
 
 public final class DeltaPackingUtils
 {
+    private static final int SHORTS_IN_LONG = Long.BYTES / Short.BYTES;
+
     private DeltaPackingUtils() {}
 
     public static void unpackDelta(byte[] output, int outputOffset, int length, SimpleSliceInputStream input, long minDelta, byte bitWidth)
@@ -34,6 +40,16 @@ public final class DeltaPackingUtils
         }
         else {
             unpackByte(output, outputOffset, input, length, bitWidth, minDelta);
+        }
+    }
+
+    public static void unpackDelta(short[] output, int outputOffset, int length, SimpleSliceInputStream input, long minDelta, byte bitWidth)
+    {
+        if (bitWidth == 0) {
+            unpackEmpty(output, outputOffset, length, toShortExact(minDelta));
+        }
+        else {
+            unpackShort(output, outputOffset, input, length, bitWidth, minDelta);
         }
     }
 
@@ -68,6 +84,54 @@ public final class DeltaPackingUtils
         }
         else {
             fillArray8(output, outputOffset, length / 8, delta);
+            for (int i = outputOffset; i < outputOffset + length; i += 32) {
+                output[i] += output[i - 1];
+                output[i + 1] += output[i];
+                output[i + 2] += output[i + 1];
+                output[i + 3] += output[i + 2];
+                output[i + 4] += output[i + 3];
+                output[i + 5] += output[i + 4];
+                output[i + 6] += output[i + 5];
+                output[i + 7] += output[i + 6];
+                output[i + 8] += output[i + 7];
+                output[i + 9] += output[i + 8];
+                output[i + 10] += output[i + 9];
+                output[i + 11] += output[i + 10];
+                output[i + 12] += output[i + 11];
+                output[i + 13] += output[i + 12];
+                output[i + 14] += output[i + 13];
+                output[i + 15] += output[i + 14];
+                output[i + 16] += output[i + 15];
+                output[i + 17] += output[i + 16];
+                output[i + 18] += output[i + 17];
+                output[i + 19] += output[i + 18];
+                output[i + 20] += output[i + 19];
+                output[i + 21] += output[i + 20];
+                output[i + 22] += output[i + 21];
+                output[i + 23] += output[i + 22];
+                output[i + 24] += output[i + 23];
+                output[i + 25] += output[i + 24];
+                output[i + 26] += output[i + 25];
+                output[i + 27] += output[i + 26];
+                output[i + 28] += output[i + 27];
+                output[i + 29] += output[i + 28];
+                output[i + 30] += output[i + 29];
+                output[i + 31] += output[i + 30];
+            }
+        }
+    }
+
+    /**
+     * Fills output array with values that differ by a constant delta.
+     * With delta = 0 all values are the same and equal to the last written one
+     */
+    private static void unpackEmpty(short[] output, int outputOffset, int length, short delta)
+    {
+        if (delta == 0) { // Common case
+            fillArray4(output, outputOffset, length / 4, output[outputOffset - 1]);
+        }
+        else {
+            fillArray4(output, outputOffset, length / 4, delta);
             for (int i = outputOffset; i < outputOffset + length; i += 32) {
                 output[i] += output[i - 1];
                 output[i + 1] += output[i];
@@ -207,6 +271,12 @@ public final class DeltaPackingUtils
         inPlacePrefixSum(output, outputOffset, length, (short) minDelta);
     }
 
+    private static void unpackShort(short[] output, int outputOffset, SimpleSliceInputStream input, int length, byte bitWidth, long minDelta)
+    {
+        getShortBitUnpacker(bitWidth).unpack(output, outputOffset, input, length);
+        inPlacePrefixSum(output, outputOffset, length, (int) minDelta);
+    }
+
     private static void unpackInt(int[] output, int outputOffset, SimpleSliceInputStream input, int length, byte bitWidth, int minDelta)
     {
         getIntBitUnpacker(bitWidth).unpack(output, outputOffset, input, length);
@@ -231,7 +301,70 @@ public final class DeltaPackingUtils
                 .fill(baseValue);
     }
 
+    /**
+     * Fill short array with a value. Fills 4 values at a time
+     *
+     * @param length Number of LONG values to write i.e. number of shorts / 4
+     */
+    private static void fillArray4(short[] output, int outputOffset, int length, short baseValue)
+    {
+        Slice buffer = Slices.wrappedShortArray(output, outputOffset, length * SHORTS_IN_LONG);
+        checkArgument(output.length - outputOffset >= length * SHORTS_IN_LONG, "Trying to write values out of array bounds");
+        long value = fillLong(baseValue);
+        for (int i = 0; i < length * Long.BYTES; i += Long.BYTES) {
+            buffer.setLong(i, value);
+        }
+    }
+
+    /**
+     * @return long value made out of the argument concatenated 4 times
+     */
+    private static long fillLong(short baseValue)
+    {
+        long value = ((long) (baseValue & 0xFFFF) << 16) | (baseValue & 0xFFFF);
+        value = (value << 32) | value;
+        return value;
+    }
+
     private static void inPlacePrefixSum(byte[] output, int outputOffset, int length, short minDelta)
+    {
+        for (int i = outputOffset; i < outputOffset + length; i += 32) {
+            output[i] += output[i - 1] + minDelta;
+            output[i + 1] += output[i] + minDelta;
+            output[i + 2] += output[i + 1] + minDelta;
+            output[i + 3] += output[i + 2] + minDelta;
+            output[i + 4] += output[i + 3] + minDelta;
+            output[i + 5] += output[i + 4] + minDelta;
+            output[i + 6] += output[i + 5] + minDelta;
+            output[i + 7] += output[i + 6] + minDelta;
+            output[i + 8] += output[i + 7] + minDelta;
+            output[i + 9] += output[i + 8] + minDelta;
+            output[i + 10] += output[i + 9] + minDelta;
+            output[i + 11] += output[i + 10] + minDelta;
+            output[i + 12] += output[i + 11] + minDelta;
+            output[i + 13] += output[i + 12] + minDelta;
+            output[i + 14] += output[i + 13] + minDelta;
+            output[i + 15] += output[i + 14] + minDelta;
+            output[i + 16] += output[i + 15] + minDelta;
+            output[i + 17] += output[i + 16] + minDelta;
+            output[i + 18] += output[i + 17] + minDelta;
+            output[i + 19] += output[i + 18] + minDelta;
+            output[i + 20] += output[i + 19] + minDelta;
+            output[i + 21] += output[i + 20] + minDelta;
+            output[i + 22] += output[i + 21] + minDelta;
+            output[i + 23] += output[i + 22] + minDelta;
+            output[i + 24] += output[i + 23] + minDelta;
+            output[i + 25] += output[i + 24] + minDelta;
+            output[i + 26] += output[i + 25] + minDelta;
+            output[i + 27] += output[i + 26] + minDelta;
+            output[i + 28] += output[i + 27] + minDelta;
+            output[i + 29] += output[i + 28] + minDelta;
+            output[i + 30] += output[i + 29] + minDelta;
+            output[i + 31] += output[i + 30] + minDelta;
+        }
+    }
+
+    private static void inPlacePrefixSum(short[] output, int outputOffset, int length, int minDelta)
     {
         for (int i = outputOffset; i < outputOffset + length; i += 32) {
             output[i] += output[i - 1] + minDelta;

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/IntBitUnpackers.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/IntBitUnpackers.java
@@ -13,6 +13,7 @@
  */
 package io.trino.parquet.reader.decoders;
 
+import io.airlift.slice.Slices;
 import io.trino.parquet.reader.SimpleSliceInputStream;
 
 public final class IntBitUnpackers
@@ -1504,30 +1505,10 @@ public final class IntBitUnpackers
     private static final class Unpacker32
             implements IntBitUnpacker
     {
-        private static void unpack8(int[] output, int outputOffset, SimpleSliceInputStream input)
-        {
-            long v0 = input.readLong();
-            long v1 = input.readLong();
-            long v2 = input.readLong();
-            long v3 = input.readLong();
-            output[outputOffset] = (int) (v0 & 0b11111111111111111111111111111111L);
-            output[outputOffset + 1] = (int) ((v0 >>> 32) & 0b11111111111111111111111111111111L);
-            output[outputOffset + 2] = (int) (v1 & 0b11111111111111111111111111111111L);
-            output[outputOffset + 3] = (int) ((v1 >>> 32) & 0b11111111111111111111111111111111L);
-            output[outputOffset + 4] = (int) (v2 & 0b11111111111111111111111111111111L);
-            output[outputOffset + 5] = (int) ((v2 >>> 32) & 0b11111111111111111111111111111111L);
-            output[outputOffset + 6] = (int) (v3 & 0b11111111111111111111111111111111L);
-            output[outputOffset + 7] = (int) ((v3 >>> 32) & 0b11111111111111111111111111111111L);
-        }
-
         @Override
         public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
         {
-            while (length >= 8) {
-                unpack8(output, outputOffset, input);
-                outputOffset += 8;
-                length -= 8;
-            }
+            input.readBytes(Slices.wrappedIntArray(output, outputOffset, length), 0, length * Integer.BYTES);
         }
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/LongBitUnpacker.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/LongBitUnpacker.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.trino.parquet.reader.SimpleSliceInputStream;
+
+public interface LongBitUnpacker
+{
+    /**
+     * @param length must be a multiple of 32
+     */
+    void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length);
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/LongBitUnpackers.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/LongBitUnpackers.java
@@ -1,0 +1,4282 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.airlift.slice.Slices;
+import io.trino.parquet.reader.SimpleSliceInputStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public final class LongBitUnpackers
+{
+    private static final LongBitUnpacker[] UNPACKERS = {
+            new Unpacker1(),
+            new Unpacker2(),
+            new Unpacker3(),
+            new Unpacker4(),
+            new Unpacker5(),
+            new Unpacker6(),
+            new Unpacker7(),
+            new Unpacker8(),
+            new Unpacker9(),
+            new Unpacker10(),
+            new Unpacker11(),
+            new Unpacker12(),
+            new Unpacker13(),
+            new Unpacker14(),
+            new Unpacker15(),
+            new Unpacker16(),
+            new Unpacker17(),
+            new Unpacker18(),
+            new Unpacker19(),
+            new Unpacker20(),
+            new Unpacker21(),
+            new Unpacker22(),
+            new Unpacker23(),
+            new Unpacker24(),
+            new Unpacker25(),
+            new Unpacker26(),
+            new Unpacker27(),
+            new Unpacker28(),
+            new Unpacker29(),
+            new Unpacker30(),
+            new Unpacker31(),
+            new Unpacker32(),
+            new Unpacker33(),
+            new Unpacker34(),
+            new Unpacker35(),
+            new Unpacker36(),
+            new Unpacker37(),
+            new Unpacker38(),
+            new Unpacker39(),
+            new Unpacker40(),
+            new Unpacker41(),
+            new Unpacker42(),
+            new Unpacker43(),
+            new Unpacker44(),
+            new Unpacker45(),
+            new Unpacker46(),
+            new Unpacker47(),
+            new Unpacker48(),
+            new Unpacker49(),
+            new Unpacker50(),
+            new Unpacker51(),
+            new Unpacker52(),
+            new Unpacker53(),
+            new Unpacker54(),
+            new Unpacker55(),
+            new Unpacker56(),
+            new Unpacker57(),
+            new Unpacker58(),
+            new Unpacker59(),
+            new Unpacker60(),
+            new Unpacker61(),
+            new Unpacker62(),
+            new Unpacker63(),
+            new Unpacker64()};
+
+    public static LongBitUnpacker getLongBitUnpacker(int bitWidth)
+    {
+        checkArgument(bitWidth > 0 && bitWidth <= Long.SIZE, "bitWidth %s should be in the range 1-64", bitWidth);
+        return UNPACKERS[bitWidth - 1];
+    }
+
+    private LongBitUnpackers()
+    {
+    }
+
+    private static final class Unpacker1
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            int v0 = input.readInt();
+            output[outputOffset] = v0 & 0b1L;
+            output[outputOffset + 1] = (v0 >>> 1) & 0b1L;
+            output[outputOffset + 2] = (v0 >>> 2) & 0b1L;
+            output[outputOffset + 3] = (v0 >>> 3) & 0b1L;
+            output[outputOffset + 4] = (v0 >>> 4) & 0b1L;
+            output[outputOffset + 5] = (v0 >>> 5) & 0b1L;
+            output[outputOffset + 6] = (v0 >>> 6) & 0b1L;
+            output[outputOffset + 7] = (v0 >>> 7) & 0b1L;
+            output[outputOffset + 8] = (v0 >>> 8) & 0b1L;
+            output[outputOffset + 9] = (v0 >>> 9) & 0b1L;
+            output[outputOffset + 10] = (v0 >>> 10) & 0b1L;
+            output[outputOffset + 11] = (v0 >>> 11) & 0b1L;
+            output[outputOffset + 12] = (v0 >>> 12) & 0b1L;
+            output[outputOffset + 13] = (v0 >>> 13) & 0b1L;
+            output[outputOffset + 14] = (v0 >>> 14) & 0b1L;
+            output[outputOffset + 15] = (v0 >>> 15) & 0b1L;
+            output[outputOffset + 16] = (v0 >>> 16) & 0b1L;
+            output[outputOffset + 17] = (v0 >>> 17) & 0b1L;
+            output[outputOffset + 18] = (v0 >>> 18) & 0b1L;
+            output[outputOffset + 19] = (v0 >>> 19) & 0b1L;
+            output[outputOffset + 20] = (v0 >>> 20) & 0b1L;
+            output[outputOffset + 21] = (v0 >>> 21) & 0b1L;
+            output[outputOffset + 22] = (v0 >>> 22) & 0b1L;
+            output[outputOffset + 23] = (v0 >>> 23) & 0b1L;
+            output[outputOffset + 24] = (v0 >>> 24) & 0b1L;
+            output[outputOffset + 25] = (v0 >>> 25) & 0b1L;
+            output[outputOffset + 26] = (v0 >>> 26) & 0b1L;
+            output[outputOffset + 27] = (v0 >>> 27) & 0b1L;
+            output[outputOffset + 28] = (v0 >>> 28) & 0b1L;
+            output[outputOffset + 29] = (v0 >>> 29) & 0b1L;
+            output[outputOffset + 30] = (v0 >>> 30) & 0b1L;
+            output[outputOffset + 31] = (v0 >>> 31) & 0b1L;
+        }
+    }
+
+    private static final class Unpacker2
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            output[outputOffset] = v0 & 0b11L;
+            output[outputOffset + 1] = (v0 >>> 2) & 0b11L;
+            output[outputOffset + 2] = (v0 >>> 4) & 0b11L;
+            output[outputOffset + 3] = (v0 >>> 6) & 0b11L;
+            output[outputOffset + 4] = (v0 >>> 8) & 0b11L;
+            output[outputOffset + 5] = (v0 >>> 10) & 0b11L;
+            output[outputOffset + 6] = (v0 >>> 12) & 0b11L;
+            output[outputOffset + 7] = (v0 >>> 14) & 0b11L;
+            output[outputOffset + 8] = (v0 >>> 16) & 0b11L;
+            output[outputOffset + 9] = (v0 >>> 18) & 0b11L;
+            output[outputOffset + 10] = (v0 >>> 20) & 0b11L;
+            output[outputOffset + 11] = (v0 >>> 22) & 0b11L;
+            output[outputOffset + 12] = (v0 >>> 24) & 0b11L;
+            output[outputOffset + 13] = (v0 >>> 26) & 0b11L;
+            output[outputOffset + 14] = (v0 >>> 28) & 0b11L;
+            output[outputOffset + 15] = (v0 >>> 30) & 0b11L;
+            output[outputOffset + 16] = (v0 >>> 32) & 0b11L;
+            output[outputOffset + 17] = (v0 >>> 34) & 0b11L;
+            output[outputOffset + 18] = (v0 >>> 36) & 0b11L;
+            output[outputOffset + 19] = (v0 >>> 38) & 0b11L;
+            output[outputOffset + 20] = (v0 >>> 40) & 0b11L;
+            output[outputOffset + 21] = (v0 >>> 42) & 0b11L;
+            output[outputOffset + 22] = (v0 >>> 44) & 0b11L;
+            output[outputOffset + 23] = (v0 >>> 46) & 0b11L;
+            output[outputOffset + 24] = (v0 >>> 48) & 0b11L;
+            output[outputOffset + 25] = (v0 >>> 50) & 0b11L;
+            output[outputOffset + 26] = (v0 >>> 52) & 0b11L;
+            output[outputOffset + 27] = (v0 >>> 54) & 0b11L;
+            output[outputOffset + 28] = (v0 >>> 56) & 0b11L;
+            output[outputOffset + 29] = (v0 >>> 58) & 0b11L;
+            output[outputOffset + 30] = (v0 >>> 60) & 0b11L;
+            output[outputOffset + 31] = (v0 >>> 62) & 0b11L;
+        }
+    }
+
+    private static final class Unpacker3
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            int v1 = input.readInt();
+            output[outputOffset] = v0 & 0b111L;
+            output[outputOffset + 1] = (v0 >>> 3) & 0b111L;
+            output[outputOffset + 2] = (v0 >>> 6) & 0b111L;
+            output[outputOffset + 3] = (v0 >>> 9) & 0b111L;
+            output[outputOffset + 4] = (v0 >>> 12) & 0b111L;
+            output[outputOffset + 5] = (v0 >>> 15) & 0b111L;
+            output[outputOffset + 6] = (v0 >>> 18) & 0b111L;
+            output[outputOffset + 7] = (v0 >>> 21) & 0b111L;
+            output[outputOffset + 8] = (v0 >>> 24) & 0b111L;
+            output[outputOffset + 9] = (v0 >>> 27) & 0b111L;
+            output[outputOffset + 10] = (v0 >>> 30) & 0b111L;
+            output[outputOffset + 11] = (v0 >>> 33) & 0b111L;
+            output[outputOffset + 12] = (v0 >>> 36) & 0b111L;
+            output[outputOffset + 13] = (v0 >>> 39) & 0b111L;
+            output[outputOffset + 14] = (v0 >>> 42) & 0b111L;
+            output[outputOffset + 15] = (v0 >>> 45) & 0b111L;
+            output[outputOffset + 16] = (v0 >>> 48) & 0b111L;
+            output[outputOffset + 17] = (v0 >>> 51) & 0b111L;
+            output[outputOffset + 18] = (v0 >>> 54) & 0b111L;
+            output[outputOffset + 19] = (v0 >>> 57) & 0b111L;
+            output[outputOffset + 20] = (v0 >>> 60) & 0b111L;
+            output[outputOffset + 21] = ((v0 >>> 63) & 0b1L) | ((v1 & 0b11L) << 1);
+            output[outputOffset + 22] = (v1 >>> 2) & 0b111L;
+            output[outputOffset + 23] = (v1 >>> 5) & 0b111L;
+            output[outputOffset + 24] = (v1 >>> 8) & 0b111L;
+            output[outputOffset + 25] = (v1 >>> 11) & 0b111L;
+            output[outputOffset + 26] = (v1 >>> 14) & 0b111L;
+            output[outputOffset + 27] = (v1 >>> 17) & 0b111L;
+            output[outputOffset + 28] = (v1 >>> 20) & 0b111L;
+            output[outputOffset + 29] = (v1 >>> 23) & 0b111L;
+            output[outputOffset + 30] = (v1 >>> 26) & 0b111L;
+            output[outputOffset + 31] = (v1 >>> 29) & 0b111L;
+        }
+    }
+
+    private static final class Unpacker4
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            output[outputOffset] = v0 & 0b1111L;
+            output[outputOffset + 1] = (v0 >>> 4) & 0b1111L;
+            output[outputOffset + 2] = (v0 >>> 8) & 0b1111L;
+            output[outputOffset + 3] = (v0 >>> 12) & 0b1111L;
+            output[outputOffset + 4] = (v0 >>> 16) & 0b1111L;
+            output[outputOffset + 5] = (v0 >>> 20) & 0b1111L;
+            output[outputOffset + 6] = (v0 >>> 24) & 0b1111L;
+            output[outputOffset + 7] = (v0 >>> 28) & 0b1111L;
+            output[outputOffset + 8] = (v0 >>> 32) & 0b1111L;
+            output[outputOffset + 9] = (v0 >>> 36) & 0b1111L;
+            output[outputOffset + 10] = (v0 >>> 40) & 0b1111L;
+            output[outputOffset + 11] = (v0 >>> 44) & 0b1111L;
+            output[outputOffset + 12] = (v0 >>> 48) & 0b1111L;
+            output[outputOffset + 13] = (v0 >>> 52) & 0b1111L;
+            output[outputOffset + 14] = (v0 >>> 56) & 0b1111L;
+            output[outputOffset + 15] = (v0 >>> 60) & 0b1111L;
+            output[outputOffset + 16] = v1 & 0b1111L;
+            output[outputOffset + 17] = (v1 >>> 4) & 0b1111L;
+            output[outputOffset + 18] = (v1 >>> 8) & 0b1111L;
+            output[outputOffset + 19] = (v1 >>> 12) & 0b1111L;
+            output[outputOffset + 20] = (v1 >>> 16) & 0b1111L;
+            output[outputOffset + 21] = (v1 >>> 20) & 0b1111L;
+            output[outputOffset + 22] = (v1 >>> 24) & 0b1111L;
+            output[outputOffset + 23] = (v1 >>> 28) & 0b1111L;
+            output[outputOffset + 24] = (v1 >>> 32) & 0b1111L;
+            output[outputOffset + 25] = (v1 >>> 36) & 0b1111L;
+            output[outputOffset + 26] = (v1 >>> 40) & 0b1111L;
+            output[outputOffset + 27] = (v1 >>> 44) & 0b1111L;
+            output[outputOffset + 28] = (v1 >>> 48) & 0b1111L;
+            output[outputOffset + 29] = (v1 >>> 52) & 0b1111L;
+            output[outputOffset + 30] = (v1 >>> 56) & 0b1111L;
+            output[outputOffset + 31] = (v1 >>> 60) & 0b1111L;
+        }
+    }
+
+    private static final class Unpacker5
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            int v2 = input.readInt();
+            output[outputOffset] = v0 & 0b11111L;
+            output[outputOffset + 1] = (v0 >>> 5) & 0b11111L;
+            output[outputOffset + 2] = (v0 >>> 10) & 0b11111L;
+            output[outputOffset + 3] = (v0 >>> 15) & 0b11111L;
+            output[outputOffset + 4] = (v0 >>> 20) & 0b11111L;
+            output[outputOffset + 5] = (v0 >>> 25) & 0b11111L;
+            output[outputOffset + 6] = (v0 >>> 30) & 0b11111L;
+            output[outputOffset + 7] = (v0 >>> 35) & 0b11111L;
+            output[outputOffset + 8] = (v0 >>> 40) & 0b11111L;
+            output[outputOffset + 9] = (v0 >>> 45) & 0b11111L;
+            output[outputOffset + 10] = (v0 >>> 50) & 0b11111L;
+            output[outputOffset + 11] = (v0 >>> 55) & 0b11111L;
+            output[outputOffset + 12] = ((v0 >>> 60) & 0b1111L) | ((v1 & 0b1L) << 4);
+            output[outputOffset + 13] = (v1 >>> 1) & 0b11111L;
+            output[outputOffset + 14] = (v1 >>> 6) & 0b11111L;
+            output[outputOffset + 15] = (v1 >>> 11) & 0b11111L;
+            output[outputOffset + 16] = (v1 >>> 16) & 0b11111L;
+            output[outputOffset + 17] = (v1 >>> 21) & 0b11111L;
+            output[outputOffset + 18] = (v1 >>> 26) & 0b11111L;
+            output[outputOffset + 19] = (v1 >>> 31) & 0b11111L;
+            output[outputOffset + 20] = (v1 >>> 36) & 0b11111L;
+            output[outputOffset + 21] = (v1 >>> 41) & 0b11111L;
+            output[outputOffset + 22] = (v1 >>> 46) & 0b11111L;
+            output[outputOffset + 23] = (v1 >>> 51) & 0b11111L;
+            output[outputOffset + 24] = (v1 >>> 56) & 0b11111L;
+            output[outputOffset + 25] = ((v1 >>> 61) & 0b111L) | ((v2 & 0b11L) << 3);
+            output[outputOffset + 26] = (v2 >>> 2) & 0b11111L;
+            output[outputOffset + 27] = (v2 >>> 7) & 0b11111L;
+            output[outputOffset + 28] = (v2 >>> 12) & 0b11111L;
+            output[outputOffset + 29] = (v2 >>> 17) & 0b11111L;
+            output[outputOffset + 30] = (v2 >>> 22) & 0b11111L;
+            output[outputOffset + 31] = (v2 >>> 27) & 0b11111L;
+        }
+    }
+
+    private static final class Unpacker6
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            output[outputOffset] = v0 & 0b111111L;
+            output[outputOffset + 1] = (v0 >>> 6) & 0b111111L;
+            output[outputOffset + 2] = (v0 >>> 12) & 0b111111L;
+            output[outputOffset + 3] = (v0 >>> 18) & 0b111111L;
+            output[outputOffset + 4] = (v0 >>> 24) & 0b111111L;
+            output[outputOffset + 5] = (v0 >>> 30) & 0b111111L;
+            output[outputOffset + 6] = (v0 >>> 36) & 0b111111L;
+            output[outputOffset + 7] = (v0 >>> 42) & 0b111111L;
+            output[outputOffset + 8] = (v0 >>> 48) & 0b111111L;
+            output[outputOffset + 9] = (v0 >>> 54) & 0b111111L;
+            output[outputOffset + 10] = ((v0 >>> 60) & 0b1111L) | ((v1 & 0b11L) << 4);
+            output[outputOffset + 11] = (v1 >>> 2) & 0b111111L;
+            output[outputOffset + 12] = (v1 >>> 8) & 0b111111L;
+            output[outputOffset + 13] = (v1 >>> 14) & 0b111111L;
+            output[outputOffset + 14] = (v1 >>> 20) & 0b111111L;
+            output[outputOffset + 15] = (v1 >>> 26) & 0b111111L;
+            output[outputOffset + 16] = (v1 >>> 32) & 0b111111L;
+            output[outputOffset + 17] = (v1 >>> 38) & 0b111111L;
+            output[outputOffset + 18] = (v1 >>> 44) & 0b111111L;
+            output[outputOffset + 19] = (v1 >>> 50) & 0b111111L;
+            output[outputOffset + 20] = (v1 >>> 56) & 0b111111L;
+            output[outputOffset + 21] = ((v1 >>> 62) & 0b11L) | ((v2 & 0b1111L) << 2);
+            output[outputOffset + 22] = (v2 >>> 4) & 0b111111L;
+            output[outputOffset + 23] = (v2 >>> 10) & 0b111111L;
+            output[outputOffset + 24] = (v2 >>> 16) & 0b111111L;
+            output[outputOffset + 25] = (v2 >>> 22) & 0b111111L;
+            output[outputOffset + 26] = (v2 >>> 28) & 0b111111L;
+            output[outputOffset + 27] = (v2 >>> 34) & 0b111111L;
+            output[outputOffset + 28] = (v2 >>> 40) & 0b111111L;
+            output[outputOffset + 29] = (v2 >>> 46) & 0b111111L;
+            output[outputOffset + 30] = (v2 >>> 52) & 0b111111L;
+            output[outputOffset + 31] = (v2 >>> 58) & 0b111111L;
+        }
+    }
+
+    private static final class Unpacker7
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            int v3 = input.readInt();
+            output[outputOffset] = v0 & 0b1111111L;
+            output[outputOffset + 1] = (v0 >>> 7) & 0b1111111L;
+            output[outputOffset + 2] = (v0 >>> 14) & 0b1111111L;
+            output[outputOffset + 3] = (v0 >>> 21) & 0b1111111L;
+            output[outputOffset + 4] = (v0 >>> 28) & 0b1111111L;
+            output[outputOffset + 5] = (v0 >>> 35) & 0b1111111L;
+            output[outputOffset + 6] = (v0 >>> 42) & 0b1111111L;
+            output[outputOffset + 7] = (v0 >>> 49) & 0b1111111L;
+            output[outputOffset + 8] = (v0 >>> 56) & 0b1111111L;
+            output[outputOffset + 9] = ((v0 >>> 63) & 0b1L) | ((v1 & 0b111111L) << 1);
+            output[outputOffset + 10] = (v1 >>> 6) & 0b1111111L;
+            output[outputOffset + 11] = (v1 >>> 13) & 0b1111111L;
+            output[outputOffset + 12] = (v1 >>> 20) & 0b1111111L;
+            output[outputOffset + 13] = (v1 >>> 27) & 0b1111111L;
+            output[outputOffset + 14] = (v1 >>> 34) & 0b1111111L;
+            output[outputOffset + 15] = (v1 >>> 41) & 0b1111111L;
+            output[outputOffset + 16] = (v1 >>> 48) & 0b1111111L;
+            output[outputOffset + 17] = (v1 >>> 55) & 0b1111111L;
+            output[outputOffset + 18] = ((v1 >>> 62) & 0b11L) | ((v2 & 0b11111L) << 2);
+            output[outputOffset + 19] = (v2 >>> 5) & 0b1111111L;
+            output[outputOffset + 20] = (v2 >>> 12) & 0b1111111L;
+            output[outputOffset + 21] = (v2 >>> 19) & 0b1111111L;
+            output[outputOffset + 22] = (v2 >>> 26) & 0b1111111L;
+            output[outputOffset + 23] = (v2 >>> 33) & 0b1111111L;
+            output[outputOffset + 24] = (v2 >>> 40) & 0b1111111L;
+            output[outputOffset + 25] = (v2 >>> 47) & 0b1111111L;
+            output[outputOffset + 26] = (v2 >>> 54) & 0b1111111L;
+            output[outputOffset + 27] = ((v2 >>> 61) & 0b111L) | ((v3 & 0b1111L) << 3);
+            output[outputOffset + 28] = (v3 >>> 4) & 0b1111111L;
+            output[outputOffset + 29] = (v3 >>> 11) & 0b1111111L;
+            output[outputOffset + 30] = (v3 >>> 18) & 0b1111111L;
+            output[outputOffset + 31] = (v3 >>> 25) & 0b1111111L;
+        }
+    }
+
+    private static final class Unpacker8
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            output[outputOffset] = v0 & 0b11111111L;
+            output[outputOffset + 1] = (v0 >>> 8) & 0b11111111L;
+            output[outputOffset + 2] = (v0 >>> 16) & 0b11111111L;
+            output[outputOffset + 3] = (v0 >>> 24) & 0b11111111L;
+            output[outputOffset + 4] = (v0 >>> 32) & 0b11111111L;
+            output[outputOffset + 5] = (v0 >>> 40) & 0b11111111L;
+            output[outputOffset + 6] = (v0 >>> 48) & 0b11111111L;
+            output[outputOffset + 7] = (v0 >>> 56) & 0b11111111L;
+            output[outputOffset + 8] = v1 & 0b11111111L;
+            output[outputOffset + 9] = (v1 >>> 8) & 0b11111111L;
+            output[outputOffset + 10] = (v1 >>> 16) & 0b11111111L;
+            output[outputOffset + 11] = (v1 >>> 24) & 0b11111111L;
+            output[outputOffset + 12] = (v1 >>> 32) & 0b11111111L;
+            output[outputOffset + 13] = (v1 >>> 40) & 0b11111111L;
+            output[outputOffset + 14] = (v1 >>> 48) & 0b11111111L;
+            output[outputOffset + 15] = (v1 >>> 56) & 0b11111111L;
+            output[outputOffset + 16] = v2 & 0b11111111L;
+            output[outputOffset + 17] = (v2 >>> 8) & 0b11111111L;
+            output[outputOffset + 18] = (v2 >>> 16) & 0b11111111L;
+            output[outputOffset + 19] = (v2 >>> 24) & 0b11111111L;
+            output[outputOffset + 20] = (v2 >>> 32) & 0b11111111L;
+            output[outputOffset + 21] = (v2 >>> 40) & 0b11111111L;
+            output[outputOffset + 22] = (v2 >>> 48) & 0b11111111L;
+            output[outputOffset + 23] = (v2 >>> 56) & 0b11111111L;
+            output[outputOffset + 24] = v3 & 0b11111111L;
+            output[outputOffset + 25] = (v3 >>> 8) & 0b11111111L;
+            output[outputOffset + 26] = (v3 >>> 16) & 0b11111111L;
+            output[outputOffset + 27] = (v3 >>> 24) & 0b11111111L;
+            output[outputOffset + 28] = (v3 >>> 32) & 0b11111111L;
+            output[outputOffset + 29] = (v3 >>> 40) & 0b11111111L;
+            output[outputOffset + 30] = (v3 >>> 48) & 0b11111111L;
+            output[outputOffset + 31] = (v3 >>> 56) & 0b11111111L;
+        }
+    }
+
+    private static final class Unpacker9
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            int v4 = input.readInt();
+            output[outputOffset] = v0 & 0b111111111L;
+            output[outputOffset + 1] = (v0 >>> 9) & 0b111111111L;
+            output[outputOffset + 2] = (v0 >>> 18) & 0b111111111L;
+            output[outputOffset + 3] = (v0 >>> 27) & 0b111111111L;
+            output[outputOffset + 4] = (v0 >>> 36) & 0b111111111L;
+            output[outputOffset + 5] = (v0 >>> 45) & 0b111111111L;
+            output[outputOffset + 6] = (v0 >>> 54) & 0b111111111L;
+            output[outputOffset + 7] = ((v0 >>> 63) & 0b1L) | ((v1 & 0b11111111L) << 1);
+            output[outputOffset + 8] = (v1 >>> 8) & 0b111111111L;
+            output[outputOffset + 9] = (v1 >>> 17) & 0b111111111L;
+            output[outputOffset + 10] = (v1 >>> 26) & 0b111111111L;
+            output[outputOffset + 11] = (v1 >>> 35) & 0b111111111L;
+            output[outputOffset + 12] = (v1 >>> 44) & 0b111111111L;
+            output[outputOffset + 13] = (v1 >>> 53) & 0b111111111L;
+            output[outputOffset + 14] = ((v1 >>> 62) & 0b11L) | ((v2 & 0b1111111L) << 2);
+            output[outputOffset + 15] = (v2 >>> 7) & 0b111111111L;
+            output[outputOffset + 16] = (v2 >>> 16) & 0b111111111L;
+            output[outputOffset + 17] = (v2 >>> 25) & 0b111111111L;
+            output[outputOffset + 18] = (v2 >>> 34) & 0b111111111L;
+            output[outputOffset + 19] = (v2 >>> 43) & 0b111111111L;
+            output[outputOffset + 20] = (v2 >>> 52) & 0b111111111L;
+            output[outputOffset + 21] = ((v2 >>> 61) & 0b111L) | ((v3 & 0b111111L) << 3);
+            output[outputOffset + 22] = (v3 >>> 6) & 0b111111111L;
+            output[outputOffset + 23] = (v3 >>> 15) & 0b111111111L;
+            output[outputOffset + 24] = (v3 >>> 24) & 0b111111111L;
+            output[outputOffset + 25] = (v3 >>> 33) & 0b111111111L;
+            output[outputOffset + 26] = (v3 >>> 42) & 0b111111111L;
+            output[outputOffset + 27] = (v3 >>> 51) & 0b111111111L;
+            output[outputOffset + 28] = ((v3 >>> 60) & 0b1111L) | ((v4 & 0b11111L) << 4);
+            output[outputOffset + 29] = (v4 >>> 5) & 0b111111111L;
+            output[outputOffset + 30] = (v4 >>> 14) & 0b111111111L;
+            output[outputOffset + 31] = (v4 >>> 23) & 0b111111111L;
+        }
+    }
+
+    private static final class Unpacker10
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            output[outputOffset] = v0 & 0b1111111111L;
+            output[outputOffset + 1] = (v0 >>> 10) & 0b1111111111L;
+            output[outputOffset + 2] = (v0 >>> 20) & 0b1111111111L;
+            output[outputOffset + 3] = (v0 >>> 30) & 0b1111111111L;
+            output[outputOffset + 4] = (v0 >>> 40) & 0b1111111111L;
+            output[outputOffset + 5] = (v0 >>> 50) & 0b1111111111L;
+            output[outputOffset + 6] = ((v0 >>> 60) & 0b1111L) | ((v1 & 0b111111L) << 4);
+            output[outputOffset + 7] = (v1 >>> 6) & 0b1111111111L;
+            output[outputOffset + 8] = (v1 >>> 16) & 0b1111111111L;
+            output[outputOffset + 9] = (v1 >>> 26) & 0b1111111111L;
+            output[outputOffset + 10] = (v1 >>> 36) & 0b1111111111L;
+            output[outputOffset + 11] = (v1 >>> 46) & 0b1111111111L;
+            output[outputOffset + 12] = ((v1 >>> 56) & 0b11111111L) | ((v2 & 0b11L) << 8);
+            output[outputOffset + 13] = (v2 >>> 2) & 0b1111111111L;
+            output[outputOffset + 14] = (v2 >>> 12) & 0b1111111111L;
+            output[outputOffset + 15] = (v2 >>> 22) & 0b1111111111L;
+            output[outputOffset + 16] = (v2 >>> 32) & 0b1111111111L;
+            output[outputOffset + 17] = (v2 >>> 42) & 0b1111111111L;
+            output[outputOffset + 18] = (v2 >>> 52) & 0b1111111111L;
+            output[outputOffset + 19] = ((v2 >>> 62) & 0b11L) | ((v3 & 0b11111111L) << 2);
+            output[outputOffset + 20] = (v3 >>> 8) & 0b1111111111L;
+            output[outputOffset + 21] = (v3 >>> 18) & 0b1111111111L;
+            output[outputOffset + 22] = (v3 >>> 28) & 0b1111111111L;
+            output[outputOffset + 23] = (v3 >>> 38) & 0b1111111111L;
+            output[outputOffset + 24] = (v3 >>> 48) & 0b1111111111L;
+            output[outputOffset + 25] = ((v3 >>> 58) & 0b111111L) | ((v4 & 0b1111L) << 6);
+            output[outputOffset + 26] = (v4 >>> 4) & 0b1111111111L;
+            output[outputOffset + 27] = (v4 >>> 14) & 0b1111111111L;
+            output[outputOffset + 28] = (v4 >>> 24) & 0b1111111111L;
+            output[outputOffset + 29] = (v4 >>> 34) & 0b1111111111L;
+            output[outputOffset + 30] = (v4 >>> 44) & 0b1111111111L;
+            output[outputOffset + 31] = (v4 >>> 54) & 0b1111111111L;
+        }
+    }
+
+    private static final class Unpacker11
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            int v5 = input.readInt();
+            output[outputOffset] = v0 & 0b11111111111L;
+            output[outputOffset + 1] = (v0 >>> 11) & 0b11111111111L;
+            output[outputOffset + 2] = (v0 >>> 22) & 0b11111111111L;
+            output[outputOffset + 3] = (v0 >>> 33) & 0b11111111111L;
+            output[outputOffset + 4] = (v0 >>> 44) & 0b11111111111L;
+            output[outputOffset + 5] = ((v0 >>> 55) & 0b111111111L) | ((v1 & 0b11L) << 9);
+            output[outputOffset + 6] = (v1 >>> 2) & 0b11111111111L;
+            output[outputOffset + 7] = (v1 >>> 13) & 0b11111111111L;
+            output[outputOffset + 8] = (v1 >>> 24) & 0b11111111111L;
+            output[outputOffset + 9] = (v1 >>> 35) & 0b11111111111L;
+            output[outputOffset + 10] = (v1 >>> 46) & 0b11111111111L;
+            output[outputOffset + 11] = ((v1 >>> 57) & 0b1111111L) | ((v2 & 0b1111L) << 7);
+            output[outputOffset + 12] = (v2 >>> 4) & 0b11111111111L;
+            output[outputOffset + 13] = (v2 >>> 15) & 0b11111111111L;
+            output[outputOffset + 14] = (v2 >>> 26) & 0b11111111111L;
+            output[outputOffset + 15] = (v2 >>> 37) & 0b11111111111L;
+            output[outputOffset + 16] = (v2 >>> 48) & 0b11111111111L;
+            output[outputOffset + 17] = ((v2 >>> 59) & 0b11111L) | ((v3 & 0b111111L) << 5);
+            output[outputOffset + 18] = (v3 >>> 6) & 0b11111111111L;
+            output[outputOffset + 19] = (v3 >>> 17) & 0b11111111111L;
+            output[outputOffset + 20] = (v3 >>> 28) & 0b11111111111L;
+            output[outputOffset + 21] = (v3 >>> 39) & 0b11111111111L;
+            output[outputOffset + 22] = (v3 >>> 50) & 0b11111111111L;
+            output[outputOffset + 23] = ((v3 >>> 61) & 0b111L) | ((v4 & 0b11111111L) << 3);
+            output[outputOffset + 24] = (v4 >>> 8) & 0b11111111111L;
+            output[outputOffset + 25] = (v4 >>> 19) & 0b11111111111L;
+            output[outputOffset + 26] = (v4 >>> 30) & 0b11111111111L;
+            output[outputOffset + 27] = (v4 >>> 41) & 0b11111111111L;
+            output[outputOffset + 28] = (v4 >>> 52) & 0b11111111111L;
+            output[outputOffset + 29] = ((v4 >>> 63) & 0b1L) | ((v5 & 0b1111111111L) << 1);
+            output[outputOffset + 30] = (v5 >>> 10) & 0b11111111111L;
+            output[outputOffset + 31] = (v5 >>> 21) & 0b11111111111L;
+        }
+    }
+
+    private static final class Unpacker12
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            output[outputOffset] = v0 & 0b111111111111L;
+            output[outputOffset + 1] = (v0 >>> 12) & 0b111111111111L;
+            output[outputOffset + 2] = (v0 >>> 24) & 0b111111111111L;
+            output[outputOffset + 3] = (v0 >>> 36) & 0b111111111111L;
+            output[outputOffset + 4] = (v0 >>> 48) & 0b111111111111L;
+            output[outputOffset + 5] = ((v0 >>> 60) & 0b1111L) | ((v1 & 0b11111111L) << 4);
+            output[outputOffset + 6] = (v1 >>> 8) & 0b111111111111L;
+            output[outputOffset + 7] = (v1 >>> 20) & 0b111111111111L;
+            output[outputOffset + 8] = (v1 >>> 32) & 0b111111111111L;
+            output[outputOffset + 9] = (v1 >>> 44) & 0b111111111111L;
+            output[outputOffset + 10] = ((v1 >>> 56) & 0b11111111L) | ((v2 & 0b1111L) << 8);
+            output[outputOffset + 11] = (v2 >>> 4) & 0b111111111111L;
+            output[outputOffset + 12] = (v2 >>> 16) & 0b111111111111L;
+            output[outputOffset + 13] = (v2 >>> 28) & 0b111111111111L;
+            output[outputOffset + 14] = (v2 >>> 40) & 0b111111111111L;
+            output[outputOffset + 15] = (v2 >>> 52) & 0b111111111111L;
+            output[outputOffset + 16] = v3 & 0b111111111111L;
+            output[outputOffset + 17] = (v3 >>> 12) & 0b111111111111L;
+            output[outputOffset + 18] = (v3 >>> 24) & 0b111111111111L;
+            output[outputOffset + 19] = (v3 >>> 36) & 0b111111111111L;
+            output[outputOffset + 20] = (v3 >>> 48) & 0b111111111111L;
+            output[outputOffset + 21] = ((v3 >>> 60) & 0b1111L) | ((v4 & 0b11111111L) << 4);
+            output[outputOffset + 22] = (v4 >>> 8) & 0b111111111111L;
+            output[outputOffset + 23] = (v4 >>> 20) & 0b111111111111L;
+            output[outputOffset + 24] = (v4 >>> 32) & 0b111111111111L;
+            output[outputOffset + 25] = (v4 >>> 44) & 0b111111111111L;
+            output[outputOffset + 26] = ((v4 >>> 56) & 0b11111111L) | ((v5 & 0b1111L) << 8);
+            output[outputOffset + 27] = (v5 >>> 4) & 0b111111111111L;
+            output[outputOffset + 28] = (v5 >>> 16) & 0b111111111111L;
+            output[outputOffset + 29] = (v5 >>> 28) & 0b111111111111L;
+            output[outputOffset + 30] = (v5 >>> 40) & 0b111111111111L;
+            output[outputOffset + 31] = (v5 >>> 52) & 0b111111111111L;
+        }
+    }
+
+    private static final class Unpacker13
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            int v6 = input.readInt();
+            output[outputOffset] = v0 & 0b1111111111111L;
+            output[outputOffset + 1] = (v0 >>> 13) & 0b1111111111111L;
+            output[outputOffset + 2] = (v0 >>> 26) & 0b1111111111111L;
+            output[outputOffset + 3] = (v0 >>> 39) & 0b1111111111111L;
+            output[outputOffset + 4] = ((v0 >>> 52) & 0b111111111111L) | ((v1 & 0b1L) << 12);
+            output[outputOffset + 5] = (v1 >>> 1) & 0b1111111111111L;
+            output[outputOffset + 6] = (v1 >>> 14) & 0b1111111111111L;
+            output[outputOffset + 7] = (v1 >>> 27) & 0b1111111111111L;
+            output[outputOffset + 8] = (v1 >>> 40) & 0b1111111111111L;
+            output[outputOffset + 9] = ((v1 >>> 53) & 0b11111111111L) | ((v2 & 0b11L) << 11);
+            output[outputOffset + 10] = (v2 >>> 2) & 0b1111111111111L;
+            output[outputOffset + 11] = (v2 >>> 15) & 0b1111111111111L;
+            output[outputOffset + 12] = (v2 >>> 28) & 0b1111111111111L;
+            output[outputOffset + 13] = (v2 >>> 41) & 0b1111111111111L;
+            output[outputOffset + 14] = ((v2 >>> 54) & 0b1111111111L) | ((v3 & 0b111L) << 10);
+            output[outputOffset + 15] = (v3 >>> 3) & 0b1111111111111L;
+            output[outputOffset + 16] = (v3 >>> 16) & 0b1111111111111L;
+            output[outputOffset + 17] = (v3 >>> 29) & 0b1111111111111L;
+            output[outputOffset + 18] = (v3 >>> 42) & 0b1111111111111L;
+            output[outputOffset + 19] = ((v3 >>> 55) & 0b111111111L) | ((v4 & 0b1111L) << 9);
+            output[outputOffset + 20] = (v4 >>> 4) & 0b1111111111111L;
+            output[outputOffset + 21] = (v4 >>> 17) & 0b1111111111111L;
+            output[outputOffset + 22] = (v4 >>> 30) & 0b1111111111111L;
+            output[outputOffset + 23] = (v4 >>> 43) & 0b1111111111111L;
+            output[outputOffset + 24] = ((v4 >>> 56) & 0b11111111L) | ((v5 & 0b11111L) << 8);
+            output[outputOffset + 25] = (v5 >>> 5) & 0b1111111111111L;
+            output[outputOffset + 26] = (v5 >>> 18) & 0b1111111111111L;
+            output[outputOffset + 27] = (v5 >>> 31) & 0b1111111111111L;
+            output[outputOffset + 28] = (v5 >>> 44) & 0b1111111111111L;
+            output[outputOffset + 29] = ((v5 >>> 57) & 0b1111111L) | ((v6 & 0b111111L) << 7);
+            output[outputOffset + 30] = (v6 >>> 6) & 0b1111111111111L;
+            output[outputOffset + 31] = (v6 >>> 19) & 0b1111111111111L;
+        }
+    }
+
+    private static final class Unpacker14
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            output[outputOffset] = v0 & 0b11111111111111L;
+            output[outputOffset + 1] = (v0 >>> 14) & 0b11111111111111L;
+            output[outputOffset + 2] = (v0 >>> 28) & 0b11111111111111L;
+            output[outputOffset + 3] = (v0 >>> 42) & 0b11111111111111L;
+            output[outputOffset + 4] = ((v0 >>> 56) & 0b11111111L) | ((v1 & 0b111111L) << 8);
+            output[outputOffset + 5] = (v1 >>> 6) & 0b11111111111111L;
+            output[outputOffset + 6] = (v1 >>> 20) & 0b11111111111111L;
+            output[outputOffset + 7] = (v1 >>> 34) & 0b11111111111111L;
+            output[outputOffset + 8] = (v1 >>> 48) & 0b11111111111111L;
+            output[outputOffset + 9] = ((v1 >>> 62) & 0b11L) | ((v2 & 0b111111111111L) << 2);
+            output[outputOffset + 10] = (v2 >>> 12) & 0b11111111111111L;
+            output[outputOffset + 11] = (v2 >>> 26) & 0b11111111111111L;
+            output[outputOffset + 12] = (v2 >>> 40) & 0b11111111111111L;
+            output[outputOffset + 13] = ((v2 >>> 54) & 0b1111111111L) | ((v3 & 0b1111L) << 10);
+            output[outputOffset + 14] = (v3 >>> 4) & 0b11111111111111L;
+            output[outputOffset + 15] = (v3 >>> 18) & 0b11111111111111L;
+            output[outputOffset + 16] = (v3 >>> 32) & 0b11111111111111L;
+            output[outputOffset + 17] = (v3 >>> 46) & 0b11111111111111L;
+            output[outputOffset + 18] = ((v3 >>> 60) & 0b1111L) | ((v4 & 0b1111111111L) << 4);
+            output[outputOffset + 19] = (v4 >>> 10) & 0b11111111111111L;
+            output[outputOffset + 20] = (v4 >>> 24) & 0b11111111111111L;
+            output[outputOffset + 21] = (v4 >>> 38) & 0b11111111111111L;
+            output[outputOffset + 22] = ((v4 >>> 52) & 0b111111111111L) | ((v5 & 0b11L) << 12);
+            output[outputOffset + 23] = (v5 >>> 2) & 0b11111111111111L;
+            output[outputOffset + 24] = (v5 >>> 16) & 0b11111111111111L;
+            output[outputOffset + 25] = (v5 >>> 30) & 0b11111111111111L;
+            output[outputOffset + 26] = (v5 >>> 44) & 0b11111111111111L;
+            output[outputOffset + 27] = ((v5 >>> 58) & 0b111111L) | ((v6 & 0b11111111L) << 6);
+            output[outputOffset + 28] = (v6 >>> 8) & 0b11111111111111L;
+            output[outputOffset + 29] = (v6 >>> 22) & 0b11111111111111L;
+            output[outputOffset + 30] = (v6 >>> 36) & 0b11111111111111L;
+            output[outputOffset + 31] = (v6 >>> 50) & 0b11111111111111L;
+        }
+    }
+
+    private static final class Unpacker15
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            int v7 = input.readInt();
+            output[outputOffset] = v0 & 0b111111111111111L;
+            output[outputOffset + 1] = (v0 >>> 15) & 0b111111111111111L;
+            output[outputOffset + 2] = (v0 >>> 30) & 0b111111111111111L;
+            output[outputOffset + 3] = (v0 >>> 45) & 0b111111111111111L;
+            output[outputOffset + 4] = ((v0 >>> 60) & 0b1111L) | ((v1 & 0b11111111111L) << 4);
+            output[outputOffset + 5] = (v1 >>> 11) & 0b111111111111111L;
+            output[outputOffset + 6] = (v1 >>> 26) & 0b111111111111111L;
+            output[outputOffset + 7] = (v1 >>> 41) & 0b111111111111111L;
+            output[outputOffset + 8] = ((v1 >>> 56) & 0b11111111L) | ((v2 & 0b1111111L) << 8);
+            output[outputOffset + 9] = (v2 >>> 7) & 0b111111111111111L;
+            output[outputOffset + 10] = (v2 >>> 22) & 0b111111111111111L;
+            output[outputOffset + 11] = (v2 >>> 37) & 0b111111111111111L;
+            output[outputOffset + 12] = ((v2 >>> 52) & 0b111111111111L) | ((v3 & 0b111L) << 12);
+            output[outputOffset + 13] = (v3 >>> 3) & 0b111111111111111L;
+            output[outputOffset + 14] = (v3 >>> 18) & 0b111111111111111L;
+            output[outputOffset + 15] = (v3 >>> 33) & 0b111111111111111L;
+            output[outputOffset + 16] = (v3 >>> 48) & 0b111111111111111L;
+            output[outputOffset + 17] = ((v3 >>> 63) & 0b1L) | ((v4 & 0b11111111111111L) << 1);
+            output[outputOffset + 18] = (v4 >>> 14) & 0b111111111111111L;
+            output[outputOffset + 19] = (v4 >>> 29) & 0b111111111111111L;
+            output[outputOffset + 20] = (v4 >>> 44) & 0b111111111111111L;
+            output[outputOffset + 21] = ((v4 >>> 59) & 0b11111L) | ((v5 & 0b1111111111L) << 5);
+            output[outputOffset + 22] = (v5 >>> 10) & 0b111111111111111L;
+            output[outputOffset + 23] = (v5 >>> 25) & 0b111111111111111L;
+            output[outputOffset + 24] = (v5 >>> 40) & 0b111111111111111L;
+            output[outputOffset + 25] = ((v5 >>> 55) & 0b111111111L) | ((v6 & 0b111111L) << 9);
+            output[outputOffset + 26] = (v6 >>> 6) & 0b111111111111111L;
+            output[outputOffset + 27] = (v6 >>> 21) & 0b111111111111111L;
+            output[outputOffset + 28] = (v6 >>> 36) & 0b111111111111111L;
+            output[outputOffset + 29] = ((v6 >>> 51) & 0b1111111111111L) | ((v7 & 0b11L) << 13);
+            output[outputOffset + 30] = (v7 >>> 2) & 0b111111111111111L;
+            output[outputOffset + 31] = (v7 >>> 17) & 0b111111111111111L;
+        }
+    }
+
+    private static final class Unpacker16
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            output[outputOffset] = v0 & 0b1111111111111111L;
+            output[outputOffset + 1] = (v0 >>> 16) & 0b1111111111111111L;
+            output[outputOffset + 2] = (v0 >>> 32) & 0b1111111111111111L;
+            output[outputOffset + 3] = (v0 >>> 48) & 0b1111111111111111L;
+            output[outputOffset + 4] = v1 & 0b1111111111111111L;
+            output[outputOffset + 5] = (v1 >>> 16) & 0b1111111111111111L;
+            output[outputOffset + 6] = (v1 >>> 32) & 0b1111111111111111L;
+            output[outputOffset + 7] = (v1 >>> 48) & 0b1111111111111111L;
+            output[outputOffset + 8] = v2 & 0b1111111111111111L;
+            output[outputOffset + 9] = (v2 >>> 16) & 0b1111111111111111L;
+            output[outputOffset + 10] = (v2 >>> 32) & 0b1111111111111111L;
+            output[outputOffset + 11] = (v2 >>> 48) & 0b1111111111111111L;
+            output[outputOffset + 12] = v3 & 0b1111111111111111L;
+            output[outputOffset + 13] = (v3 >>> 16) & 0b1111111111111111L;
+            output[outputOffset + 14] = (v3 >>> 32) & 0b1111111111111111L;
+            output[outputOffset + 15] = (v3 >>> 48) & 0b1111111111111111L;
+            output[outputOffset + 16] = v4 & 0b1111111111111111L;
+            output[outputOffset + 17] = (v4 >>> 16) & 0b1111111111111111L;
+            output[outputOffset + 18] = (v4 >>> 32) & 0b1111111111111111L;
+            output[outputOffset + 19] = (v4 >>> 48) & 0b1111111111111111L;
+            output[outputOffset + 20] = v5 & 0b1111111111111111L;
+            output[outputOffset + 21] = (v5 >>> 16) & 0b1111111111111111L;
+            output[outputOffset + 22] = (v5 >>> 32) & 0b1111111111111111L;
+            output[outputOffset + 23] = (v5 >>> 48) & 0b1111111111111111L;
+            output[outputOffset + 24] = v6 & 0b1111111111111111L;
+            output[outputOffset + 25] = (v6 >>> 16) & 0b1111111111111111L;
+            output[outputOffset + 26] = (v6 >>> 32) & 0b1111111111111111L;
+            output[outputOffset + 27] = (v6 >>> 48) & 0b1111111111111111L;
+            output[outputOffset + 28] = v7 & 0b1111111111111111L;
+            output[outputOffset + 29] = (v7 >>> 16) & 0b1111111111111111L;
+            output[outputOffset + 30] = (v7 >>> 32) & 0b1111111111111111L;
+            output[outputOffset + 31] = (v7 >>> 48) & 0b1111111111111111L;
+        }
+    }
+
+    private static final class Unpacker17
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            int v8 = input.readInt();
+            output[outputOffset] = v0 & 0b11111111111111111L;
+            output[outputOffset + 1] = (v0 >>> 17) & 0b11111111111111111L;
+            output[outputOffset + 2] = (v0 >>> 34) & 0b11111111111111111L;
+            output[outputOffset + 3] = ((v0 >>> 51) & 0b1111111111111L) | ((v1 & 0b1111L) << 13);
+            output[outputOffset + 4] = (v1 >>> 4) & 0b11111111111111111L;
+            output[outputOffset + 5] = (v1 >>> 21) & 0b11111111111111111L;
+            output[outputOffset + 6] = (v1 >>> 38) & 0b11111111111111111L;
+            output[outputOffset + 7] = ((v1 >>> 55) & 0b111111111L) | ((v2 & 0b11111111L) << 9);
+            output[outputOffset + 8] = (v2 >>> 8) & 0b11111111111111111L;
+            output[outputOffset + 9] = (v2 >>> 25) & 0b11111111111111111L;
+            output[outputOffset + 10] = (v2 >>> 42) & 0b11111111111111111L;
+            output[outputOffset + 11] = ((v2 >>> 59) & 0b11111L) | ((v3 & 0b111111111111L) << 5);
+            output[outputOffset + 12] = (v3 >>> 12) & 0b11111111111111111L;
+            output[outputOffset + 13] = (v3 >>> 29) & 0b11111111111111111L;
+            output[outputOffset + 14] = (v3 >>> 46) & 0b11111111111111111L;
+            output[outputOffset + 15] = ((v3 >>> 63) & 0b1L) | ((v4 & 0b1111111111111111L) << 1);
+            output[outputOffset + 16] = (v4 >>> 16) & 0b11111111111111111L;
+            output[outputOffset + 17] = (v4 >>> 33) & 0b11111111111111111L;
+            output[outputOffset + 18] = ((v4 >>> 50) & 0b11111111111111L) | ((v5 & 0b111L) << 14);
+            output[outputOffset + 19] = (v5 >>> 3) & 0b11111111111111111L;
+            output[outputOffset + 20] = (v5 >>> 20) & 0b11111111111111111L;
+            output[outputOffset + 21] = (v5 >>> 37) & 0b11111111111111111L;
+            output[outputOffset + 22] = ((v5 >>> 54) & 0b1111111111L) | ((v6 & 0b1111111L) << 10);
+            output[outputOffset + 23] = (v6 >>> 7) & 0b11111111111111111L;
+            output[outputOffset + 24] = (v6 >>> 24) & 0b11111111111111111L;
+            output[outputOffset + 25] = (v6 >>> 41) & 0b11111111111111111L;
+            output[outputOffset + 26] = ((v6 >>> 58) & 0b111111L) | ((v7 & 0b11111111111L) << 6);
+            output[outputOffset + 27] = (v7 >>> 11) & 0b11111111111111111L;
+            output[outputOffset + 28] = (v7 >>> 28) & 0b11111111111111111L;
+            output[outputOffset + 29] = (v7 >>> 45) & 0b11111111111111111L;
+            output[outputOffset + 30] = ((v7 >>> 62) & 0b11L) | ((v8 & 0b111111111111111L) << 2);
+            output[outputOffset + 31] = (v8 >>> 15) & 0b11111111111111111L;
+        }
+    }
+
+    private static final class Unpacker18
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            output[outputOffset] = v0 & 0b111111111111111111L;
+            output[outputOffset + 1] = (v0 >>> 18) & 0b111111111111111111L;
+            output[outputOffset + 2] = (v0 >>> 36) & 0b111111111111111111L;
+            output[outputOffset + 3] = ((v0 >>> 54) & 0b1111111111L) | ((v1 & 0b11111111L) << 10);
+            output[outputOffset + 4] = (v1 >>> 8) & 0b111111111111111111L;
+            output[outputOffset + 5] = (v1 >>> 26) & 0b111111111111111111L;
+            output[outputOffset + 6] = (v1 >>> 44) & 0b111111111111111111L;
+            output[outputOffset + 7] = ((v1 >>> 62) & 0b11L) | ((v2 & 0b1111111111111111L) << 2);
+            output[outputOffset + 8] = (v2 >>> 16) & 0b111111111111111111L;
+            output[outputOffset + 9] = (v2 >>> 34) & 0b111111111111111111L;
+            output[outputOffset + 10] = ((v2 >>> 52) & 0b111111111111L) | ((v3 & 0b111111L) << 12);
+            output[outputOffset + 11] = (v3 >>> 6) & 0b111111111111111111L;
+            output[outputOffset + 12] = (v3 >>> 24) & 0b111111111111111111L;
+            output[outputOffset + 13] = (v3 >>> 42) & 0b111111111111111111L;
+            output[outputOffset + 14] = ((v3 >>> 60) & 0b1111L) | ((v4 & 0b11111111111111L) << 4);
+            output[outputOffset + 15] = (v4 >>> 14) & 0b111111111111111111L;
+            output[outputOffset + 16] = (v4 >>> 32) & 0b111111111111111111L;
+            output[outputOffset + 17] = ((v4 >>> 50) & 0b11111111111111L) | ((v5 & 0b1111L) << 14);
+            output[outputOffset + 18] = (v5 >>> 4) & 0b111111111111111111L;
+            output[outputOffset + 19] = (v5 >>> 22) & 0b111111111111111111L;
+            output[outputOffset + 20] = (v5 >>> 40) & 0b111111111111111111L;
+            output[outputOffset + 21] = ((v5 >>> 58) & 0b111111L) | ((v6 & 0b111111111111L) << 6);
+            output[outputOffset + 22] = (v6 >>> 12) & 0b111111111111111111L;
+            output[outputOffset + 23] = (v6 >>> 30) & 0b111111111111111111L;
+            output[outputOffset + 24] = ((v6 >>> 48) & 0b1111111111111111L) | ((v7 & 0b11L) << 16);
+            output[outputOffset + 25] = (v7 >>> 2) & 0b111111111111111111L;
+            output[outputOffset + 26] = (v7 >>> 20) & 0b111111111111111111L;
+            output[outputOffset + 27] = (v7 >>> 38) & 0b111111111111111111L;
+            output[outputOffset + 28] = ((v7 >>> 56) & 0b11111111L) | ((v8 & 0b1111111111L) << 8);
+            output[outputOffset + 29] = (v8 >>> 10) & 0b111111111111111111L;
+            output[outputOffset + 30] = (v8 >>> 28) & 0b111111111111111111L;
+            output[outputOffset + 31] = (v8 >>> 46) & 0b111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker19
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            int v9 = input.readInt();
+            output[outputOffset] = v0 & 0b1111111111111111111L;
+            output[outputOffset + 1] = (v0 >>> 19) & 0b1111111111111111111L;
+            output[outputOffset + 2] = (v0 >>> 38) & 0b1111111111111111111L;
+            output[outputOffset + 3] = ((v0 >>> 57) & 0b1111111L) | ((v1 & 0b111111111111L) << 7);
+            output[outputOffset + 4] = (v1 >>> 12) & 0b1111111111111111111L;
+            output[outputOffset + 5] = (v1 >>> 31) & 0b1111111111111111111L;
+            output[outputOffset + 6] = ((v1 >>> 50) & 0b11111111111111L) | ((v2 & 0b11111L) << 14);
+            output[outputOffset + 7] = (v2 >>> 5) & 0b1111111111111111111L;
+            output[outputOffset + 8] = (v2 >>> 24) & 0b1111111111111111111L;
+            output[outputOffset + 9] = (v2 >>> 43) & 0b1111111111111111111L;
+            output[outputOffset + 10] = ((v2 >>> 62) & 0b11L) | ((v3 & 0b11111111111111111L) << 2);
+            output[outputOffset + 11] = (v3 >>> 17) & 0b1111111111111111111L;
+            output[outputOffset + 12] = (v3 >>> 36) & 0b1111111111111111111L;
+            output[outputOffset + 13] = ((v3 >>> 55) & 0b111111111L) | ((v4 & 0b1111111111L) << 9);
+            output[outputOffset + 14] = (v4 >>> 10) & 0b1111111111111111111L;
+            output[outputOffset + 15] = (v4 >>> 29) & 0b1111111111111111111L;
+            output[outputOffset + 16] = ((v4 >>> 48) & 0b1111111111111111L) | ((v5 & 0b111L) << 16);
+            output[outputOffset + 17] = (v5 >>> 3) & 0b1111111111111111111L;
+            output[outputOffset + 18] = (v5 >>> 22) & 0b1111111111111111111L;
+            output[outputOffset + 19] = (v5 >>> 41) & 0b1111111111111111111L;
+            output[outputOffset + 20] = ((v5 >>> 60) & 0b1111L) | ((v6 & 0b111111111111111L) << 4);
+            output[outputOffset + 21] = (v6 >>> 15) & 0b1111111111111111111L;
+            output[outputOffset + 22] = (v6 >>> 34) & 0b1111111111111111111L;
+            output[outputOffset + 23] = ((v6 >>> 53) & 0b11111111111L) | ((v7 & 0b11111111L) << 11);
+            output[outputOffset + 24] = (v7 >>> 8) & 0b1111111111111111111L;
+            output[outputOffset + 25] = (v7 >>> 27) & 0b1111111111111111111L;
+            output[outputOffset + 26] = ((v7 >>> 46) & 0b111111111111111111L) | ((v8 & 0b1L) << 18);
+            output[outputOffset + 27] = (v8 >>> 1) & 0b1111111111111111111L;
+            output[outputOffset + 28] = (v8 >>> 20) & 0b1111111111111111111L;
+            output[outputOffset + 29] = (v8 >>> 39) & 0b1111111111111111111L;
+            output[outputOffset + 30] = ((v8 >>> 58) & 0b111111L) | ((v9 & 0b1111111111111L) << 6);
+            output[outputOffset + 31] = (v9 >>> 13) & 0b1111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker20
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            output[outputOffset] = v0 & 0b11111111111111111111L;
+            output[outputOffset + 1] = (v0 >>> 20) & 0b11111111111111111111L;
+            output[outputOffset + 2] = (v0 >>> 40) & 0b11111111111111111111L;
+            output[outputOffset + 3] = ((v0 >>> 60) & 0b1111L) | ((v1 & 0b1111111111111111L) << 4);
+            output[outputOffset + 4] = (v1 >>> 16) & 0b11111111111111111111L;
+            output[outputOffset + 5] = (v1 >>> 36) & 0b11111111111111111111L;
+            output[outputOffset + 6] = ((v1 >>> 56) & 0b11111111L) | ((v2 & 0b111111111111L) << 8);
+            output[outputOffset + 7] = (v2 >>> 12) & 0b11111111111111111111L;
+            output[outputOffset + 8] = (v2 >>> 32) & 0b11111111111111111111L;
+            output[outputOffset + 9] = ((v2 >>> 52) & 0b111111111111L) | ((v3 & 0b11111111L) << 12);
+            output[outputOffset + 10] = (v3 >>> 8) & 0b11111111111111111111L;
+            output[outputOffset + 11] = (v3 >>> 28) & 0b11111111111111111111L;
+            output[outputOffset + 12] = ((v3 >>> 48) & 0b1111111111111111L) | ((v4 & 0b1111L) << 16);
+            output[outputOffset + 13] = (v4 >>> 4) & 0b11111111111111111111L;
+            output[outputOffset + 14] = (v4 >>> 24) & 0b11111111111111111111L;
+            output[outputOffset + 15] = (v4 >>> 44) & 0b11111111111111111111L;
+            output[outputOffset + 16] = v5 & 0b11111111111111111111L;
+            output[outputOffset + 17] = (v5 >>> 20) & 0b11111111111111111111L;
+            output[outputOffset + 18] = (v5 >>> 40) & 0b11111111111111111111L;
+            output[outputOffset + 19] = ((v5 >>> 60) & 0b1111L) | ((v6 & 0b1111111111111111L) << 4);
+            output[outputOffset + 20] = (v6 >>> 16) & 0b11111111111111111111L;
+            output[outputOffset + 21] = (v6 >>> 36) & 0b11111111111111111111L;
+            output[outputOffset + 22] = ((v6 >>> 56) & 0b11111111L) | ((v7 & 0b111111111111L) << 8);
+            output[outputOffset + 23] = (v7 >>> 12) & 0b11111111111111111111L;
+            output[outputOffset + 24] = (v7 >>> 32) & 0b11111111111111111111L;
+            output[outputOffset + 25] = ((v7 >>> 52) & 0b111111111111L) | ((v8 & 0b11111111L) << 12);
+            output[outputOffset + 26] = (v8 >>> 8) & 0b11111111111111111111L;
+            output[outputOffset + 27] = (v8 >>> 28) & 0b11111111111111111111L;
+            output[outputOffset + 28] = ((v8 >>> 48) & 0b1111111111111111L) | ((v9 & 0b1111L) << 16);
+            output[outputOffset + 29] = (v9 >>> 4) & 0b11111111111111111111L;
+            output[outputOffset + 30] = (v9 >>> 24) & 0b11111111111111111111L;
+            output[outputOffset + 31] = (v9 >>> 44) & 0b11111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker21
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            int v10 = input.readInt();
+            output[outputOffset] = v0 & 0b111111111111111111111L;
+            output[outputOffset + 1] = (v0 >>> 21) & 0b111111111111111111111L;
+            output[outputOffset + 2] = (v0 >>> 42) & 0b111111111111111111111L;
+            output[outputOffset + 3] = ((v0 >>> 63) & 0b1L) | ((v1 & 0b11111111111111111111L) << 1);
+            output[outputOffset + 4] = (v1 >>> 20) & 0b111111111111111111111L;
+            output[outputOffset + 5] = (v1 >>> 41) & 0b111111111111111111111L;
+            output[outputOffset + 6] = ((v1 >>> 62) & 0b11L) | ((v2 & 0b1111111111111111111L) << 2);
+            output[outputOffset + 7] = (v2 >>> 19) & 0b111111111111111111111L;
+            output[outputOffset + 8] = (v2 >>> 40) & 0b111111111111111111111L;
+            output[outputOffset + 9] = ((v2 >>> 61) & 0b111L) | ((v3 & 0b111111111111111111L) << 3);
+            output[outputOffset + 10] = (v3 >>> 18) & 0b111111111111111111111L;
+            output[outputOffset + 11] = (v3 >>> 39) & 0b111111111111111111111L;
+            output[outputOffset + 12] = ((v3 >>> 60) & 0b1111L) | ((v4 & 0b11111111111111111L) << 4);
+            output[outputOffset + 13] = (v4 >>> 17) & 0b111111111111111111111L;
+            output[outputOffset + 14] = (v4 >>> 38) & 0b111111111111111111111L;
+            output[outputOffset + 15] = ((v4 >>> 59) & 0b11111L) | ((v5 & 0b1111111111111111L) << 5);
+            output[outputOffset + 16] = (v5 >>> 16) & 0b111111111111111111111L;
+            output[outputOffset + 17] = (v5 >>> 37) & 0b111111111111111111111L;
+            output[outputOffset + 18] = ((v5 >>> 58) & 0b111111L) | ((v6 & 0b111111111111111L) << 6);
+            output[outputOffset + 19] = (v6 >>> 15) & 0b111111111111111111111L;
+            output[outputOffset + 20] = (v6 >>> 36) & 0b111111111111111111111L;
+            output[outputOffset + 21] = ((v6 >>> 57) & 0b1111111L) | ((v7 & 0b11111111111111L) << 7);
+            output[outputOffset + 22] = (v7 >>> 14) & 0b111111111111111111111L;
+            output[outputOffset + 23] = (v7 >>> 35) & 0b111111111111111111111L;
+            output[outputOffset + 24] = ((v7 >>> 56) & 0b11111111L) | ((v8 & 0b1111111111111L) << 8);
+            output[outputOffset + 25] = (v8 >>> 13) & 0b111111111111111111111L;
+            output[outputOffset + 26] = (v8 >>> 34) & 0b111111111111111111111L;
+            output[outputOffset + 27] = ((v8 >>> 55) & 0b111111111L) | ((v9 & 0b111111111111L) << 9);
+            output[outputOffset + 28] = (v9 >>> 12) & 0b111111111111111111111L;
+            output[outputOffset + 29] = (v9 >>> 33) & 0b111111111111111111111L;
+            output[outputOffset + 30] = ((v9 >>> 54) & 0b1111111111L) | ((v10 & 0b11111111111L) << 10);
+            output[outputOffset + 31] = (v10 >>> 11) & 0b111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker22
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            output[outputOffset] = v0 & 0b1111111111111111111111L;
+            output[outputOffset + 1] = (v0 >>> 22) & 0b1111111111111111111111L;
+            output[outputOffset + 2] = ((v0 >>> 44) & 0b11111111111111111111L) | ((v1 & 0b11L) << 20);
+            output[outputOffset + 3] = (v1 >>> 2) & 0b1111111111111111111111L;
+            output[outputOffset + 4] = (v1 >>> 24) & 0b1111111111111111111111L;
+            output[outputOffset + 5] = ((v1 >>> 46) & 0b111111111111111111L) | ((v2 & 0b1111L) << 18);
+            output[outputOffset + 6] = (v2 >>> 4) & 0b1111111111111111111111L;
+            output[outputOffset + 7] = (v2 >>> 26) & 0b1111111111111111111111L;
+            output[outputOffset + 8] = ((v2 >>> 48) & 0b1111111111111111L) | ((v3 & 0b111111L) << 16);
+            output[outputOffset + 9] = (v3 >>> 6) & 0b1111111111111111111111L;
+            output[outputOffset + 10] = (v3 >>> 28) & 0b1111111111111111111111L;
+            output[outputOffset + 11] = ((v3 >>> 50) & 0b11111111111111L) | ((v4 & 0b11111111L) << 14);
+            output[outputOffset + 12] = (v4 >>> 8) & 0b1111111111111111111111L;
+            output[outputOffset + 13] = (v4 >>> 30) & 0b1111111111111111111111L;
+            output[outputOffset + 14] = ((v4 >>> 52) & 0b111111111111L) | ((v5 & 0b1111111111L) << 12);
+            output[outputOffset + 15] = (v5 >>> 10) & 0b1111111111111111111111L;
+            output[outputOffset + 16] = (v5 >>> 32) & 0b1111111111111111111111L;
+            output[outputOffset + 17] = ((v5 >>> 54) & 0b1111111111L) | ((v6 & 0b111111111111L) << 10);
+            output[outputOffset + 18] = (v6 >>> 12) & 0b1111111111111111111111L;
+            output[outputOffset + 19] = (v6 >>> 34) & 0b1111111111111111111111L;
+            output[outputOffset + 20] = ((v6 >>> 56) & 0b11111111L) | ((v7 & 0b11111111111111L) << 8);
+            output[outputOffset + 21] = (v7 >>> 14) & 0b1111111111111111111111L;
+            output[outputOffset + 22] = (v7 >>> 36) & 0b1111111111111111111111L;
+            output[outputOffset + 23] = ((v7 >>> 58) & 0b111111L) | ((v8 & 0b1111111111111111L) << 6);
+            output[outputOffset + 24] = (v8 >>> 16) & 0b1111111111111111111111L;
+            output[outputOffset + 25] = (v8 >>> 38) & 0b1111111111111111111111L;
+            output[outputOffset + 26] = ((v8 >>> 60) & 0b1111L) | ((v9 & 0b111111111111111111L) << 4);
+            output[outputOffset + 27] = (v9 >>> 18) & 0b1111111111111111111111L;
+            output[outputOffset + 28] = (v9 >>> 40) & 0b1111111111111111111111L;
+            output[outputOffset + 29] = ((v9 >>> 62) & 0b11L) | ((v10 & 0b11111111111111111111L) << 2);
+            output[outputOffset + 30] = (v10 >>> 20) & 0b1111111111111111111111L;
+            output[outputOffset + 31] = (v10 >>> 42) & 0b1111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker23
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            int v11 = input.readInt();
+            output[outputOffset] = v0 & 0b11111111111111111111111L;
+            output[outputOffset + 1] = (v0 >>> 23) & 0b11111111111111111111111L;
+            output[outputOffset + 2] = ((v0 >>> 46) & 0b111111111111111111L) | ((v1 & 0b11111L) << 18);
+            output[outputOffset + 3] = (v1 >>> 5) & 0b11111111111111111111111L;
+            output[outputOffset + 4] = (v1 >>> 28) & 0b11111111111111111111111L;
+            output[outputOffset + 5] = ((v1 >>> 51) & 0b1111111111111L) | ((v2 & 0b1111111111L) << 13);
+            output[outputOffset + 6] = (v2 >>> 10) & 0b11111111111111111111111L;
+            output[outputOffset + 7] = (v2 >>> 33) & 0b11111111111111111111111L;
+            output[outputOffset + 8] = ((v2 >>> 56) & 0b11111111L) | ((v3 & 0b111111111111111L) << 8);
+            output[outputOffset + 9] = (v3 >>> 15) & 0b11111111111111111111111L;
+            output[outputOffset + 10] = (v3 >>> 38) & 0b11111111111111111111111L;
+            output[outputOffset + 11] = ((v3 >>> 61) & 0b111L) | ((v4 & 0b11111111111111111111L) << 3);
+            output[outputOffset + 12] = (v4 >>> 20) & 0b11111111111111111111111L;
+            output[outputOffset + 13] = ((v4 >>> 43) & 0b111111111111111111111L) | ((v5 & 0b11L) << 21);
+            output[outputOffset + 14] = (v5 >>> 2) & 0b11111111111111111111111L;
+            output[outputOffset + 15] = (v5 >>> 25) & 0b11111111111111111111111L;
+            output[outputOffset + 16] = ((v5 >>> 48) & 0b1111111111111111L) | ((v6 & 0b1111111L) << 16);
+            output[outputOffset + 17] = (v6 >>> 7) & 0b11111111111111111111111L;
+            output[outputOffset + 18] = (v6 >>> 30) & 0b11111111111111111111111L;
+            output[outputOffset + 19] = ((v6 >>> 53) & 0b11111111111L) | ((v7 & 0b111111111111L) << 11);
+            output[outputOffset + 20] = (v7 >>> 12) & 0b11111111111111111111111L;
+            output[outputOffset + 21] = (v7 >>> 35) & 0b11111111111111111111111L;
+            output[outputOffset + 22] = ((v7 >>> 58) & 0b111111L) | ((v8 & 0b11111111111111111L) << 6);
+            output[outputOffset + 23] = (v8 >>> 17) & 0b11111111111111111111111L;
+            output[outputOffset + 24] = (v8 >>> 40) & 0b11111111111111111111111L;
+            output[outputOffset + 25] = ((v8 >>> 63) & 0b1L) | ((v9 & 0b1111111111111111111111L) << 1);
+            output[outputOffset + 26] = (v9 >>> 22) & 0b11111111111111111111111L;
+            output[outputOffset + 27] = ((v9 >>> 45) & 0b1111111111111111111L) | ((v10 & 0b1111L) << 19);
+            output[outputOffset + 28] = (v10 >>> 4) & 0b11111111111111111111111L;
+            output[outputOffset + 29] = (v10 >>> 27) & 0b11111111111111111111111L;
+            output[outputOffset + 30] = ((v10 >>> 50) & 0b11111111111111L) | ((v11 & 0b111111111L) << 14);
+            output[outputOffset + 31] = (v11 >>> 9) & 0b11111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker24
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            output[outputOffset] = v0 & 0b111111111111111111111111L;
+            output[outputOffset + 1] = (v0 >>> 24) & 0b111111111111111111111111L;
+            output[outputOffset + 2] = ((v0 >>> 48) & 0b1111111111111111L) | ((v1 & 0b11111111L) << 16);
+            output[outputOffset + 3] = (v1 >>> 8) & 0b111111111111111111111111L;
+            output[outputOffset + 4] = (v1 >>> 32) & 0b111111111111111111111111L;
+            output[outputOffset + 5] = ((v1 >>> 56) & 0b11111111L) | ((v2 & 0b1111111111111111L) << 8);
+            output[outputOffset + 6] = (v2 >>> 16) & 0b111111111111111111111111L;
+            output[outputOffset + 7] = (v2 >>> 40) & 0b111111111111111111111111L;
+            output[outputOffset + 8] = v3 & 0b111111111111111111111111L;
+            output[outputOffset + 9] = (v3 >>> 24) & 0b111111111111111111111111L;
+            output[outputOffset + 10] = ((v3 >>> 48) & 0b1111111111111111L) | ((v4 & 0b11111111L) << 16);
+            output[outputOffset + 11] = (v4 >>> 8) & 0b111111111111111111111111L;
+            output[outputOffset + 12] = (v4 >>> 32) & 0b111111111111111111111111L;
+            output[outputOffset + 13] = ((v4 >>> 56) & 0b11111111L) | ((v5 & 0b1111111111111111L) << 8);
+            output[outputOffset + 14] = (v5 >>> 16) & 0b111111111111111111111111L;
+            output[outputOffset + 15] = (v5 >>> 40) & 0b111111111111111111111111L;
+            output[outputOffset + 16] = v6 & 0b111111111111111111111111L;
+            output[outputOffset + 17] = (v6 >>> 24) & 0b111111111111111111111111L;
+            output[outputOffset + 18] = ((v6 >>> 48) & 0b1111111111111111L) | ((v7 & 0b11111111L) << 16);
+            output[outputOffset + 19] = (v7 >>> 8) & 0b111111111111111111111111L;
+            output[outputOffset + 20] = (v7 >>> 32) & 0b111111111111111111111111L;
+            output[outputOffset + 21] = ((v7 >>> 56) & 0b11111111L) | ((v8 & 0b1111111111111111L) << 8);
+            output[outputOffset + 22] = (v8 >>> 16) & 0b111111111111111111111111L;
+            output[outputOffset + 23] = (v8 >>> 40) & 0b111111111111111111111111L;
+            output[outputOffset + 24] = v9 & 0b111111111111111111111111L;
+            output[outputOffset + 25] = (v9 >>> 24) & 0b111111111111111111111111L;
+            output[outputOffset + 26] = ((v9 >>> 48) & 0b1111111111111111L) | ((v10 & 0b11111111L) << 16);
+            output[outputOffset + 27] = (v10 >>> 8) & 0b111111111111111111111111L;
+            output[outputOffset + 28] = (v10 >>> 32) & 0b111111111111111111111111L;
+            output[outputOffset + 29] = ((v10 >>> 56) & 0b11111111L) | ((v11 & 0b1111111111111111L) << 8);
+            output[outputOffset + 30] = (v11 >>> 16) & 0b111111111111111111111111L;
+            output[outputOffset + 31] = (v11 >>> 40) & 0b111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker25
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            int v12 = input.readInt();
+            output[outputOffset] = v0 & 0b1111111111111111111111111L;
+            output[outputOffset + 1] = (v0 >>> 25) & 0b1111111111111111111111111L;
+            output[outputOffset + 2] = ((v0 >>> 50) & 0b11111111111111L) | ((v1 & 0b11111111111L) << 14);
+            output[outputOffset + 3] = (v1 >>> 11) & 0b1111111111111111111111111L;
+            output[outputOffset + 4] = (v1 >>> 36) & 0b1111111111111111111111111L;
+            output[outputOffset + 5] = ((v1 >>> 61) & 0b111L) | ((v2 & 0b1111111111111111111111L) << 3);
+            output[outputOffset + 6] = (v2 >>> 22) & 0b1111111111111111111111111L;
+            output[outputOffset + 7] = ((v2 >>> 47) & 0b11111111111111111L) | ((v3 & 0b11111111L) << 17);
+            output[outputOffset + 8] = (v3 >>> 8) & 0b1111111111111111111111111L;
+            output[outputOffset + 9] = (v3 >>> 33) & 0b1111111111111111111111111L;
+            output[outputOffset + 10] = ((v3 >>> 58) & 0b111111L) | ((v4 & 0b1111111111111111111L) << 6);
+            output[outputOffset + 11] = (v4 >>> 19) & 0b1111111111111111111111111L;
+            output[outputOffset + 12] = ((v4 >>> 44) & 0b11111111111111111111L) | ((v5 & 0b11111L) << 20);
+            output[outputOffset + 13] = (v5 >>> 5) & 0b1111111111111111111111111L;
+            output[outputOffset + 14] = (v5 >>> 30) & 0b1111111111111111111111111L;
+            output[outputOffset + 15] = ((v5 >>> 55) & 0b111111111L) | ((v6 & 0b1111111111111111L) << 9);
+            output[outputOffset + 16] = (v6 >>> 16) & 0b1111111111111111111111111L;
+            output[outputOffset + 17] = ((v6 >>> 41) & 0b11111111111111111111111L) | ((v7 & 0b11L) << 23);
+            output[outputOffset + 18] = (v7 >>> 2) & 0b1111111111111111111111111L;
+            output[outputOffset + 19] = (v7 >>> 27) & 0b1111111111111111111111111L;
+            output[outputOffset + 20] = ((v7 >>> 52) & 0b111111111111L) | ((v8 & 0b1111111111111L) << 12);
+            output[outputOffset + 21] = (v8 >>> 13) & 0b1111111111111111111111111L;
+            output[outputOffset + 22] = (v8 >>> 38) & 0b1111111111111111111111111L;
+            output[outputOffset + 23] = ((v8 >>> 63) & 0b1L) | ((v9 & 0b111111111111111111111111L) << 1);
+            output[outputOffset + 24] = (v9 >>> 24) & 0b1111111111111111111111111L;
+            output[outputOffset + 25] = ((v9 >>> 49) & 0b111111111111111L) | ((v10 & 0b1111111111L) << 15);
+            output[outputOffset + 26] = (v10 >>> 10) & 0b1111111111111111111111111L;
+            output[outputOffset + 27] = (v10 >>> 35) & 0b1111111111111111111111111L;
+            output[outputOffset + 28] = ((v10 >>> 60) & 0b1111L) | ((v11 & 0b111111111111111111111L) << 4);
+            output[outputOffset + 29] = (v11 >>> 21) & 0b1111111111111111111111111L;
+            output[outputOffset + 30] = ((v11 >>> 46) & 0b111111111111111111L) | ((v12 & 0b1111111L) << 18);
+            output[outputOffset + 31] = (v12 >>> 7) & 0b1111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker26
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            output[outputOffset] = v0 & 0b11111111111111111111111111L;
+            output[outputOffset + 1] = (v0 >>> 26) & 0b11111111111111111111111111L;
+            output[outputOffset + 2] = ((v0 >>> 52) & 0b111111111111L) | ((v1 & 0b11111111111111L) << 12);
+            output[outputOffset + 3] = (v1 >>> 14) & 0b11111111111111111111111111L;
+            output[outputOffset + 4] = ((v1 >>> 40) & 0b111111111111111111111111L) | ((v2 & 0b11L) << 24);
+            output[outputOffset + 5] = (v2 >>> 2) & 0b11111111111111111111111111L;
+            output[outputOffset + 6] = (v2 >>> 28) & 0b11111111111111111111111111L;
+            output[outputOffset + 7] = ((v2 >>> 54) & 0b1111111111L) | ((v3 & 0b1111111111111111L) << 10);
+            output[outputOffset + 8] = (v3 >>> 16) & 0b11111111111111111111111111L;
+            output[outputOffset + 9] = ((v3 >>> 42) & 0b1111111111111111111111L) | ((v4 & 0b1111L) << 22);
+            output[outputOffset + 10] = (v4 >>> 4) & 0b11111111111111111111111111L;
+            output[outputOffset + 11] = (v4 >>> 30) & 0b11111111111111111111111111L;
+            output[outputOffset + 12] = ((v4 >>> 56) & 0b11111111L) | ((v5 & 0b111111111111111111L) << 8);
+            output[outputOffset + 13] = (v5 >>> 18) & 0b11111111111111111111111111L;
+            output[outputOffset + 14] = ((v5 >>> 44) & 0b11111111111111111111L) | ((v6 & 0b111111L) << 20);
+            output[outputOffset + 15] = (v6 >>> 6) & 0b11111111111111111111111111L;
+            output[outputOffset + 16] = (v6 >>> 32) & 0b11111111111111111111111111L;
+            output[outputOffset + 17] = ((v6 >>> 58) & 0b111111L) | ((v7 & 0b11111111111111111111L) << 6);
+            output[outputOffset + 18] = (v7 >>> 20) & 0b11111111111111111111111111L;
+            output[outputOffset + 19] = ((v7 >>> 46) & 0b111111111111111111L) | ((v8 & 0b11111111L) << 18);
+            output[outputOffset + 20] = (v8 >>> 8) & 0b11111111111111111111111111L;
+            output[outputOffset + 21] = (v8 >>> 34) & 0b11111111111111111111111111L;
+            output[outputOffset + 22] = ((v8 >>> 60) & 0b1111L) | ((v9 & 0b1111111111111111111111L) << 4);
+            output[outputOffset + 23] = (v9 >>> 22) & 0b11111111111111111111111111L;
+            output[outputOffset + 24] = ((v9 >>> 48) & 0b1111111111111111L) | ((v10 & 0b1111111111L) << 16);
+            output[outputOffset + 25] = (v10 >>> 10) & 0b11111111111111111111111111L;
+            output[outputOffset + 26] = (v10 >>> 36) & 0b11111111111111111111111111L;
+            output[outputOffset + 27] = ((v10 >>> 62) & 0b11L) | ((v11 & 0b111111111111111111111111L) << 2);
+            output[outputOffset + 28] = (v11 >>> 24) & 0b11111111111111111111111111L;
+            output[outputOffset + 29] = ((v11 >>> 50) & 0b11111111111111L) | ((v12 & 0b111111111111L) << 14);
+            output[outputOffset + 30] = (v12 >>> 12) & 0b11111111111111111111111111L;
+            output[outputOffset + 31] = (v12 >>> 38) & 0b11111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker27
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            int v13 = input.readInt();
+            output[outputOffset] = v0 & 0b111111111111111111111111111L;
+            output[outputOffset + 1] = (v0 >>> 27) & 0b111111111111111111111111111L;
+            output[outputOffset + 2] = ((v0 >>> 54) & 0b1111111111L) | ((v1 & 0b11111111111111111L) << 10);
+            output[outputOffset + 3] = (v1 >>> 17) & 0b111111111111111111111111111L;
+            output[outputOffset + 4] = ((v1 >>> 44) & 0b11111111111111111111L) | ((v2 & 0b1111111L) << 20);
+            output[outputOffset + 5] = (v2 >>> 7) & 0b111111111111111111111111111L;
+            output[outputOffset + 6] = (v2 >>> 34) & 0b111111111111111111111111111L;
+            output[outputOffset + 7] = ((v2 >>> 61) & 0b111L) | ((v3 & 0b111111111111111111111111L) << 3);
+            output[outputOffset + 8] = (v3 >>> 24) & 0b111111111111111111111111111L;
+            output[outputOffset + 9] = ((v3 >>> 51) & 0b1111111111111L) | ((v4 & 0b11111111111111L) << 13);
+            output[outputOffset + 10] = (v4 >>> 14) & 0b111111111111111111111111111L;
+            output[outputOffset + 11] = ((v4 >>> 41) & 0b11111111111111111111111L) | ((v5 & 0b1111L) << 23);
+            output[outputOffset + 12] = (v5 >>> 4) & 0b111111111111111111111111111L;
+            output[outputOffset + 13] = (v5 >>> 31) & 0b111111111111111111111111111L;
+            output[outputOffset + 14] = ((v5 >>> 58) & 0b111111L) | ((v6 & 0b111111111111111111111L) << 6);
+            output[outputOffset + 15] = (v6 >>> 21) & 0b111111111111111111111111111L;
+            output[outputOffset + 16] = ((v6 >>> 48) & 0b1111111111111111L) | ((v7 & 0b11111111111L) << 16);
+            output[outputOffset + 17] = (v7 >>> 11) & 0b111111111111111111111111111L;
+            output[outputOffset + 18] = ((v7 >>> 38) & 0b11111111111111111111111111L) | ((v8 & 0b1L) << 26);
+            output[outputOffset + 19] = (v8 >>> 1) & 0b111111111111111111111111111L;
+            output[outputOffset + 20] = (v8 >>> 28) & 0b111111111111111111111111111L;
+            output[outputOffset + 21] = ((v8 >>> 55) & 0b111111111L) | ((v9 & 0b111111111111111111L) << 9);
+            output[outputOffset + 22] = (v9 >>> 18) & 0b111111111111111111111111111L;
+            output[outputOffset + 23] = ((v9 >>> 45) & 0b1111111111111111111L) | ((v10 & 0b11111111L) << 19);
+            output[outputOffset + 24] = (v10 >>> 8) & 0b111111111111111111111111111L;
+            output[outputOffset + 25] = (v10 >>> 35) & 0b111111111111111111111111111L;
+            output[outputOffset + 26] = ((v10 >>> 62) & 0b11L) | ((v11 & 0b1111111111111111111111111L) << 2);
+            output[outputOffset + 27] = (v11 >>> 25) & 0b111111111111111111111111111L;
+            output[outputOffset + 28] = ((v11 >>> 52) & 0b111111111111L) | ((v12 & 0b111111111111111L) << 12);
+            output[outputOffset + 29] = (v12 >>> 15) & 0b111111111111111111111111111L;
+            output[outputOffset + 30] = ((v12 >>> 42) & 0b1111111111111111111111L) | ((v13 & 0b11111L) << 22);
+            output[outputOffset + 31] = (v13 >>> 5) & 0b111111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker28
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            output[outputOffset] = v0 & 0b1111111111111111111111111111L;
+            output[outputOffset + 1] = (v0 >>> 28) & 0b1111111111111111111111111111L;
+            output[outputOffset + 2] = ((v0 >>> 56) & 0b11111111L) | ((v1 & 0b11111111111111111111L) << 8);
+            output[outputOffset + 3] = (v1 >>> 20) & 0b1111111111111111111111111111L;
+            output[outputOffset + 4] = ((v1 >>> 48) & 0b1111111111111111L) | ((v2 & 0b111111111111L) << 16);
+            output[outputOffset + 5] = (v2 >>> 12) & 0b1111111111111111111111111111L;
+            output[outputOffset + 6] = ((v2 >>> 40) & 0b111111111111111111111111L) | ((v3 & 0b1111L) << 24);
+            output[outputOffset + 7] = (v3 >>> 4) & 0b1111111111111111111111111111L;
+            output[outputOffset + 8] = (v3 >>> 32) & 0b1111111111111111111111111111L;
+            output[outputOffset + 9] = ((v3 >>> 60) & 0b1111L) | ((v4 & 0b111111111111111111111111L) << 4);
+            output[outputOffset + 10] = (v4 >>> 24) & 0b1111111111111111111111111111L;
+            output[outputOffset + 11] = ((v4 >>> 52) & 0b111111111111L) | ((v5 & 0b1111111111111111L) << 12);
+            output[outputOffset + 12] = (v5 >>> 16) & 0b1111111111111111111111111111L;
+            output[outputOffset + 13] = ((v5 >>> 44) & 0b11111111111111111111L) | ((v6 & 0b11111111L) << 20);
+            output[outputOffset + 14] = (v6 >>> 8) & 0b1111111111111111111111111111L;
+            output[outputOffset + 15] = (v6 >>> 36) & 0b1111111111111111111111111111L;
+            output[outputOffset + 16] = v7 & 0b1111111111111111111111111111L;
+            output[outputOffset + 17] = (v7 >>> 28) & 0b1111111111111111111111111111L;
+            output[outputOffset + 18] = ((v7 >>> 56) & 0b11111111L) | ((v8 & 0b11111111111111111111L) << 8);
+            output[outputOffset + 19] = (v8 >>> 20) & 0b1111111111111111111111111111L;
+            output[outputOffset + 20] = ((v8 >>> 48) & 0b1111111111111111L) | ((v9 & 0b111111111111L) << 16);
+            output[outputOffset + 21] = (v9 >>> 12) & 0b1111111111111111111111111111L;
+            output[outputOffset + 22] = ((v9 >>> 40) & 0b111111111111111111111111L) | ((v10 & 0b1111L) << 24);
+            output[outputOffset + 23] = (v10 >>> 4) & 0b1111111111111111111111111111L;
+            output[outputOffset + 24] = (v10 >>> 32) & 0b1111111111111111111111111111L;
+            output[outputOffset + 25] = ((v10 >>> 60) & 0b1111L) | ((v11 & 0b111111111111111111111111L) << 4);
+            output[outputOffset + 26] = (v11 >>> 24) & 0b1111111111111111111111111111L;
+            output[outputOffset + 27] = ((v11 >>> 52) & 0b111111111111L) | ((v12 & 0b1111111111111111L) << 12);
+            output[outputOffset + 28] = (v12 >>> 16) & 0b1111111111111111111111111111L;
+            output[outputOffset + 29] = ((v12 >>> 44) & 0b11111111111111111111L) | ((v13 & 0b11111111L) << 20);
+            output[outputOffset + 30] = (v13 >>> 8) & 0b1111111111111111111111111111L;
+            output[outputOffset + 31] = (v13 >>> 36) & 0b1111111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker29
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            int v14 = input.readInt();
+            output[outputOffset] = v0 & 0b11111111111111111111111111111L;
+            output[outputOffset + 1] = (v0 >>> 29) & 0b11111111111111111111111111111L;
+            output[outputOffset + 2] = ((v0 >>> 58) & 0b111111L) | ((v1 & 0b11111111111111111111111L) << 6);
+            output[outputOffset + 3] = (v1 >>> 23) & 0b11111111111111111111111111111L;
+            output[outputOffset + 4] = ((v1 >>> 52) & 0b111111111111L) | ((v2 & 0b11111111111111111L) << 12);
+            output[outputOffset + 5] = (v2 >>> 17) & 0b11111111111111111111111111111L;
+            output[outputOffset + 6] = ((v2 >>> 46) & 0b111111111111111111L) | ((v3 & 0b11111111111L) << 18);
+            output[outputOffset + 7] = (v3 >>> 11) & 0b11111111111111111111111111111L;
+            output[outputOffset + 8] = ((v3 >>> 40) & 0b111111111111111111111111L) | ((v4 & 0b11111L) << 24);
+            output[outputOffset + 9] = (v4 >>> 5) & 0b11111111111111111111111111111L;
+            output[outputOffset + 10] = (v4 >>> 34) & 0b11111111111111111111111111111L;
+            output[outputOffset + 11] = ((v4 >>> 63) & 0b1L) | ((v5 & 0b1111111111111111111111111111L) << 1);
+            output[outputOffset + 12] = (v5 >>> 28) & 0b11111111111111111111111111111L;
+            output[outputOffset + 13] = ((v5 >>> 57) & 0b1111111L) | ((v6 & 0b1111111111111111111111L) << 7);
+            output[outputOffset + 14] = (v6 >>> 22) & 0b11111111111111111111111111111L;
+            output[outputOffset + 15] = ((v6 >>> 51) & 0b1111111111111L) | ((v7 & 0b1111111111111111L) << 13);
+            output[outputOffset + 16] = (v7 >>> 16) & 0b11111111111111111111111111111L;
+            output[outputOffset + 17] = ((v7 >>> 45) & 0b1111111111111111111L) | ((v8 & 0b1111111111L) << 19);
+            output[outputOffset + 18] = (v8 >>> 10) & 0b11111111111111111111111111111L;
+            output[outputOffset + 19] = ((v8 >>> 39) & 0b1111111111111111111111111L) | ((v9 & 0b1111L) << 25);
+            output[outputOffset + 20] = (v9 >>> 4) & 0b11111111111111111111111111111L;
+            output[outputOffset + 21] = (v9 >>> 33) & 0b11111111111111111111111111111L;
+            output[outputOffset + 22] = ((v9 >>> 62) & 0b11L) | ((v10 & 0b111111111111111111111111111L) << 2);
+            output[outputOffset + 23] = (v10 >>> 27) & 0b11111111111111111111111111111L;
+            output[outputOffset + 24] = ((v10 >>> 56) & 0b11111111L) | ((v11 & 0b111111111111111111111L) << 8);
+            output[outputOffset + 25] = (v11 >>> 21) & 0b11111111111111111111111111111L;
+            output[outputOffset + 26] = ((v11 >>> 50) & 0b11111111111111L) | ((v12 & 0b111111111111111L) << 14);
+            output[outputOffset + 27] = (v12 >>> 15) & 0b11111111111111111111111111111L;
+            output[outputOffset + 28] = ((v12 >>> 44) & 0b11111111111111111111L) | ((v13 & 0b111111111L) << 20);
+            output[outputOffset + 29] = (v13 >>> 9) & 0b11111111111111111111111111111L;
+            output[outputOffset + 30] = ((v13 >>> 38) & 0b11111111111111111111111111L) | ((v14 & 0b111L) << 26);
+            output[outputOffset + 31] = (v14 >>> 3) & 0b11111111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker30
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            output[outputOffset] = v0 & 0b111111111111111111111111111111L;
+            output[outputOffset + 1] = (v0 >>> 30) & 0b111111111111111111111111111111L;
+            output[outputOffset + 2] = ((v0 >>> 60) & 0b1111L) | ((v1 & 0b11111111111111111111111111L) << 4);
+            output[outputOffset + 3] = (v1 >>> 26) & 0b111111111111111111111111111111L;
+            output[outputOffset + 4] = ((v1 >>> 56) & 0b11111111L) | ((v2 & 0b1111111111111111111111L) << 8);
+            output[outputOffset + 5] = (v2 >>> 22) & 0b111111111111111111111111111111L;
+            output[outputOffset + 6] = ((v2 >>> 52) & 0b111111111111L) | ((v3 & 0b111111111111111111L) << 12);
+            output[outputOffset + 7] = (v3 >>> 18) & 0b111111111111111111111111111111L;
+            output[outputOffset + 8] = ((v3 >>> 48) & 0b1111111111111111L) | ((v4 & 0b11111111111111L) << 16);
+            output[outputOffset + 9] = (v4 >>> 14) & 0b111111111111111111111111111111L;
+            output[outputOffset + 10] = ((v4 >>> 44) & 0b11111111111111111111L) | ((v5 & 0b1111111111L) << 20);
+            output[outputOffset + 11] = (v5 >>> 10) & 0b111111111111111111111111111111L;
+            output[outputOffset + 12] = ((v5 >>> 40) & 0b111111111111111111111111L) | ((v6 & 0b111111L) << 24);
+            output[outputOffset + 13] = (v6 >>> 6) & 0b111111111111111111111111111111L;
+            output[outputOffset + 14] = ((v6 >>> 36) & 0b1111111111111111111111111111L) | ((v7 & 0b11L) << 28);
+            output[outputOffset + 15] = (v7 >>> 2) & 0b111111111111111111111111111111L;
+            output[outputOffset + 16] = (v7 >>> 32) & 0b111111111111111111111111111111L;
+            output[outputOffset + 17] = ((v7 >>> 62) & 0b11L) | ((v8 & 0b1111111111111111111111111111L) << 2);
+            output[outputOffset + 18] = (v8 >>> 28) & 0b111111111111111111111111111111L;
+            output[outputOffset + 19] = ((v8 >>> 58) & 0b111111L) | ((v9 & 0b111111111111111111111111L) << 6);
+            output[outputOffset + 20] = (v9 >>> 24) & 0b111111111111111111111111111111L;
+            output[outputOffset + 21] = ((v9 >>> 54) & 0b1111111111L) | ((v10 & 0b11111111111111111111L) << 10);
+            output[outputOffset + 22] = (v10 >>> 20) & 0b111111111111111111111111111111L;
+            output[outputOffset + 23] = ((v10 >>> 50) & 0b11111111111111L) | ((v11 & 0b1111111111111111L) << 14);
+            output[outputOffset + 24] = (v11 >>> 16) & 0b111111111111111111111111111111L;
+            output[outputOffset + 25] = ((v11 >>> 46) & 0b111111111111111111L) | ((v12 & 0b111111111111L) << 18);
+            output[outputOffset + 26] = (v12 >>> 12) & 0b111111111111111111111111111111L;
+            output[outputOffset + 27] = ((v12 >>> 42) & 0b1111111111111111111111L) | ((v13 & 0b11111111L) << 22);
+            output[outputOffset + 28] = (v13 >>> 8) & 0b111111111111111111111111111111L;
+            output[outputOffset + 29] = ((v13 >>> 38) & 0b11111111111111111111111111L) | ((v14 & 0b1111L) << 26);
+            output[outputOffset + 30] = (v14 >>> 4) & 0b111111111111111111111111111111L;
+            output[outputOffset + 31] = (v14 >>> 34) & 0b111111111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker31
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            int v15 = input.readInt();
+            output[outputOffset] = v0 & 0b1111111111111111111111111111111L;
+            output[outputOffset + 1] = (v0 >>> 31) & 0b1111111111111111111111111111111L;
+            output[outputOffset + 2] = ((v0 >>> 62) & 0b11L) | ((v1 & 0b11111111111111111111111111111L) << 2);
+            output[outputOffset + 3] = (v1 >>> 29) & 0b1111111111111111111111111111111L;
+            output[outputOffset + 4] = ((v1 >>> 60) & 0b1111L) | ((v2 & 0b111111111111111111111111111L) << 4);
+            output[outputOffset + 5] = (v2 >>> 27) & 0b1111111111111111111111111111111L;
+            output[outputOffset + 6] = ((v2 >>> 58) & 0b111111L) | ((v3 & 0b1111111111111111111111111L) << 6);
+            output[outputOffset + 7] = (v3 >>> 25) & 0b1111111111111111111111111111111L;
+            output[outputOffset + 8] = ((v3 >>> 56) & 0b11111111L) | ((v4 & 0b11111111111111111111111L) << 8);
+            output[outputOffset + 9] = (v4 >>> 23) & 0b1111111111111111111111111111111L;
+            output[outputOffset + 10] = ((v4 >>> 54) & 0b1111111111L) | ((v5 & 0b111111111111111111111L) << 10);
+            output[outputOffset + 11] = (v5 >>> 21) & 0b1111111111111111111111111111111L;
+            output[outputOffset + 12] = ((v5 >>> 52) & 0b111111111111L) | ((v6 & 0b1111111111111111111L) << 12);
+            output[outputOffset + 13] = (v6 >>> 19) & 0b1111111111111111111111111111111L;
+            output[outputOffset + 14] = ((v6 >>> 50) & 0b11111111111111L) | ((v7 & 0b11111111111111111L) << 14);
+            output[outputOffset + 15] = (v7 >>> 17) & 0b1111111111111111111111111111111L;
+            output[outputOffset + 16] = ((v7 >>> 48) & 0b1111111111111111L) | ((v8 & 0b111111111111111L) << 16);
+            output[outputOffset + 17] = (v8 >>> 15) & 0b1111111111111111111111111111111L;
+            output[outputOffset + 18] = ((v8 >>> 46) & 0b111111111111111111L) | ((v9 & 0b1111111111111L) << 18);
+            output[outputOffset + 19] = (v9 >>> 13) & 0b1111111111111111111111111111111L;
+            output[outputOffset + 20] = ((v9 >>> 44) & 0b11111111111111111111L) | ((v10 & 0b11111111111L) << 20);
+            output[outputOffset + 21] = (v10 >>> 11) & 0b1111111111111111111111111111111L;
+            output[outputOffset + 22] = ((v10 >>> 42) & 0b1111111111111111111111L) | ((v11 & 0b111111111L) << 22);
+            output[outputOffset + 23] = (v11 >>> 9) & 0b1111111111111111111111111111111L;
+            output[outputOffset + 24] = ((v11 >>> 40) & 0b111111111111111111111111L) | ((v12 & 0b1111111L) << 24);
+            output[outputOffset + 25] = (v12 >>> 7) & 0b1111111111111111111111111111111L;
+            output[outputOffset + 26] = ((v12 >>> 38) & 0b11111111111111111111111111L) | ((v13 & 0b11111L) << 26);
+            output[outputOffset + 27] = (v13 >>> 5) & 0b1111111111111111111111111111111L;
+            output[outputOffset + 28] = ((v13 >>> 36) & 0b1111111111111111111111111111L) | ((v14 & 0b111L) << 28);
+            output[outputOffset + 29] = (v14 >>> 3) & 0b1111111111111111111111111111111L;
+            output[outputOffset + 30] = ((v14 >>> 34) & 0b111111111111111111111111111111L) | ((v15 & 0b1L) << 30);
+            output[outputOffset + 31] = (v15 >>> 1) & 0b1111111111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker32
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            output[outputOffset] = v0 & 0b11111111111111111111111111111111L;
+            output[outputOffset + 1] = (v0 >>> 32) & 0b11111111111111111111111111111111L;
+            output[outputOffset + 2] = v1 & 0b11111111111111111111111111111111L;
+            output[outputOffset + 3] = (v1 >>> 32) & 0b11111111111111111111111111111111L;
+            output[outputOffset + 4] = v2 & 0b11111111111111111111111111111111L;
+            output[outputOffset + 5] = (v2 >>> 32) & 0b11111111111111111111111111111111L;
+            output[outputOffset + 6] = v3 & 0b11111111111111111111111111111111L;
+            output[outputOffset + 7] = (v3 >>> 32) & 0b11111111111111111111111111111111L;
+            output[outputOffset + 8] = v4 & 0b11111111111111111111111111111111L;
+            output[outputOffset + 9] = (v4 >>> 32) & 0b11111111111111111111111111111111L;
+            output[outputOffset + 10] = v5 & 0b11111111111111111111111111111111L;
+            output[outputOffset + 11] = (v5 >>> 32) & 0b11111111111111111111111111111111L;
+            output[outputOffset + 12] = v6 & 0b11111111111111111111111111111111L;
+            output[outputOffset + 13] = (v6 >>> 32) & 0b11111111111111111111111111111111L;
+            output[outputOffset + 14] = v7 & 0b11111111111111111111111111111111L;
+            output[outputOffset + 15] = (v7 >>> 32) & 0b11111111111111111111111111111111L;
+            output[outputOffset + 16] = v8 & 0b11111111111111111111111111111111L;
+            output[outputOffset + 17] = (v8 >>> 32) & 0b11111111111111111111111111111111L;
+            output[outputOffset + 18] = v9 & 0b11111111111111111111111111111111L;
+            output[outputOffset + 19] = (v9 >>> 32) & 0b11111111111111111111111111111111L;
+            output[outputOffset + 20] = v10 & 0b11111111111111111111111111111111L;
+            output[outputOffset + 21] = (v10 >>> 32) & 0b11111111111111111111111111111111L;
+            output[outputOffset + 22] = v11 & 0b11111111111111111111111111111111L;
+            output[outputOffset + 23] = (v11 >>> 32) & 0b11111111111111111111111111111111L;
+            output[outputOffset + 24] = v12 & 0b11111111111111111111111111111111L;
+            output[outputOffset + 25] = (v12 >>> 32) & 0b11111111111111111111111111111111L;
+            output[outputOffset + 26] = v13 & 0b11111111111111111111111111111111L;
+            output[outputOffset + 27] = (v13 >>> 32) & 0b11111111111111111111111111111111L;
+            output[outputOffset + 28] = v14 & 0b11111111111111111111111111111111L;
+            output[outputOffset + 29] = (v14 >>> 32) & 0b11111111111111111111111111111111L;
+            output[outputOffset + 30] = v15 & 0b11111111111111111111111111111111L;
+            output[outputOffset + 31] = (v15 >>> 32) & 0b11111111111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker33
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            int v16 = input.readInt();
+            output[outputOffset] = v0 & 0b111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 33) & 0b1111111111111111111111111111111L) | ((v1 & 0b11L) << 31);
+            output[outputOffset + 2] = (v1 >>> 2) & 0b111111111111111111111111111111111L;
+            output[outputOffset + 3] = ((v1 >>> 35) & 0b11111111111111111111111111111L) | ((v2 & 0b1111L) << 29);
+            output[outputOffset + 4] = (v2 >>> 4) & 0b111111111111111111111111111111111L;
+            output[outputOffset + 5] = ((v2 >>> 37) & 0b111111111111111111111111111L) | ((v3 & 0b111111L) << 27);
+            output[outputOffset + 6] = (v3 >>> 6) & 0b111111111111111111111111111111111L;
+            output[outputOffset + 7] = ((v3 >>> 39) & 0b1111111111111111111111111L) | ((v4 & 0b11111111L) << 25);
+            output[outputOffset + 8] = (v4 >>> 8) & 0b111111111111111111111111111111111L;
+            output[outputOffset + 9] = ((v4 >>> 41) & 0b11111111111111111111111L) | ((v5 & 0b1111111111L) << 23);
+            output[outputOffset + 10] = (v5 >>> 10) & 0b111111111111111111111111111111111L;
+            output[outputOffset + 11] = ((v5 >>> 43) & 0b111111111111111111111L) | ((v6 & 0b111111111111L) << 21);
+            output[outputOffset + 12] = (v6 >>> 12) & 0b111111111111111111111111111111111L;
+            output[outputOffset + 13] = ((v6 >>> 45) & 0b1111111111111111111L) | ((v7 & 0b11111111111111L) << 19);
+            output[outputOffset + 14] = (v7 >>> 14) & 0b111111111111111111111111111111111L;
+            output[outputOffset + 15] = ((v7 >>> 47) & 0b11111111111111111L) | ((v8 & 0b1111111111111111L) << 17);
+            output[outputOffset + 16] = (v8 >>> 16) & 0b111111111111111111111111111111111L;
+            output[outputOffset + 17] = ((v8 >>> 49) & 0b111111111111111L) | ((v9 & 0b111111111111111111L) << 15);
+            output[outputOffset + 18] = (v9 >>> 18) & 0b111111111111111111111111111111111L;
+            output[outputOffset + 19] = ((v9 >>> 51) & 0b1111111111111L) | ((v10 & 0b11111111111111111111L) << 13);
+            output[outputOffset + 20] = (v10 >>> 20) & 0b111111111111111111111111111111111L;
+            output[outputOffset + 21] = ((v10 >>> 53) & 0b11111111111L) | ((v11 & 0b1111111111111111111111L) << 11);
+            output[outputOffset + 22] = (v11 >>> 22) & 0b111111111111111111111111111111111L;
+            output[outputOffset + 23] = ((v11 >>> 55) & 0b111111111L) | ((v12 & 0b111111111111111111111111L) << 9);
+            output[outputOffset + 24] = (v12 >>> 24) & 0b111111111111111111111111111111111L;
+            output[outputOffset + 25] = ((v12 >>> 57) & 0b1111111L) | ((v13 & 0b11111111111111111111111111L) << 7);
+            output[outputOffset + 26] = (v13 >>> 26) & 0b111111111111111111111111111111111L;
+            output[outputOffset + 27] = ((v13 >>> 59) & 0b11111L) | ((v14 & 0b1111111111111111111111111111L) << 5);
+            output[outputOffset + 28] = (v14 >>> 28) & 0b111111111111111111111111111111111L;
+            output[outputOffset + 29] = ((v14 >>> 61) & 0b111L) | ((v15 & 0b111111111111111111111111111111L) << 3);
+            output[outputOffset + 30] = (v15 >>> 30) & 0b111111111111111111111111111111111L;
+            output[outputOffset + 31] = ((v15 >>> 63) & 0b1L) | ((v16 & 0b11111111111111111111111111111111L) << 1);
+        }
+    }
+
+    private static final class Unpacker34
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            output[outputOffset] = v0 & 0b1111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 34) & 0b111111111111111111111111111111L) | ((v1 & 0b1111L) << 30);
+            output[outputOffset + 2] = (v1 >>> 4) & 0b1111111111111111111111111111111111L;
+            output[outputOffset + 3] = ((v1 >>> 38) & 0b11111111111111111111111111L) | ((v2 & 0b11111111L) << 26);
+            output[outputOffset + 4] = (v2 >>> 8) & 0b1111111111111111111111111111111111L;
+            output[outputOffset + 5] = ((v2 >>> 42) & 0b1111111111111111111111L) | ((v3 & 0b111111111111L) << 22);
+            output[outputOffset + 6] = (v3 >>> 12) & 0b1111111111111111111111111111111111L;
+            output[outputOffset + 7] = ((v3 >>> 46) & 0b111111111111111111L) | ((v4 & 0b1111111111111111L) << 18);
+            output[outputOffset + 8] = (v4 >>> 16) & 0b1111111111111111111111111111111111L;
+            output[outputOffset + 9] = ((v4 >>> 50) & 0b11111111111111L) | ((v5 & 0b11111111111111111111L) << 14);
+            output[outputOffset + 10] = (v5 >>> 20) & 0b1111111111111111111111111111111111L;
+            output[outputOffset + 11] = ((v5 >>> 54) & 0b1111111111L) | ((v6 & 0b111111111111111111111111L) << 10);
+            output[outputOffset + 12] = (v6 >>> 24) & 0b1111111111111111111111111111111111L;
+            output[outputOffset + 13] = ((v6 >>> 58) & 0b111111L) | ((v7 & 0b1111111111111111111111111111L) << 6);
+            output[outputOffset + 14] = (v7 >>> 28) & 0b1111111111111111111111111111111111L;
+            output[outputOffset + 15] = ((v7 >>> 62) & 0b11L) | ((v8 & 0b11111111111111111111111111111111L) << 2);
+            output[outputOffset + 16] = ((v8 >>> 32) & 0b11111111111111111111111111111111L) | ((v9 & 0b11L) << 32);
+            output[outputOffset + 17] = (v9 >>> 2) & 0b1111111111111111111111111111111111L;
+            output[outputOffset + 18] = ((v9 >>> 36) & 0b1111111111111111111111111111L) | ((v10 & 0b111111L) << 28);
+            output[outputOffset + 19] = (v10 >>> 6) & 0b1111111111111111111111111111111111L;
+            output[outputOffset + 20] = ((v10 >>> 40) & 0b111111111111111111111111L) | ((v11 & 0b1111111111L) << 24);
+            output[outputOffset + 21] = (v11 >>> 10) & 0b1111111111111111111111111111111111L;
+            output[outputOffset + 22] = ((v11 >>> 44) & 0b11111111111111111111L) | ((v12 & 0b11111111111111L) << 20);
+            output[outputOffset + 23] = (v12 >>> 14) & 0b1111111111111111111111111111111111L;
+            output[outputOffset + 24] = ((v12 >>> 48) & 0b1111111111111111L) | ((v13 & 0b111111111111111111L) << 16);
+            output[outputOffset + 25] = (v13 >>> 18) & 0b1111111111111111111111111111111111L;
+            output[outputOffset + 26] = ((v13 >>> 52) & 0b111111111111L) | ((v14 & 0b1111111111111111111111L) << 12);
+            output[outputOffset + 27] = (v14 >>> 22) & 0b1111111111111111111111111111111111L;
+            output[outputOffset + 28] = ((v14 >>> 56) & 0b11111111L) | ((v15 & 0b11111111111111111111111111L) << 8);
+            output[outputOffset + 29] = (v15 >>> 26) & 0b1111111111111111111111111111111111L;
+            output[outputOffset + 30] = ((v15 >>> 60) & 0b1111L) | ((v16 & 0b111111111111111111111111111111L) << 4);
+            output[outputOffset + 31] = (v16 >>> 30) & 0b1111111111111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker35
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            int v17 = input.readInt();
+            output[outputOffset] = v0 & 0b11111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 35) & 0b11111111111111111111111111111L) | ((v1 & 0b111111L) << 29);
+            output[outputOffset + 2] = (v1 >>> 6) & 0b11111111111111111111111111111111111L;
+            output[outputOffset + 3] = ((v1 >>> 41) & 0b11111111111111111111111L) | ((v2 & 0b111111111111L) << 23);
+            output[outputOffset + 4] = (v2 >>> 12) & 0b11111111111111111111111111111111111L;
+            output[outputOffset + 5] = ((v2 >>> 47) & 0b11111111111111111L) | ((v3 & 0b111111111111111111L) << 17);
+            output[outputOffset + 6] = (v3 >>> 18) & 0b11111111111111111111111111111111111L;
+            output[outputOffset + 7] = ((v3 >>> 53) & 0b11111111111L) | ((v4 & 0b111111111111111111111111L) << 11);
+            output[outputOffset + 8] = (v4 >>> 24) & 0b11111111111111111111111111111111111L;
+            output[outputOffset + 9] = ((v4 >>> 59) & 0b11111L) | ((v5 & 0b111111111111111111111111111111L) << 5);
+            output[outputOffset + 10] = ((v5 >>> 30) & 0b1111111111111111111111111111111111L) | ((v6 & 0b1L) << 34);
+            output[outputOffset + 11] = (v6 >>> 1) & 0b11111111111111111111111111111111111L;
+            output[outputOffset + 12] = ((v6 >>> 36) & 0b1111111111111111111111111111L) | ((v7 & 0b1111111L) << 28);
+            output[outputOffset + 13] = (v7 >>> 7) & 0b11111111111111111111111111111111111L;
+            output[outputOffset + 14] = ((v7 >>> 42) & 0b1111111111111111111111L) | ((v8 & 0b1111111111111L) << 22);
+            output[outputOffset + 15] = (v8 >>> 13) & 0b11111111111111111111111111111111111L;
+            output[outputOffset + 16] = ((v8 >>> 48) & 0b1111111111111111L) | ((v9 & 0b1111111111111111111L) << 16);
+            output[outputOffset + 17] = (v9 >>> 19) & 0b11111111111111111111111111111111111L;
+            output[outputOffset + 18] = ((v9 >>> 54) & 0b1111111111L) | ((v10 & 0b1111111111111111111111111L) << 10);
+            output[outputOffset + 19] = (v10 >>> 25) & 0b11111111111111111111111111111111111L;
+            output[outputOffset + 20] = ((v10 >>> 60) & 0b1111L) | ((v11 & 0b1111111111111111111111111111111L) << 4);
+            output[outputOffset + 21] = ((v11 >>> 31) & 0b111111111111111111111111111111111L) | ((v12 & 0b11L) << 33);
+            output[outputOffset + 22] = (v12 >>> 2) & 0b11111111111111111111111111111111111L;
+            output[outputOffset + 23] = ((v12 >>> 37) & 0b111111111111111111111111111L) | ((v13 & 0b11111111L) << 27);
+            output[outputOffset + 24] = (v13 >>> 8) & 0b11111111111111111111111111111111111L;
+            output[outputOffset + 25] = ((v13 >>> 43) & 0b111111111111111111111L) | ((v14 & 0b11111111111111L) << 21);
+            output[outputOffset + 26] = (v14 >>> 14) & 0b11111111111111111111111111111111111L;
+            output[outputOffset + 27] = ((v14 >>> 49) & 0b111111111111111L) | ((v15 & 0b11111111111111111111L) << 15);
+            output[outputOffset + 28] = (v15 >>> 20) & 0b11111111111111111111111111111111111L;
+            output[outputOffset + 29] = ((v15 >>> 55) & 0b111111111L) | ((v16 & 0b11111111111111111111111111L) << 9);
+            output[outputOffset + 30] = (v16 >>> 26) & 0b11111111111111111111111111111111111L;
+            output[outputOffset + 31] = ((v16 >>> 61) & 0b111L) | ((v17 & 0b11111111111111111111111111111111L) << 3);
+        }
+    }
+
+    private static final class Unpacker36
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            output[outputOffset] = v0 & 0b111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 36) & 0b1111111111111111111111111111L) | ((v1 & 0b11111111L) << 28);
+            output[outputOffset + 2] = (v1 >>> 8) & 0b111111111111111111111111111111111111L;
+            output[outputOffset + 3] = ((v1 >>> 44) & 0b11111111111111111111L) | ((v2 & 0b1111111111111111L) << 20);
+            output[outputOffset + 4] = (v2 >>> 16) & 0b111111111111111111111111111111111111L;
+            output[outputOffset + 5] = ((v2 >>> 52) & 0b111111111111L) | ((v3 & 0b111111111111111111111111L) << 12);
+            output[outputOffset + 6] = (v3 >>> 24) & 0b111111111111111111111111111111111111L;
+            output[outputOffset + 7] = ((v3 >>> 60) & 0b1111L) | ((v4 & 0b11111111111111111111111111111111L) << 4);
+            output[outputOffset + 8] = ((v4 >>> 32) & 0b11111111111111111111111111111111L) | ((v5 & 0b1111L) << 32);
+            output[outputOffset + 9] = (v5 >>> 4) & 0b111111111111111111111111111111111111L;
+            output[outputOffset + 10] = ((v5 >>> 40) & 0b111111111111111111111111L) | ((v6 & 0b111111111111L) << 24);
+            output[outputOffset + 11] = (v6 >>> 12) & 0b111111111111111111111111111111111111L;
+            output[outputOffset + 12] = ((v6 >>> 48) & 0b1111111111111111L) | ((v7 & 0b11111111111111111111L) << 16);
+            output[outputOffset + 13] = (v7 >>> 20) & 0b111111111111111111111111111111111111L;
+            output[outputOffset + 14] = ((v7 >>> 56) & 0b11111111L) | ((v8 & 0b1111111111111111111111111111L) << 8);
+            output[outputOffset + 15] = (v8 >>> 28) & 0b111111111111111111111111111111111111L;
+            output[outputOffset + 16] = v9 & 0b111111111111111111111111111111111111L;
+            output[outputOffset + 17] = ((v9 >>> 36) & 0b1111111111111111111111111111L) | ((v10 & 0b11111111L) << 28);
+            output[outputOffset + 18] = (v10 >>> 8) & 0b111111111111111111111111111111111111L;
+            output[outputOffset + 19] = ((v10 >>> 44) & 0b11111111111111111111L) | ((v11 & 0b1111111111111111L) << 20);
+            output[outputOffset + 20] = (v11 >>> 16) & 0b111111111111111111111111111111111111L;
+            output[outputOffset + 21] = ((v11 >>> 52) & 0b111111111111L) | ((v12 & 0b111111111111111111111111L) << 12);
+            output[outputOffset + 22] = (v12 >>> 24) & 0b111111111111111111111111111111111111L;
+            output[outputOffset + 23] = ((v12 >>> 60) & 0b1111L) | ((v13 & 0b11111111111111111111111111111111L) << 4);
+            output[outputOffset + 24] = ((v13 >>> 32) & 0b11111111111111111111111111111111L) | ((v14 & 0b1111L) << 32);
+            output[outputOffset + 25] = (v14 >>> 4) & 0b111111111111111111111111111111111111L;
+            output[outputOffset + 26] = ((v14 >>> 40) & 0b111111111111111111111111L) | ((v15 & 0b111111111111L) << 24);
+            output[outputOffset + 27] = (v15 >>> 12) & 0b111111111111111111111111111111111111L;
+            output[outputOffset + 28] = ((v15 >>> 48) & 0b1111111111111111L) | ((v16 & 0b11111111111111111111L) << 16);
+            output[outputOffset + 29] = (v16 >>> 20) & 0b111111111111111111111111111111111111L;
+            output[outputOffset + 30] = ((v16 >>> 56) & 0b11111111L) | ((v17 & 0b1111111111111111111111111111L) << 8);
+            output[outputOffset + 31] = (v17 >>> 28) & 0b111111111111111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker37
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            int v18 = input.readInt();
+            output[outputOffset] = v0 & 0b1111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 37) & 0b111111111111111111111111111L) | ((v1 & 0b1111111111L) << 27);
+            output[outputOffset + 2] = (v1 >>> 10) & 0b1111111111111111111111111111111111111L;
+            output[outputOffset + 3] = ((v1 >>> 47) & 0b11111111111111111L) | ((v2 & 0b11111111111111111111L) << 17);
+            output[outputOffset + 4] = (v2 >>> 20) & 0b1111111111111111111111111111111111111L;
+            output[outputOffset + 5] = ((v2 >>> 57) & 0b1111111L) | ((v3 & 0b111111111111111111111111111111L) << 7);
+            output[outputOffset + 6] = ((v3 >>> 30) & 0b1111111111111111111111111111111111L) | ((v4 & 0b111L) << 34);
+            output[outputOffset + 7] = (v4 >>> 3) & 0b1111111111111111111111111111111111111L;
+            output[outputOffset + 8] = ((v4 >>> 40) & 0b111111111111111111111111L) | ((v5 & 0b1111111111111L) << 24);
+            output[outputOffset + 9] = (v5 >>> 13) & 0b1111111111111111111111111111111111111L;
+            output[outputOffset + 10] = ((v5 >>> 50) & 0b11111111111111L) | ((v6 & 0b11111111111111111111111L) << 14);
+            output[outputOffset + 11] = (v6 >>> 23) & 0b1111111111111111111111111111111111111L;
+            output[outputOffset + 12] = ((v6 >>> 60) & 0b1111L) | ((v7 & 0b111111111111111111111111111111111L) << 4);
+            output[outputOffset + 13] = ((v7 >>> 33) & 0b1111111111111111111111111111111L) | ((v8 & 0b111111L) << 31);
+            output[outputOffset + 14] = (v8 >>> 6) & 0b1111111111111111111111111111111111111L;
+            output[outputOffset + 15] = ((v8 >>> 43) & 0b111111111111111111111L) | ((v9 & 0b1111111111111111L) << 21);
+            output[outputOffset + 16] = (v9 >>> 16) & 0b1111111111111111111111111111111111111L;
+            output[outputOffset + 17] = ((v9 >>> 53) & 0b11111111111L) | ((v10 & 0b11111111111111111111111111L) << 11);
+            output[outputOffset + 18] = (v10 >>> 26) & 0b1111111111111111111111111111111111111L;
+            output[outputOffset + 19] = ((v10 >>> 63) & 0b1L) | ((v11 & 0b111111111111111111111111111111111111L) << 1);
+            output[outputOffset + 20] = ((v11 >>> 36) & 0b1111111111111111111111111111L) | ((v12 & 0b111111111L) << 28);
+            output[outputOffset + 21] = (v12 >>> 9) & 0b1111111111111111111111111111111111111L;
+            output[outputOffset + 22] = ((v12 >>> 46) & 0b111111111111111111L) | ((v13 & 0b1111111111111111111L) << 18);
+            output[outputOffset + 23] = (v13 >>> 19) & 0b1111111111111111111111111111111111111L;
+            output[outputOffset + 24] = ((v13 >>> 56) & 0b11111111L) | ((v14 & 0b11111111111111111111111111111L) << 8);
+            output[outputOffset + 25] = ((v14 >>> 29) & 0b11111111111111111111111111111111111L) | ((v15 & 0b11L) << 35);
+            output[outputOffset + 26] = (v15 >>> 2) & 0b1111111111111111111111111111111111111L;
+            output[outputOffset + 27] = ((v15 >>> 39) & 0b1111111111111111111111111L) | ((v16 & 0b111111111111L) << 25);
+            output[outputOffset + 28] = (v16 >>> 12) & 0b1111111111111111111111111111111111111L;
+            output[outputOffset + 29] = ((v16 >>> 49) & 0b111111111111111L) | ((v17 & 0b1111111111111111111111L) << 15);
+            output[outputOffset + 30] = (v17 >>> 22) & 0b1111111111111111111111111111111111111L;
+            output[outputOffset + 31] = ((v17 >>> 59) & 0b11111L) | ((v18 & 0b11111111111111111111111111111111L) << 5);
+        }
+    }
+
+    private static final class Unpacker38
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            output[outputOffset] = v0 & 0b11111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 38) & 0b11111111111111111111111111L) | ((v1 & 0b111111111111L) << 26);
+            output[outputOffset + 2] = (v1 >>> 12) & 0b11111111111111111111111111111111111111L;
+            output[outputOffset + 3] = ((v1 >>> 50) & 0b11111111111111L) | ((v2 & 0b111111111111111111111111L) << 14);
+            output[outputOffset + 4] = (v2 >>> 24) & 0b11111111111111111111111111111111111111L;
+            output[outputOffset + 5] = ((v2 >>> 62) & 0b11L) | ((v3 & 0b111111111111111111111111111111111111L) << 2);
+            output[outputOffset + 6] = ((v3 >>> 36) & 0b1111111111111111111111111111L) | ((v4 & 0b1111111111L) << 28);
+            output[outputOffset + 7] = (v4 >>> 10) & 0b11111111111111111111111111111111111111L;
+            output[outputOffset + 8] = ((v4 >>> 48) & 0b1111111111111111L) | ((v5 & 0b1111111111111111111111L) << 16);
+            output[outputOffset + 9] = (v5 >>> 22) & 0b11111111111111111111111111111111111111L;
+            output[outputOffset + 10] = ((v5 >>> 60) & 0b1111L) | ((v6 & 0b1111111111111111111111111111111111L) << 4);
+            output[outputOffset + 11] = ((v6 >>> 34) & 0b111111111111111111111111111111L) | ((v7 & 0b11111111L) << 30);
+            output[outputOffset + 12] = (v7 >>> 8) & 0b11111111111111111111111111111111111111L;
+            output[outputOffset + 13] = ((v7 >>> 46) & 0b111111111111111111L) | ((v8 & 0b11111111111111111111L) << 18);
+            output[outputOffset + 14] = (v8 >>> 20) & 0b11111111111111111111111111111111111111L;
+            output[outputOffset + 15] = ((v8 >>> 58) & 0b111111L) | ((v9 & 0b11111111111111111111111111111111L) << 6);
+            output[outputOffset + 16] = ((v9 >>> 32) & 0b11111111111111111111111111111111L) | ((v10 & 0b111111L) << 32);
+            output[outputOffset + 17] = (v10 >>> 6) & 0b11111111111111111111111111111111111111L;
+            output[outputOffset + 18] = ((v10 >>> 44) & 0b11111111111111111111L) | ((v11 & 0b111111111111111111L) << 20);
+            output[outputOffset + 19] = (v11 >>> 18) & 0b11111111111111111111111111111111111111L;
+            output[outputOffset + 20] = ((v11 >>> 56) & 0b11111111L) | ((v12 & 0b111111111111111111111111111111L) << 8);
+            output[outputOffset + 21] = ((v12 >>> 30) & 0b1111111111111111111111111111111111L) | ((v13 & 0b1111L) << 34);
+            output[outputOffset + 22] = (v13 >>> 4) & 0b11111111111111111111111111111111111111L;
+            output[outputOffset + 23] = ((v13 >>> 42) & 0b1111111111111111111111L) | ((v14 & 0b1111111111111111L) << 22);
+            output[outputOffset + 24] = (v14 >>> 16) & 0b11111111111111111111111111111111111111L;
+            output[outputOffset + 25] = ((v14 >>> 54) & 0b1111111111L) | ((v15 & 0b1111111111111111111111111111L) << 10);
+            output[outputOffset + 26] = ((v15 >>> 28) & 0b111111111111111111111111111111111111L) | ((v16 & 0b11L) << 36);
+            output[outputOffset + 27] = (v16 >>> 2) & 0b11111111111111111111111111111111111111L;
+            output[outputOffset + 28] = ((v16 >>> 40) & 0b111111111111111111111111L) | ((v17 & 0b11111111111111L) << 24);
+            output[outputOffset + 29] = (v17 >>> 14) & 0b11111111111111111111111111111111111111L;
+            output[outputOffset + 30] = ((v17 >>> 52) & 0b111111111111L) | ((v18 & 0b11111111111111111111111111L) << 12);
+            output[outputOffset + 31] = (v18 >>> 26) & 0b11111111111111111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker39
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            int v19 = input.readInt();
+            output[outputOffset] = v0 & 0b111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 39) & 0b1111111111111111111111111L) | ((v1 & 0b11111111111111L) << 25);
+            output[outputOffset + 2] = (v1 >>> 14) & 0b111111111111111111111111111111111111111L;
+            output[outputOffset + 3] = ((v1 >>> 53) & 0b11111111111L) | ((v2 & 0b1111111111111111111111111111L) << 11);
+            output[outputOffset + 4] = ((v2 >>> 28) & 0b111111111111111111111111111111111111L) | ((v3 & 0b111L) << 36);
+            output[outputOffset + 5] = (v3 >>> 3) & 0b111111111111111111111111111111111111111L;
+            output[outputOffset + 6] = ((v3 >>> 42) & 0b1111111111111111111111L) | ((v4 & 0b11111111111111111L) << 22);
+            output[outputOffset + 7] = (v4 >>> 17) & 0b111111111111111111111111111111111111111L;
+            output[outputOffset + 8] = ((v4 >>> 56) & 0b11111111L) | ((v5 & 0b1111111111111111111111111111111L) << 8);
+            output[outputOffset + 9] = ((v5 >>> 31) & 0b111111111111111111111111111111111L) | ((v6 & 0b111111L) << 33);
+            output[outputOffset + 10] = (v6 >>> 6) & 0b111111111111111111111111111111111111111L;
+            output[outputOffset + 11] = ((v6 >>> 45) & 0b1111111111111111111L) | ((v7 & 0b11111111111111111111L) << 19);
+            output[outputOffset + 12] = (v7 >>> 20) & 0b111111111111111111111111111111111111111L;
+            output[outputOffset + 13] = ((v7 >>> 59) & 0b11111L) | ((v8 & 0b1111111111111111111111111111111111L) << 5);
+            output[outputOffset + 14] = ((v8 >>> 34) & 0b111111111111111111111111111111L) | ((v9 & 0b111111111L) << 30);
+            output[outputOffset + 15] = (v9 >>> 9) & 0b111111111111111111111111111111111111111L;
+            output[outputOffset + 16] = ((v9 >>> 48) & 0b1111111111111111L) | ((v10 & 0b11111111111111111111111L) << 16);
+            output[outputOffset + 17] = (v10 >>> 23) & 0b111111111111111111111111111111111111111L;
+            output[outputOffset + 18] = ((v10 >>> 62) & 0b11L) | ((v11 & 0b1111111111111111111111111111111111111L) << 2);
+            output[outputOffset + 19] = ((v11 >>> 37) & 0b111111111111111111111111111L) | ((v12 & 0b111111111111L) << 27);
+            output[outputOffset + 20] = (v12 >>> 12) & 0b111111111111111111111111111111111111111L;
+            output[outputOffset + 21] = ((v12 >>> 51) & 0b1111111111111L) | ((v13 & 0b11111111111111111111111111L) << 13);
+            output[outputOffset + 22] = ((v13 >>> 26) & 0b11111111111111111111111111111111111111L) | ((v14 & 0b1L) << 38);
+            output[outputOffset + 23] = (v14 >>> 1) & 0b111111111111111111111111111111111111111L;
+            output[outputOffset + 24] = ((v14 >>> 40) & 0b111111111111111111111111L) | ((v15 & 0b111111111111111L) << 24);
+            output[outputOffset + 25] = (v15 >>> 15) & 0b111111111111111111111111111111111111111L;
+            output[outputOffset + 26] = ((v15 >>> 54) & 0b1111111111L) | ((v16 & 0b11111111111111111111111111111L) << 10);
+            output[outputOffset + 27] = ((v16 >>> 29) & 0b11111111111111111111111111111111111L) | ((v17 & 0b1111L) << 35);
+            output[outputOffset + 28] = (v17 >>> 4) & 0b111111111111111111111111111111111111111L;
+            output[outputOffset + 29] = ((v17 >>> 43) & 0b111111111111111111111L) | ((v18 & 0b111111111111111111L) << 21);
+            output[outputOffset + 30] = (v18 >>> 18) & 0b111111111111111111111111111111111111111L;
+            output[outputOffset + 31] = ((v18 >>> 57) & 0b1111111L) | ((v19 & 0b11111111111111111111111111111111L) << 7);
+        }
+    }
+
+    private static final class Unpacker40
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            output[outputOffset] = v0 & 0b1111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 40) & 0b111111111111111111111111L) | ((v1 & 0b1111111111111111L) << 24);
+            output[outputOffset + 2] = (v1 >>> 16) & 0b1111111111111111111111111111111111111111L;
+            output[outputOffset + 3] = ((v1 >>> 56) & 0b11111111L) | ((v2 & 0b11111111111111111111111111111111L) << 8);
+            output[outputOffset + 4] = ((v2 >>> 32) & 0b11111111111111111111111111111111L) | ((v3 & 0b11111111L) << 32);
+            output[outputOffset + 5] = (v3 >>> 8) & 0b1111111111111111111111111111111111111111L;
+            output[outputOffset + 6] = ((v3 >>> 48) & 0b1111111111111111L) | ((v4 & 0b111111111111111111111111L) << 16);
+            output[outputOffset + 7] = (v4 >>> 24) & 0b1111111111111111111111111111111111111111L;
+            output[outputOffset + 8] = v5 & 0b1111111111111111111111111111111111111111L;
+            output[outputOffset + 9] = ((v5 >>> 40) & 0b111111111111111111111111L) | ((v6 & 0b1111111111111111L) << 24);
+            output[outputOffset + 10] = (v6 >>> 16) & 0b1111111111111111111111111111111111111111L;
+            output[outputOffset + 11] = ((v6 >>> 56) & 0b11111111L) | ((v7 & 0b11111111111111111111111111111111L) << 8);
+            output[outputOffset + 12] = ((v7 >>> 32) & 0b11111111111111111111111111111111L) | ((v8 & 0b11111111L) << 32);
+            output[outputOffset + 13] = (v8 >>> 8) & 0b1111111111111111111111111111111111111111L;
+            output[outputOffset + 14] = ((v8 >>> 48) & 0b1111111111111111L) | ((v9 & 0b111111111111111111111111L) << 16);
+            output[outputOffset + 15] = (v9 >>> 24) & 0b1111111111111111111111111111111111111111L;
+            output[outputOffset + 16] = v10 & 0b1111111111111111111111111111111111111111L;
+            output[outputOffset + 17] = ((v10 >>> 40) & 0b111111111111111111111111L) | ((v11 & 0b1111111111111111L) << 24);
+            output[outputOffset + 18] = (v11 >>> 16) & 0b1111111111111111111111111111111111111111L;
+            output[outputOffset + 19] = ((v11 >>> 56) & 0b11111111L) | ((v12 & 0b11111111111111111111111111111111L) << 8);
+            output[outputOffset + 20] = ((v12 >>> 32) & 0b11111111111111111111111111111111L) | ((v13 & 0b11111111L) << 32);
+            output[outputOffset + 21] = (v13 >>> 8) & 0b1111111111111111111111111111111111111111L;
+            output[outputOffset + 22] = ((v13 >>> 48) & 0b1111111111111111L) | ((v14 & 0b111111111111111111111111L) << 16);
+            output[outputOffset + 23] = (v14 >>> 24) & 0b1111111111111111111111111111111111111111L;
+            output[outputOffset + 24] = v15 & 0b1111111111111111111111111111111111111111L;
+            output[outputOffset + 25] = ((v15 >>> 40) & 0b111111111111111111111111L) | ((v16 & 0b1111111111111111L) << 24);
+            output[outputOffset + 26] = (v16 >>> 16) & 0b1111111111111111111111111111111111111111L;
+            output[outputOffset + 27] = ((v16 >>> 56) & 0b11111111L) | ((v17 & 0b11111111111111111111111111111111L) << 8);
+            output[outputOffset + 28] = ((v17 >>> 32) & 0b11111111111111111111111111111111L) | ((v18 & 0b11111111L) << 32);
+            output[outputOffset + 29] = (v18 >>> 8) & 0b1111111111111111111111111111111111111111L;
+            output[outputOffset + 30] = ((v18 >>> 48) & 0b1111111111111111L) | ((v19 & 0b111111111111111111111111L) << 16);
+            output[outputOffset + 31] = (v19 >>> 24) & 0b1111111111111111111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker41
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            int v20 = input.readInt();
+            output[outputOffset] = v0 & 0b11111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 41) & 0b11111111111111111111111L) | ((v1 & 0b111111111111111111L) << 23);
+            output[outputOffset + 2] = (v1 >>> 18) & 0b11111111111111111111111111111111111111111L;
+            output[outputOffset + 3] = ((v1 >>> 59) & 0b11111L) | ((v2 & 0b111111111111111111111111111111111111L) << 5);
+            output[outputOffset + 4] = ((v2 >>> 36) & 0b1111111111111111111111111111L) | ((v3 & 0b1111111111111L) << 28);
+            output[outputOffset + 5] = (v3 >>> 13) & 0b11111111111111111111111111111111111111111L;
+            output[outputOffset + 6] = ((v3 >>> 54) & 0b1111111111L) | ((v4 & 0b1111111111111111111111111111111L) << 10);
+            output[outputOffset + 7] = ((v4 >>> 31) & 0b111111111111111111111111111111111L) | ((v5 & 0b11111111L) << 33);
+            output[outputOffset + 8] = (v5 >>> 8) & 0b11111111111111111111111111111111111111111L;
+            output[outputOffset + 9] = ((v5 >>> 49) & 0b111111111111111L) | ((v6 & 0b11111111111111111111111111L) << 15);
+            output[outputOffset + 10] = ((v6 >>> 26) & 0b11111111111111111111111111111111111111L) | ((v7 & 0b111L) << 38);
+            output[outputOffset + 11] = (v7 >>> 3) & 0b11111111111111111111111111111111111111111L;
+            output[outputOffset + 12] = ((v7 >>> 44) & 0b11111111111111111111L) | ((v8 & 0b111111111111111111111L) << 20);
+            output[outputOffset + 13] = (v8 >>> 21) & 0b11111111111111111111111111111111111111111L;
+            output[outputOffset + 14] = ((v8 >>> 62) & 0b11L) | ((v9 & 0b111111111111111111111111111111111111111L) << 2);
+            output[outputOffset + 15] = ((v9 >>> 39) & 0b1111111111111111111111111L) | ((v10 & 0b1111111111111111L) << 25);
+            output[outputOffset + 16] = (v10 >>> 16) & 0b11111111111111111111111111111111111111111L;
+            output[outputOffset + 17] = ((v10 >>> 57) & 0b1111111L) | ((v11 & 0b1111111111111111111111111111111111L) << 7);
+            output[outputOffset + 18] = ((v11 >>> 34) & 0b111111111111111111111111111111L) | ((v12 & 0b11111111111L) << 30);
+            output[outputOffset + 19] = (v12 >>> 11) & 0b11111111111111111111111111111111111111111L;
+            output[outputOffset + 20] = ((v12 >>> 52) & 0b111111111111L) | ((v13 & 0b11111111111111111111111111111L) << 12);
+            output[outputOffset + 21] = ((v13 >>> 29) & 0b11111111111111111111111111111111111L) | ((v14 & 0b111111L) << 35);
+            output[outputOffset + 22] = (v14 >>> 6) & 0b11111111111111111111111111111111111111111L;
+            output[outputOffset + 23] = ((v14 >>> 47) & 0b11111111111111111L) | ((v15 & 0b111111111111111111111111L) << 17);
+            output[outputOffset + 24] = ((v15 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v16 & 0b1L) << 40);
+            output[outputOffset + 25] = (v16 >>> 1) & 0b11111111111111111111111111111111111111111L;
+            output[outputOffset + 26] = ((v16 >>> 42) & 0b1111111111111111111111L) | ((v17 & 0b1111111111111111111L) << 22);
+            output[outputOffset + 27] = (v17 >>> 19) & 0b11111111111111111111111111111111111111111L;
+            output[outputOffset + 28] = ((v17 >>> 60) & 0b1111L) | ((v18 & 0b1111111111111111111111111111111111111L) << 4);
+            output[outputOffset + 29] = ((v18 >>> 37) & 0b111111111111111111111111111L) | ((v19 & 0b11111111111111L) << 27);
+            output[outputOffset + 30] = (v19 >>> 14) & 0b11111111111111111111111111111111111111111L;
+            output[outputOffset + 31] = ((v19 >>> 55) & 0b111111111L) | ((v20 & 0b11111111111111111111111111111111L) << 9);
+        }
+    }
+
+    private static final class Unpacker42
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            output[outputOffset] = v0 & 0b111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 42) & 0b1111111111111111111111L) | ((v1 & 0b11111111111111111111L) << 22);
+            output[outputOffset + 2] = (v1 >>> 20) & 0b111111111111111111111111111111111111111111L;
+            output[outputOffset + 3] = ((v1 >>> 62) & 0b11L) | ((v2 & 0b1111111111111111111111111111111111111111L) << 2);
+            output[outputOffset + 4] = ((v2 >>> 40) & 0b111111111111111111111111L) | ((v3 & 0b111111111111111111L) << 24);
+            output[outputOffset + 5] = (v3 >>> 18) & 0b111111111111111111111111111111111111111111L;
+            output[outputOffset + 6] = ((v3 >>> 60) & 0b1111L) | ((v4 & 0b11111111111111111111111111111111111111L) << 4);
+            output[outputOffset + 7] = ((v4 >>> 38) & 0b11111111111111111111111111L) | ((v5 & 0b1111111111111111L) << 26);
+            output[outputOffset + 8] = (v5 >>> 16) & 0b111111111111111111111111111111111111111111L;
+            output[outputOffset + 9] = ((v5 >>> 58) & 0b111111L) | ((v6 & 0b111111111111111111111111111111111111L) << 6);
+            output[outputOffset + 10] = ((v6 >>> 36) & 0b1111111111111111111111111111L) | ((v7 & 0b11111111111111L) << 28);
+            output[outputOffset + 11] = (v7 >>> 14) & 0b111111111111111111111111111111111111111111L;
+            output[outputOffset + 12] = ((v7 >>> 56) & 0b11111111L) | ((v8 & 0b1111111111111111111111111111111111L) << 8);
+            output[outputOffset + 13] = ((v8 >>> 34) & 0b111111111111111111111111111111L) | ((v9 & 0b111111111111L) << 30);
+            output[outputOffset + 14] = (v9 >>> 12) & 0b111111111111111111111111111111111111111111L;
+            output[outputOffset + 15] = ((v9 >>> 54) & 0b1111111111L) | ((v10 & 0b11111111111111111111111111111111L) << 10);
+            output[outputOffset + 16] = ((v10 >>> 32) & 0b11111111111111111111111111111111L) | ((v11 & 0b1111111111L) << 32);
+            output[outputOffset + 17] = (v11 >>> 10) & 0b111111111111111111111111111111111111111111L;
+            output[outputOffset + 18] = ((v11 >>> 52) & 0b111111111111L) | ((v12 & 0b111111111111111111111111111111L) << 12);
+            output[outputOffset + 19] = ((v12 >>> 30) & 0b1111111111111111111111111111111111L) | ((v13 & 0b11111111L) << 34);
+            output[outputOffset + 20] = (v13 >>> 8) & 0b111111111111111111111111111111111111111111L;
+            output[outputOffset + 21] = ((v13 >>> 50) & 0b11111111111111L) | ((v14 & 0b1111111111111111111111111111L) << 14);
+            output[outputOffset + 22] = ((v14 >>> 28) & 0b111111111111111111111111111111111111L) | ((v15 & 0b111111L) << 36);
+            output[outputOffset + 23] = (v15 >>> 6) & 0b111111111111111111111111111111111111111111L;
+            output[outputOffset + 24] = ((v15 >>> 48) & 0b1111111111111111L) | ((v16 & 0b11111111111111111111111111L) << 16);
+            output[outputOffset + 25] = ((v16 >>> 26) & 0b11111111111111111111111111111111111111L) | ((v17 & 0b1111L) << 38);
+            output[outputOffset + 26] = (v17 >>> 4) & 0b111111111111111111111111111111111111111111L;
+            output[outputOffset + 27] = ((v17 >>> 46) & 0b111111111111111111L) | ((v18 & 0b111111111111111111111111L) << 18);
+            output[outputOffset + 28] = ((v18 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v19 & 0b11L) << 40);
+            output[outputOffset + 29] = (v19 >>> 2) & 0b111111111111111111111111111111111111111111L;
+            output[outputOffset + 30] = ((v19 >>> 44) & 0b11111111111111111111L) | ((v20 & 0b1111111111111111111111L) << 20);
+            output[outputOffset + 31] = (v20 >>> 22) & 0b111111111111111111111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker43
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            int v21 = input.readInt();
+            output[outputOffset] = v0 & 0b1111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 43) & 0b111111111111111111111L) | ((v1 & 0b1111111111111111111111L) << 21);
+            output[outputOffset + 2] = ((v1 >>> 22) & 0b111111111111111111111111111111111111111111L) | ((v2 & 0b1L) << 42);
+            output[outputOffset + 3] = (v2 >>> 1) & 0b1111111111111111111111111111111111111111111L;
+            output[outputOffset + 4] = ((v2 >>> 44) & 0b11111111111111111111L) | ((v3 & 0b11111111111111111111111L) << 20);
+            output[outputOffset + 5] = ((v3 >>> 23) & 0b11111111111111111111111111111111111111111L) | ((v4 & 0b11L) << 41);
+            output[outputOffset + 6] = (v4 >>> 2) & 0b1111111111111111111111111111111111111111111L;
+            output[outputOffset + 7] = ((v4 >>> 45) & 0b1111111111111111111L) | ((v5 & 0b111111111111111111111111L) << 19);
+            output[outputOffset + 8] = ((v5 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v6 & 0b111L) << 40);
+            output[outputOffset + 9] = (v6 >>> 3) & 0b1111111111111111111111111111111111111111111L;
+            output[outputOffset + 10] = ((v6 >>> 46) & 0b111111111111111111L) | ((v7 & 0b1111111111111111111111111L) << 18);
+            output[outputOffset + 11] = ((v7 >>> 25) & 0b111111111111111111111111111111111111111L) | ((v8 & 0b1111L) << 39);
+            output[outputOffset + 12] = (v8 >>> 4) & 0b1111111111111111111111111111111111111111111L;
+            output[outputOffset + 13] = ((v8 >>> 47) & 0b11111111111111111L) | ((v9 & 0b11111111111111111111111111L) << 17);
+            output[outputOffset + 14] = ((v9 >>> 26) & 0b11111111111111111111111111111111111111L) | ((v10 & 0b11111L) << 38);
+            output[outputOffset + 15] = (v10 >>> 5) & 0b1111111111111111111111111111111111111111111L;
+            output[outputOffset + 16] = ((v10 >>> 48) & 0b1111111111111111L) | ((v11 & 0b111111111111111111111111111L) << 16);
+            output[outputOffset + 17] = ((v11 >>> 27) & 0b1111111111111111111111111111111111111L) | ((v12 & 0b111111L) << 37);
+            output[outputOffset + 18] = (v12 >>> 6) & 0b1111111111111111111111111111111111111111111L;
+            output[outputOffset + 19] = ((v12 >>> 49) & 0b111111111111111L) | ((v13 & 0b1111111111111111111111111111L) << 15);
+            output[outputOffset + 20] = ((v13 >>> 28) & 0b111111111111111111111111111111111111L) | ((v14 & 0b1111111L) << 36);
+            output[outputOffset + 21] = (v14 >>> 7) & 0b1111111111111111111111111111111111111111111L;
+            output[outputOffset + 22] = ((v14 >>> 50) & 0b11111111111111L) | ((v15 & 0b11111111111111111111111111111L) << 14);
+            output[outputOffset + 23] = ((v15 >>> 29) & 0b11111111111111111111111111111111111L) | ((v16 & 0b11111111L) << 35);
+            output[outputOffset + 24] = (v16 >>> 8) & 0b1111111111111111111111111111111111111111111L;
+            output[outputOffset + 25] = ((v16 >>> 51) & 0b1111111111111L) | ((v17 & 0b111111111111111111111111111111L) << 13);
+            output[outputOffset + 26] = ((v17 >>> 30) & 0b1111111111111111111111111111111111L) | ((v18 & 0b111111111L) << 34);
+            output[outputOffset + 27] = (v18 >>> 9) & 0b1111111111111111111111111111111111111111111L;
+            output[outputOffset + 28] = ((v18 >>> 52) & 0b111111111111L) | ((v19 & 0b1111111111111111111111111111111L) << 12);
+            output[outputOffset + 29] = ((v19 >>> 31) & 0b111111111111111111111111111111111L) | ((v20 & 0b1111111111L) << 33);
+            output[outputOffset + 30] = (v20 >>> 10) & 0b1111111111111111111111111111111111111111111L;
+            output[outputOffset + 31] = ((v20 >>> 53) & 0b11111111111L) | ((v21 & 0b11111111111111111111111111111111L) << 11);
+        }
+    }
+
+    private static final class Unpacker44
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            long v21 = input.readLong();
+            output[outputOffset] = v0 & 0b11111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 44) & 0b11111111111111111111L) | ((v1 & 0b111111111111111111111111L) << 20);
+            output[outputOffset + 2] = ((v1 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v2 & 0b1111L) << 40);
+            output[outputOffset + 3] = (v2 >>> 4) & 0b11111111111111111111111111111111111111111111L;
+            output[outputOffset + 4] = ((v2 >>> 48) & 0b1111111111111111L) | ((v3 & 0b1111111111111111111111111111L) << 16);
+            output[outputOffset + 5] = ((v3 >>> 28) & 0b111111111111111111111111111111111111L) | ((v4 & 0b11111111L) << 36);
+            output[outputOffset + 6] = (v4 >>> 8) & 0b11111111111111111111111111111111111111111111L;
+            output[outputOffset + 7] = ((v4 >>> 52) & 0b111111111111L) | ((v5 & 0b11111111111111111111111111111111L) << 12);
+            output[outputOffset + 8] = ((v5 >>> 32) & 0b11111111111111111111111111111111L) | ((v6 & 0b111111111111L) << 32);
+            output[outputOffset + 9] = (v6 >>> 12) & 0b11111111111111111111111111111111111111111111L;
+            output[outputOffset + 10] = ((v6 >>> 56) & 0b11111111L) | ((v7 & 0b111111111111111111111111111111111111L) << 8);
+            output[outputOffset + 11] = ((v7 >>> 36) & 0b1111111111111111111111111111L) | ((v8 & 0b1111111111111111L) << 28);
+            output[outputOffset + 12] = (v8 >>> 16) & 0b11111111111111111111111111111111111111111111L;
+            output[outputOffset + 13] = ((v8 >>> 60) & 0b1111L) | ((v9 & 0b1111111111111111111111111111111111111111L) << 4);
+            output[outputOffset + 14] = ((v9 >>> 40) & 0b111111111111111111111111L) | ((v10 & 0b11111111111111111111L) << 24);
+            output[outputOffset + 15] = (v10 >>> 20) & 0b11111111111111111111111111111111111111111111L;
+            output[outputOffset + 16] = v11 & 0b11111111111111111111111111111111111111111111L;
+            output[outputOffset + 17] = ((v11 >>> 44) & 0b11111111111111111111L) | ((v12 & 0b111111111111111111111111L) << 20);
+            output[outputOffset + 18] = ((v12 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v13 & 0b1111L) << 40);
+            output[outputOffset + 19] = (v13 >>> 4) & 0b11111111111111111111111111111111111111111111L;
+            output[outputOffset + 20] = ((v13 >>> 48) & 0b1111111111111111L) | ((v14 & 0b1111111111111111111111111111L) << 16);
+            output[outputOffset + 21] = ((v14 >>> 28) & 0b111111111111111111111111111111111111L) | ((v15 & 0b11111111L) << 36);
+            output[outputOffset + 22] = (v15 >>> 8) & 0b11111111111111111111111111111111111111111111L;
+            output[outputOffset + 23] = ((v15 >>> 52) & 0b111111111111L) | ((v16 & 0b11111111111111111111111111111111L) << 12);
+            output[outputOffset + 24] = ((v16 >>> 32) & 0b11111111111111111111111111111111L) | ((v17 & 0b111111111111L) << 32);
+            output[outputOffset + 25] = (v17 >>> 12) & 0b11111111111111111111111111111111111111111111L;
+            output[outputOffset + 26] = ((v17 >>> 56) & 0b11111111L) | ((v18 & 0b111111111111111111111111111111111111L) << 8);
+            output[outputOffset + 27] = ((v18 >>> 36) & 0b1111111111111111111111111111L) | ((v19 & 0b1111111111111111L) << 28);
+            output[outputOffset + 28] = (v19 >>> 16) & 0b11111111111111111111111111111111111111111111L;
+            output[outputOffset + 29] = ((v19 >>> 60) & 0b1111L) | ((v20 & 0b1111111111111111111111111111111111111111L) << 4);
+            output[outputOffset + 30] = ((v20 >>> 40) & 0b111111111111111111111111L) | ((v21 & 0b11111111111111111111L) << 24);
+            output[outputOffset + 31] = (v21 >>> 20) & 0b11111111111111111111111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker45
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            long v21 = input.readLong();
+            int v22 = input.readInt();
+            output[outputOffset] = v0 & 0b111111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 45) & 0b1111111111111111111L) | ((v1 & 0b11111111111111111111111111L) << 19);
+            output[outputOffset + 2] = ((v1 >>> 26) & 0b11111111111111111111111111111111111111L) | ((v2 & 0b1111111L) << 38);
+            output[outputOffset + 3] = (v2 >>> 7) & 0b111111111111111111111111111111111111111111111L;
+            output[outputOffset + 4] = ((v2 >>> 52) & 0b111111111111L) | ((v3 & 0b111111111111111111111111111111111L) << 12);
+            output[outputOffset + 5] = ((v3 >>> 33) & 0b1111111111111111111111111111111L) | ((v4 & 0b11111111111111L) << 31);
+            output[outputOffset + 6] = (v4 >>> 14) & 0b111111111111111111111111111111111111111111111L;
+            output[outputOffset + 7] = ((v4 >>> 59) & 0b11111L) | ((v5 & 0b1111111111111111111111111111111111111111L) << 5);
+            output[outputOffset + 8] = ((v5 >>> 40) & 0b111111111111111111111111L) | ((v6 & 0b111111111111111111111L) << 24);
+            output[outputOffset + 9] = ((v6 >>> 21) & 0b1111111111111111111111111111111111111111111L) | ((v7 & 0b11L) << 43);
+            output[outputOffset + 10] = (v7 >>> 2) & 0b111111111111111111111111111111111111111111111L;
+            output[outputOffset + 11] = ((v7 >>> 47) & 0b11111111111111111L) | ((v8 & 0b1111111111111111111111111111L) << 17);
+            output[outputOffset + 12] = ((v8 >>> 28) & 0b111111111111111111111111111111111111L) | ((v9 & 0b111111111L) << 36);
+            output[outputOffset + 13] = (v9 >>> 9) & 0b111111111111111111111111111111111111111111111L;
+            output[outputOffset + 14] = ((v9 >>> 54) & 0b1111111111L) | ((v10 & 0b11111111111111111111111111111111111L) << 10);
+            output[outputOffset + 15] = ((v10 >>> 35) & 0b11111111111111111111111111111L) | ((v11 & 0b1111111111111111L) << 29);
+            output[outputOffset + 16] = (v11 >>> 16) & 0b111111111111111111111111111111111111111111111L;
+            output[outputOffset + 17] = ((v11 >>> 61) & 0b111L) | ((v12 & 0b111111111111111111111111111111111111111111L) << 3);
+            output[outputOffset + 18] = ((v12 >>> 42) & 0b1111111111111111111111L) | ((v13 & 0b11111111111111111111111L) << 22);
+            output[outputOffset + 19] = ((v13 >>> 23) & 0b11111111111111111111111111111111111111111L) | ((v14 & 0b1111L) << 41);
+            output[outputOffset + 20] = (v14 >>> 4) & 0b111111111111111111111111111111111111111111111L;
+            output[outputOffset + 21] = ((v14 >>> 49) & 0b111111111111111L) | ((v15 & 0b111111111111111111111111111111L) << 15);
+            output[outputOffset + 22] = ((v15 >>> 30) & 0b1111111111111111111111111111111111L) | ((v16 & 0b11111111111L) << 34);
+            output[outputOffset + 23] = (v16 >>> 11) & 0b111111111111111111111111111111111111111111111L;
+            output[outputOffset + 24] = ((v16 >>> 56) & 0b11111111L) | ((v17 & 0b1111111111111111111111111111111111111L) << 8);
+            output[outputOffset + 25] = ((v17 >>> 37) & 0b111111111111111111111111111L) | ((v18 & 0b111111111111111111L) << 27);
+            output[outputOffset + 26] = (v18 >>> 18) & 0b111111111111111111111111111111111111111111111L;
+            output[outputOffset + 27] = ((v18 >>> 63) & 0b1L) | ((v19 & 0b11111111111111111111111111111111111111111111L) << 1);
+            output[outputOffset + 28] = ((v19 >>> 44) & 0b11111111111111111111L) | ((v20 & 0b1111111111111111111111111L) << 20);
+            output[outputOffset + 29] = ((v20 >>> 25) & 0b111111111111111111111111111111111111111L) | ((v21 & 0b111111L) << 39);
+            output[outputOffset + 30] = (v21 >>> 6) & 0b111111111111111111111111111111111111111111111L;
+            output[outputOffset + 31] = ((v21 >>> 51) & 0b1111111111111L) | ((v22 & 0b11111111111111111111111111111111L) << 13);
+        }
+    }
+
+    private static final class Unpacker46
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            long v21 = input.readLong();
+            long v22 = input.readLong();
+            output[outputOffset] = v0 & 0b1111111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 46) & 0b111111111111111111L) | ((v1 & 0b1111111111111111111111111111L) << 18);
+            output[outputOffset + 2] = ((v1 >>> 28) & 0b111111111111111111111111111111111111L) | ((v2 & 0b1111111111L) << 36);
+            output[outputOffset + 3] = (v2 >>> 10) & 0b1111111111111111111111111111111111111111111111L;
+            output[outputOffset + 4] = ((v2 >>> 56) & 0b11111111L) | ((v3 & 0b11111111111111111111111111111111111111L) << 8);
+            output[outputOffset + 5] = ((v3 >>> 38) & 0b11111111111111111111111111L) | ((v4 & 0b11111111111111111111L) << 26);
+            output[outputOffset + 6] = ((v4 >>> 20) & 0b11111111111111111111111111111111111111111111L) | ((v5 & 0b11L) << 44);
+            output[outputOffset + 7] = (v5 >>> 2) & 0b1111111111111111111111111111111111111111111111L;
+            output[outputOffset + 8] = ((v5 >>> 48) & 0b1111111111111111L) | ((v6 & 0b111111111111111111111111111111L) << 16);
+            output[outputOffset + 9] = ((v6 >>> 30) & 0b1111111111111111111111111111111111L) | ((v7 & 0b111111111111L) << 34);
+            output[outputOffset + 10] = (v7 >>> 12) & 0b1111111111111111111111111111111111111111111111L;
+            output[outputOffset + 11] = ((v7 >>> 58) & 0b111111L) | ((v8 & 0b1111111111111111111111111111111111111111L) << 6);
+            output[outputOffset + 12] = ((v8 >>> 40) & 0b111111111111111111111111L) | ((v9 & 0b1111111111111111111111L) << 24);
+            output[outputOffset + 13] = ((v9 >>> 22) & 0b111111111111111111111111111111111111111111L) | ((v10 & 0b1111L) << 42);
+            output[outputOffset + 14] = (v10 >>> 4) & 0b1111111111111111111111111111111111111111111111L;
+            output[outputOffset + 15] = ((v10 >>> 50) & 0b11111111111111L) | ((v11 & 0b11111111111111111111111111111111L) << 14);
+            output[outputOffset + 16] = ((v11 >>> 32) & 0b11111111111111111111111111111111L) | ((v12 & 0b11111111111111L) << 32);
+            output[outputOffset + 17] = (v12 >>> 14) & 0b1111111111111111111111111111111111111111111111L;
+            output[outputOffset + 18] = ((v12 >>> 60) & 0b1111L) | ((v13 & 0b111111111111111111111111111111111111111111L) << 4);
+            output[outputOffset + 19] = ((v13 >>> 42) & 0b1111111111111111111111L) | ((v14 & 0b111111111111111111111111L) << 22);
+            output[outputOffset + 20] = ((v14 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v15 & 0b111111L) << 40);
+            output[outputOffset + 21] = (v15 >>> 6) & 0b1111111111111111111111111111111111111111111111L;
+            output[outputOffset + 22] = ((v15 >>> 52) & 0b111111111111L) | ((v16 & 0b1111111111111111111111111111111111L) << 12);
+            output[outputOffset + 23] = ((v16 >>> 34) & 0b111111111111111111111111111111L) | ((v17 & 0b1111111111111111L) << 30);
+            output[outputOffset + 24] = (v17 >>> 16) & 0b1111111111111111111111111111111111111111111111L;
+            output[outputOffset + 25] = ((v17 >>> 62) & 0b11L) | ((v18 & 0b11111111111111111111111111111111111111111111L) << 2);
+            output[outputOffset + 26] = ((v18 >>> 44) & 0b11111111111111111111L) | ((v19 & 0b11111111111111111111111111L) << 20);
+            output[outputOffset + 27] = ((v19 >>> 26) & 0b11111111111111111111111111111111111111L) | ((v20 & 0b11111111L) << 38);
+            output[outputOffset + 28] = (v20 >>> 8) & 0b1111111111111111111111111111111111111111111111L;
+            output[outputOffset + 29] = ((v20 >>> 54) & 0b1111111111L) | ((v21 & 0b111111111111111111111111111111111111L) << 10);
+            output[outputOffset + 30] = ((v21 >>> 36) & 0b1111111111111111111111111111L) | ((v22 & 0b111111111111111111L) << 28);
+            output[outputOffset + 31] = (v22 >>> 18) & 0b1111111111111111111111111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker47
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            long v21 = input.readLong();
+            long v22 = input.readLong();
+            int v23 = input.readInt();
+            output[outputOffset] = v0 & 0b11111111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 47) & 0b11111111111111111L) | ((v1 & 0b111111111111111111111111111111L) << 17);
+            output[outputOffset + 2] = ((v1 >>> 30) & 0b1111111111111111111111111111111111L) | ((v2 & 0b1111111111111L) << 34);
+            output[outputOffset + 3] = (v2 >>> 13) & 0b11111111111111111111111111111111111111111111111L;
+            output[outputOffset + 4] = ((v2 >>> 60) & 0b1111L) | ((v3 & 0b1111111111111111111111111111111111111111111L) << 4);
+            output[outputOffset + 5] = ((v3 >>> 43) & 0b111111111111111111111L) | ((v4 & 0b11111111111111111111111111L) << 21);
+            output[outputOffset + 6] = ((v4 >>> 26) & 0b11111111111111111111111111111111111111L) | ((v5 & 0b111111111L) << 38);
+            output[outputOffset + 7] = (v5 >>> 9) & 0b11111111111111111111111111111111111111111111111L;
+            output[outputOffset + 8] = ((v5 >>> 56) & 0b11111111L) | ((v6 & 0b111111111111111111111111111111111111111L) << 8);
+            output[outputOffset + 9] = ((v6 >>> 39) & 0b1111111111111111111111111L) | ((v7 & 0b1111111111111111111111L) << 25);
+            output[outputOffset + 10] = ((v7 >>> 22) & 0b111111111111111111111111111111111111111111L) | ((v8 & 0b11111L) << 42);
+            output[outputOffset + 11] = (v8 >>> 5) & 0b11111111111111111111111111111111111111111111111L;
+            output[outputOffset + 12] = ((v8 >>> 52) & 0b111111111111L) | ((v9 & 0b11111111111111111111111111111111111L) << 12);
+            output[outputOffset + 13] = ((v9 >>> 35) & 0b11111111111111111111111111111L) | ((v10 & 0b111111111111111111L) << 29);
+            output[outputOffset + 14] = ((v10 >>> 18) & 0b1111111111111111111111111111111111111111111111L) | ((v11 & 0b1L) << 46);
+            output[outputOffset + 15] = (v11 >>> 1) & 0b11111111111111111111111111111111111111111111111L;
+            output[outputOffset + 16] = ((v11 >>> 48) & 0b1111111111111111L) | ((v12 & 0b1111111111111111111111111111111L) << 16);
+            output[outputOffset + 17] = ((v12 >>> 31) & 0b111111111111111111111111111111111L) | ((v13 & 0b11111111111111L) << 33);
+            output[outputOffset + 18] = (v13 >>> 14) & 0b11111111111111111111111111111111111111111111111L;
+            output[outputOffset + 19] = ((v13 >>> 61) & 0b111L) | ((v14 & 0b11111111111111111111111111111111111111111111L) << 3);
+            output[outputOffset + 20] = ((v14 >>> 44) & 0b11111111111111111111L) | ((v15 & 0b111111111111111111111111111L) << 20);
+            output[outputOffset + 21] = ((v15 >>> 27) & 0b1111111111111111111111111111111111111L) | ((v16 & 0b1111111111L) << 37);
+            output[outputOffset + 22] = (v16 >>> 10) & 0b11111111111111111111111111111111111111111111111L;
+            output[outputOffset + 23] = ((v16 >>> 57) & 0b1111111L) | ((v17 & 0b1111111111111111111111111111111111111111L) << 7);
+            output[outputOffset + 24] = ((v17 >>> 40) & 0b111111111111111111111111L) | ((v18 & 0b11111111111111111111111L) << 24);
+            output[outputOffset + 25] = ((v18 >>> 23) & 0b11111111111111111111111111111111111111111L) | ((v19 & 0b111111L) << 41);
+            output[outputOffset + 26] = (v19 >>> 6) & 0b11111111111111111111111111111111111111111111111L;
+            output[outputOffset + 27] = ((v19 >>> 53) & 0b11111111111L) | ((v20 & 0b111111111111111111111111111111111111L) << 11);
+            output[outputOffset + 28] = ((v20 >>> 36) & 0b1111111111111111111111111111L) | ((v21 & 0b1111111111111111111L) << 28);
+            output[outputOffset + 29] = ((v21 >>> 19) & 0b111111111111111111111111111111111111111111111L) | ((v22 & 0b11L) << 45);
+            output[outputOffset + 30] = (v22 >>> 2) & 0b11111111111111111111111111111111111111111111111L;
+            output[outputOffset + 31] = ((v22 >>> 49) & 0b111111111111111L) | ((v23 & 0b11111111111111111111111111111111L) << 15);
+        }
+    }
+
+    private static final class Unpacker48
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            long v21 = input.readLong();
+            long v22 = input.readLong();
+            long v23 = input.readLong();
+            output[outputOffset] = v0 & 0b111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 48) & 0b1111111111111111L) | ((v1 & 0b11111111111111111111111111111111L) << 16);
+            output[outputOffset + 2] = ((v1 >>> 32) & 0b11111111111111111111111111111111L) | ((v2 & 0b1111111111111111L) << 32);
+            output[outputOffset + 3] = (v2 >>> 16) & 0b111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 4] = v3 & 0b111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 5] = ((v3 >>> 48) & 0b1111111111111111L) | ((v4 & 0b11111111111111111111111111111111L) << 16);
+            output[outputOffset + 6] = ((v4 >>> 32) & 0b11111111111111111111111111111111L) | ((v5 & 0b1111111111111111L) << 32);
+            output[outputOffset + 7] = (v5 >>> 16) & 0b111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 8] = v6 & 0b111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 9] = ((v6 >>> 48) & 0b1111111111111111L) | ((v7 & 0b11111111111111111111111111111111L) << 16);
+            output[outputOffset + 10] = ((v7 >>> 32) & 0b11111111111111111111111111111111L) | ((v8 & 0b1111111111111111L) << 32);
+            output[outputOffset + 11] = (v8 >>> 16) & 0b111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 12] = v9 & 0b111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 13] = ((v9 >>> 48) & 0b1111111111111111L) | ((v10 & 0b11111111111111111111111111111111L) << 16);
+            output[outputOffset + 14] = ((v10 >>> 32) & 0b11111111111111111111111111111111L) | ((v11 & 0b1111111111111111L) << 32);
+            output[outputOffset + 15] = (v11 >>> 16) & 0b111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 16] = v12 & 0b111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 17] = ((v12 >>> 48) & 0b1111111111111111L) | ((v13 & 0b11111111111111111111111111111111L) << 16);
+            output[outputOffset + 18] = ((v13 >>> 32) & 0b11111111111111111111111111111111L) | ((v14 & 0b1111111111111111L) << 32);
+            output[outputOffset + 19] = (v14 >>> 16) & 0b111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 20] = v15 & 0b111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 21] = ((v15 >>> 48) & 0b1111111111111111L) | ((v16 & 0b11111111111111111111111111111111L) << 16);
+            output[outputOffset + 22] = ((v16 >>> 32) & 0b11111111111111111111111111111111L) | ((v17 & 0b1111111111111111L) << 32);
+            output[outputOffset + 23] = (v17 >>> 16) & 0b111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 24] = v18 & 0b111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 25] = ((v18 >>> 48) & 0b1111111111111111L) | ((v19 & 0b11111111111111111111111111111111L) << 16);
+            output[outputOffset + 26] = ((v19 >>> 32) & 0b11111111111111111111111111111111L) | ((v20 & 0b1111111111111111L) << 32);
+            output[outputOffset + 27] = (v20 >>> 16) & 0b111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 28] = v21 & 0b111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 29] = ((v21 >>> 48) & 0b1111111111111111L) | ((v22 & 0b11111111111111111111111111111111L) << 16);
+            output[outputOffset + 30] = ((v22 >>> 32) & 0b11111111111111111111111111111111L) | ((v23 & 0b1111111111111111L) << 32);
+            output[outputOffset + 31] = (v23 >>> 16) & 0b111111111111111111111111111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker49
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            long v21 = input.readLong();
+            long v22 = input.readLong();
+            long v23 = input.readLong();
+            int v24 = input.readInt();
+            output[outputOffset] = v0 & 0b1111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 49) & 0b111111111111111L) | ((v1 & 0b1111111111111111111111111111111111L) << 15);
+            output[outputOffset + 2] = ((v1 >>> 34) & 0b111111111111111111111111111111L) | ((v2 & 0b1111111111111111111L) << 30);
+            output[outputOffset + 3] = ((v2 >>> 19) & 0b111111111111111111111111111111111111111111111L) | ((v3 & 0b1111L) << 45);
+            output[outputOffset + 4] = (v3 >>> 4) & 0b1111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 5] = ((v3 >>> 53) & 0b11111111111L) | ((v4 & 0b11111111111111111111111111111111111111L) << 11);
+            output[outputOffset + 6] = ((v4 >>> 38) & 0b11111111111111111111111111L) | ((v5 & 0b11111111111111111111111L) << 26);
+            output[outputOffset + 7] = ((v5 >>> 23) & 0b11111111111111111111111111111111111111111L) | ((v6 & 0b11111111L) << 41);
+            output[outputOffset + 8] = (v6 >>> 8) & 0b1111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 9] = ((v6 >>> 57) & 0b1111111L) | ((v7 & 0b111111111111111111111111111111111111111111L) << 7);
+            output[outputOffset + 10] = ((v7 >>> 42) & 0b1111111111111111111111L) | ((v8 & 0b111111111111111111111111111L) << 22);
+            output[outputOffset + 11] = ((v8 >>> 27) & 0b1111111111111111111111111111111111111L) | ((v9 & 0b111111111111L) << 37);
+            output[outputOffset + 12] = (v9 >>> 12) & 0b1111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 13] = ((v9 >>> 61) & 0b111L) | ((v10 & 0b1111111111111111111111111111111111111111111111L) << 3);
+            output[outputOffset + 14] = ((v10 >>> 46) & 0b111111111111111111L) | ((v11 & 0b1111111111111111111111111111111L) << 18);
+            output[outputOffset + 15] = ((v11 >>> 31) & 0b111111111111111111111111111111111L) | ((v12 & 0b1111111111111111L) << 33);
+            output[outputOffset + 16] = ((v12 >>> 16) & 0b111111111111111111111111111111111111111111111111L) | ((v13 & 0b1L) << 48);
+            output[outputOffset + 17] = (v13 >>> 1) & 0b1111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 18] = ((v13 >>> 50) & 0b11111111111111L) | ((v14 & 0b11111111111111111111111111111111111L) << 14);
+            output[outputOffset + 19] = ((v14 >>> 35) & 0b11111111111111111111111111111L) | ((v15 & 0b11111111111111111111L) << 29);
+            output[outputOffset + 20] = ((v15 >>> 20) & 0b11111111111111111111111111111111111111111111L) | ((v16 & 0b11111L) << 44);
+            output[outputOffset + 21] = (v16 >>> 5) & 0b1111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 22] = ((v16 >>> 54) & 0b1111111111L) | ((v17 & 0b111111111111111111111111111111111111111L) << 10);
+            output[outputOffset + 23] = ((v17 >>> 39) & 0b1111111111111111111111111L) | ((v18 & 0b111111111111111111111111L) << 25);
+            output[outputOffset + 24] = ((v18 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v19 & 0b111111111L) << 40);
+            output[outputOffset + 25] = (v19 >>> 9) & 0b1111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 26] = ((v19 >>> 58) & 0b111111L) | ((v20 & 0b1111111111111111111111111111111111111111111L) << 6);
+            output[outputOffset + 27] = ((v20 >>> 43) & 0b111111111111111111111L) | ((v21 & 0b1111111111111111111111111111L) << 21);
+            output[outputOffset + 28] = ((v21 >>> 28) & 0b111111111111111111111111111111111111L) | ((v22 & 0b1111111111111L) << 36);
+            output[outputOffset + 29] = (v22 >>> 13) & 0b1111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 30] = ((v22 >>> 62) & 0b11L) | ((v23 & 0b11111111111111111111111111111111111111111111111L) << 2);
+            output[outputOffset + 31] = ((v23 >>> 47) & 0b11111111111111111L) | ((v24 & 0b11111111111111111111111111111111L) << 17);
+        }
+    }
+
+    private static final class Unpacker50
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            long v21 = input.readLong();
+            long v22 = input.readLong();
+            long v23 = input.readLong();
+            long v24 = input.readLong();
+            output[outputOffset] = v0 & 0b11111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 50) & 0b11111111111111L) | ((v1 & 0b111111111111111111111111111111111111L) << 14);
+            output[outputOffset + 2] = ((v1 >>> 36) & 0b1111111111111111111111111111L) | ((v2 & 0b1111111111111111111111L) << 28);
+            output[outputOffset + 3] = ((v2 >>> 22) & 0b111111111111111111111111111111111111111111L) | ((v3 & 0b11111111L) << 42);
+            output[outputOffset + 4] = (v3 >>> 8) & 0b11111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 5] = ((v3 >>> 58) & 0b111111L) | ((v4 & 0b11111111111111111111111111111111111111111111L) << 6);
+            output[outputOffset + 6] = ((v4 >>> 44) & 0b11111111111111111111L) | ((v5 & 0b111111111111111111111111111111L) << 20);
+            output[outputOffset + 7] = ((v5 >>> 30) & 0b1111111111111111111111111111111111L) | ((v6 & 0b1111111111111111L) << 34);
+            output[outputOffset + 8] = ((v6 >>> 16) & 0b111111111111111111111111111111111111111111111111L) | ((v7 & 0b11L) << 48);
+            output[outputOffset + 9] = (v7 >>> 2) & 0b11111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 10] = ((v7 >>> 52) & 0b111111111111L) | ((v8 & 0b11111111111111111111111111111111111111L) << 12);
+            output[outputOffset + 11] = ((v8 >>> 38) & 0b11111111111111111111111111L) | ((v9 & 0b111111111111111111111111L) << 26);
+            output[outputOffset + 12] = ((v9 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v10 & 0b1111111111L) << 40);
+            output[outputOffset + 13] = (v10 >>> 10) & 0b11111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 14] = ((v10 >>> 60) & 0b1111L) | ((v11 & 0b1111111111111111111111111111111111111111111111L) << 4);
+            output[outputOffset + 15] = ((v11 >>> 46) & 0b111111111111111111L) | ((v12 & 0b11111111111111111111111111111111L) << 18);
+            output[outputOffset + 16] = ((v12 >>> 32) & 0b11111111111111111111111111111111L) | ((v13 & 0b111111111111111111L) << 32);
+            output[outputOffset + 17] = ((v13 >>> 18) & 0b1111111111111111111111111111111111111111111111L) | ((v14 & 0b1111L) << 46);
+            output[outputOffset + 18] = (v14 >>> 4) & 0b11111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 19] = ((v14 >>> 54) & 0b1111111111L) | ((v15 & 0b1111111111111111111111111111111111111111L) << 10);
+            output[outputOffset + 20] = ((v15 >>> 40) & 0b111111111111111111111111L) | ((v16 & 0b11111111111111111111111111L) << 24);
+            output[outputOffset + 21] = ((v16 >>> 26) & 0b11111111111111111111111111111111111111L) | ((v17 & 0b111111111111L) << 38);
+            output[outputOffset + 22] = (v17 >>> 12) & 0b11111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 23] = ((v17 >>> 62) & 0b11L) | ((v18 & 0b111111111111111111111111111111111111111111111111L) << 2);
+            output[outputOffset + 24] = ((v18 >>> 48) & 0b1111111111111111L) | ((v19 & 0b1111111111111111111111111111111111L) << 16);
+            output[outputOffset + 25] = ((v19 >>> 34) & 0b111111111111111111111111111111L) | ((v20 & 0b11111111111111111111L) << 30);
+            output[outputOffset + 26] = ((v20 >>> 20) & 0b11111111111111111111111111111111111111111111L) | ((v21 & 0b111111L) << 44);
+            output[outputOffset + 27] = (v21 >>> 6) & 0b11111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 28] = ((v21 >>> 56) & 0b11111111L) | ((v22 & 0b111111111111111111111111111111111111111111L) << 8);
+            output[outputOffset + 29] = ((v22 >>> 42) & 0b1111111111111111111111L) | ((v23 & 0b1111111111111111111111111111L) << 22);
+            output[outputOffset + 30] = ((v23 >>> 28) & 0b111111111111111111111111111111111111L) | ((v24 & 0b11111111111111L) << 36);
+            output[outputOffset + 31] = (v24 >>> 14) & 0b11111111111111111111111111111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker51
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            long v21 = input.readLong();
+            long v22 = input.readLong();
+            long v23 = input.readLong();
+            long v24 = input.readLong();
+            int v25 = input.readInt();
+            output[outputOffset] = v0 & 0b111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 51) & 0b1111111111111L) | ((v1 & 0b11111111111111111111111111111111111111L) << 13);
+            output[outputOffset + 2] = ((v1 >>> 38) & 0b11111111111111111111111111L) | ((v2 & 0b1111111111111111111111111L) << 26);
+            output[outputOffset + 3] = ((v2 >>> 25) & 0b111111111111111111111111111111111111111L) | ((v3 & 0b111111111111L) << 39);
+            output[outputOffset + 4] = (v3 >>> 12) & 0b111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 5] = ((v3 >>> 63) & 0b1L) | ((v4 & 0b11111111111111111111111111111111111111111111111111L) << 1);
+            output[outputOffset + 6] = ((v4 >>> 50) & 0b11111111111111L) | ((v5 & 0b1111111111111111111111111111111111111L) << 14);
+            output[outputOffset + 7] = ((v5 >>> 37) & 0b111111111111111111111111111L) | ((v6 & 0b111111111111111111111111L) << 27);
+            output[outputOffset + 8] = ((v6 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v7 & 0b11111111111L) << 40);
+            output[outputOffset + 9] = (v7 >>> 11) & 0b111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 10] = ((v7 >>> 62) & 0b11L) | ((v8 & 0b1111111111111111111111111111111111111111111111111L) << 2);
+            output[outputOffset + 11] = ((v8 >>> 49) & 0b111111111111111L) | ((v9 & 0b111111111111111111111111111111111111L) << 15);
+            output[outputOffset + 12] = ((v9 >>> 36) & 0b1111111111111111111111111111L) | ((v10 & 0b11111111111111111111111L) << 28);
+            output[outputOffset + 13] = ((v10 >>> 23) & 0b11111111111111111111111111111111111111111L) | ((v11 & 0b1111111111L) << 41);
+            output[outputOffset + 14] = (v11 >>> 10) & 0b111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 15] = ((v11 >>> 61) & 0b111L) | ((v12 & 0b111111111111111111111111111111111111111111111111L) << 3);
+            output[outputOffset + 16] = ((v12 >>> 48) & 0b1111111111111111L) | ((v13 & 0b11111111111111111111111111111111111L) << 16);
+            output[outputOffset + 17] = ((v13 >>> 35) & 0b11111111111111111111111111111L) | ((v14 & 0b1111111111111111111111L) << 29);
+            output[outputOffset + 18] = ((v14 >>> 22) & 0b111111111111111111111111111111111111111111L) | ((v15 & 0b111111111L) << 42);
+            output[outputOffset + 19] = (v15 >>> 9) & 0b111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 20] = ((v15 >>> 60) & 0b1111L) | ((v16 & 0b11111111111111111111111111111111111111111111111L) << 4);
+            output[outputOffset + 21] = ((v16 >>> 47) & 0b11111111111111111L) | ((v17 & 0b1111111111111111111111111111111111L) << 17);
+            output[outputOffset + 22] = ((v17 >>> 34) & 0b111111111111111111111111111111L) | ((v18 & 0b111111111111111111111L) << 30);
+            output[outputOffset + 23] = ((v18 >>> 21) & 0b1111111111111111111111111111111111111111111L) | ((v19 & 0b11111111L) << 43);
+            output[outputOffset + 24] = (v19 >>> 8) & 0b111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 25] = ((v19 >>> 59) & 0b11111L) | ((v20 & 0b1111111111111111111111111111111111111111111111L) << 5);
+            output[outputOffset + 26] = ((v20 >>> 46) & 0b111111111111111111L) | ((v21 & 0b111111111111111111111111111111111L) << 18);
+            output[outputOffset + 27] = ((v21 >>> 33) & 0b1111111111111111111111111111111L) | ((v22 & 0b11111111111111111111L) << 31);
+            output[outputOffset + 28] = ((v22 >>> 20) & 0b11111111111111111111111111111111111111111111L) | ((v23 & 0b1111111L) << 44);
+            output[outputOffset + 29] = (v23 >>> 7) & 0b111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 30] = ((v23 >>> 58) & 0b111111L) | ((v24 & 0b111111111111111111111111111111111111111111111L) << 6);
+            output[outputOffset + 31] = ((v24 >>> 45) & 0b1111111111111111111L) | ((v25 & 0b11111111111111111111111111111111L) << 19);
+        }
+    }
+
+    private static final class Unpacker52
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            long v21 = input.readLong();
+            long v22 = input.readLong();
+            long v23 = input.readLong();
+            long v24 = input.readLong();
+            long v25 = input.readLong();
+            output[outputOffset] = v0 & 0b1111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 52) & 0b111111111111L) | ((v1 & 0b1111111111111111111111111111111111111111L) << 12);
+            output[outputOffset + 2] = ((v1 >>> 40) & 0b111111111111111111111111L) | ((v2 & 0b1111111111111111111111111111L) << 24);
+            output[outputOffset + 3] = ((v2 >>> 28) & 0b111111111111111111111111111111111111L) | ((v3 & 0b1111111111111111L) << 36);
+            output[outputOffset + 4] = ((v3 >>> 16) & 0b111111111111111111111111111111111111111111111111L) | ((v4 & 0b1111L) << 48);
+            output[outputOffset + 5] = (v4 >>> 4) & 0b1111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 6] = ((v4 >>> 56) & 0b11111111L) | ((v5 & 0b11111111111111111111111111111111111111111111L) << 8);
+            output[outputOffset + 7] = ((v5 >>> 44) & 0b11111111111111111111L) | ((v6 & 0b11111111111111111111111111111111L) << 20);
+            output[outputOffset + 8] = ((v6 >>> 32) & 0b11111111111111111111111111111111L) | ((v7 & 0b11111111111111111111L) << 32);
+            output[outputOffset + 9] = ((v7 >>> 20) & 0b11111111111111111111111111111111111111111111L) | ((v8 & 0b11111111L) << 44);
+            output[outputOffset + 10] = (v8 >>> 8) & 0b1111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 11] = ((v8 >>> 60) & 0b1111L) | ((v9 & 0b111111111111111111111111111111111111111111111111L) << 4);
+            output[outputOffset + 12] = ((v9 >>> 48) & 0b1111111111111111L) | ((v10 & 0b111111111111111111111111111111111111L) << 16);
+            output[outputOffset + 13] = ((v10 >>> 36) & 0b1111111111111111111111111111L) | ((v11 & 0b111111111111111111111111L) << 28);
+            output[outputOffset + 14] = ((v11 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v12 & 0b111111111111L) << 40);
+            output[outputOffset + 15] = (v12 >>> 12) & 0b1111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 16] = v13 & 0b1111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 17] = ((v13 >>> 52) & 0b111111111111L) | ((v14 & 0b1111111111111111111111111111111111111111L) << 12);
+            output[outputOffset + 18] = ((v14 >>> 40) & 0b111111111111111111111111L) | ((v15 & 0b1111111111111111111111111111L) << 24);
+            output[outputOffset + 19] = ((v15 >>> 28) & 0b111111111111111111111111111111111111L) | ((v16 & 0b1111111111111111L) << 36);
+            output[outputOffset + 20] = ((v16 >>> 16) & 0b111111111111111111111111111111111111111111111111L) | ((v17 & 0b1111L) << 48);
+            output[outputOffset + 21] = (v17 >>> 4) & 0b1111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 22] = ((v17 >>> 56) & 0b11111111L) | ((v18 & 0b11111111111111111111111111111111111111111111L) << 8);
+            output[outputOffset + 23] = ((v18 >>> 44) & 0b11111111111111111111L) | ((v19 & 0b11111111111111111111111111111111L) << 20);
+            output[outputOffset + 24] = ((v19 >>> 32) & 0b11111111111111111111111111111111L) | ((v20 & 0b11111111111111111111L) << 32);
+            output[outputOffset + 25] = ((v20 >>> 20) & 0b11111111111111111111111111111111111111111111L) | ((v21 & 0b11111111L) << 44);
+            output[outputOffset + 26] = (v21 >>> 8) & 0b1111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 27] = ((v21 >>> 60) & 0b1111L) | ((v22 & 0b111111111111111111111111111111111111111111111111L) << 4);
+            output[outputOffset + 28] = ((v22 >>> 48) & 0b1111111111111111L) | ((v23 & 0b111111111111111111111111111111111111L) << 16);
+            output[outputOffset + 29] = ((v23 >>> 36) & 0b1111111111111111111111111111L) | ((v24 & 0b111111111111111111111111L) << 28);
+            output[outputOffset + 30] = ((v24 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v25 & 0b111111111111L) << 40);
+            output[outputOffset + 31] = (v25 >>> 12) & 0b1111111111111111111111111111111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker53
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            long v21 = input.readLong();
+            long v22 = input.readLong();
+            long v23 = input.readLong();
+            long v24 = input.readLong();
+            long v25 = input.readLong();
+            int v26 = input.readInt();
+            output[outputOffset] = v0 & 0b11111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 53) & 0b11111111111L) | ((v1 & 0b111111111111111111111111111111111111111111L) << 11);
+            output[outputOffset + 2] = ((v1 >>> 42) & 0b1111111111111111111111L) | ((v2 & 0b1111111111111111111111111111111L) << 22);
+            output[outputOffset + 3] = ((v2 >>> 31) & 0b111111111111111111111111111111111L) | ((v3 & 0b11111111111111111111L) << 33);
+            output[outputOffset + 4] = ((v3 >>> 20) & 0b11111111111111111111111111111111111111111111L) | ((v4 & 0b111111111L) << 44);
+            output[outputOffset + 5] = (v4 >>> 9) & 0b11111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 6] = ((v4 >>> 62) & 0b11L) | ((v5 & 0b111111111111111111111111111111111111111111111111111L) << 2);
+            output[outputOffset + 7] = ((v5 >>> 51) & 0b1111111111111L) | ((v6 & 0b1111111111111111111111111111111111111111L) << 13);
+            output[outputOffset + 8] = ((v6 >>> 40) & 0b111111111111111111111111L) | ((v7 & 0b11111111111111111111111111111L) << 24);
+            output[outputOffset + 9] = ((v7 >>> 29) & 0b11111111111111111111111111111111111L) | ((v8 & 0b111111111111111111L) << 35);
+            output[outputOffset + 10] = ((v8 >>> 18) & 0b1111111111111111111111111111111111111111111111L) | ((v9 & 0b1111111L) << 46);
+            output[outputOffset + 11] = (v9 >>> 7) & 0b11111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 12] = ((v9 >>> 60) & 0b1111L) | ((v10 & 0b1111111111111111111111111111111111111111111111111L) << 4);
+            output[outputOffset + 13] = ((v10 >>> 49) & 0b111111111111111L) | ((v11 & 0b11111111111111111111111111111111111111L) << 15);
+            output[outputOffset + 14] = ((v11 >>> 38) & 0b11111111111111111111111111L) | ((v12 & 0b111111111111111111111111111L) << 26);
+            output[outputOffset + 15] = ((v12 >>> 27) & 0b1111111111111111111111111111111111111L) | ((v13 & 0b1111111111111111L) << 37);
+            output[outputOffset + 16] = ((v13 >>> 16) & 0b111111111111111111111111111111111111111111111111L) | ((v14 & 0b11111L) << 48);
+            output[outputOffset + 17] = (v14 >>> 5) & 0b11111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 18] = ((v14 >>> 58) & 0b111111L) | ((v15 & 0b11111111111111111111111111111111111111111111111L) << 6);
+            output[outputOffset + 19] = ((v15 >>> 47) & 0b11111111111111111L) | ((v16 & 0b111111111111111111111111111111111111L) << 17);
+            output[outputOffset + 20] = ((v16 >>> 36) & 0b1111111111111111111111111111L) | ((v17 & 0b1111111111111111111111111L) << 28);
+            output[outputOffset + 21] = ((v17 >>> 25) & 0b111111111111111111111111111111111111111L) | ((v18 & 0b11111111111111L) << 39);
+            output[outputOffset + 22] = ((v18 >>> 14) & 0b11111111111111111111111111111111111111111111111111L) | ((v19 & 0b111L) << 50);
+            output[outputOffset + 23] = (v19 >>> 3) & 0b11111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 24] = ((v19 >>> 56) & 0b11111111L) | ((v20 & 0b111111111111111111111111111111111111111111111L) << 8);
+            output[outputOffset + 25] = ((v20 >>> 45) & 0b1111111111111111111L) | ((v21 & 0b1111111111111111111111111111111111L) << 19);
+            output[outputOffset + 26] = ((v21 >>> 34) & 0b111111111111111111111111111111L) | ((v22 & 0b11111111111111111111111L) << 30);
+            output[outputOffset + 27] = ((v22 >>> 23) & 0b11111111111111111111111111111111111111111L) | ((v23 & 0b111111111111L) << 41);
+            output[outputOffset + 28] = ((v23 >>> 12) & 0b1111111111111111111111111111111111111111111111111111L) | ((v24 & 0b1L) << 52);
+            output[outputOffset + 29] = (v24 >>> 1) & 0b11111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 30] = ((v24 >>> 54) & 0b1111111111L) | ((v25 & 0b1111111111111111111111111111111111111111111L) << 10);
+            output[outputOffset + 31] = ((v25 >>> 43) & 0b111111111111111111111L) | ((v26 & 0b11111111111111111111111111111111L) << 21);
+        }
+    }
+
+    private static final class Unpacker54
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            long v21 = input.readLong();
+            long v22 = input.readLong();
+            long v23 = input.readLong();
+            long v24 = input.readLong();
+            long v25 = input.readLong();
+            long v26 = input.readLong();
+            output[outputOffset] = v0 & 0b111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 54) & 0b1111111111L) | ((v1 & 0b11111111111111111111111111111111111111111111L) << 10);
+            output[outputOffset + 2] = ((v1 >>> 44) & 0b11111111111111111111L) | ((v2 & 0b1111111111111111111111111111111111L) << 20);
+            output[outputOffset + 3] = ((v2 >>> 34) & 0b111111111111111111111111111111L) | ((v3 & 0b111111111111111111111111L) << 30);
+            output[outputOffset + 4] = ((v3 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v4 & 0b11111111111111L) << 40);
+            output[outputOffset + 5] = ((v4 >>> 14) & 0b11111111111111111111111111111111111111111111111111L) | ((v5 & 0b1111L) << 50);
+            output[outputOffset + 6] = (v5 >>> 4) & 0b111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 7] = ((v5 >>> 58) & 0b111111L) | ((v6 & 0b111111111111111111111111111111111111111111111111L) << 6);
+            output[outputOffset + 8] = ((v6 >>> 48) & 0b1111111111111111L) | ((v7 & 0b11111111111111111111111111111111111111L) << 16);
+            output[outputOffset + 9] = ((v7 >>> 38) & 0b11111111111111111111111111L) | ((v8 & 0b1111111111111111111111111111L) << 26);
+            output[outputOffset + 10] = ((v8 >>> 28) & 0b111111111111111111111111111111111111L) | ((v9 & 0b111111111111111111L) << 36);
+            output[outputOffset + 11] = ((v9 >>> 18) & 0b1111111111111111111111111111111111111111111111L) | ((v10 & 0b11111111L) << 46);
+            output[outputOffset + 12] = (v10 >>> 8) & 0b111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 13] = ((v10 >>> 62) & 0b11L) | ((v11 & 0b1111111111111111111111111111111111111111111111111111L) << 2);
+            output[outputOffset + 14] = ((v11 >>> 52) & 0b111111111111L) | ((v12 & 0b111111111111111111111111111111111111111111L) << 12);
+            output[outputOffset + 15] = ((v12 >>> 42) & 0b1111111111111111111111L) | ((v13 & 0b11111111111111111111111111111111L) << 22);
+            output[outputOffset + 16] = ((v13 >>> 32) & 0b11111111111111111111111111111111L) | ((v14 & 0b1111111111111111111111L) << 32);
+            output[outputOffset + 17] = ((v14 >>> 22) & 0b111111111111111111111111111111111111111111L) | ((v15 & 0b111111111111L) << 42);
+            output[outputOffset + 18] = ((v15 >>> 12) & 0b1111111111111111111111111111111111111111111111111111L) | ((v16 & 0b11L) << 52);
+            output[outputOffset + 19] = (v16 >>> 2) & 0b111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 20] = ((v16 >>> 56) & 0b11111111L) | ((v17 & 0b1111111111111111111111111111111111111111111111L) << 8);
+            output[outputOffset + 21] = ((v17 >>> 46) & 0b111111111111111111L) | ((v18 & 0b111111111111111111111111111111111111L) << 18);
+            output[outputOffset + 22] = ((v18 >>> 36) & 0b1111111111111111111111111111L) | ((v19 & 0b11111111111111111111111111L) << 28);
+            output[outputOffset + 23] = ((v19 >>> 26) & 0b11111111111111111111111111111111111111L) | ((v20 & 0b1111111111111111L) << 38);
+            output[outputOffset + 24] = ((v20 >>> 16) & 0b111111111111111111111111111111111111111111111111L) | ((v21 & 0b111111L) << 48);
+            output[outputOffset + 25] = (v21 >>> 6) & 0b111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 26] = ((v21 >>> 60) & 0b1111L) | ((v22 & 0b11111111111111111111111111111111111111111111111111L) << 4);
+            output[outputOffset + 27] = ((v22 >>> 50) & 0b11111111111111L) | ((v23 & 0b1111111111111111111111111111111111111111L) << 14);
+            output[outputOffset + 28] = ((v23 >>> 40) & 0b111111111111111111111111L) | ((v24 & 0b111111111111111111111111111111L) << 24);
+            output[outputOffset + 29] = ((v24 >>> 30) & 0b1111111111111111111111111111111111L) | ((v25 & 0b11111111111111111111L) << 34);
+            output[outputOffset + 30] = ((v25 >>> 20) & 0b11111111111111111111111111111111111111111111L) | ((v26 & 0b1111111111L) << 44);
+            output[outputOffset + 31] = (v26 >>> 10) & 0b111111111111111111111111111111111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker55
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            long v21 = input.readLong();
+            long v22 = input.readLong();
+            long v23 = input.readLong();
+            long v24 = input.readLong();
+            long v25 = input.readLong();
+            long v26 = input.readLong();
+            int v27 = input.readInt();
+            output[outputOffset] = v0 & 0b1111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 55) & 0b111111111L) | ((v1 & 0b1111111111111111111111111111111111111111111111L) << 9);
+            output[outputOffset + 2] = ((v1 >>> 46) & 0b111111111111111111L) | ((v2 & 0b1111111111111111111111111111111111111L) << 18);
+            output[outputOffset + 3] = ((v2 >>> 37) & 0b111111111111111111111111111L) | ((v3 & 0b1111111111111111111111111111L) << 27);
+            output[outputOffset + 4] = ((v3 >>> 28) & 0b111111111111111111111111111111111111L) | ((v4 & 0b1111111111111111111L) << 36);
+            output[outputOffset + 5] = ((v4 >>> 19) & 0b111111111111111111111111111111111111111111111L) | ((v5 & 0b1111111111L) << 45);
+            output[outputOffset + 6] = ((v5 >>> 10) & 0b111111111111111111111111111111111111111111111111111111L) | ((v6 & 0b1L) << 54);
+            output[outputOffset + 7] = (v6 >>> 1) & 0b1111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 8] = ((v6 >>> 56) & 0b11111111L) | ((v7 & 0b11111111111111111111111111111111111111111111111L) << 8);
+            output[outputOffset + 9] = ((v7 >>> 47) & 0b11111111111111111L) | ((v8 & 0b11111111111111111111111111111111111111L) << 17);
+            output[outputOffset + 10] = ((v8 >>> 38) & 0b11111111111111111111111111L) | ((v9 & 0b11111111111111111111111111111L) << 26);
+            output[outputOffset + 11] = ((v9 >>> 29) & 0b11111111111111111111111111111111111L) | ((v10 & 0b11111111111111111111L) << 35);
+            output[outputOffset + 12] = ((v10 >>> 20) & 0b11111111111111111111111111111111111111111111L) | ((v11 & 0b11111111111L) << 44);
+            output[outputOffset + 13] = ((v11 >>> 11) & 0b11111111111111111111111111111111111111111111111111111L) | ((v12 & 0b11L) << 53);
+            output[outputOffset + 14] = (v12 >>> 2) & 0b1111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 15] = ((v12 >>> 57) & 0b1111111L) | ((v13 & 0b111111111111111111111111111111111111111111111111L) << 7);
+            output[outputOffset + 16] = ((v13 >>> 48) & 0b1111111111111111L) | ((v14 & 0b111111111111111111111111111111111111111L) << 16);
+            output[outputOffset + 17] = ((v14 >>> 39) & 0b1111111111111111111111111L) | ((v15 & 0b111111111111111111111111111111L) << 25);
+            output[outputOffset + 18] = ((v15 >>> 30) & 0b1111111111111111111111111111111111L) | ((v16 & 0b111111111111111111111L) << 34);
+            output[outputOffset + 19] = ((v16 >>> 21) & 0b1111111111111111111111111111111111111111111L) | ((v17 & 0b111111111111L) << 43);
+            output[outputOffset + 20] = ((v17 >>> 12) & 0b1111111111111111111111111111111111111111111111111111L) | ((v18 & 0b111L) << 52);
+            output[outputOffset + 21] = (v18 >>> 3) & 0b1111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 22] = ((v18 >>> 58) & 0b111111L) | ((v19 & 0b1111111111111111111111111111111111111111111111111L) << 6);
+            output[outputOffset + 23] = ((v19 >>> 49) & 0b111111111111111L) | ((v20 & 0b1111111111111111111111111111111111111111L) << 15);
+            output[outputOffset + 24] = ((v20 >>> 40) & 0b111111111111111111111111L) | ((v21 & 0b1111111111111111111111111111111L) << 24);
+            output[outputOffset + 25] = ((v21 >>> 31) & 0b111111111111111111111111111111111L) | ((v22 & 0b1111111111111111111111L) << 33);
+            output[outputOffset + 26] = ((v22 >>> 22) & 0b111111111111111111111111111111111111111111L) | ((v23 & 0b1111111111111L) << 42);
+            output[outputOffset + 27] = ((v23 >>> 13) & 0b111111111111111111111111111111111111111111111111111L) | ((v24 & 0b1111L) << 51);
+            output[outputOffset + 28] = (v24 >>> 4) & 0b1111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 29] = ((v24 >>> 59) & 0b11111L) | ((v25 & 0b11111111111111111111111111111111111111111111111111L) << 5);
+            output[outputOffset + 30] = ((v25 >>> 50) & 0b11111111111111L) | ((v26 & 0b11111111111111111111111111111111111111111L) << 14);
+            output[outputOffset + 31] = ((v26 >>> 41) & 0b11111111111111111111111L) | ((v27 & 0b11111111111111111111111111111111L) << 23);
+        }
+    }
+
+    private static final class Unpacker56
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            long v21 = input.readLong();
+            long v22 = input.readLong();
+            long v23 = input.readLong();
+            long v24 = input.readLong();
+            long v25 = input.readLong();
+            long v26 = input.readLong();
+            long v27 = input.readLong();
+            output[outputOffset] = v0 & 0b11111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 56) & 0b11111111L) | ((v1 & 0b111111111111111111111111111111111111111111111111L) << 8);
+            output[outputOffset + 2] = ((v1 >>> 48) & 0b1111111111111111L) | ((v2 & 0b1111111111111111111111111111111111111111L) << 16);
+            output[outputOffset + 3] = ((v2 >>> 40) & 0b111111111111111111111111L) | ((v3 & 0b11111111111111111111111111111111L) << 24);
+            output[outputOffset + 4] = ((v3 >>> 32) & 0b11111111111111111111111111111111L) | ((v4 & 0b111111111111111111111111L) << 32);
+            output[outputOffset + 5] = ((v4 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v5 & 0b1111111111111111L) << 40);
+            output[outputOffset + 6] = ((v5 >>> 16) & 0b111111111111111111111111111111111111111111111111L) | ((v6 & 0b11111111L) << 48);
+            output[outputOffset + 7] = (v6 >>> 8) & 0b11111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 8] = v7 & 0b11111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 9] = ((v7 >>> 56) & 0b11111111L) | ((v8 & 0b111111111111111111111111111111111111111111111111L) << 8);
+            output[outputOffset + 10] = ((v8 >>> 48) & 0b1111111111111111L) | ((v9 & 0b1111111111111111111111111111111111111111L) << 16);
+            output[outputOffset + 11] = ((v9 >>> 40) & 0b111111111111111111111111L) | ((v10 & 0b11111111111111111111111111111111L) << 24);
+            output[outputOffset + 12] = ((v10 >>> 32) & 0b11111111111111111111111111111111L) | ((v11 & 0b111111111111111111111111L) << 32);
+            output[outputOffset + 13] = ((v11 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v12 & 0b1111111111111111L) << 40);
+            output[outputOffset + 14] = ((v12 >>> 16) & 0b111111111111111111111111111111111111111111111111L) | ((v13 & 0b11111111L) << 48);
+            output[outputOffset + 15] = (v13 >>> 8) & 0b11111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 16] = v14 & 0b11111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 17] = ((v14 >>> 56) & 0b11111111L) | ((v15 & 0b111111111111111111111111111111111111111111111111L) << 8);
+            output[outputOffset + 18] = ((v15 >>> 48) & 0b1111111111111111L) | ((v16 & 0b1111111111111111111111111111111111111111L) << 16);
+            output[outputOffset + 19] = ((v16 >>> 40) & 0b111111111111111111111111L) | ((v17 & 0b11111111111111111111111111111111L) << 24);
+            output[outputOffset + 20] = ((v17 >>> 32) & 0b11111111111111111111111111111111L) | ((v18 & 0b111111111111111111111111L) << 32);
+            output[outputOffset + 21] = ((v18 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v19 & 0b1111111111111111L) << 40);
+            output[outputOffset + 22] = ((v19 >>> 16) & 0b111111111111111111111111111111111111111111111111L) | ((v20 & 0b11111111L) << 48);
+            output[outputOffset + 23] = (v20 >>> 8) & 0b11111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 24] = v21 & 0b11111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 25] = ((v21 >>> 56) & 0b11111111L) | ((v22 & 0b111111111111111111111111111111111111111111111111L) << 8);
+            output[outputOffset + 26] = ((v22 >>> 48) & 0b1111111111111111L) | ((v23 & 0b1111111111111111111111111111111111111111L) << 16);
+            output[outputOffset + 27] = ((v23 >>> 40) & 0b111111111111111111111111L) | ((v24 & 0b11111111111111111111111111111111L) << 24);
+            output[outputOffset + 28] = ((v24 >>> 32) & 0b11111111111111111111111111111111L) | ((v25 & 0b111111111111111111111111L) << 32);
+            output[outputOffset + 29] = ((v25 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v26 & 0b1111111111111111L) << 40);
+            output[outputOffset + 30] = ((v26 >>> 16) & 0b111111111111111111111111111111111111111111111111L) | ((v27 & 0b11111111L) << 48);
+            output[outputOffset + 31] = (v27 >>> 8) & 0b11111111111111111111111111111111111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker57
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            long v21 = input.readLong();
+            long v22 = input.readLong();
+            long v23 = input.readLong();
+            long v24 = input.readLong();
+            long v25 = input.readLong();
+            long v26 = input.readLong();
+            long v27 = input.readLong();
+            int v28 = input.readInt();
+            output[outputOffset] = v0 & 0b111111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 57) & 0b1111111L) | ((v1 & 0b11111111111111111111111111111111111111111111111111L) << 7);
+            output[outputOffset + 2] = ((v1 >>> 50) & 0b11111111111111L) | ((v2 & 0b1111111111111111111111111111111111111111111L) << 14);
+            output[outputOffset + 3] = ((v2 >>> 43) & 0b111111111111111111111L) | ((v3 & 0b111111111111111111111111111111111111L) << 21);
+            output[outputOffset + 4] = ((v3 >>> 36) & 0b1111111111111111111111111111L) | ((v4 & 0b11111111111111111111111111111L) << 28);
+            output[outputOffset + 5] = ((v4 >>> 29) & 0b11111111111111111111111111111111111L) | ((v5 & 0b1111111111111111111111L) << 35);
+            output[outputOffset + 6] = ((v5 >>> 22) & 0b111111111111111111111111111111111111111111L) | ((v6 & 0b111111111111111L) << 42);
+            output[outputOffset + 7] = ((v6 >>> 15) & 0b1111111111111111111111111111111111111111111111111L) | ((v7 & 0b11111111L) << 49);
+            output[outputOffset + 8] = ((v7 >>> 8) & 0b11111111111111111111111111111111111111111111111111111111L) | ((v8 & 0b1L) << 56);
+            output[outputOffset + 9] = (v8 >>> 1) & 0b111111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 10] = ((v8 >>> 58) & 0b111111L) | ((v9 & 0b111111111111111111111111111111111111111111111111111L) << 6);
+            output[outputOffset + 11] = ((v9 >>> 51) & 0b1111111111111L) | ((v10 & 0b11111111111111111111111111111111111111111111L) << 13);
+            output[outputOffset + 12] = ((v10 >>> 44) & 0b11111111111111111111L) | ((v11 & 0b1111111111111111111111111111111111111L) << 20);
+            output[outputOffset + 13] = ((v11 >>> 37) & 0b111111111111111111111111111L) | ((v12 & 0b111111111111111111111111111111L) << 27);
+            output[outputOffset + 14] = ((v12 >>> 30) & 0b1111111111111111111111111111111111L) | ((v13 & 0b11111111111111111111111L) << 34);
+            output[outputOffset + 15] = ((v13 >>> 23) & 0b11111111111111111111111111111111111111111L) | ((v14 & 0b1111111111111111L) << 41);
+            output[outputOffset + 16] = ((v14 >>> 16) & 0b111111111111111111111111111111111111111111111111L) | ((v15 & 0b111111111L) << 48);
+            output[outputOffset + 17] = ((v15 >>> 9) & 0b1111111111111111111111111111111111111111111111111111111L) | ((v16 & 0b11L) << 55);
+            output[outputOffset + 18] = (v16 >>> 2) & 0b111111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 19] = ((v16 >>> 59) & 0b11111L) | ((v17 & 0b1111111111111111111111111111111111111111111111111111L) << 5);
+            output[outputOffset + 20] = ((v17 >>> 52) & 0b111111111111L) | ((v18 & 0b111111111111111111111111111111111111111111111L) << 12);
+            output[outputOffset + 21] = ((v18 >>> 45) & 0b1111111111111111111L) | ((v19 & 0b11111111111111111111111111111111111111L) << 19);
+            output[outputOffset + 22] = ((v19 >>> 38) & 0b11111111111111111111111111L) | ((v20 & 0b1111111111111111111111111111111L) << 26);
+            output[outputOffset + 23] = ((v20 >>> 31) & 0b111111111111111111111111111111111L) | ((v21 & 0b111111111111111111111111L) << 33);
+            output[outputOffset + 24] = ((v21 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v22 & 0b11111111111111111L) << 40);
+            output[outputOffset + 25] = ((v22 >>> 17) & 0b11111111111111111111111111111111111111111111111L) | ((v23 & 0b1111111111L) << 47);
+            output[outputOffset + 26] = ((v23 >>> 10) & 0b111111111111111111111111111111111111111111111111111111L) | ((v24 & 0b111L) << 54);
+            output[outputOffset + 27] = (v24 >>> 3) & 0b111111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 28] = ((v24 >>> 60) & 0b1111L) | ((v25 & 0b11111111111111111111111111111111111111111111111111111L) << 4);
+            output[outputOffset + 29] = ((v25 >>> 53) & 0b11111111111L) | ((v26 & 0b1111111111111111111111111111111111111111111111L) << 11);
+            output[outputOffset + 30] = ((v26 >>> 46) & 0b111111111111111111L) | ((v27 & 0b111111111111111111111111111111111111111L) << 18);
+            output[outputOffset + 31] = ((v27 >>> 39) & 0b1111111111111111111111111L) | ((v28 & 0b11111111111111111111111111111111L) << 25);
+        }
+    }
+
+    private static final class Unpacker58
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            long v21 = input.readLong();
+            long v22 = input.readLong();
+            long v23 = input.readLong();
+            long v24 = input.readLong();
+            long v25 = input.readLong();
+            long v26 = input.readLong();
+            long v27 = input.readLong();
+            long v28 = input.readLong();
+            output[outputOffset] = v0 & 0b1111111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 58) & 0b111111L) | ((v1 & 0b1111111111111111111111111111111111111111111111111111L) << 6);
+            output[outputOffset + 2] = ((v1 >>> 52) & 0b111111111111L) | ((v2 & 0b1111111111111111111111111111111111111111111111L) << 12);
+            output[outputOffset + 3] = ((v2 >>> 46) & 0b111111111111111111L) | ((v3 & 0b1111111111111111111111111111111111111111L) << 18);
+            output[outputOffset + 4] = ((v3 >>> 40) & 0b111111111111111111111111L) | ((v4 & 0b1111111111111111111111111111111111L) << 24);
+            output[outputOffset + 5] = ((v4 >>> 34) & 0b111111111111111111111111111111L) | ((v5 & 0b1111111111111111111111111111L) << 30);
+            output[outputOffset + 6] = ((v5 >>> 28) & 0b111111111111111111111111111111111111L) | ((v6 & 0b1111111111111111111111L) << 36);
+            output[outputOffset + 7] = ((v6 >>> 22) & 0b111111111111111111111111111111111111111111L) | ((v7 & 0b1111111111111111L) << 42);
+            output[outputOffset + 8] = ((v7 >>> 16) & 0b111111111111111111111111111111111111111111111111L) | ((v8 & 0b1111111111L) << 48);
+            output[outputOffset + 9] = ((v8 >>> 10) & 0b111111111111111111111111111111111111111111111111111111L) | ((v9 & 0b1111L) << 54);
+            output[outputOffset + 10] = (v9 >>> 4) & 0b1111111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 11] = ((v9 >>> 62) & 0b11L) | ((v10 & 0b11111111111111111111111111111111111111111111111111111111L) << 2);
+            output[outputOffset + 12] = ((v10 >>> 56) & 0b11111111L) | ((v11 & 0b11111111111111111111111111111111111111111111111111L) << 8);
+            output[outputOffset + 13] = ((v11 >>> 50) & 0b11111111111111L) | ((v12 & 0b11111111111111111111111111111111111111111111L) << 14);
+            output[outputOffset + 14] = ((v12 >>> 44) & 0b11111111111111111111L) | ((v13 & 0b11111111111111111111111111111111111111L) << 20);
+            output[outputOffset + 15] = ((v13 >>> 38) & 0b11111111111111111111111111L) | ((v14 & 0b11111111111111111111111111111111L) << 26);
+            output[outputOffset + 16] = ((v14 >>> 32) & 0b11111111111111111111111111111111L) | ((v15 & 0b11111111111111111111111111L) << 32);
+            output[outputOffset + 17] = ((v15 >>> 26) & 0b11111111111111111111111111111111111111L) | ((v16 & 0b11111111111111111111L) << 38);
+            output[outputOffset + 18] = ((v16 >>> 20) & 0b11111111111111111111111111111111111111111111L) | ((v17 & 0b11111111111111L) << 44);
+            output[outputOffset + 19] = ((v17 >>> 14) & 0b11111111111111111111111111111111111111111111111111L) | ((v18 & 0b11111111L) << 50);
+            output[outputOffset + 20] = ((v18 >>> 8) & 0b11111111111111111111111111111111111111111111111111111111L) | ((v19 & 0b11L) << 56);
+            output[outputOffset + 21] = (v19 >>> 2) & 0b1111111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 22] = ((v19 >>> 60) & 0b1111L) | ((v20 & 0b111111111111111111111111111111111111111111111111111111L) << 4);
+            output[outputOffset + 23] = ((v20 >>> 54) & 0b1111111111L) | ((v21 & 0b111111111111111111111111111111111111111111111111L) << 10);
+            output[outputOffset + 24] = ((v21 >>> 48) & 0b1111111111111111L) | ((v22 & 0b111111111111111111111111111111111111111111L) << 16);
+            output[outputOffset + 25] = ((v22 >>> 42) & 0b1111111111111111111111L) | ((v23 & 0b111111111111111111111111111111111111L) << 22);
+            output[outputOffset + 26] = ((v23 >>> 36) & 0b1111111111111111111111111111L) | ((v24 & 0b111111111111111111111111111111L) << 28);
+            output[outputOffset + 27] = ((v24 >>> 30) & 0b1111111111111111111111111111111111L) | ((v25 & 0b111111111111111111111111L) << 34);
+            output[outputOffset + 28] = ((v25 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v26 & 0b111111111111111111L) << 40);
+            output[outputOffset + 29] = ((v26 >>> 18) & 0b1111111111111111111111111111111111111111111111L) | ((v27 & 0b111111111111L) << 46);
+            output[outputOffset + 30] = ((v27 >>> 12) & 0b1111111111111111111111111111111111111111111111111111L) | ((v28 & 0b111111L) << 52);
+            output[outputOffset + 31] = (v28 >>> 6) & 0b1111111111111111111111111111111111111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker59
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            long v21 = input.readLong();
+            long v22 = input.readLong();
+            long v23 = input.readLong();
+            long v24 = input.readLong();
+            long v25 = input.readLong();
+            long v26 = input.readLong();
+            long v27 = input.readLong();
+            long v28 = input.readLong();
+            int v29 = input.readInt();
+            output[outputOffset] = v0 & 0b11111111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 59) & 0b11111L) | ((v1 & 0b111111111111111111111111111111111111111111111111111111L) << 5);
+            output[outputOffset + 2] = ((v1 >>> 54) & 0b1111111111L) | ((v2 & 0b1111111111111111111111111111111111111111111111111L) << 10);
+            output[outputOffset + 3] = ((v2 >>> 49) & 0b111111111111111L) | ((v3 & 0b11111111111111111111111111111111111111111111L) << 15);
+            output[outputOffset + 4] = ((v3 >>> 44) & 0b11111111111111111111L) | ((v4 & 0b111111111111111111111111111111111111111L) << 20);
+            output[outputOffset + 5] = ((v4 >>> 39) & 0b1111111111111111111111111L) | ((v5 & 0b1111111111111111111111111111111111L) << 25);
+            output[outputOffset + 6] = ((v5 >>> 34) & 0b111111111111111111111111111111L) | ((v6 & 0b11111111111111111111111111111L) << 30);
+            output[outputOffset + 7] = ((v6 >>> 29) & 0b11111111111111111111111111111111111L) | ((v7 & 0b111111111111111111111111L) << 35);
+            output[outputOffset + 8] = ((v7 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v8 & 0b1111111111111111111L) << 40);
+            output[outputOffset + 9] = ((v8 >>> 19) & 0b111111111111111111111111111111111111111111111L) | ((v9 & 0b11111111111111L) << 45);
+            output[outputOffset + 10] = ((v9 >>> 14) & 0b11111111111111111111111111111111111111111111111111L) | ((v10 & 0b111111111L) << 50);
+            output[outputOffset + 11] = ((v10 >>> 9) & 0b1111111111111111111111111111111111111111111111111111111L) | ((v11 & 0b1111L) << 55);
+            output[outputOffset + 12] = (v11 >>> 4) & 0b11111111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 13] = ((v11 >>> 63) & 0b1L) | ((v12 & 0b1111111111111111111111111111111111111111111111111111111111L) << 1);
+            output[outputOffset + 14] = ((v12 >>> 58) & 0b111111L) | ((v13 & 0b11111111111111111111111111111111111111111111111111111L) << 6);
+            output[outputOffset + 15] = ((v13 >>> 53) & 0b11111111111L) | ((v14 & 0b111111111111111111111111111111111111111111111111L) << 11);
+            output[outputOffset + 16] = ((v14 >>> 48) & 0b1111111111111111L) | ((v15 & 0b1111111111111111111111111111111111111111111L) << 16);
+            output[outputOffset + 17] = ((v15 >>> 43) & 0b111111111111111111111L) | ((v16 & 0b11111111111111111111111111111111111111L) << 21);
+            output[outputOffset + 18] = ((v16 >>> 38) & 0b11111111111111111111111111L) | ((v17 & 0b111111111111111111111111111111111L) << 26);
+            output[outputOffset + 19] = ((v17 >>> 33) & 0b1111111111111111111111111111111L) | ((v18 & 0b1111111111111111111111111111L) << 31);
+            output[outputOffset + 20] = ((v18 >>> 28) & 0b111111111111111111111111111111111111L) | ((v19 & 0b11111111111111111111111L) << 36);
+            output[outputOffset + 21] = ((v19 >>> 23) & 0b11111111111111111111111111111111111111111L) | ((v20 & 0b111111111111111111L) << 41);
+            output[outputOffset + 22] = ((v20 >>> 18) & 0b1111111111111111111111111111111111111111111111L) | ((v21 & 0b1111111111111L) << 46);
+            output[outputOffset + 23] = ((v21 >>> 13) & 0b111111111111111111111111111111111111111111111111111L) | ((v22 & 0b11111111L) << 51);
+            output[outputOffset + 24] = ((v22 >>> 8) & 0b11111111111111111111111111111111111111111111111111111111L) | ((v23 & 0b111L) << 56);
+            output[outputOffset + 25] = (v23 >>> 3) & 0b11111111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 26] = ((v23 >>> 62) & 0b11L) | ((v24 & 0b111111111111111111111111111111111111111111111111111111111L) << 2);
+            output[outputOffset + 27] = ((v24 >>> 57) & 0b1111111L) | ((v25 & 0b1111111111111111111111111111111111111111111111111111L) << 7);
+            output[outputOffset + 28] = ((v25 >>> 52) & 0b111111111111L) | ((v26 & 0b11111111111111111111111111111111111111111111111L) << 12);
+            output[outputOffset + 29] = ((v26 >>> 47) & 0b11111111111111111L) | ((v27 & 0b111111111111111111111111111111111111111111L) << 17);
+            output[outputOffset + 30] = ((v27 >>> 42) & 0b1111111111111111111111L) | ((v28 & 0b1111111111111111111111111111111111111L) << 22);
+            output[outputOffset + 31] = ((v28 >>> 37) & 0b111111111111111111111111111L) | ((v29 & 0b11111111111111111111111111111111L) << 27);
+        }
+    }
+
+    private static final class Unpacker60
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            long v21 = input.readLong();
+            long v22 = input.readLong();
+            long v23 = input.readLong();
+            long v24 = input.readLong();
+            long v25 = input.readLong();
+            long v26 = input.readLong();
+            long v27 = input.readLong();
+            long v28 = input.readLong();
+            long v29 = input.readLong();
+            output[outputOffset] = v0 & 0b111111111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 60) & 0b1111L) | ((v1 & 0b11111111111111111111111111111111111111111111111111111111L) << 4);
+            output[outputOffset + 2] = ((v1 >>> 56) & 0b11111111L) | ((v2 & 0b1111111111111111111111111111111111111111111111111111L) << 8);
+            output[outputOffset + 3] = ((v2 >>> 52) & 0b111111111111L) | ((v3 & 0b111111111111111111111111111111111111111111111111L) << 12);
+            output[outputOffset + 4] = ((v3 >>> 48) & 0b1111111111111111L) | ((v4 & 0b11111111111111111111111111111111111111111111L) << 16);
+            output[outputOffset + 5] = ((v4 >>> 44) & 0b11111111111111111111L) | ((v5 & 0b1111111111111111111111111111111111111111L) << 20);
+            output[outputOffset + 6] = ((v5 >>> 40) & 0b111111111111111111111111L) | ((v6 & 0b111111111111111111111111111111111111L) << 24);
+            output[outputOffset + 7] = ((v6 >>> 36) & 0b1111111111111111111111111111L) | ((v7 & 0b11111111111111111111111111111111L) << 28);
+            output[outputOffset + 8] = ((v7 >>> 32) & 0b11111111111111111111111111111111L) | ((v8 & 0b1111111111111111111111111111L) << 32);
+            output[outputOffset + 9] = ((v8 >>> 28) & 0b111111111111111111111111111111111111L) | ((v9 & 0b111111111111111111111111L) << 36);
+            output[outputOffset + 10] = ((v9 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v10 & 0b11111111111111111111L) << 40);
+            output[outputOffset + 11] = ((v10 >>> 20) & 0b11111111111111111111111111111111111111111111L) | ((v11 & 0b1111111111111111L) << 44);
+            output[outputOffset + 12] = ((v11 >>> 16) & 0b111111111111111111111111111111111111111111111111L) | ((v12 & 0b111111111111L) << 48);
+            output[outputOffset + 13] = ((v12 >>> 12) & 0b1111111111111111111111111111111111111111111111111111L) | ((v13 & 0b11111111L) << 52);
+            output[outputOffset + 14] = ((v13 >>> 8) & 0b11111111111111111111111111111111111111111111111111111111L) | ((v14 & 0b1111L) << 56);
+            output[outputOffset + 15] = (v14 >>> 4) & 0b111111111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 16] = v15 & 0b111111111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 17] = ((v15 >>> 60) & 0b1111L) | ((v16 & 0b11111111111111111111111111111111111111111111111111111111L) << 4);
+            output[outputOffset + 18] = ((v16 >>> 56) & 0b11111111L) | ((v17 & 0b1111111111111111111111111111111111111111111111111111L) << 8);
+            output[outputOffset + 19] = ((v17 >>> 52) & 0b111111111111L) | ((v18 & 0b111111111111111111111111111111111111111111111111L) << 12);
+            output[outputOffset + 20] = ((v18 >>> 48) & 0b1111111111111111L) | ((v19 & 0b11111111111111111111111111111111111111111111L) << 16);
+            output[outputOffset + 21] = ((v19 >>> 44) & 0b11111111111111111111L) | ((v20 & 0b1111111111111111111111111111111111111111L) << 20);
+            output[outputOffset + 22] = ((v20 >>> 40) & 0b111111111111111111111111L) | ((v21 & 0b111111111111111111111111111111111111L) << 24);
+            output[outputOffset + 23] = ((v21 >>> 36) & 0b1111111111111111111111111111L) | ((v22 & 0b11111111111111111111111111111111L) << 28);
+            output[outputOffset + 24] = ((v22 >>> 32) & 0b11111111111111111111111111111111L) | ((v23 & 0b1111111111111111111111111111L) << 32);
+            output[outputOffset + 25] = ((v23 >>> 28) & 0b111111111111111111111111111111111111L) | ((v24 & 0b111111111111111111111111L) << 36);
+            output[outputOffset + 26] = ((v24 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v25 & 0b11111111111111111111L) << 40);
+            output[outputOffset + 27] = ((v25 >>> 20) & 0b11111111111111111111111111111111111111111111L) | ((v26 & 0b1111111111111111L) << 44);
+            output[outputOffset + 28] = ((v26 >>> 16) & 0b111111111111111111111111111111111111111111111111L) | ((v27 & 0b111111111111L) << 48);
+            output[outputOffset + 29] = ((v27 >>> 12) & 0b1111111111111111111111111111111111111111111111111111L) | ((v28 & 0b11111111L) << 52);
+            output[outputOffset + 30] = ((v28 >>> 8) & 0b11111111111111111111111111111111111111111111111111111111L) | ((v29 & 0b1111L) << 56);
+            output[outputOffset + 31] = (v29 >>> 4) & 0b111111111111111111111111111111111111111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker61
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            long v21 = input.readLong();
+            long v22 = input.readLong();
+            long v23 = input.readLong();
+            long v24 = input.readLong();
+            long v25 = input.readLong();
+            long v26 = input.readLong();
+            long v27 = input.readLong();
+            long v28 = input.readLong();
+            long v29 = input.readLong();
+            int v30 = input.readInt();
+            output[outputOffset] = v0 & 0b1111111111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 61) & 0b111L) | ((v1 & 0b1111111111111111111111111111111111111111111111111111111111L) << 3);
+            output[outputOffset + 2] = ((v1 >>> 58) & 0b111111L) | ((v2 & 0b1111111111111111111111111111111111111111111111111111111L) << 6);
+            output[outputOffset + 3] = ((v2 >>> 55) & 0b111111111L) | ((v3 & 0b1111111111111111111111111111111111111111111111111111L) << 9);
+            output[outputOffset + 4] = ((v3 >>> 52) & 0b111111111111L) | ((v4 & 0b1111111111111111111111111111111111111111111111111L) << 12);
+            output[outputOffset + 5] = ((v4 >>> 49) & 0b111111111111111L) | ((v5 & 0b1111111111111111111111111111111111111111111111L) << 15);
+            output[outputOffset + 6] = ((v5 >>> 46) & 0b111111111111111111L) | ((v6 & 0b1111111111111111111111111111111111111111111L) << 18);
+            output[outputOffset + 7] = ((v6 >>> 43) & 0b111111111111111111111L) | ((v7 & 0b1111111111111111111111111111111111111111L) << 21);
+            output[outputOffset + 8] = ((v7 >>> 40) & 0b111111111111111111111111L) | ((v8 & 0b1111111111111111111111111111111111111L) << 24);
+            output[outputOffset + 9] = ((v8 >>> 37) & 0b111111111111111111111111111L) | ((v9 & 0b1111111111111111111111111111111111L) << 27);
+            output[outputOffset + 10] = ((v9 >>> 34) & 0b111111111111111111111111111111L) | ((v10 & 0b1111111111111111111111111111111L) << 30);
+            output[outputOffset + 11] = ((v10 >>> 31) & 0b111111111111111111111111111111111L) | ((v11 & 0b1111111111111111111111111111L) << 33);
+            output[outputOffset + 12] = ((v11 >>> 28) & 0b111111111111111111111111111111111111L) | ((v12 & 0b1111111111111111111111111L) << 36);
+            output[outputOffset + 13] = ((v12 >>> 25) & 0b111111111111111111111111111111111111111L) | ((v13 & 0b1111111111111111111111L) << 39);
+            output[outputOffset + 14] = ((v13 >>> 22) & 0b111111111111111111111111111111111111111111L) | ((v14 & 0b1111111111111111111L) << 42);
+            output[outputOffset + 15] = ((v14 >>> 19) & 0b111111111111111111111111111111111111111111111L) | ((v15 & 0b1111111111111111L) << 45);
+            output[outputOffset + 16] = ((v15 >>> 16) & 0b111111111111111111111111111111111111111111111111L) | ((v16 & 0b1111111111111L) << 48);
+            output[outputOffset + 17] = ((v16 >>> 13) & 0b111111111111111111111111111111111111111111111111111L) | ((v17 & 0b1111111111L) << 51);
+            output[outputOffset + 18] = ((v17 >>> 10) & 0b111111111111111111111111111111111111111111111111111111L) | ((v18 & 0b1111111L) << 54);
+            output[outputOffset + 19] = ((v18 >>> 7) & 0b111111111111111111111111111111111111111111111111111111111L) | ((v19 & 0b1111L) << 57);
+            output[outputOffset + 20] = ((v19 >>> 4) & 0b111111111111111111111111111111111111111111111111111111111111L) | ((v20 & 0b1L) << 60);
+            output[outputOffset + 21] = (v20 >>> 1) & 0b1111111111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 22] = ((v20 >>> 62) & 0b11L) | ((v21 & 0b11111111111111111111111111111111111111111111111111111111111L) << 2);
+            output[outputOffset + 23] = ((v21 >>> 59) & 0b11111L) | ((v22 & 0b11111111111111111111111111111111111111111111111111111111L) << 5);
+            output[outputOffset + 24] = ((v22 >>> 56) & 0b11111111L) | ((v23 & 0b11111111111111111111111111111111111111111111111111111L) << 8);
+            output[outputOffset + 25] = ((v23 >>> 53) & 0b11111111111L) | ((v24 & 0b11111111111111111111111111111111111111111111111111L) << 11);
+            output[outputOffset + 26] = ((v24 >>> 50) & 0b11111111111111L) | ((v25 & 0b11111111111111111111111111111111111111111111111L) << 14);
+            output[outputOffset + 27] = ((v25 >>> 47) & 0b11111111111111111L) | ((v26 & 0b11111111111111111111111111111111111111111111L) << 17);
+            output[outputOffset + 28] = ((v26 >>> 44) & 0b11111111111111111111L) | ((v27 & 0b11111111111111111111111111111111111111111L) << 20);
+            output[outputOffset + 29] = ((v27 >>> 41) & 0b11111111111111111111111L) | ((v28 & 0b11111111111111111111111111111111111111L) << 23);
+            output[outputOffset + 30] = ((v28 >>> 38) & 0b11111111111111111111111111L) | ((v29 & 0b11111111111111111111111111111111111L) << 26);
+            output[outputOffset + 31] = ((v29 >>> 35) & 0b11111111111111111111111111111L) | ((v30 & 0b11111111111111111111111111111111L) << 29);
+        }
+    }
+
+    private static final class Unpacker62
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            long v21 = input.readLong();
+            long v22 = input.readLong();
+            long v23 = input.readLong();
+            long v24 = input.readLong();
+            long v25 = input.readLong();
+            long v26 = input.readLong();
+            long v27 = input.readLong();
+            long v28 = input.readLong();
+            long v29 = input.readLong();
+            long v30 = input.readLong();
+            output[outputOffset] = v0 & 0b11111111111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 62) & 0b11L) | ((v1 & 0b111111111111111111111111111111111111111111111111111111111111L) << 2);
+            output[outputOffset + 2] = ((v1 >>> 60) & 0b1111L) | ((v2 & 0b1111111111111111111111111111111111111111111111111111111111L) << 4);
+            output[outputOffset + 3] = ((v2 >>> 58) & 0b111111L) | ((v3 & 0b11111111111111111111111111111111111111111111111111111111L) << 6);
+            output[outputOffset + 4] = ((v3 >>> 56) & 0b11111111L) | ((v4 & 0b111111111111111111111111111111111111111111111111111111L) << 8);
+            output[outputOffset + 5] = ((v4 >>> 54) & 0b1111111111L) | ((v5 & 0b1111111111111111111111111111111111111111111111111111L) << 10);
+            output[outputOffset + 6] = ((v5 >>> 52) & 0b111111111111L) | ((v6 & 0b11111111111111111111111111111111111111111111111111L) << 12);
+            output[outputOffset + 7] = ((v6 >>> 50) & 0b11111111111111L) | ((v7 & 0b111111111111111111111111111111111111111111111111L) << 14);
+            output[outputOffset + 8] = ((v7 >>> 48) & 0b1111111111111111L) | ((v8 & 0b1111111111111111111111111111111111111111111111L) << 16);
+            output[outputOffset + 9] = ((v8 >>> 46) & 0b111111111111111111L) | ((v9 & 0b11111111111111111111111111111111111111111111L) << 18);
+            output[outputOffset + 10] = ((v9 >>> 44) & 0b11111111111111111111L) | ((v10 & 0b111111111111111111111111111111111111111111L) << 20);
+            output[outputOffset + 11] = ((v10 >>> 42) & 0b1111111111111111111111L) | ((v11 & 0b1111111111111111111111111111111111111111L) << 22);
+            output[outputOffset + 12] = ((v11 >>> 40) & 0b111111111111111111111111L) | ((v12 & 0b11111111111111111111111111111111111111L) << 24);
+            output[outputOffset + 13] = ((v12 >>> 38) & 0b11111111111111111111111111L) | ((v13 & 0b111111111111111111111111111111111111L) << 26);
+            output[outputOffset + 14] = ((v13 >>> 36) & 0b1111111111111111111111111111L) | ((v14 & 0b1111111111111111111111111111111111L) << 28);
+            output[outputOffset + 15] = ((v14 >>> 34) & 0b111111111111111111111111111111L) | ((v15 & 0b11111111111111111111111111111111L) << 30);
+            output[outputOffset + 16] = ((v15 >>> 32) & 0b11111111111111111111111111111111L) | ((v16 & 0b111111111111111111111111111111L) << 32);
+            output[outputOffset + 17] = ((v16 >>> 30) & 0b1111111111111111111111111111111111L) | ((v17 & 0b1111111111111111111111111111L) << 34);
+            output[outputOffset + 18] = ((v17 >>> 28) & 0b111111111111111111111111111111111111L) | ((v18 & 0b11111111111111111111111111L) << 36);
+            output[outputOffset + 19] = ((v18 >>> 26) & 0b11111111111111111111111111111111111111L) | ((v19 & 0b111111111111111111111111L) << 38);
+            output[outputOffset + 20] = ((v19 >>> 24) & 0b1111111111111111111111111111111111111111L) | ((v20 & 0b1111111111111111111111L) << 40);
+            output[outputOffset + 21] = ((v20 >>> 22) & 0b111111111111111111111111111111111111111111L) | ((v21 & 0b11111111111111111111L) << 42);
+            output[outputOffset + 22] = ((v21 >>> 20) & 0b11111111111111111111111111111111111111111111L) | ((v22 & 0b111111111111111111L) << 44);
+            output[outputOffset + 23] = ((v22 >>> 18) & 0b1111111111111111111111111111111111111111111111L) | ((v23 & 0b1111111111111111L) << 46);
+            output[outputOffset + 24] = ((v23 >>> 16) & 0b111111111111111111111111111111111111111111111111L) | ((v24 & 0b11111111111111L) << 48);
+            output[outputOffset + 25] = ((v24 >>> 14) & 0b11111111111111111111111111111111111111111111111111L) | ((v25 & 0b111111111111L) << 50);
+            output[outputOffset + 26] = ((v25 >>> 12) & 0b1111111111111111111111111111111111111111111111111111L) | ((v26 & 0b1111111111L) << 52);
+            output[outputOffset + 27] = ((v26 >>> 10) & 0b111111111111111111111111111111111111111111111111111111L) | ((v27 & 0b11111111L) << 54);
+            output[outputOffset + 28] = ((v27 >>> 8) & 0b11111111111111111111111111111111111111111111111111111111L) | ((v28 & 0b111111L) << 56);
+            output[outputOffset + 29] = ((v28 >>> 6) & 0b1111111111111111111111111111111111111111111111111111111111L) | ((v29 & 0b1111L) << 58);
+            output[outputOffset + 30] = ((v29 >>> 4) & 0b111111111111111111111111111111111111111111111111111111111111L) | ((v30 & 0b11L) << 60);
+            output[outputOffset + 31] = (v30 >>> 2) & 0b11111111111111111111111111111111111111111111111111111111111111L;
+        }
+    }
+
+    private static final class Unpacker63
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(long[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            long v8 = input.readLong();
+            long v9 = input.readLong();
+            long v10 = input.readLong();
+            long v11 = input.readLong();
+            long v12 = input.readLong();
+            long v13 = input.readLong();
+            long v14 = input.readLong();
+            long v15 = input.readLong();
+            long v16 = input.readLong();
+            long v17 = input.readLong();
+            long v18 = input.readLong();
+            long v19 = input.readLong();
+            long v20 = input.readLong();
+            long v21 = input.readLong();
+            long v22 = input.readLong();
+            long v23 = input.readLong();
+            long v24 = input.readLong();
+            long v25 = input.readLong();
+            long v26 = input.readLong();
+            long v27 = input.readLong();
+            long v28 = input.readLong();
+            long v29 = input.readLong();
+            long v30 = input.readLong();
+            int v31 = input.readInt();
+            output[outputOffset] = v0 & 0b111111111111111111111111111111111111111111111111111111111111111L;
+            output[outputOffset + 1] = ((v0 >>> 63) & 0b1L) | ((v1 & 0b11111111111111111111111111111111111111111111111111111111111111L) << 1);
+            output[outputOffset + 2] = ((v1 >>> 62) & 0b11L) | ((v2 & 0b1111111111111111111111111111111111111111111111111111111111111L) << 2);
+            output[outputOffset + 3] = ((v2 >>> 61) & 0b111L) | ((v3 & 0b111111111111111111111111111111111111111111111111111111111111L) << 3);
+            output[outputOffset + 4] = ((v3 >>> 60) & 0b1111L) | ((v4 & 0b11111111111111111111111111111111111111111111111111111111111L) << 4);
+            output[outputOffset + 5] = ((v4 >>> 59) & 0b11111L) | ((v5 & 0b1111111111111111111111111111111111111111111111111111111111L) << 5);
+            output[outputOffset + 6] = ((v5 >>> 58) & 0b111111L) | ((v6 & 0b111111111111111111111111111111111111111111111111111111111L) << 6);
+            output[outputOffset + 7] = ((v6 >>> 57) & 0b1111111L) | ((v7 & 0b11111111111111111111111111111111111111111111111111111111L) << 7);
+            output[outputOffset + 8] = ((v7 >>> 56) & 0b11111111L) | ((v8 & 0b1111111111111111111111111111111111111111111111111111111L) << 8);
+            output[outputOffset + 9] = ((v8 >>> 55) & 0b111111111L) | ((v9 & 0b111111111111111111111111111111111111111111111111111111L) << 9);
+            output[outputOffset + 10] = ((v9 >>> 54) & 0b1111111111L) | ((v10 & 0b11111111111111111111111111111111111111111111111111111L) << 10);
+            output[outputOffset + 11] = ((v10 >>> 53) & 0b11111111111L) | ((v11 & 0b1111111111111111111111111111111111111111111111111111L) << 11);
+            output[outputOffset + 12] = ((v11 >>> 52) & 0b111111111111L) | ((v12 & 0b111111111111111111111111111111111111111111111111111L) << 12);
+            output[outputOffset + 13] = ((v12 >>> 51) & 0b1111111111111L) | ((v13 & 0b11111111111111111111111111111111111111111111111111L) << 13);
+            output[outputOffset + 14] = ((v13 >>> 50) & 0b11111111111111L) | ((v14 & 0b1111111111111111111111111111111111111111111111111L) << 14);
+            output[outputOffset + 15] = ((v14 >>> 49) & 0b111111111111111L) | ((v15 & 0b111111111111111111111111111111111111111111111111L) << 15);
+            output[outputOffset + 16] = ((v15 >>> 48) & 0b1111111111111111L) | ((v16 & 0b11111111111111111111111111111111111111111111111L) << 16);
+            output[outputOffset + 17] = ((v16 >>> 47) & 0b11111111111111111L) | ((v17 & 0b1111111111111111111111111111111111111111111111L) << 17);
+            output[outputOffset + 18] = ((v17 >>> 46) & 0b111111111111111111L) | ((v18 & 0b111111111111111111111111111111111111111111111L) << 18);
+            output[outputOffset + 19] = ((v18 >>> 45) & 0b1111111111111111111L) | ((v19 & 0b11111111111111111111111111111111111111111111L) << 19);
+            output[outputOffset + 20] = ((v19 >>> 44) & 0b11111111111111111111L) | ((v20 & 0b1111111111111111111111111111111111111111111L) << 20);
+            output[outputOffset + 21] = ((v20 >>> 43) & 0b111111111111111111111L) | ((v21 & 0b111111111111111111111111111111111111111111L) << 21);
+            output[outputOffset + 22] = ((v21 >>> 42) & 0b1111111111111111111111L) | ((v22 & 0b11111111111111111111111111111111111111111L) << 22);
+            output[outputOffset + 23] = ((v22 >>> 41) & 0b11111111111111111111111L) | ((v23 & 0b1111111111111111111111111111111111111111L) << 23);
+            output[outputOffset + 24] = ((v23 >>> 40) & 0b111111111111111111111111L) | ((v24 & 0b111111111111111111111111111111111111111L) << 24);
+            output[outputOffset + 25] = ((v24 >>> 39) & 0b1111111111111111111111111L) | ((v25 & 0b11111111111111111111111111111111111111L) << 25);
+            output[outputOffset + 26] = ((v25 >>> 38) & 0b11111111111111111111111111L) | ((v26 & 0b1111111111111111111111111111111111111L) << 26);
+            output[outputOffset + 27] = ((v26 >>> 37) & 0b111111111111111111111111111L) | ((v27 & 0b111111111111111111111111111111111111L) << 27);
+            output[outputOffset + 28] = ((v27 >>> 36) & 0b1111111111111111111111111111L) | ((v28 & 0b11111111111111111111111111111111111L) << 28);
+            output[outputOffset + 29] = ((v28 >>> 35) & 0b11111111111111111111111111111L) | ((v29 & 0b1111111111111111111111111111111111L) << 29);
+            output[outputOffset + 30] = ((v29 >>> 34) & 0b111111111111111111111111111111L) | ((v30 & 0b111111111111111111111111111111111L) << 30);
+            output[outputOffset + 31] = ((v30 >>> 33) & 0b1111111111111111111111111111111L) | ((v31 & 0b11111111111111111111111111111111L) << 31);
+        }
+    }
+
+    private static class Unpacker64
+            implements LongBitUnpacker
+    {
+        @Override
+        public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            input.readBytes(Slices.wrappedLongArray(output, outputOffset, length), 0, length * Long.BYTES);
+        }
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/PlainValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/PlainValueDecoders.java
@@ -82,34 +82,6 @@ public final class PlainValueDecoders
         }
     }
 
-    public static final class IntToLongPlainValueDecoder
-            implements ValueDecoder<long[]>
-    {
-        private SimpleSliceInputStream input;
-
-        @Override
-        public void init(SimpleSliceInputStream input)
-        {
-            this.input = requireNonNull(input, "input is null");
-        }
-
-        @Override
-        public void read(long[] values, int offset, int length)
-        {
-            input.ensureBytesAvailable(Integer.BYTES * length);
-            int endOffset = offset + length;
-            for (int i = offset; i < endOffset; i++) {
-                values[i] = input.readIntUnsafe();
-            }
-        }
-
-        @Override
-        public void skip(int n)
-        {
-            input.skip(n * Integer.BYTES);
-        }
-    }
-
     public static final class IntToShortPlainValueDecoder
             implements ValueDecoder<short[]>
     {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ShortBitUnpacker.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ShortBitUnpacker.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.trino.parquet.reader.SimpleSliceInputStream;
+
+public interface ShortBitUnpacker
+{
+    /**
+     * @param length must be a multiple of 32
+     */
+    void unpack(short[] output, int outputOffset, SimpleSliceInputStream input, int length);
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ShortBitUnpackers.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ShortBitUnpackers.java
@@ -1,0 +1,936 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.airlift.slice.Slices;
+import io.trino.parquet.reader.SimpleSliceInputStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public final class ShortBitUnpackers
+{
+    private static final ShortBitUnpacker[] UNPACKERS = {
+            new Unpacker1(),
+            new Unpacker2(),
+            new Unpacker3(),
+            new Unpacker4(),
+            new Unpacker5(),
+            new Unpacker6(),
+            new Unpacker7(),
+            new Unpacker8(),
+            new Unpacker9(),
+            new Unpacker10(),
+            new Unpacker11(),
+            new Unpacker12(),
+            new Unpacker13(),
+            new Unpacker14(),
+            new Unpacker15(),
+            new Unpacker16(),
+            new Unpacker17()};
+
+    // Short unpacker also exists for the out-of-range 17 value.
+    // This unpacker truncates the most significant bit of the resulted numbers.
+    // This is due to the fact that deltas may require more than 16 bits to be stored.
+    public static ShortBitUnpacker getShortBitUnpacker(int bitWidth)
+    {
+        checkArgument(bitWidth > 0 && bitWidth <= 17, "bitWidth %s should be in the range 1-17", bitWidth);
+        return UNPACKERS[bitWidth - 1];
+    }
+
+    private ShortBitUnpackers() {}
+
+    private static final class Unpacker1
+            implements ShortBitUnpacker
+    {
+        @Override
+        public void unpack(short[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(short[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            int v0 = input.readInt();
+            output[outputOffset] = (short) (v0 & 0b1L);
+            output[outputOffset + 1] = (short) ((v0 >>> 1) & 0b1L);
+            output[outputOffset + 2] = (short) ((v0 >>> 2) & 0b1L);
+            output[outputOffset + 3] = (short) ((v0 >>> 3) & 0b1L);
+            output[outputOffset + 4] = (short) ((v0 >>> 4) & 0b1L);
+            output[outputOffset + 5] = (short) ((v0 >>> 5) & 0b1L);
+            output[outputOffset + 6] = (short) ((v0 >>> 6) & 0b1L);
+            output[outputOffset + 7] = (short) ((v0 >>> 7) & 0b1L);
+            output[outputOffset + 8] = (short) ((v0 >>> 8) & 0b1L);
+            output[outputOffset + 9] = (short) ((v0 >>> 9) & 0b1L);
+            output[outputOffset + 10] = (short) ((v0 >>> 10) & 0b1L);
+            output[outputOffset + 11] = (short) ((v0 >>> 11) & 0b1L);
+            output[outputOffset + 12] = (short) ((v0 >>> 12) & 0b1L);
+            output[outputOffset + 13] = (short) ((v0 >>> 13) & 0b1L);
+            output[outputOffset + 14] = (short) ((v0 >>> 14) & 0b1L);
+            output[outputOffset + 15] = (short) ((v0 >>> 15) & 0b1L);
+            output[outputOffset + 16] = (short) ((v0 >>> 16) & 0b1L);
+            output[outputOffset + 17] = (short) ((v0 >>> 17) & 0b1L);
+            output[outputOffset + 18] = (short) ((v0 >>> 18) & 0b1L);
+            output[outputOffset + 19] = (short) ((v0 >>> 19) & 0b1L);
+            output[outputOffset + 20] = (short) ((v0 >>> 20) & 0b1L);
+            output[outputOffset + 21] = (short) ((v0 >>> 21) & 0b1L);
+            output[outputOffset + 22] = (short) ((v0 >>> 22) & 0b1L);
+            output[outputOffset + 23] = (short) ((v0 >>> 23) & 0b1L);
+            output[outputOffset + 24] = (short) ((v0 >>> 24) & 0b1L);
+            output[outputOffset + 25] = (short) ((v0 >>> 25) & 0b1L);
+            output[outputOffset + 26] = (short) ((v0 >>> 26) & 0b1L);
+            output[outputOffset + 27] = (short) ((v0 >>> 27) & 0b1L);
+            output[outputOffset + 28] = (short) ((v0 >>> 28) & 0b1L);
+            output[outputOffset + 29] = (short) ((v0 >>> 29) & 0b1L);
+            output[outputOffset + 30] = (short) ((v0 >>> 30) & 0b1L);
+            output[outputOffset + 31] = (short) ((v0 >>> 31) & 0b1L);
+        }
+    }
+
+    private static final class Unpacker2
+            implements ShortBitUnpacker
+    {
+        @Override
+        public void unpack(short[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(short[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            output[outputOffset] = (short) (v0 & 0b11L);
+            output[outputOffset + 1] = (short) ((v0 >>> 2) & 0b11L);
+            output[outputOffset + 2] = (short) ((v0 >>> 4) & 0b11L);
+            output[outputOffset + 3] = (short) ((v0 >>> 6) & 0b11L);
+            output[outputOffset + 4] = (short) ((v0 >>> 8) & 0b11L);
+            output[outputOffset + 5] = (short) ((v0 >>> 10) & 0b11L);
+            output[outputOffset + 6] = (short) ((v0 >>> 12) & 0b11L);
+            output[outputOffset + 7] = (short) ((v0 >>> 14) & 0b11L);
+            output[outputOffset + 8] = (short) ((v0 >>> 16) & 0b11L);
+            output[outputOffset + 9] = (short) ((v0 >>> 18) & 0b11L);
+            output[outputOffset + 10] = (short) ((v0 >>> 20) & 0b11L);
+            output[outputOffset + 11] = (short) ((v0 >>> 22) & 0b11L);
+            output[outputOffset + 12] = (short) ((v0 >>> 24) & 0b11L);
+            output[outputOffset + 13] = (short) ((v0 >>> 26) & 0b11L);
+            output[outputOffset + 14] = (short) ((v0 >>> 28) & 0b11L);
+            output[outputOffset + 15] = (short) ((v0 >>> 30) & 0b11L);
+            output[outputOffset + 16] = (short) ((v0 >>> 32) & 0b11L);
+            output[outputOffset + 17] = (short) ((v0 >>> 34) & 0b11L);
+            output[outputOffset + 18] = (short) ((v0 >>> 36) & 0b11L);
+            output[outputOffset + 19] = (short) ((v0 >>> 38) & 0b11L);
+            output[outputOffset + 20] = (short) ((v0 >>> 40) & 0b11L);
+            output[outputOffset + 21] = (short) ((v0 >>> 42) & 0b11L);
+            output[outputOffset + 22] = (short) ((v0 >>> 44) & 0b11L);
+            output[outputOffset + 23] = (short) ((v0 >>> 46) & 0b11L);
+            output[outputOffset + 24] = (short) ((v0 >>> 48) & 0b11L);
+            output[outputOffset + 25] = (short) ((v0 >>> 50) & 0b11L);
+            output[outputOffset + 26] = (short) ((v0 >>> 52) & 0b11L);
+            output[outputOffset + 27] = (short) ((v0 >>> 54) & 0b11L);
+            output[outputOffset + 28] = (short) ((v0 >>> 56) & 0b11L);
+            output[outputOffset + 29] = (short) ((v0 >>> 58) & 0b11L);
+            output[outputOffset + 30] = (short) ((v0 >>> 60) & 0b11L);
+            output[outputOffset + 31] = (short) ((v0 >>> 62) & 0b11L);
+        }
+    }
+
+    private static final class Unpacker3
+            implements ShortBitUnpacker
+    {
+        @Override
+        public void unpack(short[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(short[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            int v1 = input.readInt();
+            output[outputOffset] = (short) (v0 & 0b111L);
+            output[outputOffset + 1] = (short) ((v0 >>> 3) & 0b111L);
+            output[outputOffset + 2] = (short) ((v0 >>> 6) & 0b111L);
+            output[outputOffset + 3] = (short) ((v0 >>> 9) & 0b111L);
+            output[outputOffset + 4] = (short) ((v0 >>> 12) & 0b111L);
+            output[outputOffset + 5] = (short) ((v0 >>> 15) & 0b111L);
+            output[outputOffset + 6] = (short) ((v0 >>> 18) & 0b111L);
+            output[outputOffset + 7] = (short) ((v0 >>> 21) & 0b111L);
+            output[outputOffset + 8] = (short) ((v0 >>> 24) & 0b111L);
+            output[outputOffset + 9] = (short) ((v0 >>> 27) & 0b111L);
+            output[outputOffset + 10] = (short) ((v0 >>> 30) & 0b111L);
+            output[outputOffset + 11] = (short) ((v0 >>> 33) & 0b111L);
+            output[outputOffset + 12] = (short) ((v0 >>> 36) & 0b111L);
+            output[outputOffset + 13] = (short) ((v0 >>> 39) & 0b111L);
+            output[outputOffset + 14] = (short) ((v0 >>> 42) & 0b111L);
+            output[outputOffset + 15] = (short) ((v0 >>> 45) & 0b111L);
+            output[outputOffset + 16] = (short) ((v0 >>> 48) & 0b111L);
+            output[outputOffset + 17] = (short) ((v0 >>> 51) & 0b111L);
+            output[outputOffset + 18] = (short) ((v0 >>> 54) & 0b111L);
+            output[outputOffset + 19] = (short) ((v0 >>> 57) & 0b111L);
+            output[outputOffset + 20] = (short) ((v0 >>> 60) & 0b111L);
+            output[outputOffset + 21] = (short) (((v0 >>> 63) & 0b1L) | ((v1 & 0b11L) << 1));
+            output[outputOffset + 22] = (short) ((v1 >>> 2) & 0b111L);
+            output[outputOffset + 23] = (short) ((v1 >>> 5) & 0b111L);
+            output[outputOffset + 24] = (short) ((v1 >>> 8) & 0b111L);
+            output[outputOffset + 25] = (short) ((v1 >>> 11) & 0b111L);
+            output[outputOffset + 26] = (short) ((v1 >>> 14) & 0b111L);
+            output[outputOffset + 27] = (short) ((v1 >>> 17) & 0b111L);
+            output[outputOffset + 28] = (short) ((v1 >>> 20) & 0b111L);
+            output[outputOffset + 29] = (short) ((v1 >>> 23) & 0b111L);
+            output[outputOffset + 30] = (short) ((v1 >>> 26) & 0b111L);
+            output[outputOffset + 31] = (short) ((v1 >>> 29) & 0b111L);
+        }
+    }
+
+    private static final class Unpacker4
+            implements ShortBitUnpacker
+    {
+        @Override
+        public void unpack(short[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(short[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            output[outputOffset] = (short) (v0 & 0b1111L);
+            output[outputOffset + 1] = (short) ((v0 >>> 4) & 0b1111L);
+            output[outputOffset + 2] = (short) ((v0 >>> 8) & 0b1111L);
+            output[outputOffset + 3] = (short) ((v0 >>> 12) & 0b1111L);
+            output[outputOffset + 4] = (short) ((v0 >>> 16) & 0b1111L);
+            output[outputOffset + 5] = (short) ((v0 >>> 20) & 0b1111L);
+            output[outputOffset + 6] = (short) ((v0 >>> 24) & 0b1111L);
+            output[outputOffset + 7] = (short) ((v0 >>> 28) & 0b1111L);
+            output[outputOffset + 8] = (short) ((v0 >>> 32) & 0b1111L);
+            output[outputOffset + 9] = (short) ((v0 >>> 36) & 0b1111L);
+            output[outputOffset + 10] = (short) ((v0 >>> 40) & 0b1111L);
+            output[outputOffset + 11] = (short) ((v0 >>> 44) & 0b1111L);
+            output[outputOffset + 12] = (short) ((v0 >>> 48) & 0b1111L);
+            output[outputOffset + 13] = (short) ((v0 >>> 52) & 0b1111L);
+            output[outputOffset + 14] = (short) ((v0 >>> 56) & 0b1111L);
+            output[outputOffset + 15] = (short) ((v0 >>> 60) & 0b1111L);
+            output[outputOffset + 16] = (short) (v1 & 0b1111L);
+            output[outputOffset + 17] = (short) ((v1 >>> 4) & 0b1111L);
+            output[outputOffset + 18] = (short) ((v1 >>> 8) & 0b1111L);
+            output[outputOffset + 19] = (short) ((v1 >>> 12) & 0b1111L);
+            output[outputOffset + 20] = (short) ((v1 >>> 16) & 0b1111L);
+            output[outputOffset + 21] = (short) ((v1 >>> 20) & 0b1111L);
+            output[outputOffset + 22] = (short) ((v1 >>> 24) & 0b1111L);
+            output[outputOffset + 23] = (short) ((v1 >>> 28) & 0b1111L);
+            output[outputOffset + 24] = (short) ((v1 >>> 32) & 0b1111L);
+            output[outputOffset + 25] = (short) ((v1 >>> 36) & 0b1111L);
+            output[outputOffset + 26] = (short) ((v1 >>> 40) & 0b1111L);
+            output[outputOffset + 27] = (short) ((v1 >>> 44) & 0b1111L);
+            output[outputOffset + 28] = (short) ((v1 >>> 48) & 0b1111L);
+            output[outputOffset + 29] = (short) ((v1 >>> 52) & 0b1111L);
+            output[outputOffset + 30] = (short) ((v1 >>> 56) & 0b1111L);
+            output[outputOffset + 31] = (short) ((v1 >>> 60) & 0b1111L);
+        }
+    }
+
+    private static final class Unpacker5
+            implements ShortBitUnpacker
+    {
+        @Override
+        public void unpack(short[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(short[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            int v2 = input.readInt();
+            output[outputOffset] = (short) (v0 & 0b11111L);
+            output[outputOffset + 1] = (short) ((v0 >>> 5) & 0b11111L);
+            output[outputOffset + 2] = (short) ((v0 >>> 10) & 0b11111L);
+            output[outputOffset + 3] = (short) ((v0 >>> 15) & 0b11111L);
+            output[outputOffset + 4] = (short) ((v0 >>> 20) & 0b11111L);
+            output[outputOffset + 5] = (short) ((v0 >>> 25) & 0b11111L);
+            output[outputOffset + 6] = (short) ((v0 >>> 30) & 0b11111L);
+            output[outputOffset + 7] = (short) ((v0 >>> 35) & 0b11111L);
+            output[outputOffset + 8] = (short) ((v0 >>> 40) & 0b11111L);
+            output[outputOffset + 9] = (short) ((v0 >>> 45) & 0b11111L);
+            output[outputOffset + 10] = (short) ((v0 >>> 50) & 0b11111L);
+            output[outputOffset + 11] = (short) ((v0 >>> 55) & 0b11111L);
+            output[outputOffset + 12] = (short) (((v0 >>> 60) & 0b1111L) | ((v1 & 0b1L) << 4));
+            output[outputOffset + 13] = (short) ((v1 >>> 1) & 0b11111L);
+            output[outputOffset + 14] = (short) ((v1 >>> 6) & 0b11111L);
+            output[outputOffset + 15] = (short) ((v1 >>> 11) & 0b11111L);
+            output[outputOffset + 16] = (short) ((v1 >>> 16) & 0b11111L);
+            output[outputOffset + 17] = (short) ((v1 >>> 21) & 0b11111L);
+            output[outputOffset + 18] = (short) ((v1 >>> 26) & 0b11111L);
+            output[outputOffset + 19] = (short) ((v1 >>> 31) & 0b11111L);
+            output[outputOffset + 20] = (short) ((v1 >>> 36) & 0b11111L);
+            output[outputOffset + 21] = (short) ((v1 >>> 41) & 0b11111L);
+            output[outputOffset + 22] = (short) ((v1 >>> 46) & 0b11111L);
+            output[outputOffset + 23] = (short) ((v1 >>> 51) & 0b11111L);
+            output[outputOffset + 24] = (short) ((v1 >>> 56) & 0b11111L);
+            output[outputOffset + 25] = (short) (((v1 >>> 61) & 0b111L) | ((v2 & 0b11L) << 3));
+            output[outputOffset + 26] = (short) ((v2 >>> 2) & 0b11111L);
+            output[outputOffset + 27] = (short) ((v2 >>> 7) & 0b11111L);
+            output[outputOffset + 28] = (short) ((v2 >>> 12) & 0b11111L);
+            output[outputOffset + 29] = (short) ((v2 >>> 17) & 0b11111L);
+            output[outputOffset + 30] = (short) ((v2 >>> 22) & 0b11111L);
+            output[outputOffset + 31] = (short) ((v2 >>> 27) & 0b11111L);
+        }
+    }
+
+    private static final class Unpacker6
+            implements ShortBitUnpacker
+    {
+        @Override
+        public void unpack(short[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(short[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            output[outputOffset] = (short) (v0 & 0b111111L);
+            output[outputOffset + 1] = (short) ((v0 >>> 6) & 0b111111L);
+            output[outputOffset + 2] = (short) ((v0 >>> 12) & 0b111111L);
+            output[outputOffset + 3] = (short) ((v0 >>> 18) & 0b111111L);
+            output[outputOffset + 4] = (short) ((v0 >>> 24) & 0b111111L);
+            output[outputOffset + 5] = (short) ((v0 >>> 30) & 0b111111L);
+            output[outputOffset + 6] = (short) ((v0 >>> 36) & 0b111111L);
+            output[outputOffset + 7] = (short) ((v0 >>> 42) & 0b111111L);
+            output[outputOffset + 8] = (short) ((v0 >>> 48) & 0b111111L);
+            output[outputOffset + 9] = (short) ((v0 >>> 54) & 0b111111L);
+            output[outputOffset + 10] = (short) (((v0 >>> 60) & 0b1111L) | ((v1 & 0b11L) << 4));
+            output[outputOffset + 11] = (short) ((v1 >>> 2) & 0b111111L);
+            output[outputOffset + 12] = (short) ((v1 >>> 8) & 0b111111L);
+            output[outputOffset + 13] = (short) ((v1 >>> 14) & 0b111111L);
+            output[outputOffset + 14] = (short) ((v1 >>> 20) & 0b111111L);
+            output[outputOffset + 15] = (short) ((v1 >>> 26) & 0b111111L);
+            output[outputOffset + 16] = (short) ((v1 >>> 32) & 0b111111L);
+            output[outputOffset + 17] = (short) ((v1 >>> 38) & 0b111111L);
+            output[outputOffset + 18] = (short) ((v1 >>> 44) & 0b111111L);
+            output[outputOffset + 19] = (short) ((v1 >>> 50) & 0b111111L);
+            output[outputOffset + 20] = (short) ((v1 >>> 56) & 0b111111L);
+            output[outputOffset + 21] = (short) (((v1 >>> 62) & 0b11L) | ((v2 & 0b1111L) << 2));
+            output[outputOffset + 22] = (short) ((v2 >>> 4) & 0b111111L);
+            output[outputOffset + 23] = (short) ((v2 >>> 10) & 0b111111L);
+            output[outputOffset + 24] = (short) ((v2 >>> 16) & 0b111111L);
+            output[outputOffset + 25] = (short) ((v2 >>> 22) & 0b111111L);
+            output[outputOffset + 26] = (short) ((v2 >>> 28) & 0b111111L);
+            output[outputOffset + 27] = (short) ((v2 >>> 34) & 0b111111L);
+            output[outputOffset + 28] = (short) ((v2 >>> 40) & 0b111111L);
+            output[outputOffset + 29] = (short) ((v2 >>> 46) & 0b111111L);
+            output[outputOffset + 30] = (short) ((v2 >>> 52) & 0b111111L);
+            output[outputOffset + 31] = (short) ((v2 >>> 58) & 0b111111L);
+        }
+    }
+
+    private static final class Unpacker7
+            implements ShortBitUnpacker
+    {
+        @Override
+        public void unpack(short[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(short[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            int v3 = input.readInt();
+            output[outputOffset] = (short) (v0 & 0b1111111L);
+            output[outputOffset + 1] = (short) ((v0 >>> 7) & 0b1111111L);
+            output[outputOffset + 2] = (short) ((v0 >>> 14) & 0b1111111L);
+            output[outputOffset + 3] = (short) ((v0 >>> 21) & 0b1111111L);
+            output[outputOffset + 4] = (short) ((v0 >>> 28) & 0b1111111L);
+            output[outputOffset + 5] = (short) ((v0 >>> 35) & 0b1111111L);
+            output[outputOffset + 6] = (short) ((v0 >>> 42) & 0b1111111L);
+            output[outputOffset + 7] = (short) ((v0 >>> 49) & 0b1111111L);
+            output[outputOffset + 8] = (short) ((v0 >>> 56) & 0b1111111L);
+            output[outputOffset + 9] = (short) (((v0 >>> 63) & 0b1L) | ((v1 & 0b111111L) << 1));
+            output[outputOffset + 10] = (short) ((v1 >>> 6) & 0b1111111L);
+            output[outputOffset + 11] = (short) ((v1 >>> 13) & 0b1111111L);
+            output[outputOffset + 12] = (short) ((v1 >>> 20) & 0b1111111L);
+            output[outputOffset + 13] = (short) ((v1 >>> 27) & 0b1111111L);
+            output[outputOffset + 14] = (short) ((v1 >>> 34) & 0b1111111L);
+            output[outputOffset + 15] = (short) ((v1 >>> 41) & 0b1111111L);
+            output[outputOffset + 16] = (short) ((v1 >>> 48) & 0b1111111L);
+            output[outputOffset + 17] = (short) ((v1 >>> 55) & 0b1111111L);
+            output[outputOffset + 18] = (short) (((v1 >>> 62) & 0b11L) | ((v2 & 0b11111L) << 2));
+            output[outputOffset + 19] = (short) ((v2 >>> 5) & 0b1111111L);
+            output[outputOffset + 20] = (short) ((v2 >>> 12) & 0b1111111L);
+            output[outputOffset + 21] = (short) ((v2 >>> 19) & 0b1111111L);
+            output[outputOffset + 22] = (short) ((v2 >>> 26) & 0b1111111L);
+            output[outputOffset + 23] = (short) ((v2 >>> 33) & 0b1111111L);
+            output[outputOffset + 24] = (short) ((v2 >>> 40) & 0b1111111L);
+            output[outputOffset + 25] = (short) ((v2 >>> 47) & 0b1111111L);
+            output[outputOffset + 26] = (short) ((v2 >>> 54) & 0b1111111L);
+            output[outputOffset + 27] = (short) (((v2 >>> 61) & 0b111L) | ((v3 & 0b1111L) << 3));
+            output[outputOffset + 28] = (short) ((v3 >>> 4) & 0b1111111L);
+            output[outputOffset + 29] = (short) ((v3 >>> 11) & 0b1111111L);
+            output[outputOffset + 30] = (short) ((v3 >>> 18) & 0b1111111L);
+            output[outputOffset + 31] = (short) ((v3 >>> 25) & 0b1111111L);
+        }
+    }
+
+    private static final class Unpacker8
+            implements ShortBitUnpacker
+    {
+        @Override
+        public void unpack(short[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(short[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            output[outputOffset] = (short) (v0 & 0b11111111L);
+            output[outputOffset + 1] = (short) ((v0 >>> 8) & 0b11111111L);
+            output[outputOffset + 2] = (short) ((v0 >>> 16) & 0b11111111L);
+            output[outputOffset + 3] = (short) ((v0 >>> 24) & 0b11111111L);
+            output[outputOffset + 4] = (short) ((v0 >>> 32) & 0b11111111L);
+            output[outputOffset + 5] = (short) ((v0 >>> 40) & 0b11111111L);
+            output[outputOffset + 6] = (short) ((v0 >>> 48) & 0b11111111L);
+            output[outputOffset + 7] = (short) ((v0 >>> 56) & 0b11111111L);
+            output[outputOffset + 8] = (short) (v1 & 0b11111111L);
+            output[outputOffset + 9] = (short) ((v1 >>> 8) & 0b11111111L);
+            output[outputOffset + 10] = (short) ((v1 >>> 16) & 0b11111111L);
+            output[outputOffset + 11] = (short) ((v1 >>> 24) & 0b11111111L);
+            output[outputOffset + 12] = (short) ((v1 >>> 32) & 0b11111111L);
+            output[outputOffset + 13] = (short) ((v1 >>> 40) & 0b11111111L);
+            output[outputOffset + 14] = (short) ((v1 >>> 48) & 0b11111111L);
+            output[outputOffset + 15] = (short) ((v1 >>> 56) & 0b11111111L);
+            output[outputOffset + 16] = (short) (v2 & 0b11111111L);
+            output[outputOffset + 17] = (short) ((v2 >>> 8) & 0b11111111L);
+            output[outputOffset + 18] = (short) ((v2 >>> 16) & 0b11111111L);
+            output[outputOffset + 19] = (short) ((v2 >>> 24) & 0b11111111L);
+            output[outputOffset + 20] = (short) ((v2 >>> 32) & 0b11111111L);
+            output[outputOffset + 21] = (short) ((v2 >>> 40) & 0b11111111L);
+            output[outputOffset + 22] = (short) ((v2 >>> 48) & 0b11111111L);
+            output[outputOffset + 23] = (short) ((v2 >>> 56) & 0b11111111L);
+            output[outputOffset + 24] = (short) (v3 & 0b11111111L);
+            output[outputOffset + 25] = (short) ((v3 >>> 8) & 0b11111111L);
+            output[outputOffset + 26] = (short) ((v3 >>> 16) & 0b11111111L);
+            output[outputOffset + 27] = (short) ((v3 >>> 24) & 0b11111111L);
+            output[outputOffset + 28] = (short) ((v3 >>> 32) & 0b11111111L);
+            output[outputOffset + 29] = (short) ((v3 >>> 40) & 0b11111111L);
+            output[outputOffset + 30] = (short) ((v3 >>> 48) & 0b11111111L);
+            output[outputOffset + 31] = (short) ((v3 >>> 56) & 0b11111111L);
+        }
+    }
+
+    private static final class Unpacker9
+            implements ShortBitUnpacker
+    {
+        @Override
+        public void unpack(short[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(short[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            int v4 = input.readInt();
+            output[outputOffset] = (short) (v0 & 0b111111111L);
+            output[outputOffset + 1] = (short) ((v0 >>> 9) & 0b111111111L);
+            output[outputOffset + 2] = (short) ((v0 >>> 18) & 0b111111111L);
+            output[outputOffset + 3] = (short) ((v0 >>> 27) & 0b111111111L);
+            output[outputOffset + 4] = (short) ((v0 >>> 36) & 0b111111111L);
+            output[outputOffset + 5] = (short) ((v0 >>> 45) & 0b111111111L);
+            output[outputOffset + 6] = (short) ((v0 >>> 54) & 0b111111111L);
+            output[outputOffset + 7] = (short) (((v0 >>> 63) & 0b1L) | ((v1 & 0b11111111L) << 1));
+            output[outputOffset + 8] = (short) ((v1 >>> 8) & 0b111111111L);
+            output[outputOffset + 9] = (short) ((v1 >>> 17) & 0b111111111L);
+            output[outputOffset + 10] = (short) ((v1 >>> 26) & 0b111111111L);
+            output[outputOffset + 11] = (short) ((v1 >>> 35) & 0b111111111L);
+            output[outputOffset + 12] = (short) ((v1 >>> 44) & 0b111111111L);
+            output[outputOffset + 13] = (short) ((v1 >>> 53) & 0b111111111L);
+            output[outputOffset + 14] = (short) (((v1 >>> 62) & 0b11L) | ((v2 & 0b1111111L) << 2));
+            output[outputOffset + 15] = (short) ((v2 >>> 7) & 0b111111111L);
+            output[outputOffset + 16] = (short) ((v2 >>> 16) & 0b111111111L);
+            output[outputOffset + 17] = (short) ((v2 >>> 25) & 0b111111111L);
+            output[outputOffset + 18] = (short) ((v2 >>> 34) & 0b111111111L);
+            output[outputOffset + 19] = (short) ((v2 >>> 43) & 0b111111111L);
+            output[outputOffset + 20] = (short) ((v2 >>> 52) & 0b111111111L);
+            output[outputOffset + 21] = (short) (((v2 >>> 61) & 0b111L) | ((v3 & 0b111111L) << 3));
+            output[outputOffset + 22] = (short) ((v3 >>> 6) & 0b111111111L);
+            output[outputOffset + 23] = (short) ((v3 >>> 15) & 0b111111111L);
+            output[outputOffset + 24] = (short) ((v3 >>> 24) & 0b111111111L);
+            output[outputOffset + 25] = (short) ((v3 >>> 33) & 0b111111111L);
+            output[outputOffset + 26] = (short) ((v3 >>> 42) & 0b111111111L);
+            output[outputOffset + 27] = (short) ((v3 >>> 51) & 0b111111111L);
+            output[outputOffset + 28] = (short) (((v3 >>> 60) & 0b1111L) | ((v4 & 0b11111L) << 4));
+            output[outputOffset + 29] = (short) ((v4 >>> 5) & 0b111111111L);
+            output[outputOffset + 30] = (short) ((v4 >>> 14) & 0b111111111L);
+            output[outputOffset + 31] = (short) ((v4 >>> 23) & 0b111111111L);
+        }
+    }
+
+    private static final class Unpacker10
+            implements ShortBitUnpacker
+    {
+        @Override
+        public void unpack(short[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(short[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            output[outputOffset] = (short) (v0 & 0b1111111111L);
+            output[outputOffset + 1] = (short) ((v0 >>> 10) & 0b1111111111L);
+            output[outputOffset + 2] = (short) ((v0 >>> 20) & 0b1111111111L);
+            output[outputOffset + 3] = (short) ((v0 >>> 30) & 0b1111111111L);
+            output[outputOffset + 4] = (short) ((v0 >>> 40) & 0b1111111111L);
+            output[outputOffset + 5] = (short) ((v0 >>> 50) & 0b1111111111L);
+            output[outputOffset + 6] = (short) (((v0 >>> 60) & 0b1111L) | ((v1 & 0b111111L) << 4));
+            output[outputOffset + 7] = (short) ((v1 >>> 6) & 0b1111111111L);
+            output[outputOffset + 8] = (short) ((v1 >>> 16) & 0b1111111111L);
+            output[outputOffset + 9] = (short) ((v1 >>> 26) & 0b1111111111L);
+            output[outputOffset + 10] = (short) ((v1 >>> 36) & 0b1111111111L);
+            output[outputOffset + 11] = (short) ((v1 >>> 46) & 0b1111111111L);
+            output[outputOffset + 12] = (short) (((v1 >>> 56) & 0b11111111L) | ((v2 & 0b11L) << 8));
+            output[outputOffset + 13] = (short) ((v2 >>> 2) & 0b1111111111L);
+            output[outputOffset + 14] = (short) ((v2 >>> 12) & 0b1111111111L);
+            output[outputOffset + 15] = (short) ((v2 >>> 22) & 0b1111111111L);
+            output[outputOffset + 16] = (short) ((v2 >>> 32) & 0b1111111111L);
+            output[outputOffset + 17] = (short) ((v2 >>> 42) & 0b1111111111L);
+            output[outputOffset + 18] = (short) ((v2 >>> 52) & 0b1111111111L);
+            output[outputOffset + 19] = (short) (((v2 >>> 62) & 0b11L) | ((v3 & 0b11111111L) << 2));
+            output[outputOffset + 20] = (short) ((v3 >>> 8) & 0b1111111111L);
+            output[outputOffset + 21] = (short) ((v3 >>> 18) & 0b1111111111L);
+            output[outputOffset + 22] = (short) ((v3 >>> 28) & 0b1111111111L);
+            output[outputOffset + 23] = (short) ((v3 >>> 38) & 0b1111111111L);
+            output[outputOffset + 24] = (short) ((v3 >>> 48) & 0b1111111111L);
+            output[outputOffset + 25] = (short) (((v3 >>> 58) & 0b111111L) | ((v4 & 0b1111L) << 6));
+            output[outputOffset + 26] = (short) ((v4 >>> 4) & 0b1111111111L);
+            output[outputOffset + 27] = (short) ((v4 >>> 14) & 0b1111111111L);
+            output[outputOffset + 28] = (short) ((v4 >>> 24) & 0b1111111111L);
+            output[outputOffset + 29] = (short) ((v4 >>> 34) & 0b1111111111L);
+            output[outputOffset + 30] = (short) ((v4 >>> 44) & 0b1111111111L);
+            output[outputOffset + 31] = (short) ((v4 >>> 54) & 0b1111111111L);
+        }
+    }
+
+    private static final class Unpacker11
+            implements ShortBitUnpacker
+    {
+        @Override
+        public void unpack(short[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(short[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            int v5 = input.readInt();
+            output[outputOffset] = (short) (v0 & 0b11111111111L);
+            output[outputOffset + 1] = (short) ((v0 >>> 11) & 0b11111111111L);
+            output[outputOffset + 2] = (short) ((v0 >>> 22) & 0b11111111111L);
+            output[outputOffset + 3] = (short) ((v0 >>> 33) & 0b11111111111L);
+            output[outputOffset + 4] = (short) ((v0 >>> 44) & 0b11111111111L);
+            output[outputOffset + 5] = (short) (((v0 >>> 55) & 0b111111111L) | ((v1 & 0b11L) << 9));
+            output[outputOffset + 6] = (short) ((v1 >>> 2) & 0b11111111111L);
+            output[outputOffset + 7] = (short) ((v1 >>> 13) & 0b11111111111L);
+            output[outputOffset + 8] = (short) ((v1 >>> 24) & 0b11111111111L);
+            output[outputOffset + 9] = (short) ((v1 >>> 35) & 0b11111111111L);
+            output[outputOffset + 10] = (short) ((v1 >>> 46) & 0b11111111111L);
+            output[outputOffset + 11] = (short) (((v1 >>> 57) & 0b1111111L) | ((v2 & 0b1111L) << 7));
+            output[outputOffset + 12] = (short) ((v2 >>> 4) & 0b11111111111L);
+            output[outputOffset + 13] = (short) ((v2 >>> 15) & 0b11111111111L);
+            output[outputOffset + 14] = (short) ((v2 >>> 26) & 0b11111111111L);
+            output[outputOffset + 15] = (short) ((v2 >>> 37) & 0b11111111111L);
+            output[outputOffset + 16] = (short) ((v2 >>> 48) & 0b11111111111L);
+            output[outputOffset + 17] = (short) (((v2 >>> 59) & 0b11111L) | ((v3 & 0b111111L) << 5));
+            output[outputOffset + 18] = (short) ((v3 >>> 6) & 0b11111111111L);
+            output[outputOffset + 19] = (short) ((v3 >>> 17) & 0b11111111111L);
+            output[outputOffset + 20] = (short) ((v3 >>> 28) & 0b11111111111L);
+            output[outputOffset + 21] = (short) ((v3 >>> 39) & 0b11111111111L);
+            output[outputOffset + 22] = (short) ((v3 >>> 50) & 0b11111111111L);
+            output[outputOffset + 23] = (short) (((v3 >>> 61) & 0b111L) | ((v4 & 0b11111111L) << 3));
+            output[outputOffset + 24] = (short) ((v4 >>> 8) & 0b11111111111L);
+            output[outputOffset + 25] = (short) ((v4 >>> 19) & 0b11111111111L);
+            output[outputOffset + 26] = (short) ((v4 >>> 30) & 0b11111111111L);
+            output[outputOffset + 27] = (short) ((v4 >>> 41) & 0b11111111111L);
+            output[outputOffset + 28] = (short) ((v4 >>> 52) & 0b11111111111L);
+            output[outputOffset + 29] = (short) (((v4 >>> 63) & 0b1L) | ((v5 & 0b1111111111L) << 1));
+            output[outputOffset + 30] = (short) ((v5 >>> 10) & 0b11111111111L);
+            output[outputOffset + 31] = (short) ((v5 >>> 21) & 0b11111111111L);
+        }
+    }
+
+    private static final class Unpacker12
+            implements ShortBitUnpacker
+    {
+        @Override
+        public void unpack(short[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(short[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            output[outputOffset] = (short) (v0 & 0b111111111111L);
+            output[outputOffset + 1] = (short) ((v0 >>> 12) & 0b111111111111L);
+            output[outputOffset + 2] = (short) ((v0 >>> 24) & 0b111111111111L);
+            output[outputOffset + 3] = (short) ((v0 >>> 36) & 0b111111111111L);
+            output[outputOffset + 4] = (short) ((v0 >>> 48) & 0b111111111111L);
+            output[outputOffset + 5] = (short) (((v0 >>> 60) & 0b1111L) | ((v1 & 0b11111111L) << 4));
+            output[outputOffset + 6] = (short) ((v1 >>> 8) & 0b111111111111L);
+            output[outputOffset + 7] = (short) ((v1 >>> 20) & 0b111111111111L);
+            output[outputOffset + 8] = (short) ((v1 >>> 32) & 0b111111111111L);
+            output[outputOffset + 9] = (short) ((v1 >>> 44) & 0b111111111111L);
+            output[outputOffset + 10] = (short) (((v1 >>> 56) & 0b11111111L) | ((v2 & 0b1111L) << 8));
+            output[outputOffset + 11] = (short) ((v2 >>> 4) & 0b111111111111L);
+            output[outputOffset + 12] = (short) ((v2 >>> 16) & 0b111111111111L);
+            output[outputOffset + 13] = (short) ((v2 >>> 28) & 0b111111111111L);
+            output[outputOffset + 14] = (short) ((v2 >>> 40) & 0b111111111111L);
+            output[outputOffset + 15] = (short) ((v2 >>> 52) & 0b111111111111L);
+            output[outputOffset + 16] = (short) (v3 & 0b111111111111L);
+            output[outputOffset + 17] = (short) ((v3 >>> 12) & 0b111111111111L);
+            output[outputOffset + 18] = (short) ((v3 >>> 24) & 0b111111111111L);
+            output[outputOffset + 19] = (short) ((v3 >>> 36) & 0b111111111111L);
+            output[outputOffset + 20] = (short) ((v3 >>> 48) & 0b111111111111L);
+            output[outputOffset + 21] = (short) (((v3 >>> 60) & 0b1111L) | ((v4 & 0b11111111L) << 4));
+            output[outputOffset + 22] = (short) ((v4 >>> 8) & 0b111111111111L);
+            output[outputOffset + 23] = (short) ((v4 >>> 20) & 0b111111111111L);
+            output[outputOffset + 24] = (short) ((v4 >>> 32) & 0b111111111111L);
+            output[outputOffset + 25] = (short) ((v4 >>> 44) & 0b111111111111L);
+            output[outputOffset + 26] = (short) (((v4 >>> 56) & 0b11111111L) | ((v5 & 0b1111L) << 8));
+            output[outputOffset + 27] = (short) ((v5 >>> 4) & 0b111111111111L);
+            output[outputOffset + 28] = (short) ((v5 >>> 16) & 0b111111111111L);
+            output[outputOffset + 29] = (short) ((v5 >>> 28) & 0b111111111111L);
+            output[outputOffset + 30] = (short) ((v5 >>> 40) & 0b111111111111L);
+            output[outputOffset + 31] = (short) ((v5 >>> 52) & 0b111111111111L);
+        }
+    }
+
+    private static final class Unpacker13
+            implements ShortBitUnpacker
+    {
+        @Override
+        public void unpack(short[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(short[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            int v6 = input.readInt();
+            output[outputOffset] = (short) (v0 & 0b1111111111111L);
+            output[outputOffset + 1] = (short) ((v0 >>> 13) & 0b1111111111111L);
+            output[outputOffset + 2] = (short) ((v0 >>> 26) & 0b1111111111111L);
+            output[outputOffset + 3] = (short) ((v0 >>> 39) & 0b1111111111111L);
+            output[outputOffset + 4] = (short) (((v0 >>> 52) & 0b111111111111L) | ((v1 & 0b1L) << 12));
+            output[outputOffset + 5] = (short) ((v1 >>> 1) & 0b1111111111111L);
+            output[outputOffset + 6] = (short) ((v1 >>> 14) & 0b1111111111111L);
+            output[outputOffset + 7] = (short) ((v1 >>> 27) & 0b1111111111111L);
+            output[outputOffset + 8] = (short) ((v1 >>> 40) & 0b1111111111111L);
+            output[outputOffset + 9] = (short) (((v1 >>> 53) & 0b11111111111L) | ((v2 & 0b11L) << 11));
+            output[outputOffset + 10] = (short) ((v2 >>> 2) & 0b1111111111111L);
+            output[outputOffset + 11] = (short) ((v2 >>> 15) & 0b1111111111111L);
+            output[outputOffset + 12] = (short) ((v2 >>> 28) & 0b1111111111111L);
+            output[outputOffset + 13] = (short) ((v2 >>> 41) & 0b1111111111111L);
+            output[outputOffset + 14] = (short) (((v2 >>> 54) & 0b1111111111L) | ((v3 & 0b111L) << 10));
+            output[outputOffset + 15] = (short) ((v3 >>> 3) & 0b1111111111111L);
+            output[outputOffset + 16] = (short) ((v3 >>> 16) & 0b1111111111111L);
+            output[outputOffset + 17] = (short) ((v3 >>> 29) & 0b1111111111111L);
+            output[outputOffset + 18] = (short) ((v3 >>> 42) & 0b1111111111111L);
+            output[outputOffset + 19] = (short) (((v3 >>> 55) & 0b111111111L) | ((v4 & 0b1111L) << 9));
+            output[outputOffset + 20] = (short) ((v4 >>> 4) & 0b1111111111111L);
+            output[outputOffset + 21] = (short) ((v4 >>> 17) & 0b1111111111111L);
+            output[outputOffset + 22] = (short) ((v4 >>> 30) & 0b1111111111111L);
+            output[outputOffset + 23] = (short) ((v4 >>> 43) & 0b1111111111111L);
+            output[outputOffset + 24] = (short) (((v4 >>> 56) & 0b11111111L) | ((v5 & 0b11111L) << 8));
+            output[outputOffset + 25] = (short) ((v5 >>> 5) & 0b1111111111111L);
+            output[outputOffset + 26] = (short) ((v5 >>> 18) & 0b1111111111111L);
+            output[outputOffset + 27] = (short) ((v5 >>> 31) & 0b1111111111111L);
+            output[outputOffset + 28] = (short) ((v5 >>> 44) & 0b1111111111111L);
+            output[outputOffset + 29] = (short) (((v5 >>> 57) & 0b1111111L) | ((v6 & 0b111111L) << 7));
+            output[outputOffset + 30] = (short) ((v6 >>> 6) & 0b1111111111111L);
+            output[outputOffset + 31] = (short) ((v6 >>> 19) & 0b1111111111111L);
+        }
+    }
+
+    private static final class Unpacker14
+            implements ShortBitUnpacker
+    {
+        @Override
+        public void unpack(short[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(short[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            output[outputOffset] = (short) (v0 & 0b11111111111111L);
+            output[outputOffset + 1] = (short) ((v0 >>> 14) & 0b11111111111111L);
+            output[outputOffset + 2] = (short) ((v0 >>> 28) & 0b11111111111111L);
+            output[outputOffset + 3] = (short) ((v0 >>> 42) & 0b11111111111111L);
+            output[outputOffset + 4] = (short) (((v0 >>> 56) & 0b11111111L) | ((v1 & 0b111111L) << 8));
+            output[outputOffset + 5] = (short) ((v1 >>> 6) & 0b11111111111111L);
+            output[outputOffset + 6] = (short) ((v1 >>> 20) & 0b11111111111111L);
+            output[outputOffset + 7] = (short) ((v1 >>> 34) & 0b11111111111111L);
+            output[outputOffset + 8] = (short) ((v1 >>> 48) & 0b11111111111111L);
+            output[outputOffset + 9] = (short) (((v1 >>> 62) & 0b11L) | ((v2 & 0b111111111111L) << 2));
+            output[outputOffset + 10] = (short) ((v2 >>> 12) & 0b11111111111111L);
+            output[outputOffset + 11] = (short) ((v2 >>> 26) & 0b11111111111111L);
+            output[outputOffset + 12] = (short) ((v2 >>> 40) & 0b11111111111111L);
+            output[outputOffset + 13] = (short) (((v2 >>> 54) & 0b1111111111L) | ((v3 & 0b1111L) << 10));
+            output[outputOffset + 14] = (short) ((v3 >>> 4) & 0b11111111111111L);
+            output[outputOffset + 15] = (short) ((v3 >>> 18) & 0b11111111111111L);
+            output[outputOffset + 16] = (short) ((v3 >>> 32) & 0b11111111111111L);
+            output[outputOffset + 17] = (short) ((v3 >>> 46) & 0b11111111111111L);
+            output[outputOffset + 18] = (short) (((v3 >>> 60) & 0b1111L) | ((v4 & 0b1111111111L) << 4));
+            output[outputOffset + 19] = (short) ((v4 >>> 10) & 0b11111111111111L);
+            output[outputOffset + 20] = (short) ((v4 >>> 24) & 0b11111111111111L);
+            output[outputOffset + 21] = (short) ((v4 >>> 38) & 0b11111111111111L);
+            output[outputOffset + 22] = (short) (((v4 >>> 52) & 0b111111111111L) | ((v5 & 0b11L) << 12));
+            output[outputOffset + 23] = (short) ((v5 >>> 2) & 0b11111111111111L);
+            output[outputOffset + 24] = (short) ((v5 >>> 16) & 0b11111111111111L);
+            output[outputOffset + 25] = (short) ((v5 >>> 30) & 0b11111111111111L);
+            output[outputOffset + 26] = (short) ((v5 >>> 44) & 0b11111111111111L);
+            output[outputOffset + 27] = (short) (((v5 >>> 58) & 0b111111L) | ((v6 & 0b11111111L) << 6));
+            output[outputOffset + 28] = (short) ((v6 >>> 8) & 0b11111111111111L);
+            output[outputOffset + 29] = (short) ((v6 >>> 22) & 0b11111111111111L);
+            output[outputOffset + 30] = (short) ((v6 >>> 36) & 0b11111111111111L);
+            output[outputOffset + 31] = (short) ((v6 >>> 50) & 0b11111111111111L);
+        }
+    }
+
+    private static final class Unpacker15
+            implements ShortBitUnpacker
+    {
+        @Override
+        public void unpack(short[] output, int outputOffset, SimpleSliceInputStream input,
+                int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(short[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            int v7 = input.readInt();
+            output[outputOffset] = (short) (v0 & 0b111111111111111L);
+            output[outputOffset + 1] = (short) ((v0 >>> 15) & 0b111111111111111L);
+            output[outputOffset + 2] = (short) ((v0 >>> 30) & 0b111111111111111L);
+            output[outputOffset + 3] = (short) ((v0 >>> 45) & 0b111111111111111L);
+            output[outputOffset + 4] = (short) (((v0 >>> 60) & 0b1111L) | ((v1 & 0b11111111111L) << 4));
+            output[outputOffset + 5] = (short) ((v1 >>> 11) & 0b111111111111111L);
+            output[outputOffset + 6] = (short) ((v1 >>> 26) & 0b111111111111111L);
+            output[outputOffset + 7] = (short) ((v1 >>> 41) & 0b111111111111111L);
+            output[outputOffset + 8] = (short) (((v1 >>> 56) & 0b11111111L) | ((v2 & 0b1111111L) << 8));
+            output[outputOffset + 9] = (short) ((v2 >>> 7) & 0b111111111111111L);
+            output[outputOffset + 10] = (short) ((v2 >>> 22) & 0b111111111111111L);
+            output[outputOffset + 11] = (short) ((v2 >>> 37) & 0b111111111111111L);
+            output[outputOffset + 12] = (short) (((v2 >>> 52) & 0b111111111111L) | ((v3 & 0b111L) << 12));
+            output[outputOffset + 13] = (short) ((v3 >>> 3) & 0b111111111111111L);
+            output[outputOffset + 14] = (short) ((v3 >>> 18) & 0b111111111111111L);
+            output[outputOffset + 15] = (short) ((v3 >>> 33) & 0b111111111111111L);
+            output[outputOffset + 16] = (short) ((v3 >>> 48) & 0b111111111111111L);
+            output[outputOffset + 17] = (short) (((v3 >>> 63) & 0b1L) | ((v4 & 0b11111111111111L) << 1));
+            output[outputOffset + 18] = (short) ((v4 >>> 14) & 0b111111111111111L);
+            output[outputOffset + 19] = (short) ((v4 >>> 29) & 0b111111111111111L);
+            output[outputOffset + 20] = (short) ((v4 >>> 44) & 0b111111111111111L);
+            output[outputOffset + 21] = (short) (((v4 >>> 59) & 0b11111L) | ((v5 & 0b1111111111L) << 5));
+            output[outputOffset + 22] = (short) ((v5 >>> 10) & 0b111111111111111L);
+            output[outputOffset + 23] = (short) ((v5 >>> 25) & 0b111111111111111L);
+            output[outputOffset + 24] = (short) ((v5 >>> 40) & 0b111111111111111L);
+            output[outputOffset + 25] = (short) (((v5 >>> 55) & 0b111111111L) | ((v6 & 0b111111L) << 9));
+            output[outputOffset + 26] = (short) ((v6 >>> 6) & 0b111111111111111L);
+            output[outputOffset + 27] = (short) ((v6 >>> 21) & 0b111111111111111L);
+            output[outputOffset + 28] = (short) ((v6 >>> 36) & 0b111111111111111L);
+            output[outputOffset + 29] = (short) (((v6 >>> 51) & 0b1111111111111L) | ((v7 & 0b11L) << 13));
+            output[outputOffset + 30] = (short) ((v7 >>> 2) & 0b111111111111111L);
+            output[outputOffset + 31] = (short) ((v7 >>> 17) & 0b111111111111111L);
+        }
+    }
+
+    private static final class Unpacker16
+            implements ShortBitUnpacker
+    {
+        @Override
+        public void unpack(short[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            input.readBytes(Slices.wrappedShortArray(output, outputOffset, length), 0, length * Short.BYTES);
+        }
+    }
+
+    private static final class Unpacker17
+            implements ShortBitUnpacker
+    {
+        @Override
+        public void unpack(short[] output, int outputOffset, SimpleSliceInputStream input, int length)
+        {
+            while (length >= 32) {
+                unpack32(output, outputOffset, input);
+                outputOffset += 32;
+                length -= 32;
+            }
+        }
+
+        private static void unpack32(short[] output, int outputOffset, SimpleSliceInputStream input)
+        {
+            long v0 = input.readLong();
+            long v1 = input.readLong();
+            long v2 = input.readLong();
+            long v3 = input.readLong();
+            long v4 = input.readLong();
+            long v5 = input.readLong();
+            long v6 = input.readLong();
+            long v7 = input.readLong();
+            int v8 = input.readInt();
+            output[outputOffset] = (short) (v0 & 0b11111111111111111L);
+            output[outputOffset + 1] = (short) ((v0 >>> 17) & 0b11111111111111111L);
+            output[outputOffset + 2] = (short) ((v0 >>> 34) & 0b11111111111111111L);
+            output[outputOffset + 3] = (short) (((v0 >>> 51) & 0b1111111111111L) | ((v1 & 0b1111L) << 13));
+            output[outputOffset + 4] = (short) ((v1 >>> 4) & 0b11111111111111111L);
+            output[outputOffset + 5] = (short) ((v1 >>> 21) & 0b11111111111111111L);
+            output[outputOffset + 6] = (short) ((v1 >>> 38) & 0b11111111111111111L);
+            output[outputOffset + 7] = (short) (((v1 >>> 55) & 0b111111111L) | ((v2 & 0b11111111L) << 9));
+            output[outputOffset + 8] = (short) ((v2 >>> 8) & 0b11111111111111111L);
+            output[outputOffset + 9] = (short) ((v2 >>> 25) & 0b11111111111111111L);
+            output[outputOffset + 10] = (short) ((v2 >>> 42) & 0b11111111111111111L);
+            output[outputOffset + 11] = (short) (((v2 >>> 59) & 0b11111L) | ((v3 & 0b111111111111L) << 5));
+            output[outputOffset + 12] = (short) ((v3 >>> 12) & 0b11111111111111111L);
+            output[outputOffset + 13] = (short) ((v3 >>> 29) & 0b11111111111111111L);
+            output[outputOffset + 14] = (short) ((v3 >>> 46) & 0b11111111111111111L);
+            output[outputOffset + 15] = (short) (((v3 >>> 63) & 0b1L) | ((v4 & 0b1111111111111111L) << 1));
+            output[outputOffset + 16] = (short) ((v4 >>> 16) & 0b11111111111111111L);
+            output[outputOffset + 17] = (short) ((v4 >>> 33) & 0b11111111111111111L);
+            output[outputOffset + 18] = (short) (((v4 >>> 50) & 0b11111111111111L) | ((v5 & 0b111L) << 14));
+            output[outputOffset + 19] = (short) ((v5 >>> 3) & 0b11111111111111111L);
+            output[outputOffset + 20] = (short) ((v5 >>> 20) & 0b11111111111111111L);
+            output[outputOffset + 21] = (short) ((v5 >>> 37) & 0b11111111111111111L);
+            output[outputOffset + 22] = (short) (((v5 >>> 54) & 0b1111111111L) | ((v6 & 0b1111111L) << 10));
+            output[outputOffset + 23] = (short) ((v6 >>> 7) & 0b11111111111111111L);
+            output[outputOffset + 24] = (short) ((v6 >>> 24) & 0b11111111111111111L);
+            output[outputOffset + 25] = (short) ((v6 >>> 41) & 0b11111111111111111L);
+            output[outputOffset + 26] = (short) (((v6 >>> 58) & 0b111111L) | ((v7 & 0b11111111111L) << 6));
+            output[outputOffset + 27] = (short) ((v7 >>> 11) & 0b11111111111111111L);
+            output[outputOffset + 28] = (short) ((v7 >>> 28) & 0b11111111111111111L);
+            output[outputOffset + 29] = (short) ((v7 >>> 45) & 0b11111111111111111L);
+            output[outputOffset + 30] = (short) (((v7 >>> 62) & 0b11L) | ((v8 & 0b111111111111111L) << 2));
+            output[outputOffset + 31] = (short) ((v8 >>> 15) & 0b11111111111111111L);
+        }
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
@@ -35,13 +35,13 @@ import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.Bounde
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ByteApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.CharApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.Int96ApacheParquetValueDecoder;
-import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.IntApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.IntToLongApacheParquetValueDecoder;
-import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.LongApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.LongDecimalApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortDecimalApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.UuidApacheParquetValueDecoder;
+import static io.trino.parquet.reader.decoders.DeltaBinaryPackedDecoders.DeltaBinaryPackedIntDecoder;
+import static io.trino.parquet.reader.decoders.DeltaBinaryPackedDecoders.DeltaBinaryPackedLongDecoder;
 import static io.trino.parquet.reader.decoders.PlainByteArrayDecoders.BinaryPlainValueDecoder;
 import static io.trino.parquet.reader.decoders.PlainByteArrayDecoders.BoundedVarcharPlainValueDecoder;
 import static io.trino.parquet.reader.decoders.PlainByteArrayDecoders.CharPlainValueDecoder;
@@ -128,7 +128,7 @@ public final class ValueDecoders
     {
         return switch (encoding) {
             case PLAIN -> new LongPlainValueDecoder();
-            case DELTA_BINARY_PACKED -> new LongApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
+            case DELTA_BINARY_PACKED -> new DeltaBinaryPackedLongDecoder();
             default -> throw wrongEncoding(encoding, field);
         };
     }
@@ -267,7 +267,7 @@ public final class ValueDecoders
     {
         return switch (encoding) {
             case PLAIN -> new IntPlainValueDecoder();
-            case DELTA_BINARY_PACKED -> new IntApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
+            case DELTA_BINARY_PACKED -> new DeltaBinaryPackedIntDecoder();
             default -> throw wrongEncoding(encoding, field);
         };
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
@@ -32,7 +32,6 @@ import static io.trino.parquet.ValuesType.VALUES;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.BinaryApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.BooleanApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.BoundedVarcharApacheParquetValueDecoder;
-import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ByteApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.CharApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.Int96ApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.IntToLongApacheParquetValueDecoder;
@@ -40,6 +39,7 @@ import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.LongDe
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortDecimalApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.UuidApacheParquetValueDecoder;
+import static io.trino.parquet.reader.decoders.DeltaBinaryPackedDecoders.DeltaBinaryPackedByteDecoder;
 import static io.trino.parquet.reader.decoders.DeltaBinaryPackedDecoders.DeltaBinaryPackedIntDecoder;
 import static io.trino.parquet.reader.decoders.DeltaBinaryPackedDecoders.DeltaBinaryPackedLongDecoder;
 import static io.trino.parquet.reader.decoders.PlainByteArrayDecoders.BinaryPlainValueDecoder;
@@ -285,7 +285,7 @@ public final class ValueDecoders
     {
         return switch (encoding) {
             case PLAIN -> new IntToBytePlainValueDecoder();
-            case DELTA_BINARY_PACKED -> new ByteApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
+            case DELTA_BINARY_PACKED -> new DeltaBinaryPackedByteDecoder();
             default -> throw wrongEncoding(encoding, field);
         };
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
@@ -36,12 +36,12 @@ import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.CharAp
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.Int96ApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.IntToLongApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.LongDecimalApacheParquetValueDecoder;
-import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortDecimalApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.UuidApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.DeltaBinaryPackedDecoders.DeltaBinaryPackedByteDecoder;
 import static io.trino.parquet.reader.decoders.DeltaBinaryPackedDecoders.DeltaBinaryPackedIntDecoder;
 import static io.trino.parquet.reader.decoders.DeltaBinaryPackedDecoders.DeltaBinaryPackedLongDecoder;
+import static io.trino.parquet.reader.decoders.DeltaBinaryPackedDecoders.DeltaBinaryPackedShortDecoder;
 import static io.trino.parquet.reader.decoders.PlainByteArrayDecoders.BinaryPlainValueDecoder;
 import static io.trino.parquet.reader.decoders.PlainByteArrayDecoders.BoundedVarcharPlainValueDecoder;
 import static io.trino.parquet.reader.decoders.PlainByteArrayDecoders.CharPlainValueDecoder;
@@ -276,7 +276,7 @@ public final class ValueDecoders
     {
         return switch (encoding) {
             case PLAIN -> new IntToShortPlainValueDecoder();
-            case DELTA_BINARY_PACKED -> new ShortApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
+            case DELTA_BINARY_PACKED -> new DeltaBinaryPackedShortDecoder();
             default -> throw wrongEncoding(encoding, field);
         };
     }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkByteColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkByteColumnReader.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.trino.parquet.ParquetEncoding;
+import io.trino.parquet.PrimitiveField;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
+import org.apache.parquet.column.values.plain.PlainValuesWriter;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.openjdk.jmh.annotations.Param;
+
+import java.util.Random;
+
+import static io.trino.parquet.ParquetEncoding.DELTA_BINARY_PACKED;
+import static io.trino.parquet.ParquetEncoding.PLAIN;
+import static io.trino.parquet.ParquetReaderUtils.toByteExact;
+import static io.trino.parquet.reader.TestData.randomInt;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static java.lang.String.format;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+
+public class BenchmarkByteColumnReader
+        extends AbstractColumnReaderBenchmark<byte[]>
+{
+    private static final Random RANDOM = new Random(23423523L);
+
+    @Param({
+            "0", "1", "2", "3", "4", "5", "6", "7", "8"
+    })
+    public int bitWidth;
+
+    @Param({
+            "PLAIN",
+            "DELTA_BINARY_PACKED",
+    })
+    public ParquetEncoding encoding;
+
+    @Override
+    protected PrimitiveField createPrimitiveField()
+    {
+        PrimitiveType parquetType = Types.optional(INT32)
+                .named("name");
+        return new PrimitiveField(
+                TINYINT,
+                true,
+                new ColumnDescriptor(new String[] {"test"}, parquetType, 0, 0),
+                0);
+    }
+
+    @Override
+    protected ValuesWriter createValuesWriter(int bufferSize)
+    {
+        if (encoding == PLAIN) {
+            return new PlainValuesWriter(bufferSize, bufferSize, HeapByteBufferAllocator.getInstance());
+        }
+        else if (encoding == DELTA_BINARY_PACKED) {
+            return new DeltaBinaryPackingValuesWriterForInteger(bufferSize, bufferSize, HeapByteBufferAllocator.getInstance());
+        }
+        throw new UnsupportedOperationException(format("encoding %s is not supported", encoding));
+    }
+
+    @Override
+    protected void writeValue(ValuesWriter writer, byte[] batch, int index)
+    {
+        writer.writeInteger(batch[index]);
+    }
+
+    @Override
+    protected byte[] generateDataBatch(int size)
+    {
+        byte[] batch = new byte[size];
+        if (bitWidth == 0) {
+            for (int i = 0; i < size; i++) {
+                batch[i] = (byte) i;
+            }
+        }
+        else {
+            for (int i = 0; i < size; i++) {
+                batch[i] = toByteExact(randomInt(RANDOM, bitWidth));
+            }
+        }
+        return batch;
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        run(BenchmarkByteColumnReader.class);
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkInt32ToLongColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkInt32ToLongColumnReader.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.trino.parquet.ParquetEncoding;
+import io.trino.parquet.PrimitiveField;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
+import org.apache.parquet.column.values.plain.PlainValuesWriter;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.openjdk.jmh.annotations.Param;
+
+import java.util.Random;
+
+import static io.trino.parquet.ParquetEncoding.DELTA_BINARY_PACKED;
+import static io.trino.parquet.ParquetEncoding.PLAIN;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+
+public class BenchmarkInt32ToLongColumnReader
+        extends AbstractColumnReaderBenchmark<long[]>
+{
+    private static final Random RANDOM = new Random(23423523L);
+
+    @Param({
+            "PLAIN",
+            "DELTA_BINARY_PACKED",
+    })
+    public ParquetEncoding encoding;
+
+    @Override
+    protected PrimitiveField createPrimitiveField()
+    {
+        PrimitiveType parquetType = Types.optional(INT32)
+                .named("name");
+        return new PrimitiveField(
+                BIGINT,
+                true,
+                new ColumnDescriptor(new String[] {"test"}, parquetType, 0, 0),
+                0);
+    }
+
+    @Override
+    protected ValuesWriter createValuesWriter(int bufferSize)
+    {
+        if (encoding == PLAIN) {
+            return new PlainValuesWriter(bufferSize, bufferSize, HeapByteBufferAllocator.getInstance());
+        }
+        else if (encoding == DELTA_BINARY_PACKED) {
+            return new DeltaBinaryPackingValuesWriterForInteger(bufferSize, bufferSize, HeapByteBufferAllocator.getInstance());
+        }
+        throw new UnsupportedOperationException(format("encoding %s is not supported", encoding));
+    }
+
+    @Override
+    protected void writeValue(ValuesWriter writer, long[] batch, int index)
+    {
+        writer.writeInteger(toIntExact(batch[index]));
+    }
+
+    @Override
+    protected long[] generateDataBatch(int size)
+    {
+        long[] batch = new long[size];
+        for (int i = 0; i < size; i++) {
+            batch[i] = RANDOM.nextInt();
+        }
+        return batch;
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        run(BenchmarkInt32ToLongColumnReader.class);
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkIntColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkIntColumnReader.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.trino.parquet.ParquetEncoding;
+import io.trino.parquet.PrimitiveField;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
+import org.apache.parquet.column.values.plain.PlainValuesWriter;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.openjdk.jmh.annotations.Param;
+
+import java.util.Random;
+
+import static io.trino.parquet.ParquetEncoding.DELTA_BINARY_PACKED;
+import static io.trino.parquet.ParquetEncoding.PLAIN;
+import static io.trino.parquet.reader.TestData.randomInt;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static java.lang.String.format;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+
+public class BenchmarkIntColumnReader
+        extends AbstractColumnReaderBenchmark<int[]>
+{
+    private static final Random RANDOM = new Random(23423523L);
+
+    @Param({
+            "0", "1", "2", "3", "4", "5", "6", "7", "8",
+            "11", "15", "20", "25", "32"
+    })
+    public int bitWidth;
+
+    @Param({
+            "PLAIN",
+            "DELTA_BINARY_PACKED",
+    })
+    public ParquetEncoding encoding;
+
+    @Override
+    protected PrimitiveField createPrimitiveField()
+    {
+        PrimitiveType parquetType = Types.optional(INT32)
+                .named("name");
+        return new PrimitiveField(
+                INTEGER,
+                true,
+                new ColumnDescriptor(new String[] {"test"}, parquetType, 0, 0),
+                0);
+    }
+
+    @Override
+    protected ValuesWriter createValuesWriter(int bufferSize)
+    {
+        if (encoding == PLAIN) {
+            return new PlainValuesWriter(bufferSize, bufferSize, HeapByteBufferAllocator.getInstance());
+        }
+        else if (encoding == DELTA_BINARY_PACKED) {
+            return new DeltaBinaryPackingValuesWriterForInteger(bufferSize, bufferSize, HeapByteBufferAllocator.getInstance());
+        }
+        throw new UnsupportedOperationException(format("encoding %s is not supported", encoding));
+    }
+
+    @Override
+    protected void writeValue(ValuesWriter writer, int[] batch, int index)
+    {
+        writer.writeInteger(batch[index]);
+    }
+
+    @Override
+    protected int[] generateDataBatch(int size)
+    {
+        int[] batch = new int[size];
+        if (bitWidth == 0) {
+            for (int i = 0; i < size; i++) {
+                batch[i] = i;
+            }
+        }
+        else {
+            for (int i = 0; i < size; i++) {
+                batch[i] = randomInt(RANDOM, bitWidth);
+            }
+        }
+        return batch;
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        run(BenchmarkIntColumnReader.class);
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkLongColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkLongColumnReader.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.trino.parquet.ParquetEncoding;
+import io.trino.parquet.PrimitiveField;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForLong;
+import org.apache.parquet.column.values.plain.PlainValuesWriter;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.openjdk.jmh.annotations.Param;
+
+import java.util.Random;
+
+import static io.trino.parquet.ParquetEncoding.DELTA_BINARY_PACKED;
+import static io.trino.parquet.ParquetEncoding.PLAIN;
+import static io.trino.parquet.reader.TestData.randomLong;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static java.lang.String.format;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+
+public class BenchmarkLongColumnReader
+        extends AbstractColumnReaderBenchmark<long[]>
+{
+    private static final Random RANDOM = new Random(23423523L);
+
+    @Param({
+            "0", "4", "8", "10", "15", "20", "25", "30",
+            "35", "40", "45", "50", "55", "60", "64"
+    })
+    public int bitWidth;
+
+    @Param({
+            "PLAIN",
+            "DELTA_BINARY_PACKED",
+    })
+    public ParquetEncoding encoding;
+
+    @Override
+    protected PrimitiveField createPrimitiveField()
+    {
+        PrimitiveType parquetType = Types.optional(INT64)
+                .named("name");
+        return new PrimitiveField(
+                BIGINT,
+                true,
+                new ColumnDescriptor(new String[] {"test"}, parquetType, 0, 0),
+                0);
+    }
+
+    @Override
+    protected ValuesWriter createValuesWriter(int bufferSize)
+    {
+        if (encoding == PLAIN) {
+            return new PlainValuesWriter(bufferSize, bufferSize, HeapByteBufferAllocator.getInstance());
+        }
+        else if (encoding == DELTA_BINARY_PACKED) {
+            return new DeltaBinaryPackingValuesWriterForLong(bufferSize, bufferSize, HeapByteBufferAllocator.getInstance());
+        }
+        throw new UnsupportedOperationException(format("encoding %s is not supported", encoding));
+    }
+
+    @Override
+    protected void writeValue(ValuesWriter writer, long[] batch, int index)
+    {
+        writer.writeLong(batch[index]);
+    }
+
+    @Override
+    protected long[] generateDataBatch(int size)
+    {
+        long[] batch = new long[size];
+        if (bitWidth == 0) {
+            for (int i = 0; i < size; i++) {
+                batch[i] = i;
+            }
+        }
+        else {
+            for (int i = 0; i < size; i++) {
+                batch[i] = randomLong(RANDOM, bitWidth);
+            }
+        }
+        return batch;
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        run(BenchmarkLongColumnReader.class);
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkReadUleb128Long.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkReadUleb128Long.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.parquet.ParquetReaderUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.jmh.Benchmarks.benchmark;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.parquet.bytes.BytesUtils.writeUnsignedVarLong;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = MILLISECONDS)
+@Warmup(iterations = 20, time = 500, timeUnit = MILLISECONDS)
+@Fork(3)
+public class BenchmarkReadUleb128Long
+{
+    @Param({
+            "1000",
+            "10000",
+    })
+    public int size;
+
+    private Slice[] inputValues;
+
+    @Setup
+    public void setUp()
+            throws IOException
+    {
+        inputValues = new Slice[size];
+        Random random = new Random(1);
+        for (int i = 0; i < size; i++) {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            writeUnsignedVarLong(random.nextLong(), bos);
+            inputValues[i] = Slices.wrappedBuffer(bos.toByteArray());
+        }
+    }
+
+    @Benchmark
+    public void readUleb128Long()
+    {
+        for (Slice input : inputValues) {
+            sink(ParquetReaderUtils.readUleb128Long(new SimpleSliceInputStream(input)));
+        }
+    }
+
+    @Benchmark
+    public void readUleb128LongLoop()
+    {
+        for (Slice input : inputValues) {
+            sink(readUleb128LongLoop(new SimpleSliceInputStream(input)));
+        }
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static void sink(long value)
+    {
+        // IT IS VERY IMPORTANT TO MATCH THE SIGNATURE TO AVOID AUTOBOXING.
+        // The method intentionally does nothing.
+    }
+
+    private static long readUleb128LongLoop(SimpleSliceInputStream input)
+    {
+        long value = 0;
+        int i = 0;
+        long b = input.readByte();
+        while ((b & 0x80) != 0) {
+            value |= (b & 0x7F) << i;
+            i += 7;
+            b = input.readByte();
+        }
+        return value | (b << i);
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        benchmark(BenchmarkReadUleb128Long.class)
+                .withOptions(optionsBuilder -> optionsBuilder.jvmArgsAppend("-Xmx4g", "-Xms4g"))
+                .run();
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkShortColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkShortColumnReader.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.trino.parquet.ParquetEncoding;
+import io.trino.parquet.PrimitiveField;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
+import org.apache.parquet.column.values.plain.PlainValuesWriter;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.openjdk.jmh.annotations.Param;
+
+import java.util.Random;
+
+import static io.trino.parquet.ParquetEncoding.DELTA_BINARY_PACKED;
+import static io.trino.parquet.ParquetEncoding.PLAIN;
+import static io.trino.parquet.ParquetReaderUtils.toShortExact;
+import static io.trino.parquet.reader.TestData.randomInt;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static java.lang.String.format;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+
+public class BenchmarkShortColumnReader
+        extends AbstractColumnReaderBenchmark<short[]>
+{
+    private static final Random RANDOM = new Random(23423523L);
+
+    @Param({
+            "0", "1", "2", "3", "4", "8", "10", "11", "14", "16"
+    })
+    public int bitWidth;
+
+    @Param({
+            "PLAIN",
+            "DELTA_BINARY_PACKED",
+    })
+    public ParquetEncoding encoding;
+
+    @Override
+    protected PrimitiveField createPrimitiveField()
+    {
+        PrimitiveType parquetType = Types.optional(INT32)
+                .named("name");
+        return new PrimitiveField(
+                SMALLINT,
+                true,
+                new ColumnDescriptor(new String[] {"test"}, parquetType, 0, 0),
+                0);
+    }
+
+    @Override
+    protected ValuesWriter createValuesWriter(int bufferSize)
+    {
+        if (encoding == PLAIN) {
+            return new PlainValuesWriter(bufferSize, bufferSize, HeapByteBufferAllocator.getInstance());
+        }
+        else if (encoding == DELTA_BINARY_PACKED) {
+            return new DeltaBinaryPackingValuesWriterForInteger(bufferSize, bufferSize, HeapByteBufferAllocator.getInstance());
+        }
+        throw new UnsupportedOperationException(format("encoding %s is not supported", encoding));
+    }
+
+    @Override
+    protected void writeValue(ValuesWriter writer, short[] batch, int index)
+    {
+        writer.writeInteger(batch[index]);
+    }
+
+    @Override
+    protected short[] generateDataBatch(int size)
+    {
+        short[] batch = new short[size];
+        if (bitWidth == 0) {
+            for (int i = 0; i < size; i++) {
+                batch[i] = (short) i;
+            }
+        }
+        else {
+            for (int i = 0; i < size; i++) {
+                batch[i] = toShortExact(randomInt(RANDOM, bitWidth));
+            }
+        }
+        return batch;
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        run(BenchmarkShortColumnReader.class);
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReaderBenchmark.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReaderBenchmark.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import static io.trino.parquet.ParquetEncoding.DELTA_BINARY_PACKED;
 import static io.trino.parquet.ParquetEncoding.PLAIN;
 
-public class TestIntColumnReaderBenchmark
+public class TestColumnReaderBenchmark
 {
     @Test
     public void testIntColumnReaderBenchmark()
@@ -31,6 +31,21 @@ public class TestIntColumnReaderBenchmark
         for (int bitWidth = 0; bitWidth <= 32; bitWidth++) {
             for (ParquetEncoding encoding : ImmutableList.of(PLAIN, DELTA_BINARY_PACKED)) {
                 BenchmarkIntColumnReader benchmark = new BenchmarkIntColumnReader();
+                benchmark.bitWidth = bitWidth;
+                benchmark.encoding = encoding;
+                benchmark.setup();
+                benchmark.read();
+            }
+        }
+    }
+
+    @Test
+    public void testLongColumnReaderBenchmark()
+            throws IOException
+    {
+        for (int bitWidth = 0; bitWidth <= 64; bitWidth++) {
+            for (ParquetEncoding encoding : ImmutableList.of(PLAIN, DELTA_BINARY_PACKED)) {
+                BenchmarkLongColumnReader benchmark = new BenchmarkLongColumnReader();
                 benchmark.bitWidth = bitWidth;
                 benchmark.encoding = encoding;
                 benchmark.setup();

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReaderBenchmark.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReaderBenchmark.java
@@ -25,6 +25,21 @@ import static io.trino.parquet.ParquetEncoding.PLAIN;
 public class TestColumnReaderBenchmark
 {
     @Test
+    public void testByteColumnReaderBenchmark()
+            throws IOException
+    {
+        for (int bitWidth = 0; bitWidth <= 8; bitWidth++) {
+            for (ParquetEncoding encoding : ImmutableList.of(PLAIN, DELTA_BINARY_PACKED)) {
+                BenchmarkByteColumnReader benchmark = new BenchmarkByteColumnReader();
+                benchmark.bitWidth = bitWidth;
+                benchmark.encoding = encoding;
+                benchmark.setup();
+                benchmark.read();
+            }
+        }
+    }
+
+    @Test
     public void testIntColumnReaderBenchmark()
             throws IOException
     {

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReaderBenchmark.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReaderBenchmark.java
@@ -70,6 +70,18 @@ public class TestColumnReaderBenchmark
     }
 
     @Test
+    public void testInt32ToLongColumnReaderBenchmark()
+            throws IOException
+    {
+        for (ParquetEncoding encoding : ImmutableList.of(PLAIN, DELTA_BINARY_PACKED)) {
+            BenchmarkInt32ToLongColumnReader benchmark = new BenchmarkInt32ToLongColumnReader();
+            benchmark.encoding = encoding;
+            benchmark.setup();
+            benchmark.read();
+        }
+    }
+
+    @Test
     public void testLongColumnReaderBenchmark()
             throws IOException
     {

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReaderBenchmark.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReaderBenchmark.java
@@ -40,6 +40,21 @@ public class TestColumnReaderBenchmark
     }
 
     @Test
+    public void testShortColumnReaderBenchmark()
+            throws IOException
+    {
+        for (int bitWidth = 0; bitWidth <= 16; bitWidth++) {
+            for (ParquetEncoding encoding : ImmutableList.of(PLAIN, DELTA_BINARY_PACKED)) {
+                BenchmarkShortColumnReader benchmark = new BenchmarkShortColumnReader();
+                benchmark.bitWidth = bitWidth;
+                benchmark.encoding = encoding;
+                benchmark.setup();
+                benchmark.read();
+            }
+        }
+    }
+
+    @Test
     public void testIntColumnReaderBenchmark()
             throws IOException
     {

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestIntColumnReaderBenchmark.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestIntColumnReaderBenchmark.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.parquet.ParquetEncoding;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static io.trino.parquet.ParquetEncoding.DELTA_BINARY_PACKED;
+import static io.trino.parquet.ParquetEncoding.PLAIN;
+
+public class TestIntColumnReaderBenchmark
+{
+    @Test
+    public void testIntColumnReaderBenchmark()
+            throws IOException
+    {
+        for (int bitWidth = 0; bitWidth <= 32; bitWidth++) {
+            for (ParquetEncoding encoding : ImmutableList.of(PLAIN, DELTA_BINARY_PACKED)) {
+                BenchmarkIntColumnReader benchmark = new BenchmarkIntColumnReader();
+                benchmark.bitWidth = bitWidth;
+                benchmark.encoding = encoding;
+                benchmark.setup();
+                benchmark.read();
+            }
+        }
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReaderUtils.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReaderUtils.java
@@ -24,6 +24,8 @@ import java.util.Random;
 
 import static io.trino.parquet.ParquetReaderUtils.readFixedWidthInt;
 import static io.trino.parquet.ParquetReaderUtils.readUleb128Int;
+import static io.trino.parquet.ParquetReaderUtils.readUleb128Long;
+import static io.trino.parquet.reader.TestData.randomLong;
 import static io.trino.parquet.reader.TestData.randomUnsignedInt;
 import static org.apache.parquet.bytes.BytesUtils.writeIntLittleEndianPaddedOnBitWidth;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,6 +46,21 @@ public class TestParquetReaderUtils
                 assertThat(sliceInputStream.asSlice().length())
                         .isEqualTo(0);
             }
+        }
+    }
+
+    @Test
+    public void testReadUleb128Long()
+            throws IOException
+    {
+        Random random = new Random(1);
+        for (int bitWidth = 1; bitWidth <= 64; bitWidth++) {
+            long value = randomLong(random, bitWidth);
+            SimpleSliceInputStream sliceInputStream = getSliceInputStream(BytesUtils::writeUnsignedVarLong, value);
+            assertThat(readUleb128Long(sliceInputStream))
+                    .isEqualTo(value);
+            assertThat(sliceInputStream.asSlice().length())
+                    .isEqualTo(0);
         }
     }
 

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReaderUtilsBenchmarks.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReaderUtilsBenchmarks.java
@@ -29,6 +29,16 @@ public class TestParquetReaderUtilsBenchmarks
     }
 
     @Test
+    public void testBenchmarkReadUleb128Long()
+            throws IOException
+    {
+        BenchmarkReadUleb128Long benchmark = new BenchmarkReadUleb128Long();
+        benchmark.size = 10000;
+        benchmark.setUp();
+        benchmark.readUleb128Long();
+    }
+
+    @Test
     public void testBenchmarkReadFixedWidthInt()
             throws IOException
     {

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/AbstractValueDecodersTest.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/AbstractValueDecodersTest.java
@@ -31,6 +31,8 @@ import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForLong;
 import org.apache.parquet.column.values.plain.BooleanPlainValuesWriter;
 import org.apache.parquet.column.values.plain.FixedLenByteArrayPlainValuesWriter;
 import org.apache.parquet.column.values.plain.PlainValuesWriter;
@@ -58,6 +60,7 @@ import java.util.stream.Stream;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.parquet.ParquetEncoding.DELTA_BINARY_PACKED;
 import static io.trino.parquet.ParquetEncoding.PLAIN;
 import static io.trino.parquet.ParquetEncoding.PLAIN_DICTIONARY;
 import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
@@ -366,6 +369,13 @@ public abstract class AbstractValueDecodersTest
                 case FLOAT -> new PlainFloatDictionaryValuesWriter(MAX_VALUE, RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
                 case DOUBLE -> new PlainDoubleDictionaryValuesWriter(MAX_VALUE, RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
                 default -> throw new IllegalArgumentException("Dictionary encoding writer is not supported for type " + typeName);
+            };
+        }
+        if (encoding.equals(DELTA_BINARY_PACKED)) {
+            return switch (typeName) {
+                case INT32 -> new DeltaBinaryPackingValuesWriterForInteger(MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
+                case INT64 -> new DeltaBinaryPackingValuesWriterForLong(MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
+                default -> throw new IllegalArgumentException("Delta binary packing encoding writer is not supported for type " + typeName);
             };
         }
         throw new UnsupportedOperationException(format("Encoding %s is not supported", encoding));

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/ApacheParquetByteUnpacker.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/ApacheParquetByteUnpacker.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import org.apache.parquet.column.values.bitpacking.BytePacker;
+import org.apache.parquet.column.values.bitpacking.Packer;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+class ApacheParquetByteUnpacker
+{
+    private final BytePacker delegate;
+    private final int byteWidth;
+    private final byte[] buffer;
+    private final int[] outputBuffer = new int[32];
+
+    public ApacheParquetByteUnpacker(int bitWidth)
+    {
+        checkArgument(bitWidth >= 0 && bitWidth <= 9, "bitWidth %s should be in the range 0-9", bitWidth);
+        this.byteWidth = bitWidth * 32 / Byte.SIZE;
+        this.buffer = new byte[byteWidth];
+        this.delegate = Packer.LITTLE_ENDIAN.newBytePacker(bitWidth);
+    }
+
+    public void unpackDelta(byte[] output, int outputOffset, SimpleSliceInputStream input, int length)
+    {
+        for (int i = outputOffset; i < outputOffset + length; i += 32) {
+            input.readBytes(buffer, 0, byteWidth);
+            delegate.unpack32Values(buffer, 0, outputBuffer, 0);
+            for (int j = 0; j < 32; j++) {
+                output[i + j] += output[i + j - 1] + (byte) outputBuffer[j];
+            }
+        }
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/ApacheParquetShortUnpacker.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/ApacheParquetShortUnpacker.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import org.apache.parquet.column.values.bitpacking.BytePacker;
+import org.apache.parquet.column.values.bitpacking.Packer;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+class ApacheParquetShortUnpacker
+{
+    private final BytePacker delegate;
+    private final int byteWidth;
+    private final byte[] buffer;
+    private final int[] outputBuffer = new int[32];
+
+    public ApacheParquetShortUnpacker(int bitWidth)
+    {
+        checkArgument(bitWidth >= 0 && bitWidth <= 17, "bitWidth %s should be in the range 0-17", bitWidth);
+        this.byteWidth = bitWidth * 32 / Byte.SIZE;
+        this.buffer = new byte[byteWidth];
+        this.delegate = Packer.LITTLE_ENDIAN.newBytePacker(bitWidth);
+    }
+
+    public void unpackDelta(short[] output, int outputOffset, SimpleSliceInputStream input, int length)
+    {
+        for (int i = outputOffset; i < outputOffset + length; i += 32) {
+            input.readBytes(buffer, 0, byteWidth);
+            delegate.unpack32Values(buffer, 0, outputBuffer, 0);
+            for (int j = 0; j < 32; j++) {
+                output[i + j] += output[i + j - 1] + (short) outputBuffer[j];
+            }
+        }
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestByteValueDecoders.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestByteValueDecoders.java
@@ -14,17 +14,24 @@
 package io.trino.parquet.reader.decoders;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.ValuesWriter;
 
+import java.util.Arrays;
 import java.util.OptionalInt;
 import java.util.Random;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
+import static io.trino.parquet.ParquetEncoding.DELTA_BINARY_PACKED;
 import static io.trino.parquet.ParquetEncoding.PLAIN;
 import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
+import static io.trino.parquet.ParquetReaderUtils.toByteExact;
 import static io.trino.parquet.reader.TestData.randomInt;
-import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ByteApacheParquetValueDecoder;
 import static io.trino.parquet.reader.flat.ByteColumnAdapter.BYTE_ADAPTER;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static java.util.Objects.requireNonNull;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,8 +48,39 @@ public final class TestByteValueDecoders
                         ByteApacheParquetValueDecoder::new,
                         BYTE_ADAPTER,
                         (actual, expected) -> assertThat(actual).isEqualTo(expected)),
-                ImmutableList.of(PLAIN, RLE_DICTIONARY),
-                ByteInputProvider.values());
+                ImmutableList.of(PLAIN, RLE_DICTIONARY, DELTA_BINARY_PACKED),
+                generateInputDataProviders());
+    }
+
+    private static InputDataProvider[] generateInputDataProviders()
+    {
+        return Stream.concat(
+                        Arrays.stream(ByteInputProvider.values()),
+                        IntStream.range(1, 9)
+                                .mapToObj(TestByteValueDecoders::createRandomInputDataProvider))
+                .toArray(InputDataProvider[]::new);
+    }
+
+    private static InputDataProvider createRandomInputDataProvider(int bitWidth)
+    {
+        return new InputDataProvider() {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                Random random = new Random(123L * bitWidth * dataSize);
+                byte[] values = new byte[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = toByteExact(randomInt(random, bitWidth));
+                }
+                return writeBytes(valuesWriter, values);
+            }
+
+            @Override
+            public String toString()
+            {
+                return "BYTE_RANDOM(" + bitWidth + ")";
+            }
+        };
     }
 
     private enum ByteInputProvider
@@ -59,6 +97,15 @@ public final class TestByteValueDecoders
                 return writeBytes(valuesWriter, values);
             }
         },
+        BYTE_CONSTANT {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                byte[] values = new byte[dataSize];
+                Arrays.fill(values, (byte) 123);
+                return writeBytes(valuesWriter, values);
+            }
+        },
         BYTE_REPEAT {
             @Override
             public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
@@ -68,18 +115,6 @@ public final class TestByteValueDecoders
                 byte[] values = new byte[dataSize];
                 for (int i = 0; i < dataSize; i++) {
                     values[i] = constants[random.nextInt(constants.length)];
-                }
-                return writeBytes(valuesWriter, values);
-            }
-        },
-        BYTE_RANDOM {
-            @Override
-            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
-            {
-                Random random = new Random(dataSize);
-                byte[] values = new byte[dataSize];
-                for (int i = 0; i < dataSize; i++) {
-                    values[i] = (byte) randomInt(random, 8);
                 }
                 return writeBytes(valuesWriter, values);
             }
@@ -93,5 +128,36 @@ public final class TestByteValueDecoders
         }
 
         return getWrittenBuffer(valuesWriter);
+    }
+
+    private static final class ByteApacheParquetValueDecoder
+            implements ValueDecoder<byte[]>
+    {
+        private final ValuesReader delegate;
+
+        public ByteApacheParquetValueDecoder(ValuesReader delegate)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            initialize(input, delegate);
+        }
+
+        @Override
+        public void read(byte[] values, int offset, int length)
+        {
+            for (int i = offset; i < offset + length; i++) {
+                values[i] = toByteExact(delegate.readInteger());
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            delegate.skip(n);
+        }
     }
 }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestIntValueDecoders.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestIntValueDecoders.java
@@ -14,21 +14,27 @@
 package io.trino.parquet.reader.decoders;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.ValuesWriter;
 
+import java.util.Arrays;
 import java.util.OptionalInt;
 import java.util.Random;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
+import static io.trino.parquet.ParquetEncoding.DELTA_BINARY_PACKED;
 import static io.trino.parquet.ParquetEncoding.PLAIN;
 import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
 import static io.trino.parquet.reader.TestData.randomInt;
-import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.IntApacheParquetValueDecoder;
 import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.IntToLongApacheParquetValueDecoder;
 import static io.trino.parquet.reader.flat.IntColumnAdapter.INT_ADAPTER;
 import static io.trino.parquet.reader.flat.LongColumnAdapter.LONG_ADAPTER;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.testing.DataProviders.concat;
+import static java.util.Objects.requireNonNull;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,8 +52,8 @@ public final class TestIntValueDecoders
                                 IntApacheParquetValueDecoder::new,
                                 INT_ADAPTER,
                                 (actual, expected) -> assertThat(actual).isEqualTo(expected)),
-                        ImmutableList.of(PLAIN, RLE_DICTIONARY),
-                        IntInputProvider.values()),
+                        ImmutableList.of(PLAIN, RLE_DICTIONARY, DELTA_BINARY_PACKED),
+                        generateInputDataProviders()),
                 testArgs(
                         new TestType<>(
                                 createField(INT32, OptionalInt.empty(), BIGINT),
@@ -55,8 +61,39 @@ public final class TestIntValueDecoders
                                 IntToLongApacheParquetValueDecoder::new,
                                 LONG_ADAPTER,
                                 (actual, expected) -> assertThat(actual).isEqualTo(expected)),
-                        ImmutableList.of(PLAIN, RLE_DICTIONARY),
-                        IntInputProvider.values()));
+                        ImmutableList.of(PLAIN, RLE_DICTIONARY, DELTA_BINARY_PACKED),
+                        generateInputDataProviders()));
+    }
+
+    private static InputDataProvider[] generateInputDataProviders()
+    {
+        return Stream.concat(
+                        Arrays.stream(IntInputProvider.values()),
+                        IntStream.range(1, 33)
+                                .mapToObj(TestIntValueDecoders::createRandomInputDataProvider))
+                .toArray(InputDataProvider[]::new);
+    }
+
+    private static InputDataProvider createRandomInputDataProvider(int bitWidth)
+    {
+        return new InputDataProvider() {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                Random random = new Random(123L * bitWidth * dataSize);
+                int[] values = new int[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = randomInt(random, bitWidth);
+                }
+                return writeInts(valuesWriter, values);
+            }
+
+            @Override
+            public String toString()
+            {
+                return "INT_RANDOM(" + bitWidth + ")";
+            }
+        };
     }
 
     private enum IntInputProvider
@@ -73,6 +110,15 @@ public final class TestIntValueDecoders
                 return writeInts(valuesWriter, values);
             }
         },
+        INT_CONSTANT {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                int[] values = new int[dataSize];
+                Arrays.fill(values, 1412341234);
+                return writeInts(valuesWriter, values);
+            }
+        },
         INT_REPEAT {
             @Override
             public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
@@ -82,18 +128,6 @@ public final class TestIntValueDecoders
                 int[] values = new int[dataSize];
                 for (int i = 0; i < dataSize; i++) {
                     values[i] = constants[random.nextInt(constants.length)];
-                }
-                return writeInts(valuesWriter, values);
-            }
-        },
-        INT_RANDOM {
-            @Override
-            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
-            {
-                Random random = new Random(dataSize);
-                int[] values = new int[dataSize];
-                for (int i = 0; i < dataSize; i++) {
-                    values[i] = randomInt(random, 32);
                 }
                 return writeInts(valuesWriter, values);
             }
@@ -107,5 +141,36 @@ public final class TestIntValueDecoders
         }
 
         return getWrittenBuffer(valuesWriter);
+    }
+
+    private static final class IntApacheParquetValueDecoder
+            implements ValueDecoder<int[]>
+    {
+        private final ValuesReader delegate;
+
+        public IntApacheParquetValueDecoder(ValuesReader delegate)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            initialize(input, delegate);
+        }
+
+        @Override
+        public void read(int[] values, int offset, int length)
+        {
+            for (int i = offset; i < offset + length; i++) {
+                values[i] = delegate.readInteger();
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            delegate.skip(n);
+        }
     }
 }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestLongValueDecoders.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestLongValueDecoders.java
@@ -14,17 +14,23 @@
 package io.trino.parquet.reader.decoders;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.ValuesWriter;
 
+import java.util.Arrays;
 import java.util.OptionalInt;
 import java.util.Random;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
+import static io.trino.parquet.ParquetEncoding.DELTA_BINARY_PACKED;
 import static io.trino.parquet.ParquetEncoding.PLAIN;
 import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
 import static io.trino.parquet.reader.TestData.randomLong;
-import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.LongApacheParquetValueDecoder;
 import static io.trino.parquet.reader.flat.LongColumnAdapter.LONG_ADAPTER;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static java.util.Objects.requireNonNull;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -35,14 +41,45 @@ public final class TestLongValueDecoders
     protected Object[][] tests()
     {
         return testArgs(
-                        new TestType<>(
-                                createField(INT64, OptionalInt.empty(), BIGINT),
-                                ValueDecoders::getLongDecoder,
-                                LongApacheParquetValueDecoder::new,
-                                LONG_ADAPTER,
-                                (actual, expected) -> assertThat(actual).isEqualTo(expected)),
-                        ImmutableList.of(PLAIN, RLE_DICTIONARY),
-                        LongInputProvider.values());
+                new TestType<>(
+                        createField(INT64, OptionalInt.empty(), BIGINT),
+                        ValueDecoders::getLongDecoder,
+                        LongApacheParquetValueDecoder::new,
+                        LONG_ADAPTER,
+                        (actual, expected) -> assertThat(actual).isEqualTo(expected)),
+                ImmutableList.of(PLAIN, RLE_DICTIONARY, DELTA_BINARY_PACKED),
+                generateInputDataProviders());
+    }
+
+    private static InputDataProvider[] generateInputDataProviders()
+    {
+        return Stream.concat(
+                        Arrays.stream(LongInputProvider.values()),
+                        IntStream.range(1, 65)
+                                .mapToObj(TestLongValueDecoders::createRandomInputDataProvider))
+                .toArray(InputDataProvider[]::new);
+    }
+
+    private static InputDataProvider createRandomInputDataProvider(int bitWidth)
+    {
+        return new InputDataProvider() {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                Random random = new Random(123L * bitWidth * dataSize);
+                long[] values = new long[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = randomLong(random, bitWidth);
+                }
+                return writeLongs(valuesWriter, values);
+            }
+
+            @Override
+            public String toString()
+            {
+                return "LONG_RANDOM(" + bitWidth + ")";
+            }
+        };
     }
 
     private enum LongInputProvider
@@ -59,6 +96,15 @@ public final class TestLongValueDecoders
                 return writeLongs(valuesWriter, values);
             }
         },
+        LONG_CONSTANT {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                long[] values = new long[dataSize];
+                Arrays.fill(values, 111222333444555L);
+                return writeLongs(valuesWriter, values);
+            }
+        },
         LONG_REPEAT {
             @Override
             public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
@@ -68,18 +114,6 @@ public final class TestLongValueDecoders
                 long[] values = new long[dataSize];
                 for (int i = 0; i < dataSize; i++) {
                     values[i] = constants[random.nextInt(constants.length)];
-                }
-                return writeLongs(valuesWriter, values);
-            }
-        },
-        LONG_RANDOM {
-            @Override
-            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
-            {
-                Random random = new Random(dataSize);
-                long[] values = new long[dataSize];
-                for (int i = 0; i < dataSize; i++) {
-                    values[i] = randomLong(random, 64);
                 }
                 return writeLongs(valuesWriter, values);
             }
@@ -93,5 +127,36 @@ public final class TestLongValueDecoders
         }
 
         return getWrittenBuffer(valuesWriter);
+    }
+
+    private static final class LongApacheParquetValueDecoder
+            implements ValueDecoder<long[]>
+    {
+        private final ValuesReader delegate;
+
+        public LongApacheParquetValueDecoder(ValuesReader delegate)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            initialize(input, delegate);
+        }
+
+        @Override
+        public void read(long[] values, int offset, int length)
+        {
+            for (int i = offset; i < offset + length; i++) {
+                values[i] = delegate.readLong();
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            delegate.skip(n);
+        }
     }
 }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestShortValueDecoders.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestShortValueDecoders.java
@@ -14,17 +14,24 @@
 package io.trino.parquet.reader.decoders;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.ValuesWriter;
 
+import java.util.Arrays;
 import java.util.OptionalInt;
 import java.util.Random;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
+import static io.trino.parquet.ParquetEncoding.DELTA_BINARY_PACKED;
 import static io.trino.parquet.ParquetEncoding.PLAIN;
 import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
+import static io.trino.parquet.ParquetReaderUtils.toShortExact;
 import static io.trino.parquet.reader.TestData.randomInt;
-import static io.trino.parquet.reader.decoders.ApacheParquetValueDecoders.ShortApacheParquetValueDecoder;
 import static io.trino.parquet.reader.flat.ShortColumnAdapter.SHORT_ADAPTER;
 import static io.trino.spi.type.SmallintType.SMALLINT;
+import static java.util.Objects.requireNonNull;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,8 +48,39 @@ public final class TestShortValueDecoders
                         ShortApacheParquetValueDecoder::new,
                         SHORT_ADAPTER,
                         (actual, expected) -> assertThat(actual).isEqualTo(expected)),
-                ImmutableList.of(PLAIN, RLE_DICTIONARY),
-                ShortInputProvider.values());
+                ImmutableList.of(PLAIN, RLE_DICTIONARY, DELTA_BINARY_PACKED),
+                generateInputDataProviders());
+    }
+
+    private static InputDataProvider[] generateInputDataProviders()
+    {
+        return Stream.concat(
+                        Arrays.stream(ShortInputProvider.values()),
+                        IntStream.range(1, 17)
+                                .mapToObj(TestShortValueDecoders::createRandomInputDataProvider))
+                .toArray(InputDataProvider[]::new);
+    }
+
+    private static InputDataProvider createRandomInputDataProvider(int bitWidth)
+    {
+        return new InputDataProvider() {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                Random random = new Random(123L * bitWidth * dataSize);
+                short[] values = new short[dataSize];
+                for (int i = 0; i < dataSize; i++) {
+                    values[i] = toShortExact(randomInt(random, bitWidth));
+                }
+                return writeShorts(valuesWriter, values);
+            }
+
+            @Override
+            public String toString()
+            {
+                return "SHORT_RANDOM(" + bitWidth + ")";
+            }
+        };
     }
 
     private enum ShortInputProvider
@@ -59,6 +97,15 @@ public final class TestShortValueDecoders
                 return writeShorts(valuesWriter, values);
             }
         },
+        SHORT_CONSTANT {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                short[] values = new short[dataSize];
+                Arrays.fill(values, (short) 4123);
+                return writeShorts(valuesWriter, values);
+            }
+        },
         SHORT_REPEAT {
             @Override
             public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
@@ -68,18 +115,6 @@ public final class TestShortValueDecoders
                 short[] values = new short[dataSize];
                 for (int i = 0; i < dataSize; i++) {
                     values[i] = constants[random.nextInt(constants.length)];
-                }
-                return writeShorts(valuesWriter, values);
-            }
-        },
-        SHORT_RANDOM {
-            @Override
-            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
-            {
-                Random random = new Random(dataSize);
-                short[] values = new short[dataSize];
-                for (int i = 0; i < dataSize; i++) {
-                    values[i] = (short) randomInt(random, 16);
                 }
                 return writeShorts(valuesWriter, values);
             }
@@ -93,5 +128,36 @@ public final class TestShortValueDecoders
         }
 
         return getWrittenBuffer(valuesWriter);
+    }
+
+    private static final class ShortApacheParquetValueDecoder
+            implements ValueDecoder<short[]>
+    {
+        private final ValuesReader delegate;
+
+        public ShortApacheParquetValueDecoder(ValuesReader delegate)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            initialize(input, delegate);
+        }
+
+        @Override
+        public void read(short[] values, int offset, int length)
+        {
+            for (int i = offset; i < offset + length; i++) {
+                values[i] = toShortExact(delegate.readInteger());
+            }
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            delegate.skip(n);
+        }
     }
 }


### PR DESCRIPTION
## Description
Optimize decoders for DELTA_BINARY_PACKED parquet encoding

## Additional context and related issues

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Hudi, Iceberg, Delta
* Improve performance of reading parquet files for numeric types. ({issue}`15850`)
```
