### PR TITLE
Return null for columns in resultsets of queries that don't return outputs

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -548,7 +548,6 @@ class Query
     {
         if (!resultsConsumed && queryInfo.getOutputStage().isEmpty()) {
             return queryResultRowsBuilder(session)
-                    .withColumnsAndTypes(ImmutableList.of(), ImmutableList.of())
                     .build();
         }
         // Remove as many pages as possible from the exchange until just greater than DESIRED_RESULT_BYTES


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Currently queries that don't return outputs(e.g. DDL queries) can return columns with either null or empty list in ResultSets. This depends on when queries are finished and how may getResult requests are made. Since the protocol explicitly states that columns will be null in the case where there is no output, it needs to be consolidated to null.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
