### PR TITLE
Fix output rendering for map aggregate functions

### DIFF
--- a/docs/src/main/sphinx/functions/aggregate.rst
+++ b/docs/src/main/sphinx/functions/aggregate.rst
@@ -260,15 +260,15 @@ Bitwise aggregate functions
 Map aggregate functions
 -----------------------
 
-.. function:: histogram(x) -> map(K,bigint)
+.. function:: histogram(x) -> map<K,bigint>
 
     Returns a map containing the count of the number of times each input value occurs.
 
-.. function:: map_agg(key, value) -> map(K,V)
+.. function:: map_agg(key, value) -> map<K,V>
 
     Returns a map created from the input ``key`` / ``value`` pairs.
 
-.. function:: map_union(x(K,V)) -> map(K,V)
+.. function:: map_union(x(K,V)) -> map<K,V>
 
    Returns the union of all the input maps. If a key is found in multiple
    input maps, that key's value in the resulting map comes from an arbitrary input map.
@@ -297,7 +297,7 @@ Map aggregate functions
         --{4.0=6, 5.0=2, 6.0=11, 1.0=50, 3.0=11}
 
 
-.. function:: multimap_agg(key, value) -> map(K,array(V))
+.. function:: multimap_agg(key, value) -> map<K,array(V)>
 
     Returns a multimap created from the input ``key`` / ``value`` pairs.
     Each key can be associated with multiple values.


### PR DESCRIPTION
## Description

As described in the related issue, for some weird reason sphinx renders the arrow wrongly or completely drops the arrow and what is afterwards. This is probably a side effect of the fact that the "function" keyword in sphinx is designed for Python function, not SQL functions. 

I chose to use [] for the output at this stage and it work nicely. Other sections of the docs also seem to use that .. and others again use <>. That works as well. I am happy to use either @martint @electrum 

## Additional context and related issues

* Fixes https://github.com/trinodb/trino/issues/16030

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
