### PR TITLE
Fix log messages which are not format strings

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/NimbusOAuth2Client.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/NimbusOAuth2Client.java
@@ -378,7 +378,7 @@ public class NimbusOAuth2Client
         try {
             UserInfoResponse response = httpClient.execute(new UserInfoRequest(userinfoUrl.get(), new BearerAccessToken(accessToken)), UserInfoResponse::parse);
             if (!response.indicatesSuccess()) {
-                LOG.error("Received bad response from userinfo endpoint: " + response.toErrorResponse().getErrorObject());
+                LOG.error("Received bad response from userinfo endpoint: %s", response.toErrorResponse().getErrorObject());
                 return Optional.empty();
             }
             return Optional.of(response.toSuccessResponse().getUserInfo().toJWTClaimsSet());

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3FileSystem.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3FileSystem.java
@@ -1134,7 +1134,7 @@ public class TrinoS3FileSystem
                     region = regionProviderChain.getRegion();
                 }
                 catch (SdkClientException ex) {
-                    log.warn("Falling back to default AWS region " + US_EAST_1);
+                    log.warn("Falling back to default AWS region %s", US_EAST_1);
                     region = US_EAST_1.getName();
                 }
             }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1310,7 +1310,7 @@ public class IcebergMetadata
                 IcebergSessionProperties.REMOVE_ORPHAN_FILES_MIN_RETENTION);
 
         if (table.currentSnapshot() == null) {
-            log.debug("Skipping remove_orphan_files procedure for empty table " + table);
+            log.debug("Skipping remove_orphan_files procedure for empty table %s", table);
             return;
         }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
@@ -311,7 +311,7 @@ public abstract class BaseTrinoCatalogTest
                 catalog.dropNamespace(SESSION, namespace);
             }
             catch (Exception e) {
-                LOG.warn("Failed to clean up namespace: " + namespace);
+                LOG.warn("Failed to clean up namespace: %s", namespace);
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

See also: 2ec05295229ba1851f7346a3654c0342423ef658

This is currently not enforced in Error Prone because it requires annotating more methods in `airlift:log` with `@FormatMethod`, but that's hard to do, because it will change their semantics.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Extracted from #14933.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
