### PR TITLE
Add user and password properties for Iceberg JDBC catalog

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -139,7 +139,9 @@ When using any database besides PostgreSQL, a JDBC driver jar file must be place
     connector.name=iceberg
     iceberg.catalog.type=jdbc
     iceberg.jdbc-catalog.catalog-name=test
-    iceberg.jdbc-catalog.connection-url=jdbc:postgresql://example.net:5432/database?user=admin&password=test
+    iceberg.jdbc-catalog.connection-url=jdbc:postgresql://example.net:5432/database
+    iceberg.jdbc-catalog.connection-user=admin
+    iceberg.jdbc-catalog.connection-password=test
     iceberg.jdbc-catalog.default-warehouse-dir=s3://bucket
 
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcCatalogConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcCatalogConfig.java
@@ -18,10 +18,15 @@ import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.ConfigSecuritySensitive;
 
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+import java.util.Optional;
 
 public class IcebergJdbcCatalogConfig
 {
     private String connectionUrl;
+    private String connectionUser;
+    private String connectionPassword;
     private String catalogName;
     private String defaultWarehouseDir;
 
@@ -36,6 +41,35 @@ public class IcebergJdbcCatalogConfig
     public IcebergJdbcCatalogConfig setConnectionUrl(String connectionUrl)
     {
         this.connectionUrl = connectionUrl;
+        return this;
+    }
+
+    @NotNull
+    public Optional<String> getConnectionUser()
+    {
+        return Optional.ofNullable(connectionUser);
+    }
+
+    @Config("iceberg.jdbc-catalog.connection-user")
+    @ConfigDescription("User name for JDBC client")
+    public IcebergJdbcCatalogConfig setConnectionUser(String connectionUser)
+    {
+        this.connectionUser = connectionUser;
+        return this;
+    }
+
+    @NotNull
+    public Optional<String> getConnectionPassword()
+    {
+        return Optional.ofNullable(connectionPassword);
+    }
+
+    @Config("iceberg.jdbc-catalog.connection-password")
+    @ConfigDescription("Password for JDBC client")
+    @ConfigSecuritySensitive
+    public IcebergJdbcCatalogConfig setConnectionPassword(String connectionPassword)
+    {
+        this.connectionPassword = connectionPassword;
         return this;
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcCatalogModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcCatalogModule.java
@@ -43,7 +43,7 @@ public class IcebergJdbcCatalogModule
     public static IcebergJdbcClient createIcebergJdbcClient(IcebergJdbcCatalogConfig config)
     {
         return new IcebergJdbcClient(
-                new IcebergJdbcConnectionFactory(config.getConnectionUrl()),
+                new IcebergJdbcConnectionFactory(config.getConnectionUrl(), config.getConnectionUser(), config.getConnectionPassword()),
                 config.getCatalogName());
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcConnectionFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcConnectionFactory.java
@@ -18,6 +18,7 @@ import org.jdbi.v3.core.ConnectionFactory;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
@@ -26,17 +27,21 @@ public class IcebergJdbcConnectionFactory
         implements ConnectionFactory
 {
     private final String connectionUrl;
+    private final Optional<String> user;
+    private final Optional<String> password;
 
-    public IcebergJdbcConnectionFactory(String connectionUrl)
+    public IcebergJdbcConnectionFactory(String connectionUrl, Optional<String> user, Optional<String> password)
     {
         this.connectionUrl = requireNonNull(connectionUrl, "connectionUrl is null");
+        this.user = requireNonNull(user, "user is null");
+        this.password = requireNonNull(password, "password is null");
     }
 
     @Override
     public Connection openConnection()
             throws SQLException
     {
-        Connection connection = DriverManager.getConnection(connectionUrl);
+        Connection connection = DriverManager.getConnection(connectionUrl, user.orElse(null), password.orElse(null));
         checkState(connection != null, "Driver returned null connection, make sure the connection URL is valid");
         return connection;
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalogFactory.java
@@ -27,9 +27,12 @@ import org.apache.iceberg.jdbc.JdbcCatalog;
 import javax.annotation.concurrent.GuardedBy;
 import javax.inject.Inject;
 
+import java.util.Optional;
+
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.CatalogProperties.URI;
 import static org.apache.iceberg.CatalogProperties.WAREHOUSE_LOCATION;
+import static org.apache.iceberg.jdbc.JdbcCatalog.PROPERTY_PREFIX;
 
 public class TrinoJdbcCatalogFactory
         implements TrinoCatalogFactory
@@ -40,6 +43,8 @@ public class TrinoJdbcCatalogFactory
     private final TrinoFileSystemFactory fileSystemFactory;
     private final String jdbcCatalogName;
     private final String connectionUrl;
+    private final Optional<String> connectionUser;
+    private final Optional<String> connectionPassword;
     private final String defaultWarehouseDir;
     private final boolean isUniqueTableLocation;
 
@@ -62,6 +67,8 @@ public class TrinoJdbcCatalogFactory
         this.isUniqueTableLocation = requireNonNull(icebergConfig, "icebergConfig is null").isUniqueTableLocation();
         this.jdbcCatalogName = jdbcConfig.getCatalogName();
         this.connectionUrl = jdbcConfig.getConnectionUrl();
+        this.connectionUser = jdbcConfig.getConnectionUser();
+        this.connectionPassword = jdbcConfig.getConnectionPassword();
         this.defaultWarehouseDir = jdbcConfig.getDefaultWarehouseDir();
     }
 
@@ -85,10 +92,12 @@ public class TrinoJdbcCatalogFactory
     private JdbcCatalog createJdbcCatalog()
     {
         JdbcCatalog jdbcCatalog = new JdbcCatalog();
-        jdbcCatalog.initialize(jdbcCatalogName, ImmutableMap.<String, String>builder()
-                .put(URI, connectionUrl)
-                .put(WAREHOUSE_LOCATION, defaultWarehouseDir)
-                .buildOrThrow());
+        ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+        properties.put(URI, connectionUrl);
+        properties.put(WAREHOUSE_LOCATION, defaultWarehouseDir);
+        connectionUser.ifPresent(user -> properties.put(PROPERTY_PREFIX + "user", user));
+        connectionPassword.ifPresent(password -> properties.put(PROPERTY_PREFIX + "password", password));
+        jdbcCatalog.initialize(jdbcCatalogName, properties.buildOrThrow());
         return jdbcCatalog;
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConfig.java
@@ -29,6 +29,8 @@ public class TestIcebergJdbcCatalogConfig
     {
         assertRecordedDefaults(recordDefaults(IcebergJdbcCatalogConfig.class)
                 .setConnectionUrl(null)
+                .setConnectionUser(null)
+                .setConnectionPassword(null)
                 .setCatalogName(null)
                 .setDefaultWarehouseDir(null));
     }
@@ -38,12 +40,16 @@ public class TestIcebergJdbcCatalogConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("iceberg.jdbc-catalog.connection-url", "jdbc:postgresql://localhost:5432/test")
+                .put("iceberg.jdbc-catalog.connection-user", "foo")
+                .put("iceberg.jdbc-catalog.connection-password", "bar")
                 .put("iceberg.jdbc-catalog.catalog-name", "test")
                 .put("iceberg.jdbc-catalog.default-warehouse-dir", "s3://bucket")
                 .buildOrThrow();
 
         IcebergJdbcCatalogConfig expected = new IcebergJdbcCatalogConfig()
                 .setConnectionUrl("jdbc:postgresql://localhost:5432/test")
+                .setConnectionUser("foo")
+                .setConnectionPassword("bar")
                 .setCatalogName("test")
                 .setDefaultWarehouseDir("s3://bucket");
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConnectorSmokeTest.java
@@ -20,6 +20,8 @@ import io.trino.plugin.iceberg.IcebergQueryRunner;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
 
+import static io.trino.plugin.iceberg.catalog.jdbc.TestingIcebergJdbcServer.PASSWORD;
+import static io.trino.plugin.iceberg.catalog.jdbc.TestingIcebergJdbcServer.USER;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestIcebergJdbcCatalogConnectorSmokeTest
@@ -53,6 +55,8 @@ public class TestIcebergJdbcCatalogConnectorSmokeTest
                                 .put("iceberg.file-format", format.name())
                                 .put("iceberg.catalog.type", "jdbc")
                                 .put("iceberg.jdbc-catalog.connection-url", server.getJdbcUrl())
+                                .put("iceberg.jdbc-catalog.connection-user", USER)
+                                .put("iceberg.jdbc-catalog.connection-password", PASSWORD)
                                 .put("iceberg.jdbc-catalog.catalog-name", "tpch")
                                 .put("iceberg.register-table-procedure.enabled", "true")
                                 .buildOrThrow())

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcConnectorTest.java
@@ -25,6 +25,8 @@ import org.testng.annotations.Test;
 
 import java.util.OptionalInt;
 
+import static io.trino.plugin.iceberg.catalog.jdbc.TestingIcebergJdbcServer.PASSWORD;
+import static io.trino.plugin.iceberg.catalog.jdbc.TestingIcebergJdbcServer.USER;
 import static io.trino.tpch.TpchTable.LINE_ITEM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -48,6 +50,8 @@ public class TestIcebergJdbcConnectorTest
                                 .put("iceberg.file-format", format.name())
                                 .put("iceberg.catalog.type", "jdbc")
                                 .put("iceberg.jdbc-catalog.connection-url", server.getJdbcUrl())
+                                .put("iceberg.jdbc-catalog.connection-user", USER)
+                                .put("iceberg.jdbc-catalog.connection-password", PASSWORD)
                                 .put("iceberg.jdbc-catalog.catalog-name", "tpch")
                                 .buildOrThrow())
                 .setInitialTables(ImmutableList.<TpchTable<?>>builder()

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestingIcebergJdbcServer.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestingIcebergJdbcServer.java
@@ -29,8 +29,8 @@ import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 public class TestingIcebergJdbcServer
         implements Closeable
 {
-    private static final String USER = "test";
-    private static final String PASSWORD = "test";
+    public static final String USER = "test";
+    public static final String PASSWORD = "test";
     private static final String DATABASE = "tpch";
 
     private final PostgreSQLContainer<?> dockerContainer;
@@ -52,7 +52,7 @@ public class TestingIcebergJdbcServer
 
     public void execute(@Language("SQL") String sql)
     {
-        try (Connection connection = DriverManager.getConnection(getJdbcUrl());
+        try (Connection connection = DriverManager.getConnection(getJdbcUrl(), USER, PASSWORD);
                 Statement statement = connection.createStatement()) {
             statement.execute(sql);
         }
@@ -64,12 +64,10 @@ public class TestingIcebergJdbcServer
     public String getJdbcUrl()
     {
         return format(
-                "jdbc:postgresql://%s:%s/%s?user=%s&password=%s&currentSchema=tpch,public",
+                "jdbc:postgresql://%s:%s/%s?currentSchema=tpch,public",
                 dockerContainer.getHost(),
                 dockerContainer.getMappedPort(POSTGRESQL_PORT),
-                DATABASE,
-                USER,
-                PASSWORD);
+                DATABASE);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestingIcebergJdbcServer.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestingIcebergJdbcServer.java
@@ -64,7 +64,7 @@ public class TestingIcebergJdbcServer
     public String getJdbcUrl()
     {
         return format(
-                "jdbc:postgresql://%s:%s/%s?currentSchema=tpch,public",
+                "jdbc:postgresql://%s:%s/%s",
                 dockerContainer.getHost(),
                 dockerContainer.getMappedPort(POSTGRESQL_PORT),
                 DATABASE);

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg-jdbc-catalog/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg-jdbc-catalog/iceberg.properties
@@ -1,6 +1,8 @@
 connector.name=iceberg
 iceberg.catalog.type=jdbc
-iceberg.jdbc-catalog.connection-url=jdbc:postgresql://postgresql:25432/test?user=test&password=test
+iceberg.jdbc-catalog.connection-url=jdbc:postgresql://postgresql:25432/test
+iceberg.jdbc-catalog.connection-user=test
+iceberg.jdbc-catalog.connection-password=test
 iceberg.jdbc-catalog.catalog-name=iceberg_test
 iceberg.jdbc-catalog.default-warehouse-dir=hdfs://hadoop-master:9000/user/hive/warehouse
 hive.hdfs.socks-proxy=hadoop-master:1180


### PR DESCRIPTION
## Description

Add user and password properties for Iceberg JDBC catalog to hide password
from the error message by Iceberg library. 

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Add `iceberg.jdbc-catalog.connection-user` and `iceberg.jdbc-catalog.connection-password` config properties
  to JDBC catalog. ({issue}`issuenumber`)
```
