### PR TITLE
Translate SimpleCase expression to connector expression

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/expression/StandardFunctions.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/expression/StandardFunctions.java
@@ -96,4 +96,6 @@ public final class StandardFunctions
      * $array creates instance of {@link ArrayType}
      */
     public static final FunctionName ARRAY_CONSTRUCTOR_FUNCTION_NAME = new FunctionName("$array");
+
+    public static final FunctionName SIMPLE_CASE_WHEN_FUNCTION_NAME = new FunctionName("$simple_case_when");
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/expression/StandardFunctions.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/expression/StandardFunctions.java
@@ -98,4 +98,6 @@ public final class StandardFunctions
     public static final FunctionName ARRAY_CONSTRUCTOR_FUNCTION_NAME = new FunctionName("$array");
 
     public static final FunctionName SIMPLE_CASE_WHEN_FUNCTION_NAME = new FunctionName("$simple_case_when");
+
+    public static final FunctionName SIMPLE_CASE_WHEN_CONDITION_FUNCTION_NAME = new FunctionName("$simple_case_when_condition");
 }

--- a/lib/trino-matching/src/main/java/io/trino/matching/DefaultPrinter.java
+++ b/lib/trino-matching/src/main/java/io/trino/matching/DefaultPrinter.java
@@ -16,6 +16,7 @@ package io.trino.matching;
 import io.trino.matching.pattern.CapturePattern;
 import io.trino.matching.pattern.EqualsPattern;
 import io.trino.matching.pattern.FilterPattern;
+import io.trino.matching.pattern.TypeOfListPattern;
 import io.trino.matching.pattern.TypeOfPattern;
 import io.trino.matching.pattern.WithPattern;
 
@@ -37,6 +38,13 @@ public class DefaultPrinter
     {
         visitPrevious(pattern);
         appendLine("typeOf(%s)", pattern.expectedClass().getSimpleName());
+    }
+
+    @Override
+    public void visitTypeOfList(TypeOfListPattern<?> pattern)
+    {
+        visitPrevious(pattern);
+        appendLine("typeOfList(%s)", pattern.expectedClass().getSimpleName());
     }
 
     @Override

--- a/lib/trino-matching/src/main/java/io/trino/matching/Pattern.java
+++ b/lib/trino-matching/src/main/java/io/trino/matching/Pattern.java
@@ -16,9 +16,11 @@ package io.trino.matching;
 import com.google.common.collect.Iterables;
 import io.trino.matching.pattern.CapturePattern;
 import io.trino.matching.pattern.FilterPattern;
+import io.trino.matching.pattern.TypeOfListPattern;
 import io.trino.matching.pattern.TypeOfPattern;
 import io.trino.matching.pattern.WithPattern;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
@@ -39,6 +41,11 @@ public abstract class Pattern<T>
     public static <T> Pattern<T> typeOf(Class<T> expectedClass)
     {
         return new TypeOfPattern<>(expectedClass);
+    }
+
+    public static <T> Pattern<List<? extends T>> typeOfList(Class<T> expectedClass)
+    {
+        return new TypeOfListPattern<>(expectedClass);
     }
 
     protected Pattern(Pattern<?> previous)

--- a/lib/trino-matching/src/main/java/io/trino/matching/PatternVisitor.java
+++ b/lib/trino-matching/src/main/java/io/trino/matching/PatternVisitor.java
@@ -16,6 +16,7 @@ package io.trino.matching;
 import io.trino.matching.pattern.CapturePattern;
 import io.trino.matching.pattern.EqualsPattern;
 import io.trino.matching.pattern.FilterPattern;
+import io.trino.matching.pattern.TypeOfListPattern;
 import io.trino.matching.pattern.TypeOfPattern;
 import io.trino.matching.pattern.WithPattern;
 
@@ -24,6 +25,8 @@ import java.util.Optional;
 public interface PatternVisitor
 {
     void visitTypeOf(TypeOfPattern<?> pattern);
+
+    void visitTypeOfList(TypeOfListPattern<?> pattern);
 
     void visitWith(WithPattern<?> pattern);
 

--- a/lib/trino-matching/src/main/java/io/trino/matching/pattern/TypeOfListPattern.java
+++ b/lib/trino-matching/src/main/java/io/trino/matching/pattern/TypeOfListPattern.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.matching.pattern;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Match;
+import io.trino.matching.Pattern;
+import io.trino.matching.PatternVisitor;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+
+public class TypeOfListPattern<T>
+        extends Pattern<List<? extends T>>
+{
+    private final Class<T> expectedClass;
+
+    public TypeOfListPattern(Class<T> expectedClass)
+    {
+        this(expectedClass, Optional.empty());
+    }
+
+    public TypeOfListPattern(Class<T> expectedClass, Optional<Pattern<?>> previous)
+    {
+        super(previous);
+        this.expectedClass = requireNonNull(expectedClass, "expectedClass is null");
+    }
+
+    public Class<T> expectedClass()
+    {
+        return expectedClass;
+    }
+
+    @Override
+    public <C> Stream<Match> accept(Object object, Captures captures, C context)
+    {
+        if (object instanceof List<?> list) {
+            if (list.stream().allMatch(expectedClass::isInstance)) {
+                return Stream.of(Match.of(captures));
+            }
+        }
+        return Stream.of();
+    }
+
+    @Override
+    public void accept(PatternVisitor patternVisitor)
+    {
+        patternVisitor.visitTypeOfList(this);
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/expression/ConnectorExpressionIndex.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/expression/ConnectorExpressionIndex.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.expression;
+
+import io.trino.spi.type.Type;
+
+public class ConnectorExpressionIndex
+{
+    private final Type type;
+
+    private final int index;
+
+    private final boolean isLast;
+
+    public ConnectorExpressionIndex(Type type, int index, boolean isLast)
+    {
+        this.type = type;
+        this.index = index;
+        this.isLast = isLast;
+    }
+
+    public Type getType()
+    {
+        return type;
+    }
+
+    public int getIndex()
+    {
+        return index;
+    }
+
+    public boolean isLast()
+    {
+        return isLast;
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/expression/ConnectorExpressionPatterns.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/expression/ConnectorExpressionPatterns.java
@@ -132,9 +132,9 @@ public final class ConnectorExpressionPatterns
                 .collect(toImmutableList()));
     }
 
-    public static Predicate<List<? extends ConnectorExpression>> expressionTypes(Predicate<ConnectorExpressionIndex> predicate)
+    public static Predicate<List<? extends ConnectorExpression>> expressionsPredicate(Predicate<ConnectorExpressionWithIndex> predicate)
     {
         return expressions -> IntStream.range(0, expressions.size())
-                .allMatch(i -> predicate.test(new ConnectorExpressionIndex(expressions.get(i).getType(), i, i == expressions.size() - 1)));
+                .allMatch(i -> predicate.test(new ConnectorExpressionWithIndex(expressions.get(i), i, i == expressions.size() - 1)));
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/expression/ConnectorExpressionPatterns.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/expression/ConnectorExpressionPatterns.java
@@ -26,6 +26,7 @@ import io.trino.spi.type.Type;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -129,5 +130,11 @@ public final class ConnectorExpressionPatterns
         return expressions -> expectedTypes.equals(expressions.stream()
                 .map(ConnectorExpression::getType)
                 .collect(toImmutableList()));
+    }
+
+    public static Predicate<List<? extends ConnectorExpression>> expressionTypes(Predicate<ConnectorExpressionIndex> predicate)
+    {
+        return expressions -> IntStream.range(0, expressions.size())
+                .allMatch(i -> predicate.test(new ConnectorExpressionIndex(expressions.get(i).getType(), i, i == expressions.size() - 1)));
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/expression/ConnectorExpressionWithIndex.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/expression/ConnectorExpressionWithIndex.java
@@ -13,26 +13,28 @@
  */
 package io.trino.plugin.base.expression;
 
-import io.trino.spi.type.Type;
+import io.trino.spi.expression.ConnectorExpression;
 
-public class ConnectorExpressionIndex
+import static java.util.Objects.requireNonNull;
+
+public class ConnectorExpressionWithIndex
 {
-    private final Type type;
+    private final ConnectorExpression connectorExpression;
 
     private final int index;
 
     private final boolean isLast;
 
-    public ConnectorExpressionIndex(Type type, int index, boolean isLast)
+    public ConnectorExpressionWithIndex(ConnectorExpression connectorExpression, int index, boolean isLast)
     {
-        this.type = type;
+        this.connectorExpression = requireNonNull(connectorExpression, "connectorExpression is null");
         this.index = index;
         this.isLast = isLast;
     }
 
-    public Type getType()
+    public ConnectorExpression getConnectorExpression()
     {
-        return type;
+        return connectorExpression;
     }
 
     public int getIndex()

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ExpressionListCapture.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ExpressionListCapture.java
@@ -16,7 +16,7 @@ package io.trino.plugin.jdbc.expression;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
-import io.trino.plugin.base.expression.ConnectorExpressionIndex;
+import io.trino.plugin.base.expression.ConnectorExpressionWithIndex;
 import io.trino.spi.expression.ConnectorExpression;
 
 import java.util.List;
@@ -24,7 +24,7 @@ import java.util.Objects;
 import java.util.function.Predicate;
 
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.expressionTypes;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.expressionsPredicate;
 import static java.util.Objects.requireNonNull;
 
 public class ExpressionListCapture
@@ -35,11 +35,12 @@ public class ExpressionListCapture
     private final Capture<List<? extends ConnectorExpression>> capture = newCapture();
     private final Pattern<List<? extends ConnectorExpression>> pattern;
 
-    public ExpressionListCapture(String name, Predicate<ConnectorExpressionIndex> predicate)
+    public ExpressionListCapture(String name, Predicate<ConnectorExpressionWithIndex> predicate)
     {
+        requireNonNull(predicate, "predicate is null");
         this.name = requireNonNull(name, "name is null");
         this.pattern = Pattern.typeOfList(ConnectorExpression.class)
-                .matching(expressionTypes(predicate))
+                .matching(expressionsPredicate(predicate))
                 .capturedAs(capture);
     }
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ExpressionListCapture.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ExpressionListCapture.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.expression;
+
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionIndex;
+import io.trino.spi.expression.ConnectorExpression;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.expressionTypes;
+import static java.util.Objects.requireNonNull;
+
+public class ExpressionListCapture
+        extends ExpressionListPattern
+{
+    private final String name;
+
+    private final Capture<List<? extends ConnectorExpression>> capture = newCapture();
+    private final Pattern<List<? extends ConnectorExpression>> pattern;
+
+    public ExpressionListCapture(String name, Predicate<ConnectorExpressionIndex> predicate)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.pattern = Pattern.typeOfList(ConnectorExpression.class)
+                .matching(expressionTypes(predicate))
+                .capturedAs(capture);
+    }
+
+    @Override
+    public Pattern<List<? extends ConnectorExpression>> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public void resolve(Captures captures, MatchContext matchContext)
+    {
+        matchContext.record(name, captures.get(capture));
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ExpressionListCapture that = (ExpressionListCapture) o;
+        return Objects.equals(name, that.name) &&
+                Objects.equals(capture, that.capture) &&
+                Objects.equals(pattern, that.pattern);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, capture, pattern);
+    }
+
+    @Override
+    public String toString()
+    {
+        return name;
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ExpressionListPattern.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ExpressionListPattern.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.spi.expression.ConnectorExpression;
+
+import java.util.List;
+
+public abstract class ExpressionListPattern
+{
+    public abstract Pattern<List<? extends ConnectorExpression>> getPattern();
+
+    public abstract void resolve(Captures captures, MatchContext matchContext);
+
+    @Override
+    public abstract boolean equals(Object o);
+
+    @Override
+    public abstract int hashCode();
+
+    @Override
+    public abstract String toString();
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/JdbcConnectorExpressionRewriterBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/JdbcConnectorExpressionRewriterBuilder.java
@@ -55,6 +55,12 @@ public class JdbcConnectorExpressionRewriterBuilder
         return this;
     }
 
+    public JdbcConnectorExpressionRewriterBuilder add(Function<Map<String, Set<String>>, ConnectorExpressionRule<?, String>> ruleFunction)
+    {
+        rules.add(ruleFunction.apply(typeClasses));
+        return this;
+    }
+
     public JdbcConnectorExpressionRewriterBuilder withTypeClass(String typeClass, Set<String> typeNames)
     {
         requireNonNull(typeClass, "typeClass is null");

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteSimpleCaseExpression.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteSimpleCaseExpression.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionIndex;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import static com.google.common.collect.MoreCollectors.toOptional;
+import static io.trino.spi.expression.StandardFunctions.SIMPLE_CASE_WHEN_FUNCTION_NAME;
+import static java.lang.String.format;
+
+public class RewriteSimpleCaseExpression
+        implements ConnectorExpressionRule<Call, String>
+{
+    public static RewriteSimpleCaseExpression createRewrite()
+    {
+        return createRewrite(Collections.emptyMap(), Optional.empty(), Optional.empty());
+    }
+
+    public static RewriteSimpleCaseExpression createRewrite(Map<String, Set<String>> typeClass,
+                                                            String operandType,
+                                                            String resultType)
+    {
+        return createRewrite(typeClass, Optional.of(operandType), Optional.of(resultType));
+    }
+
+    public static RewriteSimpleCaseExpression createRewrite(Map<String, Set<String>> typeClass,
+                                                            Optional<String> operandType,
+                                                            Optional<String> resultType)
+    {
+        ExpressionMappingParser parser = new ExpressionMappingParser(typeClass);
+        Optional<TypePattern> operandTypePattern = operandType.map(parser::createTypePattern);
+        Optional<TypePattern> resultTypePattern = resultType.map(parser::createTypePattern);
+
+        Predicate<ConnectorExpressionIndex> operandTypePredicate = connectorExpressionIndex -> {
+            int index = connectorExpressionIndex.getIndex();
+            if (index == 0 || (index % 2 != 0 && !connectorExpressionIndex.isLast())) {
+                return operandTypePattern.map(typePattern -> typePattern.getPattern()
+                                .match(connectorExpressionIndex.getType())
+                                .collect(toOptional()).isPresent()).orElse(true);
+            }
+            else {
+                return resultTypePattern.map(typePattern -> typePattern.getPattern()
+                        .match(connectorExpressionIndex.getType())
+                        .collect(toOptional()).isPresent()).orElse(true);
+            }
+        };
+
+        ExpressionListCapture expressionListCapture = new ExpressionListCapture("arguments", operandTypePredicate);
+
+        VariableLengthCallPattern variableLengthCallPattern = new VariableLengthCallPattern(
+                SIMPLE_CASE_WHEN_FUNCTION_NAME.getName(), expressionListCapture, resultTypePattern);
+
+        return new RewriteSimpleCaseExpression(variableLengthCallPattern);
+    }
+
+    private final VariableLengthCallPattern variableLengthCallPattern;
+
+    private RewriteSimpleCaseExpression(VariableLengthCallPattern variableLengthCallPattern)
+    {
+        this.variableLengthCallPattern = variableLengthCallPattern;
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        //noinspection unchecked
+        return (Pattern<Call>) this.variableLengthCallPattern.getPattern();
+    }
+
+    @Override
+    public Optional<String> rewrite(Call expression, Captures captures, RewriteContext<String> context)
+    {
+        MatchContext matchContext = new MatchContext();
+        variableLengthCallPattern.resolve(captures, matchContext);
+
+        StringBuilder rewritten = new StringBuilder();
+
+        rewritten.append("(CASE ");
+
+        Optional<Object> capture = matchContext.getIfPresent("arguments");
+
+        if (capture.isPresent()) {
+            Object value = capture.get();
+            if (value instanceof List<?> list) {
+                for (int i = 0; i < list.size(); i++) {
+                    Object arg = list.get(i);
+                    if (arg instanceof ConnectorExpression argExpression) {
+                        Optional<String> rewrittenExpression = context.defaultRewrite(argExpression);
+                        if (rewrittenExpression.isEmpty()) {
+                            return Optional.empty();
+                        }
+                        if (i == 0) {
+                            rewritten.append(rewrittenExpression.get());
+                        }
+                        else if (i % 2 != 0 && i != list.size() - 1) {
+                            rewritten.append(" WHEN ").append(rewrittenExpression.get());
+                        }
+                        else if (i % 2 == 0) {
+                            rewritten.append(" THEN ").append(rewrittenExpression.get());
+                        }
+                        else {
+                            rewritten.append(" ELSE ").append(rewrittenExpression.get());
+                        }
+                    }
+                    else {
+                        throw new UnsupportedOperationException(format("Unsupported value: %s (%s)", arg, arg.getClass()));
+                    }
+                }
+                rewritten.append(" END)");
+            }
+            else {
+                throw new UnsupportedOperationException(format("Unsupported value: %s (%s)", value, value.getClass()));
+            }
+
+            return Optional.of(rewritten.toString());
+        }
+
+        return Optional.empty();
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/VariableLengthCallPattern.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/VariableLengthCallPattern.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.arguments;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionUnqualifiedName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static java.lang.String.format;
+
+public class VariableLengthCallPattern
+        extends ExpressionPattern
+{
+    private final String functionName;
+    private final ExpressionListPattern variableLengthParameters;
+    private final Optional<TypePattern> resultType;
+    private final Pattern<Call> pattern;
+
+    public VariableLengthCallPattern(String functionName,
+                                     ExpressionListPattern variableLengthParameters,
+                                     Optional<TypePattern> resultType)
+    {
+        this.functionName = functionName;
+        this.variableLengthParameters = variableLengthParameters;
+        this.resultType = resultType;
+
+        Pattern<Call> pattern = call().with(functionUnqualifiedName().equalTo(functionName));
+        if (resultType.isPresent()) {
+            pattern = pattern.with(type().matching(resultType.get().getPattern()));
+        }
+        this.pattern = pattern.with(arguments().matching(variableLengthParameters.getPattern()));
+    }
+
+    @Override
+    public Pattern<? extends ConnectorExpression> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public void resolve(Captures captures, MatchContext matchContext)
+    {
+        variableLengthParameters.resolve(captures, matchContext);
+        resultType.ifPresent(resultType -> resultType.resolve(captures, matchContext));
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        VariableLengthCallPattern that = (VariableLengthCallPattern) o;
+        return Objects.equals(functionName, that.functionName) &&
+                Objects.equals(variableLengthParameters, that.variableLengthParameters) &&
+                Objects.equals(resultType, that.resultType);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(functionName, variableLengthParameters, resultType);
+    }
+
+    @Override
+    public String toString()
+    {
+        return format(
+                "%s(...arguments)%s",
+                functionName,
+                resultType.map(resultType -> ": " + resultType).orElse(""));
+    }
+}

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -67,6 +67,7 @@ import io.trino.plugin.jdbc.aggregation.ImplementVarianceSamp;
 import io.trino.plugin.jdbc.expression.JdbcConnectorExpressionRewriterBuilder;
 import io.trino.plugin.jdbc.expression.RewriteComparison;
 import io.trino.plugin.jdbc.expression.RewriteIn;
+import io.trino.plugin.jdbc.expression.RewriteSimpleCaseExpression;
 import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
 import io.trino.plugin.postgresql.PostgreSqlConfig.ArrayMapping;
@@ -318,6 +319,7 @@ public class PostgreSqlClient
                 .map("$not(value: boolean)").to("NOT value")
                 .map("$is_null(value)").to("value IS NULL")
                 .map("$nullif(first, second)").to("NULLIF(first, second)")
+                .add(typeMap -> RewriteSimpleCaseExpression.createRewrite(typeMap, Optional.of("integer_type"), Optional.empty()))
                 .build();
 
         JdbcTypeHandle bigintTypeHandle = new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Add translation for SimpleCaseExpression to connector expression form.
> Is this change a fix, improvement, new feature, refactoring, or other?

New feature.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core engine & postgres connector.

> How would you describe this change to a non-technical end user or system administrator?

This enabled pushdown of SimpleCase which are not expressible with Domain (i.e. references other symbols or contains function calls)

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
`GenericRewrite` cannot support translation of variable-length functions.
This pr adds several classes such as `VariableLengthCallPattern` to pattern match the entire argument list. Instead of matching each parameter individually (as variable length functions cannot do this).


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# PostgreSQL connector
* Improve performance of queries involving `SimpleCase` expression by pushing predicate computation to the PostgreSQL database. ({issue}`issuenumber`)
```
