### PR TITLE
Use stage input partitioning partitionCount instead of output partitioning

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlStage.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlStage.java
@@ -86,7 +86,7 @@ public final class SqlStage
     {
         requireNonNull(stageId, "stageId is null");
         requireNonNull(fragment, "fragment is null");
-        checkArgument(fragment.getPartitioningScheme().getBucketToPartition().isEmpty(), "bucket to partition is not expected to be set at this point");
+        checkArgument(fragment.getOutputPartitioningScheme().getBucketToPartition().isEmpty(), "bucket to partition is not expected to be set at this point");
         requireNonNull(tables, "tables is null");
         requireNonNull(remoteTaskFactory, "remoteTaskFactory is null");
         requireNonNull(session, "session is null");

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecutionFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecutionFactory.java
@@ -78,7 +78,7 @@ public class SqlTaskExecutionFactory
                         taskContext,
                         fragment.getRoot(),
                         TypeProvider.copyOf(fragment.getSymbols()),
-                        fragment.getPartitioningScheme(),
+                        fragment.getOutputPartitioningScheme(),
                         fragment.getPartitionedSources(),
                         outputBuffer);
             }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -802,7 +802,7 @@ public class EventDrivenFaultTolerantQueryScheduler
                         stage::recordGetSplitTime,
                         outputDataSizeEstimates.buildOrThrow()));
 
-                FaultTolerantPartitioningScheme sinkPartitioningScheme = partitioningSchemeFactory.get(fragment.getPartitioningScheme().getPartitioning().getHandle());
+                FaultTolerantPartitioningScheme sinkPartitioningScheme = partitioningSchemeFactory.get(fragment.getOutputPartitioningScheme().getPartitioning().getHandle());
                 ExchangeContext exchangeContext = new ExchangeContext(queryStateMachine.getQueryId(), new ExchangeId("external-exchange-" + stage.getStageId().getId()));
 
                 boolean preserveOrderWithinPartition = rootFragment && stage.getFragment().getPartitioning().equals(SINGLE_DISTRIBUTION);

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedQueryScheduler.java
@@ -946,7 +946,7 @@ public class PipelinedQueryScheduler
                         partitioningCache,
                         fragment.getRoot(),
                         fragment.getRemoteSourceNodes(),
-                        fragment.getOutputPartitioningScheme().getPartitionCount());
+                        fragment.getPartitionCount());
                 for (SqlStage childStage : stageManager.getChildren(stage.getStageId())) {
                     result.put(childStage.getFragment().getId(), bucketToPartition);
                 }
@@ -1026,7 +1026,7 @@ public class PipelinedQueryScheduler
             Session session = queryStateMachine.getSession();
             PlanFragment fragment = stageExecution.getFragment();
             PartitioningHandle partitioningHandle = fragment.getPartitioning();
-            Optional<Integer> partitionCount = fragment.getOutputPartitioningScheme().getPartitionCount();
+            Optional<Integer> partitionCount = fragment.getPartitionCount();
             Map<PlanNodeId, SplitSource> splitSources = splitSourceFactory.createSplitSources(session, fragment);
             if (!splitSources.isEmpty()) {
                 queryStateMachine.addStateChangeListener(new StateChangeListener<>()

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedQueryScheduler.java
@@ -581,7 +581,7 @@ public class PipelinedQueryScheduler
 
         private static PipelinedOutputBufferManager createSingleStreamOutputBuffer(SqlStage stage)
         {
-            PartitioningHandle partitioningHandle = stage.getFragment().getPartitioningScheme().getPartitioning().getHandle();
+            PartitioningHandle partitioningHandle = stage.getFragment().getOutputPartitioningScheme().getPartitioning().getHandle();
             checkArgument(partitioningHandle.isSingleNode(), "partitioning is expected to be single node: " + partitioningHandle);
             return new PartitionedPipelinedOutputBufferManager(partitioningHandle, 1);
         }
@@ -946,7 +946,7 @@ public class PipelinedQueryScheduler
                         partitioningCache,
                         fragment.getRoot(),
                         fragment.getRemoteSourceNodes(),
-                        fragment.getPartitioningScheme().getPartitionCount());
+                        fragment.getOutputPartitioningScheme().getPartitionCount());
                 for (SqlStage childStage : stageManager.getChildren(stage.getStageId())) {
                     result.put(childStage.getFragment().getId(), bucketToPartition);
                 }
@@ -989,7 +989,7 @@ public class PipelinedQueryScheduler
             for (SqlStage parentStage : stageManager.getDistributedStagesInTopologicalOrder()) {
                 for (SqlStage childStage : stageManager.getChildren(parentStage.getStageId())) {
                     PlanFragmentId fragmentId = childStage.getFragment().getId();
-                    PartitioningHandle partitioningHandle = childStage.getFragment().getPartitioningScheme().getPartitioning().getHandle();
+                    PartitioningHandle partitioningHandle = childStage.getFragment().getOutputPartitioningScheme().getPartitioning().getHandle();
 
                     PipelinedOutputBufferManager outputBufferManager;
                     if (partitioningHandle.equals(FIXED_BROADCAST_DISTRIBUTION)) {
@@ -1026,7 +1026,7 @@ public class PipelinedQueryScheduler
             Session session = queryStateMachine.getSession();
             PlanFragment fragment = stageExecution.getFragment();
             PartitioningHandle partitioningHandle = fragment.getPartitioning();
-            Optional<Integer> partitionCount = fragment.getPartitioningScheme().getPartitionCount();
+            Optional<Integer> partitionCount = fragment.getOutputPartitioningScheme().getPartitionCount();
             Map<PlanNodeId, SplitSource> splitSources = splitSourceFactory.createSplitSources(session, fragment);
             if (!splitSources.isEmpty()) {
                 queryStateMachine.addStateChangeListener(new StateChangeListener<>()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragment.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragment.java
@@ -49,7 +49,7 @@ public class PlanFragment
     private final List<Type> types;
     private final Set<PlanNode> partitionedSourceNodes;
     private final List<RemoteSourceNode> remoteSourceNodes;
-    private final PartitioningScheme partitioningScheme;
+    private final PartitioningScheme outputPartitioningScheme;
     private final StatsAndCosts statsAndCosts;
     private final List<CatalogProperties> activeCatalogs;
     private final Optional<String> jsonRepresentation;
@@ -65,7 +65,7 @@ public class PlanFragment
             List<Type> types,
             Set<PlanNode> partitionedSourceNodes,
             List<RemoteSourceNode> remoteSourceNodes,
-            PartitioningScheme partitioningScheme,
+            PartitioningScheme outputPartitioningScheme,
             StatsAndCosts statsAndCosts,
             List<CatalogProperties> activeCatalogs)
     {
@@ -78,7 +78,7 @@ public class PlanFragment
         this.types = requireNonNull(types, "types is null");
         this.partitionedSourceNodes = requireNonNull(partitionedSourceNodes, "partitionedSourceNodes is null");
         this.remoteSourceNodes = requireNonNull(remoteSourceNodes, "remoteSourceNodes is null");
-        this.partitioningScheme = requireNonNull(partitioningScheme, "partitioningScheme is null");
+        this.outputPartitioningScheme = requireNonNull(outputPartitioningScheme, "outputPartitioningScheme is null");
         this.statsAndCosts = requireNonNull(statsAndCosts, "statsAndCosts is null");
         this.activeCatalogs = requireNonNull(activeCatalogs, "activeCatalogs is null");
         this.jsonRepresentation = Optional.empty();
@@ -91,7 +91,7 @@ public class PlanFragment
             @JsonProperty("symbols") Map<Symbol, Type> symbols,
             @JsonProperty("partitioning") PartitioningHandle partitioning,
             @JsonProperty("partitionedSources") List<PlanNodeId> partitionedSources,
-            @JsonProperty("partitioningScheme") PartitioningScheme partitioningScheme,
+            @JsonProperty("outputPartitioningScheme") PartitioningScheme outputPartitioningScheme,
             @JsonProperty("statsAndCosts") StatsAndCosts statsAndCosts,
             @JsonProperty("activeCatalogs") List<CatalogProperties> activeCatalogs,
             @JsonProperty("jsonRepresentation") Optional<String> jsonRepresentation)
@@ -107,10 +107,10 @@ public class PlanFragment
         this.jsonRepresentation = requireNonNull(jsonRepresentation, "jsonRepresentation is null");
 
         checkArgument(partitionedSourcesSet.size() == partitionedSources.size(), "partitionedSources contains duplicates");
-        checkArgument(ImmutableSet.copyOf(root.getOutputSymbols()).containsAll(partitioningScheme.getOutputLayout()),
-                "Root node outputs (%s) does not include all fragment outputs (%s)", root.getOutputSymbols(), partitioningScheme.getOutputLayout());
+        checkArgument(ImmutableSet.copyOf(root.getOutputSymbols()).containsAll(outputPartitioningScheme.getOutputLayout()),
+                "Root node outputs (%s) does not include all fragment outputs (%s)", root.getOutputSymbols(), outputPartitioningScheme.getOutputLayout());
 
-        types = partitioningScheme.getOutputLayout().stream()
+        types = outputPartitioningScheme.getOutputLayout().stream()
                 .map(symbols::get)
                 .collect(toImmutableList());
 
@@ -120,7 +120,7 @@ public class PlanFragment
         findRemoteSourceNodes(root, remoteSourceNodes);
         this.remoteSourceNodes = remoteSourceNodes.build();
 
-        this.partitioningScheme = requireNonNull(partitioningScheme, "partitioningScheme is null");
+        this.outputPartitioningScheme = requireNonNull(outputPartitioningScheme, "partitioningScheme is null");
     }
 
     @JsonProperty
@@ -159,9 +159,9 @@ public class PlanFragment
     }
 
     @JsonProperty
-    public PartitioningScheme getPartitioningScheme()
+    public PartitioningScheme getOutputPartitioningScheme()
     {
-        return partitioningScheme;
+        return outputPartitioningScheme;
     }
 
     @JsonProperty
@@ -199,7 +199,7 @@ public class PlanFragment
                 this.types,
                 this.partitionedSourceNodes,
                 this.remoteSourceNodes,
-                this.partitioningScheme,
+                this.outputPartitioningScheme,
                 this.statsAndCosts,
                 this.activeCatalogs);
     }
@@ -255,7 +255,7 @@ public class PlanFragment
 
     public PlanFragment withBucketToPartition(Optional<int[]> bucketToPartition)
     {
-        return new PlanFragment(id, root, symbols, partitioning, partitionedSources, partitioningScheme.withBucketToPartition(bucketToPartition), statsAndCosts, activeCatalogs, jsonRepresentation);
+        return new PlanFragment(id, root, symbols, partitioning, partitionedSources, outputPartitioningScheme.withBucketToPartition(bucketToPartition), statsAndCosts, activeCatalogs, jsonRepresentation);
     }
 
     @Override
@@ -265,7 +265,7 @@ public class PlanFragment
                 .add("id", id)
                 .add("partitioning", partitioning)
                 .add("partitionedSource", partitionedSources)
-                .add("partitionFunction", partitioningScheme)
+                .add("outputPartitioningScheme", outputPartitioningScheme)
                 .toString();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragmenter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragmenter.java
@@ -182,6 +182,7 @@ public class PlanFragmenter
                 newRoot,
                 fragment.getSymbols(),
                 fragment.getPartitioning(),
+                fragment.getPartitionCount(),
                 fragment.getPartitionedSources(),
                 new PartitioningScheme(
                         newOutputPartitioning,
@@ -249,6 +250,7 @@ public class PlanFragmenter
                     root,
                     symbols,
                     properties.getPartitioningHandle(),
+                    properties.getPartitionCount(),
                     schedulingOrder,
                     properties.getPartitioningScheme(),
                     statsAndCosts.getForSubplan(root),
@@ -326,21 +328,33 @@ public class PlanFragmenter
         @Override
         public PlanNode visitTableWriter(TableWriterNode node, RewriteContext<FragmentProperties> context)
         {
-            node.getPartitioningScheme().ifPresent(scheme -> context.get().setDistribution(scheme.getPartitioning().getHandle(), metadata, session));
+            node.getPartitioningScheme().ifPresent(scheme -> context.get().setDistribution(
+                    scheme.getPartitioning().getHandle(),
+                    scheme.getPartitionCount(),
+                    metadata,
+                    session));
             return context.defaultRewrite(node, context.get());
         }
 
         @Override
         public PlanNode visitTableExecute(TableExecuteNode node, RewriteContext<FragmentProperties> context)
         {
-            node.getPartitioningScheme().ifPresent(scheme -> context.get().setDistribution(scheme.getPartitioning().getHandle(), metadata, session));
+            node.getPartitioningScheme().ifPresent(scheme -> context.get().setDistribution(
+                    scheme.getPartitioning().getHandle(),
+                    scheme.getPartitionCount(),
+                    metadata,
+                    session));
             return context.defaultRewrite(node, context.get());
         }
 
         @Override
         public PlanNode visitMergeWriter(MergeWriterNode node, RewriteContext<FragmentProperties> context)
         {
-            node.getPartitioningScheme().ifPresent(scheme -> context.get().setDistribution(scheme.getPartitioning().getHandle(), metadata, session));
+            node.getPartitioningScheme().ifPresent(scheme -> context.get().setDistribution(
+                    scheme.getPartitioning().getHandle(),
+                    scheme.getPartitionCount(),
+                    metadata,
+                    session));
             return context.defaultRewrite(node, context.get());
         }
 
@@ -368,7 +382,11 @@ public class PlanFragmenter
                 context.get().setSingleNodeDistribution();
             }
             else if (exchange.getType() == ExchangeNode.Type.REPARTITION) {
-                context.get().setDistribution(partitioningScheme.getPartitioning().getHandle(), metadata, session);
+                context.get().setDistribution(
+                        partitioningScheme.getPartitioning().getHandle(),
+                        partitioningScheme.getPartitionCount(),
+                        metadata,
+                        session);
             }
 
             ImmutableList.Builder<FragmentProperties> childrenProperties = ImmutableList.builder();
@@ -427,6 +445,7 @@ public class PlanFragmenter
         private final PartitioningScheme partitioningScheme;
 
         private Optional<PartitioningHandle> partitioningHandle = Optional.empty();
+        private Optional<Integer> partitionCount = Optional.empty();
         private final Set<PlanNodeId> partitionedSources = new HashSet<>();
 
         public FragmentProperties(PartitioningScheme partitioningScheme)
@@ -461,10 +480,15 @@ public class PlanFragmenter
             return this;
         }
 
-        public FragmentProperties setDistribution(PartitioningHandle distribution, Metadata metadata, Session session)
+        public FragmentProperties setDistribution(
+                PartitioningHandle distribution,
+                Optional<Integer> partitionCount,
+                Metadata metadata,
+                Session session)
         {
             if (partitioningHandle.isEmpty()) {
                 partitioningHandle = Optional.of(distribution);
+                this.partitionCount = partitionCount;
                 return this;
             }
 
@@ -485,6 +509,7 @@ public class PlanFragmenter
 
             if (isCompatibleScaledWriterPartitioning(currentPartitioning, distribution)) {
                 this.partitioningHandle = Optional.of(distribution);
+                this.partitionCount = partitionCount;
                 return this;
             }
 
@@ -595,6 +620,11 @@ public class PlanFragmenter
         public PartitioningHandle getPartitioningHandle()
         {
             return partitioningHandle.get();
+        }
+
+        public Optional<Integer> getPartitionCount()
+        {
+            return partitionCount;
         }
 
         public Set<PlanNodeId> getPartitionedSources()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragmenter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragmenter.java
@@ -171,7 +171,7 @@ public class PlanFragmenter
             PartitioningHandleReassigner partitioningHandleReassigner = new PartitioningHandleReassigner(fragment.getPartitioning(), metadata, session);
             newRoot = SimplePlanRewriter.rewriteWith(partitioningHandleReassigner, newRoot);
         }
-        PartitioningScheme outputPartitioningScheme = fragment.getPartitioningScheme();
+        PartitioningScheme outputPartitioningScheme = fragment.getOutputPartitioningScheme();
         Partitioning newOutputPartitioning = outputPartitioningScheme.getPartitioning();
         if (outputPartitioningScheme.getPartitioning().getHandle().getCatalogHandle().isPresent()) {
             // Do not replace the handle if the source's output handle is a system one, e.g. broadcast.

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -550,7 +550,7 @@ public class PlanPrinter
             }
         }
 
-        PartitioningScheme partitioningScheme = fragment.getPartitioningScheme();
+        PartitioningScheme partitioningScheme = fragment.getOutputPartitioningScheme();
         List<String> layout = partitioningScheme.getOutputLayout().stream()
                 .map(anonymizer::anonymize)
                 .collect(toImmutableList());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -584,7 +584,7 @@ public class PlanPrinter
                     hashColumn));
         }
 
-        partitioningScheme.getPartitionCount().ifPresent(partitionCount -> builder.append(format("Partition count: %s\n", partitionCount)));
+        fragment.getPartitionCount().ifPresent(partitionCount -> builder.append(format("Partition count: %s\n", partitionCount)));
 
         builder.append(
                         new PlanPrinter(
@@ -633,6 +633,7 @@ public class PlanPrinter
                 plan,
                 types.allTypes(),
                 SINGLE_DISTRIBUTION,
+                Optional.empty(),
                 ImmutableList.of(plan.getId()),
                 new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), plan.getOutputSymbols()),
                 StatsAndCosts.empty(),

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -986,7 +986,7 @@ public class LocalQueryRunner
         LocalExecutionPlan localExecutionPlan = executionPlanner.plan(
                 taskContext,
                 subplan.getFragment().getRoot(),
-                subplan.getFragment().getPartitioningScheme().getOutputLayout(),
+                subplan.getFragment().getOutputPartitioningScheme().getOutputLayout(),
                 plan.getTypes(),
                 subplan.getFragment().getPartitionedSources(),
                 outputFactory);

--- a/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
@@ -118,6 +118,7 @@ public class MockRemoteTaskFactory
                         Optional.empty()),
                 ImmutableMap.of(symbol, VARCHAR),
                 SOURCE_DISTRIBUTION,
+                Optional.empty(),
                 ImmutableList.of(sourceId),
                 new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(symbol)),
                 StatsAndCosts.empty(),

--- a/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
@@ -96,6 +96,7 @@ public final class TaskTestUtils
                     Optional.empty()),
             ImmutableMap.of(SYMBOL, VARCHAR),
             SOURCE_DISTRIBUTION,
+            Optional.empty(),
             ImmutableList.of(TABLE_SCAN_NODE_ID),
             new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(SYMBOL))
                     .withBucketToPartition(Optional.of(new int[1])),
@@ -119,6 +120,7 @@ public final class TaskTestUtils
                     ImmutableMap.of(DYNAMIC_FILTER_SOURCE_ID, SYMBOL)),
             ImmutableMap.of(SYMBOL, VARCHAR),
             SOURCE_DISTRIBUTION,
+            Optional.empty(),
             ImmutableList.of(TABLE_SCAN_NODE_ID),
             new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(SYMBOL))
                     .withBucketToPartition(Optional.of(new int[1])),

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlStage.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlStage.java
@@ -180,6 +180,7 @@ public class TestSqlStage
                 planNode,
                 types.buildOrThrow(),
                 SOURCE_DISTRIBUTION,
+                Optional.empty(),
                 ImmutableList.of(planNode.getId()),
                 new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), planNode.getOutputSymbols()),
                 StatsAndCosts.empty(),

--- a/core/trino-main/src/test/java/io/trino/execution/TestStageStateMachine.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestStageStateMachine.java
@@ -250,6 +250,7 @@ public class TestStageStateMachine
                         ImmutableList.of(new Row(ImmutableList.of(new StringLiteral("foo"))))),
                 ImmutableMap.of(symbol, VARCHAR),
                 SOURCE_DISTRIBUTION,
+                Optional.empty(),
                 ImmutableList.of(valuesNodeId),
                 new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(symbol)),
                 StatsAndCosts.empty(),

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestScaledWriterScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestScaledWriterScheduler.java
@@ -358,6 +358,7 @@ public class TestScaledWriterScheduler
                 tableScan,
                 ImmutableMap.of(symbol, VARCHAR),
                 SOURCE_DISTRIBUTION,
+                Optional.empty(),
                 ImmutableList.of(TABLE_SCAN_NODE_ID),
                 new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(symbol)),
                 StatsAndCosts.empty(),

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -705,6 +705,7 @@ public class TestSourcePartitionedScheduler
                         Optional.empty()),
                 ImmutableMap.of(symbol, VARCHAR),
                 SOURCE_DISTRIBUTION,
+                Optional.empty(),
                 ImmutableList.of(TABLE_SCAN_NODE_ID),
                 new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(symbol)),
                 StatsAndCosts.empty(),

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/policy/PlanUtils.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/policy/PlanUtils.java
@@ -195,6 +195,7 @@ final class PlanUtils
                 planNode,
                 types.buildOrThrow(),
                 SOURCE_DISTRIBUTION,
+                Optional.empty(),
                 ImmutableList.of(planNode.getId()),
                 new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), planNode.getOutputSymbols()),
                 StatsAndCosts.empty(),

--- a/core/trino-main/src/test/java/io/trino/server/TestDynamicFilterService.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestDynamicFilterService.java
@@ -1084,6 +1084,7 @@ public class TestDynamicFilterService
                         Optional.empty()),
                 ImmutableMap.of(symbol, VARCHAR),
                 stagePartitioning,
+                Optional.empty(),
                 ImmutableList.of(tableScanNodeId),
                 new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(symbol)),
                 StatsAndCosts.empty(),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestPlanFragmentPartitionCount.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestPlanFragmentPartitionCount.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.graph.Traverser;
+import io.trino.Session;
+import io.trino.cost.StatsAndCosts;
+import io.trino.execution.QueryManagerConfig;
+import io.trino.execution.warnings.WarningCollector;
+import io.trino.plugin.tpch.TpchConnectorFactory;
+import io.trino.security.AllowAllAccessControl;
+import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.OutputNode;
+import io.trino.sql.planner.plan.PlanFragmentId;
+import io.trino.testing.LocalQueryRunner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
+import static io.trino.testing.TestingHandles.TEST_CATALOG_NAME;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.transaction.TransactionBuilder.transaction;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestPlanFragmentPartitionCount
+{
+    private PlanFragmenter planFragmenter;
+    private Session session;
+    private LocalQueryRunner localQueryRunner;
+
+    @BeforeClass
+    public void setUp()
+    {
+        session = testSessionBuilder().setCatalog(TEST_CATALOG_NAME).build();
+        localQueryRunner = LocalQueryRunner.create(session);
+        localQueryRunner.createCatalog(TEST_CATALOG_NAME, new TpchConnectorFactory(), ImmutableMap.of());
+
+        planFragmenter = new PlanFragmenter(
+                localQueryRunner.getMetadata(),
+                localQueryRunner.getFunctionManager(),
+                localQueryRunner.getTransactionManager(),
+                localQueryRunner.getCatalogManager(),
+                new QueryManagerConfig());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        planFragmenter = null;
+        session = null;
+        localQueryRunner.close();
+        localQueryRunner = null;
+    }
+
+    @Test
+    public void testPartitionCountInPlanFragment()
+    {
+        PlanBuilder p = new PlanBuilder(new PlanNodeIdAllocator(), localQueryRunner.getMetadata(), session);
+        Symbol a = p.symbol("a", VARCHAR);
+        Symbol b = p.symbol("b", VARCHAR);
+        Symbol c = p.symbol("c", VARCHAR);
+        Symbol d = p.symbol("d", VARCHAR);
+        Symbol f = p.symbol("f", VARCHAR);
+        Symbol g = p.symbol("g", VARCHAR);
+        Symbol h = p.symbol("h", VARCHAR);
+        Symbol i = p.symbol("i", VARCHAR);
+
+        OutputNode output = p.output(o -> o
+                .source(
+                        p.exchange(e -> e
+                                .type(REPARTITION)
+                                .addSource(
+                                        p.exchange(exc -> exc
+                                                .type(REPARTITION)
+                                                .addSource(
+                                                        p.join(
+                                                                INNER,
+                                                                p.exchange(ex -> ex
+                                                                        .type(REPARTITION)
+                                                                        .addSource(p.values(a, b))
+                                                                        .addInputsSet(a, b)
+                                                                        .fixedHashDistributionPartitioningScheme(ImmutableList.of(a, b), ImmutableList.of(b), 5)),
+                                                                p.exchange(ex -> ex
+                                                                        .type(REPARTITION)
+                                                                        .addSource(p.values(c, d))
+                                                                        .addInputsSet(c, d)
+                                                                        .fixedHashDistributionPartitioningScheme(ImmutableList.of(c, d), ImmutableList.of(d), 5)),
+                                                                new JoinNode.EquiJoinClause(b, d)))
+                                                .addInputsSet(a, b, c, d)
+                                                .fixedArbitraryDistributionPartitioningScheme(ImmutableList.of(a, b, c, d), 2)))
+                                .addSource(p.values(f, g, h, i))
+                                .addInputsSet(a, b, c, d)
+                                .addInputsSet(f, g, h, i)
+                                .fixedHashDistributionPartitioningScheme(
+                                        ImmutableList.of(a, b, c, d),
+                                        ImmutableList.of(b),
+                                        3))));
+
+        Plan plan = new Plan(output, p.getTypes(), StatsAndCosts.empty());
+        SubPlan rootSubPlan = fragment(plan);
+        ImmutableMap.Builder<PlanFragmentId, Optional<Integer>> actualPartitionCount = ImmutableMap.builder();
+        Traverser.forTree(SubPlan::getChildren).depthFirstPreOrder(rootSubPlan).forEach(subPlan ->
+                actualPartitionCount.put(subPlan.getFragment().getId(), subPlan.getFragment().getPartitionCount()));
+
+        Map<PlanFragmentId, Optional<Integer>> expectedPartitionCount = ImmutableMap.of(
+                // for output fragment
+                new PlanFragmentId("0"), Optional.of(3),
+                // for union exchange fragment
+                new PlanFragmentId("1"), Optional.of(2),
+                // for join fragment
+                new PlanFragmentId("2"), Optional.of(5),
+                // for all other fragments partitionCount should be empty
+                new PlanFragmentId("3"), Optional.empty(),
+                new PlanFragmentId("4"), Optional.empty(),
+                new PlanFragmentId("5"), Optional.empty());
+
+        assertThat(expectedPartitionCount).isEqualTo(actualPartitionCount.buildOrThrow());
+    }
+
+    private SubPlan fragment(Plan plan)
+    {
+        return inTransaction(session -> planFragmenter.createSubPlans(session, plan, false, WarningCollector.NOOP));
+    }
+
+    private <T> T inTransaction(Function<Session, T> transactionSessionConsumer)
+    {
+        return transaction(localQueryRunner.getTransactionManager(), new AllowAllAccessControl())
+                .singleStatement()
+                .execute(session, session -> {
+                    // metadata.getCatalogHandle() registers the catalog for the transaction
+                    session.getCatalog().ifPresent(catalog -> localQueryRunner.getMetadata().getCatalogHandle(session, catalog));
+                    return transactionSessionConsumer.apply(session);
+                });
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -135,6 +135,7 @@ import static io.trino.spi.connector.RowChangeParadigm.DELETE_ROW_AND_INSERT_ROW
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
@@ -887,6 +888,30 @@ public class PlanBuilder
                     ImmutableList.copyOf(partitioningSymbols)),
                     ImmutableList.copyOf(outputSymbols),
                     Optional.of(hashSymbol)));
+        }
+
+        public ExchangeBuilder fixedHashDistributionPartitioningScheme(List<Symbol> outputSymbols, List<Symbol> partitioningSymbols, int partitionCount)
+        {
+            return partitioningScheme(new PartitioningScheme(Partitioning.create(
+                    FIXED_HASH_DISTRIBUTION,
+                    ImmutableList.copyOf(partitioningSymbols)),
+                    ImmutableList.copyOf(outputSymbols),
+                    Optional.empty(),
+                    false,
+                    Optional.empty(),
+                    Optional.of(partitionCount)));
+        }
+
+        public ExchangeBuilder fixedArbitraryDistributionPartitioningScheme(List<Symbol> outputSymbols, int partitionCount)
+        {
+            return partitioningScheme(new PartitioningScheme(Partitioning.create(
+                    FIXED_ARBITRARY_DISTRIBUTION,
+                    ImmutableList.of()),
+                    ImmutableList.copyOf(outputSymbols),
+                    Optional.empty(),
+                    false,
+                    Optional.empty(),
+                    Optional.of(partitionCount)));
         }
 
         public ExchangeBuilder partitioningScheme(PartitioningScheme partitioningScheme)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Instead of using output partitioning scheme's partitionCount, use the input partitionCount for selecting the number of nodes for that stage.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
