### PR TITLE
Drop the check regarding the presence of all computed partition statistics

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -1479,7 +1479,6 @@ public class HiveMetadata
                     .collect(toImmutableMap(HiveColumnHandle::getName, column -> ImmutableSet.copyOf(metastore.getSupportedColumnStatistics(column.getType()))));
             Supplier<PartitionStatistics> emptyPartitionStatistics = Suppliers.memoize(() -> createEmptyPartitionStatistics(columnTypes, columnStatisticTypes));
 
-            int usedComputedStatistics = 0;
             List<Type> partitionTypes = handle.getPartitionColumns().stream()
                     .map(HiveColumnHandle::getType)
                     .collect(toImmutableList());
@@ -1494,11 +1493,9 @@ public class HiveMetadata
                     partitionStatistics.put(partitionValues, emptyPartitionStatistics.get());
                 }
                 else {
-                    usedComputedStatistics++;
                     partitionStatistics.put(partitionValues, createPartitionStatistics(columnTypes, collectedStatistics));
                 }
             }
-            verify(usedComputedStatistics == computedStatistics.size(), "All computed statistics must be used");
             metastore.setPartitionStatistics(table, partitionStatistics.buildOrThrow());
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

While computing the statistics, it may very well happen that the number of partitions in the table will change (partitions get added/dropped). Avoid failing the `ANALYZE` operation because of inequality of the number of computed partition statistics vs existing table partitions.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

In some situations it may happen that `ANALYZE table` operation is failing with the message

```
All computed statistics must be used
```

If the number of the partitions of the table changes between the time when the computing of the partitions  stats has started and when it ended, this exception is likely to appear.
Avoid the failure of the operation by dropping the verification for the  equality of the number of computed partition statistics vs existing table partitions.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
