### PR TITLE
Remove unsupported properties from MongoDB documentation

### DIFF
--- a/docs/src/main/sphinx/connector/mongodb.rst
+++ b/docs/src/main/sphinx/connector/mongodb.rst
@@ -49,11 +49,9 @@ The following configuration properties are available:
 ========================================== ==============================================================
 Property name                              Description
 ========================================== ==============================================================
-``mongodb.seeds``                          List of all MongoDB servers
 ``mongodb.connection-url``                 The connection url that the driver uses to connect to a MongoDB deployment
 ``mongodb.schema-collection``              A collection which contains schema information
 ``mongodb.case-insensitive-name-matching`` Match database and collection names case insensitively
-``mongodb.credentials``                    List of credentials
 ``mongodb.min-connections-per-host``       The minimum size of the connection pool per host
 ``mongodb.connections-per-host``           The maximum size of the connection pool per host
 ``mongodb.max-wait-time``                  The maximum wait time
@@ -71,13 +69,6 @@ Property name                              Description
 ``mongodb.cursor-batch-size``              The number of elements to return in a batch
 ========================================== ==============================================================
 
-``mongodb.seeds``
-^^^^^^^^^^^^^^^^^
-
-Comma-separated list of ``hostname[:port]`` all MongoDB servers in the same replica set, or a list of MongoDB servers in the same sharded cluster. If a port is not specified, port 27017 will be used.
-
-This property is deprecated and will be removed in a future release. Use ``mongodb.connection-url`` property instead.
-
 ``mongodb.connection-url``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -92,7 +83,8 @@ used. The user/pass credentials must be for a user with write access to the
 
 See the `MongoDB Connection URI <https://docs.mongodb.com/drivers/java/sync/current/fundamentals/connection/#connection-uri>`_ for more information.
 
-This property is required; there is no default. A connection url or seeds must be provided to connect to a MongoDB deployment.
+This property is required; there is no default. A connection URL must be
+provided to connect to a MongoDB deployment.
 
 ``mongodb.schema-collection``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -113,13 +105,6 @@ This property is optional; the default is ``_schema``.
 Match database and collection names case insensitively.
 
 This property is optional; the default is ``false``.
-
-``mongodb.credentials``
-^^^^^^^^^^^^^^^^^^^^^^^
-
-A comma separated list of ``username:password@database`` credentials.
-
-This property is optional; no default value. The ``database`` should be the authentication database for the user (e.g. ``admin``).
 
 ``mongodb.min-connections-per-host``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -223,7 +208,7 @@ The required replica set name. With this option set, the MongoClient instance pe
 
 #. Connect in replica set mode, and discover all members of the set based on the given servers
 #. Make sure that the set name reported by all members matches the required set name.
-#. Refuse to service any requests, if any member of the seed list is not part of a replica set with the required name.
+#. Refuse to service any requests, if authenticated user is not part of a replica set with the required name.
 
 This property is optional; no default value.
 


### PR DESCRIPTION
## Description

Removing documentation for a deprecated property from MongoDB connector that was finally removed in 405, but documentation update was missed.


## Additional context and related issues

Missed doc update from https://github.com/trinodb/trino/pull/15263/files 

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
