### PR TITLE
Fix: use parent project id in BigQuery session

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -188,6 +188,18 @@ public class BigQueryClient
         return materializationCache.getCachedTable(this, query, viewExpiration, remoteTableId);
     }
 
+    /**
+     * The Google Cloud Project ID that will be used to create the underlying BigQuery read session.
+     * Effectively, this is the project that will be used for billing attribution.
+     */
+    public String getParentProjectId()
+    {
+        return bigQuery.getOptions().getProjectId();
+    }
+
+    /**
+     * The Google Cloud Project ID where the data resides.
+     */
     public String getProjectId()
     {
         String projectId = configProjectId.orElseGet(() -> bigQuery.getOptions().getProjectId());

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
@@ -100,7 +100,7 @@ public class ReadSessionCreator
                         .build());
             }
             CreateReadSessionRequest createReadSessionRequest = CreateReadSessionRequest.newBuilder()
-                    .setParent("projects/" + client.getProjectId())
+                    .setParent("projects/" + client.getParentProjectId())
                     .setReadSession(ReadSession.newBuilder()
                             .setDataFormat(format)
                             .setTable(toTableResourceName(actualTable.getTableId()))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This issue appears when upgrading from `403` to `405`. 

BigQuery client session should use parent project id when creating a session. 



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes #15867



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
