### PR TITLE
Remove extra cache backreferences when loading part and part stats

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -279,16 +279,6 @@ public class CachingHiveMetastore
         partitionCache = partitionCacheFactory.buildBulkCache(this::loadPartitionsByNames);
     }
 
-    private static <K, V> LoadingCache<K, V> neverCache(com.google.common.base.Function<K, V> loader)
-    {
-        return buildCache(OptionalLong.of(0), OptionalLong.empty(), Optional.empty(), 0, StatsRecording.DISABLED, loader);
-    }
-
-    private static <K, V> LoadingCache<K, V> neverCache(Function<Iterable<K>, Map<K, V>> bulkLoader)
-    {
-        return buildCache(OptionalLong.of(0), 0, StatsRecording.DISABLED, bulkLoader);
-    }
-
     @Managed
     public void flushCache()
     {
@@ -1131,20 +1121,12 @@ public class CachingHiveMetastore
 
     private static CacheFactory neverCacheFactory()
     {
-        return new CacheFactory()
-        {
-            @Override
-            public <K, V> LoadingCache<K, V> buildCache(com.google.common.base.Function<K, V> loader)
-            {
-                return neverCache(loader);
-            }
-
-            @Override
-            public <K, V> LoadingCache<K, V> buildBulkCache(Function<Iterable<K>, Map<K, V>> bulkLoader)
-            {
-                return neverCache(bulkLoader);
-            }
-        };
+        return cacheFactory(
+                OptionalLong.of(0),
+                OptionalLong.empty(),
+                Optional.empty(),
+                0,
+                StatsRecording.DISABLED);
     }
 
     private static <K, V> LoadingCache<K, V> buildCache(

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
@@ -445,7 +445,7 @@ public class TestCachingHiveMetastore
 
         // Fetching both should only result in one batched access
         assertEquals(metastore.getPartitionsByNames(table, ImmutableList.of(TEST_PARTITION1, TEST_PARTITION2)).size(), 2);
-        assertEquals(mockClient.getAccessCount(), 5);
+        assertEquals(mockClient.getAccessCount(), 4);
     }
 
     @Test
@@ -522,11 +522,11 @@ public class TestCachingHiveMetastore
         assertEquals(metastore.getPartitionStatisticsStats().getRequestCount(), 2);
         assertEquals(metastore.getPartitionStatisticsStats().getHitRate(), 0.5);
 
-        assertEquals(metastore.getTableStats().getRequestCount(), 2);
-        assertEquals(metastore.getTableStats().getHitRate(), 1.0 / 2);
+        assertEquals(metastore.getTableStats().getRequestCount(), 1);
+        assertEquals(metastore.getTableStats().getHitRate(), 0.0);
 
-        assertEquals(metastore.getPartitionStats().getRequestCount(), 2);
-        assertEquals(metastore.getPartitionStats().getHitRate(), 0.5);
+        assertEquals(metastore.getPartitionStats().getRequestCount(), 1);
+        assertEquals(metastore.getPartitionStats().getHitRate(), 0.0);
     }
 
     @Test


### PR DESCRIPTION
This allows to split statistics cache from metadata cache because loading of partition statistics doesn't require yet another fetch of Table and Partition objects which might not be cached.

* no release notes * 