### PR TITLE
Ignore Hive system schema when listing views/materialized views

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -602,6 +602,7 @@ public class TrinoHiveCatalog
     {
         if (namespace.isPresent()) {
             if (isHiveSystemSchema(namespace.get())) {
+                // TODO https://github.com/trinodb/trino/issues/1559 information_schema should be handled by the engine fully
                 return ImmutableList.of();
             }
             return ImmutableList.of(namespace.get());

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
@@ -437,6 +437,19 @@ public abstract class BaseConnectorSmokeTest
         assertUpdate("DROP SCHEMA " + schemaName);
     }
 
+    /**
+     * This seemingly duplicate test of {@link BaseConnectorTest#testShowInformationSchemaTables()}
+     * is used in the context of this class in order to be able to test
+     * against a wider range of connector configurations.
+     */
+    @Test
+    public void testShowInformationSchemaTables()
+    {
+        assertThat(query("SHOW TABLES FROM information_schema"))
+                .skippingTypesCheck()
+                .containsAll("VALUES 'applicable_roles', 'columns', 'enabled_roles', 'roles', 'schemata', 'table_privileges', 'tables', 'views'");
+    }
+
     @Test
     public void testSelectInformationSchemaTables()
     {

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -776,6 +776,14 @@ public abstract class BaseConnectorTest
     }
 
     @Test
+    public void testShowInformationSchemaTables()
+    {
+        assertThat(query("SHOW TABLES FROM information_schema"))
+                .skippingTypesCheck()
+                .containsAll("VALUES 'applicable_roles', 'columns', 'enabled_roles', 'roles', 'schemata', 'table_privileges', 'tables', 'views'");
+    }
+
+    @Test
     public void testView()
     {
         if (!hasBehavior(SUPPORTS_CREATE_VIEW)) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

On the Iceberg connector when trying to see the tables from within information_schema schema while working with AWS Glue metastore:

```
SHOW TABLES FROM s3.information_schema;
```

The following exception occurs:

```
"io.trino.plugin.iceberg.catalog.glue.TrinoGlueCatalog.listMaterializedViews(TrinoGlueCatalog.java:782)"
"io.trino.plugin.iceberg.IcebergMetadata.listMaterializedViews(IcebergMetadata.java:2477)"
"io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata.listMaterializedViews(ClassLoaderSafeConnectorMetadata.java:961)"
"io.trino.plugin.objectstore.ObjectStoreMetadata.listMaterializedViews(ObjectStoreMetadata.java:317)"
"io.trino.metadata.MetadataManager.listMaterializedViews(MetadataManager.java:1296)"
"io.trino.metadata.MetadataListing.listMaterializedViews(MetadataListing.java:131)"
"io.trino.connector.informationschema.InformationSchemaPageSource.addTablesRecords(InformationSchemaPageSource.java:275)"
"io.trino.connector.informationschema.InformationSchemaPageSource.buildPages(InformationSchemaPageSource.java:215)"
"io.trino.connector.informationschema.InformationSchemaPageSource.getNextPage(InformationSchemaPageSource.java:179)"
```

Solution
Same as on the `TrinoHiveCatalog` make use of an utility method to ignore Hive system schemas while listing the views/materialized views:

https://github.com/trinodb/trino/blob/49e4c06aff0889f84f69158aa5cf4b185da840e8/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java#L464

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
