### PR TITLE
Move parameterizing enums to the top of enclosing class

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/JoinNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/JoinNode.java
@@ -47,6 +47,42 @@ import static java.util.Objects.requireNonNull;
 public class JoinNode
         extends PlanNode
 {
+    public enum DistributionType
+    {
+        PARTITIONED,
+        REPLICATED
+    }
+
+    public enum Type
+    {
+        INNER("InnerJoin"),
+        LEFT("LeftJoin"),
+        RIGHT("RightJoin"),
+        FULL("FullJoin");
+
+        private final String joinLabel;
+
+        Type(String joinLabel)
+        {
+            this.joinLabel = joinLabel;
+        }
+
+        public String getJoinLabel()
+        {
+            return joinLabel;
+        }
+
+        public static Type typeConvert(Join.Type joinType)
+        {
+            return switch (joinType) {
+                case CROSS, IMPLICIT, INNER -> Type.INNER;
+                case LEFT -> Type.LEFT;
+                case RIGHT -> Type.RIGHT;
+                case FULL -> Type.FULL;
+            };
+        }
+    }
+
     private final Type type;
     private final PlanNode left;
     private final PlanNode right;
@@ -177,42 +213,6 @@ public class JoinNode
         return joinCriteria.stream()
                 .map(EquiJoinClause::flip)
                 .collect(toImmutableList());
-    }
-
-    public enum DistributionType
-    {
-        PARTITIONED,
-        REPLICATED
-    }
-
-    public enum Type
-    {
-        INNER("InnerJoin"),
-        LEFT("LeftJoin"),
-        RIGHT("RightJoin"),
-        FULL("FullJoin");
-
-        private final String joinLabel;
-
-        Type(String joinLabel)
-        {
-            this.joinLabel = joinLabel;
-        }
-
-        public String getJoinLabel()
-        {
-            return joinLabel;
-        }
-
-        public static Type typeConvert(Join.Type joinType)
-        {
-            return switch (joinType) {
-                case CROSS, IMPLICIT, INNER -> Type.INNER;
-                case LEFT -> Type.LEFT;
-                case RIGHT -> Type.RIGHT;
-                case FULL -> Type.FULL;
-            };
-        }
     }
 
     @JsonProperty("type")

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ComparisonExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ComparisonExpression.java
@@ -24,6 +24,72 @@ import static java.util.Objects.requireNonNull;
 public class ComparisonExpression
         extends Expression
 {
+    public enum Operator
+    {
+        EQUAL("="),
+        NOT_EQUAL("<>"),
+        LESS_THAN("<"),
+        LESS_THAN_OR_EQUAL("<="),
+        GREATER_THAN(">"),
+        GREATER_THAN_OR_EQUAL(">="),
+        IS_DISTINCT_FROM("IS DISTINCT FROM");
+
+        private final String value;
+
+        Operator(String value)
+        {
+            this.value = value;
+        }
+
+        public String getValue()
+        {
+            return value;
+        }
+
+        public Operator flip()
+        {
+            switch (this) {
+                case EQUAL:
+                    return EQUAL;
+                case NOT_EQUAL:
+                    return NOT_EQUAL;
+                case LESS_THAN:
+                    return GREATER_THAN;
+                case LESS_THAN_OR_EQUAL:
+                    return GREATER_THAN_OR_EQUAL;
+                case GREATER_THAN:
+                    return LESS_THAN;
+                case GREATER_THAN_OR_EQUAL:
+                    return LESS_THAN_OR_EQUAL;
+                case IS_DISTINCT_FROM:
+                    return IS_DISTINCT_FROM;
+            }
+            throw new IllegalArgumentException("Unsupported comparison: " + this);
+        }
+
+        public Operator negate()
+        {
+            switch (this) {
+                case EQUAL:
+                    return NOT_EQUAL;
+                case NOT_EQUAL:
+                    return EQUAL;
+                case LESS_THAN:
+                    return GREATER_THAN_OR_EQUAL;
+                case LESS_THAN_OR_EQUAL:
+                    return GREATER_THAN;
+                case GREATER_THAN:
+                    return LESS_THAN_OR_EQUAL;
+                case GREATER_THAN_OR_EQUAL:
+                    return LESS_THAN;
+                case IS_DISTINCT_FROM:
+                    // Cannot negate
+                    break;
+            }
+            throw new IllegalArgumentException("Unsupported comparison: " + this);
+        }
+    }
+
     private final Operator operator;
     private final Expression left;
     private final Expression right;
@@ -97,72 +163,6 @@ public class ComparisonExpression
     public int hashCode()
     {
         return Objects.hash(operator, left, right);
-    }
-
-    public enum Operator
-    {
-        EQUAL("="),
-        NOT_EQUAL("<>"),
-        LESS_THAN("<"),
-        LESS_THAN_OR_EQUAL("<="),
-        GREATER_THAN(">"),
-        GREATER_THAN_OR_EQUAL(">="),
-        IS_DISTINCT_FROM("IS DISTINCT FROM");
-
-        private final String value;
-
-        Operator(String value)
-        {
-            this.value = value;
-        }
-
-        public String getValue()
-        {
-            return value;
-        }
-
-        public Operator flip()
-        {
-            switch (this) {
-                case EQUAL:
-                    return EQUAL;
-                case NOT_EQUAL:
-                    return NOT_EQUAL;
-                case LESS_THAN:
-                    return GREATER_THAN;
-                case LESS_THAN_OR_EQUAL:
-                    return GREATER_THAN_OR_EQUAL;
-                case GREATER_THAN:
-                    return LESS_THAN;
-                case GREATER_THAN_OR_EQUAL:
-                    return LESS_THAN_OR_EQUAL;
-                case IS_DISTINCT_FROM:
-                    return IS_DISTINCT_FROM;
-            }
-            throw new IllegalArgumentException("Unsupported comparison: " + this);
-        }
-
-        public Operator negate()
-        {
-            switch (this) {
-                case EQUAL:
-                    return NOT_EQUAL;
-                case NOT_EQUAL:
-                    return EQUAL;
-                case LESS_THAN:
-                    return GREATER_THAN_OR_EQUAL;
-                case LESS_THAN_OR_EQUAL:
-                    return GREATER_THAN;
-                case GREATER_THAN:
-                    return LESS_THAN_OR_EQUAL;
-                case GREATER_THAN_OR_EQUAL:
-                    return LESS_THAN;
-                case IS_DISTINCT_FROM:
-                    // Cannot negate
-                    break;
-            }
-            throw new IllegalArgumentException("Unsupported comparison: " + this);
-        }
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Join.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Join.java
@@ -26,6 +26,11 @@ import static java.util.Objects.requireNonNull;
 public class Join
         extends Relation
 {
+    public enum Type
+    {
+        CROSS, INNER, LEFT, RIGHT, FULL, IMPLICIT
+    }
+
     public Join(Type type, Relation left, Relation right, Optional<JoinCriteria> criteria)
     {
         this(Optional.empty(), type, left, right, criteria);
@@ -52,11 +57,6 @@ public class Join
         this.left = left;
         this.right = right;
         this.criteria = criteria;
-    }
-
-    public enum Type
-    {
-        CROSS, INNER, LEFT, RIGHT, FULL, IMPLICIT
     }
 
     private final Type type;


### PR DESCRIPTION
That makes it easier to understand how the class is parameterized. Consistent with code style in `LogicalExpression`.

We could also choose to place such enums at the bottom (not my preference). In any case, they should not be somewhere in the middle, mixed between instance methods.

cc @trinodb/maintainers for code style related