### PR TITLE
Obtain and refresh sink instance handle asynchronously

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -954,7 +954,7 @@ public class EventDrivenFaultTolerantQueryScheduler
                         @Override
                         public void onFailure(Throwable t)
                         {
-                            eventQueue.add(new TaskSourceFailureEvent(stageExecution.getStageId(), t));
+                            eventQueue.add(new StageFailureEvent(stageExecution.getStageId(), t));
                         }
                     }, queryExecutor));
                 }
@@ -1040,7 +1040,7 @@ public class EventDrivenFaultTolerantQueryScheduler
         }
 
         @Override
-        public void onTaskSourceFailure(TaskSourceFailureEvent event)
+        public void onStageFailure(StageFailureEvent event)
         {
             StageExecution stageExecution = getStageExecution(event.getStageId());
             stageExecution.fail(event.getFailure());
@@ -1952,7 +1952,7 @@ public class EventDrivenFaultTolerantQueryScheduler
 
         void onSplitAssignment(SplitAssignmentEvent event);
 
-        void onTaskSourceFailure(TaskSourceFailureEvent event);
+        void onStageFailure(StageFailureEvent event);
     }
 
     private static class RemoteTaskCompletedEvent
@@ -2002,7 +2002,7 @@ public class EventDrivenFaultTolerantQueryScheduler
     }
 
     private static class SplitAssignmentEvent
-            extends TaskSourceEvent
+            extends StageEvent
     {
         private final AssignmentResult assignmentResult;
 
@@ -2024,12 +2024,12 @@ public class EventDrivenFaultTolerantQueryScheduler
         }
     }
 
-    private static class TaskSourceFailureEvent
-            extends TaskSourceEvent
+    private static class StageFailureEvent
+            extends StageEvent
     {
         private final Throwable failure;
 
-        public TaskSourceFailureEvent(StageId stageId, Throwable failure)
+        public StageFailureEvent(StageId stageId, Throwable failure)
         {
             super(stageId);
             this.failure = requireNonNull(failure, "failure is null");
@@ -2043,16 +2043,16 @@ public class EventDrivenFaultTolerantQueryScheduler
         @Override
         public void accept(EventListener listener)
         {
-            listener.onTaskSourceFailure(this);
+            listener.onStageFailure(this);
         }
     }
 
-    private abstract static class TaskSourceEvent
+    private abstract static class StageEvent
             implements Event
     {
         private final StageId stageId;
 
-        protected TaskSourceEvent(StageId stageId)
+        protected StageEvent(StageId stageId)
         {
             this.stageId = requireNonNull(stageId, "stageId is null");
         }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -1044,7 +1044,6 @@ public class EventDrivenFaultTolerantQueryScheduler
         {
             StageExecution stageExecution = getStageExecution(event.getStageId());
             stageExecution.fail(event.getFailure());
-            stageExecution.taskDescriptorLoadingComplete();
         }
 
         private StageExecution getStageExecution(StageId stageId)
@@ -1519,6 +1518,7 @@ public class EventDrivenFaultTolerantQueryScheduler
             catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
+            taskDescriptorLoadingComplete();
         }
 
         private Closer createStageExecutionCloser()

--- a/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
@@ -282,7 +282,7 @@ public class DeduplicatingDirectExchangeBuffer
 
         Map<TaskId, Throwable> failures;
         switch (retryPolicy) {
-            case TASK: {
+            case TASK -> {
                 Set<Integer> allPartitions = allTasks.stream()
                         .map(TaskId::getPartitionId)
                         .collect(toImmutableSet());
@@ -316,9 +316,8 @@ public class DeduplicatingDirectExchangeBuffer
                         .filter(entry -> !successfulPartitions.contains(entry.getKey().getPartitionId()))
                         .filter(entry -> !runningPartitions.contains(entry.getKey().getPartitionId()))
                         .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
-                break;
             }
-            case QUERY: {
+            case QUERY -> {
                 Set<TaskId> latestAttemptTasks = allTasks.stream()
                         .filter(taskId -> taskId.getAttemptId() == maxAttemptId)
                         .collect(toImmutableSet());
@@ -332,10 +331,8 @@ public class DeduplicatingDirectExchangeBuffer
                 failures = failedTasks.entrySet().stream()
                         .filter(entry -> entry.getKey().getAttemptId() == maxAttemptId)
                         .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
-                break;
             }
-            default:
-                throw new UnsupportedOperationException("unexpected retry policy: " + retryPolicy);
+            default -> throw new UnsupportedOperationException("unexpected retry policy: " + retryPolicy);
         }
 
         Throwable failure = null;

--- a/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
@@ -265,6 +265,7 @@ public class DeduplicatingDirectExchangeBuffer
         checkInputFinished();
     }
 
+    @GuardedBy("this")
     private void checkInputFinished()
     {
         if (failure != null) {
@@ -398,18 +399,21 @@ public class DeduplicatingDirectExchangeBuffer
     }
 
     @Override
+    @GuardedBy("this")
     public int getBufferedPageCount()
     {
         return pageBuffer.getBufferedPageCount();
     }
 
     @Override
+    @GuardedBy("this")
     public long getSpilledBytes()
     {
         return pageBuffer.getSpilledBytes();
     }
 
     @Override
+    @GuardedBy("this")
     public int getSpilledPageCount()
     {
         return pageBuffer.getSpilledPageCount();
@@ -425,12 +429,14 @@ public class DeduplicatingDirectExchangeBuffer
         closeAndUnblock();
     }
 
+    @GuardedBy("this")
     private void fail(Throwable failure)
     {
         this.failure = failure;
         closeAndUnblock();
     }
 
+    @GuardedBy("this")
     private void throwIfFailed()
     {
         if (failure != null) {
@@ -439,6 +445,7 @@ public class DeduplicatingDirectExchangeBuffer
         }
     }
 
+    @GuardedBy("this")
     private void closeAndUnblock()
     {
         try (Closer closer = Closer.create()) {
@@ -453,6 +460,7 @@ public class DeduplicatingDirectExchangeBuffer
         }
     }
 
+    @GuardedBy("this")
     private void updateMaxRetainedSize()
     {
         maxRetainedSizeInBytes = max(maxRetainedSizeInBytes, getRetainedSizeInBytes());
@@ -571,6 +579,7 @@ public class DeduplicatingDirectExchangeBuffer
             return result;
         }
 
+        @GuardedBy("this")
         private void writeToSink(TaskId taskId, List<Slice> pages)
         {
             verify(exchangeSink != null, "exchangeSink is expected to be initialized");
@@ -604,6 +613,7 @@ public class DeduplicatingDirectExchangeBuffer
             }
         }
 
+        @GuardedBy("this")
         private void updateSinkInstanceHandleIfNecessary()
         {
             verify(Thread.holdsLock(this), "this method is expected to be called under a lock");

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestEventDrivenTaskSource.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestEventDrivenTaskSource.java
@@ -601,13 +601,13 @@ public class TestEventDrivenTaskSource
         }
 
         @Override
-        public ExchangeSinkInstanceHandle instantiateSink(ExchangeSinkHandle sinkHandle, int taskAttemptId)
+        public CompletableFuture<ExchangeSinkInstanceHandle> instantiateSink(ExchangeSinkHandle sinkHandle, int taskAttemptId)
         {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public ExchangeSinkInstanceHandle updateSinkInstanceHandle(ExchangeSinkHandle sinkHandle, int taskAttemptId)
+        public CompletableFuture<ExchangeSinkInstanceHandle> updateSinkInstanceHandle(ExchangeSinkHandle sinkHandle, int taskAttemptId)
         {
             throw new UnsupportedOperationException();
         }

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/Exchange.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/Exchange.java
@@ -18,6 +18,7 @@ import io.trino.spi.Experimental;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.io.Closeable;
+import java.util.concurrent.CompletableFuture;
 
 @ThreadSafe
 @Experimental(eta = "2023-01-01")
@@ -61,7 +62,7 @@ public interface Exchange
      * @return ExchangeSinkInstanceHandle to be sent to a worker that is needed to create an {@link ExchangeSink} instance using
      * {@link ExchangeManager#createSink(ExchangeSinkInstanceHandle)}
      */
-    ExchangeSinkInstanceHandle instantiateSink(ExchangeSinkHandle sinkHandle, int taskAttemptId);
+    CompletableFuture<ExchangeSinkInstanceHandle> instantiateSink(ExchangeSinkHandle sinkHandle, int taskAttemptId);
 
     /**
      * Update {@link ExchangeSinkInstanceHandle}. Update is requested by {@link ExchangeSink}.
@@ -71,7 +72,7 @@ public interface Exchange
      * @param taskAttemptId - attempt id
      * @return updated handle
      */
-    ExchangeSinkInstanceHandle updateSinkInstanceHandle(ExchangeSinkHandle sinkHandle, int taskAttemptId);
+    CompletableFuture<ExchangeSinkInstanceHandle> updateSinkInstanceHandle(ExchangeSinkHandle sinkHandle, int taskAttemptId);
 
     /**
      * Called by the engine when an attempt finishes successfully.

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchange.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchange.java
@@ -62,6 +62,7 @@ import static io.trino.plugin.exchange.filesystem.FileSystemExchangeSink.DATA_FI
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 
 public class FileSystemExchange
         implements Exchange
@@ -142,7 +143,7 @@ public class FileSystemExchange
     }
 
     @Override
-    public ExchangeSinkInstanceHandle instantiateSink(ExchangeSinkHandle sinkHandle, int taskAttemptId)
+    public CompletableFuture<ExchangeSinkInstanceHandle> instantiateSink(ExchangeSinkHandle sinkHandle, int taskAttemptId)
     {
         FileSystemExchangeSinkHandle fileSystemExchangeSinkHandle = (FileSystemExchangeSinkHandle) sinkHandle;
         int taskPartitionId = fileSystemExchangeSinkHandle.getPartitionId();
@@ -154,11 +155,11 @@ public class FileSystemExchange
             throw new UncheckedIOException(e);
         }
 
-        return new FileSystemExchangeSinkInstanceHandle(fileSystemExchangeSinkHandle, outputDirectory, outputPartitionCount, preserveOrderWithinPartition);
+        return completedFuture(new FileSystemExchangeSinkInstanceHandle(fileSystemExchangeSinkHandle, outputDirectory, outputPartitionCount, preserveOrderWithinPartition));
     }
 
     @Override
-    public ExchangeSinkInstanceHandle updateSinkInstanceHandle(ExchangeSinkHandle sinkHandle, int taskAttemptId)
+    public CompletableFuture<ExchangeSinkInstanceHandle> updateSinkInstanceHandle(ExchangeSinkHandle sinkHandle, int taskAttemptId)
     {
         // this implementation never requests an update
         throw new UnsupportedOperationException();

--- a/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/AbstractTestExchangeManager.java
+++ b/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/AbstractTestExchangeManager.java
@@ -89,7 +89,7 @@ public abstract class AbstractTestExchangeManager
         ExchangeSinkHandle sinkHandle2 = exchange.addSink(2);
         exchange.noMoreSinks();
 
-        ExchangeSinkInstanceHandle sinkInstanceHandle = exchange.instantiateSink(sinkHandle0, 0);
+        ExchangeSinkInstanceHandle sinkInstanceHandle = exchange.instantiateSink(sinkHandle0, 0).get();
         writeData(
                 sinkInstanceHandle,
                 ImmutableListMultimap.of(
@@ -99,7 +99,7 @@ public abstract class AbstractTestExchangeManager
                         1, "0-1-1"),
                 true);
         exchange.sinkFinished(sinkHandle0, 0);
-        sinkInstanceHandle = exchange.instantiateSink(sinkHandle0, 1);
+        sinkInstanceHandle = exchange.instantiateSink(sinkHandle0, 1).get();
         writeData(
                 sinkInstanceHandle,
                 ImmutableListMultimap.of(
@@ -109,7 +109,7 @@ public abstract class AbstractTestExchangeManager
                         1, "0-1-1"),
                 true);
         exchange.sinkFinished(sinkHandle0, 1);
-        sinkInstanceHandle = exchange.instantiateSink(sinkHandle0, 2);
+        sinkInstanceHandle = exchange.instantiateSink(sinkHandle0, 2).get();
         writeData(
                 sinkInstanceHandle,
                 ImmutableListMultimap.of(
@@ -118,7 +118,7 @@ public abstract class AbstractTestExchangeManager
                 false);
         exchange.sinkFinished(sinkHandle0, 2);
 
-        sinkInstanceHandle = exchange.instantiateSink(sinkHandle1, 0);
+        sinkInstanceHandle = exchange.instantiateSink(sinkHandle1, 0).get();
         writeData(
                 sinkInstanceHandle,
                 ImmutableListMultimap.of(
@@ -128,7 +128,7 @@ public abstract class AbstractTestExchangeManager
                         1, "1-1-1"),
                 true);
         exchange.sinkFinished(sinkHandle1, 0);
-        sinkInstanceHandle = exchange.instantiateSink(sinkHandle1, 1);
+        sinkInstanceHandle = exchange.instantiateSink(sinkHandle1, 1).get();
         writeData(
                 sinkInstanceHandle,
                 ImmutableListMultimap.of(
@@ -138,7 +138,7 @@ public abstract class AbstractTestExchangeManager
                         1, "1-1-1"),
                 true);
         exchange.sinkFinished(sinkHandle1, 1);
-        sinkInstanceHandle = exchange.instantiateSink(sinkHandle1, 2);
+        sinkInstanceHandle = exchange.instantiateSink(sinkHandle1, 2).get();
         writeData(
                 sinkInstanceHandle,
                 ImmutableListMultimap.of(
@@ -147,7 +147,7 @@ public abstract class AbstractTestExchangeManager
                 false);
         exchange.sinkFinished(sinkHandle1, 2);
 
-        sinkInstanceHandle = exchange.instantiateSink(sinkHandle2, 2);
+        sinkInstanceHandle = exchange.instantiateSink(sinkHandle2, 2).get();
         writeData(
                 sinkInstanceHandle,
                 ImmutableListMultimap.of(
@@ -197,7 +197,7 @@ public abstract class AbstractTestExchangeManager
         ExchangeSinkHandle sinkHandle2 = exchange.addSink(2);
         exchange.noMoreSinks();
 
-        ExchangeSinkInstanceHandle sinkInstanceHandle = exchange.instantiateSink(sinkHandle0, 0);
+        ExchangeSinkInstanceHandle sinkInstanceHandle = exchange.instantiateSink(sinkHandle0, 0).get();
         writeData(
                 sinkInstanceHandle,
                 new ImmutableListMultimap.Builder<Integer, String>()
@@ -208,7 +208,7 @@ public abstract class AbstractTestExchangeManager
                 true);
         exchange.sinkFinished(sinkHandle0, 0);
 
-        sinkInstanceHandle = exchange.instantiateSink(sinkHandle1, 0);
+        sinkInstanceHandle = exchange.instantiateSink(sinkHandle1, 0).get();
         writeData(
                 sinkInstanceHandle,
                 new ImmutableListMultimap.Builder<Integer, String>()
@@ -219,7 +219,7 @@ public abstract class AbstractTestExchangeManager
                 true);
         exchange.sinkFinished(sinkHandle1, 0);
 
-        sinkInstanceHandle = exchange.instantiateSink(sinkHandle2, 0);
+        sinkInstanceHandle = exchange.instantiateSink(sinkHandle2, 0).get();
         writeData(
                 sinkInstanceHandle,
                 new ImmutableListMultimap.Builder<Integer, String>()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

It is not always possible for exchange implementation to
provide an immediate return for calls to:
* `Exchange.instantiateSink `and
* `Exchange.updateSinkInstanceHandle`

depending on exchange implementation sometimes there needs to be a network
the communication involved or another lengthy process. To allow for such
exchange implementations and not block engine threads this PR changes
SPI so the two methods listed above now return
`CompletableFuture<ExchangeSinkInstanceHandle>`.

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

