### PR TITLE
fix estimatedWrittenBytes bug

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/exchange/UniformPartitionRebalancer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/UniformPartitionRebalancer.java
@@ -161,9 +161,12 @@ public class UniformPartitionRebalancer
 
             for (WriterId minSkewedWriter : minSkewedWriters) {
                 // There's no need to add the maxWriter back to priority queues if no partition rebalancing happened
-                if (context.rebalancePartition(maxWriter, minSkewedWriter)) {
-                    maxWriters.addOrUpdate(maxWriter, context.getWriterEstimatedWrittenBytes(maxWriter));
-                    minWriters.addOrUpdate(maxWriter, Long.MAX_VALUE - context.getWriterEstimatedWrittenBytes(maxWriter));
+                List<WriterId> affectedWriters = context.rebalancePartition(maxWriter, minSkewedWriter);
+                if (!affectedWriters.isEmpty()) {
+                    for (WriterId affectedWriter : affectedWriters) {
+                        maxWriters.addOrUpdate(affectedWriter, context.getWriterEstimatedWrittenBytes(maxWriter));
+                        minWriters.addOrUpdate(affectedWriter, Long.MAX_VALUE - context.getWriterEstimatedWrittenBytes(maxWriter));
+                    }
                     break;
                 }
             }
@@ -256,9 +259,10 @@ public class UniformPartitionRebalancer
             });
         }
 
-        private boolean rebalancePartition(WriterId from, WriterId to)
+        private List<WriterId> rebalancePartition(WriterId from, WriterId to)
         {
             IndexedPriorityQueue<PartitionIdWithRowCount> maxPartitions = writerMaxPartitions.get(from.id);
+            ImmutableList.Builder<WriterId> affectedWriters = ImmutableList.builder();
 
             for (PartitionIdWithRowCount partitionToRebalance : maxPartitions) {
                 // Find the partition with maximum written bytes since last rebalance
@@ -280,25 +284,33 @@ public class UniformPartitionRebalancer
                     if (partitionInfo.getWriterCount() <= numberOfWriters && estimatedPartitionWrittenBytes >= writerMinSize) {
                         partitionInfo.addWriter(to.id);
                         rebalancedPartitions.add(partitionToRebalance.id);
-                        updateWriterEstimatedWrittenBytes(from, to, estimatedPartitionWrittenBytesSinceLastRebalance, partitionInfo.getWriterCount());
+                        updateWriterEstimatedWrittenBytes(to, estimatedPartitionWrittenBytesSinceLastRebalance, partitionInfo);
+                        for (int writer : partitionInfo.getWriterIds()) {
+                            affectedWriters.add(new WriterId(writer));
+                        }
                         log.debug("Scaled partition (%s) to writer %s with writer count %s", partitionToRebalance.id, to.id, partitionInfo.getWriterCount());
-                        return true;
                     }
 
                     break;
                 }
             }
 
-            return false;
+            return affectedWriters.build();
         }
 
-        private void updateWriterEstimatedWrittenBytes(WriterId from, WriterId to, long estimatedPartitionWrittenBytesSinceLastRebalance, int newWriterCount)
+        private void updateWriterEstimatedWrittenBytes(WriterId to, long estimatedPartitionWrittenBytesSinceLastRebalance, PartitionInfo partitionInfo)
         {
             // Since a partition is rebalanced from max to min skewed writer, decrease the priority of max
             // writer as well as increase the priority of min writer.
+            int newWriterCount = partitionInfo.getWriterCount();
             int oldWriterCount = newWriterCount - 1;
-            writerEstimatedWrittenBytes[from.id] -= (estimatedPartitionWrittenBytesSinceLastRebalance * oldWriterCount) / newWriterCount;
-            writerEstimatedWrittenBytes[to.id] += (estimatedPartitionWrittenBytesSinceLastRebalance * oldWriterCount) / newWriterCount;
+            for (int writer : partitionInfo.getWriterIds()) {
+                if (writer != to.id) {
+                    writerEstimatedWrittenBytes[writer] -= estimatedPartitionWrittenBytesSinceLastRebalance / newWriterCount;
+                }
+            }
+
+            writerEstimatedWrittenBytes[to.id] += estimatedPartitionWrittenBytesSinceLastRebalance * oldWriterCount / newWriterCount;
         }
 
         private long getWriterEstimatedWrittenBytes(WriterId writer)

--- a/core/trino-main/src/test/java/io/trino/operator/exchange/TestUniformPartitionRebalancer.java
+++ b/core/trino-main/src/test/java/io/trino/operator/exchange/TestUniformPartitionRebalancer.java
@@ -108,6 +108,208 @@ public class TestUniformPartitionRebalancer
     }
 
     @Test
+    public void testComputeRebalanceThroughputWithAllWritersOfTheSamePartition()
+    {
+        AtomicLong physicalWrittenBytesForWriter0 = new AtomicLong(0);
+        AtomicLong physicalWrittenBytesForWriter1 = new AtomicLong(0);
+        AtomicLong physicalWrittenBytesForWriter2 = new AtomicLong(0);
+        AtomicLong physicalWrittenBytesForWriter3 = new AtomicLong(0);
+        AtomicLong physicalWrittenBytesForWriter4 = new AtomicLong(0);
+        AtomicLong physicalWrittenBytesForWriter5 = new AtomicLong(0);
+        List<Supplier<Long>> writerPhysicalWrittenBytes = ImmutableList.of(
+                physicalWrittenBytesForWriter0::get,
+                physicalWrittenBytesForWriter1::get,
+                physicalWrittenBytesForWriter2::get,
+                physicalWrittenBytesForWriter3::get,
+                physicalWrittenBytesForWriter4::get,
+                physicalWrittenBytesForWriter5::get);
+        AtomicReference<Long2LongMap> partitionRowCounts = new AtomicReference<>(new Long2LongOpenHashMap());
+
+        UniformPartitionRebalancer partitionRebalancer = new UniformPartitionRebalancer(
+                writerPhysicalWrittenBytes,
+                partitionRowCounts::get,
+                2,
+                6,
+                DataSize.of(4, MEGABYTE).toBytes());
+
+        // init 6 writers and 2 partitions, so partition0 -> writer0 and partition1 -> writer1
+        assertThat(getWriterIdsForPartitions(partitionRebalancer, 2))
+                .containsExactly(
+                        ImmutableList.of(0),
+                        ImmutableList.of(1));
+
+        // new data, partition0 -> writer0 has 100M, and partition1 -> writer1 has 1M
+        partitionRowCounts.set(serializeToLong2LongMap(ImmutableMap.of(
+                new WriterPartitionId(0, 0), 10000L,
+                new WriterPartitionId(1, 1), 100L)));
+
+        physicalWrittenBytesForWriter0.set(DataSize.of(100, MEGABYTE).toBytes());
+        physicalWrittenBytesForWriter1.set(DataSize.of(1, MEGABYTE).toBytes());
+
+        partitionRebalancer.rebalancePartitions();
+
+        // check partition0 rebalanced, partition0 -> writer[0, 2]
+        // partition1's data is less than threshold.
+        assertThat(getWriterIdsForPartitions(partitionRebalancer, 2))
+                .containsExactly(
+                        ImmutableList.of(0, 2),
+                        ImmutableList.of(1));
+
+        // new data, partition0 -> writer[0, 2] each has 100M, and partition1 -> writer1 has 1M
+        partitionRowCounts.set(serializeToLong2LongMap(ImmutableMap.of(
+                new WriterPartitionId(0, 0), 20000L,
+                new WriterPartitionId(1, 1), 200L,
+                new WriterPartitionId(2, 0), 10000L)));
+
+        physicalWrittenBytesForWriter0.set(DataSize.of(200, MEGABYTE).toBytes());
+        physicalWrittenBytesForWriter1.set(DataSize.of(2, MEGABYTE).toBytes());
+        physicalWrittenBytesForWriter2.set(DataSize.of(100, MEGABYTE).toBytes());
+
+        partitionRebalancer.rebalancePartitions();
+
+        // check partition0 rebalanced, partition0 -> writer[0, 2, 3]
+        // partition1's data is less than threshold.
+        assertThat(getWriterIdsForPartitions(partitionRebalancer, 2))
+                .containsExactly(
+                        ImmutableList.of(0, 2, 3),
+                        ImmutableList.of(1));
+
+        // new data, partition0 -> writer[0, 2, 3] each has 100M, and partition1 -> writer1 has 1M
+        partitionRowCounts.set(serializeToLong2LongMap(ImmutableMap.of(
+                new WriterPartitionId(0, 0), 30000L,
+                new WriterPartitionId(1, 1), 300L,
+                new WriterPartitionId(2, 0), 20000L,
+                new WriterPartitionId(3, 0), 10000L)));
+
+        physicalWrittenBytesForWriter0.set(DataSize.of(300, MEGABYTE).toBytes());
+        physicalWrittenBytesForWriter1.set(DataSize.of(3, MEGABYTE).toBytes());
+        physicalWrittenBytesForWriter2.set(DataSize.of(200, MEGABYTE).toBytes());
+        physicalWrittenBytesForWriter3.set(DataSize.of(100, MEGABYTE).toBytes());
+
+        partitionRebalancer.rebalancePartitions();
+
+        // check partition0 rebalanced, partition0 -> writer[0, 2, 3, 4]
+        // partition1's data is less than threshold.
+        assertThat(getWriterIdsForPartitions(partitionRebalancer, 2))
+                .containsExactly(
+                        ImmutableList.of(0, 2, 3, 4),
+                        ImmutableList.of(1));
+
+        // new data, partition0 -> writer[0, 2, 3, 4] each has 100M, and partition1 -> writer1 has 90M
+        partitionRowCounts.set(serializeToLong2LongMap(ImmutableMap.of(
+                new WriterPartitionId(0, 0), 40000L,
+                new WriterPartitionId(1, 1), 9300L,
+                new WriterPartitionId(2, 0), 30000L,
+                new WriterPartitionId(3, 0), 20000L,
+                new WriterPartitionId(4, 0), 10000L)));
+
+        physicalWrittenBytesForWriter0.set(DataSize.of(400, MEGABYTE).toBytes());
+        physicalWrittenBytesForWriter1.set(DataSize.of(93, MEGABYTE).toBytes());
+        physicalWrittenBytesForWriter2.set(DataSize.of(300, MEGABYTE).toBytes());
+        physicalWrittenBytesForWriter3.set(DataSize.of(200, MEGABYTE).toBytes());
+        physicalWrittenBytesForWriter4.set(DataSize.of(100, MEGABYTE).toBytes());
+
+        partitionRebalancer.rebalancePartitions();
+
+        // check partition0 be rebalanced, partition0 -> writer[0, 2, 3, 4, 5]
+        // only partition0 rebalanced, because after rebalanced partition0
+        // we estimate 6 writers' throughput are [80, 90, 80, 80, 80, 80],
+        // and data skew is less than threshold.
+        assertThat(getWriterIdsForPartitions(partitionRebalancer, 2))
+                .containsExactly(
+                        ImmutableList.of(0, 2, 3, 4, 5),
+                        ImmutableList.of(1));
+    }
+
+    @Test
+    public void testRebalanceAffectAllWritersOfTheSamePartition()
+    {
+        AtomicLong physicalWrittenBytesForWriter0 = new AtomicLong(0);
+        AtomicLong physicalWrittenBytesForWriter1 = new AtomicLong(0);
+        AtomicLong physicalWrittenBytesForWriter2 = new AtomicLong(0);
+        AtomicLong physicalWrittenBytesForWriter3 = new AtomicLong(0);
+        List<Supplier<Long>> writerPhysicalWrittenBytes = ImmutableList.of(
+                physicalWrittenBytesForWriter0::get,
+                physicalWrittenBytesForWriter1::get,
+                physicalWrittenBytesForWriter2::get,
+                physicalWrittenBytesForWriter3::get);
+        AtomicReference<Long2LongMap> partitionRowCounts = new AtomicReference<>(new Long2LongOpenHashMap());
+
+        UniformPartitionRebalancer partitionRebalancer = new UniformPartitionRebalancer(
+                writerPhysicalWrittenBytes,
+                partitionRowCounts::get,
+                3,
+                4,
+                DataSize.of(4, MEGABYTE).toBytes());
+
+        // init 4 writers and 3 partitions, so partition0 -> writer0, partition1 -> writer1 and
+        // partition2 -> writer2
+        assertThat(getWriterIdsForPartitions(partitionRebalancer, 3))
+                .containsExactly(
+                        ImmutableList.of(0),
+                        ImmutableList.of(1),
+                        ImmutableList.of(2));
+
+        // new data, partition0 -> writer0 has 100M
+        partitionRowCounts.set(serializeToLong2LongMap(ImmutableMap.of(
+                new WriterPartitionId(0, 0), 10000L)));
+
+        physicalWrittenBytesForWriter0.set(DataSize.of(100, MEGABYTE).toBytes());
+
+        partitionRebalancer.rebalancePartitions();
+
+        // check partition0 rebalanced, partition0 -> writer[0, 1]
+        assertThat(getWriterIdsForPartitions(partitionRebalancer, 3))
+                .containsExactly(
+                        ImmutableList.of(0, 1),
+                        ImmutableList.of(1),
+                        ImmutableList.of(2));
+
+        // new data, partition1 -> writer1 has 100M
+        partitionRowCounts.set(serializeToLong2LongMap(ImmutableMap.of(
+                new WriterPartitionId(0, 0), 10000L,
+                new WriterPartitionId(1, 1), 10000L)));
+
+        physicalWrittenBytesForWriter0.set(DataSize.of(100, MEGABYTE).toBytes());
+        physicalWrittenBytesForWriter1.set(DataSize.of(100, MEGABYTE).toBytes());
+
+        partitionRebalancer.rebalancePartitions();
+
+        // check partition1 rebalanced, partition0 -> writer[0, 1], partition1 -> writer[1, 0]
+        assertThat(getWriterIdsForPartitions(partitionRebalancer, 3))
+                .containsExactly(
+                        ImmutableList.of(0, 1),
+                        ImmutableList.of(1, 0),
+                        ImmutableList.of(2));
+
+        // new data, partition0 -> wrter0 31M, partition0 -> writer1 30M
+        // partition1 -> writer0 10M, partition1 -> writer1 10M
+        // partition2 -> writer2 10M
+        partitionRowCounts.set(serializeToLong2LongMap(ImmutableMap.of(
+                new WriterPartitionId(0, 0), 13000L,
+                new WriterPartitionId(0, 1), 3000L,
+                new WriterPartitionId(1, 0), 1000L,
+                new WriterPartitionId(1, 1), 11000L,
+                new WriterPartitionId(2, 2), 1000L)));
+
+        physicalWrittenBytesForWriter0.set(DataSize.of(141, MEGABYTE).toBytes());
+        physicalWrittenBytesForWriter1.set(DataSize.of(140, MEGABYTE).toBytes());
+        physicalWrittenBytesForWriter2.set(DataSize.of(10, MEGABYTE).toBytes());
+
+        partitionRebalancer.rebalancePartitions();
+
+        // check partition0 rebalanced, partition0 -> writer[0, 1, 3]
+        // this affect the writer1 and writer3's throughput,
+        // now all writers' throughput is [30, 30, 10, 20] and the skew is less than threshold,
+        // no more rebalance needed.
+        assertThat(getWriterIdsForPartitions(partitionRebalancer, 3))
+                .containsExactly(
+                        ImmutableList.of(0, 1, 3),
+                        ImmutableList.of(1, 0),
+                        ImmutableList.of(2));
+    }
+
+    @Test
     public void testNoRebalanceWhenDataWrittenIsLessThanTheRebalanceLimit()
     {
         AtomicLong physicalWrittenBytesForWriter0 = new AtomicLong(0);


### PR DESCRIPTION
Signed-off-by: zombee0 <flylucas_10@163.com>

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

We can assume that there were originally two writers and now there are three writers, so the load of each old writer is reduced by 1/3, and the load of the new writer is increased by 2/3.
before: writer0->100, writer1->100;
after:writer0->66, writer1->66; writer2->66;

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
