### PR TITLE
Free PagePartitioner memory even if flush fails

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPagePartitioner.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPagePartitioner.java
@@ -29,6 +29,7 @@ import io.trino.execution.buffer.OutputBuffers;
 import io.trino.execution.buffer.PageDeserializer;
 import io.trino.execution.buffer.PagesSerdeFactory;
 import io.trino.execution.buffer.PipelinedOutputBuffers.OutputBufferId;
+import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.operator.BucketPartitionFunction;
 import io.trino.operator.DriverContext;
 import io.trino.operator.OperatorContext;
@@ -96,6 +97,8 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
 
 @Test(singleThreaded = true)
 public class TestPagePartitioner
@@ -366,6 +369,33 @@ public class TestPagePartitioner
         testOutputEqualsInput(type, PartitioningMode.ROW_WISE, PartitioningMode.COLUMNAR);
     }
 
+    @Test(dataProvider = "partitioningMode")
+    public void testMemoryReleased(PartitioningMode partitioningMode)
+    {
+        AggregatedMemoryContext memoryContext = newSimpleAggregatedMemoryContext();
+        PagePartitioner pagePartitioner = pagePartitioner(BIGINT).withMemoryContext(memoryContext).build();
+        Page page = new Page(createLongsBlock(0L, 1L, 2L, 3L, null));
+
+        processPages(pagePartitioner, partitioningMode, page);
+
+        assertEquals(memoryContext.getBytes(), 0);
+    }
+
+    @Test(dataProvider = "partitioningMode")
+    public void testMemoryReleasedOnFailure(PartitioningMode partitioningMode)
+    {
+        AggregatedMemoryContext memoryContext = newSimpleAggregatedMemoryContext();
+        RuntimeException exception = new RuntimeException();
+        outputBuffer.throwOnEnqueue(exception);
+        PagePartitioner pagePartitioner = pagePartitioner(BIGINT).withMemoryContext(memoryContext).build();
+        Page page = new Page(createLongsBlock(0L, 1L, 2L, 3L, null));
+
+        partitioningMode.partitionPage(pagePartitioner, page);
+
+        assertThatThrownBy(pagePartitioner::close).isEqualTo(exception);
+        assertEquals(memoryContext.getBytes(), 0);
+    }
+
     private void testOutputEqualsInput(Type type, PartitioningMode mode1, PartitioningMode mode2)
     {
         PagePartitionerBuilder pagePartitionerBuilder = pagePartitioner(BIGINT, type, type);
@@ -513,6 +543,7 @@ public class TestPagePartitioner
         private boolean shouldReplicate;
         private OptionalInt nullChannel = OptionalInt.empty();
         private List<Type> types;
+        private AggregatedMemoryContext memoryContext = newSimpleAggregatedMemoryContext();
 
         PagePartitionerBuilder(ExecutorService executor, ScheduledExecutorService scheduledExecutor, OutputBuffer outputBuffer)
         {
@@ -582,6 +613,12 @@ public class TestPagePartitioner
             return this;
         }
 
+        public PagePartitionerBuilder withMemoryContext(AggregatedMemoryContext memoryContext)
+        {
+            this.memoryContext = memoryContext;
+            return this;
+        }
+
         public PartitionedOutputOperator buildPartitionedOutputOperator()
         {
             DriverContext driverContext = buildDriverContext();
@@ -596,7 +633,7 @@ public class TestPagePartitioner
                     PARTITION_MAX_MEMORY,
                     POSITIONS_APPENDER_FACTORY,
                     Optional.empty(),
-                    newSimpleAggregatedMemoryContext(),
+                    memoryContext,
                     1);
             OperatorFactory factory = operatorFactory.createOutputOperator(0, new PlanNodeId("plan-node-0"), types, Function.identity(), PAGES_SERDE_FACTORY);
             PartitionedOutputOperator operator = (PartitionedOutputOperator) factory
@@ -623,7 +660,7 @@ public class TestPagePartitioner
                     PARTITION_MAX_MEMORY,
                     POSITIONS_APPENDER_FACTORY,
                     Optional.empty(),
-                    newSimpleAggregatedMemoryContext());
+                    memoryContext);
             pagePartitioner.setupOperator(operatorContext);
 
             return pagePartitioner;
@@ -643,6 +680,7 @@ public class TestPagePartitioner
             implements OutputBuffer
     {
         private final Multimap<Integer, Slice> enqueued = ArrayListMultimap.create();
+        private RuntimeException throwOnEnqueue;
 
         public Stream<Page> getEnqueuedDeserialized()
         {
@@ -670,9 +708,17 @@ public class TestPagePartitioner
             return serializedPages == null ? ImmutableList.of() : ImmutableList.copyOf(serializedPages);
         }
 
+        public void throwOnEnqueue(RuntimeException throwOnEnqueue)
+        {
+            this.throwOnEnqueue = throwOnEnqueue;
+        }
+
         @Override
         public void enqueue(int partition, List<Slice> pages)
         {
+            if (throwOnEnqueue != null) {
+                throw throwOnEnqueue;
+            }
             enqueued.putAll(partition, pages);
         }
 

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPagePartitionerPool.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPagePartitionerPool.java
@@ -57,6 +57,7 @@ import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregate
 import static io.trino.spi.type.BigintType.BIGINT;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 
 public class TestPagePartitionerPool
@@ -84,23 +85,7 @@ public class TestPagePartitionerPool
 
         OutputBufferMock outputBuffer = new OutputBufferMock();
         AggregatedMemoryContext memoryContext = newSimpleAggregatedMemoryContext();
-        PartitionedOutputOperatorFactory factory = new PartitionedOutputOperatorFactory(
-                0,
-                new PlanNodeId("0"),
-                ImmutableList.of(BIGINT),
-                PageChannelSelector.identitySelection(),
-                new BucketPartitionFunction((page, position) -> 0, new int[1]),
-                ImmutableList.of(0),
-                ImmutableList.of(),
-                false,
-                OptionalInt.empty(),
-                outputBuffer,
-                new TestingPagesSerdeFactory(),
-                maxPagePartitioningBufferSize,
-                new PositionsAppenderFactory(new BlockTypeOperators()),
-                Optional.empty(),
-                memoryContext,
-                2);
+        PartitionedOutputOperatorFactory factory = createFactory(maxPagePartitioningBufferSize, outputBuffer, memoryContext);
 
         assertEquals(memoryContext.getBytes(), 0);
         // first split, too small for a flush
@@ -147,6 +132,51 @@ public class TestPagePartitionerPool
         assertEquals(outputBuffer.totalEnqueuedPageCount(), 9);
         // pool is closed, all operators are finished/flushed, the retained memory should be 0
         assertEquals(memoryContext.getBytes(), 0);
+    }
+
+    @Test
+    public void testMemoryReleasedOnFailure()
+    {
+        Page split = new Page(createLongsBlock(1));
+        // one split fit in the buffer but 2 do not
+        DataSize maxPagePartitioningBufferSize = DataSize.ofBytes(split.getSizeInBytes() + 1);
+        RuntimeException exception = new RuntimeException();
+        OutputBufferMock outputBuffer = new OutputBufferMock() {
+            @Override
+            public void enqueue(int partition, List<Slice> pages)
+            {
+                throw exception;
+            }
+        };
+        AggregatedMemoryContext memoryContext = newSimpleAggregatedMemoryContext();
+        PartitionedOutputOperatorFactory factory = createFactory(maxPagePartitioningBufferSize, outputBuffer, memoryContext);
+
+        long initialRetainedBytesOneOperator = processSplitsConcurrently(factory, memoryContext, split);
+        assertThat(memoryContext.getBytes()).isGreaterThanOrEqualTo(initialRetainedBytesOneOperator + split.getSizeInBytes());
+
+        assertThatThrownBy(factory::noMoreOperators).isEqualTo(exception);
+        assertEquals(memoryContext.getBytes(), 0);
+    }
+
+    private static PartitionedOutputOperatorFactory createFactory(DataSize maxPagePartitioningBufferSize, OutputBufferMock outputBuffer, AggregatedMemoryContext memoryContext)
+    {
+        return new PartitionedOutputOperatorFactory(
+                0,
+                new PlanNodeId("0"),
+                ImmutableList.of(BIGINT),
+                PageChannelSelector.identitySelection(),
+                new BucketPartitionFunction((page, position) -> 0, new int[1]),
+                ImmutableList.of(0),
+                ImmutableList.of(),
+                false,
+                OptionalInt.empty(),
+                outputBuffer,
+                new TestingPagesSerdeFactory(),
+                maxPagePartitioningBufferSize,
+                new PositionsAppenderFactory(new BlockTypeOperators()),
+                Optional.empty(),
+                memoryContext,
+                2);
     }
 
     private long processSplitsConcurrently(PartitionedOutputOperatorFactory factory, AggregatedMemoryContext memoryContext, Page... splits)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Memory has to be released to the memory pool
even if the flush fails e.g. due to a bug


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
