### PR TITLE
Check argument type before evaluating expression

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantDateTrunc.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantDateTrunc.java
@@ -77,15 +77,13 @@ public class RemoveRedundantDateTrunc
             String functionName = extractFunctionName(node.getName());
             if (functionName.equals("date_trunc") && node.getArguments().size() == 2) {
                 Expression unitExpression = node.getArguments().get(0);
-                if (getType(unitExpression) instanceof VarcharType && isEffectivelyLiteral(plannerContext, session, unitExpression)) {
+                Expression argument = node.getArguments().get(1);
+                if (getType(argument) == DATE && getType(unitExpression) instanceof VarcharType && isEffectivelyLiteral(plannerContext, session, unitExpression)) {
                     Slice unitValue = (Slice) new ExpressionInterpreter(unitExpression, plannerContext, session, expressionTypes)
                             .optimize(NoOpSymbolResolver.INSTANCE);
                     if (unitValue != null && "day".equals(unitValue.toStringUtf8().toLowerCase(Locale.ENGLISH))) {
-                        Expression argument = node.getArguments().get(1);
-                        if (getType(argument) == DATE) {
-                            // date_trunc(day, a_date) is a no-op
-                            return treeRewriter.rewrite(argument, context);
-                        }
+                        // date_trunc(day, a_date) is a no-op
+                        return treeRewriter.rewrite(argument, context);
                     }
                 }
             }


### PR DESCRIPTION
When simplifying `date_trunc` on date values, check it's indeed the date before evaluating the first operand. I.e. do cheaper check first.
