### PR TITLE
Remove unused FTE config property

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
@@ -179,11 +179,6 @@ queries/tasks are no longer retried in the event of repeated failures:
        declaring the query as failed.
      - ``4``
      - Only ``QUERY``
-   * - ``task-retry-attempts-overall``
-     - Maximum number retries across all tasks within a given query
-       before declaring the query as failed.
-     - ``null`` (no limit)
-     - Only ``TASK``
    * - ``task-retry-attempts-per-task``
      - Maximum number of times Trino may attempt to retry a single task before
        declaring the query as failed.
@@ -252,16 +247,6 @@ properties only apply to a ``TASK`` retry policy.
        ``fault_tolerant_execution_target_task_split_count``
        :ref:`session property <session-properties-definition>`.
      - ``64``
-   * - ``fault-tolerant-execution-min-task-split-count``
-     - Minimum number of :ref:`splits <trino-concept-splits>` processed by
-       a single task. This value is not split weight-adjusted and serves as
-       protection against situations where catalogs report an incorrect split
-       weight.
-
-       May be overridden for the current session with the
-       ``fault_tolerant_execution_min_task_split_count``
-       :ref:`session property <session-properties-definition>`.
-     - ``16``
    * - ``fault-tolerant-execution-max-task-split-count``
      - Maximum number of :ref:`splits <trino-concept-splits>` processed by a
        single task. This value is not split weight-adjusted and serves as

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
@@ -99,7 +99,6 @@ public abstract class BaseFailureRecoveryTest
                         .put("retry-policy", retryPolicy.toString())
                         .put("retry-initial-delay", "0s")
                         .put("query-retry-attempts", "1")
-                        .put("task-retry-attempts-overall", "1")
                         .put("failure-injection.request-timeout", new Duration(REQUEST_TIMEOUT.toMillis() * 2, MILLISECONDS).toString())
                         // making http timeouts shorter so tests which simulate communication timeouts finish in reasonable amount of time
                         .put("exchange.http-client.idle-timeout", REQUEST_TIMEOUT.toString())


### PR DESCRIPTION
Follow-up of https://github.com/trinodb/trino/commit/920d14c82c5adefd2f06feadfac1a0a96f9ff5ac