### PR TITLE
Add the `array_histogram` operator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -99,6 +99,7 @@ import io.trino.operator.scalar.ArrayElementAtFunction;
 import io.trino.operator.scalar.ArrayExceptFunction;
 import io.trino.operator.scalar.ArrayFilterFunction;
 import io.trino.operator.scalar.ArrayFunctions;
+import io.trino.operator.scalar.ArrayHistogramFunction;
 import io.trino.operator.scalar.ArrayIntersectFunction;
 import io.trino.operator.scalar.ArrayMaxFunction;
 import io.trino.operator.scalar.ArrayMinFunction;
@@ -584,7 +585,8 @@ public final class SystemFunctionBundle
                 .scalars(SetDigestOperators.class)
                 .scalars(WilsonInterval.class)
                 .aggregates(BigintApproximateMostFrequent.class)
-                .aggregates(VarcharApproximateMostFrequent.class);
+                .aggregates(VarcharApproximateMostFrequent.class)
+                .scalar(ArrayHistogramFunction.class);
 
         // timestamp operators and functions
         builder

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/histogram/SingleTypedHistogram.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/histogram/SingleTypedHistogram.java
@@ -172,6 +172,11 @@ public class SingleTypedHistogram
         return values.getPositionCount() == 0;
     }
 
+    public int getPositionCount()
+    {
+        return values.getPositionCount();
+    }
+
     private void addNewGroup(int hashPosition, int position, Block block, long count)
     {
         hashPositions.set(hashPosition, values.getPositionCount());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayHistogramFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayHistogramFunction.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.trino.operator.aggregation.histogram.SingleTypedHistogram;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.MapBlock;
+import io.trino.spi.function.Convention;
+import io.trino.spi.function.Description;
+import io.trino.spi.function.OperatorDependency;
+import io.trino.spi.function.OperatorType;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.function.TypeParameter;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.Type;
+import io.trino.type.BlockTypeOperators.BlockPositionEqual;
+import io.trino.type.BlockTypeOperators.BlockPositionHashCode;
+
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
+
+@Description("Return a map containing the counts of the elements in the array")
+@ScalarFunction(value = "array_histogram")
+public final class ArrayHistogramFunction
+{
+    private static final int EXPECTED_HISTOGRAM_SIZE = 10;
+
+    private ArrayHistogramFunction() {}
+
+    @TypeParameter("T")
+    @SqlType("map(T, bigint)")
+    public static Block arrayHistogram(
+            @TypeParameter("T") Type elementType,
+            @OperatorDependency(
+                    operator = OperatorType.EQUAL,
+                    argumentTypes = {"T", "T"},
+                    convention = @Convention(arguments = {BLOCK_POSITION, BLOCK_POSITION}, result = NULLABLE_RETURN))
+            BlockPositionEqual equalOperator,
+            @OperatorDependency(
+                    operator = OperatorType.HASH_CODE,
+                    argumentTypes = "T",
+                    convention = @Convention(arguments = BLOCK_POSITION, result = FAIL_ON_NULL))
+            BlockPositionHashCode hashCodeOperator,
+            @TypeParameter("map(T, bigint)") MapType mapType,
+            @SqlType("array(T)") Block arrayBlock)
+    {
+        SingleTypedHistogram histogram = new SingleTypedHistogram(
+                elementType,
+                equalOperator,
+                hashCodeOperator,
+                EXPECTED_HISTOGRAM_SIZE);
+        int positionCount = arrayBlock.getPositionCount();
+        for (int position = 0; position < positionCount; position++) {
+            if (!arrayBlock.isNull(position)) {
+                histogram.add(position, arrayBlock, 1L);
+            }
+        }
+        BlockBuilder blockBuilder = mapType.createBlockBuilder(null, histogram.getPositionCount());
+        histogram.serialize(blockBuilder);
+        MapBlock mapBlock = (MapBlock) blockBuilder.build();
+        return mapBlock.getObject(0, Block.class);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestTypedHistogram.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestTypedHistogram.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator.aggregation;
 
+import io.trino.block.BlockAssertions;
 import io.trino.operator.aggregation.histogram.SingleTypedHistogram;
 import io.trino.operator.aggregation.histogram.TypedHistogram;
 import io.trino.spi.block.Block;
@@ -31,25 +32,24 @@ import static org.testng.Assert.assertEquals;
 
 public class TestTypedHistogram
 {
+    private static final BlockTypeOperators BLOCK_TYPE_OPERATORS = new BlockTypeOperators(new TypeOperators());
+
     @Test
     public void testMassive()
     {
         BlockBuilder inputBlockBuilder = BIGINT.createBlockBuilder(null, 5000);
 
-        BlockTypeOperators blockTypeOperators = new BlockTypeOperators(new TypeOperators());
         TypedHistogram typedHistogram = new SingleTypedHistogram(
                 BIGINT,
-                blockTypeOperators.getEqualOperator(BIGINT),
-                blockTypeOperators.getHashCodeOperator(BIGINT),
+                BLOCK_TYPE_OPERATORS.getEqualOperator(BIGINT),
+                BLOCK_TYPE_OPERATORS.getHashCodeOperator(BIGINT),
                 1000);
         IntStream.range(1, 2000)
                 .flatMap(i -> IntStream.iterate(i, IntUnaryOperator.identity()).limit(i))
                 .forEach(j -> BIGINT.writeLong(inputBlockBuilder, j));
 
         Block inputBlock = inputBlockBuilder.build();
-        for (int i = 0; i < inputBlock.getPositionCount(); i++) {
-            typedHistogram.add(i, inputBlock, 1);
-        }
+        addInputBlockToTypedHistogram(typedHistogram, inputBlock);
 
         MapType mapType = mapType(BIGINT, BIGINT);
         BlockBuilder out = mapType.createBlockBuilder(null, 1);
@@ -57,6 +57,72 @@ public class TestTypedHistogram
         Block outputBlock = mapType.getObject(out, 0);
         for (int i = 0; i < outputBlock.getPositionCount(); i += 2) {
             assertEquals(BIGINT.getLong(outputBlock, i + 1), BIGINT.getLong(outputBlock, i));
+        }
+    }
+
+    @Test
+    public void testGetPositionCountBasic()
+    {
+        Block inputBlock = BlockAssertions.createLongsBlock(1, 2, 3);
+
+        SingleTypedHistogram typedHistogram = new SingleTypedHistogram(
+                BIGINT,
+                BLOCK_TYPE_OPERATORS.getEqualOperator(BIGINT),
+                BLOCK_TYPE_OPERATORS.getHashCodeOperator(BIGINT),
+                inputBlock.getPositionCount());
+
+        addInputBlockToTypedHistogram(typedHistogram, inputBlock);
+        assertEquals(typedHistogram.getPositionCount(), 3);
+    }
+
+    @Test
+    public void testGetPositionCountDuplicates()
+    {
+        Block inputBlock = BlockAssertions.createLongsBlock(1, 2, 1);
+
+        SingleTypedHistogram typedHistogram = new SingleTypedHistogram(
+                BIGINT,
+                BLOCK_TYPE_OPERATORS.getEqualOperator(BIGINT),
+                BLOCK_TYPE_OPERATORS.getHashCodeOperator(BIGINT),
+                inputBlock.getPositionCount());
+
+        addInputBlockToTypedHistogram(typedHistogram, inputBlock);
+        assertEquals(typedHistogram.getPositionCount(), 2);
+    }
+
+    @Test
+    public void testGetPositionCountLargeExpected()
+    {
+        Block inputBlock = BlockAssertions.createLongsBlock(1, 2, 3);
+
+        SingleTypedHistogram typedHistogram = new SingleTypedHistogram(
+                BIGINT,
+                BLOCK_TYPE_OPERATORS.getEqualOperator(BIGINT),
+                BLOCK_TYPE_OPERATORS.getHashCodeOperator(BIGINT),
+                99);
+
+        addInputBlockToTypedHistogram(typedHistogram, inputBlock);
+        assertEquals(typedHistogram.getPositionCount(), 3);
+    }
+
+    @Test
+    public void testGetPositionCountEmpty()
+    {
+        Block inputBlock = BIGINT.createBlockBuilder(null, 0).build();
+        SingleTypedHistogram typedHistogram = new SingleTypedHistogram(
+                BIGINT,
+                BLOCK_TYPE_OPERATORS.getEqualOperator(BIGINT),
+                BLOCK_TYPE_OPERATORS.getHashCodeOperator(BIGINT),
+                1);
+
+        addInputBlockToTypedHistogram(typedHistogram, inputBlock);
+        assertEquals(typedHistogram.getPositionCount(), 0);
+    }
+
+    private void addInputBlockToTypedHistogram(TypedHistogram typedHistogram, Block inputBlock)
+    {
+        for (int i = 0; i < inputBlock.getPositionCount(); i++) {
+            typedHistogram.add(i, inputBlock, 1);
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayHistogramFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayHistogramFunction.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.trino.sql.query.QueryAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestArrayHistogramFunction
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testBasic()
+    {
+        assertThat(assertions.function("array_histogram", "ARRAY[42]"))
+                .isEqualTo(Map.of(42, 1L));
+
+        assertThat(assertions.function("array_histogram", "ARRAY[42]"))
+                .isEqualTo(Map.of(42, 1L));
+
+        assertThat(assertions.function("array_histogram", "ARRAY[42, 7]"))
+                .isEqualTo(Map.of(42, 1L, 7, 1L));
+
+        assertThat(assertions.function("array_histogram", "ARRAY[42, 42, 42]"))
+                .isEqualTo(Map.of(42, 3L));
+
+        assertThat(assertions.function("array_histogram", "ARRAY['a', 'b', 'a']"))
+                .isEqualTo(Map.of("a", 2L, "b", 1L));
+    }
+
+    @Test
+    public void testDuplicateKeys()
+    {
+        assertThat(assertions.function("array_histogram", "ARRAY[42, 42, 42]"))
+                .isEqualTo(Map.of(42, 3L));
+
+        assertThat(assertions.function("array_histogram", "ARRAY['a', 'b', 'a']"))
+                .isEqualTo(Map.of("a", 2L, "b", 1L));
+    }
+
+    @Test
+    public void testEmpty()
+    {
+        assertThat(assertions.function("array_histogram", "ARRAY[]"))
+                .isEqualTo(Map.of());
+    }
+
+    @Test
+    public void testNullsIgnored()
+    {
+        assertThat(assertions.function("array_histogram", "ARRAY[NULL]"))
+                .isEqualTo(Map.of());
+
+        assertThat(assertions.function("array_histogram", "ARRAY[42, NULL]"))
+                .isEqualTo(Map.of(42, 1L));
+
+        assertThat(assertions.function("array_histogram", "ARRAY[NULL, NULL, NULL, NULL, NULL]"))
+                .isEqualTo(Map.of());
+    }
+
+    @Test
+    public void testLargeArray()
+    {
+        assertThat(assertions.function("array_histogram", "ARRAY[42, 42, 42, 7, 1, 7, 1, 42, 7, 1, 1, 42, 7, 42, 1, 7, 2, 3, 7, 42, 42]"))
+                .isEqualTo(Map.of(1, 5L, 2, 1L, 3, 1L, 7, 6L, 42, 8L));
+    }
+
+    @Test
+    public void testEdgeCaseValues()
+    {
+        assertThat(assertions.function("array_histogram", "ARRAY[NULL, '', NULL, '']"))
+                .matches("MAP(ARRAY[''], CAST(ARRAY[2] AS ARRAY(BIGINT)))");
+
+        assertThat(assertions.function("array_histogram", "CAST(ARRAY[NULL, -0.1, 0, 0.1, -0.1, NULL, 0.0] AS ARRAY(DECIMAL(1,1)))"))
+                .matches("MAP(CAST(ARRAY[-0.1, 0.0, 0.1] AS ARRAY(DECIMAL(1,1))), CAST(ARRAY[2, 2, 1] AS ARRAY(BIGINT)))");
+
+        assertThat(assertions.function("array_histogram", "ARRAY[IPADDRESS '10.0.0.1', IPADDRESS '::ffff:a00:1']"))
+                .matches("MAP(ARRAY[IPADDRESS '::ffff:a00:1'], CAST(ARRAY[2] AS ARRAY(BIGINT)))");
+
+        assertThat(assertions.expression("transform_keys(array_histogram(a), (k, v) -> k AT TIME ZONE 'UTC')")
+                             .binding("a", "ARRAY[TIMESTAMP '2001-01-01 01:00:00.000 UTC', TIMESTAMP '2001-01-01 02:00:00.000 +01:00']"))
+                .matches("MAP(ARRAY[TIMESTAMP '2001-01-01 01:00:00.000 UTC'], CAST(ARRAY[2] AS ARRAY(BIGINT)))");
+    }
+
+    @Test
+    public void testTypes()
+    {
+        assertThat(assertions.function("array_histogram", "ARRAY[true, false, true]"))
+                .matches("MAP(ARRAY[true, false], CAST(ARRAY[2, 1] AS ARRAY(BIGINT)))");
+
+        assertThat(assertions.function("array_histogram", "ARRAY[42, 7, 42]"))
+                .matches("MAP(ARRAY[42, 7], CAST(ARRAY[2, 1] AS ARRAY(BIGINT)))");
+
+        assertThat(assertions.function("array_histogram", "ARRAY[42.1, 7.7, 42.1]"))
+                .matches("MAP(ARRAY[42.1, 7.7], CAST(ARRAY[2, 1] AS ARRAY(BIGINT)))");
+
+        assertThat(assertions.function("array_histogram", "ARRAY[DECIMAL '42.1', DECIMAL '7.7', DECIMAL '42.1']"))
+                .matches("MAP(ARRAY[DECIMAL '42.1', DECIMAL '7.7'], CAST(ARRAY[2, 1] AS ARRAY(BIGINT)))");
+
+        assertThat(assertions.function("array_histogram", "ARRAY[X'42', X'77', X'42']"))
+                .matches("MAP(ARRAY[X'42', X'77'], CAST(ARRAY[2, 1] AS ARRAY(BIGINT)))");
+
+        assertThat(assertions.function("array_histogram", "ARRAY[json_object('k1': 42), json_object('k1': 7), json_object('k1': 42)]"))
+                .matches("MAP(ARRAY[json_object('k1': 42), json_object('k1': 7)], CAST(ARRAY[2, 1] AS ARRAY(BIGINT)))");
+
+        assertThat(assertions.function("array_histogram", "ARRAY[DATE '2023-01-01', DATE '2023-07-07', DATE '2023-01-01']"))
+                .matches("MAP(ARRAY[DATE '2023-01-01', DATE '2023-07-07'], CAST(ARRAY[2, 1] AS ARRAY(BIGINT)))");
+
+        assertThat(assertions.function("array_histogram", "ARRAY[TIMESTAMP '2023-01-01 00:00:42', TIMESTAMP '2023-07-07 00:00:07', TIMESTAMP '2023-01-01 00:00:42']"))
+                .matches("MAP(ARRAY[TIMESTAMP '2023-01-01 00:00:42', TIMESTAMP '2023-07-07 00:00:07'], CAST(ARRAY[2, 1] AS ARRAY(BIGINT)))");
+
+        assertThat(assertions.function("array_histogram", "ARRAY[ARRAY[42], ARRAY[42, 7], ARRAY[42]]"))
+                .matches("MAP(ARRAY[ARRAY[42], ARRAY[42, 7]], CAST(ARRAY[2, 1] AS ARRAY(BIGINT)))");
+
+        assertThat(assertions.function("array_histogram", "ARRAY[MAP(ARRAY[42], ARRAY[1]), MAP(ARRAY[42, 7], ARRAY[1, 1]), MAP(ARRAY[42], ARRAY[1])]"))
+                .matches("MAP(ARRAY[MAP(ARRAY[42], ARRAY[1]), MAP(ARRAY[42, 7], ARRAY[1, 1])], CAST(ARRAY[2, 1] AS ARRAY(BIGINT)))");
+
+        assertThat(assertions.function("array_histogram", "ARRAY[ROW(42, 42), ROW(7, 7), ROW(42, 42)]"))
+                .matches("MAP(ARRAY[ROW(42, 42), ROW(7, 7)], CAST(ARRAY[2, 1] AS ARRAY(BIGINT)))");
+    }
+}

--- a/docs/src/main/sphinx/functions/array.rst
+++ b/docs/src/main/sphinx/functions/array.rst
@@ -60,6 +60,20 @@ Array functions
 
     Returns an array of elements in ``x`` but not in ``y``, without duplicates.
 
+.. function:: array_histogram(x) -> map<K, bigint>
+
+    Returns a map where the keys are the unique elements in the input array
+    ``x`` and the values are the number of times that each element appears in
+    ``x``. Null values are ignored. ::
+
+        SELECT array_histogram(ARRAY[42, 7, 42, NULL]);
+        -- {42=2, 7=1}
+
+    Returns an empty map if the input array has no non-null elements. ::
+
+        SELECT array_histogram(ARRAY[NULL, NULL]);
+        -- {}
+
 .. function:: array_join(x, delimiter, null_replacement) -> varchar
 
     Concatenates the elements of the given array using the delimiter and an optional string to replace nulls.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Adds the `array_histogram` function along with tests and documentation for it.

Fixes https://github.com/trinodb/trino/issues/14725

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

The `array_histogram` function was requested in [issue 14725](https://github.com/trinodb/trino/issues/14725). `martint` suggested the name `array_histogram` to make it consistent with the existing `histogram` function. I've implemented this as a scalar function with the behavior shown below (the input to the function is an array and the output is a map, nulls are ignored).

```sql
SELECT array_histogram(a) FROM (VALUES (ARRAY[1, 2, 1]), (ARRAY[42, 7, 42, null])) t(a);
    _col0
-------------
 {1=2, 2=1}
 {42=2, 7=1}
```

This is my first attempt to contribute to Trino (got the CLA confirmation email and org invite yesterday), feedback is very welcome and I will happily address it, I'm eager to understand the codebase more (this PR was essentially just pattern matching, so I expect there are things I've misused or misunderstood). I've left some comments with questions for reviewers inline as well.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Add the `array_histogram` function. ({issue}`14725 `)
```
