### PR TITLE
Fix row output estimation for global aggregation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/cost/AggregationStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/AggregationStatsRule.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 
+import static io.trino.sql.planner.plan.AggregationNode.Step.FINAL;
 import static io.trino.sql.planner.plan.AggregationNode.Step.SINGLE;
 import static io.trino.sql.planner.plan.Patterns.aggregation;
 import static java.lang.Math.min;
@@ -53,7 +54,7 @@ public class AggregationStatsRule
             return Optional.empty();
         }
 
-        if (node.getStep() != SINGLE) {
+        if (node.getStep() != SINGLE && node.getStep() != FINAL) {
             return Optional.empty();
         }
 

--- a/core/trino-main/src/test/java/io/trino/cost/TestAggregationStatsRule.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestAggregationStatsRule.java
@@ -14,7 +14,9 @@
 package io.trino.cost;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.plan.AggregationNode;
 import org.testng.annotations.Test;
 
 import java.util.function.Consumer;
@@ -147,5 +149,35 @@ public class TestAggregationStatsRule
                         .addSymbolStatistics(new Symbol("z"), SymbolStatsEstimate.builder().setDistinctValuesCount(50).build())
                         .build())
                 .check(check -> check.outputRowsCount(100));
+    }
+
+    @Test
+    public void testAggregationWithGlobalGrouping()
+    {
+        tester().assertStatsFor(pb -> pb
+                        .aggregation(ab -> ab
+                                .addAggregation(pb.symbol("count_on_x", BIGINT), expression("count(x)"), ImmutableList.of(BIGINT))
+                                .addAggregation(pb.symbol("sum", BIGINT), expression("sum(x)"), ImmutableList.of(BIGINT))
+                                .globalGrouping()
+                                .source(pb.values(pb.symbol("x", BIGINT), pb.symbol("y", BIGINT), pb.symbol("z", BIGINT)))))
+                .withSourceStats(PlanNodeStatsEstimate.unknown())
+                .check(check -> check.outputRowsCount(1));
+    }
+
+    @Test
+    public void testAggregationWithMoreGroupingSets()
+    {
+        tester().assertStatsFor(pb -> pb
+                        .aggregation(ab -> ab
+                                .addAggregation(pb.symbol("count_on_x", BIGINT), expression("count(x)"), ImmutableList.of(BIGINT))
+                                .addAggregation(pb.symbol("sum", BIGINT), expression("sum(x)"), ImmutableList.of(BIGINT))
+                                .groupingSets(new AggregationNode.GroupingSetDescriptor(ImmutableList.of(pb.symbol("y"), pb.symbol("z")), 3, ImmutableSet.of(0)))
+                                .source(pb.values(pb.symbol("x", BIGINT), pb.symbol("y", BIGINT), pb.symbol("z", BIGINT)))))
+                .withSourceStats(PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(100)
+                        .addSymbolStatistics(new Symbol("y"), SymbolStatsEstimate.builder().setDistinctValuesCount(50).build())
+                        .addSymbolStatistics(new Symbol("z"), SymbolStatsEstimate.builder().setDistinctValuesCount(50).build())
+                        .build())
+                .check(check -> check.outputRowsCountUnknown());
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestShowStats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestShowStats.java
@@ -492,12 +492,11 @@ public class TestShowStats
     @Test
     public void testShowStatsWithAggregation()
     {
-        // TODO - row count should be 1 - https://github.com/trinodb/trino/issues/6323
         assertQuery(
                 "SHOW STATS FOR (SELECT count(*) AS x FROM orders)",
                 "VALUES " +
                         "   ('x', null, null, null, null, null, null), " +
-                        "   (null, null, null, null, null, null, null)");
+                        "   (null, null, null, null, 1, null, null)");
 
         assertQuery(
                 sessionWith(getSession(), PREFER_PARTIAL_AGGREGATION, "false"),


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Global aggregation always produces a single row, and it does not depend on input stats. 


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Global aggregation could produce `NaN` output rows count if source stats were unavailable, which could cause choosing of suboptimal plan during query execution.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
