### PR TITLE
Fix ConcurrentModificationException in parser error handler

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/parser/ErrorHandler.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/ErrorHandler.java
@@ -211,14 +211,12 @@ class ErrorHandler
             }
 
             Set<Integer> endTokens = process(new ParsingState(currentState, tokenIndex, false, parser), 0);
-            Set<Integer> nextTokens = new HashSet<>();
             while (!endTokens.isEmpty() && context.invokingState != -1) {
-                for (int endToken : endTokens) {
-                    ATNState nextState = ((RuleTransition) atn.states.get(context.invokingState).transition(0)).followState;
-                    nextTokens.addAll(process(new ParsingState(nextState, endToken, false, parser), 0));
-                }
+                ATNState nextState = ((RuleTransition) atn.states.get(context.invokingState).transition(0)).followState;
+                endTokens = endTokens.stream()
+                    .flatMap(endToken -> process(new ParsingState(nextState, endToken, false, parser), 0).stream())
+                    .collect(Collectors.toSet());
                 context = context.parent;
-                endTokens = nextTokens;
             }
 
             return new Result(furthestTokenIndex, candidates);

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
@@ -136,8 +136,8 @@ public class TestSqlParserErrorHandling
                 Arguments.of("SELECT a FROM \"\".s.t",
                         "line 1:15: Zero-length delimited identifier not allowed"),
                 Arguments.of("WITH t AS (SELECT 1 SELECT t.* FROM t",
-                        "line 1:21: mismatched input 'SELECT'. Expecting: '%', '(', ')', '*', '+', ',', '-', '.', '/', 'AND', 'AS', 'AT', 'EXCEPT', 'FETCH', 'FROM', " +
-                                "'GROUP', 'HAVING', 'INTERSECT', 'LIMIT', 'OFFSET', 'OR', 'ORDER', 'SELECT', 'TABLE', 'UNION', 'VALUES', 'WHERE', 'WINDOW', '[', '||', <EOF>, " +
+                        "line 1:21: mismatched input 'SELECT'. Expecting: '%', ')', '*', '+', ',', '-', '.', '/', 'AND', 'AS', 'AT', 'EXCEPT', 'FETCH', 'FROM', " +
+                                "'GROUP', 'HAVING', 'INTERSECT', 'LIMIT', 'OFFSET', 'OR', 'ORDER', 'UNION', 'WHERE', 'WINDOW', '[', '||', " +
                                 "<identifier>, <predicate>"),
                 Arguments.of("SHOW CATALOGS LIKE '%$_%' ESCAPE",
                         "line 1:33: mismatched input '<EOF>'. Expecting: <string>"),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Exception:
```
Unexpected failure when handling parsing error. This is likely a bug in the implementation
java.util.ConcurrentModificationException
        at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1597)
        at java.base/java.util.HashMap$KeyIterator.next(HashMap.java:1620)
        at io.trino.sql.parser.ErrorHandler$Analyzer.process(ErrorHandler.java:216)
```

This was happening because after the first iteration of the while loop,
`endTokens` is a reference to `nextTokens`, so when we iterate through
`endTokens`, we are actually iterating through `nextTokens`. So since we are
iterating through `nextTokens` and also adding to `nextTokens` at the same
time, we end up with a `ConcurrentModificationException`.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

