### PR TITLE
Remove empty values node after predicate-expression based pruning

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
@@ -1292,8 +1292,8 @@ public class TestTrinoDatabaseMetaData
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
                 list(list(COUNTING_CATALOG, "test_schema1", "test_table1", "column_17", "varchar")),
                 new MetadataCallsCount()
-                        .withListSchemasCount(2)
-                        .withListTablesCount(3)
+                        .withListSchemasCount(1)
+                        .withListTablesCount(2)
                         .withGetColumnsCount(1));
 
         // LIKE predicate on schema name and table name, but no predicate on catalog name
@@ -1306,8 +1306,8 @@ public class TestTrinoDatabaseMetaData
                         .mapToObj(columnIndex -> list(COUNTING_CATALOG, "test_schema1", "test_table1", "column_" + columnIndex, "varchar"))
                         .collect(toImmutableList()),
                 new MetadataCallsCount()
-                        .withListSchemasCount(2)
-                        .withListTablesCount(3)
+                        .withListSchemasCount(1)
+                        .withListTablesCount(2)
                         .withGetColumnsCount(1));
 
         // LIKE predicate on schema name, but no predicate on catalog name and table name
@@ -1322,7 +1322,7 @@ public class TestTrinoDatabaseMetaData
                                         .mapToObj(columnIndex -> list(COUNTING_CATALOG, "test_schema1", "test_table" + tableIndex, "column_" + columnIndex, "varchar")))
                         .collect(toImmutableList()),
                 new MetadataCallsCount()
-                        .withListSchemasCount(2)
+                        .withListSchemasCount(4)
                         .withListTablesCount(1)
                         .withGetColumnsCount(1000));
 
@@ -1338,9 +1338,9 @@ public class TestTrinoDatabaseMetaData
                                         .mapToObj(columnIndex -> list(COUNTING_CATALOG, "test_schema" + schemaIndex, "test_table1", "column_" + columnIndex, "varchar")))
                         .collect(toImmutableList()),
                 new MetadataCallsCount()
-                        .withListSchemasCount(3)
-                        .withListTablesCount(8)
-                        .withGetTableHandleCount(2)
+                        .withListSchemasCount(5)
+                        .withListTablesCount(5)
+                        .withGetTableHandleCount(8)
                         .withGetColumnsCount(2));
 
         // Equality predicate on schema name and table name, but no predicate on catalog name
@@ -1383,7 +1383,7 @@ public class TestTrinoDatabaseMetaData
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
                 list(),
                 new MetadataCallsCount()
-                        .withListSchemasCount(2)
+                        .withListSchemasCount(1)
                         .withListTablesCount(0)
                         .withGetColumnsCount(0));
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -587,7 +587,7 @@ public class PlanOptimizers
                         ImmutableSet.of(
                                 new ApplyTableScanRedirection(plannerContext),
                                 new PruneTableScanColumns(metadata),
-                                new PushPredicateIntoTableScan(plannerContext, typeAnalyzer))));
+                                new PushPredicateIntoTableScan(plannerContext, typeAnalyzer, false))));
 
         Set<Rule<?>> pushIntoTableScanRulesExceptJoins = ImmutableSet.<Rule<?>>builder()
                 .addAll(columnPruningRules)
@@ -595,7 +595,7 @@ public class PlanOptimizers
                 .add(new PushProjectionIntoTableScan(plannerContext, typeAnalyzer, scalarStatsCalculator))
                 .add(new RemoveRedundantIdentityProjections())
                 .add(new PushLimitIntoTableScan(metadata))
-                .add(new PushPredicateIntoTableScan(plannerContext, typeAnalyzer))
+                .add(new PushPredicateIntoTableScan(plannerContext, typeAnalyzer, false))
                 .add(new PushSampleIntoTableScan(metadata))
                 .add(new PushAggregationIntoTableScan(plannerContext, typeAnalyzer))
                 .add(new PushDistinctLimitIntoTableScan(plannerContext, typeAnalyzer))
@@ -663,7 +663,7 @@ public class PlanOptimizers
                         costCalculator,
                         ImmutableSet.<Rule<?>>builder()
                                 .addAll(simplifyOptimizerRules) // Should be always run after PredicatePushDown
-                                .add(new PushPredicateIntoTableScan(plannerContext, typeAnalyzer))
+                                .add(new PushPredicateIntoTableScan(plannerContext, typeAnalyzer, false))
                                 .build()),
                 new UnaliasSymbolReferences(metadata), // Run again because predicate pushdown and projection pushdown might add more projections
                 columnPruningOptimizer, // Make sure to run this before index join. Filtered projections may not have all the columns.
@@ -728,7 +728,7 @@ public class PlanOptimizers
                         costCalculator,
                         ImmutableSet.<Rule<?>>builder()
                                 .addAll(simplifyOptimizerRules) // Should be always run after PredicatePushDown
-                                .add(new PushPredicateIntoTableScan(plannerContext, typeAnalyzer))
+                                .add(new PushPredicateIntoTableScan(plannerContext, typeAnalyzer, false))
                                 .build()),
                 pushProjectionIntoTableScanOptimizer,
                 // Projection pushdown rules may push reducing projections (e.g. dereferences) below filters for potential
@@ -742,7 +742,7 @@ public class PlanOptimizers
                         costCalculator,
                         ImmutableSet.<Rule<?>>builder()
                                 .addAll(simplifyOptimizerRules) // Should be always run after PredicatePushDown
-                                .add(new PushPredicateIntoTableScan(plannerContext, typeAnalyzer))
+                                .add(new PushPredicateIntoTableScan(plannerContext, typeAnalyzer, false))
                                 .build()),
                 columnPruningOptimizer,
                 new IterativeOptimizer(
@@ -807,6 +807,21 @@ public class PlanOptimizers
                         // Must run after join reordering because join reordering creates
                         // new join nodes without JoinNode.maySkipOutputDuplicates flag set
                         new OptimizeDuplicateInsensitiveJoins(metadata))));
+
+        // Previous invocations of PushPredicateIntoTableScan do not prune using predicate expression. The invocation in AddExchanges
+        // does this pruning - and we may end up with empty union branches after that. We invoke PushPredicateIntoTableScan
+        // and rules to remove empty branches here to get empty values node through pushdown and then prune them.
+        builder.add(new IterativeOptimizer(
+                plannerContext,
+                ruleStats,
+                statsCalculator,
+                costCalculator,
+                ImmutableSet.of(
+                        new PushPredicateIntoTableScan(plannerContext, typeAnalyzer, true),
+                        new RemoveEmptyUnionBranches(),
+                        new EvaluateEmptyIntersect(),
+                        new RemoveEmptyExceptBranches(),
+                        new TransformFilteringSemiJoinToInnerJoin())));
 
         if (!forceSingleNode) {
             builder.add(new IterativeOptimizer(
@@ -895,7 +910,7 @@ public class PlanOptimizers
                 costCalculator,
                 ImmutableSet.<Rule<?>>builder()
                         .addAll(simplifyOptimizerRules) // Should be always run after PredicatePushDown
-                        .add(new PushPredicateIntoTableScan(plannerContext, typeAnalyzer))
+                        .add(new PushPredicateIntoTableScan(plannerContext, typeAnalyzer, false))
                         .add(new RemoveRedundantPredicateAboveTableScan(plannerContext, typeAnalyzer))
                         .build()));
         builder.add(inlineProjections);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
@@ -50,6 +50,7 @@ import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.sql.planner.plan.ValuesNode;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.NodeRef;
+import org.assertj.core.util.VisibleForTesting;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -90,10 +91,13 @@ public class PushPredicateIntoTableScan
     private final PlannerContext plannerContext;
     private final TypeAnalyzer typeAnalyzer;
 
-    public PushPredicateIntoTableScan(PlannerContext plannerContext, TypeAnalyzer typeAnalyzer)
+    private final boolean pruneWithPredicateExpression;
+
+    public PushPredicateIntoTableScan(PlannerContext plannerContext, TypeAnalyzer typeAnalyzer, boolean pruneWithPredicateExpression)
     {
         this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
         this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
+        this.pruneWithPredicateExpression = pruneWithPredicateExpression;
     }
 
     @Override
@@ -116,7 +120,7 @@ public class PushPredicateIntoTableScan
         Optional<PlanNode> rewritten = pushFilterIntoTableScan(
                 filterNode,
                 tableScan,
-                false,
+                pruneWithPredicateExpression,
                 context.getSession(),
                 context.getSymbolAllocator(),
                 plannerContext,
@@ -414,6 +418,12 @@ public class PushPredicateIntoTableScan
             }
         }
         return TupleDomain.withColumnDomains(enforcedDomainsBuilder.buildOrThrow());
+    }
+
+    @VisibleForTesting
+    public boolean getPruneWithPredicateExpression()
+    {
+        return pruneWithPredicateExpression;
     }
 
     private static class SplitExpression

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateIntoTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateIntoTableScan.java
@@ -97,7 +97,7 @@ public class TestPushPredicateIntoTableScan
     @BeforeClass
     public void setUpBeforeClass()
     {
-        pushPredicateIntoTableScan = new PushPredicateIntoTableScan(tester().getPlannerContext(), createTestingTypeAnalyzer(tester().getPlannerContext()));
+        pushPredicateIntoTableScan = new PushPredicateIntoTableScan(tester().getPlannerContext(), createTestingTypeAnalyzer(tester().getPlannerContext()), false);
 
         CatalogHandle catalogHandle = tester().getCurrentCatalogHandle();
         tester().getQueryRunner().createCatalog(MOCK_CATALOG, createMockFactory(), ImmutableMap.of());

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveEmptyUnionBranches.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveEmptyUnionBranches.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.optimizations;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.connector.MockConnectorColumnHandle;
+import io.trino.connector.MockConnectorFactory;
+import io.trino.connector.MockConnectorTableHandle;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorTableProperties;
+import io.trino.spi.connector.ConnectorViewDefinition;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.connector.ConstraintApplicationResult;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.NullableValue;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.sql.planner.assertions.BasePlanTest;
+import io.trino.testing.LocalQueryRunner;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.output;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.util.Collections.emptyList;
+
+public class TestRemoveEmptyUnionBranches
+        extends BasePlanTest
+{
+    private static final String CATALOG_NAME = "test";
+    private static final String SCHEMA_NAME = "default";
+
+    private final Set<String> tables = ImmutableSet.of("table_one", "table_two", "table_three");
+    private final List<String> columnNames = ImmutableList.of("a", "b", "c");
+    private final String pushdownColumn = "c";
+    private final Map<String, ColumnHandle> columnHandles = columnNames.stream()
+            .collect(toImmutableMap(Function.identity(), name -> new MockConnectorColumnHandle(name, VARCHAR)));
+
+    private final Map<SchemaTableName, ConnectorViewDefinition> views =
+            ImmutableMap.of(
+                    new SchemaTableName(SCHEMA_NAME, "view_of_union"),
+                    new ConnectorViewDefinition(
+                            "SELECT " +
+                                    "   t1.a, t1.b, t1.c " +
+                                    "FROM " +
+                                    "   table_one t1 " +
+                                    "WHERE " +
+                                    "   t1.c = 'X' " +
+                                    "UNION ALL " +
+                                    "SELECT " +
+                                    "   t2.a, t2.b, t2.c " +
+                                    "FROM " +
+                                    "   table_two t2 " +
+                                    "WHERE " +
+                                    "   t2.c = 'Y'",
+                            Optional.of(CATALOG_NAME),
+                            Optional.of(SCHEMA_NAME),
+                            columnNames.stream()
+                                    .map(name -> new ConnectorViewDefinition.ViewColumn(name, VARCHAR.getTypeId(), Optional.empty()))
+                                    .collect(toImmutableList()),
+                            Optional.empty(),
+                            Optional.empty(),
+                            true));
+
+    @Override
+    protected LocalQueryRunner createLocalQueryRunner()
+    {
+        LocalQueryRunner queryRunner = LocalQueryRunner.create(
+                testSessionBuilder()
+                        .setCatalog(CATALOG_NAME)
+                        .setSchema(SCHEMA_NAME)
+                        .build());
+        queryRunner.createCatalog(
+                CATALOG_NAME,
+                createConnectorFactory(CATALOG_NAME),
+                ImmutableMap.of());
+        return queryRunner;
+    }
+
+    private MockConnectorFactory createConnectorFactory(String catalogHandle)
+    {
+        return MockConnectorFactory.builder()
+                .withGetTableHandle((session, tableName) -> {
+                    if (tableName.getSchemaName().equals(SCHEMA_NAME) && tables.contains(tableName.getTableName())) {
+                        return new MockConnectorTableHandle(tableName);
+                    }
+                    return null;
+                })
+                .withGetViews((session, schemaName) -> {
+                    return views;
+                })
+                .withGetColumns(schemaTableName -> columnNames.stream()
+                        .map(name -> new ColumnMetadata(name, VARCHAR))
+                        .collect(toImmutableList()))
+                .withGetTableProperties((session, handle) -> {
+                    MockConnectorTableHandle table = (MockConnectorTableHandle) handle;
+                    return new ConnectorTableProperties(table.getConstraint(), Optional.empty(), Optional.empty(), Optional.empty(), emptyList());
+                })
+                .withApplyFilter(applyFilter())
+                .withName(catalogHandle)
+                .build();
+    }
+
+    private MockConnectorFactory.ApplyFilter applyFilter()
+    {
+        return (session, table, constraint) -> {
+            if (table instanceof MockConnectorTableHandle handle) {
+                SchemaTableName schemaTable = handle.getTableName();
+                if (schemaTable.getSchemaName().equals(SCHEMA_NAME) && tables.contains(schemaTable.getTableName())) {
+                    Predicate<ColumnHandle> shouldPushdown = columnHandle -> ((MockConnectorColumnHandle) columnHandle).getName().equals(pushdownColumn);
+                    TupleDomain<ColumnHandle> oldDomain = handle.getConstraint();
+                    TupleDomain<ColumnHandle> newDomain = oldDomain.intersect(constraint.getSummary()
+                            .filter((columnHandle, domain) -> shouldPushdown.test(columnHandle)));
+
+                    // Check if predicate and constraint lead to Tupledomain.none().
+                    boolean nonePredicateOnPushdownColumn = discoveredNonePredicateOnPushdownColumn(newDomain, constraint);
+                    if (nonePredicateOnPushdownColumn) {
+                        return Optional.of(
+                                new ConstraintApplicationResult<>(
+                                        new MockConnectorTableHandle(handle.getTableName(), TupleDomain.none(), Optional.empty()),
+                                        constraint.getSummary()
+                                                .filter((ch, domain) -> !shouldPushdown.test(ch)),
+                                        false));
+                    }
+
+                    if (oldDomain.equals(newDomain)) {
+                        return Optional.empty();
+                    }
+
+                    return Optional.of(
+                            new ConstraintApplicationResult<>(
+                                    new MockConnectorTableHandle(handle.getTableName(), newDomain, Optional.empty()),
+                                    constraint.getSummary()
+                                            .filter((columnHandle, domain) -> !shouldPushdown.test(columnHandle)),
+                                    false));
+                }
+            }
+
+            return Optional.empty();
+        };
+    }
+
+    // This method tries to detect whether we encountered a domain and a predicate that yields no values - and hence
+    // results in a "none" domain effectively.
+    private boolean discoveredNonePredicateOnPushdownColumn(TupleDomain<ColumnHandle> domain, Constraint constraint)
+    {
+        if (domain.isNone() || constraint.predicate().isEmpty()) {
+            // We're not discovering a new "none" domain if the domain is already none OR
+            // predicate isn't present
+            return false;
+        }
+
+        Domain pushdownColumnDomain = domain.getDomains().get().get(columnHandles.get(pushdownColumn));
+        Optional<Predicate<Map<ColumnHandle, NullableValue>>> predicate = constraint.predicate();
+
+        if (pushdownColumnDomain != null && pushdownColumnDomain.isNullableDiscreteSet()) {
+            Domain.DiscreteSet discreteSet = pushdownColumnDomain.getNullableDiscreteSet();
+            if (discreteSet != null) {
+                List<NullableValue> nullableValues = discreteSet.getNonNullValues().stream()
+                        .map(object -> NullableValue.of(VARCHAR, object))
+                        .collect(toImmutableList());
+                ColumnHandle columnHandle = new MockConnectorColumnHandle("c", VARCHAR);
+
+                return nullableValues.stream()
+                        .allMatch(value -> !predicate.get().test(ImmutableMap.of(columnHandle, value)));
+            }
+        }
+
+        return false;
+    }
+
+    @Test
+    public void testRemoveUnionBranches()
+    {
+        assertPlan("SELECT v1.a FROM view_of_union v1 JOIN table_three t3 ON v1.a = t3.a WHERE substring(v1.c, 1, 10) = 'Y' ",
+                output(
+                        join(INNER, builder -> builder
+                                .equiCriteria("symbol_a", "symbol_a2")
+                                .left(anyTree(tableScan("table_two", ImmutableMap.of("symbol_a", "a", "symbol_c", "c"))))
+                                .right(anyTree(tableScan("table_three", ImmutableMap.of("symbol_a2", "a"))))
+                                .build())));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
@@ -101,7 +101,7 @@ public class TestJsonRepresentation
                                 ImmutableList.of(),
                                 ImmutableList.of(new PlanNodeStatsAndCostSummary(10, 90, 90, 0, 0)),
                                 ImmutableList.of(new JsonRenderedNode(
-                                        "147",
+                                        "149",
                                         "LocalExchange",
                                         ImmutableMap.of(
                                                 "partitioning", "SINGLE",
@@ -144,7 +144,7 @@ public class TestJsonRepresentation
                         ImmutableList.of(),
                         ImmutableList.of(new PlanNodeStatsAndCostSummary(10, 90, 90, 0, 0)),
                         ImmutableList.of(new JsonRenderedNode(
-                                "147",
+                                "149",
                                 "LocalExchange",
                                 ImmutableMap.of(
                                         "partitioning", "SINGLE",

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
@@ -210,7 +210,7 @@ public class TestConnectorPushdownRulesWithHive
         String tableName = "predicate_test";
         tester().getQueryRunner().execute(format("CREATE TABLE %s (a, b) AS SELECT 5, 6", tableName));
 
-        PushPredicateIntoTableScan pushPredicateIntoTableScan = new PushPredicateIntoTableScan(tester().getPlannerContext(), tester().getTypeAnalyzer());
+        PushPredicateIntoTableScan pushPredicateIntoTableScan = new PushPredicateIntoTableScan(tester().getPlannerContext(), tester().getTypeAnalyzer(), false);
 
         HiveTableHandle hiveTable = new HiveTableHandle(SCHEMA_NAME, tableName, ImmutableMap.of(), ImmutableList.of(), ImmutableList.of(), Optional.empty());
         TableHandle table = new TableHandle(catalogHandle, hiveTable, new HiveTransactionHandle(false));

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
@@ -227,7 +227,7 @@ public class TestConnectorPushdownRulesWithIceberg
         tester().getQueryRunner().execute(format("CREATE TABLE %s (a, b) AS SELECT 5, 6", tableName));
         Long snapshotId = (Long) tester().getQueryRunner().execute(format("SELECT snapshot_id FROM \"%s$snapshots\" LIMIT 1", tableName)).getOnlyValue();
 
-        PushPredicateIntoTableScan pushPredicateIntoTableScan = new PushPredicateIntoTableScan(tester().getPlannerContext(), tester().getTypeAnalyzer());
+        PushPredicateIntoTableScan pushPredicateIntoTableScan = new PushPredicateIntoTableScan(tester().getPlannerContext(), tester().getTypeAnalyzer(), false);
 
         IcebergTableHandle icebergTable = new IcebergTableHandle(
                 SCHEMA_NAME,

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -1172,7 +1172,7 @@ public class TestEventListenerBasic
                                 ImmutableList.of(),
                                 ImmutableList.of(),
                                 ImmutableList.of(new JsonRenderedNode(
-                                        "171",
+                                        "173",
                                         "LocalExchange",
                                         ImmutableMap.of(
                                                 "partitioning", "[connectorHandleType = SystemPartitioningHandle, partitioning = SINGLE, function = SINGLE]",
@@ -1183,7 +1183,7 @@ public class TestEventListenerBasic
                                         ImmutableList.of(),
                                         ImmutableList.of(),
                                         ImmutableList.of(new JsonRenderedNode(
-                                                "138",
+                                                "140",
                                                 "RemoteSource",
                                                 ImmutableMap.of("sourceFragmentIds", "[1]"),
                                                 ImmutableList.of(typedSymbol("symbol_1", "double")),
@@ -1191,7 +1191,7 @@ public class TestEventListenerBasic
                                                 ImmutableList.of(),
                                                 ImmutableList.of()))))))),
                 "1", new JsonRenderedNode(
-                        "137",
+                        "139",
                         "LimitPartial",
                         ImmutableMap.of(
                                 "count", "10",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

`PushPredicateIntoTableScan` rule invokes `pushFilterIntoTableScan` with `pruneWithPredicateExpression=false`. AddExchanges invokes this with pushFilterIntoTableScan=true, seems like the reason being that we've more control over the # of times such a potentially expensive optimization is invoked through a visitor based optimizer. 

Because of this - there can be cases where predicate-expression based pruning only happens during AddExchanges - leaving us with empty values node at this stage. And if that ends up on the left side of a replicated join - we end up in a situation where a single task is doing a join with LHS being local empty values node and RHS being a remote scan.

This PR adds an invocation of `pushFilterIntoTableScan` with `pruneWithPredicateExpression=true` before AddExchanges happens, giving us an opportunity to prune the empty values node - yielding a much more efficient plan.

For the test added in this PR:

With the optimization:

```
Output[columnNames = [a]]
│   Layout: [a_3:varchar]
│   a := a_3
└─ InnerJoin[criteria = ("a_3" = "a_6"), hash = [$hashvalue, $hashvalue_9]]
   │   Layout: [a_3:varchar]
   │   dynamicFilterAssignments = {a_6 -> #df_648}
   ├─ ScanFilterProject[table = test:io.trino.connector.MockConnectorTableHandle@5ebb65cd, filterPredicate = (substring("c_5", BIGINT '1', BIGINT '10') = VARCHAR 'Y'), dynamicFilters = {"a_3" = #df_648}]
   │      Layout: [a_3:varchar, $hashvalue:bigint]
   │      $hashvalue := combine_hash(bigint '0', COALESCE("$operator$hash_code"("a_3"), 0))
   │      a_3 := MockConnectorColumnHandle{name=a, type=varchar}
   │      c_5 := MockConnectorColumnHandle{name=c, type=varchar}
   │          :: [[Y]]
   └─ LocalExchange[partitioning = HASH, hashColumn = [$hashvalue_9], arguments = ["a_6"]]
      │   Layout: [a_6:varchar, $hashvalue_9:bigint]
      └─ ScanProject[table = test:io.trino.connector.MockConnectorTableHandle@f087706d]
             Layout: [a_6:varchar, $hashvalue_10:bigint]
             $hashvalue_10 := combine_hash(bigint '0', COALESCE("$operator$hash_code"("a_6"), 0))
             a_6 := MockConnectorColumnHandle{name=a, type=varchar}
```

Without the optimization: (with broadcast join enabled and forceSingleNode=false)

```
Output[columnNames = [a]]
│   Layout: [a:varchar]
└─ InnerJoin[criteria = ("a" = "a_6"), hash = [$hashvalue, $hashvalue_13], distribution = REPLICATED]
   │   Layout: [a:varchar]
   │   Distribution: REPLICATED
   │   dynamicFilterAssignments = {a_6 -> #df_686}
   ├─ LocalExchange[partitioning = ROUND_ROBIN]
   │  │   Layout: [a:varchar, $hashvalue:bigint]
   │  ├─ Project[]
   │  │  │   Layout: [a_0:varchar, $hashvalue_10:bigint]
   │  │  │   $hashvalue_10 := combine_hash(bigint '0', COALESCE("$operator$hash_code"("a_0"), 0))
   │  │  └─ Values[]
   │  │         Layout: [a_0:varchar]
   │  └─ RemoteExchange[type = GATHER]
   │     │   Layout: [a_3:varchar, $hashvalue_11:bigint]
   │     └─ ScanFilterProject[table = test:io.trino.connector.MockConnectorTableHandle@5ebb65cd, filterPredicate = (substring("c_5", BIGINT '1', BIGINT '10') = VARCHAR 'Y'), dynamicFilters = {"a_3" = #df_686}]
   │            Layout: [a_3:varchar, $hashvalue_12:bigint]
   │            $hashvalue_12 := combine_hash(bigint '0', COALESCE("$operator$hash_code"("a_3"), 0))
   │            a_3 := MockConnectorColumnHandle{name=a, type=varchar}
   │            c_5 := MockConnectorColumnHandle{name=c, type=varchar}
   │                :: [[Y]]
   └─ LocalExchange[partitioning = HASH, hashColumn = [$hashvalue_13], arguments = ["a_6"]]
      │   Layout: [a_6:varchar, $hashvalue_13:bigint]
      └─ RemoteExchange[type = GATHER]
         │   Layout: [a_6:varchar, $hashvalue_14:bigint]
         └─ ScanProject[table = test:io.trino.connector.MockConnectorTableHandle@f087706d]
                Layout: [a_6:varchar, $hashvalue_15:bigint]
                $hashvalue_15 := combine_hash(bigint '0', COALESCE("$operator$hash_code"("a_6"), 0))
                a_6 := MockConnectorColumnHandle{name=a, type=varchar}
```


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# General
* Improve execution for some query shapes involving unions by pushing down predicates more aggressively. ({issue}`16019`)
```
