### PR TITLE
Fix flakiness from random input in TestParquetReaderMemoryUsage

### DIFF
--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReaderMemoryUsage.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReaderMemoryUsage.java
@@ -40,7 +40,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ThreadLocalRandom;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Throwables.throwIfUnchecked;
@@ -154,7 +153,7 @@ public class TestParquetReaderMemoryUsage
     {
         BlockBuilder blockBuilder = type.createBlockBuilder(null, positions);
         for (int i = 0; i < positions; i++) {
-            writeNativeValue(type, blockBuilder, ThreadLocalRandom.current().nextLong(0, 1000));
+            writeNativeValue(type, blockBuilder, (long) i);
         }
         return blockBuilder.build();
     }


### PR DESCRIPTION
## Description
Test can sometimes fail due to random input
```
io.trino.parquet.reader.TestParquetReaderMemoryUsage.testColumnReaderMemoryUsage  Time elapsed: 0.283 s  <<< FAILURE!
2023-02-06T20:14:38.2933047Z java.lang.AssertionError: 
2023-02-06T20:14:38.2933574Z 
2023-02-06T20:14:38.2933892Z Expecting value to be false but was true
2023-02-06T20:14:38.2934661Z 	at io.trino.parquet.reader.TestParquetReaderMemoryUsage.lambda$testColumnReaderMemoryUsage$0(TestParquetReaderMemoryUsage.java:75)
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
