### PR TITLE
Revert "Add column add/drop/rename events"

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/DisabledSystemSecurityMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/DisabledSystemSecurityMetadata.java
@@ -184,15 +184,6 @@ public class DisabledSystemSecurityMetadata
     @Override
     public void tableDropped(Session session, CatalogSchemaTableName table) {}
 
-    @Override
-    public void columnCreated(Session session, CatalogSchemaTableName table, String column) {}
-
-    @Override
-    public void columnRenamed(Session session, CatalogSchemaTableName table, String oldColumn, String newColumn) {}
-
-    @Override
-    public void columnDropped(Session session, CatalogSchemaTableName table, String column) {}
-
     private static TrinoException notSupportedException(String catalogName)
     {
         return new TrinoException(NOT_SUPPORTED, "Catalog does not support permission management: " + catalogName);

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -726,14 +726,6 @@ public final class MetadataManager
         CatalogHandle catalogHandle = tableHandle.getCatalogHandle();
         ConnectorMetadata metadata = getMetadataForWrite(session, catalogHandle);
         metadata.renameColumn(session.toConnectorSession(catalogHandle), tableHandle.getConnectorHandle(), source, target.toLowerCase(ENGLISH));
-
-        CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, catalogHandle);
-        ColumnMetadata sourceColumnMetadata = getColumnMetadata(session, tableHandle, source);
-        if (catalogMetadata.getSecurityManagement() != CONNECTOR) {
-            TableMetadata tableMetadata = getTableMetadata(session, tableHandle);
-            CatalogSchemaTableName sourceTableName = new CatalogSchemaTableName(catalogHandle.getCatalogName(), tableMetadata.getTable());
-            systemSecurityMetadata.columnRenamed(session, sourceTableName, sourceColumnMetadata.getName(), target);
-        }
     }
 
     @Override
@@ -742,13 +734,6 @@ public final class MetadataManager
         CatalogHandle catalogHandle = tableHandle.getCatalogHandle();
         ConnectorMetadata metadata = getMetadataForWrite(session, catalogHandle);
         metadata.addColumn(session.toConnectorSession(catalogHandle), tableHandle.getConnectorHandle(), column);
-
-        CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, catalogHandle);
-        if (catalogMetadata.getSecurityManagement() != CONNECTOR) {
-            TableMetadata tableMetadata = getTableMetadata(session, tableHandle);
-            CatalogSchemaTableName sourceTableName = new CatalogSchemaTableName(catalogHandle.getCatalogName(), tableMetadata.getTable());
-            systemSecurityMetadata.columnCreated(session, sourceTableName, column.getName());
-        }
     }
 
     @Override
@@ -756,14 +741,7 @@ public final class MetadataManager
     {
         CatalogHandle catalogHandle = tableHandle.getCatalogHandle();
         ConnectorMetadata metadata = getMetadataForWrite(session, catalogHandle);
-        CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, catalogHandle);
         metadata.dropColumn(session.toConnectorSession(catalogHandle), tableHandle.getConnectorHandle(), column);
-        if (catalogMetadata.getSecurityManagement() != CONNECTOR) {
-            String columnName = getColumnMetadata(session, tableHandle, column).getName();
-            TableMetadata tableMetadata = getTableMetadata(session, tableHandle);
-            CatalogSchemaTableName sourceTableName = new CatalogSchemaTableName(catalogHandle.getCatalogName(), tableMetadata.getTable());
-            systemSecurityMetadata.columnDropped(session, sourceTableName, columnName);
-        }
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/metadata/SystemSecurityMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemSecurityMetadata.java
@@ -167,19 +167,4 @@ public interface SystemSecurityMetadata
      * A table or view was dropped
      */
     void tableDropped(Session session, CatalogSchemaTableName table);
-
-    /**
-     * A column was created
-     */
-    void columnCreated(Session session, CatalogSchemaTableName table, String column);
-
-    /**
-     * A column was renamed
-     */
-    void columnRenamed(Session session, CatalogSchemaTableName table, String oldColumn, String newColumn);
-
-    /**
-     * A column was dropped
-     */
-    void columnDropped(Session session, CatalogSchemaTableName table, String column);
 }

--- a/testing/trino-tests/src/test/java/io/trino/security/TestingSystemSecurityMetadata.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestingSystemSecurityMetadata.java
@@ -259,13 +259,4 @@ class TestingSystemSecurityMetadata
 
     @Override
     public void tableDropped(Session session, CatalogSchemaTableName table) {}
-
-    @Override
-    public void columnCreated(Session session, CatalogSchemaTableName table, String column) {}
-
-    @Override
-    public void columnRenamed(Session session, CatalogSchemaTableName table, String oldColumn, String newColumn) {}
-
-    @Override
-    public void columnDropped(Session session, CatalogSchemaTableName table, String column) {}
 }


### PR DESCRIPTION
Reverts trinodb/trino#15225

The current implementation has the following problems

- does not work for Hive connector with `hive.security=system` (https://github.com/trinodb/trino/pull/15225#discussion_r1093300534)
- notifications are propagated even if transaction doesn't end up committing the DDL changes (https://github.com/trinodb/trino/pull/15225#discussion_r1094648449)
- notification propagation may disrupt transaction finish even if changes already applied in the external system (https://github.com/trinodb/trino/issues/12535#issuecomment-1417684880), for any connector that's using SYSTEM security (Iceberg, Delta with system security, or any JDBC connector)

The revert is only temporary, the functionality will be reintroduced soon.

Fixes https://github.com/trinodb/trino/issues/12535