### PR TITLE
Adjust the drop table logic for Delta Lake managed tables

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -1812,7 +1812,7 @@ public class DeltaLakeMetadata
         Table table = metastore.getTable(handle.getSchemaName(), handle.getTableName())
                 .orElseThrow(() -> new TableNotFoundException(handle.getSchemaTableName()));
 
-        metastore.dropTable(session, handle.getSchemaName(), handle.getTableName(), table.getTableType().equals(EXTERNAL_TABLE.toString()));
+        metastore.dropTable(session, handle.getSchemaName(), handle.getTableName(), table.getTableType().equals(MANAGED_TABLE.toString()));
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
@@ -45,7 +45,7 @@ public interface DeltaLakeMetastore
 
     void createTable(ConnectorSession session, Table table, PrincipalPrivileges principalPrivileges);
 
-    void dropTable(ConnectorSession session, String databaseName, String tableName, boolean externalTable);
+    void dropTable(ConnectorSession session, String databaseName, String tableName, boolean deleteData);
 
     void renameTable(ConnectorSession session, SchemaTableName from, SchemaTableName to);
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -166,13 +166,13 @@ public class HiveMetastoreBackedDeltaLakeMetastore
     }
 
     @Override
-    public void dropTable(ConnectorSession session, String databaseName, String tableName, boolean externalTable)
+    public void dropTable(ConnectorSession session, String databaseName, String tableName, boolean deleteData)
     {
         String tableLocation = getTableLocation(new SchemaTableName(databaseName, tableName), session);
-        delegate.dropTable(databaseName, tableName, true);
+        delegate.dropTable(databaseName, tableName, deleteData);
         statisticsAccess.invalidateCache(tableLocation);
         transactionLogAccess.invalidateCaches(tableLocation);
-        if (!externalTable) {
+        if (deleteData) {
             try {
                 fileSystemFactory.create(session).deleteDirectory(tableLocation);
             }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
@@ -261,7 +261,7 @@ public class TestDeltaLakeSplitManager
         }
 
         @Override
-        public void dropTable(ConnectorSession session, String databaseName, String tableName, boolean externalTable)
+        public void dropTable(ConnectorSession session, String databaseName, String tableName, boolean deleteData)
         {
             throw new UnsupportedOperationException("Unimplemented");
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Advise the metastore to delete table data only when dealing with managed tables.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Delta Lake same as Hive works with `MANAGED` and `EXTERNAL` table types. In case of dealing with `MANAGED` tables, the engine is responsible (either through delegating internally this responsibility to the metastore - HMS or doing this operation itself in case of AWS) to remove the content of the table when executing `DROP TABLE table_name` statements.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
