### PR TITLE
Enhance TrinoFileSystem#deleteFiles with files failure count

### DIFF
--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoFileSystem.java
@@ -33,9 +33,10 @@ public interface TrinoFileSystem
      * Delete paths in batches, it is not guaranteed to be atomic.
      *
      * @param paths collection of paths to be deleted
+     * @return number of files that failed to delete
      * @throws IOException when there is a problem with deletion of one or more specific paths
      */
-    void deleteFiles(Collection<String> paths)
+    int deleteFiles(Collection<String> paths)
             throws IOException;
 
     void deleteDirectory(String path)

--- a/lib/trino-hdfs/src/main/java/io/trino/hdfs/FileSystemWithBatchDelete.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/hdfs/FileSystemWithBatchDelete.java
@@ -20,6 +20,9 @@ import java.util.Collection;
 
 public interface FileSystemWithBatchDelete
 {
-    void deleteFiles(Collection<Path> paths)
+    /**
+     * @return number of files that failed to delete
+     */
+    int deleteFiles(Collection<Path> paths)
             throws IOException;
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/VacuumProcedure.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/VacuumProcedure.java
@@ -210,6 +210,7 @@ public class VacuumProcedure
         long retainedKnownFiles = 0;
         long retainedUnknownFiles = 0;
         long removedFiles = 0;
+        long failedToDelete = 0;
 
         List<String> filesToDelete = new ArrayList<>();
         FileIterator listing = fileSystem.listFiles(tableLocation.toString());
@@ -259,19 +260,20 @@ public class VacuumProcedure
                     modificationInstant);
             filesToDelete.add(path);
             if (filesToDelete.size() == DELETE_BATCH_SIZE) {
-                fileSystem.deleteFiles(filesToDelete);
+                failedToDelete += fileSystem.deleteFiles(filesToDelete);
                 removedFiles += filesToDelete.size();
                 filesToDelete.clear();
             }
         }
 
         if (!filesToDelete.isEmpty()) {
-            fileSystem.deleteFiles(filesToDelete);
+            failedToDelete += fileSystem.deleteFiles(filesToDelete);
             removedFiles += filesToDelete.size();
         }
 
         log.info(
-                "[%s] finished vacuuming table %s [%s]: files checked: %s; metadata files: %s; retained known files: %s; retained unknown files: %s; removed files: %s",
+                "[%s] finished vacuuming table %s [%s]: files checked: %s; metadata files: %s; retained known files: %s;" +
+                        " retained unknown files: %s; removed files: %s; failed to delete files: %s",
                 queryId,
                 tableName,
                 tableLocation,
@@ -279,6 +281,7 @@ public class VacuumProcedure
                 transactionLogFiles,
                 retainedKnownFiles,
                 retainedUnknownFiles,
-                removedFiles);
+                removedFiles,
+                failedToDelete);
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/AccessTrackingFileSystemFactory.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/AccessTrackingFileSystemFactory.java
@@ -100,7 +100,7 @@ public final class AccessTrackingFileSystemFactory
         }
 
         @Override
-        public void deleteFiles(Collection<String> paths)
+        public int deleteFiles(Collection<String> paths)
         {
             throw new UnsupportedOperationException();
         }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TrackingFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TrackingFileSystemFactory.java
@@ -135,10 +135,10 @@ public class TrackingFileSystemFactory
         }
 
         @Override
-        public void deleteFiles(Collection<String> paths)
+        public int deleteFiles(Collection<String> paths)
                 throws IOException
         {
-            delegate.deleteFiles(paths);
+            return delegate.deleteFiles(paths);
         }
 
         @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

I am proposing to enhance TrinoFileSystem#deleteFiles to track the number of files that failed to delete.

Failure count is needed for the case when we want to throw `BulkDeletionFailureException` in https://github.com/trinodb/trino/pull/15981

See Comments here
https://github.com/trinodb/trino/pull/15981#discussion_r1097954799
https://github.com/trinodb/trino/pull/15981#discussion_r1098291440

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
