### PR TITLE
Add table function to execute stored procedure in SQLServer

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/system/SystemPageSourceProvider.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SystemPageSourceProvider.java
@@ -14,6 +14,8 @@
 package io.trino.connector.system;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.plugin.base.MappedPageSource;
+import io.trino.plugin.base.MappedRecordSet;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
@@ -32,8 +34,6 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.Type;
-import io.trino.split.MappedPageSource;
-import io.trino.split.MappedRecordSet;
 
 import java.util.HashMap;
 import java.util.List;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -149,6 +149,7 @@ import io.trino.operator.window.pattern.MeasureComputation.MeasureComputationSup
 import io.trino.operator.window.pattern.PhysicalValueAccessor;
 import io.trino.operator.window.pattern.PhysicalValuePointer;
 import io.trino.operator.window.pattern.SetEvaluator.SetEvaluatorSupplier;
+import io.trino.plugin.base.MappedRecordSet;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.TrinoException;
@@ -172,7 +173,6 @@ import io.trino.spi.type.Type;
 import io.trino.spiller.PartitioningSpillerFactory;
 import io.trino.spiller.SingleStreamSpillerFactory;
 import io.trino.spiller.SpillerFactory;
-import io.trino.split.MappedRecordSet;
 import io.trino.split.PageSinkManager;
 import io.trino.split.PageSourceProvider;
 import io.trino.sql.DynamicFilters;

--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -367,6 +367,46 @@ nations by population::
         )
       );
 
+.. _sqlserver-procedure-function:
+
+``procedure(varchar) -> table``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``procedure`` function allows you to run stored procedures on the underlying
+database directly.
+
+.. note::
+
+    The ``procedure`` function does not support running StoredProcedures that return multiple statements,
+    use a non-select statement, use output parameters, or use conditional statements.
+
+
+The follow example runs the stored procedure ``employee_sp`` in the ``example`` catalog and the
+``example_schema`` in the underlying SQL Server database::
+
+    SELECT
+      *
+    FROM
+      TABLE(
+        example.system.procedure(
+          schema    => 'example_schema',
+          procedure => 'employee_sp'
+        )
+      );
+
+If the stored procedure ``employee_sp`` requires any input, it can be specified via ``inputs``
+argument as an ``array<varchar>``::
+
+    SELECT
+      *
+    FROM
+      TABLE(
+        example.system.procedure(
+          schema    => 'example_schema',
+          procedure => 'employee_sp',
+          inputs    => ARRAY['0']
+        )
+      );
 
 Performance
 -----------

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/MappedPageSource.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/MappedPageSource.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.split;
+package io.trino.plugin.base;
 
 import com.google.common.primitives.Ints;
 import io.trino.spi.Page;

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/MappedRecordSet.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/MappedRecordSet.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.split;
+package io.trino.plugin.base;
 
 import com.google.common.primitives.Ints;
 import io.airlift.slice.Slice;

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -245,44 +245,49 @@ public abstract class BaseJdbcClient
     @Override
     public JdbcTableHandle getTableHandle(ConnectorSession session, PreparedQuery preparedQuery)
     {
-        ImmutableList.Builder<JdbcColumnHandle> columns = ImmutableList.builder();
         try (Connection connection = connectionFactory.openConnection(session);
                 PreparedStatement preparedStatement = queryBuilder.prepareStatement(this, session, connection, preparedQuery)) {
             ResultSetMetaData metadata = preparedStatement.getMetaData();
             if (metadata == null) {
                 throw new UnsupportedOperationException("Query not supported: ResultSetMetaData not available for query: " + preparedQuery.getQuery());
             }
-            for (int column = 1; column <= metadata.getColumnCount(); column++) {
-                // Use getColumnLabel method because query pass-through table function may contain column aliases
-                String name = metadata.getColumnLabel(column);
-                JdbcTypeHandle jdbcTypeHandle = new JdbcTypeHandle(
-                        metadata.getColumnType(column),
-                        Optional.ofNullable(metadata.getColumnTypeName(column)),
-                        Optional.of(metadata.getPrecision(column)),
-                        Optional.of(metadata.getScale(column)),
-                        Optional.empty(), // TODO support arrays
-                        Optional.of(metadata.isCaseSensitive(column) ? CASE_SENSITIVE : CASE_INSENSITIVE));
-                Type type = toColumnMapping(session, connection, jdbcTypeHandle)
-                        .orElseThrow(() -> new UnsupportedOperationException(format("Unsupported type: %s of column: %s", jdbcTypeHandle, name)))
-                        .getType();
-                columns.add(new JdbcColumnHandle(name, jdbcTypeHandle, type));
-            }
+            return new JdbcTableHandle(
+                    new JdbcQueryRelationHandle(preparedQuery),
+                    TupleDomain.all(),
+                    ImmutableList.of(),
+                    Optional.empty(),
+                    OptionalLong.empty(),
+                    Optional.of(getColumns(session, connection, metadata)),
+                    // The query is opaque, so we don't know referenced tables
+                    Optional.empty(),
+                    0,
+                    Optional.empty());
         }
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, "Failed to get table handle for prepared query. " + firstNonNull(e.getMessage(), e), e);
         }
+    }
 
-        return new JdbcTableHandle(
-                new JdbcQueryRelationHandle(preparedQuery),
-                TupleDomain.all(),
-                ImmutableList.of(),
-                Optional.empty(),
-                OptionalLong.empty(),
-                Optional.of(columns.build()),
-                // The query is opaque, so we don't know referenced tables
-                Optional.empty(),
-                0,
-                Optional.empty());
+    protected List<JdbcColumnHandle> getColumns(ConnectorSession session, Connection connection, ResultSetMetaData metadata)
+            throws SQLException
+    {
+        ImmutableList.Builder<JdbcColumnHandle> columns = ImmutableList.builder();
+        for (int column = 1; column <= metadata.getColumnCount(); column++) {
+            // Use getColumnLabel method because query pass-through table function may contain column aliases
+            String name = metadata.getColumnLabel(column);
+            JdbcTypeHandle jdbcTypeHandle = new JdbcTypeHandle(
+                    metadata.getColumnType(column),
+                    Optional.ofNullable(metadata.getColumnTypeName(column)),
+                    Optional.of(metadata.getPrecision(column)),
+                    Optional.of(metadata.getScale(column)),
+                    Optional.empty(), // TODO support arrays
+                    Optional.of(metadata.isCaseSensitive(column) ? CASE_SENSITIVE : CASE_INSENSITIVE));
+            Type type = toColumnMapping(session, connection, jdbcTypeHandle)
+                    .orElseThrow(() -> new UnsupportedOperationException(format("Unsupported type: %s of column: %s", jdbcTypeHandle, name)))
+                    .getType();
+            columns.add(new JdbcColumnHandle(name, jdbcTypeHandle, type));
+        }
+        return columns.build();
     }
 
     @Override
@@ -423,6 +428,12 @@ public abstract class BaseJdbcClient
             throws SQLException
     {
         verify(tableHandle.getAuthorization().isEmpty(), "Unexpected authorization is required for table: %s".formatted(tableHandle));
+        return getConnection(session);
+    }
+
+    private Connection getConnection(ConnectorSession session)
+            throws SQLException
+    {
         Connection connection = connectionFactory.openConnection(session);
         try {
             connection.setReadOnly(true);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcConnectorTableHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcConnectorTableHandle.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import io.trino.spi.connector.ConnectorTableHandle;
+
+import java.util.List;
+import java.util.Optional;
+
+public abstract class BaseJdbcConnectorTableHandle
+        implements ConnectorTableHandle
+{
+    public abstract Optional<List<JdbcColumnHandle>> getColumns();
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -18,6 +18,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
 import io.trino.plugin.jdbc.PredicatePushdownController.DomainPushdownResult;
+import io.trino.plugin.jdbc.ptf.Procedure.ProcedureFunctionHandle;
+import io.trino.plugin.jdbc.ptf.Procedure.ProcedureInformation;
 import io.trino.plugin.jdbc.ptf.Query.QueryFunctionHandle;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.AggregateFunction;
@@ -142,6 +144,12 @@ public class DefaultJdbcMetadata
     }
 
     @Override
+    public JdbcProcedureHandle getProcedureHandle(ConnectorSession session, ProcedureInformation procedureInformation)
+    {
+        return jdbcClient.getProcedureHandle(session, procedureInformation);
+    }
+
+    @Override
     public Optional<SystemTable> getSystemTable(ConnectorSession session, SchemaTableName tableName)
     {
         return jdbcClient.getSystemTable(session, tableName);
@@ -150,6 +158,10 @@ public class DefaultJdbcMetadata
     @Override
     public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint constraint)
     {
+        if (table instanceof JdbcProcedureHandle) {
+            return Optional.empty();
+        }
+
         JdbcTableHandle handle = (JdbcTableHandle) table;
         if (handle.getSortOrder().isPresent() && handle.getLimit().isPresent()) {
             handle = flushAttributesAsQuery(session, handle);
@@ -259,6 +271,10 @@ public class DefaultJdbcMetadata
             List<ConnectorExpression> projections,
             Map<String, ColumnHandle> assignments)
     {
+        if (table instanceof JdbcProcedureHandle) {
+            return Optional.empty();
+        }
+
         JdbcTableHandle handle = (JdbcTableHandle) table;
 
         List<JdbcColumnHandle> newColumns = assignments.values().stream()
@@ -309,6 +325,10 @@ public class DefaultJdbcMetadata
             Map<String, ColumnHandle> assignments,
             List<List<ColumnHandle>> groupingSets)
     {
+        if (table instanceof JdbcProcedureHandle) {
+            return Optional.empty();
+        }
+
         if (!isAggregationPushdownEnabled(session)) {
             return Optional.empty();
         }
@@ -412,6 +432,10 @@ public class DefaultJdbcMetadata
             Map<String, ColumnHandle> rightAssignments,
             JoinStatistics statistics)
     {
+        if (left instanceof JdbcProcedureHandle || right instanceof JdbcProcedureHandle) {
+            return Optional.empty();
+        }
+
         if (!isJoinPushdownEnabled(session)) {
             return Optional.empty();
         }
@@ -521,6 +545,10 @@ public class DefaultJdbcMetadata
     @Override
     public Optional<LimitApplicationResult<ConnectorTableHandle>> applyLimit(ConnectorSession session, ConnectorTableHandle table, long limit)
     {
+        if (table instanceof JdbcProcedureHandle) {
+            return Optional.empty();
+        }
+
         JdbcTableHandle handle = (JdbcTableHandle) table;
 
         if (limit > Integer.MAX_VALUE) {
@@ -558,6 +586,10 @@ public class DefaultJdbcMetadata
             List<SortItem> sortItems,
             Map<String, ColumnHandle> assignments)
     {
+        if (table instanceof JdbcProcedureHandle) {
+            return Optional.empty();
+        }
+
         if (!isTopNPushdownEnabled(session)) {
             return Optional.empty();
         }
@@ -603,11 +635,17 @@ public class DefaultJdbcMetadata
     @Override
     public Optional<TableFunctionApplicationResult<ConnectorTableHandle>> applyTableFunction(ConnectorSession session, ConnectorTableFunctionHandle handle)
     {
-        if (!(handle instanceof QueryFunctionHandle)) {
-            return Optional.empty();
+        if (handle instanceof QueryFunctionHandle queryFunctionHandle) {
+            return Optional.of(getTableFunctionApplicationResult(session, queryFunctionHandle.getTableHandle()));
         }
+        if (handle instanceof ProcedureFunctionHandle procedureFunctionHandle) {
+            return Optional.of(getTableFunctionApplicationResult(session, procedureFunctionHandle.getTableHandle()));
+        }
+        return Optional.empty();
+    }
 
-        ConnectorTableHandle tableHandle = ((QueryFunctionHandle) handle).getTableHandle();
+    private TableFunctionApplicationResult<ConnectorTableHandle> getTableFunctionApplicationResult(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
         ConnectorTableSchema tableSchema = getTableSchema(session, tableHandle);
         Map<String, ColumnHandle> columnHandlesByName = getColumnHandles(session, tableHandle);
         List<ColumnHandle> columnHandles = tableSchema.getColumns().stream()
@@ -615,12 +653,16 @@ public class DefaultJdbcMetadata
                 .map(columnHandlesByName::get)
                 .collect(toImmutableList());
 
-        return Optional.of(new TableFunctionApplicationResult<>(tableHandle, columnHandles));
+        return new TableFunctionApplicationResult<>(tableHandle, columnHandles);
     }
 
     @Override
     public Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(ConnectorSession session, ConnectorTableHandle table)
     {
+        if (table instanceof JdbcProcedureHandle) {
+            return Optional.empty();
+        }
+
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
         return jdbcClient.getTableScanRedirection(session, tableHandle);
     }
@@ -628,6 +670,14 @@ public class DefaultJdbcMetadata
     @Override
     public ConnectorTableSchema getTableSchema(ConnectorSession session, ConnectorTableHandle table)
     {
+        if (table instanceof JdbcProcedureHandle procedureHandle) {
+            return new ConnectorTableSchema(
+                    getSchemaTableNameForProcedureHandle(),
+                    procedureHandle.getColumns().orElseThrow().stream()
+                            .map(JdbcColumnHandle::getColumnSchema)
+                            .collect(toImmutableList()));
+        }
+
         JdbcTableHandle handle = (JdbcTableHandle) table;
 
         return new ConnectorTableSchema(
@@ -640,6 +690,14 @@ public class DefaultJdbcMetadata
     @Override
     public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
     {
+        if (table instanceof JdbcProcedureHandle procedureHandle) {
+            return new ConnectorTableMetadata(
+                    getSchemaTableNameForProcedureHandle(),
+                    procedureHandle.getColumns().orElseThrow().stream()
+                            .map(JdbcColumnHandle::getColumnMetadata)
+                            .collect(toImmutableList()));
+        }
+
         JdbcTableHandle handle = (JdbcTableHandle) table;
 
         return new ConnectorTableMetadata(
@@ -659,6 +717,12 @@ public class DefaultJdbcMetadata
                 : new SchemaTableName("_generated", "_generated_query");
     }
 
+    private static SchemaTableName getSchemaTableNameForProcedureHandle()
+    {
+        // TODO (https://github.com/trinodb/trino/issues/6694) SchemaTableName should not be required for synthetic JdbcProcedureHandle
+        return new SchemaTableName("_generated", "_generated_procedure");
+    }
+
     public static Optional<String> getTableComment(JdbcTableHandle handle)
     {
         return handle.isNamedRelation() ? handle.getRequiredNamedRelation().getComment() : Optional.empty();
@@ -673,6 +737,11 @@ public class DefaultJdbcMetadata
     @Override
     public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
+        if (tableHandle instanceof JdbcProcedureHandle procedureHandle) {
+            return procedureHandle.getColumns().orElseThrow().stream()
+                    .collect(toImmutableMap(columnHandle -> columnHandle.getColumnMetadata().getName(), identity()));
+        }
+
         return jdbcClient.getColumns(session, (JdbcTableHandle) tableHandle).stream()
                 .collect(toImmutableMap(columnHandle -> columnHandle.getColumnMetadata().getName(), identity()));
     }
@@ -824,6 +893,7 @@ public class DefaultJdbcMetadata
     @Override
     public ColumnHandle getMergeRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
+        verify(!(tableHandle instanceof JdbcProcedureHandle), "Not a table reference: %s", tableHandle);
         // The column is used for row-level merge, which is not supported, but it's required during analysis anyway.
         return new JdbcColumnHandle(
                 "$merge_row_id",
@@ -834,6 +904,7 @@ public class DefaultJdbcMetadata
     @Override
     public Optional<ConnectorTableHandle> applyDelete(ConnectorSession session, ConnectorTableHandle handle)
     {
+        verify(!(handle instanceof JdbcProcedureHandle), "Not a table reference: %s", handle);
         return Optional.of(handle);
     }
 
@@ -920,6 +991,9 @@ public class DefaultJdbcMetadata
     @Override
     public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
+        if (tableHandle instanceof JdbcProcedureHandle) {
+            return TableStatistics.empty();
+        }
         JdbcTableHandle handle = (JdbcTableHandle) tableHandle;
         return jdbcClient.getTableStatistics(session, handle);
     }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
@@ -19,7 +19,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
+import io.trino.plugin.jdbc.JdbcProcedureHandle.ProcedureQuery;
 import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
+import io.trino.plugin.jdbc.ptf.Procedure.ProcedureInformation;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.JoinType;
@@ -29,6 +31,7 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
 import io.trino.spi.type.Type;
 
+import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -206,6 +209,19 @@ public class DefaultQueryBuilder
         }
 
         return statement;
+    }
+
+    @Override
+    public ProcedureQuery createProcedureQuery(JdbcClient client, ConnectorSession session, Connection connection, ProcedureInformation procedureInformation)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CallableStatement callProcedure(JdbcClient client, ConnectorSession session, Connection connection, ProcedureQuery procedureQuery)
+            throws SQLException
+    {
+        return connection.prepareCall(procedureQuery.query());
     }
 
     protected String formatJoinCondition(JdbcClient client, String leftRelationAlias, String rightRelationAlias, JdbcJoinCondition condition)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.jdbc;
 
+import io.trino.plugin.jdbc.ptf.Procedure.ProcedureInformation;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
@@ -29,6 +30,7 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.spi.type.Type;
 
+import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -91,6 +93,12 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
+    public JdbcProcedureHandle getProcedureHandle(ConnectorSession session, ProcedureInformation procedureInformation)
+    {
+        return delegate().getProcedureHandle(session, procedureInformation);
+    }
+
+    @Override
     public List<JdbcColumnHandle> getColumns(ConnectorSession session, JdbcTableHandle tableHandle)
     {
         return delegate().getColumns(session, tableHandle);
@@ -139,10 +147,23 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
+    public ConnectorSplitSource getSplits(ConnectorSession session, JdbcProcedureHandle procedureHandle)
+    {
+        return delegate().getSplits(session, procedureHandle);
+    }
+
+    @Override
     public Connection getConnection(ConnectorSession session, JdbcSplit split, JdbcTableHandle tableHandle)
             throws SQLException
     {
         return delegate().getConnection(session, split, tableHandle);
+    }
+
+    @Override
+    public Connection getConnection(ConnectorSession session, JdbcSplit split, JdbcProcedureHandle procedureHandle)
+            throws SQLException
+    {
+        return delegate().getConnection(session, split, procedureHandle);
     }
 
     @Override
@@ -168,6 +189,13 @@ public abstract class ForwardingJdbcClient
             throws SQLException
     {
         return delegate().buildSql(session, connection, split, tableHandle, columnHandles);
+    }
+
+    @Override
+    public CallableStatement buildProcedure(ConnectorSession session, Connection connection, JdbcSplit split, JdbcProcedureHandle procedureHandle)
+            throws SQLException
+    {
+        return delegate().buildProcedure(session, connection, split, procedureHandle);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.jdbc;
 
+import io.trino.plugin.jdbc.ptf.Procedure.ProcedureInformation;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.ColumnHandle;
@@ -30,6 +31,7 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.spi.type.Type;
 
+import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -56,6 +58,8 @@ public interface JdbcClient
     Optional<JdbcTableHandle> getTableHandle(ConnectorSession session, SchemaTableName schemaTableName);
 
     JdbcTableHandle getTableHandle(ConnectorSession session, PreparedQuery preparedQuery);
+
+    JdbcProcedureHandle getProcedureHandle(ConnectorSession session, ProcedureInformation procedureInformation);
 
     List<JdbcColumnHandle> getColumns(ConnectorSession session, JdbcTableHandle tableHandle);
 
@@ -85,7 +89,12 @@ public interface JdbcClient
 
     ConnectorSplitSource getSplits(ConnectorSession session, JdbcTableHandle tableHandle);
 
+    ConnectorSplitSource getSplits(ConnectorSession session, JdbcProcedureHandle procedureHandle);
+
     Connection getConnection(ConnectorSession session, JdbcSplit split, JdbcTableHandle tableHandle)
+            throws SQLException;
+
+    Connection getConnection(ConnectorSession session, JdbcSplit split, JdbcProcedureHandle procedureHandle)
             throws SQLException;
 
     default void abortReadConnection(Connection connection, ResultSet resultSet)
@@ -102,6 +111,9 @@ public interface JdbcClient
             Map<String, String> columnExpressions);
 
     PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columns)
+            throws SQLException;
+
+    CallableStatement buildProcedure(ConnectorSession session, Connection connection, JdbcSplit split, JdbcProcedureHandle procedureHandle)
             throws SQLException;
 
     Optional<PreparedQuery> implementJoin(

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcDynamicFilteringSplitManager.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcDynamicFilteringSplitManager.java
@@ -69,6 +69,11 @@ public class JdbcDynamicFilteringSplitManager
             DynamicFilter dynamicFilter,
             Constraint constraint)
     {
+        // JdbcProcedureHandle doesn't support any pushdown operation, so we rely on delegateSplitManager
+        if (table instanceof JdbcProcedureHandle) {
+            return delegateSplitManager.getSplits(transaction, session, table, dynamicFilter, constraint);
+        }
+
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
         // pushing DF through limit could reduce query performance
         boolean hasLimit = tableHandle.getLimit().isPresent();

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadata.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.jdbc;
 
+import io.trino.plugin.jdbc.ptf.Procedure.ProcedureInformation;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorSession;
 
@@ -20,6 +21,8 @@ public interface JdbcMetadata
         extends ConnectorMetadata
 {
     JdbcTableHandle getTableHandle(ConnectorSession session, PreparedQuery preparedQuery);
+
+    JdbcProcedureHandle getProcedureHandle(ConnectorSession session, ProcedureInformation procedureQuery);
 
     void rollback();
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcProcedureHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcProcedureHandle.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class JdbcProcedureHandle
+        extends BaseJdbcConnectorTableHandle
+{
+    private final ProcedureQuery procedure;
+    private final List<JdbcColumnHandle> columns;
+
+    @JsonCreator
+    public JdbcProcedureHandle(@JsonProperty ProcedureQuery procedureQuery, @JsonProperty List<JdbcColumnHandle> columns)
+    {
+        this.procedure = requireNonNull(procedureQuery, "procedureQuery is null");
+        this.columns = requireNonNull(columns, "columns is null");
+    }
+
+    @JsonProperty
+    public ProcedureQuery getProcedureQuery()
+    {
+        return procedure;
+    }
+
+    @Override
+    @JsonProperty
+    public Optional<List<JdbcColumnHandle>> getColumns()
+    {
+        return Optional.of(columns);
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("Procedure[%s], Columns=%s", procedure, columns);
+    }
+
+    public record ProcedureQuery(@JsonProperty String query)
+    {
+        @JsonCreator
+        public ProcedureQuery
+        {
+            requireNonNull(query, "query is null");
+        }
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordCursor.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordCursor.java
@@ -63,7 +63,7 @@ public class JdbcRecordCursor
     private ResultSet resultSet;
     private boolean closed;
 
-    public JdbcRecordCursor(JdbcClient jdbcClient, ExecutorService executor, ConnectorSession session, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columnHandles)
+    public JdbcRecordCursor(JdbcClient jdbcClient, ExecutorService executor, ConnectorSession session, JdbcSplit split, BaseJdbcConnectorTableHandle table, List<JdbcColumnHandle> columnHandles)
     {
         this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
         this.executor = requireNonNull(executor, "executor is null");
@@ -78,7 +78,7 @@ public class JdbcRecordCursor
         objectReadFunctions = new ObjectReadFunction[columnHandles.size()];
 
         try {
-            connection = jdbcClient.getConnection(session, split, table);
+            connection = jdbcClient.getConnection(session, split, (JdbcTableHandle) table);
 
             for (int i = 0; i < this.columnHandles.length; i++) {
                 JdbcColumnHandle columnHandle = columnHandles.get(i);
@@ -109,7 +109,7 @@ public class JdbcRecordCursor
                 }
             }
 
-            statement = jdbcClient.buildSql(session, connection, split, table, columnHandles);
+            statement = jdbcClient.buildSql(session, connection, split, (JdbcTableHandle) table, columnHandles);
         }
         catch (SQLException | RuntimeException e) {
             throw handleSqlException(e);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordCursor.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordCursor.java
@@ -78,7 +78,12 @@ public class JdbcRecordCursor
         objectReadFunctions = new ObjectReadFunction[columnHandles.size()];
 
         try {
-            connection = jdbcClient.getConnection(session, split, (JdbcTableHandle) table);
+            if (table instanceof JdbcProcedureHandle procedureHandle) {
+                connection = jdbcClient.getConnection(session, split, procedureHandle);
+            }
+            else {
+                connection = jdbcClient.getConnection(session, split, (JdbcTableHandle) table);
+            }
 
             for (int i = 0; i < this.columnHandles.length; i++) {
                 JdbcColumnHandle columnHandle = columnHandles.get(i);
@@ -109,7 +114,12 @@ public class JdbcRecordCursor
                 }
             }
 
-            statement = jdbcClient.buildSql(session, connection, split, (JdbcTableHandle) table, columnHandles);
+            if (table instanceof JdbcProcedureHandle procedureHandle) {
+                statement = jdbcClient.buildProcedure(session, connection, split, procedureHandle);
+            }
+            else {
+                statement = jdbcClient.buildSql(session, connection, split, (JdbcTableHandle) table, columnHandles);
+            }
         }
         catch (SQLException | RuntimeException e) {
             throw handleSqlException(e);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordSet.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordSet.java
@@ -29,13 +29,13 @@ public class JdbcRecordSet
 {
     private final JdbcClient jdbcClient;
     private final ExecutorService executor;
-    private final JdbcTableHandle table;
+    private final BaseJdbcConnectorTableHandle table;
     private final List<JdbcColumnHandle> columnHandles;
     private final List<Type> columnTypes;
     private final JdbcSplit split;
     private final ConnectorSession session;
 
-    public JdbcRecordSet(JdbcClient jdbcClient, ExecutorService executor, ConnectorSession session, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columnHandles)
+    public JdbcRecordSet(JdbcClient jdbcClient, ExecutorService executor, ConnectorSession session, JdbcSplit split, BaseJdbcConnectorTableHandle table, List<JdbcColumnHandle> columnHandles)
     {
         this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
         this.executor = requireNonNull(executor, "executor is null");

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcSplitManager.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcSplitManager.java
@@ -45,6 +45,10 @@ public class JdbcSplitManager
             DynamicFilter dynamicFilter,
             Constraint constraint)
     {
+        if (table instanceof JdbcProcedureHandle procedureHandle) {
+            return jdbcClient.getSplits(session, procedureHandle);
+        }
+
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
         ConnectorSplitSource jdbcSplitSource = jdbcClient.getSplits(session, tableHandle);
         if (dynamicFilteringEnabled(session)) {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcTableHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcTableHandle.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.trino.spi.connector.ColumnHandle;
-import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 
@@ -34,7 +33,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 public final class JdbcTableHandle
-        implements ConnectorTableHandle
+        extends BaseJdbcConnectorTableHandle
 {
     private final JdbcRelationHandle relationHandle;
 
@@ -149,6 +148,7 @@ public final class JdbcTableHandle
         return limit;
     }
 
+    @Override
     @JsonProperty
     public Optional<List<JdbcColumnHandle>> getColumns()
     {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
@@ -13,11 +13,14 @@
  */
 package io.trino.plugin.jdbc;
 
+import io.trino.plugin.jdbc.JdbcProcedureHandle.ProcedureQuery;
+import io.trino.plugin.jdbc.ptf.Procedure.ProcedureInformation;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.JoinType;
 import io.trino.spi.predicate.TupleDomain;
 
+import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -62,5 +65,19 @@ public interface QueryBuilder
             ConnectorSession session,
             Connection connection,
             PreparedQuery preparedQuery)
+            throws SQLException;
+
+    ProcedureQuery createProcedureQuery(
+            JdbcClient client,
+            ConnectorSession session,
+            Connection connection,
+            ProcedureInformation procedureInformation)
+            throws SQLException;
+
+    CallableStatement callProcedure(
+            JdbcClient client,
+            ConnectorSession session,
+            Connection connection,
+            ProcedureQuery procedureQuery)
             throws SQLException;
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/JdbcClientStats.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/JdbcClientStats.java
@@ -25,6 +25,7 @@ public final class JdbcClientStats
     private final JdbcApiStats buildInsertSql = new JdbcApiStats();
     private final JdbcApiStats prepareQuery = new JdbcApiStats();
     private final JdbcApiStats buildSql = new JdbcApiStats();
+    private final JdbcApiStats buildProcedure = new JdbcApiStats();
     private final JdbcApiStats implementJoin = new JdbcApiStats();
     private final JdbcApiStats commitCreateTable = new JdbcApiStats();
     private final JdbcApiStats createSchema = new JdbcApiStats();
@@ -40,11 +41,14 @@ public final class JdbcClientStats
     private final JdbcApiStats getColumns = new JdbcApiStats();
     private final JdbcApiStats getConnectionWithHandle = new JdbcApiStats();
     private final JdbcApiStats getConnectionWithSplit = new JdbcApiStats();
+    private final JdbcApiStats getConnectionWithProcedure = new JdbcApiStats();
     private final JdbcApiStats getPreparedStatement = new JdbcApiStats();
     private final JdbcApiStats getSchemaNames = new JdbcApiStats();
     private final JdbcApiStats getSplits = new JdbcApiStats();
+    private final JdbcApiStats getSplitsForProcedure = new JdbcApiStats();
     private final JdbcApiStats getTableHandle = new JdbcApiStats();
     private final JdbcApiStats getTableHandleForQuery = new JdbcApiStats();
+    private final JdbcApiStats getProcedureHandle = new JdbcApiStats();
     private final JdbcApiStats getTableNames = new JdbcApiStats();
     private final JdbcApiStats getTableStatistics = new JdbcApiStats();
     private final JdbcApiStats renameColumn = new JdbcApiStats();
@@ -109,6 +113,13 @@ public final class JdbcClientStats
     public JdbcApiStats getBuildSql()
     {
         return buildSql;
+    }
+
+    @Managed
+    @Nested
+    public JdbcApiStats getBuildProcedure()
+    {
+        return buildProcedure;
     }
 
     @Managed
@@ -218,6 +229,13 @@ public final class JdbcClientStats
 
     @Managed
     @Nested
+    public JdbcApiStats getGetConnectionWithProcedure()
+    {
+        return getConnectionWithProcedure;
+    }
+
+    @Managed
+    @Nested
     public JdbcApiStats getGetPreparedStatement()
     {
         return getPreparedStatement;
@@ -239,6 +257,13 @@ public final class JdbcClientStats
 
     @Managed
     @Nested
+    public JdbcApiStats getGetSplitsForProcedure()
+    {
+        return getSplitsForProcedure;
+    }
+
+    @Managed
+    @Nested
     public JdbcApiStats getGetTableHandle()
     {
         return getTableHandle;
@@ -249,6 +274,13 @@ public final class JdbcClientStats
     public JdbcApiStats getGetTableHandleForQuery()
     {
         return getTableHandleForQuery;
+    }
+
+    @Managed
+    @Nested
+    public JdbcApiStats getGetProcedureHandle()
+    {
+        return getProcedureHandle;
     }
 
     @Managed

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ptf/Procedure.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ptf/Procedure.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.ptf;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorTableFunction;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcMetadata;
+import io.trino.plugin.jdbc.JdbcProcedureHandle;
+import io.trino.plugin.jdbc.JdbcTransactionManager;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.predicate.NullableValue;
+import io.trino.spi.ptf.AbstractConnectorTableFunction;
+import io.trino.spi.ptf.Argument;
+import io.trino.spi.ptf.ConnectorTableFunction;
+import io.trino.spi.ptf.ConnectorTableFunctionHandle;
+import io.trino.spi.ptf.Descriptor;
+import io.trino.spi.ptf.Descriptor.Field;
+import io.trino.spi.ptf.ScalarArgument;
+import io.trino.spi.ptf.ScalarArgumentSpecification;
+import io.trino.spi.ptf.TableFunctionAnalysis;
+import io.trino.spi.type.ArrayType;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.ptf.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public class Procedure
+        implements Provider<ConnectorTableFunction>
+{
+    public static final String SCHEMA_NAME = "system";
+    public static final String NAME = "procedure";
+
+    private final JdbcTransactionManager transactionManager;
+
+    @Inject
+    public Procedure(JdbcTransactionManager transactionManager)
+    {
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+    }
+
+    @Override
+    public ConnectorTableFunction get()
+    {
+        return new ClassLoaderSafeConnectorTableFunction(new ProcedureFunction(transactionManager), getClass().getClassLoader());
+    }
+
+    public static class ProcedureFunction
+            extends AbstractConnectorTableFunction
+    {
+        private final JdbcTransactionManager transactionManager;
+
+        public ProcedureFunction(JdbcTransactionManager transactionManager)
+        {
+            super(
+                    SCHEMA_NAME,
+                    NAME,
+                    List.of(
+                            ScalarArgumentSpecification.builder()
+                                    .name("SCHEMA")
+                                    .type(VARCHAR)
+                                    .build(),
+                            ScalarArgumentSpecification.builder()
+                                    .name("PROCEDURE")
+                                    .type(VARCHAR)
+                                    .build(),
+                            ScalarArgumentSpecification.builder()
+                                    .name("INPUTS")
+                                    .type(new ArrayType(VARCHAR))
+                                    .defaultValue(null)
+                                    .build()),
+                    GENERIC_TABLE);
+            this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        }
+
+        @Override
+        public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
+        {
+            String schema = ((Slice) ((ScalarArgument) arguments.get("SCHEMA")).getValue()).toStringUtf8();
+            String procedure = ((Slice) ((ScalarArgument) arguments.get("PROCEDURE")).getValue()).toStringUtf8();
+            ScalarArgument inputArgument = ((ScalarArgument) arguments.get("INPUTS"));
+            NullableValue inputs = inputArgument.getNullableValue();
+            List<String> inputArguments = ImmutableList.of();
+
+            if (!inputs.isNull()) {
+                inputArguments = ((List<Object>) inputArgument.getType().getObjectValue(session, inputs.asBlock(), 0)).stream()
+                        .map(String.class::cast)
+                        .collect(toImmutableList());
+            }
+
+            JdbcMetadata metadata = transactionManager.getMetadata(transaction);
+            JdbcProcedureHandle tableHandle = metadata.getProcedureHandle(session, new ProcedureInformation(schema, procedure, inputArguments));
+            List<JdbcColumnHandle> columns = tableHandle.getColumns().orElseThrow(() -> new IllegalStateException("Handle doesn't have columns info"));
+            Descriptor returnedType = new Descriptor(columns.stream()
+                    .map(column -> new Field(column.getColumnName(), Optional.of(column.getColumnType())))
+                    .collect(toImmutableList()));
+
+            ProcedureFunctionHandle handle = new ProcedureFunctionHandle(tableHandle);
+
+            return TableFunctionAnalysis.builder()
+                    .returnedType(returnedType)
+                    .handle(handle)
+                    .build();
+        }
+    }
+
+    public static class ProcedureFunctionHandle
+            implements ConnectorTableFunctionHandle
+    {
+        private final JdbcProcedureHandle tableHandle;
+
+        @JsonCreator
+        public ProcedureFunctionHandle(@JsonProperty("tableHandle") JdbcProcedureHandle tableHandle)
+        {
+            this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
+        }
+
+        @JsonProperty
+        public ConnectorTableHandle getTableHandle()
+        {
+            return tableHandle;
+        }
+    }
+
+    public record ProcedureInformation(String schemaName, String procedureName, List<String> inputArguments)
+    {
+        public ProcedureInformation
+        {
+            requireNonNull(schemaName, "schemaName is null");
+            requireNonNull(procedureName, "procedureName is null");
+            inputArguments = ImmutableList.copyOf(requireNonNull(inputArguments, "inputArguments is null"));
+        }
+    }
+}

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestCachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestCachingJdbcClient.java
@@ -20,6 +20,7 @@ import com.google.common.util.concurrent.Futures;
 import io.airlift.units.Duration;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.plugin.jdbc.credential.ExtraCredentialConfig;
+import io.trino.plugin.jdbc.ptf.Procedure.ProcedureInformation;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
@@ -35,6 +36,10 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -307,6 +312,39 @@ public class TestCachingJdbcClient
     }
 
     @Test
+    public void testProcedureHandleCached()
+            throws Exception
+    {
+        SchemaTableName phantomTable = new SchemaTableName(schema, "phantom_table");
+
+        createTable(phantomTable);
+        createProcedure("test_procedure");
+
+        ProcedureInformation query = new ProcedureInformation(
+                schema,
+                "test_procedure",
+                ImmutableList.of("'" + phantomTable + "'"));
+        JdbcProcedureHandle cachedProcedure = assertProcedureHandleByQueryCache(cachingJdbcClient)
+                .misses(1)
+                .loads(1)
+                .calling(() -> cachingJdbcClient.getProcedureHandle(SESSION, query));
+        assertThat(cachedProcedure.getColumns().orElseThrow())
+                .hasSize(0);
+
+        dropProcedure("test_procedure");
+
+        assertThatThrownBy(() -> jdbcClient.getProcedureHandle(SESSION, query))
+                .hasMessageContaining("Failed to get table handle for procedure query");
+
+        assertProcedureHandleByQueryCache(cachingJdbcClient)
+                .hits(1)
+                .afterRunning(() -> assertThat(cachingJdbcClient.getProcedureHandle(SESSION, query))
+                        .isEqualTo(cachedProcedure));
+
+        dropTable(phantomTable);
+    }
+
+    @Test
     public void testTableHandleInvalidatedOnColumnsModifications()
     {
         JdbcTableHandle table = createTable(new SchemaTableName(schema, "a_table"));
@@ -367,6 +405,29 @@ public class TestCachingJdbcClient
     {
         jdbcClient.createTable(SESSION, new ConnectorTableMetadata(phantomTable, emptyList()));
         return jdbcClient.getTableHandle(SESSION, phantomTable).orElseThrow();
+    }
+
+    private void createProcedure(String procedureName)
+            throws SQLException
+    {
+        try (Statement statement = database.getConnection().createStatement()) {
+            statement.execute("CREATE ALIAS %s.%s FOR \"io.trino.plugin.jdbc.TestCachingJdbcClient.generateData\"".formatted(schema, procedureName));
+        }
+    }
+
+    private void dropProcedure(String procedureName)
+            throws SQLException
+    {
+        try (Statement statement = database.getConnection().createStatement()) {
+            statement.execute("DROP ALIAS %s.%s".formatted(schema, procedureName));
+        }
+    }
+
+    // Used by H2 for executing Stored Procedure
+    public static ResultSet generateData(Connection connection, String table)
+            throws SQLException
+    {
+        return connection.createStatement().executeQuery("SELECT * FROM " + table);
     }
 
     private void dropTable(JdbcTableHandle tableHandle)
@@ -1044,6 +1105,11 @@ public class TestCachingJdbcClient
         return assertCacheStats(client, CachingJdbcCache.TABLE_HANDLES_BY_QUERY_CACHE);
     }
 
+    private static SingleJdbcCacheStatsAssertions assertProcedureHandleByQueryCache(CachingJdbcClient client)
+    {
+        return assertCacheStats(client, CachingJdbcCache.PROCEDURE_HANDLES_BY_QUERY_CACHE);
+    }
+
     private static SingleJdbcCacheStatsAssertions assertColumnCacheStats(CachingJdbcClient client)
     {
         return assertCacheStats(client, CachingJdbcCache.COLUMNS_CACHE);
@@ -1178,6 +1244,7 @@ public class TestCachingJdbcClient
         TABLE_NAMES_CACHE(CachingJdbcClient::getTableNamesCacheStats),
         TABLE_HANDLES_BY_NAME_CACHE(CachingJdbcClient::getTableHandlesByNameCacheStats),
         TABLE_HANDLES_BY_QUERY_CACHE(CachingJdbcClient::getTableHandlesByQueryCacheStats),
+        PROCEDURE_HANDLES_BY_QUERY_CACHE(CachingJdbcClient::getProcedureHandlesByQueryCacheStats),
         COLUMNS_CACHE(CachingJdbcClient::getColumnsCacheStats),
         STATISTICS_CACHE(CachingJdbcClient::getStatisticsCacheStats),
         /**/;

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestProcedure.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestProcedure.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import io.trino.testing.sql.SqlExecutor;
+import io.trino.testing.sql.TemporaryRelation;
+
+import static java.util.Objects.requireNonNull;
+
+public class TestProcedure
+        implements TemporaryRelation
+{
+    protected final SqlExecutor sqlExecutor;
+    protected final String name;
+
+    public TestProcedure(SqlExecutor sqlExecutor, String name, String createProcedureTemplate)
+    {
+        this.sqlExecutor = requireNonNull(sqlExecutor, "sqlExecutor is null");
+        this.name = requireNonNull(name, "name is null");
+        sqlExecutor.execute(createProcedureTemplate.formatted(name));
+    }
+
+    @Override
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public void close()
+    {
+        sqlExecutor.execute("DROP PROCEDURE " + name);
+    }
+}

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcClient.java
@@ -18,12 +18,14 @@ import dev.failsafe.Failsafe;
 import dev.failsafe.RetryPolicy;
 import io.airlift.log.Logger;
 import io.trino.plugin.base.aggregation.AggregateFunctionRewriter;
+import io.trino.plugin.jdbc.JdbcProcedureHandle.ProcedureQuery;
 import io.trino.plugin.jdbc.aggregation.ImplementCountAll;
 import io.trino.plugin.jdbc.expression.JdbcConnectorExpressionRewriterBuilder;
 import io.trino.plugin.jdbc.expression.RewriteVariable;
 import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.plugin.jdbc.mapping.DefaultIdentifierMapping;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
+import io.trino.plugin.jdbc.ptf.Procedure.ProcedureInformation;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.ColumnHandle;
@@ -34,14 +36,19 @@ import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 
+import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.booleanColumnMapping;
@@ -93,7 +100,7 @@ class TestingH2JdbcClient
 
     public TestingH2JdbcClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, IdentifierMapping identifierMapping)
     {
-        super(config, "\"", connectionFactory, new DefaultQueryBuilder(RemoteQueryModifier.NONE), identifierMapping, RemoteQueryModifier.NONE);
+        super(config, "\"", connectionFactory, new TestingH2QueryBuilder(RemoteQueryModifier.NONE), identifierMapping, RemoteQueryModifier.NONE);
     }
 
     @Override
@@ -249,5 +256,30 @@ class TestingH2JdbcClient
             throw new TrinoException(NOT_SUPPORTED, "This connector does not support renaming tables across schemas");
         }
         super.renameTable(session, catalogName, schemaName, tableName, newTable);
+    }
+
+    @Override
+    public JdbcProcedureHandle getProcedureHandle(ConnectorSession session, ProcedureInformation procedureInformation)
+
+    {
+        try (Connection connection = connectionFactory.openConnection(session)) {
+            ProcedureQuery procedureQuery = queryBuilder.createProcedureQuery(this, session, connection, procedureInformation);
+
+            try (CallableStatement statement = queryBuilder.callProcedure(this, session, connection, procedureQuery);
+                    ResultSet resultSet = statement.executeQuery()) {
+                ResultSetMetaData metadata = resultSet.getMetaData();
+                if (metadata == null) {
+                    throw new TrinoException(NOT_SUPPORTED, "Procedure not supported: ResultSetMetaData not available for query: " + procedureQuery.query());
+                }
+                JdbcProcedureHandle procedureHandle = new JdbcProcedureHandle(procedureQuery, getColumns(session, connection, metadata));
+                if (statement.getMoreResults()) {
+                    throw new TrinoException(NOT_SUPPORTED, "Procedure has multiple ResultSets for query: " + procedureQuery.query());
+                }
+                return procedureHandle;
+            }
+        }
+        catch (SQLException e) {
+            throw new TrinoException(JDBC_ERROR, "Failed to get table handle for procedure query. " + firstNonNull(e.getMessage(), e), e);
+        }
     }
 }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2QueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2QueryBuilder.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import com.google.common.base.Joiner;
+import io.trino.plugin.jdbc.JdbcProcedureHandle.ProcedureQuery;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
+import io.trino.plugin.jdbc.ptf.Procedure;
+import io.trino.spi.connector.ConnectorSession;
+
+import javax.inject.Inject;
+
+import java.sql.Connection;
+
+public class TestingH2QueryBuilder
+        extends DefaultQueryBuilder
+{
+    @Inject
+    public TestingH2QueryBuilder(RemoteQueryModifier queryModifier)
+    {
+        super(queryModifier);
+    }
+
+    @Override
+    public ProcedureQuery createProcedureQuery(JdbcClient client, ConnectorSession session, Connection connection, Procedure.ProcedureInformation procedureInformation)
+    {
+        return new JdbcProcedureHandle.ProcedureQuery(
+                "CALL %s.%s (%s)"
+                        .formatted(
+                                procedureInformation.schemaName(),
+                                procedureInformation.procedureName(),
+                                Joiner.on(", ").join(procedureInformation.inputArguments())));
+    }
+}

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClientModule.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClientModule.java
@@ -28,7 +28,9 @@ import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcJoinPushdownSupportModule;
 import io.trino.plugin.jdbc.JdbcStatisticsConfig;
 import io.trino.plugin.jdbc.MaxDomainCompactionThreshold;
+import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
+import io.trino.plugin.jdbc.ptf.Procedure;
 import io.trino.plugin.jdbc.ptf.Query;
 import io.trino.spi.ptf.ConnectorTableFunction;
 
@@ -50,8 +52,10 @@ public class SqlServerClientModule
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(SqlServerClient.class).in(Scopes.SINGLETON);
         bindTablePropertiesProvider(binder, SqlServerTableProperties.class);
         bindSessionPropertiesProvider(binder, SqlServerSessionProperties.class);
+        newOptionalBinder(binder, QueryBuilder.class).setBinding().to(SqlServerQueryBuilder.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, Key.get(int.class, MaxDomainCompactionThreshold.class)).setBinding().toInstance(SQL_SERVER_MAX_LIST_EXPRESSIONS);
         newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Query.class).in(Scopes.SINGLETON);
+        newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Procedure.class).in(Scopes.SINGLETON);
         install(new JdbcJoinPushdownSupportModule());
     }
 

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerQueryBuilder.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerQueryBuilder.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.sqlserver;
+
+import com.google.common.base.Joiner;
+import io.trino.plugin.jdbc.DefaultQueryBuilder;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcProcedureHandle.ProcedureQuery;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
+import io.trino.plugin.jdbc.ptf.Procedure.ProcedureInformation;
+import io.trino.spi.connector.ConnectorSession;
+
+import javax.inject.Inject;
+
+import java.sql.Connection;
+
+public class SqlServerQueryBuilder
+        extends DefaultQueryBuilder
+{
+    @Inject
+    public SqlServerQueryBuilder(RemoteQueryModifier queryModifier)
+    {
+        super(queryModifier);
+    }
+
+    @Override
+    public ProcedureQuery createProcedureQuery(JdbcClient client, ConnectorSession session, Connection connection, ProcedureInformation procedureInformation)
+    {
+        return new ProcedureQuery(
+                "EXECUTE %s.%s %s"
+                        .formatted(
+                                procedureInformation.schemaName(),
+                                procedureInformation.procedureName(),
+                                Joiner.on(", ").join(procedureInformation.inputArguments())));
+    }
+}

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
@@ -18,7 +18,9 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.plugin.jdbc.BaseJdbcConnectorTest;
 import io.trino.plugin.jdbc.JdbcTableHandle;
+import io.trino.plugin.jdbc.TestProcedure;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.TestTable;
@@ -660,6 +662,328 @@ public abstract class BaseSqlServerConnectorTest
     protected void verifyColumnNameLengthFailurePermissible(Throwable e)
     {
         assertThat(e).hasMessageMatching("Column name must be shorter than or equal to '128' characters but got '129': '.*'");
+    }
+
+    @Test
+    public void testSelectFromProcedureFunction()
+    {
+        try (TestProcedure testProcedure = createTestingProcedure("SELECT * FROM nation WHERE nationkey = 1")) {
+            assertQuery(
+                    format("SELECT name FROM TABLE(system.procedure(schema => '%s', procedure => '%s')) ".formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()), getSession().getSchema().orElseThrow()),
+                    "VALUES 'ARGENTINA'");
+        }
+    }
+
+    @Test
+    public void testSelectFromProcedureFunctionWithInputParameter()
+    {
+        try (TestProcedure testProcedure = createTestingProcedure(
+                "@nationkey bigint, @name varchar(30)",
+                "SELECT * FROM nation WHERE nationkey = @nationkey AND name = @name")) {
+            assertQuery(
+                    "SELECT nationkey, name FROM TABLE(system.procedure(schema => '%s', procedure => '%s', inputs => ARRAY['0', 'ALGERIA'])) ".formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()),
+                    "VALUES (0, 'ALGERIA')");
+        }
+    }
+
+    @Test
+    public void testSelectFromProcedureFunctionWithOutputParameter()
+    {
+        try (TestProcedure testProcedure = createTestingProcedure("@row_count bigint OUTPUT", "SELECT * FROM nation; SELECT @row_count = @@ROWCOUNT")) {
+            assertQueryFails(
+                    "SELECT name FROM TABLE(system.procedure(schema => '%s', procedure => '%s')) ".formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()),
+                    "Failed to get table handle for procedure query\\. Procedure or function '.*' expects parameter '@row_count', which was not supplied\\.");
+        }
+    }
+
+    @Test
+    public void testFilterPushdownRestrictedForProcedureFunction()
+    {
+        try (TestProcedure testProcedure = createTestingProcedure("SELECT * FROM nation")) {
+            assertThat(query("SELECT name FROM TABLE(system.procedure(schema => '%s', procedure => '%s')) WHERE nationkey = 0".formatted(getSession().getSchema().orElseThrow(), testProcedure.getName())))
+                    .isNotFullyPushedDown(FilterNode.class)
+                    .skippingTypesCheck()
+                    .matches("VALUES 'ALGERIA'");
+        }
+    }
+
+    @Test
+    public void testAggregationPushdownRestrictedForProcedureFunction()
+    {
+        try (TestProcedure testProcedure = createTestingProcedure("SELECT * FROM nation")) {
+            assertThat(query(
+                    "SELECT COUNT(*) FROM TABLE(system.procedure(schema => '%s', procedure => '%s'))"
+                            .formatted(getSession().getSchema().orElseThrow(), testProcedure.getName())))
+                    .isNotFullyPushedDown(AggregationNode.class)
+                    .matches("VALUES BIGINT '25'");
+        }
+    }
+
+    @Test
+    public void testJoinPushdownRestrictedForProcedureFunction()
+    {
+        try (TestProcedure testProcedure = createTestingProcedure("SELECT * FROM nation")) {
+            assertThat(query(
+                    joinPushdownEnabled(getSession()),
+                    "SELECT nationkey FROM TABLE(system.procedure(schema => '%s', procedure => '%s')) INNER JOIN nation USING (nationkey) ORDER BY 1 LIMIT 1"
+                            .formatted(getSession().getSchema().orElseThrow(), testProcedure.getName())))
+                    .joinIsNotFullyPushedDown()
+                    .matches("VALUES BIGINT '0'");
+        }
+    }
+
+    @Test
+    public void testProcedureWithSingleIfStatement()
+    {
+        try (TestProcedure testProcedure = createTestingProcedure(
+                "@id INTEGER",
+                """
+                IF @id > 50
+                    SELECT 1 as first_column;
+                """)) {
+            assertQuery(
+                    format("SELECT first_column FROM TABLE(system.procedure(schema => '%s', procedure => '%s', inputs => ARRAY['100'])) ".formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()), getSession().getSchema().orElseThrow()),
+                    "VALUES 1");
+
+            assertQueryFails(
+                    "SELECT first_column FROM TABLE(system.procedure(schema => '%s', procedure => '%s', inputs => ARRAY['10'])) ".formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()),
+                    "The statement did not return a result set.");
+        }
+    }
+
+    @Test
+    public void testProcedureWithIfElseStatement()
+    {
+        try (TestProcedure testProcedure = createTestingProcedure(
+                "@id INTEGER",
+                """
+                IF @id > 50
+                    SELECT 1 as first_column;
+                ELSE
+                    SELECT '2' as second_column;
+                """)) {
+            assertQueryFails(
+                    "SELECT * FROM TABLE(system.procedure(schema => '%s', procedure => '%s', inputs => ARRAY['100'])) "
+                            .formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()),
+                    "Procedure has multiple ResultSets for query: .*");
+        }
+    }
+
+    @Test
+    public void testProcedureWithSingleIfElse()
+    {
+        try (TestProcedure testProcedure = createTestingProcedure("SELECT 1 as first_row; SELECT 2 as second_row")) {
+            assertQueryFails(
+                    "SELECT * FROM TABLE(system.procedure(schema => '%s', procedure => '%s')) "
+                            .formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()),
+                    "Procedure has multiple ResultSets for query: .*");
+        }
+    }
+
+    @Test
+    public void testProcedureWithMultipleResultSet()
+    {
+        try (TestProcedure testProcedure = createTestingProcedure("SELECT 1 as first_row; SELECT 2 as second_row")) {
+            assertQueryFails(
+                    "SELECT * FROM TABLE(system.procedure(schema => '%s', procedure => '%s')) "
+                            .formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()),
+                    "Procedure has multiple ResultSets for query: .*");
+        }
+    }
+
+    @Test
+    public void testProcedureWithCreateOperation()
+    {
+        String tableName = "table_to_create" + randomNameSuffix();
+        try (TestProcedure testProcedure = createTestingProcedure("CREATE TABLE %s (id BIGINT)".formatted(tableName))) {
+            assertQueryFails(
+                    "SELECT * FROM TABLE(system.procedure(schema => '%s', procedure => '%s'))"
+                            .formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()),
+                    "Failed to get table handle for procedure query. The statement did not return a result set.");
+            assertQueryReturnsEmptyResult("SHOW TABLES LIKE '%s'".formatted(tableName));
+        }
+    }
+
+    @Test
+    public void testProcedureWithDropOperation()
+    {
+        try (TestTable table = new TestTable(onRemoteDatabase(), "table_to_drop", "(id BIGINT)")) {
+            try (TestProcedure testProcedure = createTestingProcedure("DROP TABLE " + table.getName())) {
+                assertQueryFails(
+                        "SELECT * FROM TABLE(system.procedure(schema => '%s', procedure => '%s'))"
+                                .formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()),
+                        "Failed to get table handle for procedure query. The statement did not return a result set.");
+                assertQuery("SHOW TABLES LIKE '%s'".formatted(table.getName()), "VALUES '%s'".formatted(table.getName()));
+            }
+        }
+    }
+
+    @Test
+    public void testProcedureWithInsertOperation()
+    {
+        try (TestTable table = new TestTable(onRemoteDatabase(), "table_to_insert", "(id BIGINT)");
+                TestTable tableForInsertedRows = new TestTable(onRemoteDatabase(), "table_to_capture_inserted_rows", "(id BIGINT)")) {
+            try (TestProcedure testProcedure = createTestingProcedure("INSERT INTO %s VALUES (1)".formatted(table.getName()))) {
+                assertQueryFails(
+                        "SELECT * FROM TABLE(system.procedure(schema => '%s', procedure => '%s'))"
+                                .formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()),
+                        "Failed to get table handle for procedure query. The statement did not return a result set.");
+                assertQueryReturnsEmptyResult("SELECT * FROM " + table.getName());
+            }
+
+            try (TestProcedure testProcedure = createTestingProcedure("INSERT %s OUTPUT INSERTED.* VALUES (1)".formatted(table.getName()))) {
+                assertQueryFails(
+                        "SELECT * FROM TABLE(system.procedure(schema => '%s', procedure => '%s'))"
+                                .formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()),
+                        "Procedure not supported: Procedure updates or inserts data.*");
+                assertQueryReturnsEmptyResult("SELECT * FROM " + table.getName());
+            }
+
+            try (TestProcedure testProcedure = createTestingProcedure("INSERT %s OUTPUT INSERTED.*INTO %s VALUES (1)".formatted(table.getName(), tableForInsertedRows.getName()))) {
+                assertQueryFails(
+                        "SELECT * FROM TABLE(system.procedure(schema => '%s', procedure => '%s'))"
+                                .formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()),
+                        "Failed to get table handle for procedure query. The statement did not return a result set.");
+                assertQueryReturnsEmptyResult("SELECT * FROM " + table.getName());
+                assertQueryReturnsEmptyResult("SELECT * FROM " + tableForInsertedRows.getName());
+            }
+        }
+    }
+
+    @Test
+    public void testProcedureWithDeleteOperation()
+    {
+        try (TestTable table = new TestTable(onRemoteDatabase(), "table_to_delete", "(id BIGINT)", ImmutableList.of("1", "2", "3"));
+                TestTable tableForDeletedRows = new TestTable(onRemoteDatabase(), "table_to_capture_deleted_rows", "(id BIGINT)")) {
+            try (TestProcedure testProcedure = createTestingProcedure("DELETE %s".formatted(table.getName()))) {
+                assertQueryFails(
+                        "SELECT * FROM TABLE(system.procedure(schema => '%s', procedure => '%s'))"
+                                .formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()),
+                        "Failed to get table handle for procedure query. The statement did not return a result set.");
+                assertQuery("SELECT * FROM " + table.getName(), "VALUES (1), (2), (3)");
+            }
+
+            try (TestProcedure testProcedure = createTestingProcedure("DELETE %s OUTPUT DELETED.*".formatted(table.getName()))) {
+                assertQueryFails(
+                        "SELECT * FROM TABLE(system.procedure(schema => '%s', procedure => '%s'))"
+                                .formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()),
+                        "Procedure not supported: Procedure updates or inserts data.*");
+                assertQuery("SELECT * FROM " + table.getName(), "VALUES (1), (2), (3)");
+            }
+
+            try (TestProcedure testProcedure = createTestingProcedure("DELETE %s OUTPUT DELETED.* INTO %s".formatted(table.getName(), tableForDeletedRows.getName()))) {
+                assertQueryFails(
+                        "SELECT * FROM TABLE(system.procedure(schema => '%s', procedure => '%s'))"
+                                .formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()),
+                        "Failed to get table handle for procedure query. The statement did not return a result set.");
+                assertQuery("SELECT * FROM " + table.getName(), "VALUES (1), (2), (3)");
+                assertQueryReturnsEmptyResult("SELECT * FROM " + tableForDeletedRows.getName());
+            }
+        }
+    }
+
+    @Test
+    public void testProcedureWithUpdateOperation()
+    {
+        try (TestTable table = new TestTable(onRemoteDatabase(), "table_to_update", "(id BIGINT)", ImmutableList.of("1", "2", "3"));
+                TestTable tableForDeletedRows = new TestTable(onRemoteDatabase(), "table_to_capture_update", "(inserted BIGINT, deleted BIGINT)")) {
+            try (TestProcedure testProcedure = createTestingProcedure("UPDATE %s SET id = 4".formatted(table.getName()))) {
+                assertQueryFails(
+                        "SELECT * FROM TABLE(system.procedure(schema => '%s', procedure => '%s'))"
+                                .formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()),
+                        "Failed to get table handle for procedure query. The statement did not return a result set.");
+                assertQuery("SELECT * FROM " + table.getName(), "VALUES (1), (2), (3)");
+            }
+
+            try (TestProcedure testProcedure = createTestingProcedure("UPDATE %s SET id = 4 OUTPUT DELETED.*, INSERTED.*".formatted(table.getName()))) {
+                assertQueryFails(
+                        "SELECT * FROM TABLE(system.procedure(schema => '%s', procedure => '%s'))"
+                                .formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()),
+                        "Procedure not supported: Procedure updates or inserts data.*");
+                assertQuery("SELECT * FROM " + table.getName(), "VALUES (1), (2), (3)");
+            }
+
+            try (TestProcedure testProcedure = createTestingProcedure("UPDATE %s SET id = 4 OUTPUT DELETED.id as inserted, INSERTED.id as deleted INTO %s".formatted(table.getName(), tableForDeletedRows.getName()))) {
+                assertQueryFails(
+                        "SELECT * FROM TABLE(system.procedure(schema => '%s', procedure => '%s'))"
+                                .formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()),
+                        "Failed to get table handle for procedure query. The statement did not return a result set.");
+                assertQuery("SELECT * FROM " + table.getName(), "VALUES (1), (2), (3)");
+                assertQueryReturnsEmptyResult("SELECT * FROM " + tableForDeletedRows.getName());
+            }
+        }
+    }
+
+    @Test
+    public void testProcedureWithMergeOperation()
+    {
+        try (TestTable sourceTable = new TestTable(onRemoteDatabase(), "source_table", "(id BIGINT)", ImmutableList.of("1", "2", "3"));
+                TestTable targetTable = new TestTable(onRemoteDatabase(), "destination_table", "(id BIGINT)", ImmutableList.of("3", "4", "5"));
+                TestTable tableForChangedRows = new TestTable(onRemoteDatabase(), "table_to_capture_change", "(inserted BIGINT, deleted BIGINT)")) {
+            String mergeQuery = """
+                    MERGE %s AS TARGET USING %s AS SOURCE
+                    ON (TARGET.id = SOURCE.id)
+                    WHEN NOT MATCHED BY TARGET
+                        THEN INSERT(id) VALUES(SOURCE.id)
+                    WHEN NOT MATCHED BY SOURCE
+                        THEN DELETE
+                    """.formatted(targetTable.getName(), sourceTable.getName());
+            try (TestProcedure testProcedure = createTestingProcedure(mergeQuery + ";")) {
+                assertQueryFails(
+                        "SELECT * FROM TABLE(system.procedure(schema => '%s', procedure => '%s'))"
+                                .formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()),
+                        "Failed to get table handle for procedure query. The statement did not return a result set.");
+                assertQuery("SELECT * FROM " + targetTable.getName(), "VALUES (3), (4), (5)");
+            }
+
+            try (TestProcedure testProcedure = createTestingProcedure(mergeQuery + "OUTPUT DELETED.*, INSERTED.* ;")) {
+                assertQueryFails(
+                        "SELECT * FROM TABLE(system.procedure(schema => '%s', procedure => '%s'))"
+                                .formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()),
+                        "Procedure not supported: Procedure updates or inserts data.*");
+                assertQuery("SELECT * FROM " + targetTable.getName(), "VALUES (3), (4), (5)");
+            }
+
+            try (TestProcedure testProcedure = createTestingProcedure(mergeQuery + "OUTPUT DELETED.id as inserted, INSERTED.id as deleted INTO %s ;".formatted(tableForChangedRows.getName()))) {
+                assertQueryFails(
+                        "SELECT * FROM TABLE(system.procedure(schema => '%s', procedure => '%s'))"
+                                .formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()),
+                        "Failed to get table handle for procedure query. The statement did not return a result set.");
+                assertQuery("SELECT * FROM " + targetTable.getName(), "VALUES (3), (4), (5)");
+                assertQueryReturnsEmptyResult("SELECT * FROM " + tableForChangedRows.getName());
+            }
+        }
+    }
+
+    @Test
+    public void testCustomSqlStatementPassedAsArguments()
+    {
+        try (TestProcedure testProcedure = createTestingProcedure("SELECT 1 as colA ")) {
+            assertQueryFails(
+                    "SELECT * FROM TABLE(system.procedure(schema => '%s', procedure => '%s', inputs => ARRAY['; DROP TABLE nation']))"
+                            .formatted(getSession().getSchema().orElseThrow(), testProcedure.getName()),
+                    "InputArgument doesn't support special characters like ';'");
+            assertQuery("SHOW TABLES LIKE 'nation'", "VALUES 'nation'");
+        }
+    }
+
+    private TestProcedure createTestingProcedure(String baseQuery)
+    {
+        return createTestingProcedure("", baseQuery);
+    }
+
+    private TestProcedure createTestingProcedure(String inputArguments, String baseQuery)
+    {
+        String procedureName = "procedure" + randomNameSuffix();
+        return new TestProcedure(
+                onRemoteDatabase(),
+                procedureName,
+                """
+                    CREATE PROCEDURE %s.%s %s
+                    AS BEGIN
+                        %s
+                    END
+                """.formatted(getSession().getSchema().orElseThrow(), procedureName, inputArguments, baseQuery));
     }
 
     private String getLongInClause(int start, int length)

--- a/plugin/trino-thrift-testing-server/pom.xml
+++ b/plugin/trino-thrift-testing-server/pom.xml
@@ -21,7 +21,7 @@
     <dependencies>
         <dependency>
             <groupId>io.trino</groupId>
-            <artifactId>trino-main</artifactId>
+            <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 
         <dependency>

--- a/plugin/trino-thrift-testing-server/src/main/java/io/trino/plugin/thrift/server/ThriftIndexedTpchService.java
+++ b/plugin/trino-thrift-testing-server/src/main/java/io/trino/plugin/thrift/server/ThriftIndexedTpchService.java
@@ -15,6 +15,7 @@ package io.trino.plugin.thrift.server;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import io.trino.plugin.base.MappedRecordSet;
 import io.trino.plugin.thrift.api.TrinoThriftBlock;
 import io.trino.plugin.thrift.api.TrinoThriftId;
 import io.trino.plugin.thrift.api.TrinoThriftNullableToken;
@@ -27,7 +28,6 @@ import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.RecordPageSource;
 import io.trino.spi.connector.RecordSet;
 import io.trino.spi.type.Type;
-import io.trino.split.MappedRecordSet;
 import io.trino.testing.tpch.TpchIndexedData;
 import io.trino.testing.tpch.TpchIndexedData.IndexedTable;
 import io.trino.testing.tpch.TpchScaledTable;

--- a/testing/trino-testing/src/main/java/io/trino/testing/tpch/TpchIndexProvider.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/tpch/TpchIndexProvider.java
@@ -14,6 +14,7 @@
 package io.trino.testing.tpch;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.plugin.base.MappedRecordSet;
 import io.trino.plugin.tpch.TpchColumnHandle;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorIndex;
@@ -25,7 +26,6 @@ import io.trino.spi.connector.RecordSet;
 import io.trino.spi.predicate.NullableValue;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.Type;
-import io.trino.split.MappedRecordSet;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

A dedicated table function which allows us to run stored procedures in SQLServer. We can't use existing query table function - as it wraps with inside a query like `SELECT * FROM (EXEC my_procedure) o` -  so we are handing them via a different function.  All the pushdown are disabled for `JdbcProcedureHandle` resolved by this `Procedure`. 

Slightly different implementation from https://github.com/trinodb/trino/pull/15813

#### Limitation

- In case of stored procedures with multiple statement - we process the `ResultSet` only for the first statement. (Test to be added)
- Stored procedures with output variables are not supported.
- Input variables for the stored procedures are not parameterized(yet). 


#### Example 

```
SELECT * FROM TABLE(system.procedure(query => 'CALL my_new_procedure()')
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# SQLServer 
* Add support for executing stored procedures using `procedure` table function. 
```
