### PR TITLE
Optimize plans involving table functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -200,6 +200,7 @@ import io.trino.sql.planner.iterative.rule.RemoveRedundantOffset;
 import io.trino.sql.planner.iterative.rule.RemoveRedundantPredicateAboveTableScan;
 import io.trino.sql.planner.iterative.rule.RemoveRedundantSort;
 import io.trino.sql.planner.iterative.rule.RemoveRedundantSortBelowLimitWithTies;
+import io.trino.sql.planner.iterative.rule.RemoveRedundantTableFunction;
 import io.trino.sql.planner.iterative.rule.RemoveRedundantTopN;
 import io.trino.sql.planner.iterative.rule.RemoveRedundantWindow;
 import io.trino.sql.planner.iterative.rule.RemoveTrivialFilters;
@@ -440,6 +441,7 @@ public class PlanOptimizers
                                         new RemoveRedundantOffset(),
                                         new RemoveRedundantSort(),
                                         new RemoveRedundantSortBelowLimitWithTies(),
+                                        new RemoveRedundantTableFunction(),
                                         new RemoveRedundantTopN(),
                                         new RemoveRedundantDistinctLimit(),
                                         new ReplaceRedundantJoinWithSource(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -121,6 +121,7 @@ import io.trino.sql.planner.iterative.rule.PruneSpatialJoinChildrenColumns;
 import io.trino.sql.planner.iterative.rule.PruneSpatialJoinColumns;
 import io.trino.sql.planner.iterative.rule.PruneTableExecuteSourceColumns;
 import io.trino.sql.planner.iterative.rule.PruneTableFunctionProcessorColumns;
+import io.trino.sql.planner.iterative.rule.PruneTableFunctionProcessorSourceColumns;
 import io.trino.sql.planner.iterative.rule.PruneTableScanColumns;
 import io.trino.sql.planner.iterative.rule.PruneTableWriterSourceColumns;
 import io.trino.sql.planner.iterative.rule.PruneTopNColumns;
@@ -1036,6 +1037,7 @@ public class PlanOptimizers
                 new PruneSpatialJoinColumns(),
                 new PruneTableExecuteSourceColumns(),
                 new PruneTableFunctionProcessorColumns(),
+                new PruneTableFunctionProcessorSourceColumns(),
                 new PruneTableScanColumns(metadata),
                 new PruneTableWriterSourceColumns(),
                 new PruneTopNColumns(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -120,6 +120,7 @@ import io.trino.sql.planner.iterative.rule.PruneSortColumns;
 import io.trino.sql.planner.iterative.rule.PruneSpatialJoinChildrenColumns;
 import io.trino.sql.planner.iterative.rule.PruneSpatialJoinColumns;
 import io.trino.sql.planner.iterative.rule.PruneTableExecuteSourceColumns;
+import io.trino.sql.planner.iterative.rule.PruneTableFunctionProcessorColumns;
 import io.trino.sql.planner.iterative.rule.PruneTableScanColumns;
 import io.trino.sql.planner.iterative.rule.PruneTableWriterSourceColumns;
 import io.trino.sql.planner.iterative.rule.PruneTopNColumns;
@@ -1034,6 +1035,7 @@ public class PlanOptimizers
                 new PruneSpatialJoinChildrenColumns(),
                 new PruneSpatialJoinColumns(),
                 new PruneTableExecuteSourceColumns(),
+                new PruneTableFunctionProcessorColumns(),
                 new PruneTableScanColumns(metadata),
                 new PruneTableWriterSourceColumns(),
                 new PruneTopNColumns(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneTableFunctionProcessorColumns.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneTableFunctionProcessorColumns.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughColumn;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughSpecification;
+import io.trino.sql.planner.plan.TableFunctionProcessorNode;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.sql.planner.plan.Patterns.tableFunctionProcessor;
+
+/**
+ * TableFunctionProcessorNode has two kinds of outputs:
+ * - proper outputs, which are the columns produced by the table function,
+ * - pass-through outputs, which are the columns copied from table arguments.
+ * This rule filters out unreferenced pass-through symbols.
+ * Unreferenced proper symbols are not pruned, because there is currently no way
+ * to communicate to the table function the request for not producing certain columns.
+ * // TODO prune table function's proper outputs
+ */
+public class PruneTableFunctionProcessorColumns
+        extends ProjectOffPushDownRule<TableFunctionProcessorNode>
+{
+    public PruneTableFunctionProcessorColumns()
+    {
+        super(tableFunctionProcessor());
+    }
+
+    @Override
+    protected Optional<PlanNode> pushDownProjectOff(Context context, TableFunctionProcessorNode node, Set<Symbol> referencedOutputs)
+    {
+        List<PassThroughSpecification> prunedPassThroughSpecifications = node.getPassThroughSpecifications().stream()
+                .map(sourceSpecification -> {
+                    List<PassThroughColumn> prunedPassThroughColumns = sourceSpecification.columns().stream()
+                            .filter(column -> referencedOutputs.contains(column.symbol()))
+                            .collect(toImmutableList());
+                    return new PassThroughSpecification(sourceSpecification.declaredAsPassThrough(), prunedPassThroughColumns);
+                })
+                .collect(toImmutableList());
+
+        int originalPassThroughCount = node.getPassThroughSpecifications().stream()
+                .map(PassThroughSpecification::columns)
+                .mapToInt(List::size)
+                .sum();
+
+        int prunedPassThroughCount = prunedPassThroughSpecifications.stream()
+                .map(PassThroughSpecification::columns)
+                .mapToInt(List::size)
+                .sum();
+
+        if (originalPassThroughCount == prunedPassThroughCount) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new TableFunctionProcessorNode(
+                node.getId(),
+                node.getName(),
+                node.getFunctionCatalog(),
+                node.getProperOutputs(),
+                node.getSource(),
+                node.isPruneWhenEmpty(),
+                prunedPassThroughSpecifications,
+                node.getRequiredSymbols(),
+                node.getMarkerSymbols(),
+                node.getSpecification(),
+                node.getPrePartitioned(),
+                node.getPreSorted(),
+                node.getHashSymbol(),
+                node.getHandle()));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneTableFunctionProcessorSourceColumns.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneTableFunctionProcessorSourceColumns.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughColumn;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughSpecification;
+import io.trino.sql.planner.plan.TableFunctionProcessorNode;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.collect.Maps.filterKeys;
+import static io.trino.sql.planner.iterative.rule.Util.restrictOutputs;
+import static io.trino.sql.planner.plan.Patterns.tableFunctionProcessor;
+
+/**
+ * This rule prunes unreferenced outputs of TableFunctionProcessorNode.
+ * First, it extracts all symbols required for:
+ * - pass-through
+ * - table function computation
+ * - partitioning and ordering (including the hashSymbol)
+ * Next, a mapping of input symbols to marker symbols is updated
+ * so that it only contains mappings for the required symbols.
+ * Last, all the remaining marker symbols are added to the collection
+ * of required symbols.
+ * Any source output symbols not included in the required symbols
+ * can be pruned.
+ */
+public class PruneTableFunctionProcessorSourceColumns
+        implements Rule<TableFunctionProcessorNode>
+{
+    private static final Pattern<TableFunctionProcessorNode> PATTERN = tableFunctionProcessor();
+
+    @Override
+    public Pattern<TableFunctionProcessorNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(TableFunctionProcessorNode node, Captures captures, Context context)
+    {
+        if (node.getSource().isEmpty()) {
+            return Result.empty();
+        }
+
+        ImmutableSet.Builder<Symbol> requiredInputs = ImmutableSet.builder();
+
+        node.getPassThroughSpecifications().stream()
+                .map(PassThroughSpecification::columns)
+                .flatMap(Collection::stream)
+                .map(PassThroughColumn::symbol)
+                .forEach(requiredInputs::add);
+
+        node.getRequiredSymbols().stream()
+                .forEach(requiredInputs::addAll);
+
+        node.getSpecification().ifPresent(specification -> {
+            requiredInputs.addAll(specification.getPartitionBy());
+            specification.getOrderingScheme().ifPresent(orderingScheme -> requiredInputs.addAll(orderingScheme.getOrderBy()));
+        });
+
+        node.getHashSymbol().ifPresent(requiredInputs::add);
+
+        Optional<Map<Symbol, Symbol>> updatedMarkerSymbols = node.getMarkerSymbols()
+                .map(mapping -> filterKeys(mapping, requiredInputs.build()::contains));
+
+        updatedMarkerSymbols.ifPresent(mapping -> requiredInputs.addAll(mapping.values()));
+
+        return restrictOutputs(context.getIdAllocator(), node.getSource().orElseThrow(), requiredInputs.build())
+                .map(child -> Result.ofPlanNode(new TableFunctionProcessorNode(
+                        node.getId(),
+                        node.getName(),
+                        node.getFunctionCatalog(),
+                        node.getProperOutputs(),
+                        Optional.of(child),
+                        node.isPruneWhenEmpty(),
+                        node.getPassThroughSpecifications(),
+                        node.getRequiredSymbols(),
+                        updatedMarkerSymbols,
+                        node.getSpecification(),
+                        node.getPrePartitioned(),
+                        node.getPreSorted(),
+                        node.getHashSymbol(),
+                        node.getHandle())))
+                .orElse(Result.empty());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantTableFunction.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantTableFunction.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.TableFunctionProcessorNode;
+import io.trino.sql.planner.plan.ValuesNode;
+
+import static io.trino.sql.planner.optimizations.QueryCardinalityUtil.isEmpty;
+import static io.trino.sql.planner.plan.Patterns.tableFunctionProcessor;
+
+/**
+ * Table function can take multiple table arguments. Each argument is either "prune when empty" or "keep when empty".
+ * "Prune when empty" means that if this argument has no rows, the function result is empty, so the function can be
+ * removed from the plan, and replaced with empty values.
+ * "Keep when empty" means that even if the argument has no rows, the function should still be executed, and it can
+ * return a non-empty result.
+ * All the table arguments are combined into a single source of a TableFunctionProcessorNode. If either argument is
+ * "prune when empty", the overall result is "prune when empty". This rule removes a redundant TableFunctionProcessorNode
+ * based on the "prune when empty" property.
+ */
+public class RemoveRedundantTableFunction
+        implements Rule<TableFunctionProcessorNode>
+{
+    private static final Pattern<TableFunctionProcessorNode> PATTERN = tableFunctionProcessor();
+
+    @Override
+    public Pattern<TableFunctionProcessorNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(TableFunctionProcessorNode node, Captures captures, Context context)
+    {
+        if (node.isPruneWhenEmpty() && node.getSource().isPresent()) {
+            if (isEmpty(node.getSource().orElseThrow(), context.getLookup())) {
+                return Result.ofPlanNode(new ValuesNode(node.getId(), node.getOutputSymbols(), ImmutableList.of()));
+            }
+        }
+
+        return Result.empty();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/TableFunctionProcessorMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/TableFunctionProcessorMatcher.java
@@ -48,6 +48,7 @@ public class TableFunctionProcessorMatcher
     private final List<List<String>> requiredSymbols;
     private final Optional<Map<String, String>> markerSymbols;
     private final Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification;
+    private final Optional<String> hashSymbol;
 
     private TableFunctionProcessorMatcher(
             String name,
@@ -55,7 +56,8 @@ public class TableFunctionProcessorMatcher
             List<List<String>> passThroughSymbols,
             List<List<String>> requiredSymbols,
             Optional<Map<String, String>> markerSymbols,
-            Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification)
+            Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification,
+            Optional<String> hashSymbol)
     {
         this.name = requireNonNull(name, "name is null");
         this.properOutputs = ImmutableList.copyOf(properOutputs);
@@ -67,6 +69,7 @@ public class TableFunctionProcessorMatcher
                 .collect(toImmutableList());
         this.markerSymbols = markerSymbols.map(ImmutableMap::copyOf);
         this.specification = requireNonNull(specification, "specification is null");
+        this.hashSymbol = requireNonNull(hashSymbol, "hashSymbol is null");
     }
 
     @Override
@@ -142,6 +145,12 @@ public class TableFunctionProcessorMatcher
             }
         }
 
+        if (hashSymbol.isPresent()) {
+            if (!hashSymbol.map(symbolAliases::get).equals(tableFunctionProcessorNode.getHashSymbol().map(Symbol::toSymbolReference))) {
+                return NO_MATCH;
+            }
+        }
+
         ImmutableMap.Builder<String, SymbolReference> properOutputsMapping = ImmutableMap.builder();
         for (int i = 0; i < properOutputs.size(); i++) {
             properOutputsMapping.put(properOutputs.get(i), tableFunctionProcessorNode.getProperOutputs().get(i).toSymbolReference());
@@ -164,6 +173,7 @@ public class TableFunctionProcessorMatcher
                 .add("requiredSymbols", requiredSymbols)
                 .add("markerSymbols", markerSymbols)
                 .add("specification", specification)
+                .add("hashSymbol", hashSymbol)
                 .toString();
     }
 
@@ -176,6 +186,7 @@ public class TableFunctionProcessorMatcher
         private List<List<String>> requiredSymbols = ImmutableList.of();
         private Optional<Map<String, String>> markerSymbols = Optional.empty();
         private Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification = Optional.empty();
+        private Optional<String> hashSymbol = Optional.empty();
 
         public Builder()
         {
@@ -223,11 +234,17 @@ public class TableFunctionProcessorMatcher
             return this;
         }
 
+        public Builder hashSymbol(String hashSymbol)
+        {
+            this.hashSymbol = Optional.of(hashSymbol);
+            return this;
+        }
+
         public PlanMatchPattern build()
         {
             PlanMatchPattern[] sources = source.map(sourcePattern -> new PlanMatchPattern[] {sourcePattern}).orElse(new PlanMatchPattern[] {});
             return node(TableFunctionProcessorNode.class, sources)
-                    .with(new TableFunctionProcessorMatcher(name, properOutputs, passThroughSymbols, requiredSymbols, markerSymbols, specification));
+                    .with(new TableFunctionProcessorMatcher(name, properOutputs, passThroughSymbols, requiredSymbols, markerSymbols, specification, hashSymbol));
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestImplementTableFunctionSource.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestImplementTableFunctionSource.java
@@ -88,7 +88,8 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableList.of(ImmutableList.of())),
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of()))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c"))),
                         values("c")));
 
         // pass-through columns
@@ -113,7 +114,8 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"))),
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c"))),
                         values("c")));
     }
 
@@ -144,6 +146,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of()))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c", "d")))
                                 .specification(specification(ImmutableList.of(), ImmutableList.of("d"), ImmutableMap.of("d", ASC_NULLS_LAST))),
                         values("c", "d")));
 
@@ -171,6 +174,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c", "d")))
                                 .specification(specification(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableMap.of("d", ASC_NULLS_LAST))),
                         values("c", "d")));
 
@@ -198,6 +202,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c", "d")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("d")))
                                 .specification(specification(ImmutableList.of("c"), ImmutableList.of(), ImmutableMap.of())),
                         values("c", "d")));
     }
@@ -240,6 +245,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e", "f")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("d"), ImmutableList.of("f")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_1",
@@ -326,6 +332,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e", "f"), ImmutableList.of()))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("d"), ImmutableList.of("f"), ImmutableList.of("h")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_1",
@@ -424,6 +431,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e", "f")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c", "d"), ImmutableList.of("f")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_1",
@@ -502,6 +510,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2"))
@@ -574,6 +583,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2"))
@@ -646,6 +656,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2"))
@@ -718,6 +729,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2"))
@@ -802,6 +814,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableList.of("e")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableList.of("e")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2",
@@ -922,6 +935,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableList.of("e"), ImmutableList.of("f")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableList.of("e"), ImmutableList.of("g")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2",
@@ -1052,6 +1066,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableList.of("e")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableList.of("e")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2",
@@ -1158,6 +1173,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e", "f")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c", "d"), ImmutableList.of("f")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "c_coerced", "marker_1",
@@ -1240,6 +1256,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c", "d"), ImmutableList.of("e", "f")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_1",
@@ -1321,6 +1338,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e", "f")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("d"), ImmutableList.of("e")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_1",

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestImplementTableFunctionSource.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestImplementTableFunctionSource.java
@@ -15,7 +15,6 @@ package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.trino.sql.planner.OrderingScheme;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
@@ -88,7 +87,8 @@ public class TestImplementTableFunctionSource
                 })
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
-                                .properOutputs(ImmutableList.of("a", "b")),
+                                .properOutputs(ImmutableList.of("a", "b"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of())),
                         values("c")));
 
         // pass-through columns
@@ -113,7 +113,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c")),
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"))),
                         values("c")));
     }
 
@@ -143,6 +143,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of()))
                                 .specification(specification(ImmutableList.of(), ImmutableList.of("d"), ImmutableMap.of("d", ASC_NULLS_LAST))),
                         values("c", "d")));
 
@@ -169,7 +170,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c")))
                                 .specification(specification(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableMap.of("d", ASC_NULLS_LAST))),
                         values("c", "d")));
 
@@ -196,7 +197,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "d"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c", "d")))
                                 .specification(specification(ImmutableList.of("c"), ImmutableList.of(), ImmutableMap.of())),
                         values("c", "d")));
     }
@@ -238,7 +239,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "e", "f"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e", "f")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_1",
@@ -324,7 +325,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "e", "f"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e", "f"), ImmutableList.of()))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_1",
@@ -422,7 +423,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "e", "f"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e", "f")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_1",
@@ -500,7 +501,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "d"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2"))
@@ -572,7 +573,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "d"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2"))
@@ -644,7 +645,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "d"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2"))
@@ -716,7 +717,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "d"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2"))
@@ -800,7 +801,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "d", "e"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableList.of("e")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2",
@@ -920,7 +921,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "d", "e", "f"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableList.of("e"), ImmutableList.of("f")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2",
@@ -1050,7 +1051,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "d", "e"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableList.of("e")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2",
@@ -1156,7 +1157,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "e", "f"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e", "f")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "c_coerced", "marker_1",
@@ -1238,7 +1239,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "d", "e", "f"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c", "d"), ImmutableList.of("e", "f")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_1",
@@ -1319,7 +1320,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "e", "f"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e", "f")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_1",

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneTableFunctionProcessorColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneTableFunctionProcessorColumns.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughColumn;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughSpecification;
+import org.testng.annotations.Test;
+
+import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.tableFunctionProcessor;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestPruneTableFunctionProcessorColumns
+        extends BaseRuleTest
+{
+    @Test
+    public void testDoNotPruneProperOutputs()
+    {
+        tester().assertThat(new PruneTableFunctionProcessorColumns())
+                .on(p -> p.project(
+                        Assignments.of(),
+                        p.tableFunctionProcessor(
+                                builder -> builder
+                                        .name("test_function")
+                                        .properOutputs(p.symbol("p"))
+                                        .source(p.values(p.symbol("x"))))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testPrunePassThroughOutputs()
+    {
+        tester().assertThat(new PruneTableFunctionProcessorColumns())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.project(
+                            Assignments.of(),
+                            p.tableFunctionProcessor(
+                                    builder -> builder
+                                            .name("test_function")
+                                            .passThroughSpecifications(
+                                                    new PassThroughSpecification(
+                                                            true,
+                                                            ImmutableList.of(
+                                                                    new PassThroughColumn(a, true),
+                                                                    new PassThroughColumn(b, false))))
+                                            .source(p.values(a, b))));
+                })
+                .matches(project(
+                        ImmutableMap.of(),
+                        tableFunctionProcessor(builder -> builder
+                                        .name("test_function")
+                                        .passThroughSymbols(ImmutableList.of(ImmutableList.of())),
+                                values("a", "b"))));
+
+        tester().assertThat(new PruneTableFunctionProcessorColumns())
+                .on(p -> {
+                    Symbol proper = p.symbol("proper");
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.project(
+                            Assignments.of(),
+                            p.tableFunctionProcessor(
+                                    builder -> builder
+                                            .name("test_function")
+                                            .properOutputs(proper)
+                                            .passThroughSpecifications(
+                                                    new PassThroughSpecification(
+                                                            true,
+                                                            ImmutableList.of(
+                                                                    new PassThroughColumn(a, true),
+                                                                    new PassThroughColumn(b, false))))
+                                            .source(p.values(a, b))));
+                })
+                .matches(project(
+                        ImmutableMap.of(),
+                        tableFunctionProcessor(builder -> builder
+                                        .name("test_function")
+                                        .properOutputs(ImmutableList.of("proper"))
+                                        .passThroughSymbols(ImmutableList.of(ImmutableList.of())),
+                                values("a", "b"))));
+    }
+
+    @Test
+    public void testReferencedPassThroughOutputs()
+    {
+        tester().assertThat(new PruneTableFunctionProcessorColumns())
+                .on(p -> {
+                    Symbol x = p.symbol("x");
+                    Symbol y = p.symbol("y");
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.project(
+                            Assignments.identity(y, b),
+                            p.tableFunctionProcessor(
+                                    builder -> builder
+                                            .name("test_function")
+                                            .properOutputs(x, y)
+                                            .passThroughSpecifications(
+                                                    new PassThroughSpecification(
+                                                            true,
+                                                            ImmutableList.of(
+                                                                    new PassThroughColumn(a, true),
+                                                                    new PassThroughColumn(b, false))))
+                                            .source(p.values(a, b))));
+                })
+                .matches(project(
+                        ImmutableMap.of("y", expression("y"), "b", expression("b")),
+                        tableFunctionProcessor(builder -> builder
+                                        .name("test_function")
+                                        .properOutputs(ImmutableList.of("x", "y"))
+                                        .passThroughSymbols(ImmutableList.of(ImmutableList.of("b"))),
+                                values("a", "b"))));
+    }
+
+    @Test
+    public void testAllPassThroughOutputsReferenced()
+    {
+        tester().assertThat(new PruneTableFunctionProcessorColumns())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.project(
+                            Assignments.identity(a, b),
+                            p.tableFunctionProcessor(
+                                    builder -> builder
+                                            .name("test_function")
+                                            .passThroughSpecifications(
+                                                    new PassThroughSpecification(
+                                                            true,
+                                                            ImmutableList.of(
+                                                                    new PassThroughColumn(a, true),
+                                                                    new PassThroughColumn(b, false))))
+                                            .source(p.values(a, b))));
+                })
+                .doesNotFire();
+
+        tester().assertThat(new PruneTableFunctionProcessorColumns())
+                .on(p -> {
+                    Symbol proper = p.symbol("proper");
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.project(
+                            Assignments.identity(a, b),
+                            p.tableFunctionProcessor(
+                                    builder -> builder
+                                            .name("test_function")
+                                            .properOutputs(proper)
+                                            .passThroughSpecifications(
+                                                    new PassThroughSpecification(
+                                                            true,
+                                                            ImmutableList.of(
+                                                                    new PassThroughColumn(a, true),
+                                                                    new PassThroughColumn(b, false))))
+                                            .source(p.values(a, b))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testNoSource()
+    {
+        tester().assertThat(new PruneTableFunctionProcessorColumns())
+                .on(p -> p.project(
+                        Assignments.of(),
+                        p.tableFunctionProcessor(
+                                builder -> builder
+                                        .name("test_function")
+                                        .properOutputs(p.symbol("proper")))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testMultipleTableArguments()
+    {
+        // multiple pass-through specifications indicate that the table function has multiple table arguments
+        tester().assertThat(new PruneTableFunctionProcessorColumns())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    Symbol d = p.symbol("d");
+                    return p.project(
+                            Assignments.identity(b),
+                            p.tableFunctionProcessor(
+                                    builder -> builder
+                                            .name("test_function")
+                                            .properOutputs(p.symbol("proper"))
+                                            .passThroughSpecifications(
+                                                    new PassThroughSpecification(false, ImmutableList.of(new PassThroughColumn(a, true))),
+                                                    new PassThroughSpecification(false, ImmutableList.of(new PassThroughColumn(b, true))),
+                                                    new PassThroughSpecification(true, ImmutableList.of(new PassThroughColumn(c, false))))
+                                            .source(p.values(a, b, c, d))));
+                })
+                .matches(project(
+                        ImmutableMap.of("b", expression("b")),
+                        tableFunctionProcessor(builder -> builder
+                                        .name("test_function")
+                                        .properOutputs(ImmutableList.of("proper"))
+                                        .passThroughSymbols(ImmutableList.of(ImmutableList.of(), ImmutableList.of("b"), ImmutableList.of())),
+                                values("a", "b", "c", "d"))));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneTableFunctionProcessorSourceColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneTableFunctionProcessorSourceColumns.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.sql.planner.OrderingScheme;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughColumn;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughSpecification;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.spi.connector.SortOrder.ASC_NULLS_FIRST;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.specification;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.tableFunctionProcessor;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestPruneTableFunctionProcessorSourceColumns
+        extends BaseRuleTest
+{
+    @Test
+    public void testPruneUnreferencedSymbol()
+    {
+        // symbols 'a', 'b', 'c', 'd', 'hash', and 'marker' are used by the node.
+        // symbol 'unreferenced' is pruned out. Also, the mapping for this symbol is removed from marker mappings
+        tester().assertThat(new PruneTableFunctionProcessorSourceColumns())
+                .on(p -> {
+                    Symbol proper = p.symbol("proper");
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    Symbol d = p.symbol("d");
+                    Symbol unreferenced = p.symbol("unreferenced");
+                    Symbol hash = p.symbol("hash");
+                    Symbol marker = p.symbol("marker");
+                    return p.tableFunctionProcessor(
+                            builder -> builder
+                                    .name("test_function")
+                                    .properOutputs(proper)
+                                    .passThroughSpecifications(new PassThroughSpecification(true, ImmutableList.of(new PassThroughColumn(a, false))))
+                                    .requiredSymbols(ImmutableList.of(ImmutableList.of(b)))
+                                    .markerSymbols(ImmutableMap.of(
+                                            a, marker,
+                                            b, marker,
+                                            c, marker,
+                                            d, marker,
+                                            unreferenced, marker))
+                                    .specification(new DataOrganizationSpecification(ImmutableList.of(c), Optional.of(new OrderingScheme(ImmutableList.of(d), ImmutableMap.of(d, ASC_NULLS_FIRST)))))
+                                    .hashSymbol(hash)
+                                    .source(p.values(a, b, c, d, unreferenced, hash, marker)));
+                })
+                .matches(tableFunctionProcessor(builder -> builder
+                                .name("test_function")
+                                .properOutputs(ImmutableList.of("proper"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("a")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("b")))
+                                .markerSymbols(ImmutableMap.of(
+                                        "a", "marker",
+                                        "b", "marker",
+                                        "c", "marker",
+                                        "d", "marker"))
+                                .specification(specification(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableMap.of("d", ASC_NULLS_FIRST)))
+                                .hashSymbol("hash"),
+                        project(
+                                ImmutableMap.of(
+                                        "a", expression("a"),
+                                        "b", expression("b"),
+                                        "c", expression("c"),
+                                        "d", expression("d"),
+                                        "hash", expression("hash"),
+                                        "marker", expression("marker")),
+                                values("a", "b", "c", "d", "unreferenced", "hash", "marker"))));
+    }
+
+    @Test
+    public void testPruneUnusedMarkerSymbol()
+    {
+        // symbol 'unreferenced' is pruned out because the node does not use it.
+        // also, the mapping for this symbol is removed from marker mappings.
+        // because the marker symbol 'marker' is no longer used, it is pruned out too.
+        // note: currently a marker symbol cannot become unused because the function
+        // must use at least one symbol from each source. it might change in the future.
+        tester().assertThat(new PruneTableFunctionProcessorSourceColumns())
+                .on(p -> {
+                    Symbol unreferenced = p.symbol("unreferenced");
+                    Symbol marker = p.symbol("marker");
+                    return p.tableFunctionProcessor(
+                            builder -> builder
+                                    .name("test_function")
+                                    .markerSymbols(ImmutableMap.of(unreferenced, marker))
+                                    .source(p.values(unreferenced, marker)));
+                })
+                .matches(tableFunctionProcessor(builder -> builder
+                                .name("test_function")
+                                .markerSymbols(ImmutableMap.of()),
+                        project(
+                                ImmutableMap.of(),
+                                values("unreferenced", "marker"))));
+    }
+
+    @Test
+    public void testMultipleSources()
+    {
+        // multiple pass-through specifications indicate that the table function has multiple table arguments
+        // the third argument provides symbols 'e', 'f', and 'unreferenced'. those symbols are mapped to common marker symbol 'marker3'
+        tester().assertThat(new PruneTableFunctionProcessorSourceColumns())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    Symbol d = p.symbol("d");
+                    Symbol e = p.symbol("e");
+                    Symbol f = p.symbol("f");
+                    Symbol marker1 = p.symbol("marker1");
+                    Symbol marker2 = p.symbol("marker2");
+                    Symbol marker3 = p.symbol("marker3");
+                    Symbol unreferenced = p.symbol("unreferenced");
+                    return p.tableFunctionProcessor(
+                            builder -> builder
+                                    .name("test_function")
+                                    .passThroughSpecifications(
+                                            new PassThroughSpecification(true, ImmutableList.of(new PassThroughColumn(a, false))),
+                                            new PassThroughSpecification(false, ImmutableList.of(new PassThroughColumn(c, true))),
+                                            new PassThroughSpecification(false, ImmutableList.of(new PassThroughColumn(e, true))))
+                                    .requiredSymbols(ImmutableList.of(
+                                            ImmutableList.of(b),
+                                            ImmutableList.of(d),
+                                            ImmutableList.of(f)))
+                                    .markerSymbols(ImmutableMap.of(
+                                            a, marker1,
+                                            b, marker1,
+                                            c, marker2,
+                                            d, marker2,
+                                            e, marker3,
+                                            f, marker3,
+                                            unreferenced, marker3))
+                                    .source(p.values(a, b, c, d, e, f, marker1, marker2, marker3, unreferenced)));
+                })
+                .matches(tableFunctionProcessor(builder -> builder
+                                .name("test_function")
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("a"), ImmutableList.of("c"), ImmutableList.of("e")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("b"), ImmutableList.of("d"), ImmutableList.of("f")))
+                                .markerSymbols(ImmutableMap.of(
+                                        "a", "marker1",
+                                        "b", "marker1",
+                                        "c", "marker2",
+                                        "d", "marker2",
+                                        "e", "marker3",
+                                        "f", "marker3")),
+                        project(
+                                ImmutableMap.of(
+                                        "a", expression("a"),
+                                        "b", expression("b"),
+                                        "c", expression("c"),
+                                        "d", expression("d"),
+                                        "e", expression("e"),
+                                        "f", expression("f"),
+                                        "marker1", expression("marker1"),
+                                        "marker2", expression("marker2"),
+                                        "marker3", expression("marker3")),
+                                values("a", "b", "c", "d", "e", "f", "marker1", "marker2", "marker3", "unreferenced"))));
+    }
+
+    @Test
+    public void allSymbolsReferenced()
+    {
+        tester().assertThat(new PruneTableFunctionProcessorSourceColumns())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol marker = p.symbol("marker");
+                    return p.tableFunctionProcessor(
+                            builder -> builder
+                                    .name("test_function")
+                                    .requiredSymbols(ImmutableList.of(ImmutableList.of(a)))
+                                    .markerSymbols(ImmutableMap.of(a, marker))
+                                    .source(p.values(a, marker)));
+                })
+                .doesNotFire();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantTableFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantTableFunction.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughColumn;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughSpecification;
+import org.testng.annotations.Test;
+
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestRemoveRedundantTableFunction
+        extends BaseRuleTest
+{
+    @Test
+    public void testRemoveTableFunction()
+    {
+        tester().assertThat(new RemoveRedundantTableFunction())
+                .on(p -> {
+                    Symbol passThrough = p.symbol("pass_through");
+                    Symbol proper = p.symbol("proper");
+                    return p.tableFunctionProcessor(
+                            builder -> builder
+                                    .name("test_function")
+                                    .pruneWhenEmpty()
+                                    .properOutputs(proper)
+                                    .passThroughSpecifications(new PassThroughSpecification(false, ImmutableList.of(new PassThroughColumn(passThrough, true))))
+                                    .source(p.values(passThrough)));
+                })
+                .matches(values("proper", "pass_through"));
+    }
+
+    @Test
+    public void testDoNotRemoveKeepWhenEmpty()
+    {
+        tester().assertThat(new RemoveRedundantTableFunction())
+                .on(p -> {
+                    Symbol passThrough = p.symbol("pass_through");
+                    Symbol proper = p.symbol("proper");
+                    return p.tableFunctionProcessor(
+                            builder -> builder
+                                    .name("test_function")
+                                    .properOutputs(proper)
+                                    .passThroughSpecifications(new PassThroughSpecification(false, ImmutableList.of(new PassThroughColumn(passThrough, true))))
+                                    .source(p.values(passThrough)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoNotRemoveNonEmptyInput()
+    {
+        tester().assertThat(new RemoveRedundantTableFunction())
+                .on(p -> {
+                    Symbol passThrough = p.symbol("pass_through");
+                    Symbol proper = p.symbol("proper");
+                    return p.tableFunctionProcessor(
+                            builder -> builder
+                                    .name("test_function")
+                                    .pruneWhenEmpty()
+                                    .properOutputs(proper)
+                                    .passThroughSpecifications(new PassThroughSpecification(false, ImmutableList.of(new PassThroughColumn(passThrough, true))))
+                                    .source(p.values(5, passThrough)));
+                })
+                .doesNotFire();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -92,6 +92,7 @@ import io.trino.sql.planner.plan.TableExecuteNode;
 import io.trino.sql.planner.plan.TableFinishNode;
 import io.trino.sql.planner.plan.TableFunctionNode;
 import io.trino.sql.planner.plan.TableFunctionNode.TableArgumentProperties;
+import io.trino.sql.planner.plan.TableFunctionProcessorNode;
 import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.sql.planner.plan.TableWriterNode;
 import io.trino.sql.planner.plan.TableWriterNode.CreateTarget;
@@ -1229,6 +1230,13 @@ public class PlanBuilder
                 tableArgumentProperties,
                 copartitioningLists,
                 new TableFunctionHandle(TEST_CATALOG_HANDLE, new SchemaFunctionName("system", name), new ConnectorTableFunctionHandle() {}, TestingTransactionHandle.create()));
+    }
+
+    public TableFunctionProcessorNode tableFunctionProcessor(Consumer<TableFunctionProcessorBuilder> consumer)
+    {
+        TableFunctionProcessorBuilder tableFunctionProcessorBuilder = new TableFunctionProcessorBuilder();
+        consumer.accept(tableFunctionProcessorBuilder);
+        return tableFunctionProcessorBuilder.build(idAllocator);
     }
 
     public PartitioningScheme partitioningScheme(List<Symbol> outputSymbols, List<Symbol> partitioningSymbols, Symbol hashSymbol)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/TableFunctionProcessorBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/TableFunctionProcessorBuilder.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule.test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.trino.metadata.TableFunctionHandle;
+import io.trino.spi.function.SchemaFunctionName;
+import io.trino.spi.ptf.ConnectorTableFunctionHandle;
+import io.trino.sql.planner.PlanNodeIdAllocator;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughSpecification;
+import io.trino.sql.planner.plan.TableFunctionProcessorNode;
+import io.trino.testing.TestingTransactionHandle;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
+
+public class TableFunctionProcessorBuilder
+{
+    private String name;
+    private List<Symbol> properOutputs = ImmutableList.of();
+    private Optional<PlanNode> source = Optional.empty();
+    private boolean pruneWhenEmpty;
+    private List<PassThroughSpecification> passThroughSpecifications = ImmutableList.of();
+    private List<List<Symbol>> requiredSymbols = ImmutableList.of();
+    private Optional<Map<Symbol, Symbol>> markerSymbols = Optional.empty();
+    private Optional<DataOrganizationSpecification> specification = Optional.empty();
+    private Set<Symbol> prePartitioned = ImmutableSet.of();
+    private int preSorted;
+    private Optional<Symbol> hashSymbol = Optional.empty();
+
+    public TableFunctionProcessorBuilder() {}
+
+    public TableFunctionProcessorBuilder name(String name)
+    {
+        this.name = name;
+        return this;
+    }
+
+    public TableFunctionProcessorBuilder properOutputs(Symbol... properOutputs)
+    {
+        this.properOutputs = ImmutableList.copyOf(properOutputs);
+        return this;
+    }
+
+    public TableFunctionProcessorBuilder source(PlanNode source)
+    {
+        this.source = Optional.of(source);
+        return this;
+    }
+
+    public TableFunctionProcessorBuilder pruneWhenEmpty()
+    {
+        this.pruneWhenEmpty = true;
+        return this;
+    }
+
+    public TableFunctionProcessorBuilder passThroughSpecifications(PassThroughSpecification... passThroughSpecifications)
+    {
+        this.passThroughSpecifications = ImmutableList.copyOf(passThroughSpecifications);
+        return this;
+    }
+
+    public TableFunctionProcessorBuilder requiredSymbols(List<List<Symbol>> requiredSymbols)
+    {
+        this.requiredSymbols = requiredSymbols;
+        return this;
+    }
+
+    public TableFunctionProcessorBuilder markerSymbols(Map<Symbol, Symbol> markerSymbols)
+    {
+        this.markerSymbols = Optional.of(markerSymbols);
+        return this;
+    }
+
+    public TableFunctionProcessorBuilder specification(DataOrganizationSpecification specification)
+    {
+        this.specification = Optional.of(specification);
+        return this;
+    }
+
+    public TableFunctionProcessorBuilder prePartitioned(Set<Symbol> prePartitioned)
+    {
+        this.prePartitioned = prePartitioned;
+        return this;
+    }
+
+    public TableFunctionProcessorBuilder preSorted(int preSorted)
+    {
+        this.preSorted = preSorted;
+        return this;
+    }
+
+    public TableFunctionProcessorBuilder hashSymbol(Symbol hashSymbol)
+    {
+        this.hashSymbol = Optional.of(hashSymbol);
+        return this;
+    }
+
+    public TableFunctionProcessorNode build(PlanNodeIdAllocator idAllocator)
+    {
+        return new TableFunctionProcessorNode(
+                idAllocator.getNextId(),
+                name,
+                TEST_CATALOG_HANDLE,
+                properOutputs,
+                source,
+                pruneWhenEmpty,
+                passThroughSpecifications,
+                requiredSymbols,
+                markerSymbols,
+                specification,
+                prePartitioned,
+                preSorted,
+                hashSymbol,
+                new TableFunctionHandle(TEST_CATALOG_HANDLE, new SchemaFunctionName("system", name), new ConnectorTableFunctionHandle() {}, TestingTransactionHandle.create()));
+    }
+}


### PR DESCRIPTION
This PR introduces optimizer rules for column pruning and redundant node pruning of `TableFunctionProcessorNode`.

Docs not needed.

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# General
* Optimize queries involving table functions with table arguments.
```