### PR TITLE
Fix flaky spill tests

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/memory/TestMemoryManager.java
+++ b/testing/trino-tests/src/test/java/io/trino/memory/TestMemoryManager.java
@@ -48,6 +48,7 @@ import static io.trino.operator.BlockedReason.WAITING_FOR_MEMORY;
 import static io.trino.spi.StandardErrorCode.CLUSTER_OUT_OF_MEMORY;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static io.trino.testing.assertions.Assert.assertEventually;
+import static java.util.UUID.randomUUID;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -326,7 +327,7 @@ public class TestMemoryManager
                 // The user memory enforcement is tested in testQueryTotalMemoryLimit().
                 // Total memory = user memory + revocable memory.
                 .put("spill-enabled", "true")
-                .put("spiller-spill-path", Paths.get(System.getProperty("java.io.tmpdir"), "trino", "spills").toString())
+                .put("spiller-spill-path", Paths.get(System.getProperty("java.io.tmpdir"), "trino", "spills", randomUUID().toString()).toString())
                 .put("spiller-max-used-space-threshold", "1.0")
                 .buildOrThrow();
         try (QueryRunner queryRunner = createQueryRunner(SESSION, properties)) {

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestDistributedSpilledQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestDistributedSpilledQueries.java
@@ -25,6 +25,7 @@ import java.nio.file.Paths;
 
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDistributedSpilledQueries
@@ -49,7 +50,7 @@ public class TestDistributedSpilledQueries
                 .build();
 
         ImmutableMap<String, String> extraProperties = ImmutableMap.<String, String>builder()
-                .put("spiller-spill-path", Paths.get(System.getProperty("java.io.tmpdir"), "trino", "spills").toString())
+                .put("spiller-spill-path", Paths.get(System.getProperty("java.io.tmpdir"), "trino", "spills", randomUUID().toString()).toString())
                 .put("spiller-max-used-space-threshold", "1.0")
                 .put("memory-revoking-threshold", "0.0") // revoke always
                 .put("memory-revoking-target", "0.0")


### PR DESCRIPTION
FileSingleStreamSpillerFactory#cleanupOldSpillFiles() will cleanup spill files, which means there is a race condition when multiple spill tests are running
using same spill path.

* no release notes *

Fixes: https://github.com/trinodb/trino/issues/13288