### PR TITLE
Fix precision loss when coercing TIME to TIME TZ and fix abundant precision when coercing DATE to TIMESTAMP TZ

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/TypeCoercion.java
+++ b/core/trino-main/src/main/java/io/trino/type/TypeCoercion.java
@@ -46,7 +46,6 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.RowType.Field;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimeType.createTimeType;
-import static io.trino.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.trino.spi.type.TimeWithTimeZoneType.createTimeWithTimeZoneType;
 import static io.trino.spi.type.TimestampType.createTimestampType;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
@@ -461,7 +460,7 @@ public final class TypeCoercion
             case StandardTypes.TIME: {
                 switch (resultTypeBase) {
                     case StandardTypes.TIME_WITH_TIME_ZONE:
-                        return Optional.of(TIME_WITH_TIME_ZONE);
+                        return Optional.of(createTimeWithTimeZoneType(((TimeType) sourceType).getPrecision()));
                     default:
                         return Optional.empty();
                 }

--- a/core/trino-main/src/main/java/io/trino/type/TypeCoercion.java
+++ b/core/trino-main/src/main/java/io/trino/type/TypeCoercion.java
@@ -48,7 +48,6 @@ import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimeType.createTimeType;
 import static io.trino.spi.type.TimeWithTimeZoneType.createTimeWithTimeZoneType;
 import static io.trino.spi.type.TimestampType.createTimestampType;
-import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
@@ -452,7 +451,7 @@ public final class TypeCoercion
                     case StandardTypes.TIMESTAMP:
                         return Optional.of(createTimestampType(0));
                     case StandardTypes.TIMESTAMP_WITH_TIME_ZONE:
-                        return Optional.of(TIMESTAMP_TZ_MILLIS);
+                        return Optional.of(createTimestampWithTimeZoneType(0));
                     default:
                         return Optional.empty();
                 }

--- a/core/trino-main/src/test/java/io/trino/type/TestTypeCoercion.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestTypeCoercion.java
@@ -44,7 +44,9 @@ import static io.trino.spi.type.TimeType.createTimeType;
 import static io.trino.spi.type.TimeWithTimeZoneType.TIME_TZ_MILLIS;
 import static io.trino.spi.type.TimeWithTimeZoneType.createTimeWithTimeZoneType;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampType.createTimestampType;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -126,8 +128,19 @@ public class TestTypeCoercion
         assertThat(UNKNOWN, BIGINT).hasCommonSuperType(BIGINT).canCoerceFirstToSecondOnly();
 
         assertThat(BIGINT, DOUBLE).hasCommonSuperType(DOUBLE).canCoerceFirstToSecondOnly();
+
+        // date / timestamp
+        assertThat(DATE, createTimestampType(0)).hasCommonSuperType(createTimestampType(0));
+        assertThat(DATE, createTimestampType(2)).hasCommonSuperType(createTimestampType(2));
         assertThat(DATE, TIMESTAMP_MILLIS).hasCommonSuperType(TIMESTAMP_MILLIS).canCoerceFirstToSecondOnly();
+        assertThat(DATE, createTimestampType(7)).hasCommonSuperType(createTimestampType(7));
+
+        // date / timestamp with time zone
+        assertThat(DATE, createTimestampWithTimeZoneType(0)).hasCommonSuperType(createTimestampWithTimeZoneType(0));
+        assertThat(DATE, createTimestampWithTimeZoneType(2)).hasCommonSuperType(createTimestampWithTimeZoneType(2));
         assertThat(DATE, TIMESTAMP_TZ_MILLIS).hasCommonSuperType(TIMESTAMP_TZ_MILLIS).canCoerceFirstToSecondOnly();
+        assertThat(DATE, createTimestampWithTimeZoneType(7)).hasCommonSuperType(createTimestampWithTimeZoneType(7));
+
         assertThat(TIME_MILLIS, TIME_TZ_MILLIS).hasCommonSuperType(TIME_TZ_MILLIS).canCoerceFirstToSecondOnly();
         assertThat(TIMESTAMP_MILLIS, TIMESTAMP_TZ_MILLIS).hasCommonSuperType(TIMESTAMP_TZ_MILLIS).canCoerceFirstToSecondOnly();
         assertThat(VARCHAR, JONI_REGEXP).hasCommonSuperType(JONI_REGEXP).canCoerceFirstToSecondOnly();

--- a/core/trino-main/src/test/java/io/trino/type/TestTypeCoercion.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestTypeCoercion.java
@@ -40,7 +40,9 @@ import static io.trino.spi.type.RowType.field;
 import static io.trino.spi.type.RowType.rowType;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimeType.TIME_MILLIS;
+import static io.trino.spi.type.TimeType.createTimeType;
 import static io.trino.spi.type.TimeWithTimeZoneType.TIME_TZ_MILLIS;
+import static io.trino.spi.type.TimeWithTimeZoneType.createTimeWithTimeZoneType;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.TinyintType.TINYINT;
@@ -146,6 +148,20 @@ public class TestTypeCoercion
         assertThat(new ArrayType(BIGINT), new ArrayType(UNKNOWN)).hasCommonSuperType(new ArrayType(BIGINT)).canCoerceSecondToFirstOnly();
         assertThat(mapType(BIGINT, DOUBLE), mapType(BIGINT, DOUBLE)).hasCommonSuperType(mapType(BIGINT, DOUBLE)).canCoerceToEachOther();
         assertThat(mapType(BIGINT, DOUBLE), mapType(DOUBLE, DOUBLE)).hasCommonSuperType(mapType(DOUBLE, DOUBLE)).canCoerceFirstToSecondOnly();
+
+        // time / time
+        assertThat(createTimeType(5), createTimeType(9)).hasCommonSuperType(createTimeType(9));
+        assertThat(createTimeType(9), createTimeType(5)).hasCommonSuperType(createTimeType(9));
+
+        // time / time with time zone
+        assertThat(createTimeType(5), createTimeWithTimeZoneType(9)).hasCommonSuperType(createTimeWithTimeZoneType(9));
+        assertThat(createTimeType(9), createTimeWithTimeZoneType(5)).hasCommonSuperType(createTimeWithTimeZoneType(9));
+        assertThat(createTimeWithTimeZoneType(5), createTimeType(9)).hasCommonSuperType(createTimeWithTimeZoneType(9));
+        assertThat(createTimeWithTimeZoneType(9), createTimeType(5)).hasCommonSuperType(createTimeWithTimeZoneType(9));
+
+        // time with time zone / time with time zone
+        assertThat(createTimeWithTimeZoneType(5), createTimeWithTimeZoneType(9)).hasCommonSuperType(createTimeWithTimeZoneType(9));
+        assertThat(createTimeWithTimeZoneType(9), createTimeWithTimeZoneType(5)).hasCommonSuperType(createTimeWithTimeZoneType(9));
 
         assertThat(
                 rowType(field("a", BIGINT), field("b", DOUBLE), field("c", VARCHAR)),


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/15861
Fixes https://github.com/trinodb/trino/issues/15865