### PR TITLE
Require 1+ retained node for isNotFullyPushedDown check

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
@@ -15,6 +15,7 @@ package io.trino.sql.query;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.FunctionBundle;
@@ -505,9 +506,10 @@ public class QueryAssertions
          */
         @SafeVarargs
         @CanIgnoreReturnValue
-        public final QueryAssert isNotFullyPushedDown(Class<? extends PlanNode>... retainedNodes)
+        public final QueryAssert isNotFullyPushedDown(Class<? extends PlanNode> firstRetainedNode, Class<? extends PlanNode>... moreRetainedNodes)
         {
             PlanMatchPattern expectedPlan = PlanMatchPattern.node(TableScanNode.class);
+            List<Class<? extends PlanNode>> retainedNodes = Lists.asList(firstRetainedNode, moreRetainedNodes);
             for (Class<? extends PlanNode> retainedNode : ImmutableList.copyOf(retainedNodes).reverse()) {
                 expectedPlan = PlanMatchPattern.node(retainedNode, expectedPlan);
             }

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/BasePinotIntegrationConnectorSmokeTest.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/BasePinotIntegrationConnectorSmokeTest.java
@@ -1759,7 +1759,7 @@ public abstract class BasePinotIntegrationConnectorSmokeTest
                 .isFullyPushedDown();
         // Distinct on int is partially pushed down
         assertThat(query("SELECT DISTINCT int_col FROM " + ALL_TYPES_TABLE))
-                .isNotFullyPushedDown();
+                .isFullyPushedDown();
 
         // Distinct on 2 columns for supported types:
         assertThat(query("SELECT DISTINCT bool_col, string_col FROM " + ALL_TYPES_TABLE))
@@ -1773,7 +1773,7 @@ public abstract class BasePinotIntegrationConnectorSmokeTest
         assertThat(query("SELECT DISTINCT bool_col, timestamp_col FROM " + ALL_TYPES_TABLE))
                 .isFullyPushedDown();
         assertThat(query("SELECT DISTINCT bool_col, int_col FROM " + ALL_TYPES_TABLE))
-                .isNotFullyPushedDown();
+                .isFullyPushedDown();
 
         // Test distinct for mixed case values
         assertThat(query("SELECT DISTINCT string_col FROM " + MIXED_CASE_DISTINCT_TABLE))
@@ -1804,7 +1804,7 @@ public abstract class BasePinotIntegrationConnectorSmokeTest
                 .isFullyPushedDown();
         // Approx distinct on int is partially pushed down
         assertThat(query("SELECT approx_distinct(int_col) FROM " + ALL_TYPES_TABLE))
-                .isNotFullyPushedDown();
+                .isFullyPushedDown();
 
         // Approx distinct on 2 columns for supported types:
         assertThat(query("SELECT bool_col, approx_distinct(string_col) FROM " + ALL_TYPES_TABLE + " GROUP BY bool_col"))
@@ -1816,7 +1816,7 @@ public abstract class BasePinotIntegrationConnectorSmokeTest
         assertThat(query("SELECT bool_col, approx_distinct(long_col) FROM " + ALL_TYPES_TABLE + " GROUP BY bool_col"))
                 .isFullyPushedDown();
         assertThat(query("SELECT bool_col, approx_distinct(int_col) FROM " + ALL_TYPES_TABLE + " GROUP BY bool_col"))
-                .isNotFullyPushedDown();
+                .isFullyPushedDown();
 
         // Distinct count is fully pushed down by default
         assertThat(query("SELECT bool_col, COUNT(DISTINCT string_col) FROM " + ALL_TYPES_TABLE + " GROUP BY bool_col"))


### PR DESCRIPTION
It was always the original intention, let's enforce it with the type system.
