### PR TITLE
Support `register_table` and `unregister_table` procedures in Iceberg JDBC catalog

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalogFactory.java
@@ -41,6 +41,7 @@ public class TrinoJdbcCatalogFactory
     private final TypeManager typeManager;
     private final IcebergTableOperationsProvider tableOperationsProvider;
     private final TrinoFileSystemFactory fileSystemFactory;
+    private final IcebergJdbcClient jdbcClient;
     private final String jdbcCatalogName;
     private final String connectionUrl;
     private final Optional<String> connectionUser;
@@ -57,6 +58,7 @@ public class TrinoJdbcCatalogFactory
             TypeManager typeManager,
             IcebergTableOperationsProvider tableOperationsProvider,
             TrinoFileSystemFactory fileSystemFactory,
+            IcebergJdbcClient jdbcClient,
             IcebergJdbcCatalogConfig jdbcConfig,
             IcebergConfig icebergConfig)
     {
@@ -65,6 +67,7 @@ public class TrinoJdbcCatalogFactory
         this.tableOperationsProvider = requireNonNull(tableOperationsProvider, "tableOperationsProvider is null");
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.isUniqueTableLocation = requireNonNull(icebergConfig, "icebergConfig is null").isUniqueTableLocation();
+        this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
         this.jdbcCatalogName = jdbcConfig.getCatalogName();
         this.connectionUrl = jdbcConfig.getConnectionUrl();
         this.connectionUser = jdbcConfig.getConnectionUser();
@@ -84,6 +87,7 @@ public class TrinoJdbcCatalogFactory
                 typeManager,
                 tableOperationsProvider,
                 icebergCatalog,
+                jdbcClient,
                 fileSystemFactory,
                 isUniqueTableLocation,
                 defaultWarehouseDir);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConnectorSmokeTest.java
@@ -14,13 +14,20 @@
 package io.trino.plugin.iceberg.catalog.jdbc;
 
 import com.google.common.collect.ImmutableMap;
+import io.trino.hadoop.ConfigurationInstantiator;
 import io.trino.plugin.iceberg.BaseIcebergConnectorSmokeTest;
 import io.trino.plugin.iceberg.IcebergConfig;
 import io.trino.plugin.iceberg.IcebergQueryRunner;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.jdbc.JdbcCatalog;
+import org.testng.annotations.AfterClass;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -29,11 +36,17 @@ import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.plugin.iceberg.catalog.jdbc.TestingIcebergJdbcServer.PASSWORD;
 import static io.trino.plugin.iceberg.catalog.jdbc.TestingIcebergJdbcServer.USER;
 import static java.lang.String.format;
+import static org.apache.iceberg.CatalogProperties.CATALOG_IMPL;
+import static org.apache.iceberg.CatalogProperties.URI;
+import static org.apache.iceberg.CatalogProperties.WAREHOUSE_LOCATION;
+import static org.apache.iceberg.CatalogUtil.buildIcebergCatalog;
+import static org.apache.iceberg.jdbc.JdbcCatalog.PROPERTY_PREFIX;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestIcebergJdbcCatalogConnectorSmokeTest
         extends BaseIcebergConnectorSmokeTest
 {
+    private JdbcCatalog jdbcCatalog;
     private File warehouseLocation;
 
     public TestIcebergJdbcCatalogConnectorSmokeTest()
@@ -60,6 +73,14 @@ public class TestIcebergJdbcCatalogConnectorSmokeTest
         warehouseLocation = Files.createTempDirectory("test_iceberg_jdbc_catalog_smoke_test").toFile();
         closeAfterClass(() -> deleteRecursively(warehouseLocation.toPath(), ALLOW_INSECURE));
         TestingIcebergJdbcServer server = closeAfterClass(new TestingIcebergJdbcServer());
+        jdbcCatalog = (JdbcCatalog) buildIcebergCatalog("tpch", ImmutableMap.<String, String>builder()
+                        .put(CATALOG_IMPL, JdbcCatalog.class.getName())
+                        .put(URI, server.getJdbcUrl())
+                        .put(PROPERTY_PREFIX + "user", USER)
+                        .put(PROPERTY_PREFIX + "password", PASSWORD)
+                        .put(WAREHOUSE_LOCATION, warehouseLocation.getAbsolutePath())
+                        .buildOrThrow(),
+                ConfigurationInstantiator.newEmptyConfiguration());
         return IcebergQueryRunner.builder()
                 .setIcebergProperties(
                         ImmutableMap.<String, String>builder()
@@ -74,6 +95,13 @@ public class TestIcebergJdbcCatalogConnectorSmokeTest
                                 .buildOrThrow())
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .build();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public final void destroy()
+    {
+        jdbcCatalog.close();
+        jdbcCatalog = null;
     }
 
     @Override
@@ -100,14 +128,14 @@ public class TestIcebergJdbcCatalogConnectorSmokeTest
     @Override
     protected void dropTableFromMetastore(String tableName)
     {
-        // used when registering a table, which is not supported by the JDBC catalog
+        jdbcCatalog.dropTable(toIdentifier(tableName), false);
     }
 
     @Override
     protected String getMetadataLocation(String tableName)
     {
-        // used when registering a table, which is not supported by the JDBC catalog
-        throw new UnsupportedOperationException("metadata location for register_table is not supported");
+        BaseTable table = (BaseTable) jdbcCatalog.loadTable(toIdentifier(tableName));
+        return table.operations().current().metadataFileLocation();
     }
 
     @Override
@@ -122,79 +150,19 @@ public class TestIcebergJdbcCatalogConnectorSmokeTest
         return Files.exists(Path.of(location));
     }
 
-    @Override
-    public void testRegisterTableWithTableLocation()
+    private TableIdentifier toIdentifier(String tableName)
     {
-        assertThatThrownBy(super::testRegisterTableWithTableLocation)
-                .hasMessageContaining("registerTable is not supported for Iceberg JDBC catalogs");
-    }
-
-    @Override
-    public void testRegisterTableWithComments()
-    {
-        assertThatThrownBy(super::testRegisterTableWithComments)
-                .hasMessageContaining("registerTable is not supported for Iceberg JDBC catalogs");
-    }
-
-    @Override
-    public void testRegisterTableWithShowCreateTable()
-    {
-        assertThatThrownBy(super::testRegisterTableWithShowCreateTable)
-                .hasMessageContaining("registerTable is not supported for Iceberg JDBC catalogs");
-    }
-
-    @Override
-    public void testRegisterTableWithReInsert()
-    {
-        assertThatThrownBy(super::testRegisterTableWithReInsert)
-                .hasMessageContaining("registerTable is not supported for Iceberg JDBC catalogs");
-    }
-
-    @Override
-    public void testRegisterTableWithDifferentTableName()
-    {
-        assertThatThrownBy(super::testRegisterTableWithDifferentTableName)
-                .hasMessageContaining("registerTable is not supported for Iceberg JDBC catalogs");
-    }
-
-    @Override
-    public void testRegisterTableWithMetadataFile()
-    {
-        assertThatThrownBy(super::testRegisterTableWithMetadataFile)
-                .hasMessageContaining("metadata location for register_table is not supported");
-    }
-
-    @Override
-    public void testUnregisterTable()
-    {
-        assertThatThrownBy(super::testUnregisterTable)
-                .hasMessageContaining("unregisterTable is not supported for Iceberg JDBC catalogs");
-    }
-
-    @Override
-    public void testUnregisterBrokenTable()
-    {
-        assertThatThrownBy(super::testUnregisterBrokenTable)
-                .hasMessageContaining("unregisterTable is not supported for Iceberg JDBC catalogs");
-    }
-
-    @Override
-    public void testUnregisterTableNotExistingTable()
-    {
-        assertThatThrownBy(super::testUnregisterTableNotExistingTable)
-                .hasMessageContaining("unregisterTable is not supported for Iceberg JDBC catalogs");
-    }
-
-    @Override
-    public void testRepeatUnregisterTable()
-    {
-        assertThatThrownBy(super::testRepeatUnregisterTable)
-                .hasMessageContaining("unregisterTable is not supported for Iceberg JDBC catalogs");
+        return TableIdentifier.of(getSession().getSchema().orElseThrow(), tableName);
     }
 
     @Override
     protected void deleteDirectory(String location)
     {
-        // used when unregistering a table, which is not supported by the JDBC catalog
+        try {
+            deleteRecursively(Path.of(location), ALLOW_INSECURE);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }


### PR DESCRIPTION
## Description

Support `register_table` and `unregister_table` procedures in Iceberg JDBC catalog
Fixes #15853

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Add support for `register_table` and `unregister_table` procedures in JDBC catalog. ({issue}`15853`)
```
