### PR TITLE
Optimize DELTA_LENGTH_BYTE_ARRAY decoder in parquet

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/SimpleSliceInputStream.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/SimpleSliceInputStream.java
@@ -89,6 +89,13 @@ public final class SimpleSliceInputStream
         offset += length;
     }
 
+    public Slice readSlice(int length)
+    {
+        Slice result = slice.slice(offset, length);
+        offset += length;
+        return result;
+    }
+
     public void skip(int n)
     {
         offset += n;

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/DeltaLengthByteArrayDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/DeltaLengthByteArrayDecoders.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import io.trino.parquet.reader.flat.BinaryBuffer;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.VarcharType;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.parquet.reader.decoders.DeltaBinaryPackedDecoders.DeltaBinaryPackedIntDecoder;
+import static io.trino.spi.type.Chars.byteCountWithoutTrailingSpace;
+import static io.trino.spi.type.Varchars.byteCount;
+import static java.lang.Math.max;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Implementation of decoding for the encoding described at
+ * <a href="https://github.com/apache/parquet-format/blob/master/Encodings.md#delta-length-byte-array-delta_length_byte_array--6">delta-length-byte-array</a>.
+ * Data encoding here is identical to the one in Trino block. It the values are
+ * not trimmed due to type bounds, it will push a single Slice object that will
+ * effectively be used in Trino blocks without copying.
+ * <p>
+ * If the trimming occurs, data will be copied into a single byte array
+ */
+public class DeltaLengthByteArrayDecoders
+{
+    private DeltaLengthByteArrayDecoders() {}
+
+    public static final class BoundedVarcharDeltaLengthDecoder
+            extends AbstractDeltaLengthDecoder
+    {
+        private final int boundedLength;
+
+        public BoundedVarcharDeltaLengthDecoder(VarcharType varcharType)
+        {
+            checkArgument(
+                    !varcharType.isUnbounded(),
+                    "Trino type %s is not a bounded varchar",
+                    varcharType);
+            this.boundedLength = varcharType.getBoundedLength();
+        }
+
+        @Override
+        public void read(BinaryBuffer values, int offset, int length)
+        {
+            InputLengths lengths = getInputAndMaxLength(length);
+            int maxLength = lengths.maxInputLength();
+            int totalInputLength = lengths.totalInputLength();
+            boolean truncate = maxLength > boundedLength;
+            if (truncate) {
+                readBounded(values, offset, length, totalInputLength);
+            }
+            else {
+                readUnbounded(values, offset, length, totalInputLength);
+            }
+        }
+
+        @Override
+        protected int truncatedLength(Slice slice, int offset, int length)
+        {
+            return byteCount(slice, offset, length, boundedLength);
+        }
+    }
+
+    public static final class CharDeltaLengthDecoder
+            extends AbstractDeltaLengthDecoder
+    {
+        private final int maxLength;
+
+        public CharDeltaLengthDecoder(CharType charType)
+        {
+            this.maxLength = charType.getLength();
+        }
+
+        @Override
+        public void read(BinaryBuffer values, int offset, int length)
+        {
+            int totalInputLength = getInputLength(length);
+            readBounded(values, offset, length, totalInputLength);
+        }
+
+        @Override
+        protected int truncatedLength(Slice slice, int offset, int length)
+        {
+            return byteCountWithoutTrailingSpace(slice, offset, length, maxLength);
+        }
+    }
+
+    public static final class BinaryDeltaLengthDecoder
+            extends AbstractDeltaLengthDecoder
+    {
+        @Override
+        protected int truncatedLength(Slice slice, int offset, int length)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void read(BinaryBuffer values, int offset, int length)
+        {
+            int totalInputLength = getInputLength(length);
+            readUnbounded(values, offset, length, totalInputLength);
+        }
+    }
+
+    private abstract static class AbstractDeltaLengthDecoder
+            implements ValueDecoder<BinaryBuffer>
+    {
+        private int[] inputLengths;
+        private int inputLengthsOffset;
+        private SimpleSliceInputStream input;
+
+        @Override
+        public void init(SimpleSliceInputStream input)
+        {
+            this.input = requireNonNull(input, "input is null");
+            this.inputLengths = readInputLengths(input);
+        }
+
+        @Override
+        public void skip(int n)
+        {
+            int totalInputLength = getInputLength(n);
+            input.skip(totalInputLength);
+            inputLengthsOffset += n;
+        }
+
+        protected abstract int truncatedLength(Slice slice, int offset, int length);
+
+        protected int getInputLength(int length)
+        {
+            int totalInputLength = 0;
+            for (int i = 0; i < length; i++) {
+                totalInputLength += inputLengths[inputLengthsOffset + i];
+            }
+            return totalInputLength;
+        }
+
+        protected InputLengths getInputAndMaxLength(int length)
+        {
+            int totalInputLength = 0;
+            int maxLength = 0;
+            for (int i = 0; i < length; i++) {
+                int inputLength = inputLengths[inputLengthsOffset + i];
+                totalInputLength += inputLength;
+                maxLength = max(maxLength, inputLength);
+            }
+            return new InputLengths(totalInputLength, maxLength);
+        }
+
+        protected void readUnbounded(BinaryBuffer values, int offset, int length, int totalInputLength)
+        {
+            values.addChunk(input.readSlice(totalInputLength));
+            int[] outputOffsets = values.getOffsets();
+
+            // Some positions in offsets might have been skipped before this read,
+            // adjust for this difference when copying offsets to the output
+            int outputLength = 0;
+            int baseOutputOffset = outputOffsets[offset];
+            for (int i = 0; i < length; i++) {
+                outputLength += inputLengths[inputLengthsOffset + i];
+                outputOffsets[offset + i + 1] = baseOutputOffset + outputLength;
+            }
+            inputLengthsOffset += length;
+        }
+
+        protected void readBounded(BinaryBuffer values, int offset, int length, int totalInputLength)
+        {
+            // Use offset arrays to temporarily store output lengths
+            int[] outputOffsets = values.getOffsets();
+            Slice inputSlice = input.readSlice(totalInputLength);
+
+            int currentInputOffset = 0;
+            int totalOutputLength = 0;
+            int baseOutputOffset = outputOffsets[offset];
+            for (int i = 0; i < length; i++) {
+                int currentLength = inputLengths[inputLengthsOffset + i];
+
+                int currentOutputLength = truncatedLength(inputSlice, currentInputOffset, currentLength);
+                currentInputOffset += currentLength;
+                totalOutputLength += currentOutputLength;
+                outputOffsets[offset + i + 1] = baseOutputOffset + totalOutputLength;
+            }
+
+            // No copying needed if there was no truncation
+            if (totalOutputLength == totalInputLength) {
+                values.addChunk(inputSlice);
+            }
+            else {
+                values.addChunk(createOutputBuffer(outputOffsets, offset, length, inputSlice, totalOutputLength));
+            }
+            inputLengthsOffset += length;
+        }
+
+        /**
+         * Constructs the output buffer out of input data and length array
+         */
+        private Slice createOutputBuffer(
+                int[] outputOffsets,
+                int offset,
+                int length,
+                Slice inputSlice,
+                int totalOutputLength)
+        {
+            byte[] output = new byte[totalOutputLength];
+            int outputOffset = 0;
+            int outputLength = 0;
+            int currentInputOffset = 0;
+            int inputLength = 0;
+            for (int i = 0; i < length; i++) {
+                outputLength += outputOffsets[offset + i + 1] - outputOffsets[offset + i];
+                inputLength += inputLengths[inputLengthsOffset + i];
+
+                if (outputLength != inputLength) {
+                    inputSlice.getBytes(currentInputOffset, output, outputOffset, outputLength);
+                    currentInputOffset += inputLength;
+                    inputLength = 0;
+                    outputOffset += outputLength;
+                    outputLength = 0;
+                }
+            }
+            if (outputLength != 0) { // Write the remaining slice
+                inputSlice.getBytes(currentInputOffset, output, outputOffset, outputLength);
+            }
+            return Slices.wrappedBuffer(output);
+        }
+
+        protected record InputLengths(int totalInputLength, int maxInputLength) {}
+    }
+
+    private static int[] readInputLengths(SimpleSliceInputStream input)
+    {
+        DeltaBinaryPackedIntDecoder decoder = new DeltaBinaryPackedIntDecoder();
+        decoder.init(input);
+        int valueCount = decoder.getValueCount();
+        int[] lengths = new int[valueCount];
+        decoder.read(lengths, 0, valueCount);
+        return lengths;
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
@@ -41,6 +41,9 @@ import static io.trino.parquet.reader.decoders.DeltaBinaryPackedDecoders.DeltaBi
 import static io.trino.parquet.reader.decoders.DeltaBinaryPackedDecoders.DeltaBinaryPackedIntDecoder;
 import static io.trino.parquet.reader.decoders.DeltaBinaryPackedDecoders.DeltaBinaryPackedLongDecoder;
 import static io.trino.parquet.reader.decoders.DeltaBinaryPackedDecoders.DeltaBinaryPackedShortDecoder;
+import static io.trino.parquet.reader.decoders.DeltaLengthByteArrayDecoders.BinaryDeltaLengthDecoder;
+import static io.trino.parquet.reader.decoders.DeltaLengthByteArrayDecoders.BoundedVarcharDeltaLengthDecoder;
+import static io.trino.parquet.reader.decoders.DeltaLengthByteArrayDecoders.CharDeltaLengthDecoder;
 import static io.trino.parquet.reader.decoders.PlainByteArrayDecoders.BinaryPlainValueDecoder;
 import static io.trino.parquet.reader.decoders.PlainByteArrayDecoders.BoundedVarcharPlainValueDecoder;
 import static io.trino.parquet.reader.decoders.PlainByteArrayDecoders.CharPlainValueDecoder;
@@ -206,7 +209,8 @@ public final class ValueDecoders
                 trinoType);
         return switch (encoding) {
             case PLAIN -> new BoundedVarcharPlainValueDecoder((VarcharType) trinoType);
-            case DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY ->
+            case DELTA_LENGTH_BYTE_ARRAY -> new BoundedVarcharDeltaLengthDecoder((VarcharType) trinoType);
+            case DELTA_BYTE_ARRAY ->
                     new BoundedVarcharApacheParquetValueDecoder(getApacheParquetReader(encoding, field), (VarcharType) trinoType);
             default -> throw wrongEncoding(encoding, field);
         };
@@ -221,7 +225,8 @@ public final class ValueDecoders
                 trinoType);
         return switch (encoding) {
             case PLAIN -> new CharPlainValueDecoder((CharType) trinoType);
-            case DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY ->
+            case DELTA_LENGTH_BYTE_ARRAY -> new CharDeltaLengthDecoder((CharType) trinoType);
+            case DELTA_BYTE_ARRAY ->
                     new CharApacheParquetValueDecoder(getApacheParquetReader(encoding, field), (CharType) trinoType);
             default -> throw wrongEncoding(encoding, field);
         };
@@ -231,7 +236,8 @@ public final class ValueDecoders
     {
         return switch (encoding) {
             case PLAIN -> new BinaryPlainValueDecoder();
-            case DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY ->
+            case DELTA_LENGTH_BYTE_ARRAY -> new BinaryDeltaLengthDecoder();
+            case DELTA_BYTE_ARRAY ->
                     new BinaryApacheParquetValueDecoder(getApacheParquetReader(encoding, field));
             default -> throw wrongEncoding(encoding, field);
         };

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkBinaryColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkBinaryColumnReader.java
@@ -20,6 +20,7 @@ import io.trino.spi.type.VarcharType;
 import org.apache.parquet.bytes.HeapByteBufferAllocator;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesWriter;
 import org.apache.parquet.column.values.deltastrings.DeltaByteArrayWriter;
 import org.apache.parquet.column.values.plain.PlainValuesWriter;
 import org.apache.parquet.io.api.Binary;
@@ -94,6 +95,13 @@ public class BenchmarkBinaryColumnReader
             ValuesWriter getWriter(int bufferSize)
             {
                 return new DeltaByteArrayWriter(bufferSize, bufferSize, HeapByteBufferAllocator.getInstance());
+            }
+        },
+        DELTA_LENGTH_BYTE_ARRAY {
+            @Override
+            ValuesWriter getWriter(int bufferSize)
+            {
+                return new DeltaLengthByteArrayValuesWriter(bufferSize, bufferSize, HeapByteBufferAllocator.getInstance());
             }
         };
 

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/AbstractValueDecodersTest.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/AbstractValueDecodersTest.java
@@ -33,6 +33,7 @@ import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForLong;
+import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesWriter;
 import org.apache.parquet.column.values.plain.BooleanPlainValuesWriter;
 import org.apache.parquet.column.values.plain.FixedLenByteArrayPlainValuesWriter;
 import org.apache.parquet.column.values.plain.PlainValuesWriter;
@@ -61,6 +62,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.parquet.ParquetEncoding.DELTA_BINARY_PACKED;
+import static io.trino.parquet.ParquetEncoding.DELTA_LENGTH_BYTE_ARRAY;
 import static io.trino.parquet.ParquetEncoding.PLAIN;
 import static io.trino.parquet.ParquetEncoding.PLAIN_DICTIONARY;
 import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
@@ -82,6 +84,7 @@ import static org.apache.parquet.column.values.dictionary.DictionaryValuesWriter
 import static org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainIntegerDictionaryValuesWriter;
 import static org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainLongDictionaryValuesWriter;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 
 public abstract class AbstractValueDecodersTest
 {
@@ -377,6 +380,12 @@ public abstract class AbstractValueDecodersTest
                 case INT64 -> new DeltaBinaryPackingValuesWriterForLong(MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
                 default -> throw new IllegalArgumentException("Delta binary packing encoding writer is not supported for type " + typeName);
             };
+        }
+        if (encoding.equals(DELTA_LENGTH_BYTE_ARRAY)) {
+            if (typeName.equals(BINARY)) {
+                return new DeltaLengthByteArrayValuesWriter(MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
+            }
+            throw new IllegalArgumentException("Delta length byte array encoding writer is not supported for type " + typeName);
         }
         throw new UnsupportedOperationException(format("Encoding %s is not supported", encoding));
     }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestByteArrayValueDecoders.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestByteArrayValueDecoders.java
@@ -29,6 +29,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static io.trino.parquet.ParquetEncoding.DELTA_LENGTH_BYTE_ARRAY;
 import static io.trino.parquet.ParquetEncoding.PLAIN;
 import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
 import static io.trino.parquet.reader.TestData.randomAsciiData;
@@ -64,7 +65,7 @@ public final class TestByteArrayValueDecoders
                                 BinaryApacheParquetValueDecoder::new,
                                 BINARY_ADAPTER,
                                 BINARY_ASSERT),
-                        ImmutableList.of(PLAIN, RLE_DICTIONARY),
+                        ImmutableList.of(PLAIN, RLE_DICTIONARY, DELTA_LENGTH_BYTE_ARRAY),
                         generateUnboundedBinaryInputs()),
                 testArgs(
                         new TestType<>(
@@ -73,15 +74,15 @@ public final class TestByteArrayValueDecoders
                                 BinaryApacheParquetValueDecoder::new,
                                 BINARY_ADAPTER,
                                 BINARY_ASSERT),
-                        ImmutableList.of(PLAIN, RLE_DICTIONARY),
+                        ImmutableList.of(PLAIN, RLE_DICTIONARY, DELTA_LENGTH_BYTE_ARRAY),
                         generateUnboundedBinaryInputs()),
                 testArgs(
                         createBoundedVarcharTestType(),
-                        ImmutableList.of(PLAIN, RLE_DICTIONARY),
+                        ImmutableList.of(PLAIN, RLE_DICTIONARY, DELTA_LENGTH_BYTE_ARRAY),
                         generateBoundedVarcharInputs()),
                 testArgs(
                         createCharTestType(),
-                        ImmutableList.of(PLAIN, RLE_DICTIONARY),
+                        ImmutableList.of(PLAIN, RLE_DICTIONARY, DELTA_LENGTH_BYTE_ARRAY),
                         generateCharInputs()));
     }
 


### PR DESCRIPTION
## Description
Optimize DELTA_LENGTH_BYTE_ARRAY decoder in parquet

```
Benchmark                         (positionLength)                             (type)   Mode  Cnt    Before             After              Units
BenchmarkBinaryColumnReader.read    VARIABLE_0_100                          UNBOUNDED  thrpt   10    1.795 ±  0.793     87.765 ±    6.190  ops/s
BenchmarkBinaryColumnReader.read    VARIABLE_0_100          VARCHAR_ASCII_BOUND_EXACT  thrpt   10    2.065 ±  0.539     96.691 ±   13.081  ops/s
BenchmarkBinaryColumnReader.read    VARIABLE_0_100              CHAR_ASCII_BOUND_HALF  thrpt   10    2.401 ±  0.134      5.792 ±    1.579  ops/s
BenchmarkBinaryColumnReader.read    VARIABLE_0_100  CHAR_BOUND_HALF_PADDING_SOMETIMES  thrpt   10    2.607 ±  0.113      7.328 ±    2.045  ops/s
BenchmarkBinaryColumnReader.read   VARIABLE_0_1000                          UNBOUNDED  thrpt   10  669.902 ± 85.391  72508.841 ± 1083.144  ops/s
BenchmarkBinaryColumnReader.read   VARIABLE_0_1000          VARCHAR_ASCII_BOUND_EXACT  thrpt   10  587.317 ± 21.659  66455.490 ± 1082.769  ops/s
BenchmarkBinaryColumnReader.read   VARIABLE_0_1000              CHAR_ASCII_BOUND_HALF  thrpt   10  505.577 ± 69.876   1758.385 ±   37.769  ops/s
BenchmarkBinaryColumnReader.read   VARIABLE_0_1000  CHAR_BOUND_HALF_PADDING_SOMETIMES  thrpt   10  472.345 ± 60.199   1683.888 ±   45.331  ops/s
BenchmarkBinaryColumnReader.read          FIXED_10                          UNBOUNDED  thrpt   10    4.192 ±  0.806    252.310 ±    7.160  ops/s
BenchmarkBinaryColumnReader.read          FIXED_10          VARCHAR_ASCII_BOUND_EXACT  thrpt   10    3.741 ±  0.761    241.414 ±    5.647  ops/s
BenchmarkBinaryColumnReader.read          FIXED_10              CHAR_ASCII_BOUND_HALF  thrpt   10    3.386 ±  0.582     13.649 ±    0.220  ops/s
BenchmarkBinaryColumnReader.read          FIXED_10  CHAR_BOUND_HALF_PADDING_SOMETIMES  thrpt   10    4.587 ±  0.424     14.169 ±    0.302  ops/s
BenchmarkBinaryColumnReader.read         FIXED_100                          UNBOUNDED  thrpt   10  423.869 ± 26.744  31731.563 ±  842.399  ops/s
BenchmarkBinaryColumnReader.read         FIXED_100          VARCHAR_ASCII_BOUND_EXACT  thrpt   10  468.546 ± 13.797  27931.904 ±  438.979  ops/s
BenchmarkBinaryColumnReader.read         FIXED_100              CHAR_ASCII_BOUND_HALF  thrpt   10  348.080 ± 54.947    872.921 ±   63.038  ops/s
BenchmarkBinaryColumnReader.read         FIXED_100  CHAR_BOUND_HALF_PADDING_SOMETIMES  thrpt   10  337.808 ± 55.891    840.805 ±   74.542  ops/s
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Hudi, Delta, Iceberg
* Improve performance of reading string data types from parquet files. ({issue}`15897`)
```
