### PR TITLE
Fix spelling in FTE docs

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
@@ -46,7 +46,7 @@ depending on the desired :ref:`retry policy <fte-retry-policy>`.
 
   * Fault-tolerant execution of :ref:`read operations <sql-read-operations>` is
     supported by all connectors.
-  * Fault tolerant execution of :ref:`write operations <sql-write-operations>`
+  * Fault-tolerant execution of :ref:`write operations <sql-write-operations>`
     is supported by the following connectors:
 
     * :doc:`/connector/bigquery`


### PR DESCRIPTION
## Description

See title

## Additional context and related issues

I ran into this when looking at #15620

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
