### PR TITLE
Obtain and refresh sink instance handle asynchronously

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -105,6 +105,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -884,32 +885,68 @@ public class EventDrivenFaultTolerantQueryScheduler
                 }
                 else if (nodeLease.getNode().isDone()) {
                     nodeAcquisitionIterator.remove();
-                    try {
-                        InternalNode node = getDone(nodeLease.getNode());
-                        Optional<RemoteTask> remoteTask = stageExecution.schedule(scheduledTask.partitionId(), node);
-                        remoteTask.ifPresent(task -> {
-                            task.addStateChangeListener(createExchangeSinkInstanceHandleUpdateRequiredListener());
-                            task.addStateChangeListener(taskStatus -> {
-                                if (taskStatus.getState().isDone()) {
-                                    nodeLease.release();
-                                }
-                            });
-                            task.addFinalTaskInfoListener(taskExecutionStats::update);
-                            task.addFinalTaskInfoListener(taskInfo -> eventQueue.add(new RemoteTaskCompletedEvent(taskInfo.getTaskStatus())));
-                            nodeLease.attachTaskId(task.getTaskId());
-                            task.start();
-                            if (queryStateMachine.getQueryState() == QueryState.STARTING) {
-                                queryStateMachine.transitionToRunning();
+                    Optional<StageExecution.GetExchangeSinkInstanceHandleResult> getExchangeSinkInstanceHandleResult = stageExecution.getExchangeSinkInstanceHandle(scheduledTask.partitionId());
+                    if (getExchangeSinkInstanceHandleResult.isPresent()) {
+                        CompletableFuture<ExchangeSinkInstanceHandle> sinkInstanceHandleFuture = getExchangeSinkInstanceHandleResult.get().exchangeSinkInstanceHandleFuture();
+                        sinkInstanceHandleFuture.whenComplete((sinkInstanceHandle, throwable) -> {
+                            if (throwable != null) {
+                                eventQueue.add(new StageFailureEvent(scheduledTask.stageId, throwable));
+                            }
+                            else {
+                                eventQueue.add(new SinkInstanceHandleAcquiredEvent(
+                                        scheduledTask.stageId(),
+                                        scheduledTask.partitionId(),
+                                        nodeLease,
+                                        getExchangeSinkInstanceHandleResult.get().attempt(),
+                                        sinkInstanceHandle));
                             }
                         });
-                        if (remoteTask.isEmpty()) {
-                            nodeLease.release();
-                        }
                     }
-                    catch (ExecutionException e) {
-                        throw new UncheckedExecutionException(e);
+                    else {
+                        nodeLease.release();
                     }
                 }
+            }
+        }
+
+        @Override
+        public void onSinkInstanceHandleAcquired(SinkInstanceHandleAcquiredEvent sinkInstanceHandleAcquiredEvent)
+        {
+            NodeLease nodeLease = sinkInstanceHandleAcquiredEvent.getNodeLease();
+            int partitionId = sinkInstanceHandleAcquiredEvent.getPartitionId();
+            StageId stageId = sinkInstanceHandleAcquiredEvent.getStageId();
+            int attempt = sinkInstanceHandleAcquiredEvent.getAttempt();
+            ExchangeSinkInstanceHandle sinkInstanceHandle = sinkInstanceHandleAcquiredEvent.getSinkInstanceHandle();
+            StageExecution stageExecution = getStageExecution(stageId);
+
+            if (stageExecution.getState().isDone()) {
+                nodeLease.release();
+                return;
+            }
+            try {
+                InternalNode node = getDone(nodeLease.getNode());
+                Optional<RemoteTask> remoteTask = stageExecution.schedule(partitionId, sinkInstanceHandle, attempt, node);
+                remoteTask.ifPresent(task -> {
+                    task.addStateChangeListener(createExchangeSinkInstanceHandleUpdateRequiredListener());
+                    task.addStateChangeListener(taskStatus -> {
+                        if (taskStatus.getState().isDone()) {
+                            nodeLease.release();
+                        }
+                    });
+                    task.addFinalTaskInfoListener(taskExecutionStats::update);
+                    task.addFinalTaskInfoListener(taskInfo -> eventQueue.add(new RemoteTaskCompletedEvent(taskInfo.getTaskStatus())));
+                    nodeLease.attachTaskId(task.getTaskId());
+                    task.start();
+                    if (queryStateMachine.getQueryState() == QueryState.STARTING) {
+                        queryStateMachine.transitionToRunning();
+                    }
+                });
+                if (remoteTask.isEmpty()) {
+                    nodeLease.release();
+                }
+            }
+            catch (ExecutionException e) {
+                throw new UncheckedExecutionException(e);
             }
         }
 
@@ -1004,7 +1041,15 @@ public class EventDrivenFaultTolerantQueryScheduler
         {
             TaskId taskId = event.getTaskStatus().getTaskId();
             StageExecution stageExecution = getStageExecution(taskId.getStageId());
-            stageExecution.updateExchangeSinkInstanceHandle(taskId);
+            stageExecution.initializeUpdateOfExchangeSinkInstanceHandle(taskId, eventQueue);
+        }
+
+        @Override
+        public void onRemoteTaskExchangeUpdatedSinkAcquired(RemoteTaskExchangeUpdatedSinkAcquired event)
+        {
+            TaskId taskId = event.getTaskId();
+            StageExecution stageExecution = getStageExecution(taskId.getStageId());
+            stageExecution.finalizeUpdateOfExchangeSinkInstanceHandle(taskId, event.getExchangeSinkInstanceHandle());
         }
 
         @Override
@@ -1241,7 +1286,32 @@ public class EventDrivenFaultTolerantQueryScheduler
             }
         }
 
-        public Optional<RemoteTask> schedule(int partitionId, InternalNode node)
+        public Optional<GetExchangeSinkInstanceHandleResult> getExchangeSinkInstanceHandle(int partitionId)
+        {
+            if (getState().isDone()) {
+                return Optional.empty();
+            }
+
+            StagePartition partition = getStagePartition(partitionId);
+            verify(partition.getRemainingAttempts() >= 0, "remaining attempts is expected to be greater than or equal to zero: %s", partition.getRemainingAttempts());
+
+            if (partition.isFinished()) {
+                return Optional.empty();
+            }
+
+            int attempt = maxTaskExecutionAttempts - partition.getRemainingAttempts();
+            return Optional.of(new GetExchangeSinkInstanceHandleResult(
+                    exchange.instantiateSink(partition.getExchangeSinkHandle(), attempt),
+                    attempt));
+        }
+
+        public record GetExchangeSinkInstanceHandleResult(CompletableFuture<ExchangeSinkInstanceHandle> exchangeSinkInstanceHandleFuture, int attempt) {
+            public GetExchangeSinkInstanceHandleResult {
+                requireNonNull(exchangeSinkInstanceHandleFuture, "exchangeSinkInstanceHandleFuture is null");
+            }
+        }
+
+        public Optional<RemoteTask> schedule(int partitionId, ExchangeSinkInstanceHandle exchangeSinkInstanceHandle, int attempt, InternalNode node)
         {
             if (getState().isDone()) {
                 return Optional.empty();
@@ -1273,8 +1343,6 @@ public class EventDrivenFaultTolerantQueryScheduler
                 }
             }
 
-            int attempt = maxTaskExecutionAttempts - partition.getRemainingAttempts();
-            ExchangeSinkInstanceHandle exchangeSinkInstanceHandle = exchange.instantiateSink(partition.getExchangeSinkHandle(), attempt);
             SpoolingOutputBuffers outputBuffers = SpoolingOutputBuffers.createInitial(exchangeSinkInstanceHandle, sinkPartitioningScheme.getPartitionCount());
             Optional<RemoteTask> task = stage.createTask(
                     node,
@@ -1327,14 +1395,31 @@ public class EventDrivenFaultTolerantQueryScheduler
             return result.buildOrThrow();
         }
 
-        public void updateExchangeSinkInstanceHandle(TaskId taskId)
+        public void initializeUpdateOfExchangeSinkInstanceHandle(TaskId taskId, BlockingQueue<Event> eventQueue)
         {
             if (getState().isDone()) {
                 return;
             }
             StagePartition partition = getStagePartition(taskId.getPartitionId());
-            ExchangeSinkInstanceHandle exchangeSinkInstanceHandle = exchange.updateSinkInstanceHandle(partition.getExchangeSinkHandle(), taskId.getAttemptId());
-            partition.updateExchangeSinkInstanceHandle(taskId, exchangeSinkInstanceHandle);
+            CompletableFuture<ExchangeSinkInstanceHandle> exchangeSinkInstanceHandleFuture = exchange.updateSinkInstanceHandle(partition.getExchangeSinkHandle(), taskId.getAttemptId());
+
+            exchangeSinkInstanceHandleFuture.whenComplete((sinkInstanceHandle, throwable) -> {
+                if (throwable != null) {
+                    eventQueue.add(new StageFailureEvent(taskId.getStageId(), throwable));
+                }
+                else {
+                    eventQueue.add(new RemoteTaskExchangeUpdatedSinkAcquired(taskId, sinkInstanceHandle));
+                }
+            });
+        }
+
+        public void finalizeUpdateOfExchangeSinkInstanceHandle(TaskId taskId, ExchangeSinkInstanceHandle updatedExchangeSinkInstanceHandle)
+        {
+            if (getState().isDone()) {
+                return;
+            }
+            StagePartition partition = getStagePartition(taskId.getPartitionId());
+            partition.updateExchangeSinkInstanceHandle(taskId, updatedExchangeSinkInstanceHandle);
         }
 
         public void taskFinished(TaskId taskId, TaskStatus taskStatus)
@@ -1950,9 +2035,63 @@ public class EventDrivenFaultTolerantQueryScheduler
 
         void onRemoteTaskExchangeSinkUpdateRequired(RemoteTaskExchangeSinkUpdateRequiredEvent event);
 
+        void onRemoteTaskExchangeUpdatedSinkAcquired(RemoteTaskExchangeUpdatedSinkAcquired event);
+
         void onSplitAssignment(SplitAssignmentEvent event);
 
         void onStageFailureFailure(StageFailureEvent event);
+
+        void onSinkInstanceHandleAcquired(SinkInstanceHandleAcquiredEvent sinkInstanceHandleAcquiredEvent);
+    }
+
+    private static class SinkInstanceHandleAcquiredEvent
+            implements Event
+    {
+        private final StageId stageId;
+        private final int partitionId;
+        private final NodeLease nodeLease;
+        private final int attempt;
+        private final ExchangeSinkInstanceHandle sinkInstanceHandle;
+
+        public SinkInstanceHandleAcquiredEvent(StageId stageId, int partitionId, NodeLease nodeLease, int attempt, ExchangeSinkInstanceHandle sinkInstanceHandle)
+        {
+            this.stageId = requireNonNull(stageId, "stageId is null");
+            this.partitionId = partitionId;
+            this.nodeLease = requireNonNull(nodeLease, "nodeLease is null");
+            this.attempt = attempt;
+            this.sinkInstanceHandle = requireNonNull(sinkInstanceHandle, "sinkInstanceHandle is null");
+        }
+
+        public StageId getStageId()
+        {
+            return stageId;
+        }
+
+        public int getPartitionId()
+        {
+            return partitionId;
+        }
+
+        public NodeLease getNodeLease()
+        {
+            return nodeLease;
+        }
+
+        public int getAttempt()
+        {
+            return attempt;
+        }
+
+        public ExchangeSinkInstanceHandle getSinkInstanceHandle()
+        {
+            return sinkInstanceHandle;
+        }
+
+        @Override
+        public void accept(EventListener listener)
+        {
+            listener.onSinkInstanceHandleAcquired(this);
+        }
     }
 
     private static class RemoteTaskCompletedEvent
@@ -1982,6 +2121,35 @@ public class EventDrivenFaultTolerantQueryScheduler
         public void accept(EventListener listener)
         {
             listener.onRemoteTaskExchangeSinkUpdateRequired(this);
+        }
+    }
+
+    private static class RemoteTaskExchangeUpdatedSinkAcquired
+            implements Event
+    {
+        private final TaskId taskId;
+        private final ExchangeSinkInstanceHandle exchangeSinkInstanceHandle;
+
+        private RemoteTaskExchangeUpdatedSinkAcquired(TaskId taskId, ExchangeSinkInstanceHandle exchangeSinkInstanceHandle)
+        {
+            this.taskId = requireNonNull(taskId, "taskId is null");
+            this.exchangeSinkInstanceHandle = requireNonNull(exchangeSinkInstanceHandle, "exchangeSinkInstanceHandle is null");
+        }
+
+        @Override
+        public void accept(EventListener listener)
+        {
+            listener.onRemoteTaskExchangeUpdatedSinkAcquired(this);
+        }
+
+        public TaskId getTaskId()
+        {
+            return taskId;
+        }
+
+        public ExchangeSinkInstanceHandle getExchangeSinkInstanceHandle()
+        {
+            return exchangeSinkInstanceHandle;
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -954,7 +954,7 @@ public class EventDrivenFaultTolerantQueryScheduler
                         @Override
                         public void onFailure(Throwable t)
                         {
-                            eventQueue.add(new TaskSourceFailureEvent(stageExecution.getStageId(), t));
+                            eventQueue.add(new StageFailureEvent(stageExecution.getStageId(), t));
                         }
                     }, queryExecutor));
                 }
@@ -1040,7 +1040,7 @@ public class EventDrivenFaultTolerantQueryScheduler
         }
 
         @Override
-        public void onTaskSourceFailure(TaskSourceFailureEvent event)
+        public void onStageFailureFailure(StageFailureEvent event)
         {
             StageExecution stageExecution = getStageExecution(event.getStageId());
             stageExecution.fail(event.getFailure());
@@ -1952,7 +1952,7 @@ public class EventDrivenFaultTolerantQueryScheduler
 
         void onSplitAssignment(SplitAssignmentEvent event);
 
-        void onTaskSourceFailure(TaskSourceFailureEvent event);
+        void onStageFailureFailure(StageFailureEvent event);
     }
 
     private static class RemoteTaskCompletedEvent
@@ -2002,7 +2002,7 @@ public class EventDrivenFaultTolerantQueryScheduler
     }
 
     private static class SplitAssignmentEvent
-            extends TaskSourceEvent
+            extends StageEvent
     {
         private final AssignmentResult assignmentResult;
 
@@ -2024,12 +2024,12 @@ public class EventDrivenFaultTolerantQueryScheduler
         }
     }
 
-    private static class TaskSourceFailureEvent
-            extends TaskSourceEvent
+    private static class StageFailureEvent
+            extends StageEvent
     {
         private final Throwable failure;
 
-        public TaskSourceFailureEvent(StageId stageId, Throwable failure)
+        public StageFailureEvent(StageId stageId, Throwable failure)
         {
             super(stageId);
             this.failure = requireNonNull(failure, "failure is null");
@@ -2043,16 +2043,16 @@ public class EventDrivenFaultTolerantQueryScheduler
         @Override
         public void accept(EventListener listener)
         {
-            listener.onTaskSourceFailure(this);
+            listener.onStageFailureFailure(this);
         }
     }
 
-    private abstract static class TaskSourceEvent
+    private abstract static class StageEvent
             implements Event
     {
         private final StageId stageId;
 
-        protected TaskSourceEvent(StageId stageId)
+        protected StageEvent(StageId stageId)
         {
             this.stageId = requireNonNull(stageId, "stageId is null");
         }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -1044,7 +1044,6 @@ public class EventDrivenFaultTolerantQueryScheduler
         {
             StageExecution stageExecution = getStageExecution(event.getStageId());
             stageExecution.fail(event.getFailure());
-            stageExecution.taskDescriptorLoadingComplete();
         }
 
         private StageExecution getStageExecution(StageId stageId)
@@ -1519,6 +1518,7 @@ public class EventDrivenFaultTolerantQueryScheduler
             catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
+            taskDescriptorLoadingComplete();
         }
 
         private Closer createStageExecutionCloser()

--- a/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
@@ -28,6 +28,7 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import io.trino.exchange.ExchangeManagerRegistry;
 import io.trino.execution.StageId;
 import io.trino.execution.TaskId;
@@ -39,6 +40,7 @@ import io.trino.spi.exchange.ExchangeId;
 import io.trino.spi.exchange.ExchangeManager;
 import io.trino.spi.exchange.ExchangeSink;
 import io.trino.spi.exchange.ExchangeSinkHandle;
+import io.trino.spi.exchange.ExchangeSinkInstanceHandle;
 import io.trino.spi.exchange.ExchangeSource;
 import io.trino.spi.exchange.ExchangeSourceOutputSelector;
 
@@ -81,12 +83,15 @@ import static io.trino.spi.StandardErrorCode.REMOTE_TASK_FAILED;
 import static io.trino.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
 import static java.lang.Math.max;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class DeduplicatingDirectExchangeBuffer
         implements DirectExchangeBuffer
 {
     private static final Logger log = Logger.get(DeduplicatingDirectExchangeBuffer.class);
+
+    private static final Duration SINK_INSTANCE_HANDLE_GET_TIMEOUT = Duration.succinctDuration(60, SECONDS);
 
     private final Executor executor;
     private final RetryPolicy retryPolicy;
@@ -550,7 +555,18 @@ public class DeduplicatingDirectExchangeBuffer
 
                 sinkHandle = exchange.addSink(0);
                 exchange.noMoreSinks();
-                exchangeSink = exchangeManager.createSink(exchange.instantiateSink(sinkHandle, 0));
+                ExchangeSinkInstanceHandle sinkInstanceHandle;
+                try {
+                    sinkInstanceHandle = exchange.instantiateSink(this.sinkHandle, 0).get(60, SECONDS);
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+                catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                exchangeSink = exchangeManager.createSink(sinkInstanceHandle);
 
                 writeBuffer = new DynamicSliceOutput(DEFAULT_MAX_PAGE_SIZE_IN_BYTES);
             }
@@ -619,7 +635,19 @@ public class DeduplicatingDirectExchangeBuffer
             verify(sinkHandle != null, "sinkHandle is null");
 
             if (exchangeSink.isHandleUpdateRequired()) {
-                exchangeSink.updateHandle(exchange.updateSinkInstanceHandle(sinkHandle, 0));
+                CompletableFuture<ExchangeSinkInstanceHandle> sinkInstanceHandleFuture = exchange.updateSinkInstanceHandle(sinkHandle, 0);
+                ExchangeSinkInstanceHandle sinkInstanceHandle;
+                try {
+                    sinkInstanceHandle = sinkInstanceHandleFuture.get(SINK_INSTANCE_HANDLE_GET_TIMEOUT.toMillis(), MILLISECONDS);
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+                catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                exchangeSink.updateHandle(sinkInstanceHandle);
             }
         }
 

--- a/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
@@ -282,7 +282,7 @@ public class DeduplicatingDirectExchangeBuffer
 
         Map<TaskId, Throwable> failures;
         switch (retryPolicy) {
-            case TASK: {
+            case TASK -> {
                 Set<Integer> allPartitions = allTasks.stream()
                         .map(TaskId::getPartitionId)
                         .collect(toImmutableSet());
@@ -316,9 +316,8 @@ public class DeduplicatingDirectExchangeBuffer
                         .filter(entry -> !successfulPartitions.contains(entry.getKey().getPartitionId()))
                         .filter(entry -> !runningPartitions.contains(entry.getKey().getPartitionId()))
                         .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
-                break;
             }
-            case QUERY: {
+            case QUERY -> {
                 Set<TaskId> latestAttemptTasks = allTasks.stream()
                         .filter(taskId -> taskId.getAttemptId() == maxAttemptId)
                         .collect(toImmutableSet());
@@ -332,10 +331,8 @@ public class DeduplicatingDirectExchangeBuffer
                 failures = failedTasks.entrySet().stream()
                         .filter(entry -> entry.getKey().getAttemptId() == maxAttemptId)
                         .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
-                break;
             }
-            default:
-                throw new UnsupportedOperationException("unexpected retry policy: " + retryPolicy);
+            default -> throw new UnsupportedOperationException("unexpected retry policy: " + retryPolicy);
         }
 
         Throwable failure = null;

--- a/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
@@ -265,6 +265,7 @@ public class DeduplicatingDirectExchangeBuffer
         checkInputFinished();
     }
 
+    @GuardedBy("this")
     private void checkInputFinished()
     {
         if (failure != null) {
@@ -398,18 +399,21 @@ public class DeduplicatingDirectExchangeBuffer
     }
 
     @Override
+    @GuardedBy("this")
     public int getBufferedPageCount()
     {
         return pageBuffer.getBufferedPageCount();
     }
 
     @Override
+    @GuardedBy("this")
     public long getSpilledBytes()
     {
         return pageBuffer.getSpilledBytes();
     }
 
     @Override
+    @GuardedBy("this")
     public int getSpilledPageCount()
     {
         return pageBuffer.getSpilledPageCount();
@@ -425,12 +429,14 @@ public class DeduplicatingDirectExchangeBuffer
         closeAndUnblock();
     }
 
+    @GuardedBy("this")
     private void fail(Throwable failure)
     {
         this.failure = failure;
         closeAndUnblock();
     }
 
+    @GuardedBy("this")
     private void throwIfFailed()
     {
         if (failure != null) {
@@ -439,6 +445,7 @@ public class DeduplicatingDirectExchangeBuffer
         }
     }
 
+    @GuardedBy("this")
     private void closeAndUnblock()
     {
         try (Closer closer = Closer.create()) {
@@ -453,6 +460,7 @@ public class DeduplicatingDirectExchangeBuffer
         }
     }
 
+    @GuardedBy("this")
     private void updateMaxRetainedSize()
     {
         maxRetainedSizeInBytes = max(maxRetainedSizeInBytes, getRetainedSizeInBytes());
@@ -571,6 +579,7 @@ public class DeduplicatingDirectExchangeBuffer
             return result;
         }
 
+        @GuardedBy("this")
         private void writeToSink(TaskId taskId, List<Slice> pages)
         {
             verify(exchangeSink != null, "exchangeSink is expected to be initialized");
@@ -604,6 +613,7 @@ public class DeduplicatingDirectExchangeBuffer
             }
         }
 
+        @GuardedBy("this")
         private void updateSinkInstanceHandleIfNecessary()
         {
             verify(Thread.holdsLock(this), "this method is expected to be called under a lock");

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/Exchange.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/Exchange.java
@@ -18,6 +18,8 @@ import io.trino.spi.Experimental;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.io.Closeable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 
 @ThreadSafe
 @Experimental(eta = "2023-01-01")
@@ -61,7 +63,7 @@ public interface Exchange
      * @return ExchangeSinkInstanceHandle to be sent to a worker that is needed to create an {@link ExchangeSink} instance using
      * {@link ExchangeManager#createSink(ExchangeSinkInstanceHandle)}
      */
-    ExchangeSinkInstanceHandle instantiateSink(ExchangeSinkHandle sinkHandle, int taskAttemptId);
+    CompletableFuture<ExchangeSinkInstanceHandle> instantiateSink(ExchangeSinkHandle sinkHandle, int taskAttemptId);
 
     /**
      * Update {@link ExchangeSinkInstanceHandle}. Update is requested by {@link ExchangeSink}.
@@ -71,7 +73,7 @@ public interface Exchange
      * @param taskAttemptId - attempt id
      * @return updated handle
      */
-    ExchangeSinkInstanceHandle updateSinkInstanceHandle(ExchangeSinkHandle sinkHandle, int taskAttemptId);
+    CompletableFuture<ExchangeSinkInstanceHandle> updateSinkInstanceHandle(ExchangeSinkHandle sinkHandle, int taskAttemptId);
 
     /**
      * Called by the engine when an attempt finishes successfully.

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchange.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchange.java
@@ -62,6 +62,7 @@ import static io.trino.plugin.exchange.filesystem.FileSystemExchangeSink.DATA_FI
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 
 public class FileSystemExchange
         implements Exchange
@@ -142,7 +143,7 @@ public class FileSystemExchange
     }
 
     @Override
-    public ExchangeSinkInstanceHandle instantiateSink(ExchangeSinkHandle sinkHandle, int taskAttemptId)
+    public CompletableFuture<ExchangeSinkInstanceHandle> instantiateSink(ExchangeSinkHandle sinkHandle, int taskAttemptId)
     {
         FileSystemExchangeSinkHandle fileSystemExchangeSinkHandle = (FileSystemExchangeSinkHandle) sinkHandle;
         int taskPartitionId = fileSystemExchangeSinkHandle.getPartitionId();
@@ -154,11 +155,11 @@ public class FileSystemExchange
             throw new UncheckedIOException(e);
         }
 
-        return new FileSystemExchangeSinkInstanceHandle(fileSystemExchangeSinkHandle, outputDirectory, outputPartitionCount, preserveOrderWithinPartition);
+        return completedFuture(new FileSystemExchangeSinkInstanceHandle(fileSystemExchangeSinkHandle, outputDirectory, outputPartitionCount, preserveOrderWithinPartition));
     }
 
     @Override
-    public ExchangeSinkInstanceHandle updateSinkInstanceHandle(ExchangeSinkHandle sinkHandle, int taskAttemptId)
+    public CompletableFuture<ExchangeSinkInstanceHandle> updateSinkInstanceHandle(ExchangeSinkHandle sinkHandle, int taskAttemptId)
     {
         // this implementation never requests an update
         throw new UnsupportedOperationException();

--- a/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/AbstractTestExchangeManager.java
+++ b/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/AbstractTestExchangeManager.java
@@ -89,7 +89,7 @@ public abstract class AbstractTestExchangeManager
         ExchangeSinkHandle sinkHandle2 = exchange.addSink(2);
         exchange.noMoreSinks();
 
-        ExchangeSinkInstanceHandle sinkInstanceHandle = exchange.instantiateSink(sinkHandle0, 0);
+        ExchangeSinkInstanceHandle sinkInstanceHandle = exchange.instantiateSink(sinkHandle0, 0).get();
         writeData(
                 sinkInstanceHandle,
                 ImmutableListMultimap.of(
@@ -99,7 +99,7 @@ public abstract class AbstractTestExchangeManager
                         1, "0-1-1"),
                 true);
         exchange.sinkFinished(sinkHandle0, 0);
-        sinkInstanceHandle = exchange.instantiateSink(sinkHandle0, 1);
+        sinkInstanceHandle = exchange.instantiateSink(sinkHandle0, 1).get();
         writeData(
                 sinkInstanceHandle,
                 ImmutableListMultimap.of(
@@ -109,7 +109,7 @@ public abstract class AbstractTestExchangeManager
                         1, "0-1-1"),
                 true);
         exchange.sinkFinished(sinkHandle0, 1);
-        sinkInstanceHandle = exchange.instantiateSink(sinkHandle0, 2);
+        sinkInstanceHandle = exchange.instantiateSink(sinkHandle0, 2).get();
         writeData(
                 sinkInstanceHandle,
                 ImmutableListMultimap.of(
@@ -118,7 +118,7 @@ public abstract class AbstractTestExchangeManager
                 false);
         exchange.sinkFinished(sinkHandle0, 2);
 
-        sinkInstanceHandle = exchange.instantiateSink(sinkHandle1, 0);
+        sinkInstanceHandle = exchange.instantiateSink(sinkHandle1, 0).get();
         writeData(
                 sinkInstanceHandle,
                 ImmutableListMultimap.of(
@@ -128,7 +128,7 @@ public abstract class AbstractTestExchangeManager
                         1, "1-1-1"),
                 true);
         exchange.sinkFinished(sinkHandle1, 0);
-        sinkInstanceHandle = exchange.instantiateSink(sinkHandle1, 1);
+        sinkInstanceHandle = exchange.instantiateSink(sinkHandle1, 1).get();
         writeData(
                 sinkInstanceHandle,
                 ImmutableListMultimap.of(
@@ -138,7 +138,7 @@ public abstract class AbstractTestExchangeManager
                         1, "1-1-1"),
                 true);
         exchange.sinkFinished(sinkHandle1, 1);
-        sinkInstanceHandle = exchange.instantiateSink(sinkHandle1, 2);
+        sinkInstanceHandle = exchange.instantiateSink(sinkHandle1, 2).get();
         writeData(
                 sinkInstanceHandle,
                 ImmutableListMultimap.of(
@@ -147,7 +147,7 @@ public abstract class AbstractTestExchangeManager
                 false);
         exchange.sinkFinished(sinkHandle1, 2);
 
-        sinkInstanceHandle = exchange.instantiateSink(sinkHandle2, 2);
+        sinkInstanceHandle = exchange.instantiateSink(sinkHandle2, 2).get();
         writeData(
                 sinkInstanceHandle,
                 ImmutableListMultimap.of(
@@ -197,7 +197,7 @@ public abstract class AbstractTestExchangeManager
         ExchangeSinkHandle sinkHandle2 = exchange.addSink(2);
         exchange.noMoreSinks();
 
-        ExchangeSinkInstanceHandle sinkInstanceHandle = exchange.instantiateSink(sinkHandle0, 0);
+        ExchangeSinkInstanceHandle sinkInstanceHandle = exchange.instantiateSink(sinkHandle0, 0).get();
         writeData(
                 sinkInstanceHandle,
                 new ImmutableListMultimap.Builder<Integer, String>()
@@ -208,7 +208,7 @@ public abstract class AbstractTestExchangeManager
                 true);
         exchange.sinkFinished(sinkHandle0, 0);
 
-        sinkInstanceHandle = exchange.instantiateSink(sinkHandle1, 0);
+        sinkInstanceHandle = exchange.instantiateSink(sinkHandle1, 0).get();
         writeData(
                 sinkInstanceHandle,
                 new ImmutableListMultimap.Builder<Integer, String>()
@@ -219,7 +219,7 @@ public abstract class AbstractTestExchangeManager
                 true);
         exchange.sinkFinished(sinkHandle1, 0);
 
-        sinkInstanceHandle = exchange.instantiateSink(sinkHandle2, 0);
+        sinkInstanceHandle = exchange.instantiateSink(sinkHandle2, 0).get();
         writeData(
                 sinkInstanceHandle,
                 new ImmutableListMultimap.Builder<Integer, String>()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

It is not always possible for exchange implementation to
provide an immediate return for calls to:
* `Exchange.instantiateSink `and
* `Exchange.updateSinkInstanceHandle`

depending on exchange implementation sometimes there needs to be a network
the communication involved or another lengthy process. To allow for such
exchange implementations and not block engine threads this PR changes
SPI so the two methods listed above now return
`CompletableFuture<ExchangeSinkInstanceHandle>`.

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

