### PR TITLE
Fix verify() call in RcFileReader

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/rcfile/RcFileReader.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/rcfile/RcFileReader.java
@@ -454,7 +454,7 @@ public class RcFileReader
             throws IOException
     {
         int length = toIntExact(ReadWriteUtils.readVInt(in));
-        verify(length <= MAX_METADATA_STRING_LENGTH, "Metadata string value is too long (%s) in RCFile %s", length, in);
+        verify(length <= MAX_METADATA_STRING_LENGTH, "Metadata string value is too long (%s) in RCFile %s", length, location);
         return in.readSlice(length);
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The `in` parameter recently changed type from `SliceInput` to `DataSeekableInputStream`, the latter of which does not implement `toString`. Error Prone complains with `ObjectToString` because of that.

Note that this only happens with #14933 merged, because otherwise the `verify` method is not a `@FormatMethod` and Error Prone can't verify correctness of its invocations.

Passing `location` instead of `in` as the format string arguments is correct, because the stream is derived from a file at the location named by `location`.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

It's kind of a shameless plug to promote #14933, which got stuck in reviews for some reason.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
