### PR TITLE
Remove old expired kerberos tickets before relogging in

### DIFF
--- a/lib/trino-hdfs/src/main/java/io/trino/hdfs/authentication/KerberosHadoopAuthentication.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/hdfs/authentication/KerberosHadoopAuthentication.java
@@ -56,7 +56,7 @@ public class KerberosHadoopAuthentication
     @Override
     public UserGroupInformation getUserGroupInformation()
     {
-        Subject subject = kerberosAuthentication.getSubject();
+        Subject subject = kerberosAuthentication.getLoginContext().getSubject();
         return createUserGroupInformationForSubject(subject);
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/authentication/KerberosAuthentication.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/authentication/KerberosAuthentication.java
@@ -42,27 +42,18 @@ public class KerberosAuthentication
         this.configuration = kerberosConfiguration.getConfiguration();
     }
 
-    public Subject getSubject()
+    public LoginContext getLoginContext()
     {
         Subject subject = new Subject(false, ImmutableSet.of(principal), emptySet(), emptySet());
+        return loginFromSubject(subject);
+    }
+
+    public LoginContext loginFromSubject(Subject subject)
+    {
         try {
             LoginContext loginContext = new LoginContext("", subject, null, configuration);
             loginContext.login();
-            return loginContext.getSubject();
-        }
-        catch (LoginException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public void attemptLogin(Subject subject)
-    {
-        try {
-            synchronized (subject.getPrivateCredentials()) {
-                subject.getPrivateCredentials().clear();
-                LoginContext loginContext = new LoginContext("", subject, null, configuration);
-                loginContext.login();
-            }
+            return loginContext;
         }
         catch (LoginException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This ensures old Kerberos tickets are removed before logging in again. 

Approach is similar to this PR: https://github.com/trinodb/trino/pull/14373

but instead uses the `LoginContext#logout` method, which internally does similar logic to `subject.getPrivateCredentials().clear()`

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Stress test PR is here: https://github.com/trinodb/trino/pull/16018/files

Fixes: https://github.com/trinodb/trino/issues/14372
Fixes: https://github.com/trinodb/trino/issues/14441


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
Fix a bug in Kudu Kerberos ticket management. ({issue}`14372`)
```
