### PR TITLE
Fix bad parameter count in code generator when column uses double slots

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/gen/BytecodeUtils.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/BytecodeUtils.java
@@ -354,7 +354,7 @@ public final class BytecodeUtils
     private static InvocationArgumentConvention getPreferredArgumentConvention(BytecodeNode argument, int argumentCount, boolean nullable)
     {
         // a Java function can only have 255 arguments, so if the count is low use block position or boxed nullable as they are more efficient
-        if (argumentCount <= 84) {
+        if (argumentCount <= 64) {
             if (argument instanceof InputReferenceNode) {
                 return BLOCK_POSITION;
             }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/BytecodeUtils.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/BytecodeUtils.java
@@ -354,7 +354,7 @@ public final class BytecodeUtils
     private static InvocationArgumentConvention getPreferredArgumentConvention(BytecodeNode argument, int argumentCount, boolean nullable)
     {
         // a Java function can only have 255 arguments, so if the count is low use block position or boxed nullable as they are more efficient
-        if (argumentCount <= 100) {
+        if (argumentCount <= 84) {
             if (argument instanceof InputReferenceNode) {
                 return BLOCK_POSITION;
             }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This change [/pull/7014] was trying to fix a bad parameter count issue when there are too many parameters for code generators, and this change makes sure when there are 100 or below number of parameters, BLOCK_POSITION will not be used to prevent issues. However, 100 is not enough especially when it comes to double slots type like Long. Double slots for long plus a nullable flag will cause the number of parameters surpass the max of 255 and causing query compiler error. This change further limits it down so double slots types with number of parameters between 85 to 100 will not throw error


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

/pull/7014


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( X) Release notes are required, with the following suggested text:


```markdown
# Section
* Fix an compiler error when there are 85 to 100 columns in an array
```
