### PR TITLE
Improve performance of LIKE matchers

### DIFF
--- a/core/trino-main/src/main/java/io/trino/likematcher/DFA.java
+++ b/core/trino-main/src/main/java/io/trino/likematcher/DFA.java
@@ -14,25 +14,22 @@
 package io.trino.likematcher;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-record DFA(State start, State failed, List<State> states, Map<Integer, List<Transition>> transitions)
+record DFA(State start, State failed, List<State> states, List<List<Transition>> transitions)
 {
     DFA
     {
         requireNonNull(start, "start is null");
         requireNonNull(failed, "failed is null");
         states = ImmutableList.copyOf(states);
-        transitions = ImmutableMap.copyOf(transitions);
+        transitions = ImmutableList.copyOf(transitions);
     }
 
     public List<Transition> transitions(State state)
@@ -67,12 +64,13 @@ record DFA(State start, State failed, List<State> states, Map<Integer, List<Tran
         private State start;
         private State failed;
         private final List<State> states = new ArrayList<>();
-        private final Map<Integer, List<Transition>> transitions = new HashMap<>();
+        private final List<List<Transition>> transitions = new ArrayList<>();
 
         public State addState(String label, boolean accept)
         {
             State state = new State(nextId++, label, accept);
             states.add(state);
+            transitions.add(new ArrayList<>());
             return state;
         }
 
@@ -94,8 +92,7 @@ record DFA(State start, State failed, List<State> states, Map<Integer, List<Tran
 
         public void addTransition(State from, int value, State to)
         {
-            transitions.computeIfAbsent(from.id(), key -> new ArrayList<>())
-                    .add(new Transition(value, to));
+            transitions.get(from.id()).add(new Transition(value, to));
         }
 
         public DFA build()

--- a/core/trino-main/src/main/java/io/trino/likematcher/DFA.java
+++ b/core/trino-main/src/main/java/io/trino/likematcher/DFA.java
@@ -14,42 +14,23 @@
 package io.trino.likematcher;
 
 import com.google.common.collect.ImmutableList;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-record DFA(State start, State failed, List<State> states, List<List<Transition>> transitions)
+record DFA(int start, int failed, IntArrayList acceptStates, List<List<Transition>> transitions)
 {
     DFA
     {
-        requireNonNull(start, "start is null");
-        requireNonNull(failed, "failed is null");
-        states = ImmutableList.copyOf(states);
+        requireNonNull(acceptStates, "acceptStates is null");
         transitions = ImmutableList.copyOf(transitions);
     }
 
-    public List<Transition> transitions(State state)
-    {
-        return transitions.get(state.id);
-    }
-
-    record State(int id, String label, boolean accept)
-    {
-        @Override
-        public String toString()
-        {
-            return "%s:%s%s".formatted(
-                    id,
-                    accept ? "*" : "",
-                    label);
-        }
-    }
-
-    record Transition(int value, State target)
+    record Transition(int value, int target)
     {
         @Override
         public String toString()
@@ -61,43 +42,41 @@ record DFA(State start, State failed, List<State> states, List<List<Transition>>
     public static class Builder
     {
         private int nextId;
-        private State start;
-        private State failed;
-        private final List<State> states = new ArrayList<>();
+        private int start;
+        private int failed;
+        private final IntArrayList acceptStates = new IntArrayList();
         private final List<List<Transition>> transitions = new ArrayList<>();
 
-        public State addState(String label, boolean accept)
+        public int addState(boolean accept)
         {
-            State state = new State(nextId++, label, accept);
-            states.add(state);
+            int state = nextId++;
             transitions.add(new ArrayList<>());
+            if (accept) {
+                acceptStates.add(state);
+            }
             return state;
         }
 
-        public State addStartState(String label, boolean accept)
+        public int addStartState(boolean accept)
         {
-            checkState(start == null, "Start state already set");
-            State state = addState(label, accept);
-            start = state;
-            return state;
+            start = addState(accept);
+            return start;
         }
 
-        public State addFailState()
+        public int addFailState()
         {
-            checkState(failed == null, "Fail state already set");
-            State state = addState("fail", false);
-            failed = state;
-            return state;
+            failed = addState(false);
+            return failed;
         }
 
-        public void addTransition(State from, int value, State to)
+        public void addTransition(int from, int value, int to)
         {
-            transitions.get(from.id()).add(new Transition(value, to));
+            transitions.get(from).add(new Transition(value, to));
         }
 
         public DFA build()
         {
-            return new DFA(start, failed, states, transitions);
+            return new DFA(start, failed, acceptStates, transitions);
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/likematcher/DFA.java
+++ b/core/trino-main/src/main/java/io/trino/likematcher/DFA.java
@@ -22,7 +22,7 @@ import java.util.List;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-record DFA(int start, int failed, IntArrayList acceptStates, List<List<Transition>> transitions)
+record DFA(int start, IntArrayList acceptStates, List<List<Transition>> transitions)
 {
     DFA
     {
@@ -43,7 +43,6 @@ record DFA(int start, int failed, IntArrayList acceptStates, List<List<Transitio
     {
         private int nextId;
         private int start;
-        private int failed;
         private final IntArrayList acceptStates = new IntArrayList();
         private final List<List<Transition>> transitions = new ArrayList<>();
 
@@ -63,12 +62,6 @@ record DFA(int start, int failed, IntArrayList acceptStates, List<List<Transitio
             return start;
         }
 
-        public int addFailState()
-        {
-            failed = addState(false);
-            return failed;
-        }
-
         public void addTransition(int from, int value, int to)
         {
             transitions.get(from).add(new Transition(value, to));
@@ -76,7 +69,7 @@ record DFA(int start, int failed, IntArrayList acceptStates, List<List<Transitio
 
         public DFA build()
         {
-            return new DFA(start, failed, acceptStates, transitions);
+            return new DFA(start, acceptStates, transitions);
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/likematcher/DenseDfaMatcher.java
+++ b/core/trino-main/src/main/java/io/trino/likematcher/DenseDfaMatcher.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 class DenseDfaMatcher
+        implements Matcher
 {
     public static final int FAIL_STATE = -1;
 
@@ -69,6 +70,7 @@ class DenseDfaMatcher
         this.exact = exact;
     }
 
+    @Override
     public boolean match(byte[] input, int offset, int length)
     {
         if (exact) {

--- a/core/trino-main/src/main/java/io/trino/likematcher/DenseDfaMatcher.java
+++ b/core/trino-main/src/main/java/io/trino/likematcher/DenseDfaMatcher.java
@@ -18,154 +18,167 @@ import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 
 class DenseDfaMatcher
         implements Matcher
 {
     public static final int FAIL_STATE = -1;
 
-    // The DFA is encoded as a sequence of transitions for each possible byte value for each state.
-    // I.e., 256 transitions per state.
-    // The content of the transitions array is the base offset into
-    // the next state to follow. I.e., the desired state * 256
-    private final int[] transitions;
-
-    // The starting state
-    private final int start;
-
-    // For each state, whether it's an accepting state
-    private final boolean[] accept;
-
+    private final List<Pattern> pattern;
     private final boolean exact;
 
-    /**
-     * @param exact whether to match to the end of the input
-     */
-    public static DenseDfaMatcher newInstance(List<Pattern> pattern, boolean exact)
+    private volatile DenseDfa matcher;
+
+    public DenseDfaMatcher(List<Pattern> pattern, boolean exact)
     {
-        DFA dfa = makeNfa(pattern).toDfa();
-
-        int[] transitions = new int[dfa.transitions().size() * 256];
-        Arrays.fill(transitions, FAIL_STATE);
-
-        for (int state = 0; state < dfa.transitions().size(); state++) {
-            for (DFA.Transition transition : dfa.transitions().get(state)) {
-                transitions[state * 256 + transition.value()] = transition.target() * 256;
-            }
-        }
-
-        boolean[] accept = new boolean[dfa.transitions().size()];
-        for (int state : dfa.acceptStates()) {
-            accept[state] = true;
-        }
-
-        return new DenseDfaMatcher(transitions, dfa.start(), accept, exact);
-    }
-
-    private DenseDfaMatcher(int[] transitions, int start, boolean[] accept, boolean exact)
-    {
-        this.transitions = transitions;
-        this.start = start;
-        this.accept = accept;
+        this.pattern = requireNonNull(pattern, "pattern is null");
         this.exact = exact;
     }
 
     @Override
     public boolean match(byte[] input, int offset, int length)
     {
+        DenseDfa matcher = this.matcher;
+        if (matcher == null) {
+            matcher = DenseDfa.newInstance(pattern);
+            this.matcher = matcher;
+        }
+
         if (exact) {
-            return exactMatch(input, offset, length);
+            return matcher.exactMatch(input, offset, length);
         }
 
-        return prefixMatch(input, offset, length);
+        return matcher.prefixMatch(input, offset, length);
     }
 
-    /**
-     * Returns a positive match when the final state after all input has been consumed is an accepting state
-     */
-    private boolean exactMatch(byte[] input, int offset, int length)
+    private static class DenseDfa
     {
-        int state = start << 8;
-        for (int i = offset; i < offset + length; i++) {
-            byte inputByte = input[i];
-            state = transitions[state | (inputByte & 0xFF)];
+        // The DFA is encoded as a sequence of transitions for each possible byte value for each state.
+        // I.e., 256 transitions per state.
+        // The content of the transitions array is the base offset into
+        // the next state to follow. I.e., the desired state * 256
+        private final int[] transitions;
 
-            if (state == FAIL_STATE) {
-                return false;
-            }
-        }
+        // The starting state
+        private final int start;
 
-        return accept[state >>> 8];
-    }
+        // For each state, whether it's an accepting state
+        private final boolean[] accept;
 
-    /**
-     * Returns a positive match as soon as the DFA reaches an accepting state, regardless of whether
-     * the whole input has been consumed
-     */
-    private boolean prefixMatch(byte[] input, int offset, int length)
-    {
-        int state = start << 8;
-        for (int i = offset; i < offset + length; i++) {
-            byte inputByte = input[i];
-            state = transitions[state | (inputByte & 0xFF)];
+        public static DenseDfa newInstance(List<Pattern> pattern)
+        {
+            DFA dfa = makeNfa(pattern).toDfa();
 
-            if (state == FAIL_STATE) {
-                return false;
-            }
+            int[] transitions = new int[dfa.transitions().size() * 256];
+            Arrays.fill(transitions, FAIL_STATE);
 
-            if (accept[state >>> 8]) {
-                return true;
-            }
-        }
-
-        return accept[state >>> 8];
-    }
-
-    private static NFA makeNfa(List<Pattern> pattern)
-    {
-        checkArgument(!pattern.isEmpty(), "pattern is empty");
-
-        NFA.Builder builder = new NFA.Builder();
-
-        int state = builder.addStartState();
-
-        for (Pattern item : pattern) {
-            if (item instanceof Pattern.Literal literal) {
-                for (byte current : literal.value().getBytes(UTF_8)) {
-                    state = matchByte(builder, state, current);
+            for (int state = 0; state < dfa.transitions().size(); state++) {
+                for (DFA.Transition transition : dfa.transitions().get(state)) {
+                    transitions[state * 256 + transition.value()] = transition.target() * 256;
                 }
             }
-            else if (item instanceof Pattern.Any any) {
-                for (int i = 0; i < any.min(); i++) {
-                    int next = builder.addState();
-                    matchSingleUtf8(builder, state, next);
-                    state = next;
-                }
+            boolean[] accept = new boolean[dfa.transitions().size()];
+            for (int state : dfa.acceptStates()) {
+                accept[state] = true;
+            }
 
-                if (any.unbounded()) {
-                    matchSingleUtf8(builder, state, state);
-                }
-            }
-            else {
-                throw new UnsupportedOperationException("Not supported: " + item.getClass().getName());
-            }
+            return new DenseDfa(transitions, dfa.start(), accept);
         }
 
-        builder.setAccept(state);
+        private DenseDfa(int[] transitions, int start, boolean[] accept)
+        {
+            this.transitions = transitions;
+            this.start = start;
+            this.accept = accept;
+        }
 
-        return builder.build();
-    }
+        /**
+         * Returns a positive match when the final state after all input has been consumed is an accepting state
+         */
+        public boolean exactMatch(byte[] input, int offset, int length)
+        {
+            int state = start << 8;
+            for (int i = offset; i < offset + length; i++) {
+                byte inputByte = input[i];
+                state = transitions[state | (inputByte & 0xFF)];
 
-    private static int matchByte(NFA.Builder builder, int state, byte value)
-    {
-        int next = builder.addState();
-        builder.addTransition(state, new NFA.Value(value), next);
-        return next;
-    }
+                if (state == FAIL_STATE) {
+                    return false;
+                }
+            }
 
-    private static void matchSingleUtf8(NFA.Builder builder, int from, int to)
-    {
-        /*
+            return accept[state >>> 8];
+        }
+
+        /**
+         * Returns a positive match as soon as the DFA reaches an accepting state, regardless of whether
+         * the whole input has been consumed
+         */
+        public boolean prefixMatch(byte[] input, int offset, int length)
+        {
+            int state = start << 8;
+            for (int i = offset; i < offset + length; i++) {
+                byte inputByte = input[i];
+                state = transitions[state | (inputByte & 0xFF)];
+
+                if (state == FAIL_STATE) {
+                    return false;
+                }
+
+                if (accept[state >>> 8]) {
+                    return true;
+                }
+            }
+
+            return accept[state >>> 8];
+        }
+
+        private static NFA makeNfa(List<Pattern> pattern)
+        {
+            checkArgument(!pattern.isEmpty(), "pattern is empty");
+
+            NFA.Builder builder = new NFA.Builder();
+
+            int state = builder.addStartState();
+
+            for (Pattern item : pattern) {
+                if (item instanceof Pattern.Literal literal) {
+                    for (byte current : literal.value().getBytes(UTF_8)) {
+                        state = matchByte(builder, state, current);
+                    }
+                }
+                else if (item instanceof Pattern.Any any) {
+                    for (int i = 0; i < any.min(); i++) {
+                        int next = builder.addState();
+                        matchSingleUtf8(builder, state, next);
+                        state = next;
+                    }
+
+                    if (any.unbounded()) {
+                        matchSingleUtf8(builder, state, state);
+                    }
+                }
+                else {
+                    throw new UnsupportedOperationException("Not supported: " + item.getClass().getName());
+                }
+            }
+
+            builder.setAccept(state);
+
+            return builder.build();
+        }
+
+        private static int matchByte(NFA.Builder builder, int state, byte value)
+        {
+            int next = builder.addState();
+            builder.addTransition(state, new NFA.Value(value), next);
+            return next;
+        }
+
+        private static void matchSingleUtf8(NFA.Builder builder, int from, int to)
+        {
+            /*
             Implements a state machine to recognize UTF-8 characters.
 
                   11110xxx       10xxxxxx       10xxxxxx       10xxxxxx
@@ -179,20 +192,21 @@ class DenseDfaMatcher
               │                                                           │
               └───────────────────────────────────────────────────────────┘
                                         0xxxxxxx
-        */
+            */
 
-        builder.addTransition(from, new NFA.Prefix(0, 1), to);
+            builder.addTransition(from, new NFA.Prefix(0, 1), to);
 
-        int state1 = builder.addState();
-        int state2 = builder.addState();
-        int state3 = builder.addState();
+            int state1 = builder.addState();
+            int state2 = builder.addState();
+            int state3 = builder.addState();
 
-        builder.addTransition(from, new NFA.Prefix(0b11110, 5), state1);
-        builder.addTransition(from, new NFA.Prefix(0b1110, 4), state2);
-        builder.addTransition(from, new NFA.Prefix(0b110, 3), state3);
+            builder.addTransition(from, new NFA.Prefix(0b11110, 5), state1);
+            builder.addTransition(from, new NFA.Prefix(0b1110, 4), state2);
+            builder.addTransition(from, new NFA.Prefix(0b110, 3), state3);
 
-        builder.addTransition(state1, new NFA.Prefix(0b10, 2), state2);
-        builder.addTransition(state2, new NFA.Prefix(0b10, 2), state3);
-        builder.addTransition(state3, new NFA.Prefix(0b10, 2), to);
+            builder.addTransition(state1, new NFA.Prefix(0b10, 2), state2);
+            builder.addTransition(state2, new NFA.Prefix(0b10, 2), state3);
+            builder.addTransition(state3, new NFA.Prefix(0b10, 2), to);
+        }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/likematcher/LikeMatcher.java
+++ b/core/trino-main/src/main/java/io/trino/likematcher/LikeMatcher.java
@@ -151,7 +151,7 @@ public class LikeMatcher
         Optional<Matcher> matcher = Optional.empty();
         if (!middle.isEmpty()) {
             if (optimize) {
-                matcher = Optional.of(DenseDfaMatcher.newInstance(middle, exact));
+                matcher = Optional.of(new DenseDfaMatcher(middle, exact));
             }
             else {
                 matcher = Optional.of(new NfaMatcher(middle, exact));

--- a/core/trino-main/src/main/java/io/trino/likematcher/Matcher.java
+++ b/core/trino-main/src/main/java/io/trino/likematcher/Matcher.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.likematcher;
+
+public interface Matcher
+{
+    boolean match(byte[] input, int offset, int length);
+}

--- a/core/trino-main/src/main/java/io/trino/likematcher/NFA.java
+++ b/core/trino-main/src/main/java/io/trino/likematcher/NFA.java
@@ -45,10 +45,6 @@ final class NFA
         Map<IntSet, Integer> activeStates = new HashMap<>();
 
         DFA.Builder builder = new DFA.Builder();
-        int failed = builder.addFailState();
-        for (int i = 0; i < 256; i++) {
-            builder.addTransition(failed, i, failed);
-        }
 
         IntSet initial = new IntArraySet();
         initial.add(start);
@@ -85,13 +81,13 @@ final class NFA
                     }
                 }
 
-                int from = activeStates.get(current);
-                int to = failed;
                 if (!next.isEmpty()) {
-                    to = activeStates.computeIfAbsent(next, nfaStates -> builder.addState(nfaStates.contains(accept)));
+                    int from = activeStates.get(current);
+                    int to = activeStates.computeIfAbsent(next, nfaStates -> builder.addState(nfaStates.contains(accept)));
+                    builder.addTransition(from, byteValue, to);
+
                     queue.add(next);
                 }
-                builder.addTransition(from, byteValue, to);
             }
         }
 

--- a/core/trino-main/src/main/java/io/trino/likematcher/NFA.java
+++ b/core/trino-main/src/main/java/io/trino/likematcher/NFA.java
@@ -14,7 +14,6 @@
 package io.trino.likematcher;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -29,13 +28,13 @@ import java.util.stream.Collectors;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
-record NFA(State start, State accept, List<State> states, Map<Integer, List<Transition>> transitions)
+record NFA(State start, State accept, List<State> states, List<List<Transition>> transitions)
 {
     NFA {
         requireNonNull(start, "start is null");
         requireNonNull(accept, "accept is null");
         states = ImmutableList.copyOf(states);
-        transitions = ImmutableMap.copyOf(transitions);
+        transitions = ImmutableList.copyOf(transitions);
     }
 
     public DFA toDfa()
@@ -97,7 +96,7 @@ record NFA(State start, State accept, List<State> states, Map<Integer, List<Tran
 
     private List<Transition> transitions(State state)
     {
-        return transitions.getOrDefault(state.id(), ImmutableList.of());
+        return transitions.get(state.id());
     }
 
     private String makeLabel(Set<NFA.State> states)
@@ -115,12 +114,13 @@ record NFA(State start, State accept, List<State> states, Map<Integer, List<Tran
         private State start;
         private State accept;
         private final List<State> states = new ArrayList<>();
-        private final Map<Integer, List<Transition>> transitions = new HashMap<>();
+        private final List<List<Transition>> transitions = new ArrayList<>();
 
         public State addState()
         {
             State state = new State(nextId++);
             states.add(state);
+            transitions.add(new ArrayList<>());
             return state;
         }
 
@@ -139,8 +139,7 @@ record NFA(State start, State accept, List<State> states, Map<Integer, List<Tran
 
         public void addTransition(State from, Condition condition, State to)
         {
-            transitions.computeIfAbsent(from.id(), key -> new ArrayList<>())
-                    .add(new Transition(to.id(), condition));
+            transitions.get(from.id()).add(new Transition(to.id(), condition));
         }
 
         public NFA build()

--- a/core/trino-main/src/main/java/io/trino/likematcher/NfaMatcher.java
+++ b/core/trino-main/src/main/java/io/trino/likematcher/NfaMatcher.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.likematcher;
+
+import java.util.Arrays;
+import java.util.List;
+
+final class NfaMatcher
+        implements Matcher
+{
+    private static final int ANY = -1;
+    private static final int NONE = -2;
+    private static final int INVALID_CODEPOINT = -1;
+
+    private final boolean exact;
+
+    private final boolean[] loopback;
+    private final int[] match;
+    private final int acceptState;
+    private final int stateCount;
+
+    public NfaMatcher(List<Pattern> pattern, boolean exact)
+    {
+        this.exact = exact;
+
+        stateCount = calculateStateCount(pattern);
+
+        loopback = new boolean[stateCount];
+        match = new int[stateCount];
+        Arrays.fill(match, NONE);
+        acceptState = stateCount - 1;
+
+        int state = 0;
+        for (Pattern element : pattern) {
+            if (element instanceof Pattern.Literal literal) {
+                for (int i = 0; i < literal.value().length(); i++) {
+                    match[state++] = literal.value().charAt(i);
+                }
+            }
+            else if (element instanceof Pattern.Any any) {
+                for (int i = 0; i < any.min(); i++) {
+                    match[state++] = ANY;
+                }
+
+                if (any.unbounded()) {
+                    loopback[state] = true;
+                }
+            }
+        }
+    }
+
+    private static int calculateStateCount(List<Pattern> pattern)
+    {
+        int states = 1;
+        for (Pattern element : pattern) {
+            if (element instanceof Pattern.Literal literal) {
+                states += literal.value().length();
+            }
+            else if (element instanceof Pattern.Any any) {
+                states += any.min();
+            }
+        }
+        return states;
+    }
+
+    @Override
+    public boolean match(byte[] input, int offset, int length)
+    {
+        boolean[] seen = new boolean[stateCount + 1];
+        int[] currentStates = new int[stateCount];
+        int[] nextStates = new int[stateCount];
+        int currentStatesIndex = 0;
+        int nextStatesIndex;
+
+        currentStates[currentStatesIndex++] = 0;
+
+        int limit = offset + length;
+        int current = offset;
+        boolean accept = false;
+        while (current < limit) {
+            int codepoint = INVALID_CODEPOINT;
+
+            // decode the next UTF-8 codepoint
+            int header = input[current] & 0xFF;
+            if (header < 0x80) {
+                // normal ASCII
+                // 0xxx_xxxx
+                codepoint = header;
+                current++;
+            }
+            else if ((header & 0b1110_0000) == 0b1100_0000) {
+                // 110x_xxxx 10xx_xxxx
+                if (current + 1 < limit) {
+                    codepoint = ((header & 0b0001_1111) << 6) | (input[current + 1] & 0b0011_1111);
+                    current += 2;
+                }
+            }
+            else if ((header & 0b1111_0000) == 0b1110_0000) {
+                // 1110_xxxx 10xx_xxxx 10xx_xxxx
+                if (current + 2 < limit) {
+                    codepoint = ((header & 0b0000_1111) << 12) | ((input[current + 1] & 0b0011_1111) << 6) | (input[current + 2] & 0b0011_1111);
+                    current += 3;
+                }
+            }
+            else if ((header & 0b1111_1000) == 0b1111_0000) {
+                // 1111_0xxx 10xx_xxxx 10xx_xxxx 10xx_xxxx
+                if (current + 3 < limit) {
+                    codepoint = ((header & 0b0000_0111) << 18) | ((input[current + 1] & 0b0011_1111) << 12) | ((input[current + 2] & 0b0011_1111) << 6) | (input[current + 3] & 0b0011_1111);
+                    current += 4;
+                }
+            }
+
+            if (codepoint == INVALID_CODEPOINT) {
+                return false;
+            }
+
+            accept = false;
+            nextStatesIndex = 0;
+            Arrays.fill(seen, false);
+            for (int i = 0; i < currentStatesIndex; i++) {
+                int state = currentStates[i];
+                if (!seen[state] && loopback[state]) {
+                    nextStates[nextStatesIndex++] = state;
+                    accept |= state == acceptState;
+                    seen[state] = true;
+                }
+                int next = state + 1;
+                if (!seen[next] && (match[state] == ANY || match[state] == codepoint)) {
+                    nextStates[nextStatesIndex++] = next;
+                    accept |= next == acceptState;
+                    seen[next] = true;
+                }
+            }
+
+            if (nextStatesIndex == 0) {
+                return false;
+            }
+
+            if (!exact && accept) {
+                return true;
+            }
+
+            int[] tmp = currentStates;
+            currentStates = nextStates;
+            nextStates = tmp;
+            currentStatesIndex = nextStatesIndex;
+        }
+
+        return accept;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/likematcher/Pattern.java
+++ b/core/trino-main/src/main/java/io/trino/likematcher/Pattern.java
@@ -13,11 +13,12 @@
  */
 package io.trino.likematcher;
 
+import com.google.common.base.Strings;
+
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.lang.String.format;
 
 sealed interface Pattern
-        permits Pattern.Any, Pattern.Literal
+        permits Pattern.Any, Pattern.Literal, Pattern.ZeroOrMore
 {
     record Literal(String value)
             implements Pattern
@@ -29,18 +30,28 @@ sealed interface Pattern
         }
     }
 
-    record Any(int min, boolean unbounded)
+    record ZeroOrMore()
+            implements Pattern
+    {
+        @Override
+        public String toString()
+        {
+            return "%";
+        }
+    }
+
+    record Any(int length)
             implements Pattern
     {
         public Any
         {
-            checkArgument(min > 0 || unbounded, "Any must be unbounded or require at least 1 character");
+            checkArgument(length > 0, "Length must be > 0");
         }
 
         @Override
         public String toString()
         {
-            return format("{%s%s}", min, unbounded ? "+" : "");
+            return Strings.repeat("_", length);
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/type/LikeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/type/LikeFunctions.java
@@ -61,7 +61,7 @@ public final class LikeFunctions
     @SqlType(LikePatternType.NAME)
     public static LikeMatcher likePattern(@SqlType("varchar") Slice pattern)
     {
-        return LikeMatcher.compile(pattern.toStringUtf8(), Optional.empty());
+        return LikeMatcher.compile(pattern.toStringUtf8(), Optional.empty(), false);
     }
 
     @ScalarFunction(value = LIKE_PATTERN_FUNCTION_NAME, hidden = true)
@@ -69,7 +69,7 @@ public final class LikeFunctions
     public static LikeMatcher likePattern(@SqlType("varchar") Slice pattern, @SqlType("varchar") Slice escape)
     {
         try {
-            return LikeMatcher.compile(pattern.toStringUtf8(), getEscapeCharacter(Optional.of(escape)));
+            return LikeMatcher.compile(pattern.toStringUtf8(), getEscapeCharacter(Optional.of(escape)), false);
         }
         catch (RuntimeException e) {
             throw new TrinoException(INVALID_FUNCTION_ARGUMENT, e);

--- a/core/trino-main/src/test/java/io/trino/likematcher/TestLikeMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/likematcher/TestLikeMatcher.java
@@ -101,6 +101,8 @@ public class TestLikeMatcher
         assertTrue(match("-%", "%", '-'));
         assertTrue(match("-_", "_", '-'));
         assertTrue(match("--", "-", '-'));
+
+        assertTrue(match("%$_%", "xxxxx_xxxxx", '$'));
     }
 
     private static boolean match(String pattern, String value)

--- a/core/trino-main/src/test/java/io/trino/likematcher/TestLikeMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/likematcher/TestLikeMatcher.java
@@ -74,13 +74,23 @@ public class TestLikeMatcher
         // optimization of consecutive _ and %
         assertTrue(match("_%_%_%_%", "abcdefghij"));
 
+        assertTrue(match("%a%a%a%a%a%a%", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+        assertTrue(match("%a%a%a%a%a%a%", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"));
+        assertTrue(match("%a%b%a%b%a%b%", "aabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabb"));
+        assertTrue(match("%aaaa%bbbb%aaaa%bbbb%aaaa%bbbb%", "aaaabbbbaaaabbbbaaaabbbb"));
+        assertTrue(match("%aaaaaaaaaaaaaaaaaaaaaaaaaa%", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+
         // utf-8
-        LikeMatcher single = LikeMatcher.compile("_");
-        LikeMatcher multiple = LikeMatcher.compile("_a%b_"); // prefix and suffix with _a and b_ to avoid optimizations
+        LikeMatcher singleOptimized = LikeMatcher.compile("_", Optional.empty(), true);
+        LikeMatcher multipleOptimized = LikeMatcher.compile("_a%b_", Optional.empty(), true); // prefix and suffix with _a and b_ to avoid optimizations
+        LikeMatcher single = LikeMatcher.compile("_", Optional.empty(), false);
+        LikeMatcher multiple = LikeMatcher.compile("_a%b_", Optional.empty(), false); // prefix and suffix with _a and b_ to avoid optimizations
         for (int i = 0; i < Character.MAX_CODE_POINT; i++) {
+            assertTrue(singleOptimized.match(Character.toString(i).getBytes(StandardCharsets.UTF_8)));
             assertTrue(single.match(Character.toString(i).getBytes(StandardCharsets.UTF_8)));
 
             String value = "aa" + (char) i + "bb";
+            assertTrue(multipleOptimized.match(value.getBytes(StandardCharsets.UTF_8)));
             assertTrue(multiple.match(value.getBytes(StandardCharsets.UTF_8)));
         }
     }
@@ -109,10 +119,17 @@ public class TestLikeMatcher
         String padded = padding + value + padding;
         byte[] bytes = padded.getBytes(StandardCharsets.UTF_8);
 
-        boolean withoutPadding = LikeMatcher.compile(pattern, escape).match(value.getBytes(StandardCharsets.UTF_8));
-        boolean withPadding = LikeMatcher.compile(pattern, escape).match(bytes, padding.length(), bytes.length - padding.length() * 2);  // exclude padding
+        boolean optimizedWithoutPadding = LikeMatcher.compile(pattern, escape, true).match(value.getBytes(StandardCharsets.UTF_8));
 
-        assertEquals(withoutPadding, withPadding);
+        boolean optimizedWithPadding = LikeMatcher.compile(pattern, escape, true).match(bytes, padding.length(), bytes.length - padding.length() * 2);  // exclude padding
+        assertEquals(optimizedWithoutPadding, optimizedWithPadding);
+
+        boolean withoutPadding = LikeMatcher.compile(pattern, escape, false).match(value.getBytes(StandardCharsets.UTF_8));
+        assertEquals(optimizedWithoutPadding, withoutPadding);
+
+        boolean withPadding = LikeMatcher.compile(pattern, escape, false).match(bytes, padding.length(), bytes.length - padding.length() * 2);  // exclude padding
+        assertEquals(optimizedWithoutPadding, withPadding);
+
         return withPadding;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkLike.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkLike.java
@@ -85,6 +85,8 @@ public class BenchmarkLike
                 "_____",
                 "abc%def%ghi",
                 "%abc%def%",
+                "%a%a%a%a%",
+                "%aaaaaaaaaaaaaaaaaaaaaaaaaa%"
         })
         private String pattern;
 
@@ -105,6 +107,8 @@ public class BenchmarkLike
                         case "_____" -> "abcde";
                         case "abc%def%ghi" -> "abc qeroighqeorhgqerhb2eriuyerqiubgier def ubgleuqrbgilquebriuqebryqebrhqerhqsnajkbcowuhet ghi";
                         case "%abc%def%" -> "fdnbqerbfklerqbgqjerbgkr abc qeroighqeorhgqerhb2eriuyerqiubgier def ubgleuqrbgilquebriuqebryqebrhqerhqsnajkbcowuhet";
+                        case "%a%a%a%a%" -> "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+                        case "%aaaaaaaaaaaaaaaaaaaaaaaaaa%" -> "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
                         default -> throw new IllegalArgumentException("Unknown pattern: " + pattern);
                     });
 
@@ -125,6 +129,18 @@ public class BenchmarkLike
     public boolean benchmarkCurrent(Data data)
     {
         return data.matcher.match(data.bytes, 0, data.bytes.length);
+    }
+
+    @Benchmark
+    public JoniRegexp compileJoni(Data data)
+    {
+        return compileJoni(data.pattern, (char) 0, false);
+    }
+
+    @Benchmark
+    public LikeMatcher compile(Data data)
+    {
+        return LikeMatcher.compile(data.pattern, Optional.empty());
     }
 
     public static boolean likeVarchar(Slice value, JoniRegexp pattern)


### PR DESCRIPTION
Improve performance of LIKE matchers.

* Improves performance when compiling the NFA and DFA for the LIKE matcher
* Introduces an NFA-based matcher that's cheaper to construct to use when matching dynamic patterns.

Before this change, compilation times for the DFA vs Joni:

    compileDFA    %abc%def%    1484095.662 ± 13372.922  ns/op
    compileJoni   %abc%def%        767.662 ±     6.783  ns/op

Performance after this change (note that compilation for the DFA is now lazy, so that paid for on first match and amortized over multiple matches:

    compileDFA     %abc%def%       128.121 ± 1.557  ns/op
    compileNFA     %abc%def%       212.063 ± 3.552  ns/op
    compileJoni    %abc%def%       779.040 ± 9.597  ns/op

Additionally, this is the relative amortized performance for calls to match in each of the implementation:

    matchDFA      %abc%def%        146.179 ± 1.182  ns/op
    matchNFA      %abc%def%        263.210 ± 5.038  ns/op
    matchJoni     %abc%def%        450.610 ± 4.898  ns/op

Finally, this is the relative performance for a "dynamic pattern" scenario, i.e., when the matcher is constructed, used once and thrown away. Note that this includes some optimizations to the algorithm for compiling the DFA, hence the difference with the original numbers above.

    dfa    249740.218 ± 2133.271  ns/op
    nfa       570.003 ±    3.615  ns/op
    joni     1268.622 ±   12.690  ns/op

## Release notes

TBD
