### PR TITLE
Annotate semanticException factories as format methods

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SetColumnTypeTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetColumnTypeTask.java
@@ -93,7 +93,7 @@ public class SetColumnTypeTask
                 exceptionMessage += ", but a view with that name exists.";
             }
             if (!statement.isTableExists()) {
-                throw semanticException(TABLE_NOT_FOUND, statement, exceptionMessage);
+                throw semanticException(TABLE_NOT_FOUND, statement, "%s", exceptionMessage);
             }
             return immediateVoidFuture();
         }

--- a/core/trino-main/src/main/java/io/trino/execution/SetSessionTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetSessionTask.java
@@ -109,7 +109,7 @@ public class SetSessionTask
             propertyMetadata.decode(objectValue);
         }
         catch (RuntimeException e) {
-            throw semanticException(INVALID_SESSION_PROPERTY, statement, e.getMessage());
+            throw semanticException(INVALID_SESSION_PROPERTY, statement, "Invalid value of session property '%s': %s", propertyName.toString(), e.getMessage());
         }
 
         stateMachine.addSetSessionProperties(propertyName.toString(), value);

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
@@ -449,8 +449,7 @@ class AggregationAnalyzer
                 if (node.getFilter().isPresent()) {
                     throw semanticException(FUNCTION_NOT_AGGREGATE,
                             node,
-                            "Filter is only valid for aggregation functions",
-                            node);
+                            "Filter is only valid for aggregation functions");
                 }
                 if (node.getOrderBy().isPresent()) {
                     throw semanticException(FUNCTION_NOT_AGGREGATE, node, "ORDER BY is only valid for aggregation functions");
@@ -803,7 +802,7 @@ class AggregationAnalyzer
         getReferencesToScope(node, analysis, orderByScope.get())
                 .findFirst()
                 .ifPresent(expression -> {
-                    throw semanticException(errorCode, expression, errorString);
+                    throw semanticException(errorCode, expression, "%s", errorString);
                 });
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -22,6 +22,8 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Streams;
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.FunctionResolver;
@@ -3129,7 +3131,8 @@ public class ExpressionAnalyzer
             coerceType(expression, actualType, expectedType, message);
         }
 
-        private Type coerceToSingleType(StackableAstVisitorContext<Context> context, Node node, String message, Expression first, Expression second)
+        @FormatMethod
+        private Type coerceToSingleType(StackableAstVisitorContext<Context> context, Node node, @FormatString String message, Expression first, Expression second)
         {
             Type firstType = UNKNOWN;
             if (first != null) {

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -763,7 +763,7 @@ public class ExpressionAnalyzer
             for (RowType.Field rowField : rowType.getFields()) {
                 if (fieldName.equalsIgnoreCase(rowField.getName().orElse(null))) {
                     if (foundFieldName) {
-                        throw semanticException(AMBIGUOUS_NAME, field, "Ambiguous row field reference: " + fieldName);
+                        throw semanticException(AMBIGUOUS_NAME, field, "Ambiguous row field reference: %s", fieldName);
                     }
                     foundFieldName = true;
                     rowFieldType = rowField.getType();
@@ -1250,7 +1250,7 @@ public class ExpressionAnalyzer
                 Expression expression = arguments.get(0);
                 Type expressionType = process(expression, context);
                 if (!(expressionType instanceof VarcharType)) {
-                    throw semanticException(TYPE_MISMATCH, node, format("Expected expression of varchar, but '%s' has %s type", expression, expressionType.getDisplayName()));
+                    throw semanticException(TYPE_MISMATCH, node, "Expected expression of varchar, but '%s' has %s type", expression, expressionType.getDisplayName());
                 }
             }
 
@@ -1490,7 +1490,7 @@ public class ExpressionAnalyzer
                     }
                 }
                 else {
-                    throw semanticException(NOT_SUPPORTED, frame, "Unsupported frame type: " + frame.getType());
+                    throw semanticException(NOT_SUPPORTED, frame, "Unsupported frame type: %s", frame.getType());
                 }
             }
         }
@@ -2417,7 +2417,7 @@ public class ExpressionAnalyzer
 
             if (types.size() != lambdaArguments.size()) {
                 throw semanticException(INVALID_PARAMETER_USAGE, node,
-                        format("Expected a lambda that takes %s argument(s) but got %s", types.size(), lambdaArguments.size()));
+                        "Expected a lambda that takes %s argument(s) but got %s", types.size(), lambdaArguments.size());
             }
 
             ImmutableList.Builder<Field> fields = ImmutableList.builder();
@@ -2552,7 +2552,7 @@ public class ExpressionAnalyzer
                     !isDateTimeType(returnedType) ||
                     returnedType.equals(INTERVAL_DAY_TIME) ||
                     returnedType.equals(INTERVAL_YEAR_MONTH)) {
-                throw semanticException(TYPE_MISMATCH, node, "Invalid return type of function JSON_VALUE: " + node.getReturnedType().get());
+                throw semanticException(TYPE_MISMATCH, node, "Invalid return type of function JSON_VALUE: %s", node.getReturnedType().get());
             }
 
             JsonPathAnalysis pathAnalysis = jsonPathAnalyses.get(NodeRef.of(node));
@@ -2799,7 +2799,7 @@ public class ExpressionAnalyzer
                     if (isStringType(type)) {
                         yield VARBINARY_TO_JSON;
                     }
-                    throw semanticException(TYPE_MISMATCH, node, format("Cannot read input of type %s as JSON using formatting %s", type, format));
+                    throw semanticException(TYPE_MISMATCH, node, "Cannot read input of type %s as JSON using formatting %s", type, format);
                 }
                 case UTF8 -> VARBINARY_UTF8_TO_JSON;
                 case UTF16 -> VARBINARY_UTF16_TO_JSON;
@@ -2824,23 +2824,23 @@ public class ExpressionAnalyzer
                     if (isStringType(type)) {
                         yield JSON_TO_VARBINARY;
                     }
-                    throw semanticException(TYPE_MISMATCH, node, format("Cannot output JSON value as %s using formatting %s", type, format));
+                    throw semanticException(TYPE_MISMATCH, node, "Cannot output JSON value as %s using formatting %s", type, format);
                 }
                 case UTF8 -> {
                     if (!VARBINARY.equals(type)) {
-                        throw semanticException(TYPE_MISMATCH, node, format("Cannot output JSON value as %s using formatting %s", type, format));
+                        throw semanticException(TYPE_MISMATCH, node, "Cannot output JSON value as %s using formatting %s", type, format);
                     }
                     yield JSON_TO_VARBINARY_UTF8;
                 }
                 case UTF16 -> {
                     if (!VARBINARY.equals(type)) {
-                        throw semanticException(TYPE_MISMATCH, node, format("Cannot output JSON value as %s using formatting %s", type, format));
+                        throw semanticException(TYPE_MISMATCH, node, "Cannot output JSON value as %s using formatting %s", type, format);
                     }
                     yield JSON_TO_VARBINARY_UTF16;
                 }
                 case UTF32 -> {
                     if (!VARBINARY.equals(type)) {
-                        throw semanticException(TYPE_MISMATCH, node, format("Cannot output JSON value as %s using formatting %s", type, format));
+                        throw semanticException(TYPE_MISMATCH, node, "Cannot output JSON value as %s using formatting %s", type, format);
                     }
                     yield JSON_TO_VARBINARY_UTF32;
                 }
@@ -3158,7 +3158,7 @@ public class ExpressionAnalyzer
                 return superType;
             }
 
-            throw semanticException(TYPE_MISMATCH, node, message, firstType, secondType);
+            throw semanticException(TYPE_MISMATCH, node, "%s", format(message, firstType, secondType));
         }
 
         private Type coerceToSingleType(StackableAstVisitorContext<Context> context, String description, List<Expression> expressions)
@@ -3179,12 +3179,12 @@ public class ExpressionAnalyzer
             for (Type type : types) {
                 Optional<Type> newSuperType = typeCoercion.getCommonSuperType(superType, type);
                 if (newSuperType.isEmpty()) {
-                    throw semanticException(TYPE_MISMATCH, Iterables.get(typeExpressions.get(type), 0).getNode(), format(
+                    throw semanticException(TYPE_MISMATCH, Iterables.get(typeExpressions.get(type), 0).getNode(),
                             "%s must be the same type or coercible to a common type. Cannot find common type between %s and %s, all types (without duplicates): %s",
                             description,
                             superType,
                             type,
-                            typeExpressions.keySet()));
+                            typeExpressions.keySet());
                 }
                 superType = newSuperType.get();
             }
@@ -3195,12 +3195,12 @@ public class ExpressionAnalyzer
 
                 if (!type.equals(superType)) {
                     if (!typeCoercion.canCoerce(type, superType)) {
-                        throw semanticException(TYPE_MISMATCH, Iterables.get(coercionCandidates, 0).getNode(), format(
+                        throw semanticException(TYPE_MISMATCH, Iterables.get(coercionCandidates, 0).getNode(),
                                 "%s must be the same type or coercible to a common type. Cannot find common type between %s and %s, all types (without duplicates): %s",
                                 description,
                                 superType,
                                 type,
-                                typeExpressions.keySet()));
+                                typeExpressions.keySet());
                     }
                     addOrReplaceExpressionsCoercion(coercionCandidates, type, superType);
                 }
@@ -3463,7 +3463,7 @@ public class ExpressionAnalyzer
                 plannerContext,
                 accessControl,
                 (node, ignored) -> {
-                    throw semanticException(errorCode, node, message);
+                    throw semanticException(errorCode, node, "%s", message);
                 },
                 session,
                 TypeProvider.empty(),
@@ -3585,7 +3585,7 @@ public class ExpressionAnalyzer
                 session,
                 TypeProvider.empty(),
                 parameters,
-                node -> semanticException(errorCode, node, message),
+                node -> semanticException(errorCode, node, "%s", message),
                 warningCollector,
                 isDescribe);
     }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/JsonPathAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/JsonPathAnalyzer.java
@@ -83,7 +83,6 @@ import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.trino.sql.jsonpath.tree.ArithmeticUnary.Sign.PLUS;
 import static io.trino.type.Json2016Type.JSON_2016;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class JsonPathAnalyzer
@@ -368,9 +367,9 @@ public class JsonPathAnalyzer
                         .filter(name -> name.equalsIgnoreCase(node.getName()))
                         .findFirst();
                 if (similarName.isPresent()) {
-                    throw semanticException(INVALID_PATH, pathNode, format("no value passed for parameter %s. Try quoting \"%s\" in the PASSING clause to match case", node.getName(), node.getName()));
+                    throw semanticException(INVALID_PATH, pathNode, "no value passed for parameter %s. Try quoting \"%s\" in the PASSING clause to match case", node.getName(), node.getName());
                 }
-                throw semanticException(INVALID_PATH, pathNode, "no value passed for parameter " + node.getName());
+                throw semanticException(INVALID_PATH, pathNode, "no value passed for parameter %s", node.getName());
             }
 
             if (parameterType.equals(JSON_2016)) {

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/SemanticExceptions.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/SemanticExceptions.java
@@ -13,6 +13,7 @@
  */
 package io.trino.sql.analyzer;
 
+import com.google.errorprone.annotations.FormatMethod;
 import io.trino.spi.ErrorCodeSupplier;
 import io.trino.spi.TrinoException;
 import io.trino.sql.tree.Expression;
@@ -38,11 +39,13 @@ public final class SemanticExceptions
         throw semanticException(AMBIGUOUS_NAME, node, "Column '%s' is ambiguous", name);
     }
 
+    @FormatMethod
     public static TrinoException semanticException(ErrorCodeSupplier code, Node node, String format, Object... args)
     {
         return semanticException(code, node, null, format, args);
     }
 
+    @FormatMethod
     public static TrinoException semanticException(ErrorCodeSupplier code, Node node, Throwable cause, String format, Object... args)
     {
         throw new TrinoException(code, extractLocation(node), format(format, args), cause);

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1520,7 +1520,7 @@ class StatementAnalyzer
             verify(isTopLevel || node.getFunctions().isEmpty(), "Inline functions must be at the top level");
             for (FunctionSpecification function : node.getFunctions()) {
                 if (function.getName().getPrefix().isPresent()) {
-                    throw semanticException(SYNTAX_ERROR, function, "Inline function names cannot be qualified: " + function.getName());
+                    throw semanticException(SYNTAX_ERROR, function, "Inline function names cannot be qualified: %s", function.getName());
                 }
                 function.getRoutineCharacteristics().stream()
                         .filter(SecurityCharacteristic.class::isInstance)
@@ -2501,7 +2501,7 @@ class StatementAnalyzer
             Query query = parseView(originalSql, name, table);
 
             if (!query.getFunctions().isEmpty()) {
-                throw semanticException(NOT_SUPPORTED, table, "View contains inline function: " + name);
+                throw semanticException(NOT_SUPPORTED, table, "View contains inline function: %s", name);
             }
 
             analysis.registerTableForView(table);

--- a/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineAnalyzer.java
@@ -192,7 +192,7 @@ public class SqlRoutineAnalyzer
             return plannerContext.getTypeManager().getType(toTypeSignature(type));
         }
         catch (TypeNotFoundException e) {
-            throw semanticException(TYPE_MISMATCH, node, "Unknown type: " + type);
+            throw semanticException(TYPE_MISMATCH, node, "Unknown type: %s", type);
         }
     }
 
@@ -218,7 +218,7 @@ public class SqlRoutineAnalyzer
             }
             String name = identifierValue(parameter.getName().get());
             if (!argumentNames.add(name)) {
-                throw semanticException(INVALID_ARGUMENTS, parameter, "Duplicate function parameter name: " + name);
+                throw semanticException(INVALID_ARGUMENTS, parameter, "Duplicate function parameter name: %s", name);
             }
         }
     }
@@ -514,7 +514,7 @@ public class SqlRoutineAnalyzer
                 return;
             }
             if (!typeCoercion.canCoerce(actualType, expectedType)) {
-                throw semanticException(TYPE_MISMATCH, expression, message + " must evaluate to %s (actual: %s)", expectedType, actualType);
+                throw semanticException(TYPE_MISMATCH, expression, "%s must evaluate to %s (actual: %s)", message, expectedType, actualType);
             }
 
             addCoercion(expression, actualType, expectedType);

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetSessionTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetSessionTask.java
@@ -169,7 +169,7 @@ public class TestSetSessionTask
 
         assertThatThrownBy(() -> testSetSession("positive_property", new LongLiteral("-1"), "-1"))
                 .isInstanceOf(TrinoException.class)
-                .hasMessage(MUST_BE_POSITIVE);
+                .hasMessage("Invalid value of session property 'my_catalog.positive_property': " + MUST_BE_POSITIVE);
     }
 
     @Test
@@ -177,7 +177,7 @@ public class TestSetSessionTask
     {
         assertThatThrownBy(() -> testSetSession("size_property", new StringLiteral("XL"), "XL"))
                 .isInstanceOf(TrinoException.class)
-                .hasMessage("Invalid value [XL]. Valid values: [SMALL, MEDIUM, LARGE]")
+                .hasMessage("Invalid value of session property 'my_catalog.size_property': Invalid value [XL]. Valid values: [SMALL, MEDIUM, LARGE]")
                 .matches(throwable -> ((TrinoException) throwable).getErrorCode() == INVALID_SESSION_PROPERTY.toErrorCode());
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -533,11 +533,11 @@ public abstract class BaseHiveConnectorTest
     {
         assertQueryFails(
                 "SET SESSION hive.query_partition_filter_required_schemas = ARRAY['tpch', null]",
-                "line 1:1: Invalid null or empty value in query_partition_filter_required_schemas property");
+                "line 1:1: Invalid value of session property 'hive.query_partition_filter_required_schemas': Invalid null or empty value in query_partition_filter_required_schemas property");
 
         assertQueryFails(
                 "SET SESSION hive.query_partition_filter_required_schemas = ARRAY['tpch', '']",
-                "line 1:1: Invalid null or empty value in query_partition_filter_required_schemas property");
+                "line 1:1: Invalid value of session property 'hive.query_partition_filter_required_schemas': Invalid null or empty value in query_partition_filter_required_schemas property");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This annotation allows more cases to be checked by the `FormatStringAnnotation` checker. Fixes up all the trivial cases where they can be used as a format methods but weren't.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Extracted from #14933.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
