### PR TITLE
Fix null projects handling in RowPositionsAppender

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppender.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppender.java
@@ -40,6 +40,7 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
 import io.trino.type.BlockTypeOperators;
+import io.trino.type.UnknownType;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -93,6 +94,8 @@ public class TestPositionsAppender
         List<BlockView> input = ImmutableList.of(
                 input(emptyBlock(type)),
                 input(nullBlock(type, 3), 0, 2),
+                input(nullBlock(TestType.UNKNOWN, 3), 0, 2), // a := null projections are handled by UnknownType null block
+                input(nullBlock(TestType.UNKNOWN, 1), 0), // a := null projections are handled by UnknownType null block, 1 position uses non RLE block
                 input(notNullBlock(type, 3), 1, 2),
                 input(partiallyNullBlock(type, 4), 0, 1, 2, 3),
                 input(partiallyNullBlock(type, 4)), // empty position list
@@ -270,6 +273,7 @@ public class TestPositionsAppender
     public static Object[][] types()
     {
         return Arrays.stream(TestType.values())
+                .filter(testType -> !testType.equals(TestType.UNKNOWN))
                 .map(type -> new Object[] {type})
                 .toArray(Object[][]::new);
     }
@@ -434,7 +438,8 @@ public class TestPositionsAppender
         LONG_TIMESTAMP(createTimestampType(9)),
         ROW_BIGINT_VARCHAR(anonymousRow(BigintType.BIGINT, VarcharType.VARCHAR)),
         ARRAY_BIGINT(new ArrayType(BigintType.BIGINT)),
-        VARCHAR_WITH_TEST_BLOCK(VarcharType.VARCHAR, TestVariableWidthBlock.adaptation());
+        VARCHAR_WITH_TEST_BLOCK(VarcharType.VARCHAR, TestVariableWidthBlock.adaptation()),
+        UNKNOWN(UnknownType.UNKNOWN);
 
         private final Type type;
         private final Function<Block, Block> blockAdaptation;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In case of null projection with UnknownType,
Rle with null ByteArrayBlock value is created.
This breaks RowPositionsAppender assumption
about incoming block type.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
