### PR TITLE
Decorrelate single-row values

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
@@ -2290,6 +2290,17 @@ public class TestLogicalPlanner
                                                 anyTree(node(ValuesNode.class)))))));
     }
 
+    @Test
+    public void testDecorrelateSingleRowSubquery()
+    {
+        assertPlan("SELECT * FROM (VALUES 1, 2, 3) t(a), LATERAL (VALUES a * 3)",
+                output(
+                        values(ImmutableList.of("a", "expr"), ImmutableList.of(
+                                ImmutableList.of(new LongLiteral("1"), new LongLiteral("3")),
+                                ImmutableList.of(new LongLiteral("2"), new LongLiteral("6")),
+                                ImmutableList.of(new LongLiteral("3"), new LongLiteral("9"))))));
+    }
+
     private Session noJoinReordering()
     {
         return Session.builder(getQueryRunner().getDefaultSession())

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestMergeProjectWithValues.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestMergeProjectWithValues.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 @TestInstance(PER_CLASS)
@@ -49,8 +48,7 @@ public class TestMergeProjectWithValues
         assertThat(assertions.query("SELECT a, b + 1, 'x' FROM (VALUES (1, 10, true), (null, null, null), (3, 30, true)) t(a, b, c)"))
                 .matches("VALUES (1, 11, 'x'), (null, null, 'x'), (3, 31, 'x')");
 
-        // cannot decorrelate values
-        assertThatThrownBy(() -> assertions.query("SELECT (SELECT a * 10 FROM (VALUES x) t(a)) FROM (VALUES 1, 2, 3) t2(x)"))
-                .hasMessage("line 1:9: Given correlated subquery is not supported");
+        assertThat(assertions.query("SELECT (SELECT a * 10 FROM (VALUES x) t(a)) FROM (VALUES 1, 2, 3) t2(x)"))
+                .matches("VALUES 10, 20, 30");
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestSelectAll.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestSelectAll.java
@@ -249,6 +249,6 @@ public class TestSelectAll
         assertThat(assertions.query("SELECT * FROM (VALUES 0, 1) t(a), LATERAL (SELECT t2.* from (VALUES 2), LATERAL (SELECT t.*) t2(b))")).matches("VALUES (0, 0), (1, 1)");
         assertThat(assertions.query("SELECT * FROM (VALUES 0, 1) t(a), LATERAL (SELECT t2.b from (VALUES 2), LATERAL (SELECT t.*) t2(b))")).matches("VALUES (0, 0), (1, 1)");
         assertThatThrownBy(() -> assertions.query("SELECT * FROM (VALUES 0) t(a), LATERAL (SELECT t2.* from (VALUES 1, 2), LATERAL (SELECT t.*) t2(b))")).hasMessageMatching(UNSUPPORTED_DECORRELATION_MESSAGE);
-        assertThatThrownBy(() -> assertions.query("SELECT * FROM (VALUES 0, 1) t(a), LATERAL (SELECT * from (VALUES 2), LATERAL (SELECT t.*))")).hasMessageMatching(UNSUPPORTED_DECORRELATION_MESSAGE);
+        assertThat(assertions.query("SELECT * FROM (VALUES 0, 1) t(a), LATERAL (SELECT * from (VALUES 2), LATERAL (SELECT t.*))")).matches("VALUES (0, 2, 0), (1, 2, 1)");
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestSubqueries.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestSubqueries.java
@@ -710,12 +710,12 @@ public class TestSubqueries
         assertThat(assertions.query(
                 "SELECT (SELECT outer_relation.b FROM (VALUES 1) inner_relation) FROM (values 2) outer_relation(b)"))
                 .matches("VALUES 2");
-        assertThatThrownBy(() -> assertions.query(
+        assertThat(assertions.query(
                 "SELECT (VALUES b) FROM (VALUES 2) outer_relation(b)"))
-                .hasMessageMatching(UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG);
-        assertThatThrownBy(() -> assertions.query(
+                .matches("VALUES 2");
+        assertThat(assertions.query(
                 "SELECT (SELECT a + b FROM (VALUES 1) inner_relation(a)) FROM (VALUES 2) outer_relation(b)"))
-                .hasMessageMatching(UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG);
+                .matches("VALUES 3");
         assertThatThrownBy(() -> assertions.query(
                 "SELECT (SELECT rank() OVER(partition by b) FROM (VALUES 1) inner_relation(a)) FROM (VALUES 2) outer_relation(b)"))
                 .hasMessageMatching(UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG);


### PR DESCRIPTION
Before this change, the rule `TransformCorrelatedSingleRowSubqueryToProject` matched a CorrelatedJoinNode with arbitrary number of ProjectNodes in the subquery. It supported identity projections and at most one non-identity projection.
After this change, the rule supports 0 or 1 projection. Projections can be inlined by the rule `InlineProjections`.

This change also extends the rule to handle more kinds of ValuesNode: after the change any single-row values is supported provided that the values row is an expression of type `Row`.

This change can be also considered a preparatory step before the rule `MergeProjectWithValues` is used more widely. It removes dependency between the `MergeProjectWithValues` rule and the de-correlating rules.

```markdown
# General
* Support correlated queries involving single-row Values.
```