### PR TITLE
Support replace src string in char type

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
@@ -126,6 +126,27 @@ public final class StringFunctions
         return replace(str, search, Slices.EMPTY_SLICE);
     }
 
+    @Description("Greedily removes occurrences of a pattern in a string")
+    @ScalarFunction
+    @LiteralParameters({"x", "y"})
+    @SqlType("varchar(x)")
+    public static Slice replace(@LiteralParameter("x") Long x, @LiteralParameter("y") Long y, @SqlType("char(x)") Slice str, @SqlType("varchar(y)") Slice search)
+    {
+        str = padSpaces(str, x.intValue());
+        return replace(str, search, Slices.EMPTY_SLICE);
+    }
+
+    @Description("Greedily replaces occurrences of a pattern with a string")
+    @ScalarFunction
+    @LiteralParameters({"x", "y", "z", "u"})
+    @Constraint(variable = "u", expression = "min(2147483647, x + z * (x + 1))")
+    @SqlType("varchar(u)")
+    public static Slice replace(@LiteralParameter("x") Long x, @SqlType("char(x)") Slice str, @SqlType("varchar(y)") Slice search, @SqlType("varchar(z)") Slice replace)
+    {
+        str = padSpaces(str, x.intValue());
+        return replace(str, search, replace);
+    }
+
     @Description("Greedily replaces occurrences of a pattern with a string")
     @ScalarFunction
     @LiteralParameters({"x", "y", "z", "u"})

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
@@ -241,6 +241,23 @@ public class TestStringFunctions
         assertFunction("REPLACE('::\uD801\uDC2D::', ':', '')", createVarcharType(5), "\uD801\uDC2D"); //\uD801\uDC2D is one character
         assertFunction("REPLACE('\u00D6sterreich', '\u00D6', 'Oe')", createVarcharType(32), "Oesterreich");
 
+        // Test replace (char(x), varchar(y), varchar(z)) and replace (char(x), varchar(y))
+        assertFunction("REPLACE(CHAR 'aaa', 'a', 'aa')", createVarcharType(11), "aaaaaa");
+        assertFunction("REPLACE(CHAR 'abcdefabcdef', 'cd', 'XX')", createVarcharType(38), "abXXefabXXef");
+        assertFunction("REPLACE(CHAR 'abcdefabcdef', 'cd')", createVarcharType(12), "abefabef");
+        assertFunction("REPLACE(CHAR '0000123', '0')", createVarcharType(7), "123");
+        assertFunction("REPLACE(CHAR '0000123', '0', ' ')", createVarcharType(15), "    123");
+        assertFunction("REPLACE(CHAR 'foo', '')", createVarcharType(3), "foo");
+        assertFunction("REPLACE(CHAR 'foo', '', '')", createVarcharType(3), "foo");
+        assertFunction("REPLACE(CHAR 'foo', 'foo', '')", createVarcharType(3), "");
+        assertFunction("REPLACE(CHAR 'abc', '', 'xx')", createVarcharType(11), "xxaxxbxxcxx");
+        assertFunction("REPLACE(CHAR '', '', 'xx')", createVarcharType(2), "xx");
+        assertFunction("REPLACE(CHAR '', '')", createVarcharType(0), "");
+        assertFunction("REPLACE(CHAR '', '', '')", createVarcharType(0), "");
+        assertFunction("REPLACE(CHAR '  a  bc  ', '  ', 'XX')", createVarcharType(29), "XXaXXbcXX");
+        assertFunction("REPLACE(CHAR 'abc', 'c', ' ')", createVarcharType(7), "ab ");
+        assertFunction("REPLACE(CHAR 'abc ', 'c', 'z')", createVarcharType(9), "abz ");
+
         assertFunction("CAST(REPLACE(utf8(from_hex('CE')), '', 'X') AS VARBINARY)", VARBINARY, sqlVarbinaryFromIso("X\u00CEX"));
         assertFunction("CAST(REPLACE('abc' || utf8(from_hex('CE')), '', 'X') AS VARBINARY)", VARBINARY, sqlVarbinaryFromIso("XaXbXcX\u00CEX"));
         assertFunction("CAST(REPLACE(utf8(from_hex('CE')) || 'xyz', '', 'X') AS VARBINARY)", VARBINARY, sqlVarbinaryFromIso("X\u00CEXxXyXzX"));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

As a temporary solution while fixing the coercion from char to varchar, adding replace function signature that supports CHAR as input type for the source string to be compatible with previous behavior.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Related issue: https://github.com/trinodb/trino/issues/9031

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
