### PR TITLE
Dependency benchto-driver was upgraded from 0.22 to 0.23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -726,7 +726,7 @@
             <dependency>
                 <groupId>io.trino.benchto</groupId>
                 <artifactId>benchto-driver</artifactId>
-                <version>0.22</version>
+                <version>0.23</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Upgrading benchto-driver to 0.23 version

## Release notes

( *) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
