### PR TITLE
Do not rely on the X-<protocol>-User HTTP header to detect a protocol

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/ProtocolHeaders.java
+++ b/client/trino-client/src/main/java/io/trino/client/ProtocolHeaders.java
@@ -192,10 +192,8 @@ public final class ProtocolHeaders
 
         if (alternateHeaderName.isPresent() && !alternateHeaderName.get().equalsIgnoreCase("Trino")) {
             String headerPrefix = "x-" + alternateHeaderName.get().toLowerCase(ENGLISH);
-            if (headerNames.stream()
-                    .anyMatch(header -> header.toLowerCase(ENGLISH).startsWith(headerPrefix))) {
-                if (headerNames.stream()
-                        .anyMatch(header -> header.toLowerCase(ENGLISH).startsWith("x-trino-"))) {
+            if (headerNames.stream().anyMatch(header -> header.toLowerCase(ENGLISH).startsWith(headerPrefix))) {
+                if (headerNames.stream().anyMatch(header -> header.toLowerCase(ENGLISH).startsWith("x-trino-"))) {
                     throw new ProtocolDetectionException("Both Trino and " + alternateHeaderName.get() + " headers detected");
                 }
                 return createProtocolHeaders(alternateHeaderName.get());

--- a/client/trino-client/src/main/java/io/trino/client/ProtocolHeaders.java
+++ b/client/trino-client/src/main/java/io/trino/client/ProtocolHeaders.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public final class ProtocolHeaders
@@ -190,8 +191,11 @@ public final class ProtocolHeaders
         requireNonNull(headerNames, "headerNames is null");
 
         if (alternateHeaderName.isPresent() && !alternateHeaderName.get().equalsIgnoreCase("Trino")) {
-            if (headerNames.contains("X-" + alternateHeaderName.get() + "-User")) {
-                if (headerNames.contains("X-Trino-User")) {
+            String headerPrefix = "x-" + alternateHeaderName.get().toLowerCase(ENGLISH);
+            if (headerNames.stream()
+                    .anyMatch(header -> header.toLowerCase(ENGLISH).startsWith(headerPrefix))) {
+                if (headerNames.stream()
+                        .anyMatch(header -> header.toLowerCase(ENGLISH).startsWith("x-trino-"))) {
                     throw new ProtocolDetectionException("Both Trino and " + alternateHeaderName.get() + " headers detected");
                 }
                 return createProtocolHeaders(alternateHeaderName.get());

--- a/client/trino-client/src/test/java/io/trino/client/TestProtocolHeaders.java
+++ b/client/trino-client/src/test/java/io/trino/client/TestProtocolHeaders.java
@@ -34,15 +34,14 @@ public class TestProtocolHeaders
         // simple match
         assertEquals(detectProtocol(Optional.of("Trino"), ImmutableSet.of("X-Trino-User")).getProtocolName(), "Trino");
         assertEquals(detectProtocol(Optional.of("Taco"), ImmutableSet.of("X-Taco-User")).getProtocolName(), "Taco");
+        assertEquals(detectProtocol(Optional.of("Taco"), ImmutableSet.of("X-Taco-Source")).getProtocolName(), "Taco");
 
         // only specified header name is tested
         assertEquals(detectProtocol(Optional.of("Taco"), ImmutableSet.of("X-Burrito-User", "X-Burrito-Source")).getProtocolName(), "Trino");
 
-        // only the user header
-        assertEquals(detectProtocol(Optional.of("Taco"), ImmutableSet.of("X-Taco-Source")).getProtocolName(), "Trino");
-        assertEquals(detectProtocol(Optional.of("Taco"), ImmutableSet.of("X-Taco-User", "X-Trino-Source")).getProtocolName(), "Taco");
-
         // multiple protocols is not allowed
+        assertThatThrownBy(() -> detectProtocol(Optional.of("Taco"), ImmutableSet.of("X-Taco-User", "X-Trino-Source")))
+                .isInstanceOf(ProtocolDetectionException.class);
         assertThatThrownBy(() -> detectProtocol(Optional.of("Taco"), ImmutableSet.of("X-Trino-User", "X-Taco-User")))
                 .isInstanceOf(ProtocolDetectionException.class);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Change the logic to detect a non-Trino protocol to stop relying on the X-<protocol>-User HTTP header.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Trino detects alternative protocols (e.g. Presto) by looking whether the X-<protocol>-User HTTP header exists. In some cases however no such header is provided. So change the logic to avoid relying on that particular HTTP header and instead look for any X-<protocol>-* HTTP header.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
