### PR TITLE
Add more tests for operator-executed table functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/GlobalFunctionCatalog.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/GlobalFunctionCatalog.java
@@ -31,6 +31,7 @@ import io.trino.spi.function.ScalarFunctionImplementation;
 import io.trino.spi.function.SchemaFunctionName;
 import io.trino.spi.function.Signature;
 import io.trino.spi.function.WindowFunctionSupplier;
+import io.trino.spi.ptf.TableFunctionProcessorProvider;
 import io.trino.spi.type.TypeSignature;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -170,6 +171,12 @@ public class GlobalFunctionCatalog
             InvocationConvention invocationConvention)
     {
         return functions.getFunctionBundle(functionId).getScalarFunctionImplementation(functionId, boundSignature, functionDependencies, invocationConvention);
+    }
+
+    @Override
+    public TableFunctionProcessorProvider getTableFunctionProcessorProvider(SchemaFunctionName name)
+    {
+        return null;
     }
 
     private static class FunctionMap

--- a/core/trino-main/src/main/java/io/trino/metadata/HandleJsonModule.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/HandleJsonModule.java
@@ -29,6 +29,7 @@ import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.exchange.ExchangeSinkInstanceHandle;
 import io.trino.spi.exchange.ExchangeSourceHandle;
+import io.trino.spi.ptf.ConnectorTableFunctionHandle;
 
 public class HandleJsonModule
         implements Module
@@ -109,5 +110,11 @@ public class HandleJsonModule
     public static com.fasterxml.jackson.databind.Module exchangeSourceHandleModule(HandleResolver resolver)
     {
         return new AbstractTypedJacksonModule<>(ExchangeSourceHandle.class, resolver::getId, resolver::getHandleClass) {};
+    }
+
+    @ProvidesIntoSet
+    public static com.fasterxml.jackson.databind.Module tableFunctionHandleModule(HandleResolver resolver)
+    {
+        return new AbstractTypedJacksonModule<>(ConnectorTableFunctionHandle.class, resolver::getId, resolver::getHandleClass) {};
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/EmptyTableFunctionPartition.java
+++ b/core/trino-main/src/main/java/io/trino/operator/EmptyTableFunctionPartition.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import io.trino.spi.Page;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.ptf.TableFunctionProcessor;
+import io.trino.spi.ptf.TableFunctionProcessorState;
+import io.trino.spi.ptf.TableFunctionProcessorState.Blocked;
+import io.trino.spi.ptf.TableFunctionProcessorState.Processed;
+import io.trino.spi.type.Type;
+
+import java.util.List;
+
+import static io.airlift.concurrent.MoreFutures.toListenableFuture;
+import static io.trino.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
+import static io.trino.spi.ptf.TableFunctionProcessorState.Finished.FINISHED;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This is a class representing empty input to a table function. An EmptyTableFunctionPartition is created
+ * when the table function has KEEP WHEN EMPTY property, which means that the function should be executed
+ * even if the input is empty, and all the table arguments are empty relations.
+ * <p>
+ * An EmptyTableFunctionPartition is created and processed once per node. To avoid duplicated execution,
+ * a table function having KEEP WHEN EMPTY property must have single distribution.
+ */
+public class EmptyTableFunctionPartition
+        implements TableFunctionPartition
+{
+    private final TableFunctionProcessor tableFunction;
+    private final int properChannelsCount;
+    private final int passThroughSourcesCount;
+    private final Type[] passThroughTypes;
+
+    public EmptyTableFunctionPartition(TableFunctionProcessor tableFunction, int properChannelsCount, int passThroughSourcesCount, List<Type> passThroughTypes)
+    {
+        this.tableFunction = requireNonNull(tableFunction, "tableFunction is null");
+        this.properChannelsCount = properChannelsCount;
+        this.passThroughSourcesCount = passThroughSourcesCount;
+        this.passThroughTypes = passThroughTypes.toArray(new Type[] {});
+    }
+
+    @Override
+    public WorkProcessor<Page> toOutputPages()
+    {
+        return WorkProcessor.create(() -> {
+            TableFunctionProcessorState state = tableFunction.process(null);
+            if (state == FINISHED) {
+                return WorkProcessor.ProcessState.finished();
+            }
+            if (state instanceof Blocked blocked) {
+                return WorkProcessor.ProcessState.blocked(toListenableFuture(blocked.getFuture()));
+            }
+            Processed processed = (Processed) state;
+            if (processed.getResult() != null) {
+                return WorkProcessor.ProcessState.ofResult(appendNullsForPassThroughColumns(processed.getResult()));
+            }
+            throw new TrinoException(FUNCTION_IMPLEMENTATION_ERROR, "When function got no input, it should either produce output or return Blocked state");
+        });
+    }
+
+    private Page appendNullsForPassThroughColumns(Page page)
+    {
+        if (page.getChannelCount() != properChannelsCount + passThroughSourcesCount) {
+            throw new TrinoException(
+                    FUNCTION_IMPLEMENTATION_ERROR,
+                    format(
+                            "Table function returned a page containing %s channels. Expected channel number: %s (%s proper columns, %s pass-through index columns)",
+                            page.getChannelCount(),
+                            properChannelsCount + passThroughSourcesCount,
+                            properChannelsCount,
+                            passThroughSourcesCount));
+        }
+
+        Block[] resultBlocks = new Block[properChannelsCount + passThroughTypes.length];
+
+        // proper outputs first
+        for (int channel = 0; channel < properChannelsCount; channel++) {
+            resultBlocks[channel] = page.getBlock(channel);
+        }
+
+        // pass-through columns next
+        // because no input was processed, all pass-through indexes in the result page must be null (there are no input rows they could refer to).
+        // for performance reasons this is not checked. All pass-through columns are filled with nulls.
+        int channel = properChannelsCount;
+        for (Type type : passThroughTypes) {
+            resultBlocks[channel] = RunLengthEncodedBlock.create(type, null, page.getPositionCount());
+            channel++;
+        }
+
+        // pass the position count so that the Page can be successfully created in the case when there are no output channels (resultBlocks is empty)
+        return new Page(page.getPositionCount(), resultBlocks);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/EmptyTableFunctionPartition.java
+++ b/core/trino-main/src/main/java/io/trino/operator/EmptyTableFunctionPartition.java
@@ -17,7 +17,7 @@ import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.RunLengthEncodedBlock;
-import io.trino.spi.ptf.TableFunctionProcessor;
+import io.trino.spi.ptf.TableFunctionDataProcessor;
 import io.trino.spi.ptf.TableFunctionProcessorState;
 import io.trino.spi.ptf.TableFunctionProcessorState.Blocked;
 import io.trino.spi.ptf.TableFunctionProcessorState.Processed;
@@ -42,12 +42,12 @@ import static java.util.Objects.requireNonNull;
 public class EmptyTableFunctionPartition
         implements TableFunctionPartition
 {
-    private final TableFunctionProcessor tableFunction;
+    private final TableFunctionDataProcessor tableFunction;
     private final int properChannelsCount;
     private final int passThroughSourcesCount;
     private final Type[] passThroughTypes;
 
-    public EmptyTableFunctionPartition(TableFunctionProcessor tableFunction, int properChannelsCount, int passThroughSourcesCount, List<Type> passThroughTypes)
+    public EmptyTableFunctionPartition(TableFunctionDataProcessor tableFunction, int properChannelsCount, int passThroughSourcesCount, List<Type> passThroughTypes)
     {
         this.tableFunction = requireNonNull(tableFunction, "tableFunction is null");
         this.properChannelsCount = properChannelsCount;

--- a/core/trino-main/src/main/java/io/trino/operator/LeafTableFunctionOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/LeafTableFunctionOperator.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import io.trino.metadata.Split;
+import io.trino.spi.Page;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.ptf.ConnectorTableFunctionHandle;
+import io.trino.spi.ptf.TableFunctionProcessorProvider;
+import io.trino.spi.ptf.TableFunctionProcessorState;
+import io.trino.spi.ptf.TableFunctionProcessorState.Blocked;
+import io.trino.spi.ptf.TableFunctionProcessorState.Processed;
+import io.trino.spi.ptf.TableFunctionSplitProcessor;
+import io.trino.sql.planner.plan.PlanNodeId;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.concurrent.MoreFutures.toListenableFuture;
+import static io.trino.spi.ptf.TableFunctionProcessorState.Finished.FINISHED;
+import static java.util.Objects.requireNonNull;
+
+public class LeafTableFunctionOperator
+        implements SourceOperator
+{
+    public static class LeafTableFunctionOperatorFactory
+            implements SourceOperatorFactory
+    {
+        private final int operatorId;
+        private final PlanNodeId sourceId;
+        private final TableFunctionProcessorProvider tableFunctionProvider;
+        private final ConnectorTableFunctionHandle functionHandle;
+        private boolean closed;
+
+        public LeafTableFunctionOperatorFactory(int operatorId, PlanNodeId sourceId, TableFunctionProcessorProvider tableFunctionProvider, ConnectorTableFunctionHandle functionHandle)
+        {
+            this.operatorId = operatorId;
+            this.sourceId = requireNonNull(sourceId, "sourceId is null");
+            this.tableFunctionProvider = requireNonNull(tableFunctionProvider, "tableFunctionProvider is null");
+            this.functionHandle = requireNonNull(functionHandle, "functionHandle is null");
+        }
+
+        @Override
+        public PlanNodeId getSourceId()
+        {
+            return sourceId;
+        }
+
+        @Override
+        public SourceOperator createOperator(DriverContext driverContext)
+        {
+            checkState(!closed, "Factory is already closed");
+            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, sourceId, LeafTableFunctionOperator.class.getSimpleName());
+            return new LeafTableFunctionOperator(operatorContext, sourceId, tableFunctionProvider, functionHandle);
+        }
+
+        @Override
+        public void noMoreOperators()
+        {
+            closed = true;
+        }
+    }
+
+    private final OperatorContext operatorContext;
+    private final PlanNodeId sourceId;
+    private final TableFunctionProcessorProvider tableFunctionProvider;
+    private final ConnectorTableFunctionHandle functionHandle;
+
+    private ConnectorSplit currentSplit;
+    private final List<ConnectorSplit> pendingSplits = new ArrayList<>();
+    private boolean noMoreSplits;
+
+    private TableFunctionSplitProcessor processor;
+    private boolean processorUsedData;
+    private boolean processorFinishedSplit = true;
+    private ListenableFuture<Void> processorBlocked = NOT_BLOCKED;
+
+    public LeafTableFunctionOperator(OperatorContext operatorContext, PlanNodeId sourceId, TableFunctionProcessorProvider tableFunctionProvider, ConnectorTableFunctionHandle functionHandle)
+    {
+        this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
+        this.sourceId = requireNonNull(sourceId, "sourceId is null");
+        this.tableFunctionProvider = requireNonNull(tableFunctionProvider, "tableFunctionProvider is null");
+        this.functionHandle = requireNonNull(functionHandle, "functionHandle is null");
+    }
+
+    private void resetProcessor()
+    {
+        this.processor = tableFunctionProvider.getSplitProcessor(functionHandle);
+        this.processorUsedData = false;
+        this.processorFinishedSplit = false;
+        this.processorBlocked = NOT_BLOCKED;
+    }
+
+    @Override
+    public OperatorContext getOperatorContext()
+    {
+        return operatorContext;
+    }
+
+    @Override
+    public PlanNodeId getSourceId()
+    {
+        return sourceId;
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return false;
+    }
+
+    @Override
+    public void addInput(Page page)
+    {
+        throw new UnsupportedOperationException(getClass().getName() + " does not take input");
+    }
+
+    @Override
+    public void addSplit(Split split)
+    {
+        checkState(!noMoreSplits, "no more splits expected");
+        pendingSplits.add(split.getConnectorSplit());
+    }
+
+    @Override
+    public void noMoreSplits()
+    {
+        noMoreSplits = true;
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        if (processorFinishedSplit) {
+            // start processing a new split
+            if (pendingSplits.isEmpty()) {
+                // no more splits to process at the moment
+                return null;
+            }
+            currentSplit = pendingSplits.remove(0);
+            resetProcessor();
+        }
+        else {
+            // a split is being processed
+            requireNonNull(currentSplit, "currentSplit is null");
+        }
+
+        TableFunctionProcessorState state = processor.process(processorUsedData ? null : currentSplit);
+        if (state == FINISHED) {
+            processorFinishedSplit = true;
+        }
+        if (state instanceof Blocked blocked) {
+            processorBlocked = toListenableFuture(blocked.getFuture());
+        }
+        if (state instanceof Processed processed) {
+            if (processed.isUsedInput()) {
+                processorUsedData = true;
+            }
+            if (processed.getResult() != null) {
+                return processed.getResult();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public ListenableFuture<Void> isBlocked()
+    {
+        return processorBlocked;
+    }
+
+    @Override
+    public void finish()
+    {
+        // this method is redundant. the operator takes no input at all. noMoreSplits() should be called instead.
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return processorFinishedSplit && pendingSplits.isEmpty() && noMoreSplits;
+    }
+
+    @Override
+    public void close()
+            throws Exception
+    {
+        // TODO
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/RegularTableFunctionPartition.java
+++ b/core/trino-main/src/main/java/io/trino/operator/RegularTableFunctionPartition.java
@@ -22,7 +22,7 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.RunLengthEncodedBlock;
-import io.trino.spi.ptf.TableFunctionProcessor;
+import io.trino.spi.ptf.TableFunctionDataProcessor;
 import io.trino.spi.ptf.TableFunctionProcessorState;
 import io.trino.spi.ptf.TableFunctionProcessorState.Blocked;
 import io.trino.spi.ptf.TableFunctionProcessorState.Processed;
@@ -57,7 +57,7 @@ public class RegularTableFunctionPartition
     private final int partitionEnd;
     private final Iterator<Page> sortedPages;
 
-    private final TableFunctionProcessor tableFunction;
+    private final TableFunctionDataProcessor tableFunction;
     private final int properChannelsCount;
     private final int passThroughSourcesCount;
 
@@ -77,7 +77,7 @@ public class RegularTableFunctionPartition
             PagesIndex pagesIndex,
             int partitionStart,
             int partitionEnd,
-            TableFunctionProcessor tableFunction,
+            TableFunctionDataProcessor tableFunction,
             int properChannelsCount,
             int passThroughSourcesCount,
             List<List<Integer>> requiredChannels,

--- a/core/trino-main/src/main/java/io/trino/operator/RegularTableFunctionPartition.java
+++ b/core/trino-main/src/main/java/io/trino/operator/RegularTableFunctionPartition.java
@@ -1,0 +1,408 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Ints;
+import io.trino.spi.Page;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.ptf.TableFunctionProcessor;
+import io.trino.spi.ptf.TableFunctionProcessorState;
+import io.trino.spi.ptf.TableFunctionProcessorState.Blocked;
+import io.trino.spi.ptf.TableFunctionProcessorState.Processed;
+import io.trino.spi.type.Type;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static io.airlift.concurrent.MoreFutures.toListenableFuture;
+import static io.trino.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
+import static io.trino.spi.ptf.TableFunctionProcessorState.Finished.FINISHED;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class RegularTableFunctionPartition
+        implements TableFunctionPartition
+{
+    private final PagesIndex pagesIndex;
+    private final int partitionStart;
+    private final int partitionEnd;
+    private final Iterator<Page> sortedPages;
+
+    private final TableFunctionProcessor tableFunction;
+    private final int properChannelsCount;
+    private final int passThroughSourcesCount;
+
+    // channels required by the table function, listed by source in order of argument declarations
+    private final int[][] requiredChannels;
+
+    // for each input channel, the end position of actual data in that channel (exclusive) relative to partition. The remaining rows are "filler" rows, and should not be passed to table function or passed-through
+    private final int[] endOfData;
+
+    // a builder for each pass-through column, in order of argument declarations
+    private final PassThroughColumnProvider[] passThroughProviders;
+
+    // number of processed input positions from partition start. all sources have been processed up to this position, except the sources whose partitions ended earlier.
+    private int processedPositions;
+
+    public RegularTableFunctionPartition(
+            PagesIndex pagesIndex,
+            int partitionStart,
+            int partitionEnd,
+            TableFunctionProcessor tableFunction,
+            int properChannelsCount,
+            int passThroughSourcesCount,
+            List<List<Integer>> requiredChannels,
+            Optional<Map<Integer, Integer>> markerChannels,
+            List<PassThroughColumnSpecification> passThroughSpecifications)
+
+    {
+        checkArgument(pagesIndex.getPositionCount() != 0, "PagesIndex is empty for regular table function partition");
+        this.pagesIndex = pagesIndex;
+        this.partitionStart = partitionStart;
+        this.partitionEnd = partitionEnd;
+        this.sortedPages = pagesIndex.getSortedPages(partitionStart, partitionEnd);
+        this.tableFunction = requireNonNull(tableFunction, "tableFunction is null");
+        this.properChannelsCount = properChannelsCount;
+        this.passThroughSourcesCount = passThroughSourcesCount;
+        this.requiredChannels = requiredChannels.stream()
+                .map(Ints::toArray)
+                .toArray(int[][]::new);
+        this.endOfData = findEndOfData(markerChannels, requiredChannels, passThroughSpecifications);
+        for (List<Integer> channels : requiredChannels) {
+            checkState(
+                    channels.stream()
+                            .mapToInt(channel -> endOfData[channel])
+                            .distinct()
+                            .count() <= 1,
+                    "end-of-data position is inconsistent within a table function source");
+        }
+        this.passThroughProviders = new PassThroughColumnProvider[passThroughSpecifications.size()];
+        for (int i = 0; i < passThroughSpecifications.size(); i++) {
+            passThroughProviders[i] = createColumnProvider(passThroughSpecifications.get(i));
+        }
+    }
+
+    @Override
+    public WorkProcessor<Page> toOutputPages()
+    {
+        return WorkProcessor.create(new WorkProcessor.Process<>()
+        {
+            List<Optional<Page>> inputPages = prepareInputPages();
+
+            @Override
+            public WorkProcessor.ProcessState<Page> process()
+            {
+                TableFunctionProcessorState state = tableFunction.process(inputPages);
+                boolean functionGotNoData = inputPages == null;
+                if (state == FINISHED) {
+                    return WorkProcessor.ProcessState.finished();
+                }
+                if (state instanceof Blocked blocked) {
+                    return WorkProcessor.ProcessState.blocked(toListenableFuture(blocked.getFuture()));
+                }
+                Processed processed = (Processed) state;
+                if (processed.isUsedInput()) {
+                    inputPages = prepareInputPages();
+                }
+                if (processed.getResult() != null) {
+                    return WorkProcessor.ProcessState.ofResult(appendPassThroughColumns(processed.getResult()));
+                }
+                if (functionGotNoData) {
+                    throw new TrinoException(FUNCTION_IMPLEMENTATION_ERROR, "When function got no input, it should either produce output or return Blocked state");
+                }
+                return WorkProcessor.ProcessState.blocked(immediateFuture(null));
+            }
+        });
+    }
+
+    /**
+     * Iterate over the partition by page and extract pages for each table function source from the input page.
+     * For each source, project the columns required by the table function.
+     * If for some source all data in the partition has been consumed, Optional.empty() is returned for that source.
+     * It happens when the partition of this source is shorter than the partition of some other source.
+     * The overall length of the table function partition is equal to the length of the longest source partition.
+     * When all sources are fully consumed, this method returns null.
+     * <p>
+     * NOTE: There are two types of table function's source semantics: set and row. The two types of sources should be handled
+     * by the TableFunctionProcessor in different ways. For a source with set semantics, the whole partition can be used for computations,
+     * while for a source with row semantics, each row should be processed independently from all other rows.
+     * To enforce that behavior, we could pass to the TableFunctionProcessor only one row from a table with row semantics.
+     * However, for performance reasons, we handle sources with row and set semantics in the same way: the TableFunctionProcessor
+     * gets a page of data from each source. The TableFunctionProcessor is responsible for using the provided data accordingly
+     * to the declared source semantics (set or rows).
+     *
+     * @return A List containing:
+     * - Optional Page for every source that is not fully consumed
+     * - Optional.empty() for every source that is fully consumed
+     * or null if all sources are fully consumed.
+     */
+    private List<Optional<Page>> prepareInputPages()
+    {
+        if (!sortedPages.hasNext()) {
+            return null;
+        }
+
+        Page inputPage = sortedPages.next();
+        ImmutableList.Builder<Optional<Page>> sourcePages = ImmutableList.builder();
+
+        for (int[] channelsForSource : requiredChannels) {
+            if (channelsForSource.length == 0) {
+                sourcePages.add(Optional.of(new Page(inputPage.getPositionCount())));
+            }
+            else {
+                int endOfDataForSource = endOfData[channelsForSource[0]]; // end-of-data position is validated to be consistent for all channels from source
+                if (endOfDataForSource <= processedPositions) {
+                    // all data for this source was already processed
+                    sourcePages.add(Optional.empty());
+                }
+                else {
+                    Block[] sourceBlocks = new Block[channelsForSource.length];
+                    if (endOfDataForSource < processedPositions + inputPage.getPositionCount()) {
+                        // data for this source ends within the current page
+                        for (int i = 0; i < channelsForSource.length; i++) {
+                            int inputChannel = channelsForSource[i];
+                            sourceBlocks[i] = inputPage.getBlock(inputChannel).getRegion(0, endOfDataForSource - processedPositions);
+                        }
+                    }
+                    else {
+                        // data for this source does not end within the current page
+                        for (int i = 0; i < channelsForSource.length; i++) {
+                            int inputChannel = channelsForSource[i];
+                            sourceBlocks[i] = inputPage.getBlock(inputChannel);
+                        }
+                    }
+                    sourcePages.add(Optional.of(new Page(sourceBlocks)));
+                }
+            }
+        }
+
+        processedPositions += inputPage.getPositionCount();
+
+        return sourcePages.build();
+    }
+
+    /**
+     * There are two types of table function's source semantics: set and row.
+     * <p>
+     * For a source with row semantics, the table function result depends on the whole partition,
+     * so it is not always possible to associate an output row with a specific input row.
+     * The TableFunctionProcessor can return null as the pass-through index to indicate that
+     * the output row is not associated with any row from the given source.
+     * <p>
+     * For a source with row semantics, the output is determined on a row-by-row basis, so every
+     * output row is associated with a specific input row. In such case, the pass-through index
+     * should never be null.
+     * <p>
+     * In our implementation, we handle sources with row and set semantics in the same way.
+     * For performance reasons, we do not validate the null pass-through indexes.
+     * The TableFunctionProcessor is responsible for using the pass-through capability
+     * accordingly to the declared source semantics (set or rows).
+     */
+    private Page appendPassThroughColumns(Page page)
+    {
+        if (page.getChannelCount() != properChannelsCount + passThroughSourcesCount) {
+            throw new TrinoException(
+                    FUNCTION_IMPLEMENTATION_ERROR,
+                    format(
+                            "Table function returned a page containing %s channels. Expected channel number: %s (%s proper columns, %s pass-through index columns)",
+                            page.getChannelCount(),
+                            properChannelsCount + passThroughSourcesCount,
+                            properChannelsCount,
+                            passThroughSourcesCount));
+        }
+        // TODO is it possible to verify types of columns returned by TF?
+
+        Block[] resultBlocks = new Block[properChannelsCount + passThroughProviders.length];
+
+        // proper outputs first
+        for (int channel = 0; channel < properChannelsCount; channel++) {
+            resultBlocks[channel] = page.getBlock(channel);
+        }
+
+        // pass-through columns next
+        int channel = properChannelsCount;
+        for (PassThroughColumnProvider provider : passThroughProviders) {
+            resultBlocks[channel] = provider.getPassThroughColumn(page);
+            channel++;
+        }
+
+        // pass the position count so that the Page can be successfully created in the case when there are no output channels (resultBlocks is empty)
+        return new Page(page.getPositionCount(), resultBlocks);
+    }
+
+    private int[] findEndOfData(Optional<Map<Integer, Integer>> markerChannels, List<List<Integer>> requiredChannels, List<PassThroughColumnSpecification> passThroughSpecifications)
+    {
+        Set<Integer> referencedChannels = ImmutableSet.<Integer>builder()
+                .addAll(requiredChannels.stream()
+                        .flatMap(Collection::stream)
+                        .collect(toImmutableList()))
+                .addAll(passThroughSpecifications.stream()
+                        .map(PassThroughColumnSpecification::inputChannel)
+                        .collect(toImmutableList()))
+                .build();
+
+        if (referencedChannels.isEmpty()) {
+            // no required or pass-through channels
+            return null;
+        }
+
+        int maxInputChannel = referencedChannels.stream()
+                .mapToInt(Integer::intValue)
+                .max()
+                .orElseThrow();
+
+        int[] result = new int[maxInputChannel + 1];
+        Arrays.fill(result, -1);
+
+        // if table function had one source, adding a marker channel was not necessary.
+        // end-of-data position is equal to partition end for each input channel
+        if (markerChannels.isEmpty()) {
+            referencedChannels.stream()
+                    .forEach(channel -> result[channel] = partitionEnd - partitionStart);
+            return result;
+        }
+
+        // if table function had more than one source, the markers map shall be present, and it shall contain mapping for each input channel
+        ImmutableMap.Builder<Integer, Integer> endOfDataPerMarkerBuilder = ImmutableMap.builder();
+        for (int markerChannel : ImmutableSet.copyOf(markerChannels.orElseThrow().values())) {
+            endOfDataPerMarkerBuilder.put(markerChannel, findFirstNullPosition(markerChannel));
+        }
+        Map<Integer, Integer> endOfDataPerMarker = endOfDataPerMarkerBuilder.buildOrThrow();
+        referencedChannels.stream()
+                .forEach(channel -> result[channel] = endOfDataPerMarker.get(markerChannels.orElseThrow().get(channel)) - partitionStart);
+
+        return result;
+    }
+
+    private int findFirstNullPosition(int markerChannel)
+    {
+        if (pagesIndex.isNull(markerChannel, partitionStart)) {
+            return partitionStart;
+        }
+        if (!pagesIndex.isNull(markerChannel, partitionEnd - 1)) {
+            return partitionEnd;
+        }
+
+        int start = partitionStart;
+        int end = partitionEnd;
+        // value at start is not null, value at end is null
+        while (end - start > 1) {
+            int mid = start + end >>> 1;
+            if (pagesIndex.isNull(markerChannel, mid)) {
+                end = mid;
+            }
+            else {
+                start = mid;
+            }
+        }
+        return end;
+    }
+
+    public record PassThroughColumnSpecification(boolean isPartitioningColumn, int inputChannel, int indexChannel)
+    {
+    }
+
+    private PassThroughColumnProvider createColumnProvider(PassThroughColumnSpecification specification)
+    {
+        if (specification.isPartitioningColumn()) {
+            return new PartitioningColumnProvider(pagesIndex.getSingleValueBlock(specification.inputChannel(), partitionStart));
+        }
+        return new NonPartitioningColumnProvider(specification.inputChannel(), specification.indexChannel());
+    }
+
+    private sealed interface PassThroughColumnProvider
+            permits PartitioningColumnProvider, NonPartitioningColumnProvider
+    {
+        Block getPassThroughColumn(Page page);
+    }
+
+    private record PartitioningColumnProvider(Block partitioningValue)
+            implements PassThroughColumnProvider
+    {
+        private PartitioningColumnProvider
+        {
+            requireNonNull(partitioningValue, "partitioningValue is null");
+        }
+
+        @Override
+        public Block getPassThroughColumn(Page page)
+        {
+            return RunLengthEncodedBlock.create(partitioningValue, page.getPositionCount());
+        }
+    }
+
+    private final class NonPartitioningColumnProvider
+            implements PassThroughColumnProvider
+    {
+        private final int inputChannel;
+        private final Type type;
+        private final int indexChannel;
+
+        public NonPartitioningColumnProvider(int inputChannel, int indexChannel)
+        {
+            this.inputChannel = inputChannel;
+            this.type = pagesIndex.getType(inputChannel);
+            this.indexChannel = indexChannel;
+        }
+
+        @Override
+        public Block getPassThroughColumn(Page page)
+        {
+            Block indexes = page.getBlock(indexChannel);
+            BlockBuilder builder = type.createBlockBuilder(null, page.getPositionCount());
+            for (int position = 0; position < page.getPositionCount(); position++) {
+                if (indexes.isNull(position)) {
+                    builder.appendNull();
+                }
+                else {
+                    // table function returns index from partition start
+                    long index = BIGINT.getLong(indexes, position);
+                    // validate index
+                    if (index < 0 || index >= endOfData[inputChannel] || index >= processedPositions) {
+                        int end = min(endOfData[inputChannel], processedPositions) - 1;
+                        if (end >= 0) {
+                            throw new TrinoException(FUNCTION_IMPLEMENTATION_ERROR, format("Index of a pass-through row: %s out of processed portion of partition [0, %s]", index, end));
+                        }
+                        else {
+                            throw new TrinoException(FUNCTION_IMPLEMENTATION_ERROR, "Index of a pass-through row must be null when no input data from the partition was processed. Actual: " + index);
+                        }
+                    }
+                    // index in PagesIndex
+                    long absoluteIndex = partitionStart + index;
+                    pagesIndex.appendTo(inputChannel, toIntExact(absoluteIndex), builder);
+                }
+            }
+
+            return builder.build();
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/TableFunctionOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableFunctionOperator.java
@@ -576,7 +576,7 @@ public class TableFunctionOperator
                         // empty PagesIndex can only be passed once as the result of PartitionAndSort. Neither this nor any future instance of Process will ever get an empty PagesIndex again.
                         processEmpty = false;
                         return WorkProcessor.ProcessState.ofResult(new EmptyTableFunctionPartition(
-                                tableFunctionProvider.get(functionHandle),
+                                tableFunctionProvider.getDataProcessor(functionHandle),
                                 properChannelsCount,
                                 passThroughSourcesCount,
                                 passThroughSpecifications.stream()
@@ -596,7 +596,7 @@ public class TableFunctionOperator
                         pagesIndex,
                         partitionStart,
                         partitionEnd,
-                        tableFunctionProvider.get(functionHandle),
+                        tableFunctionProvider.getDataProcessor(functionHandle),
                         properChannelsCount,
                         passThroughSourcesCount,
                         requiredChannels,

--- a/core/trino-main/src/main/java/io/trino/operator/TableFunctionOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableFunctionOperator.java
@@ -1,0 +1,611 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.primitives.Ints;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.trino.memory.context.LocalMemoryContext;
+import io.trino.operator.RegularTableFunctionPartition.PassThroughColumnSpecification;
+import io.trino.spi.Page;
+import io.trino.spi.connector.SortOrder;
+import io.trino.spi.ptf.ConnectorTableFunctionHandle;
+import io.trino.spi.ptf.TableFunctionProcessorProvider;
+import io.trino.spi.type.Type;
+import io.trino.sql.planner.plan.PlanNodeId;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkPositionIndex;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.concat;
+import static io.trino.spi.connector.SortOrder.ASC_NULLS_LAST;
+import static java.util.Collections.nCopies;
+import static java.util.Objects.requireNonNull;
+
+public class TableFunctionOperator
+        implements Operator
+{
+    public static class TableFunctionOperatorFactory
+            implements OperatorFactory
+    {
+        private final int operatorId;
+        private final PlanNodeId planNodeId;
+
+        // a provider of table function processor to be called once per partition
+        private final TableFunctionProcessorProvider tableFunctionProvider;
+
+        // all information necessary to execute the table function collected during analysis
+        private final ConnectorTableFunctionHandle functionHandle;
+
+        // number of proper columns produced by the table function
+        private final int properChannelsCount;
+
+        // number of input tables declared as pass-through
+        private final int passThroughSourcesCount;
+
+        // columns required by the table function, in order of input tables
+        private final List<List<Integer>> requiredChannels;
+
+        // map from input channel to marker channel
+        // for each input table, there is a channel that marks which rows contain original data, and which are "filler" rows.
+        // the "filler" rows are part of the algorithm, and they should not be processed by the table function, or passed-through.
+        // In this map, every original column from the input table is associated with the appropriate marker.
+        private final Optional<Map<Integer, Integer>> markerChannels;
+
+        // necessary information to build a pass-through column, for all pass-through columns, ordered as expected on the output
+        // it includes columns from sources declared as pass-through as well as partitioning columns from other sources
+        private final List<PassThroughColumnSpecification> passThroughSpecifications;
+
+        // specifies whether the function should be pruned or executed when the input is empty
+        // pruneWhenEmpty is false if and only if all original input tables are KEEP WHEN EMPTY
+        private final boolean pruneWhenEmpty;
+
+        // partitioning channels from all sources
+        private final List<Integer> partitionChannels;
+
+        // subset of partition channels that are already grouped
+        private final List<Integer> prePartitionedChannels;
+
+        // channels necessary to sort all sources:
+        // - for a single source, these are the source's sort channels
+        // - for multiple sources, this is a single synthesized row number channel
+        private final List<Integer> sortChannels;
+        private final List<SortOrder> sortOrders;
+
+        // number of leading sort channels that are already sorted
+        private final int preSortedPrefix;
+
+        private final List<Type> sourceTypes;
+        private final int expectedPositions;
+        private final PagesIndex.Factory pagesIndexFactory;
+
+        private boolean closed;
+
+        public TableFunctionOperatorFactory(
+                int operatorId,
+                PlanNodeId planNodeId,
+                TableFunctionProcessorProvider tableFunctionProvider,
+                ConnectorTableFunctionHandle functionHandle,
+                int properChannelsCount,
+                int passThroughSourcesCount,
+                List<List<Integer>> requiredChannels,
+                Optional<Map<Integer, Integer>> markerChannels,
+                List<PassThroughColumnSpecification> passThroughSpecifications,
+                boolean pruneWhenEmpty,
+                List<Integer> partitionChannels,
+                List<Integer> prePartitionedChannels,
+                List<Integer> sortChannels,
+                List<SortOrder> sortOrders,
+                int preSortedPrefix,
+                List<? extends Type> sourceTypes,
+                int expectedPositions,
+                PagesIndex.Factory pagesIndexFactory)
+        {
+            requireNonNull(planNodeId, "planNodeId is null");
+            requireNonNull(tableFunctionProvider, "tableFunctionProvider is null");
+            requireNonNull(functionHandle, "functionHandle is null");
+            requireNonNull(requiredChannels, "requiredChannels is null");
+            requireNonNull(markerChannels, "markerChannels is null");
+            requireNonNull(passThroughSpecifications, "passThroughSpecifications is null");
+            requireNonNull(partitionChannels, "partitionChannels is null");
+            requireNonNull(prePartitionedChannels, "prePartitionedChannels is null");
+            checkArgument(partitionChannels.containsAll(prePartitionedChannels), "prePartitionedChannels must be a subset of partitionChannels");
+            requireNonNull(sortChannels, "sortChannels is null");
+            requireNonNull(sortOrders, "sortOrders is null");
+            checkArgument(sortChannels.size() == sortOrders.size(), "The number of sort channels must be equal to the number of sort orders");
+            checkArgument(preSortedPrefix <= sortChannels.size(), "The number of pre-sorted channels must be lower or equal to the number of sort channels");
+            checkArgument(preSortedPrefix == 0 || ImmutableSet.copyOf(prePartitionedChannels).equals(ImmutableSet.copyOf(partitionChannels)), "preSortedPrefix can only be greater than zero if all partition channels are pre-grouped");
+            requireNonNull(sourceTypes, "sourceTypes is null");
+            requireNonNull(pagesIndexFactory, "pagesIndexFactory is null");
+
+            this.operatorId = operatorId;
+            this.planNodeId = planNodeId;
+            this.tableFunctionProvider = tableFunctionProvider;
+            this.functionHandle = functionHandle;
+            this.properChannelsCount = properChannelsCount;
+            this.passThroughSourcesCount = passThroughSourcesCount;
+            this.requiredChannels = requiredChannels.stream()
+                    .map(ImmutableList::copyOf)
+                    .collect(toImmutableList());
+            this.markerChannels = markerChannels.map(ImmutableMap::copyOf);
+            this.passThroughSpecifications = ImmutableList.copyOf(passThroughSpecifications);
+            this.pruneWhenEmpty = pruneWhenEmpty;
+            this.partitionChannels = ImmutableList.copyOf(partitionChannels);
+            this.prePartitionedChannels = ImmutableList.copyOf(prePartitionedChannels);
+            this.sortChannels = ImmutableList.copyOf(sortChannels);
+            this.sortOrders = ImmutableList.copyOf(sortOrders);
+            this.preSortedPrefix = preSortedPrefix;
+            this.sourceTypes = ImmutableList.copyOf(sourceTypes);
+            this.expectedPositions = expectedPositions;
+            this.pagesIndexFactory = pagesIndexFactory;
+        }
+
+        @Override
+        public Operator createOperator(DriverContext driverContext)
+        {
+            checkState(!closed, "Factory is already closed");
+
+            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, TableFunctionOperator.class.getSimpleName());
+            return new TableFunctionOperator(
+                    operatorContext,
+                    tableFunctionProvider,
+                    functionHandle,
+                    properChannelsCount,
+                    passThroughSourcesCount,
+                    requiredChannels,
+                    markerChannels,
+                    passThroughSpecifications,
+                    pruneWhenEmpty,
+                    partitionChannels,
+                    prePartitionedChannels,
+                    sortChannels,
+                    sortOrders,
+                    preSortedPrefix,
+                    sourceTypes,
+                    expectedPositions,
+                    pagesIndexFactory);
+        }
+
+        @Override
+        public void noMoreOperators()
+        {
+            closed = true;
+        }
+
+        @Override
+        public OperatorFactory duplicate()
+        {
+            return new TableFunctionOperatorFactory(
+                    operatorId,
+                    planNodeId,
+                    tableFunctionProvider,
+                    functionHandle,
+                    properChannelsCount,
+                    passThroughSourcesCount,
+                    requiredChannels,
+                    markerChannels,
+                    passThroughSpecifications,
+                    pruneWhenEmpty,
+                    partitionChannels,
+                    prePartitionedChannels,
+                    sortChannels,
+                    sortOrders,
+                    preSortedPrefix,
+                    sourceTypes,
+                    expectedPositions,
+                    pagesIndexFactory);
+        }
+    }
+
+    private final OperatorContext operatorContext;
+
+    private final PageBuffer pageBuffer = new PageBuffer();
+    private final WorkProcessor<Page> outputPages;
+    private final boolean processEmptyInput;
+
+    public TableFunctionOperator(
+            OperatorContext operatorContext,
+            TableFunctionProcessorProvider tableFunctionProvider,
+            ConnectorTableFunctionHandle functionHandle,
+            int properChannelsCount,
+            int passThroughSourcesCount,
+            List<List<Integer>> requiredChannels,
+            Optional<Map<Integer, Integer>> markerChannels,
+            List<PassThroughColumnSpecification> passThroughSpecifications,
+            boolean pruneWhenEmpty,
+            List<Integer> partitionChannels,
+            List<Integer> prePartitionedChannels,
+            List<Integer> sortChannels,
+            List<SortOrder> sortOrders,
+            int preSortedPrefix,
+            List<Type> sourceTypes,
+            int expectedPositions,
+            PagesIndex.Factory pagesIndexFactory)
+    {
+        requireNonNull(operatorContext, "operatorContext is null");
+        requireNonNull(tableFunctionProvider, "tableFunctionProvider is null");
+        requireNonNull(functionHandle, "functionHandle is null");
+        requireNonNull(requiredChannels, "requiredChannels is null");
+        requireNonNull(markerChannels, "markerChannels is null");
+        requireNonNull(passThroughSpecifications, "passThroughSpecifications is null");
+        requireNonNull(partitionChannels, "partitionChannels is null");
+        requireNonNull(prePartitionedChannels, "prePartitionedChannels is null");
+        checkArgument(partitionChannels.containsAll(prePartitionedChannels), "prePartitionedChannels must be a subset of partitionChannels");
+        requireNonNull(sortChannels, "sortChannels is null");
+        requireNonNull(sortOrders, "sortOrders is null");
+        checkArgument(sortChannels.size() == sortOrders.size(), "The number of sort channels must be equal to the number of sort orders");
+        checkArgument(preSortedPrefix <= sortChannels.size(), "The number of pre-sorted channels must be lower or equal to the number of sort channels");
+        checkArgument(preSortedPrefix == 0 || ImmutableSet.copyOf(prePartitionedChannels).equals(ImmutableSet.copyOf(partitionChannels)), "preSortedPrefix can only be greater than zero if all partition channels are pre-grouped");
+        requireNonNull(sourceTypes, "sourceTypes is null");
+        requireNonNull(pagesIndexFactory, "pagesIndexFactory is null");
+
+        this.operatorContext = operatorContext;
+
+        this.processEmptyInput = !pruneWhenEmpty;
+
+        PagesIndex pagesIndex = pagesIndexFactory.newPagesIndex(sourceTypes, expectedPositions);
+        HashStrategies hashStrategies = new HashStrategies(pagesIndex, partitionChannels, prePartitionedChannels, sortChannels, sortOrders, preSortedPrefix);
+
+        this.outputPages = pageBuffer.pages()
+                .transform(new PartitionAndSort(pagesIndex, hashStrategies, processEmptyInput))
+                .flatMap(groupPagesIndex -> pagesIndexToTableFunctionPartitions(
+                        groupPagesIndex,
+                        hashStrategies,
+                        tableFunctionProvider,
+                        functionHandle,
+                        properChannelsCount,
+                        passThroughSourcesCount,
+                        requiredChannels,
+                        markerChannels,
+                        passThroughSpecifications,
+                        processEmptyInput))
+                .flatMap(TableFunctionPartition::toOutputPages);
+    }
+
+    @Override
+    public OperatorContext getOperatorContext()
+    {
+        return operatorContext;
+    }
+
+    @Override
+    public void finish()
+    {
+        pageBuffer.finish();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return outputPages.isFinished();
+    }
+
+    @Override
+    public ListenableFuture<Void> isBlocked()
+    {
+        if (outputPages.isBlocked()) {
+            return outputPages.getBlockedFuture();
+        }
+
+        return NOT_BLOCKED;
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return pageBuffer.isEmpty() && !pageBuffer.isFinished();
+    }
+
+    @Override
+    public void addInput(Page page)
+    {
+        pageBuffer.add(page);
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        if (!outputPages.process()) {
+            return null;
+        }
+
+        if (outputPages.isFinished()) {
+            return null;
+        }
+
+        return outputPages.getResult();
+    }
+
+    private static class HashStrategies
+    {
+        final PagesHashStrategy prePartitionedStrategy;
+        final PagesHashStrategy remainingPartitionStrategy;
+        final PagesHashStrategy preSortedStrategy;
+        final List<Integer> remainingPartitionAndSortChannels;
+        final List<SortOrder> remainingSortOrders;
+        final int[] prePartitionedChannelsArray;
+
+        public HashStrategies(
+                PagesIndex pagesIndex,
+                List<Integer> partitionChannels,
+                List<Integer> prePartitionedChannels,
+                List<Integer> sortChannels,
+                List<SortOrder> sortOrders,
+                int preSortedPrefix)
+        {
+            this.prePartitionedStrategy = pagesIndex.createPagesHashStrategy(prePartitionedChannels, OptionalInt.empty());
+
+            List<Integer> remainingPartitionChannels = partitionChannels.stream()
+                    .filter(channel -> !prePartitionedChannels.contains(channel))
+                    .collect(toImmutableList());
+            this.remainingPartitionStrategy = pagesIndex.createPagesHashStrategy(remainingPartitionChannels, OptionalInt.empty());
+
+            List<Integer> preSortedChannels = sortChannels.stream()
+                    .limit(preSortedPrefix)
+                    .collect(toImmutableList());
+            this.preSortedStrategy = pagesIndex.createPagesHashStrategy(preSortedChannels, OptionalInt.empty());
+
+            if (preSortedPrefix > 0) {
+                // preSortedPrefix > 0 implies that all partition channels are already pre-partitioned (enforced by check in the constructor), so we only need to do the remaining sort
+                this.remainingPartitionAndSortChannels = ImmutableList.copyOf(Iterables.skip(sortChannels, preSortedPrefix));
+                this.remainingSortOrders = ImmutableList.copyOf(Iterables.skip(sortOrders, preSortedPrefix));
+            }
+            else {
+                // we need to sort by the remaining partition channels so that the input is fully partitioned,
+                // and then need to we sort by all the sort channels so that the input is fully sorted
+                this.remainingPartitionAndSortChannels = ImmutableList.copyOf(concat(remainingPartitionChannels, sortChannels));
+                this.remainingSortOrders = ImmutableList.copyOf(concat(nCopies(remainingPartitionChannels.size(), ASC_NULLS_LAST), sortOrders));
+            }
+
+            this.prePartitionedChannelsArray = Ints.toArray(prePartitionedChannels);
+        }
+    }
+
+    private class PartitionAndSort
+            implements WorkProcessor.Transformation<Page, PagesIndex>
+    {
+        private final PagesIndex pagesIndex;
+        private final HashStrategies hashStrategies;
+        private final LocalMemoryContext memoryContext;
+
+        private boolean resetPagesIndex;
+        private int inputPosition;
+        private boolean processEmptyInput;
+
+        public PartitionAndSort(PagesIndex pagesIndex, HashStrategies hashStrategies, boolean processEmptyInput)
+        {
+            this.pagesIndex = pagesIndex;
+            this.hashStrategies = hashStrategies;
+            this.memoryContext = operatorContext.aggregateUserMemoryContext().newLocalMemoryContext(PartitionAndSort.class.getSimpleName());
+            this.processEmptyInput = processEmptyInput;
+        }
+
+        @Override
+        public WorkProcessor.TransformationState<PagesIndex> process(Page input)
+        {
+            if (resetPagesIndex) {
+                pagesIndex.clear();
+                updateMemoryUsage();
+                resetPagesIndex = false;
+            }
+
+            if (input == null && pagesIndex.getPositionCount() == 0) {
+                if (processEmptyInput) {
+                    // it can only happen at the first call to process(), which implies that there is no input. Empty PagesIndex can be passed on only once.
+                    processEmptyInput = false;
+                    return WorkProcessor.TransformationState.ofResult(pagesIndex, false);
+                }
+                else {
+                    memoryContext.close();
+                    return WorkProcessor.TransformationState.finished();
+                }
+            }
+
+            // there is input, so we are not interested in processing empty input
+            processEmptyInput = false;
+
+            if (input != null) {
+                // append rows from input which belong to the current group wrt pre-partitioned columns
+                // it might be one or more partitions
+                inputPosition = appendCurrentGroup(pagesIndex, hashStrategies, input, inputPosition);
+                updateMemoryUsage();
+
+                if (inputPosition >= input.getPositionCount()) {
+                    inputPosition = 0;
+                    return WorkProcessor.TransformationState.needsMoreData();
+                }
+            }
+
+            // we have unused input or the input is finished. we have buffered a full group
+            // the group contains one or more partitions, as it was determined by the pre-partitioned columns
+            // sorting serves two purposes:
+            // - sort by the remaining partition channels so that the input is fully partitioned,
+            // - sort by all the sort channels so that the input is fully sorted
+            sortCurrentGroup(pagesIndex, hashStrategies);
+            resetPagesIndex = true;
+            return WorkProcessor.TransformationState.ofResult(pagesIndex, false);
+        }
+
+        void updateMemoryUsage()
+        {
+            memoryContext.setBytes(pagesIndex.getEstimatedSize().toBytes());
+        }
+    }
+
+    private static int appendCurrentGroup(PagesIndex pagesIndex, HashStrategies hashStrategies, Page page, int startPosition)
+    {
+        checkArgument(page.getPositionCount() > startPosition);
+
+        PagesHashStrategy prePartitionedStrategy = hashStrategies.prePartitionedStrategy;
+        Page prePartitionedPage = page.getColumns(hashStrategies.prePartitionedChannelsArray);
+
+        if (pagesIndex.getPositionCount() == 0 || pagesIndex.positionNotDistinctFromRow(prePartitionedStrategy, 0, startPosition, prePartitionedPage)) {
+            // we are within the current group. find the position where the pre-grouped columns change
+            int groupEnd = findGroupEnd(prePartitionedPage, prePartitionedStrategy, startPosition);
+
+            // add the section of the page that contains values for the current group
+            pagesIndex.addPage(page.getRegion(startPosition, groupEnd - startPosition));
+
+            if (page.getPositionCount() - groupEnd > 0) {
+                // the remaining prt of the page contains the next group
+                return groupEnd;
+            }
+            // page fully consumed: it contains the current group only
+            return page.getPositionCount();
+        }
+
+        // we had previous results buffered, but the remaining page starts with new group values
+        return startPosition;
+    }
+
+    private static void sortCurrentGroup(PagesIndex pagesIndex, HashStrategies hashStrategies)
+    {
+        PagesHashStrategy preSortedStrategy = hashStrategies.preSortedStrategy;
+        List<Integer> remainingPartitionAndSortChannels = hashStrategies.remainingPartitionAndSortChannels;
+        List<SortOrder> remainingSortOrders = hashStrategies.remainingSortOrders;
+
+        if (pagesIndex.getPositionCount() > 1 && !remainingPartitionAndSortChannels.isEmpty()) {
+            int startPosition = 0;
+            while (startPosition < pagesIndex.getPositionCount()) {
+                int endPosition = findGroupEnd(pagesIndex, preSortedStrategy, startPosition);
+                pagesIndex.sort(remainingPartitionAndSortChannels, remainingSortOrders, startPosition, endPosition);
+                startPosition = endPosition;
+            }
+        }
+    }
+
+    // Assumes input grouped on relevant pagesHashStrategy columns
+    private static int findGroupEnd(Page page, PagesHashStrategy pagesHashStrategy, int startPosition)
+    {
+        checkArgument(page.getPositionCount() > 0, "Must have at least one position");
+        checkPositionIndex(startPosition, page.getPositionCount(), "startPosition out of bounds");
+
+        return findEndPosition(startPosition, page.getPositionCount(), (firstPosition, secondPosition) -> pagesHashStrategy.rowNotDistinctFromRow(firstPosition, page, secondPosition, page));
+    }
+
+    // Assumes input grouped on relevant pagesHashStrategy columns
+    private static int findGroupEnd(PagesIndex pagesIndex, PagesHashStrategy pagesHashStrategy, int startPosition)
+    {
+        checkArgument(pagesIndex.getPositionCount() > 0, "Must have at least one position");
+        checkPositionIndex(startPosition, pagesIndex.getPositionCount(), "startPosition out of bounds");
+
+        return findEndPosition(startPosition, pagesIndex.getPositionCount(), (firstPosition, secondPosition) -> pagesIndex.positionNotDistinctFromPosition(pagesHashStrategy, firstPosition, secondPosition));
+    }
+
+    /**
+     * @param startPosition - inclusive
+     * @param endPosition - exclusive
+     * @param comparator - returns true if positions given as parameters are equal
+     * @return the end of the group position exclusive (the position the very next group starts)
+     */
+    @VisibleForTesting
+    static int findEndPosition(int startPosition, int endPosition, PositionComparator comparator)
+    {
+        checkArgument(startPosition >= 0, "startPosition must be greater or equal than zero: %s", startPosition);
+        checkArgument(startPosition < endPosition, "startPosition (%s) must be less than endPosition (%s)", startPosition, endPosition);
+
+        int left = startPosition;
+        int right = endPosition;
+
+        while (right - left > 1) {
+            int middle = (left + right) >>> 1;
+
+            if (comparator.test(startPosition, middle)) {
+                left = middle;
+            }
+            else {
+                right = middle;
+            }
+        }
+
+        return right;
+    }
+
+    private interface PositionComparator
+    {
+        boolean test(int first, int second);
+    }
+
+    private WorkProcessor<TableFunctionPartition> pagesIndexToTableFunctionPartitions(
+            PagesIndex pagesIndex,
+            HashStrategies hashStrategies,
+            TableFunctionProcessorProvider tableFunctionProvider,
+            ConnectorTableFunctionHandle functionHandle,
+            int properChannelsCount,
+            int passThroughSourcesCount,
+            List<List<Integer>> requiredChannels,
+            Optional<Map<Integer, Integer>> markerChannels,
+            List<PassThroughColumnSpecification> passThroughSpecifications,
+            boolean processEmptyInput)
+    {
+        // pagesIndex contains the full grouped and sorted data for one or more partitions
+
+        PagesHashStrategy remainingPartitionStrategy = hashStrategies.remainingPartitionStrategy;
+
+        return WorkProcessor.create(new WorkProcessor.Process<>()
+        {
+            private int partitionStart;
+            private boolean processEmpty = processEmptyInput;
+
+            @Override
+            public WorkProcessor.ProcessState<TableFunctionPartition> process()
+            {
+                if (partitionStart == pagesIndex.getPositionCount()) {
+                    if (processEmpty && pagesIndex.getPositionCount() == 0) {
+                        // empty PagesIndex can only be passed once as the result of PartitionAndSort. Neither this nor any future instance of Process will ever get an empty PagesIndex again.
+                        processEmpty = false;
+                        return WorkProcessor.ProcessState.ofResult(new EmptyTableFunctionPartition(
+                                tableFunctionProvider.get(functionHandle),
+                                properChannelsCount,
+                                passThroughSourcesCount,
+                                passThroughSpecifications.stream()
+                                        .map(PassThroughColumnSpecification::inputChannel)
+                                        .map(pagesIndex::getType)
+                                        .collect(toImmutableList())));
+                    }
+                    return WorkProcessor.ProcessState.finished();
+                }
+
+                // there is input, so we are not interested in processing empty input
+                processEmpty = false;
+
+                int partitionEnd = findGroupEnd(pagesIndex, remainingPartitionStrategy, partitionStart);
+
+                RegularTableFunctionPartition partition = new RegularTableFunctionPartition(
+                        pagesIndex,
+                        partitionStart,
+                        partitionEnd,
+                        tableFunctionProvider.get(functionHandle),
+                        properChannelsCount,
+                        passThroughSourcesCount,
+                        requiredChannels,
+                        markerChannels,
+                        passThroughSpecifications);
+
+                partitionStart = partitionEnd;
+                return WorkProcessor.ProcessState.ofResult(partition);
+            }
+        });
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/TableFunctionPartition.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableFunctionPartition.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import io.trino.spi.Page;
+
+public interface TableFunctionPartition
+{
+    WorkProcessor<Page> toOutputPages();
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -77,6 +77,7 @@ import io.trino.operator.PagesIndex;
 import io.trino.operator.PagesSpatialIndexFactory;
 import io.trino.operator.PartitionFunction;
 import io.trino.operator.RefreshMaterializedViewOperator.RefreshMaterializedViewOperatorFactory;
+import io.trino.operator.RegularTableFunctionPartition.PassThroughColumnSpecification;
 import io.trino.operator.RetryPolicy;
 import io.trino.operator.RowNumberOperator;
 import io.trino.operator.ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory;
@@ -90,6 +91,7 @@ import io.trino.operator.SpatialJoinOperator.SpatialJoinOperatorFactory;
 import io.trino.operator.StatisticsWriterOperator.StatisticsWriterOperatorFactory;
 import io.trino.operator.StreamingAggregationOperator;
 import io.trino.operator.TableDeleteOperator.TableDeleteOperatorFactory;
+import io.trino.operator.TableFunctionOperator.TableFunctionOperatorFactory;
 import io.trino.operator.TableScanOperator.TableScanOperatorFactory;
 import io.trino.operator.TaskContext;
 import io.trino.operator.TopNOperator;
@@ -163,6 +165,7 @@ import io.trino.spi.function.FunctionKind;
 import io.trino.spi.function.WindowFunctionSupplier;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.NullableValue;
+import io.trino.spi.ptf.TableFunctionProcessorProvider;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.spiller.PartitioningSpillerFactory;
@@ -185,6 +188,7 @@ import io.trino.sql.planner.plan.AggregationNode.Aggregation;
 import io.trino.sql.planner.plan.AggregationNode.Step;
 import io.trino.sql.planner.plan.AssignUniqueId;
 import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.DistinctLimitNode;
 import io.trino.sql.planner.plan.DynamicFilterId;
 import io.trino.sql.planner.plan.DynamicFilterSourceNode;
@@ -221,6 +225,8 @@ import io.trino.sql.planner.plan.TableDeleteNode;
 import io.trino.sql.planner.plan.TableExecuteNode;
 import io.trino.sql.planner.plan.TableFinishNode;
 import io.trino.sql.planner.plan.TableFunctionNode;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughColumn;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughSpecification;
 import io.trino.sql.planner.plan.TableFunctionProcessorNode;
 import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.sql.planner.plan.TableWriterNode;
@@ -367,6 +373,8 @@ import static io.trino.util.SpatialJoinUtils.ST_INTERSECTS;
 import static io.trino.util.SpatialJoinUtils.ST_WITHIN;
 import static io.trino.util.SpatialJoinUtils.extractSupportedSpatialComparisons;
 import static io.trino.util.SpatialJoinUtils.extractSupportedSpatialFunctions;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.stream.Collectors.partitioningBy;
@@ -1656,13 +1664,92 @@ public class LocalExecutionPlanner
         @Override
         public PhysicalOperation visitTableFunction(TableFunctionNode node, LocalExecutionPlanContext context)
         {
-            throw new UnsupportedOperationException("execution by operator is not yet implemented for table function " + node.getName());
+            throw new IllegalStateException(format("Unexpected node: TableFunctionNode (%s)", node.getName()));
         }
 
         @Override
         public PhysicalOperation visitTableFunctionProcessor(TableFunctionProcessorNode node, LocalExecutionPlanContext context)
         {
-            throw new UnsupportedOperationException("execution by operator is not yet implemented for table function " + node.getName());
+            if (node.getSource().isEmpty()) {
+                throw new UnsupportedOperationException("table function operator is not yet implemented for table functions without input tables"); // TODO
+            }
+
+            PhysicalOperation source = node.getSource().orElseThrow().accept(this, context);
+
+            TableFunctionProcessorProvider processorProvider = plannerContext.getFunctionManager().getTableFunctionProcessorProvider(node.getHandle());
+
+            int properChannelsCount = node.getProperOutputs().size();
+
+            long passThroughSourcesCount = node.getPassThroughSpecifications().stream()
+                    .filter(PassThroughSpecification::declaredAsPassThrough)
+                    .count();
+
+            List<List<Integer>> requiredChannels = node.getRequiredSymbols().stream()
+                    .map(list -> getChannelsForSymbols(list, source.getLayout()))
+                    .collect(toImmutableList());
+
+            Optional<Map<Integer, Integer>> markerChannels = node.getMarkerSymbols()
+                    .map(map -> map.entrySet().stream()
+                            .collect(toImmutableMap(entry -> source.getLayout().get(entry.getKey()), entry -> source.getLayout().get(entry.getValue()))));
+
+            int channel = properChannelsCount;
+            ImmutableList.Builder<PassThroughColumnSpecification> passThroughColumnSpecifications = ImmutableList.builder();
+            for (PassThroughSpecification specification : node.getPassThroughSpecifications()) {
+                // the table function produces one index channel for each source declared as pass-through. They are laid out after the proper channels.
+                int indexChannel = specification.declaredAsPassThrough() ? channel++ : -1;
+                for (PassThroughColumn column : specification.columns()) {
+                    passThroughColumnSpecifications.add(new PassThroughColumnSpecification(column.isPartitioningColumn(), source.getLayout().get(column.symbol()), indexChannel));
+                }
+            }
+
+            List<Integer> partitionChannels = node.getSpecification()
+                    .map(DataOrganizationSpecification::getPartitionBy)
+                    .map(list -> getChannelsForSymbols(list, source.getLayout()))
+                    .orElse(ImmutableList.of());
+
+            List<Integer> sortChannels = ImmutableList.of();
+            List<SortOrder> sortOrders = ImmutableList.of();
+            if (node.getSpecification().flatMap(DataOrganizationSpecification::getOrderingScheme).isPresent()) {
+                OrderingScheme orderingScheme = node.getSpecification().flatMap(DataOrganizationSpecification::getOrderingScheme).orElseThrow();
+                sortChannels = getChannelsForSymbols(orderingScheme.getOrderBy(), source.getLayout());
+                sortOrders = orderingScheme.getOrderingList();
+            }
+
+            OperatorFactory operator = new TableFunctionOperatorFactory(
+                    context.getNextOperatorId(),
+                    node.getId(),
+                    processorProvider,
+                    node.getHandle().getFunctionHandle(),
+                    properChannelsCount,
+                    toIntExact(passThroughSourcesCount),
+                    requiredChannels,
+                    markerChannels,
+                    passThroughColumnSpecifications.build(),
+                    node.isPruneWhenEmpty(),
+                    partitionChannels,
+                    getChannelsForSymbols(ImmutableList.copyOf(node.getPrePartitioned()), source.getLayout()),
+                    sortChannels,
+                    sortOrders,
+                    node.getPreSorted(),
+                    source.getTypes(),
+                    10_000,
+                    pagesIndexFactory);
+
+            ImmutableMap.Builder<Symbol, Integer> outputMappings = ImmutableMap.builder();
+            for (int i = 0; i < node.getProperOutputs().size(); i++) {
+                outputMappings.put(node.getProperOutputs().get(i), i);
+            }
+            List<Symbol> passThroughSymbols = node.getPassThroughSpecifications().stream()
+                    .map(PassThroughSpecification::columns)
+                    .flatMap(Collection::stream)
+                    .map(PassThroughColumn::symbol)
+                    .collect(toImmutableList());
+            int outputChannel = properChannelsCount;
+            for (Symbol passThroughSymbol : passThroughSymbols) {
+                outputMappings.put(passThroughSymbol, outputChannel++);
+            }
+
+            return new PhysicalOperation(operator, outputMappings.buildOrThrow(), context, source);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -200,6 +200,7 @@ import io.trino.sql.planner.iterative.rule.RemoveRedundantOffset;
 import io.trino.sql.planner.iterative.rule.RemoveRedundantPredicateAboveTableScan;
 import io.trino.sql.planner.iterative.rule.RemoveRedundantSort;
 import io.trino.sql.planner.iterative.rule.RemoveRedundantSortBelowLimitWithTies;
+import io.trino.sql.planner.iterative.rule.RemoveRedundantTableFunction;
 import io.trino.sql.planner.iterative.rule.RemoveRedundantTopN;
 import io.trino.sql.planner.iterative.rule.RemoveRedundantWindow;
 import io.trino.sql.planner.iterative.rule.RemoveTrivialFilters;
@@ -438,6 +439,7 @@ public class PlanOptimizers
                                         new RemoveRedundantOffset(),
                                         new RemoveRedundantSort(),
                                         new RemoveRedundantSortBelowLimitWithTies(),
+                                        new RemoveRedundantTableFunction(),
                                         new RemoveRedundantTopN(),
                                         new RemoveRedundantDistinctLimit(),
                                         new ReplaceRedundantJoinWithSource(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -121,6 +121,7 @@ import io.trino.sql.planner.iterative.rule.PruneSpatialJoinChildrenColumns;
 import io.trino.sql.planner.iterative.rule.PruneSpatialJoinColumns;
 import io.trino.sql.planner.iterative.rule.PruneTableExecuteSourceColumns;
 import io.trino.sql.planner.iterative.rule.PruneTableFunctionProcessorColumns;
+import io.trino.sql.planner.iterative.rule.PruneTableFunctionProcessorSourceColumns;
 import io.trino.sql.planner.iterative.rule.PruneTableScanColumns;
 import io.trino.sql.planner.iterative.rule.PruneTableWriterSourceColumns;
 import io.trino.sql.planner.iterative.rule.PruneTopNColumns;
@@ -1019,6 +1020,7 @@ public class PlanOptimizers
                 new PruneSpatialJoinColumns(),
                 new PruneTableExecuteSourceColumns(),
                 new PruneTableFunctionProcessorColumns(),
+                new PruneTableFunctionProcessorSourceColumns(),
                 new PruneTableScanColumns(metadata),
                 new PruneTableWriterSourceColumns(),
                 new PruneTopNColumns(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -120,6 +120,7 @@ import io.trino.sql.planner.iterative.rule.PruneSortColumns;
 import io.trino.sql.planner.iterative.rule.PruneSpatialJoinChildrenColumns;
 import io.trino.sql.planner.iterative.rule.PruneSpatialJoinColumns;
 import io.trino.sql.planner.iterative.rule.PruneTableExecuteSourceColumns;
+import io.trino.sql.planner.iterative.rule.PruneTableFunctionProcessorColumns;
 import io.trino.sql.planner.iterative.rule.PruneTableScanColumns;
 import io.trino.sql.planner.iterative.rule.PruneTableWriterSourceColumns;
 import io.trino.sql.planner.iterative.rule.PruneTopNColumns;
@@ -1017,6 +1018,7 @@ public class PlanOptimizers
                 new PruneSpatialJoinChildrenColumns(),
                 new PruneSpatialJoinColumns(),
                 new PruneTableExecuteSourceColumns(),
+                new PruneTableFunctionProcessorColumns(),
                 new PruneTableScanColumns(metadata),
                 new PruneTableWriterSourceColumns(),
                 new PruneTopNColumns(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/SchedulingOrderVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SchedulingOrderVisitor.java
@@ -21,6 +21,7 @@ import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.planner.plan.SemiJoinNode;
 import io.trino.sql.planner.plan.SpatialJoinNode;
+import io.trino.sql.planner.plan.TableFunctionProcessorNode;
 import io.trino.sql.planner.plan.TableScanNode;
 
 import java.util.List;
@@ -85,6 +86,18 @@ public final class SchedulingOrderVisitor
         public Void visitTableScan(TableScanNode node, Void context)
         {
             schedulingOrder.accept(node.getId());
+            return null;
+        }
+
+        @Override
+        public Void visitTableFunctionProcessor(TableFunctionProcessorNode node, Void context)
+        {
+            if (node.getSource().isEmpty()) {
+                schedulingOrder.accept(node.getId());
+            }
+            else {
+                node.getSource().orElseThrow().accept(this, context);
+            }
             return null;
         }
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/SplitSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SplitSourceFactory.java
@@ -310,7 +310,11 @@ public class SplitSourceFactory
         public Map<PlanNodeId, SplitSource> visitTableFunctionProcessor(TableFunctionProcessorNode node, Void context)
         {
             if (node.getSource().isEmpty()) {
-                return ImmutableMap.of(); // TODO optional splits for table function without sources
+                // this is a source node, so produce splits
+                SplitSource splitSource = splitManager.getSplits(session, node.getHandle());
+                splitSources.add(splitSource);
+
+                return ImmutableMap.of(node.getId(), splitSource);
             }
 
             return node.getSource().orElseThrow().accept(this, context);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/SplitSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SplitSourceFactory.java
@@ -59,6 +59,7 @@ import io.trino.sql.planner.plan.StatisticsWriterNode;
 import io.trino.sql.planner.plan.TableDeleteNode;
 import io.trino.sql.planner.plan.TableExecuteNode;
 import io.trino.sql.planner.plan.TableFinishNode;
+import io.trino.sql.planner.plan.TableFunctionProcessorNode;
 import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.sql.planner.plan.TableWriterNode;
 import io.trino.sql.planner.plan.TopNNode;
@@ -303,6 +304,16 @@ public class SplitSourceFactory
         public Map<PlanNodeId, SplitSource> visitPatternRecognition(PatternRecognitionNode node, Void context)
         {
             return node.getSource().accept(this, context);
+        }
+
+        @Override
+        public Map<PlanNodeId, SplitSource> visitTableFunctionProcessor(TableFunctionProcessorNode node, Void context)
+        {
+            if (node.getSource().isEmpty()) {
+                return ImmutableMap.of(); // TODO optional splits for table function without sources
+            }
+
+            return node.getSource().orElseThrow().accept(this, context);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneTableFunctionProcessorColumns.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneTableFunctionProcessorColumns.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughColumn;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughSpecification;
+import io.trino.sql.planner.plan.TableFunctionProcessorNode;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.sql.planner.plan.Patterns.tableFunctionProcessor;
+
+/**
+ * TableFunctionProcessorNode has two kinds of outputs:
+ * - proper outputs, which are the columns produced by the table function,
+ * - pass-through outputs, which are the columns copied from table arguments.
+ * This rule filters out unreferenced pass-through symbols.
+ * Unreferenced proper symbols are not pruned, because there is currently no way
+ * to communicate to the table function the request for not producing certain columns.
+ * // TODO prune table function's proper outputs
+ */
+public class PruneTableFunctionProcessorColumns
+        extends ProjectOffPushDownRule<TableFunctionProcessorNode>
+{
+    public PruneTableFunctionProcessorColumns()
+    {
+        super(tableFunctionProcessor());
+    }
+
+    @Override
+    protected Optional<PlanNode> pushDownProjectOff(Context context, TableFunctionProcessorNode node, Set<Symbol> referencedOutputs)
+    {
+        List<PassThroughSpecification> prunedPassThroughSpecifications = node.getPassThroughSpecifications().stream()
+                .map(sourceSpecification -> {
+                    List<PassThroughColumn> prunedPassThroughColumns = sourceSpecification.columns().stream()
+                            .filter(column -> referencedOutputs.contains(column.symbol()))
+                            .collect(toImmutableList());
+                    return new PassThroughSpecification(sourceSpecification.declaredAsPassThrough(), prunedPassThroughColumns);
+                })
+                .collect(toImmutableList());
+
+        int originalPassThroughCount = node.getPassThroughSpecifications().stream()
+                .map(PassThroughSpecification::columns)
+                .mapToInt(List::size)
+                .sum();
+
+        int prunedPassThroughCount = prunedPassThroughSpecifications.stream()
+                .map(PassThroughSpecification::columns)
+                .mapToInt(List::size)
+                .sum();
+
+        if (originalPassThroughCount == prunedPassThroughCount) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new TableFunctionProcessorNode(
+                node.getId(),
+                node.getName(),
+                node.getProperOutputs(),
+                node.getSource(),
+                node.isPruneWhenEmpty(),
+                prunedPassThroughSpecifications,
+                node.getRequiredSymbols(),
+                node.getMarkerSymbols(),
+                node.getSpecification(),
+                node.getPrePartitioned(),
+                node.getPreSorted(),
+                node.getHashSymbol(),
+                node.getHandle()));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneTableFunctionProcessorSourceColumns.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneTableFunctionProcessorSourceColumns.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughColumn;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughSpecification;
+import io.trino.sql.planner.plan.TableFunctionProcessorNode;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.collect.Maps.filterKeys;
+import static io.trino.sql.planner.iterative.rule.Util.restrictOutputs;
+import static io.trino.sql.planner.plan.Patterns.tableFunctionProcessor;
+
+/**
+ * This rule prunes unreferenced outputs of TableFunctionProcessorNode.
+ * First, it extracts all symbols required for:
+ * - pass-through
+ * - table function computation
+ * - partitioning and ordering (including the hashSymbol)
+ * Next, a mapping of input symbols to marker symbols is updated
+ * so that it only contains mappings for the required symbols.
+ * Last, all the remaining marker symbols are added to the collection
+ * of required symbols.
+ * Any source output symbols not included in the required symbols
+ * can be pruned.
+ */
+public class PruneTableFunctionProcessorSourceColumns
+        implements Rule<TableFunctionProcessorNode>
+{
+    private static final Pattern<TableFunctionProcessorNode> PATTERN = tableFunctionProcessor();
+
+    @Override
+    public Pattern<TableFunctionProcessorNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(TableFunctionProcessorNode node, Captures captures, Context context)
+    {
+        if (node.getSource().isEmpty()) {
+            return Result.empty();
+        }
+
+        ImmutableSet.Builder<Symbol> requiredInputs = ImmutableSet.builder();
+
+        node.getPassThroughSpecifications().stream()
+                .map(PassThroughSpecification::columns)
+                .flatMap(Collection::stream)
+                .map(PassThroughColumn::symbol)
+                .forEach(requiredInputs::add);
+
+        node.getRequiredSymbols().stream()
+                .forEach(requiredInputs::addAll);
+
+        node.getSpecification().ifPresent(specification -> {
+            requiredInputs.addAll(specification.getPartitionBy());
+            specification.getOrderingScheme().ifPresent(orderingScheme -> requiredInputs.addAll(orderingScheme.getOrderBy()));
+        });
+
+        node.getHashSymbol().ifPresent(requiredInputs::add);
+
+        Optional<Map<Symbol, Symbol>> prunedMarkerSymbols = node.getMarkerSymbols()
+                .map(mapping -> filterKeys(mapping, requiredInputs.build()::contains));
+
+        prunedMarkerSymbols.ifPresent(mapping -> requiredInputs.addAll(mapping.values()));
+
+        return restrictOutputs(context.getIdAllocator(), node.getSource().orElseThrow(), requiredInputs.build())
+                .map(child -> Result.ofPlanNode(new TableFunctionProcessorNode(
+                        node.getId(),
+                        node.getName(),
+                        node.getProperOutputs(),
+                        Optional.of(child),
+                        node.isPruneWhenEmpty(),
+                        node.getPassThroughSpecifications(),
+                        node.getRequiredSymbols(),
+                        prunedMarkerSymbols,
+                        node.getSpecification(),
+                        node.getPrePartitioned(),
+                        node.getPreSorted(),
+                        node.getHashSymbol(),
+                        node.getHandle())))
+                .orElse(Result.empty());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantTableFunction.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantTableFunction.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.TableFunctionProcessorNode;
+import io.trino.sql.planner.plan.ValuesNode;
+
+import static io.trino.sql.planner.optimizations.QueryCardinalityUtil.isEmpty;
+import static io.trino.sql.planner.plan.Patterns.tableFunctionProcessor;
+
+/**
+ * Table function can take multiple table arguments. Each argument is either "prune when empty" or "keep when empty".
+ * "Prune when empty" means that if this argument has no rows, the function result is empty, so the function can be
+ * removed from the plan, and replaced with empty values.
+ * "Keep when empty" means that even if the argument has no rows, the function should still be executed, and it can
+ * return a non-empty result.
+ * All the table arguments are combined into a single source of a TableFunctionProcessorNode. If either argument is
+ * "prune when empty", the overall result is "prune when empty". This rule removes a redundant TableFunctionProcessorNode
+ * based on the "prune when empty" property.
+ */
+public class RemoveRedundantTableFunction
+        implements Rule<TableFunctionProcessorNode>
+{
+    private static final Pattern<TableFunctionProcessorNode> PATTERN = tableFunctionProcessor();
+
+    @Override
+    public Pattern<TableFunctionProcessorNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(TableFunctionProcessorNode node, Captures captures, Context context)
+    {
+        if (node.isPruneWhenEmpty() && node.getSource().isPresent()) {
+            if (isEmpty(node.getSource().orElseThrow(), context.getLookup())) {
+                return Result.ofPlanNode(new ValuesNode(node.getId(), node.getOutputSymbols(), ImmutableList.of()));
+            }
+        }
+
+        return Result.empty();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
@@ -381,6 +381,7 @@ public class SymbolMapper
             newPassThroughSpecifications.add(new PassThroughSpecification(specification.declaredAsPassThrough(), newColumns.build()));
         }
 
+        // rewrite required symbols without deduplication. the table function expects specific input layout
         List<List<Symbol>> newRequiredSymbols = node.getRequiredSymbols().stream()
                 .map(this::map)
                 .collect(toImmutableList());
@@ -396,6 +397,7 @@ public class SymbolMapper
                                     return first;
                                 })));
 
+        // rewrite and deduplicate specification
         Optional<SpecificationWithPreSortedPrefix> newSpecification = node.getSpecification().map(specification -> mapAndDistinct(specification, node.getPreSorted()));
 
         return new TableFunctionProcessorNode(

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -83,6 +83,7 @@ import io.trino.spi.connector.TableScanRedirectApplicationResult;
 import io.trino.spi.connector.TopNApplicationResult;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.function.FunctionProvider;
 import io.trino.spi.metrics.Metrics;
 import io.trino.spi.procedure.Procedure;
 import io.trino.spi.ptf.ConnectorTableFunction;
@@ -159,6 +160,7 @@ public class MockConnector
     private final Set<Procedure> procedures;
     private final Set<TableProcedureMetadata> tableProcedures;
     private final Set<ConnectorTableFunction> tableFunctions;
+    private final Optional<FunctionProvider> functionProvider;
     private final boolean supportsReportingWrittenBytes;
     private final boolean allowMissingColumnsOnInsert;
     private final Supplier<List<PropertyMetadata<?>>> analyzeProperties;
@@ -201,6 +203,7 @@ public class MockConnector
             Set<Procedure> procedures,
             Set<TableProcedureMetadata> tableProcedures,
             Set<ConnectorTableFunction> tableFunctions,
+            Optional<FunctionProvider> functionProvider,
             boolean allowMissingColumnsOnInsert,
             Supplier<List<PropertyMetadata<?>>> analyzeProperties,
             Supplier<List<PropertyMetadata<?>>> schemaProperties,
@@ -241,6 +244,7 @@ public class MockConnector
         this.procedures = requireNonNull(procedures, "procedures is null");
         this.tableProcedures = requireNonNull(tableProcedures, "tableProcedures is null");
         this.tableFunctions = requireNonNull(tableFunctions, "tableFunctions is null");
+        this.functionProvider = requireNonNull(functionProvider, "functionProvider is null");
         this.supportsReportingWrittenBytes = supportsReportingWrittenBytes;
         this.allowMissingColumnsOnInsert = allowMissingColumnsOnInsert;
         this.analyzeProperties = requireNonNull(analyzeProperties, "analyzeProperties is null");
@@ -331,6 +335,12 @@ public class MockConnector
     public Set<ConnectorTableFunction> getTableFunctions()
     {
         return tableFunctions;
+    }
+
+    @Override
+    public Optional<FunctionProvider> getFunctionProvider()
+    {
+        return functionProvider;
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
@@ -49,6 +49,7 @@ import io.trino.spi.connector.TableScanRedirectApplicationResult;
 import io.trino.spi.connector.TopNApplicationResult;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.function.FunctionProvider;
 import io.trino.spi.metrics.Metrics;
 import io.trino.spi.procedure.Procedure;
 import io.trino.spi.ptf.ConnectorTableFunction;
@@ -111,6 +112,7 @@ public class MockConnectorFactory
     private final Set<Procedure> procedures;
     private final Set<TableProcedureMetadata> tableProcedures;
     private final Set<ConnectorTableFunction> tableFunctions;
+    private final Optional<FunctionProvider> functionProvider;
     private final boolean allowMissingColumnsOnInsert;
     private final Supplier<List<PropertyMetadata<?>>> analyzeProperties;
     private final Supplier<List<PropertyMetadata<?>>> schemaProperties;
@@ -155,6 +157,7 @@ public class MockConnectorFactory
             Set<Procedure> procedures,
             Set<TableProcedureMetadata> tableProcedures,
             Set<ConnectorTableFunction> tableFunctions,
+            Optional<FunctionProvider> functionProvider,
             Supplier<List<PropertyMetadata<?>>> analyzeProperties,
             Supplier<List<PropertyMetadata<?>>> schemaProperties,
             Supplier<List<PropertyMetadata<?>>> tableProperties,
@@ -203,6 +206,7 @@ public class MockConnectorFactory
         this.procedures = requireNonNull(procedures, "procedures is null");
         this.tableProcedures = requireNonNull(tableProcedures, "tableProcedures is null");
         this.tableFunctions = requireNonNull(tableFunctions, "tableFunctions is null");
+        this.functionProvider = requireNonNull(functionProvider, "functionProvider is null");
         this.allowMissingColumnsOnInsert = allowMissingColumnsOnInsert;
         this.supportsReportingWrittenBytes = supportsReportingWrittenBytes;
     }
@@ -250,6 +254,7 @@ public class MockConnectorFactory
                 procedures,
                 tableProcedures,
                 tableFunctions,
+                functionProvider,
                 allowMissingColumnsOnInsert,
                 analyzeProperties,
                 schemaProperties,
@@ -375,6 +380,7 @@ public class MockConnectorFactory
         private Set<Procedure> procedures = ImmutableSet.of();
         private Set<TableProcedureMetadata> tableProcedures = ImmutableSet.of();
         private Set<ConnectorTableFunction> tableFunctions = ImmutableSet.of();
+        private Optional<FunctionProvider> functionProvider = Optional.empty();
         private Supplier<List<PropertyMetadata<?>>> analyzeProperties = ImmutableList::of;
         private Supplier<List<PropertyMetadata<?>>> schemaProperties = ImmutableList::of;
         private Supplier<List<PropertyMetadata<?>>> tableProperties = ImmutableList::of;
@@ -597,6 +603,12 @@ public class MockConnectorFactory
             return this;
         }
 
+        public Builder withFunctionProvider(Optional<FunctionProvider> functionProvider)
+        {
+            this.functionProvider = requireNonNull(functionProvider, "functionProvider is null");
+            return this;
+        }
+
         public Builder withAnalyzeProperties(Supplier<List<PropertyMetadata<?>>> analyzeProperties)
         {
             this.analyzeProperties = requireNonNull(analyzeProperties, "analyzeProperties is null");
@@ -712,6 +724,7 @@ public class MockConnectorFactory
                     procedures,
                     tableProcedures,
                     tableFunctions,
+                    functionProvider,
                     analyzeProperties,
                     schemaProperties,
                     tableProperties,

--- a/core/trino-main/src/test/java/io/trino/connector/TestingTableFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/connector/TestingTableFunctions.java
@@ -13,8 +13,13 @@
  */
 package io.trino.connector;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.SchemaTableName;
@@ -27,20 +32,35 @@ import io.trino.spi.ptf.DescriptorArgumentSpecification;
 import io.trino.spi.ptf.ReturnTypeSpecification.DescribedTable;
 import io.trino.spi.ptf.ScalarArgument;
 import io.trino.spi.ptf.ScalarArgumentSpecification;
+import io.trino.spi.ptf.TableArgument;
 import io.trino.spi.ptf.TableArgumentSpecification;
 import io.trino.spi.ptf.TableFunctionAnalysis;
+import io.trino.spi.ptf.TableFunctionProcessor;
+import io.trino.spi.ptf.TableFunctionProcessorProvider;
+import io.trino.spi.ptf.TableFunctionProcessorState;
+import io.trino.spi.ptf.TableFunctionProcessorState.Processed;
+import io.trino.spi.type.RowType;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.IntStream;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.ptf.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
 import static io.trino.spi.ptf.ReturnTypeSpecification.OnlyPassThrough.ONLY_PASS_THROUGH;
+import static io.trino.spi.ptf.TableFunctionProcessorState.Finished.FINISHED;
+import static io.trino.spi.ptf.TableFunctionProcessorState.Processed.produced;
+import static io.trino.spi.ptf.TableFunctionProcessorState.Processed.usedInput;
+import static io.trino.spi.ptf.TableFunctionProcessorState.Processed.usedInputAndProduced;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
 
 public class TestingTableFunctions
 {
@@ -442,5 +462,612 @@ public class TestingTableFunctions
         {
             return tableHandle;
         }
+    }
+
+    // for testing execution by operator
+
+    public static class IdentityFunction
+            extends AbstractConnectorTableFunction
+    {
+        public IdentityFunction()
+        {
+            super(
+                    SCHEMA_NAME,
+                    "identity_function",
+                    ImmutableList.of(
+                            TableArgumentSpecification.builder()
+                                    .name("INPUT")
+                                    .keepWhenEmpty()
+                                    .build()),
+                    GENERIC_TABLE);
+        }
+
+        @Override
+        public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
+        {
+            List<RowType.Field> inputColumns = ((TableArgument) arguments.get("INPUT")).getRowType().getFields();
+            Descriptor returnedType = new Descriptor(inputColumns.stream()
+                    .map(field -> new Descriptor.Field(field.getName().orElse("anonymous_column"), Optional.of(field.getType())))
+                    .collect(toImmutableList()));
+            return TableFunctionAnalysis.builder()
+                    .handle(new EmptyTableFunctionHandle())
+                    .returnedType(returnedType)
+                    .requiredColumns("INPUT", IntStream.range(0, inputColumns.size()).boxed().collect(toImmutableList()))
+                    .build();
+        }
+
+        public static class IdentityFunctionProcessorProvider
+                implements TableFunctionProcessorProvider
+        {
+            @Override
+            public TableFunctionProcessor get(ConnectorTableFunctionHandle handle)
+            {
+                return input -> {
+                    if (input == null) {
+                        return FINISHED;
+                    }
+                    Optional<Page> inputPage = getOnlyElement(input);
+                    return inputPage.map(Processed::usedInputAndProduced).orElseThrow();
+                };
+            }
+        }
+    }
+
+    public static class IdentityPassThroughFunction
+            extends AbstractConnectorTableFunction
+    {
+        public IdentityPassThroughFunction()
+        {
+            super(
+                    SCHEMA_NAME,
+                    "identity_pass_through_function",
+                    ImmutableList.of(
+                            TableArgumentSpecification.builder()
+                                    .name("INPUT")
+                                    .passThroughColumns()
+                                    .keepWhenEmpty()
+                                    .build()),
+                    ONLY_PASS_THROUGH);
+        }
+
+        @Override
+        public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
+        {
+            return TableFunctionAnalysis.builder()
+                    .handle(new EmptyTableFunctionHandle())
+                    .requiredColumns("INPUT", ImmutableList.of(0)) // per spec, function must require at least one column
+                    .build();
+        }
+
+        public static class IdentityPassThroughFunctionProcessorProvider
+                implements TableFunctionProcessorProvider
+        {
+            @Override
+            public TableFunctionProcessor get(ConnectorTableFunctionHandle handle)
+            {
+                return new IdentityPassThroughFunctionProcessor();
+            }
+        }
+
+        public static class IdentityPassThroughFunctionProcessor
+                implements TableFunctionProcessor
+        {
+            private long processedPositions; // stateful
+
+            @Override
+            public TableFunctionProcessorState process(List<Optional<Page>> input)
+            {
+                if (input == null) {
+                    return FINISHED;
+                }
+
+                Page page = getOnlyElement(input).orElseThrow();
+                BlockBuilder builder = BIGINT.createBlockBuilder(null, page.getPositionCount());
+                for (long index = processedPositions; index < processedPositions + page.getPositionCount(); index++) {
+                    // TODO check for long overflow
+                    builder.writeLong(index);
+                }
+                processedPositions = processedPositions + page.getPositionCount();
+                return usedInputAndProduced(new Page(builder.build()));
+            }
+        }
+    }
+
+    public static class RepeatFunction
+            extends AbstractConnectorTableFunction
+    {
+        public RepeatFunction()
+        {
+            super(
+                    SCHEMA_NAME,
+                    "repeat",
+                    ImmutableList.of(
+                            TableArgumentSpecification.builder()
+                                    .name("INPUT")
+                                    .passThroughColumns()
+                                    .keepWhenEmpty()
+                                    .build(),
+                            ScalarArgumentSpecification.builder()
+                                    .name("N")
+                                    .type(INTEGER)
+                                    .defaultValue(2L)
+                                    .build()),
+                    ONLY_PASS_THROUGH);
+        }
+
+        @Override
+        public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
+        {
+            ScalarArgument count = (ScalarArgument) arguments.get("N");
+            requireNonNull(count.getValue(), "count value for function repeat() is null");
+            checkArgument((long) count.getValue() > 0, "count value for function repeat() must be positive");
+
+            return TableFunctionAnalysis.builder()
+                    .handle(new RepeatFunctionHandle((long) count.getValue()))
+                    .requiredColumns("INPUT", ImmutableList.of(0)) // per spec, function must require at least one column
+                    .build();
+        }
+
+        public static class RepeatFunctionHandle
+                implements ConnectorTableFunctionHandle
+        {
+            private final long count;
+
+            @JsonCreator
+            public RepeatFunctionHandle(@JsonProperty("count") long count)
+            {
+                this.count = count;
+            }
+
+            @JsonProperty
+            public long getCount()
+            {
+                return count;
+            }
+        }
+
+        public static class RepeatFunctionProcessorProvider
+                implements TableFunctionProcessorProvider
+        {
+            @Override
+            public TableFunctionProcessor get(ConnectorTableFunctionHandle handle)
+            {
+                return new RepeatFunctionProcessor(((RepeatFunctionHandle) handle).getCount());
+            }
+        }
+
+        public static class RepeatFunctionProcessor
+                implements TableFunctionProcessor
+        {
+            private final long count;
+
+            // stateful
+            private long processedPositions;
+            private long processedRounds;
+            private Block indexes;
+            boolean usedData;
+
+            public RepeatFunctionProcessor(long count)
+            {
+                this.count = count;
+            }
+
+            @Override
+            public TableFunctionProcessorState process(List<Optional<Page>> input)
+            {
+                if (input == null) {
+                    if (processedRounds < count && indexes != null) {
+                        processedRounds++;
+                        return produced(new Page(indexes));
+                    }
+                    return FINISHED;
+                }
+
+                Page page = getOnlyElement(input).orElseThrow();
+                if (processedRounds == 0) {
+                    BlockBuilder builder = BIGINT.createBlockBuilder(null, page.getPositionCount());
+                    for (long index = processedPositions; index < processedPositions + page.getPositionCount(); index++) {
+                        // TODO check for long overflow
+                        builder.writeLong(index);
+                    }
+                    processedPositions = processedPositions + page.getPositionCount();
+                    indexes = builder.build();
+                    usedData = true;
+                }
+                else {
+                    usedData = false;
+                }
+                processedRounds++;
+
+                Page result = new Page(indexes);
+
+                if (processedRounds == count) {
+                    processedRounds = 0;
+                    indexes = null;
+                }
+
+                if (usedData) {
+                    return usedInputAndProduced(result);
+                }
+                return produced(result);
+            }
+        }
+    }
+
+    public static class EmptyOutputFunction
+            extends AbstractConnectorTableFunction
+    {
+        public EmptyOutputFunction()
+        {
+            super(
+                    SCHEMA_NAME,
+                    "empty_output",
+                    ImmutableList.of(TableArgumentSpecification.builder()
+                            .name("INPUT")
+                            .keepWhenEmpty()
+                            .build()),
+                    new DescribedTable(new Descriptor(ImmutableList.of(new Descriptor.Field("column", Optional.of(BOOLEAN))))));
+        }
+
+        @Override
+        public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
+        {
+            return TableFunctionAnalysis.builder()
+                    .handle(new EmptyTableFunctionHandle())
+                    .requiredColumns("INPUT", IntStream.range(0, ((TableArgument) arguments.get("INPUT")).getRowType().getFields().size()).boxed().collect(toImmutableList()))
+                    .build();
+        }
+
+        public static class EmptyOutputProcessorProvider
+                implements TableFunctionProcessorProvider
+        {
+            @Override
+            public TableFunctionProcessor get(ConnectorTableFunctionHandle handle)
+            {
+                return new EmptyOutputProcessor();
+            }
+        }
+
+        // returns an empty Page (one column, zero rows) for each Page of input
+        private static class EmptyOutputProcessor
+                implements TableFunctionProcessor
+        {
+            private static final Page EMPTY_PAGE = new Page(BOOLEAN.createBlockBuilder(null, 0).build());
+
+            @Override
+            public TableFunctionProcessorState process(List<Optional<Page>> input)
+            {
+                if (input == null) {
+                    return FINISHED;
+                }
+                return usedInputAndProduced(EMPTY_PAGE);
+            }
+        }
+    }
+
+    public static class EmptyOutputWithPassThroughFunction
+            extends AbstractConnectorTableFunction
+    {
+        public EmptyOutputWithPassThroughFunction()
+        {
+            super(
+                    SCHEMA_NAME,
+                    "empty_output_with_pass_through",
+                    ImmutableList.of(TableArgumentSpecification.builder()
+                            .name("INPUT")
+                            .keepWhenEmpty()
+                            .passThroughColumns()
+                            .build()),
+                    new DescribedTable(new Descriptor(ImmutableList.of(new Descriptor.Field("column", Optional.of(BOOLEAN))))));
+        }
+
+        @Override
+        public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
+        {
+            return TableFunctionAnalysis.builder()
+                    .handle(new EmptyTableFunctionHandle())
+                    .requiredColumns("INPUT", IntStream.range(0, ((TableArgument) arguments.get("INPUT")).getRowType().getFields().size()).boxed().collect(toImmutableList()))
+                    .build();
+        }
+
+        public static class EmptyOutputWithPassThroughProcessorProvider
+                implements TableFunctionProcessorProvider
+        {
+            @Override
+            public TableFunctionProcessor get(ConnectorTableFunctionHandle handle)
+            {
+                return new EmptyOutputWithPassThroughProcessor();
+            }
+        }
+
+        // returns an empty Page (one proper column and pass-through, zero rows) for each Page of input
+        private static class EmptyOutputWithPassThroughProcessor
+                implements TableFunctionProcessor
+        {
+            // one proper channel, and one pass-through index channel
+            private static final Page EMPTY_PAGE = new Page(
+                    BOOLEAN.createBlockBuilder(null, 0).build(),
+                    BIGINT.createBlockBuilder(null, 0).build());
+
+            @Override
+            public TableFunctionProcessorState process(List<Optional<Page>> input)
+            {
+                if (input == null) {
+                    return FINISHED;
+                }
+                return usedInputAndProduced(EMPTY_PAGE);
+            }
+        }
+    }
+
+    public static class TestInputsFunction
+            extends AbstractConnectorTableFunction
+    {
+        public TestInputsFunction()
+        {
+            super(
+                    SCHEMA_NAME,
+                    "test_inputs_function",
+                    ImmutableList.of(
+                            TableArgumentSpecification.builder()
+                                    .rowSemantics()
+                                    .name("INPUT_1")
+                                    .build(),
+                            TableArgumentSpecification.builder()
+                                    .name("INPUT_2")
+                                    .keepWhenEmpty()
+                                    .build(),
+                            TableArgumentSpecification.builder()
+                                    .name("INPUT_3")
+                                    .keepWhenEmpty()
+                                    .build(),
+                            TableArgumentSpecification.builder()
+                                    .name("INPUT_4")
+                                    .keepWhenEmpty()
+                                    .build()),
+                    new DescribedTable(new Descriptor(ImmutableList.of(new Descriptor.Field("boolean_result", Optional.of(BOOLEAN))))));
+        }
+
+        @Override
+        public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
+        {
+            return TableFunctionAnalysis.builder()
+                    .handle(new EmptyTableFunctionHandle())
+                    .requiredColumns("INPUT_1", IntStream.range(0, ((TableArgument) arguments.get("INPUT_1")).getRowType().getFields().size()).boxed().collect(toImmutableList()))
+                    .requiredColumns("INPUT_2", IntStream.range(0, ((TableArgument) arguments.get("INPUT_2")).getRowType().getFields().size()).boxed().collect(toImmutableList()))
+                    .requiredColumns("INPUT_3", IntStream.range(0, ((TableArgument) arguments.get("INPUT_3")).getRowType().getFields().size()).boxed().collect(toImmutableList()))
+                    .requiredColumns("INPUT_4", IntStream.range(0, ((TableArgument) arguments.get("INPUT_4")).getRowType().getFields().size()).boxed().collect(toImmutableList()))
+                    .build();
+        }
+
+        public static class TestInputsFunctionProcessorProvider
+                implements TableFunctionProcessorProvider
+        {
+            @Override
+            public TableFunctionProcessor get(ConnectorTableFunctionHandle handle)
+            {
+                BlockBuilder resultBuilder = BOOLEAN.createBlockBuilder(null, 1);
+                BOOLEAN.writeBoolean(resultBuilder, true);
+
+                Page result = new Page(resultBuilder.build());
+
+                return input -> {
+                    if (input == null) {
+                        return FINISHED;
+                    }
+                    return usedInputAndProduced(result);
+                };
+            }
+        }
+    }
+
+    public static class PassThroughInputFunction
+            extends AbstractConnectorTableFunction
+    {
+        public PassThroughInputFunction()
+        {
+            super(
+                    SCHEMA_NAME,
+                    "pass_through",
+                    ImmutableList.of(
+                            TableArgumentSpecification.builder()
+                                    .name("INPUT_1")
+                                    .passThroughColumns()
+                                    .keepWhenEmpty()
+                                    .build(),
+                            TableArgumentSpecification.builder()
+                                    .name("INPUT_2")
+                                    .passThroughColumns()
+                                    .keepWhenEmpty()
+                                    .build()),
+                    new DescribedTable(new Descriptor(ImmutableList.of(
+                            new Descriptor.Field("input_1_present", Optional.of(BOOLEAN)),
+                            new Descriptor.Field("input_2_present", Optional.of(BOOLEAN))))));
+        }
+
+        @Override
+        public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
+        {
+            return TableFunctionAnalysis.builder()
+                    .handle(new EmptyTableFunctionHandle())
+                    .requiredColumns("INPUT_1", ImmutableList.of(0))
+                    .requiredColumns("INPUT_2", ImmutableList.of(0))
+                    .build();
+        }
+
+        public static class PassThroughInputProcessorProvider
+                implements TableFunctionProcessorProvider
+        {
+            @Override
+            public TableFunctionProcessor get(ConnectorTableFunctionHandle handle)
+            {
+                return new PassThroughInputProcessor();
+            }
+        }
+
+        private static class PassThroughInputProcessor
+                implements TableFunctionProcessor
+        {
+            private boolean input1Present;
+            private boolean input2Present;
+            private int input1EndIndex;
+            private int input2EndIndex;
+            private boolean finished;
+
+            @Override
+            public TableFunctionProcessorState process(List<Optional<Page>> input)
+            {
+                if (finished) {
+                    return FINISHED;
+                }
+                if (input == null) {
+                    finished = true;
+
+                    // proper column input_1_present
+                    BlockBuilder input1Builder = BOOLEAN.createBlockBuilder(null, 1);
+                    BOOLEAN.writeBoolean(input1Builder, input1Present);
+
+                    // proper column input_2_present
+                    BlockBuilder input2Builder = BOOLEAN.createBlockBuilder(null, 1);
+                    BOOLEAN.writeBoolean(input2Builder, input2Present);
+
+                    // pass-through index for input_1
+                    BlockBuilder input1PassThroughBuilder = BIGINT.createBlockBuilder(null, 1);
+                    if (input1Present) {
+                        input1PassThroughBuilder.writeLong(input1EndIndex - 1);
+                    }
+                    else {
+                        input1PassThroughBuilder.appendNull();
+                    }
+
+                    // pass-through index for input_2
+                    BlockBuilder input2PassThroughBuilder = BIGINT.createBlockBuilder(null, 1);
+                    if (input2Present) {
+                        input2PassThroughBuilder.writeLong(input2EndIndex - 1);
+                    }
+                    else {
+                        input2PassThroughBuilder.appendNull();
+                    }
+
+                    return produced(new Page(input1Builder.build(), input2Builder.build(), input1PassThroughBuilder.build(), input2PassThroughBuilder.build()));
+                }
+                input.get(0).ifPresent(page -> {
+                    input1Present = true;
+                    input1EndIndex += page.getPositionCount();
+                });
+                input.get(1).ifPresent(page -> {
+                    input2Present = true;
+                    input2EndIndex += page.getPositionCount();
+                });
+                return usedInput();
+            }
+        }
+    }
+
+    public static class TestInputFunction
+            extends AbstractConnectorTableFunction
+    {
+        public TestInputFunction()
+        {
+            super(
+                    SCHEMA_NAME,
+                    "test_input",
+                    ImmutableList.of(TableArgumentSpecification.builder()
+                            .name("INPUT")
+                            .keepWhenEmpty()
+                            .build()),
+                    new DescribedTable(new Descriptor(ImmutableList.of(new Descriptor.Field("got_input", Optional.of(BOOLEAN))))));
+        }
+
+        @Override
+        public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
+        {
+            return TableFunctionAnalysis.builder()
+                    .handle(new EmptyTableFunctionHandle())
+                    .requiredColumns("INPUT", IntStream.range(0, ((TableArgument) arguments.get("INPUT")).getRowType().getFields().size()).boxed().collect(toImmutableList()))
+                    .build();
+        }
+
+        public static class TestInputProcessorProvider
+                implements TableFunctionProcessorProvider
+        {
+            @Override
+            public TableFunctionProcessor get(ConnectorTableFunctionHandle handle)
+            {
+                return new TestInputProcessor();
+            }
+        }
+
+        private static class TestInputProcessor
+                implements TableFunctionProcessor
+        {
+            private boolean processorGotInput;
+            private boolean finished;
+
+            @Override
+            public TableFunctionProcessorState process(List<Optional<Page>> input)
+            {
+                if (finished) {
+                    return FINISHED;
+                }
+                if (input == null) {
+                    finished = true;
+                    BlockBuilder builder = BOOLEAN.createBlockBuilder(null, 1);
+                    BOOLEAN.writeBoolean(builder, processorGotInput);
+                    return produced(new Page(builder.build()));
+                }
+                processorGotInput = true;
+                return usedInput();
+            }
+        }
+    }
+
+    public static class TestSingleInputRowSemanticsFunction
+            extends AbstractConnectorTableFunction
+    {
+        public TestSingleInputRowSemanticsFunction()
+        {
+            super(
+                    SCHEMA_NAME,
+                    "test_single_input_function",
+                    ImmutableList.of(TableArgumentSpecification.builder()
+                            .rowSemantics()
+                            .name("INPUT")
+                            .build()),
+                    new DescribedTable(new Descriptor(ImmutableList.of(new Descriptor.Field("boolean_result", Optional.of(BOOLEAN))))));
+        }
+
+        @Override
+        public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
+        {
+            return TableFunctionAnalysis.builder()
+                    .handle(new EmptyTableFunctionHandle())
+                    .requiredColumns("INPUT", IntStream.range(0, ((TableArgument) arguments.get("INPUT")).getRowType().getFields().size()).boxed().collect(toImmutableList()))
+                    .build();
+        }
+
+        public static class TestSingleInputFunctionProcessorProvider
+                implements TableFunctionProcessorProvider
+        {
+            @Override
+            public TableFunctionProcessor get(ConnectorTableFunctionHandle handle)
+            {
+                BlockBuilder builder = BOOLEAN.createBlockBuilder(null, 1);
+                BOOLEAN.writeBoolean(builder, true);
+                Page result = new Page(builder.build());
+
+                return input -> {
+                    if (input == null) {
+                        return FINISHED;
+                    }
+                    return usedInputAndProduced(result);
+                };
+            }
+        }
+    }
+
+    public static class EmptyTableFunctionHandle
+            implements ConnectorTableFunctionHandle
+    {
     }
 }

--- a/core/trino-main/src/test/java/io/trino/connector/TestingTableFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/connector/TestingTableFunctions.java
@@ -35,7 +35,7 @@ import io.trino.spi.ptf.ScalarArgumentSpecification;
 import io.trino.spi.ptf.TableArgument;
 import io.trino.spi.ptf.TableArgumentSpecification;
 import io.trino.spi.ptf.TableFunctionAnalysis;
-import io.trino.spi.ptf.TableFunctionProcessor;
+import io.trino.spi.ptf.TableFunctionDataProcessor;
 import io.trino.spi.ptf.TableFunctionProcessorProvider;
 import io.trino.spi.ptf.TableFunctionProcessorState;
 import io.trino.spi.ptf.TableFunctionProcessorState.Processed;
@@ -500,7 +500,7 @@ public class TestingTableFunctions
                 implements TableFunctionProcessorProvider
         {
             @Override
-            public TableFunctionProcessor get(ConnectorTableFunctionHandle handle)
+            public TableFunctionDataProcessor getDataProcessor(ConnectorTableFunctionHandle handle)
             {
                 return input -> {
                     if (input == null) {
@@ -543,14 +543,14 @@ public class TestingTableFunctions
                 implements TableFunctionProcessorProvider
         {
             @Override
-            public TableFunctionProcessor get(ConnectorTableFunctionHandle handle)
+            public TableFunctionDataProcessor getDataProcessor(ConnectorTableFunctionHandle handle)
             {
                 return new IdentityPassThroughFunctionProcessor();
             }
         }
 
         public static class IdentityPassThroughFunctionProcessor
-                implements TableFunctionProcessor
+                implements TableFunctionDataProcessor
         {
             private long processedPositions; // stateful
 
@@ -630,14 +630,14 @@ public class TestingTableFunctions
                 implements TableFunctionProcessorProvider
         {
             @Override
-            public TableFunctionProcessor get(ConnectorTableFunctionHandle handle)
+            public TableFunctionDataProcessor getDataProcessor(ConnectorTableFunctionHandle handle)
             {
                 return new RepeatFunctionProcessor(((RepeatFunctionHandle) handle).getCount());
             }
         }
 
         public static class RepeatFunctionProcessor
-                implements TableFunctionProcessor
+                implements TableFunctionDataProcessor
         {
             private final long count;
 
@@ -722,7 +722,7 @@ public class TestingTableFunctions
                 implements TableFunctionProcessorProvider
         {
             @Override
-            public TableFunctionProcessor get(ConnectorTableFunctionHandle handle)
+            public TableFunctionDataProcessor getDataProcessor(ConnectorTableFunctionHandle handle)
             {
                 return new EmptyOutputProcessor();
             }
@@ -730,7 +730,7 @@ public class TestingTableFunctions
 
         // returns an empty Page (one column, zero rows) for each Page of input
         private static class EmptyOutputProcessor
-                implements TableFunctionProcessor
+                implements TableFunctionDataProcessor
         {
             private static final Page EMPTY_PAGE = new Page(BOOLEAN.createBlockBuilder(null, 0).build());
 
@@ -774,7 +774,7 @@ public class TestingTableFunctions
                 implements TableFunctionProcessorProvider
         {
             @Override
-            public TableFunctionProcessor get(ConnectorTableFunctionHandle handle)
+            public TableFunctionDataProcessor getDataProcessor(ConnectorTableFunctionHandle handle)
             {
                 return new EmptyOutputWithPassThroughProcessor();
             }
@@ -782,7 +782,7 @@ public class TestingTableFunctions
 
         // returns an empty Page (one proper column and pass-through, zero rows) for each Page of input
         private static class EmptyOutputWithPassThroughProcessor
-                implements TableFunctionProcessor
+                implements TableFunctionDataProcessor
         {
             // one proper channel, and one pass-through index channel
             private static final Page EMPTY_PAGE = new Page(
@@ -844,7 +844,7 @@ public class TestingTableFunctions
                 implements TableFunctionProcessorProvider
         {
             @Override
-            public TableFunctionProcessor get(ConnectorTableFunctionHandle handle)
+            public TableFunctionDataProcessor getDataProcessor(ConnectorTableFunctionHandle handle)
             {
                 BlockBuilder resultBuilder = BOOLEAN.createBlockBuilder(null, 1);
                 BOOLEAN.writeBoolean(resultBuilder, true);
@@ -899,14 +899,14 @@ public class TestingTableFunctions
                 implements TableFunctionProcessorProvider
         {
             @Override
-            public TableFunctionProcessor get(ConnectorTableFunctionHandle handle)
+            public TableFunctionDataProcessor getDataProcessor(ConnectorTableFunctionHandle handle)
             {
                 return new PassThroughInputProcessor();
             }
         }
 
         private static class PassThroughInputProcessor
-                implements TableFunctionProcessor
+                implements TableFunctionDataProcessor
         {
             private boolean input1Present;
             private boolean input2Present;
@@ -992,14 +992,14 @@ public class TestingTableFunctions
                 implements TableFunctionProcessorProvider
         {
             @Override
-            public TableFunctionProcessor get(ConnectorTableFunctionHandle handle)
+            public TableFunctionDataProcessor getDataProcessor(ConnectorTableFunctionHandle handle)
             {
                 return new TestInputProcessor();
             }
         }
 
         private static class TestInputProcessor
-                implements TableFunctionProcessor
+                implements TableFunctionDataProcessor
         {
             private boolean processorGotInput;
             private boolean finished;
@@ -1050,7 +1050,7 @@ public class TestingTableFunctions
                 implements TableFunctionProcessorProvider
         {
             @Override
-            public TableFunctionProcessor get(ConnectorTableFunctionHandle handle)
+            public TableFunctionDataProcessor getDataProcessor(ConnectorTableFunctionHandle handle)
             {
                 BlockBuilder builder = BOOLEAN.createBlockBuilder(null, 1);
                 BOOLEAN.writeBoolean(builder, true);

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestTableFunctionInvocation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestTableFunctionInvocation.java
@@ -29,7 +29,6 @@ import io.trino.spi.ptf.Descriptor;
 import io.trino.spi.ptf.Descriptor.Field;
 import io.trino.sql.planner.assertions.BasePlanTest;
 import io.trino.sql.planner.assertions.RowNumberSymbolMatcher;
-import io.trino.sql.planner.optimizations.AddLocalExchanges;
 import io.trino.sql.planner.plan.TableFunctionProcessorNode;
 import io.trino.sql.tree.GenericLiteral;
 import io.trino.sql.tree.LongLiteral;
@@ -42,7 +41,6 @@ import static io.trino.spi.connector.SortOrder.ASC_NULLS_LAST;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.sql.planner.LogicalPlanner.Stage.CREATED;
-import static io.trino.sql.planner.LogicalPlanner.Stage.OPTIMIZED;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
@@ -202,7 +200,6 @@ public class TestTableFunctionInvocation
     {
         // all table function outputs are referenced with SELECT *, no pruning
         assertPlan("SELECT * FROM TABLE(mock.system.pass_through_function(input => TABLE(SELECT 1, true) t(a, b)))",
-                OPTIMIZED,
                 strictOutput(
                         ImmutableList.of("x", "a", "b"),
                         tableFunctionProcessor(
@@ -212,12 +209,10 @@ public class TestTableFunctionInvocation
                                         .passThroughSymbols(ImmutableList.of(ImmutableList.of("a", "b")))
                                         .requiredSymbols(ImmutableList.of(ImmutableList.of("a")))
                                         .specification(specification(ImmutableList.of(), ImmutableList.of(), ImmutableMap.of())),
-                                values(ImmutableList.of("a", "b"), ImmutableList.of(ImmutableList.of(new LongLiteral("1"), TRUE_LITERAL))))),
-                optimizer -> !(optimizer instanceof AddLocalExchanges)); // TODO remove the optimizer filter when TableFunctionProcessorNode is supported in StreamPropertyDerivations
+                                values(ImmutableList.of("a", "b"), ImmutableList.of(ImmutableList.of(new LongLiteral("1"), TRUE_LITERAL))))));
 
         // no table function outputs are referenced. All pass-through symbols are pruned from the TableFunctionProcessorNode. The unused symbol "b" is pruned from the source values node.
         assertPlan("SELECT 'constant' c FROM TABLE(mock.system.pass_through_function(input => TABLE(SELECT 1, true) t(a, b)))",
-                OPTIMIZED,
                 strictOutput(
                         ImmutableList.of("c"),
                         strictProject(
@@ -229,8 +224,7 @@ public class TestTableFunctionInvocation
                                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of()))
                                                 .requiredSymbols(ImmutableList.of(ImmutableList.of("a")))
                                                 .specification(specification(ImmutableList.of(), ImmutableList.of(), ImmutableMap.of())),
-                                        values(ImmutableList.of("a"), ImmutableList.of(ImmutableList.of(new LongLiteral("1"))))))),
-                optimizer -> !(optimizer instanceof AddLocalExchanges)); // TODO remove the optimizer filter when TableFunctionProcessorNode is supported in StreamPropertyDerivations
+                                        values(ImmutableList.of("a"), ImmutableList.of(ImmutableList.of(new LongLiteral("1"))))))));
     }
 
     @Test
@@ -269,11 +263,9 @@ public class TestTableFunctionInvocation
                                         input1 => TABLE(SELECT 1, true WHERE false) t1(a, b) KEEP WHEN EMPTY,
                                         input2 => TABLE(SELECT 2, false WHERE false) t2(c, d) KEEP WHEN EMPTY))
                         """,
-                OPTIMIZED,
                 output(
                         node(TableFunctionProcessorNode.class,
-                                values(ImmutableList.of("a", "marker_1", "c", "marker_2", "row_number")))),
-                optimizer -> !(optimizer instanceof AddLocalExchanges)); // TODO remove the optimizer filter when TableFunctionProcessorNode is supported in StreamPropertyDerivations
+                                values(ImmutableList.of("a", "marker_1", "c", "marker_2", "row_number")))));
 
         assertPlan("""
                         SELECT *
@@ -281,7 +273,6 @@ public class TestTableFunctionInvocation
                                         input1 => TABLE(SELECT 1, true WHERE false) t1(a, b) KEEP WHEN EMPTY,
                                         input2 => TABLE(SELECT 2, false) t2(c, d) PRUNE WHEN EMPTY))
                         """,
-                OPTIMIZED,
                 output(
                         node(TableFunctionProcessorNode.class,
                                 project(
@@ -289,7 +280,6 @@ public class TestTableFunctionInvocation
                                                 rowNumber(
                                                         builder -> builder.partitionBy(ImmutableList.of()),
                                                         values(ImmutableList.of("c"), ImmutableList.of(ImmutableList.of(new LongLiteral("2")))))
-                                                        .withAlias("input_2_row_number", new RowNumberSymbolMatcher()))))),
-                optimizer -> !(optimizer instanceof AddLocalExchanges)); // TODO remove the optimizer filter when TableFunctionProcessorNode is supported in StreamPropertyDerivations
+                                                        .withAlias("input_2_row_number", new RowNumberSymbolMatcher()))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/TableFunctionProcessorMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/TableFunctionProcessorMatcher.java
@@ -48,6 +48,7 @@ public class TableFunctionProcessorMatcher
     private final List<List<String>> requiredSymbols;
     private final Optional<Map<String, String>> markerSymbols;
     private final Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification;
+    private final Optional<String> hashSymbol;
 
     private TableFunctionProcessorMatcher(
             String name,
@@ -55,7 +56,8 @@ public class TableFunctionProcessorMatcher
             List<List<String>> passThroughSymbols,
             List<List<String>> requiredSymbols,
             Optional<Map<String, String>> markerSymbols,
-            Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification)
+            Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification,
+            Optional<String> hashSymbol)
     {
         this.name = requireNonNull(name, "name is null");
         this.properOutputs = ImmutableList.copyOf(properOutputs);
@@ -67,6 +69,7 @@ public class TableFunctionProcessorMatcher
                 .collect(toImmutableList());
         this.markerSymbols = markerSymbols.map(ImmutableMap::copyOf);
         this.specification = requireNonNull(specification, "specification is null");
+        this.hashSymbol = requireNonNull(hashSymbol, "hashSymbol is null");
     }
 
     @Override
@@ -142,6 +145,10 @@ public class TableFunctionProcessorMatcher
             }
         }
 
+        if (!hashSymbol.map(symbolAliases::get).equals(tableFunctionProcessorNode.getHashSymbol().map(Symbol::toSymbolReference))) {
+            return NO_MATCH;
+        }
+
         ImmutableMap.Builder<String, SymbolReference> properOutputsMapping = ImmutableMap.builder();
         for (int i = 0; i < properOutputs.size(); i++) {
             properOutputsMapping.put(properOutputs.get(i), tableFunctionProcessorNode.getProperOutputs().get(i).toSymbolReference());
@@ -164,6 +171,7 @@ public class TableFunctionProcessorMatcher
                 .add("requiredSymbols", requiredSymbols)
                 .add("markerSymbols", markerSymbols)
                 .add("specification", specification)
+                .add("hashSymbol", hashSymbol)
                 .toString();
     }
 
@@ -176,6 +184,7 @@ public class TableFunctionProcessorMatcher
         private List<List<String>> requiredSymbols = ImmutableList.of();
         private Optional<Map<String, String>> markerSymbols = Optional.empty();
         private Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification = Optional.empty();
+        private Optional<String> hashSymbol = Optional.empty();
 
         public Builder()
         {
@@ -223,11 +232,17 @@ public class TableFunctionProcessorMatcher
             return this;
         }
 
+        public Builder hashSymbol(String hashSymbol)
+        {
+            this.hashSymbol = Optional.of(hashSymbol);
+            return this;
+        }
+
         public PlanMatchPattern build()
         {
             PlanMatchPattern[] sources = source.map(sourcePattern -> new PlanMatchPattern[] {sourcePattern}).orElse(new PlanMatchPattern[] {});
             return node(TableFunctionProcessorNode.class, sources)
-                    .with(new TableFunctionProcessorMatcher(name, properOutputs, passThroughSymbols, requiredSymbols, markerSymbols, specification));
+                    .with(new TableFunctionProcessorMatcher(name, properOutputs, passThroughSymbols, requiredSymbols, markerSymbols, specification, hashSymbol));
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestImplementTableFunctionSource.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestImplementTableFunctionSource.java
@@ -88,7 +88,8 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableList.of(ImmutableList.of())),
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of()))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c"))),
                         values("c")));
 
         // pass-through columns
@@ -113,7 +114,8 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"))),
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c"))),
                         values("c")));
     }
 
@@ -144,6 +146,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of()))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c", "d")))
                                 .specification(specification(ImmutableList.of(), ImmutableList.of("d"), ImmutableMap.of("d", ASC_NULLS_LAST))),
                         values("c", "d")));
 
@@ -171,6 +174,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c", "d")))
                                 .specification(specification(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableMap.of("d", ASC_NULLS_LAST))),
                         values("c", "d")));
 
@@ -198,6 +202,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c", "d")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("d")))
                                 .specification(specification(ImmutableList.of("c"), ImmutableList.of(), ImmutableMap.of())),
                         values("c", "d")));
     }
@@ -240,6 +245,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e", "f")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("d"), ImmutableList.of("f")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_1",
@@ -326,6 +332,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e", "f"), ImmutableList.of()))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("d"), ImmutableList.of("f"), ImmutableList.of("h")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_1",
@@ -424,6 +431,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e", "f")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c", "d"), ImmutableList.of("f")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_1",
@@ -502,6 +510,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2"))
@@ -574,6 +583,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2"))
@@ -646,6 +656,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2"))
@@ -718,6 +729,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2"))
@@ -802,6 +814,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableList.of("e")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableList.of("e")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2",
@@ -922,6 +935,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableList.of("e"), ImmutableList.of("f")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableList.of("e"), ImmutableList.of("g")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2",
@@ -1052,6 +1066,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableList.of("e")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableList.of("e")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2",
@@ -1158,6 +1173,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e", "f")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c", "d"), ImmutableList.of("f")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "c_coerced", "marker_1",
@@ -1240,6 +1256,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c", "d"), ImmutableList.of("e", "f")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_1",
@@ -1321,6 +1338,7 @@ public class TestImplementTableFunctionSource
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e", "f")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("d"), ImmutableList.of("e")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_1",

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestImplementTableFunctionSource.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestImplementTableFunctionSource.java
@@ -15,7 +15,6 @@ package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.trino.sql.planner.OrderingScheme;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
@@ -88,7 +87,8 @@ public class TestImplementTableFunctionSource
                 })
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
-                                .properOutputs(ImmutableList.of("a", "b")),
+                                .properOutputs(ImmutableList.of("a", "b"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of())),
                         values("c")));
 
         // pass-through columns
@@ -113,7 +113,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c")),
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"))),
                         values("c")));
     }
 
@@ -143,6 +143,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of()))
                                 .specification(specification(ImmutableList.of(), ImmutableList.of("d"), ImmutableMap.of("d", ASC_NULLS_LAST))),
                         values("c", "d")));
 
@@ -169,7 +170,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c")))
                                 .specification(specification(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableMap.of("d", ASC_NULLS_LAST))),
                         values("c", "d")));
 
@@ -196,7 +197,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "d"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c", "d")))
                                 .specification(specification(ImmutableList.of("c"), ImmutableList.of(), ImmutableMap.of())),
                         values("c", "d")));
     }
@@ -238,7 +239,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "e", "f"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e", "f")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_1",
@@ -324,7 +325,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "e", "f"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e", "f"), ImmutableList.of()))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_1",
@@ -422,7 +423,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "e", "f"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e", "f")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_1",
@@ -500,7 +501,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "d"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2"))
@@ -572,7 +573,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "d"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2"))
@@ -644,7 +645,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "d"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2"))
@@ -716,7 +717,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "d"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2"))
@@ -800,7 +801,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "d", "e"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableList.of("e")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2",
@@ -920,7 +921,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "d", "e", "f"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableList.of("e"), ImmutableList.of("f")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2",
@@ -1050,7 +1051,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "d", "e"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableList.of("e")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_2",
@@ -1156,7 +1157,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "e", "f"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e", "f")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "c_coerced", "marker_1",
@@ -1238,7 +1239,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "d", "e", "f"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c", "d"), ImmutableList.of("e", "f")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_1",
@@ -1319,7 +1320,7 @@ public class TestImplementTableFunctionSource
                 .matches(PlanMatchPattern.tableFunctionProcessor(builder -> builder
                                 .name("test_function")
                                 .properOutputs(ImmutableList.of("a", "b"))
-                                .passThroughSymbols(ImmutableSet.of("c", "e", "f"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("c"), ImmutableList.of("e", "f")))
                                 .markerSymbols(ImmutableMap.of(
                                         "c", "marker_1",
                                         "d", "marker_1",

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneTableFunctionProcessorColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneTableFunctionProcessorColumns.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughColumn;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughSpecification;
+import org.testng.annotations.Test;
+
+import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.tableFunctionProcessor;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestPruneTableFunctionProcessorColumns
+        extends BaseRuleTest
+{
+    @Test
+    public void testDoNotPruneProperOutputs()
+    {
+        tester().assertThat(new PruneTableFunctionProcessorColumns())
+                .on(p -> p.project(
+                        Assignments.of(),
+                        p.tableFunctionProcessor(
+                                builder -> builder
+                                        .name("test_function")
+                                        .properOutputs(p.symbol("p"))
+                                        .source(p.values(p.symbol("x"))))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testPrunePassThroughOutputs()
+    {
+        tester().assertThat(new PruneTableFunctionProcessorColumns())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.project(
+                            Assignments.of(),
+                            p.tableFunctionProcessor(
+                                    builder -> builder
+                                            .name("test_function")
+                                            .passThroughSpecifications(
+                                                    new PassThroughSpecification(
+                                                            true,
+                                                            ImmutableList.of(
+                                                                    new PassThroughColumn(a, true),
+                                                                    new PassThroughColumn(b, false))))
+                                            .source(p.values(a, b))));
+                })
+                .matches(project(
+                        ImmutableMap.of(),
+                        tableFunctionProcessor(builder -> builder
+                                        .name("test_function")
+                                        .passThroughSymbols(ImmutableList.of(ImmutableList.of())),
+                                values("a", "b"))));
+
+        tester().assertThat(new PruneTableFunctionProcessorColumns())
+                .on(p -> {
+                    Symbol proper = p.symbol("proper");
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.project(
+                            Assignments.of(),
+                            p.tableFunctionProcessor(
+                                    builder -> builder
+                                            .name("test_function")
+                                            .properOutputs(proper)
+                                            .passThroughSpecifications(
+                                                    new PassThroughSpecification(
+                                                            true,
+                                                            ImmutableList.of(
+                                                                    new PassThroughColumn(a, true),
+                                                                    new PassThroughColumn(b, false))))
+                                            .source(p.values(a, b))));
+                })
+                .matches(project(
+                        ImmutableMap.of(),
+                        tableFunctionProcessor(builder -> builder
+                                        .name("test_function")
+                                        .properOutputs(ImmutableList.of("proper"))
+                                        .passThroughSymbols(ImmutableList.of(ImmutableList.of())),
+                                values("a", "b"))));
+    }
+
+    @Test
+    public void testReferencedPassThroughOutputs()
+    {
+        tester().assertThat(new PruneTableFunctionProcessorColumns())
+                .on(p -> {
+                    Symbol x = p.symbol("x");
+                    Symbol y = p.symbol("y");
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.project(
+                            Assignments.identity(y, b),
+                            p.tableFunctionProcessor(
+                                    builder -> builder
+                                            .name("test_function")
+                                            .properOutputs(x, y)
+                                            .passThroughSpecifications(
+                                                    new PassThroughSpecification(
+                                                            true,
+                                                            ImmutableList.of(
+                                                                    new PassThroughColumn(a, true),
+                                                                    new PassThroughColumn(b, false))))
+                                            .source(p.values(a, b))));
+                })
+                .matches(project(
+                        ImmutableMap.of("y", expression("y"), "b", expression("b")),
+                        tableFunctionProcessor(builder -> builder
+                                        .name("test_function")
+                                        .properOutputs(ImmutableList.of("x", "y"))
+                                        .passThroughSymbols(ImmutableList.of(ImmutableList.of("b"))),
+                                values("a", "b"))));
+    }
+
+    @Test
+    public void testAllPassThroughOutputsReferenced()
+    {
+        tester().assertThat(new PruneTableFunctionProcessorColumns())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.project(
+                            Assignments.identity(a, b),
+                            p.tableFunctionProcessor(
+                                    builder -> builder
+                                            .name("test_function")
+                                            .passThroughSpecifications(
+                                                    new PassThroughSpecification(
+                                                            true,
+                                                            ImmutableList.of(
+                                                                    new PassThroughColumn(a, true),
+                                                                    new PassThroughColumn(b, false))))
+                                            .source(p.values(a, b))));
+                })
+                .doesNotFire();
+
+        tester().assertThat(new PruneTableFunctionProcessorColumns())
+                .on(p -> {
+                    Symbol proper = p.symbol("proper");
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.project(
+                            Assignments.identity(a, b),
+                            p.tableFunctionProcessor(
+                                    builder -> builder
+                                            .name("test_function")
+                                            .properOutputs(proper)
+                                            .passThroughSpecifications(
+                                                    new PassThroughSpecification(
+                                                            true,
+                                                            ImmutableList.of(
+                                                                    new PassThroughColumn(a, true),
+                                                                    new PassThroughColumn(b, false))))
+                                            .source(p.values(a, b))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testNoSource()
+    {
+        tester().assertThat(new PruneTableFunctionProcessorColumns())
+                .on(p -> p.project(
+                        Assignments.of(),
+                        p.tableFunctionProcessor(
+                                builder -> builder
+                                        .name("test_function")
+                                        .properOutputs(p.symbol("proper")))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testMultipleTableArguments()
+    {
+        // multiple pass-through specifications indicate that the table function has multiple table arguments
+        tester().assertThat(new PruneTableFunctionProcessorColumns())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    Symbol d = p.symbol("d");
+                    return p.project(
+                            Assignments.identity(b),
+                            p.tableFunctionProcessor(
+                                    builder -> builder
+                                            .name("test_function")
+                                            .properOutputs(p.symbol("proper"))
+                                            .passThroughSpecifications(
+                                                    new PassThroughSpecification(false, ImmutableList.of(new PassThroughColumn(a, true))),
+                                                    new PassThroughSpecification(false, ImmutableList.of(new PassThroughColumn(b, true))),
+                                                    new PassThroughSpecification(true, ImmutableList.of(new PassThroughColumn(c, false))))
+                                            .source(p.values(a, b, c, d))));
+                })
+                .matches(project(
+                        ImmutableMap.of("b", expression("b")),
+                        tableFunctionProcessor(builder -> builder
+                                        .name("test_function")
+                                        .properOutputs(ImmutableList.of("proper"))
+                                        .passThroughSymbols(ImmutableList.of(ImmutableList.of(), ImmutableList.of("b"), ImmutableList.of())),
+                                values("a", "b", "c", "d"))));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneTableFunctionProcessorSourceColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneTableFunctionProcessorSourceColumns.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.sql.planner.OrderingScheme;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughColumn;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughSpecification;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.spi.connector.SortOrder.ASC_NULLS_FIRST;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.specification;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.tableFunctionProcessor;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestPruneTableFunctionProcessorSourceColumns
+        extends BaseRuleTest
+{
+    @Test
+    public void testPruneUnreferencedSymbol()
+    {
+        // symbols 'a', 'b', 'c', 'd', 'hash', and 'marker' are used by the node.
+        // symbol 'unreferenced' is pruned out. Also, the mapping for this symbol is removed from marker mappings
+        tester().assertThat(new PruneTableFunctionProcessorSourceColumns())
+                .on(p -> {
+                    Symbol proper = p.symbol("proper");
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    Symbol d = p.symbol("d");
+                    Symbol unreferenced = p.symbol("unreferenced");
+                    Symbol hash = p.symbol("hash");
+                    Symbol marker = p.symbol("marker");
+                    return p.tableFunctionProcessor(
+                            builder -> builder
+                                    .name("test_function")
+                                    .properOutputs(proper)
+                                    .passThroughSpecifications(new PassThroughSpecification(true, ImmutableList.of(new PassThroughColumn(a, false))))
+                                    .requiredSymbols(ImmutableList.of(ImmutableList.of(b)))
+                                    .markerSymbols(ImmutableMap.of(
+                                            a, marker,
+                                            b, marker,
+                                            c, marker,
+                                            d, marker,
+                                            unreferenced, marker))
+                                    .specification(new DataOrganizationSpecification(ImmutableList.of(c), Optional.of(new OrderingScheme(ImmutableList.of(d), ImmutableMap.of(d, ASC_NULLS_FIRST)))))
+                                    .hashSymbol(hash)
+                                    .source(p.values(a, b, c, d, unreferenced, hash, marker)));
+                })
+                .matches(tableFunctionProcessor(builder -> builder
+                                .name("test_function")
+                                .properOutputs(ImmutableList.of("proper"))
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("a")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("b")))
+                                .markerSymbols(ImmutableMap.of(
+                                        "a", "marker",
+                                        "b", "marker",
+                                        "c", "marker",
+                                        "d", "marker"))
+                                .specification(specification(ImmutableList.of("c"), ImmutableList.of("d"), ImmutableMap.of("d", ASC_NULLS_FIRST)))
+                                .hashSymbol("hash"),
+                        project(
+                                ImmutableMap.of(
+                                        "a", expression("a"),
+                                        "b", expression("b"),
+                                        "c", expression("c"),
+                                        "d", expression("d"),
+                                        "hash", expression("hash"),
+                                        "marker", expression("marker")),
+                                values("a", "b", "c", "d", "unreferenced", "hash", "marker"))));
+    }
+
+    @Test
+    public void testPruneUnusedMarkerSymbol()
+    {
+        // symbol 'unreferenced' is pruned out because the node does not use it.
+        // also, the mapping for this symbol is removed from marker mappings.
+        // because the marker symbol 'marker' is no longer used, it is pruned out too.
+        // note: currently a marker symbol cannot become unused because the function
+        // must use at least one symbol from each source. it might change in the future.
+        tester().assertThat(new PruneTableFunctionProcessorSourceColumns())
+                .on(p -> {
+                    Symbol unreferenced = p.symbol("unreferenced");
+                    Symbol marker = p.symbol("marker");
+                    return p.tableFunctionProcessor(
+                            builder -> builder
+                                    .name("test_function")
+                                    .markerSymbols(ImmutableMap.of(unreferenced, marker))
+                                    .source(p.values(unreferenced, marker)));
+                })
+                .matches(tableFunctionProcessor(builder -> builder
+                                .name("test_function")
+                                .markerSymbols(ImmutableMap.of()),
+                        project(
+                                ImmutableMap.of(),
+                                values("unreferenced", "marker"))));
+    }
+
+    @Test
+    public void testMultipleSources()
+    {
+        // multiple pass-through specifications indicate that the table function has multiple table arguments
+        // the third argument provides symbols 'e', 'f', and 'unreferenced'. those symbols are mapped to common marker symbol 'marker3'
+        tester().assertThat(new PruneTableFunctionProcessorSourceColumns())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    Symbol d = p.symbol("d");
+                    Symbol e = p.symbol("e");
+                    Symbol f = p.symbol("f");
+                    Symbol marker1 = p.symbol("marker1");
+                    Symbol marker2 = p.symbol("marker2");
+                    Symbol marker3 = p.symbol("marker3");
+                    Symbol unreferenced = p.symbol("unreferenced");
+                    return p.tableFunctionProcessor(
+                            builder -> builder
+                                    .name("test_function")
+                                    .passThroughSpecifications(
+                                            new PassThroughSpecification(true, ImmutableList.of(new PassThroughColumn(a, false))),
+                                            new PassThroughSpecification(false, ImmutableList.of(new PassThroughColumn(c, true))),
+                                            new PassThroughSpecification(false, ImmutableList.of(new PassThroughColumn(e, true))))
+                                    .requiredSymbols(ImmutableList.of(
+                                            ImmutableList.of(b),
+                                            ImmutableList.of(d),
+                                            ImmutableList.of(f)))
+                                    .markerSymbols(ImmutableMap.of(
+                                            a, marker1,
+                                            b, marker1,
+                                            c, marker2,
+                                            d, marker2,
+                                            e, marker3,
+                                            f, marker3,
+                                            unreferenced, marker3))
+                                    .source(p.values(a, b, c, d, e, f, marker1, marker2, marker3, unreferenced)));
+                })
+                .matches(tableFunctionProcessor(builder -> builder
+                                .name("test_function")
+                                .passThroughSymbols(ImmutableList.of(ImmutableList.of("a"), ImmutableList.of("c"), ImmutableList.of("e")))
+                                .requiredSymbols(ImmutableList.of(ImmutableList.of("b"), ImmutableList.of("d"), ImmutableList.of("f")))
+                                .markerSymbols(ImmutableMap.of(
+                                        "a", "marker1",
+                                        "b", "marker1",
+                                        "c", "marker2",
+                                        "d", "marker2",
+                                        "e", "marker3",
+                                        "f", "marker3")),
+                        project(
+                                ImmutableMap.of(
+                                        "a", expression("a"),
+                                        "b", expression("b"),
+                                        "c", expression("c"),
+                                        "d", expression("d"),
+                                        "e", expression("e"),
+                                        "f", expression("f"),
+                                        "marker1", expression("marker1"),
+                                        "marker2", expression("marker2"),
+                                        "marker3", expression("marker3")),
+                                values("a", "b", "c", "d", "e", "f", "marker1", "marker2", "marker3", "unreferenced"))));
+    }
+
+    @Test
+    public void allSymbolsReferenced()
+    {
+        tester().assertThat(new PruneTableFunctionProcessorSourceColumns())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol marker = p.symbol("marker");
+                    return p.tableFunctionProcessor(
+                            builder -> builder
+                                    .name("test_function")
+                                    .requiredSymbols(ImmutableList.of(ImmutableList.of(a)))
+                                    .markerSymbols(ImmutableMap.of(a, marker))
+                                    .source(p.values(a, marker)));
+                })
+                .doesNotFire();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantTableFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantTableFunction.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughColumn;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughSpecification;
+import org.testng.annotations.Test;
+
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestRemoveRedundantTableFunction
+        extends BaseRuleTest
+{
+    @Test
+    public void testRemoveTableFunction()
+    {
+        tester().assertThat(new RemoveRedundantTableFunction())
+                .on(p -> {
+                    Symbol passThrough = p.symbol("pass_through");
+                    Symbol proper = p.symbol("proper");
+                    return p.tableFunctionProcessor(
+                            builder -> builder
+                                    .name("test_function")
+                                    .pruneWhenEmpty()
+                                    .properOutputs(proper)
+                                    .passThroughSpecifications(new PassThroughSpecification(false, ImmutableList.of(new PassThroughColumn(passThrough, true))))
+                                    .source(p.values(passThrough)));
+                })
+                .matches(values("proper", "pass_through"));
+    }
+
+    @Test
+    public void testDoNotRemoveKeepWhenEmpty()
+    {
+        tester().assertThat(new RemoveRedundantTableFunction())
+                .on(p -> {
+                    Symbol passThrough = p.symbol("pass_through");
+                    Symbol proper = p.symbol("proper");
+                    return p.tableFunctionProcessor(
+                            builder -> builder
+                                    .name("test_function")
+                                    .properOutputs(proper)
+                                    .passThroughSpecifications(new PassThroughSpecification(false, ImmutableList.of(new PassThroughColumn(passThrough, true))))
+                                    .source(p.values(passThrough)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoNotRemoveNonEmptyInput()
+    {
+        tester().assertThat(new RemoveRedundantTableFunction())
+                .on(p -> {
+                    Symbol passThrough = p.symbol("pass_through");
+                    Symbol proper = p.symbol("proper");
+                    return p.tableFunctionProcessor(
+                            builder -> builder
+                                    .name("test_function")
+                                    .pruneWhenEmpty()
+                                    .properOutputs(proper)
+                                    .passThroughSpecifications(new PassThroughSpecification(false, ImmutableList.of(new PassThroughColumn(passThrough, true))))
+                                    .source(p.values(5, passThrough)));
+                })
+                .doesNotFire();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -92,6 +92,7 @@ import io.trino.sql.planner.plan.TableExecuteNode;
 import io.trino.sql.planner.plan.TableFinishNode;
 import io.trino.sql.planner.plan.TableFunctionNode;
 import io.trino.sql.planner.plan.TableFunctionNode.TableArgumentProperties;
+import io.trino.sql.planner.plan.TableFunctionProcessorNode;
 import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.sql.planner.plan.TableWriterNode;
 import io.trino.sql.planner.plan.TableWriterNode.CreateTarget;
@@ -1221,6 +1222,13 @@ public class PlanBuilder
                 tableArgumentProperties,
                 copartitioningLists,
                 new TableFunctionHandle(TEST_CATALOG_HANDLE, new SchemaFunctionName("system", name), new ConnectorTableFunctionHandle() {}, TestingTransactionHandle.create()));
+    }
+
+    public TableFunctionProcessorNode tableFunctionProcessor(Consumer<TableFunctionProcessorBuilder> consumer)
+    {
+        TableFunctionProcessorBuilder tableFunctionProcessorBuilder = new TableFunctionProcessorBuilder();
+        consumer.accept(tableFunctionProcessorBuilder);
+        return tableFunctionProcessorBuilder.build(idAllocator);
     }
 
     public PartitioningScheme partitioningScheme(List<Symbol> outputSymbols, List<Symbol> partitioningSymbols, Symbol hashSymbol)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/TableFunctionProcessorBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/TableFunctionProcessorBuilder.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule.test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.trino.metadata.TableFunctionHandle;
+import io.trino.spi.function.SchemaFunctionName;
+import io.trino.spi.ptf.ConnectorTableFunctionHandle;
+import io.trino.sql.planner.PlanNodeIdAllocator;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.TableFunctionNode.PassThroughSpecification;
+import io.trino.sql.planner.plan.TableFunctionProcessorNode;
+import io.trino.testing.TestingTransactionHandle;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
+
+public class TableFunctionProcessorBuilder
+{
+    private String name;
+    private List<Symbol> properOutputs = ImmutableList.of();
+    private Optional<PlanNode> source = Optional.empty();
+    private boolean pruneWhenEmpty;
+    private List<PassThroughSpecification> passThroughSpecifications = ImmutableList.of();
+    private List<List<Symbol>> requiredSymbols = ImmutableList.of();
+    private Optional<Map<Symbol, Symbol>> markerSymbols = Optional.empty();
+    private Optional<DataOrganizationSpecification> specification = Optional.empty();
+    private Set<Symbol> prePartitioned = ImmutableSet.of();
+    private int preSorted;
+    private Optional<Symbol> hashSymbol = Optional.empty();
+
+    public TableFunctionProcessorBuilder() {}
+
+    public TableFunctionProcessorBuilder name(String name)
+    {
+        this.name = name;
+        return this;
+    }
+
+    public TableFunctionProcessorBuilder properOutputs(Symbol... properOutputs)
+    {
+        this.properOutputs = ImmutableList.copyOf(properOutputs);
+        return this;
+    }
+
+    public TableFunctionProcessorBuilder source(PlanNode source)
+    {
+        this.source = Optional.of(source);
+        return this;
+    }
+
+    public TableFunctionProcessorBuilder pruneWhenEmpty()
+    {
+        this.pruneWhenEmpty = true;
+        return this;
+    }
+
+    public TableFunctionProcessorBuilder passThroughSpecifications(PassThroughSpecification... passThroughSpecifications)
+    {
+        this.passThroughSpecifications = ImmutableList.copyOf(passThroughSpecifications);
+        return this;
+    }
+
+    public TableFunctionProcessorBuilder requiredSymbols(List<List<Symbol>> requiredSymbols)
+    {
+        this.requiredSymbols = requiredSymbols;
+        return this;
+    }
+
+    public TableFunctionProcessorBuilder markerSymbols(Map<Symbol, Symbol> markerSymbols)
+    {
+        this.markerSymbols = Optional.of(markerSymbols);
+        return this;
+    }
+
+    public TableFunctionProcessorBuilder specification(DataOrganizationSpecification specification)
+    {
+        this.specification = Optional.of(specification);
+        return this;
+    }
+
+    public TableFunctionProcessorBuilder prePartitioned(Set<Symbol> prePartitioned)
+    {
+        this.prePartitioned = prePartitioned;
+        return this;
+    }
+
+    public TableFunctionProcessorBuilder preSorted(int preSorted)
+    {
+        this.preSorted = preSorted;
+        return this;
+    }
+
+    public TableFunctionProcessorBuilder hashSymbol(Symbol hashSymbol)
+    {
+        this.hashSymbol = Optional.of(hashSymbol);
+        return this;
+    }
+
+    public TableFunctionProcessorNode build(PlanNodeIdAllocator idAllocator)
+    {
+        return new TableFunctionProcessorNode(
+                idAllocator.getNextId(),
+                name,
+                properOutputs,
+                source,
+                pruneWhenEmpty,
+                passThroughSpecifications,
+                requiredSymbols,
+                markerSymbols,
+                specification,
+                prePartitioned,
+                preSorted,
+                hashSymbol,
+                new TableFunctionHandle(TEST_CATALOG_HANDLE, new SchemaFunctionName("system", name), new ConnectorTableFunctionHandle() {}, TestingTransactionHandle.create()));
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplitManager.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplitManager.java
@@ -13,6 +13,10 @@
  */
 package io.trino.spi.connector;
 
+import io.trino.spi.Experimental;
+import io.trino.spi.function.SchemaFunctionName;
+import io.trino.spi.ptf.ConnectorTableFunctionHandle;
+
 public interface ConnectorSplitManager
 {
     default ConnectorSplitSource getSplits(
@@ -21,6 +25,16 @@ public interface ConnectorSplitManager
             ConnectorTableHandle table,
             DynamicFilter dynamicFilter,
             Constraint constraint)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Experimental(eta = "2023-03-31")
+    default ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            SchemaFunctionName name,
+            ConnectorTableFunctionHandle function)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/function/FunctionProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/FunctionProvider.java
@@ -14,8 +14,9 @@
 package io.trino.spi.function;
 
 import io.trino.spi.Experimental;
+import io.trino.spi.ptf.TableFunctionProcessorProvider;
 
-@Experimental(eta = "2022-10-31")
+@Experimental(eta = "2023-03-31")
 public interface FunctionProvider
 {
     ScalarFunctionImplementation getScalarFunctionImplementation(
@@ -27,4 +28,6 @@ public interface FunctionProvider
     AggregationImplementation getAggregationImplementation(FunctionId functionId, BoundSignature boundSignature, FunctionDependencies functionDependencies);
 
     WindowFunctionSupplier getWindowFunctionSupplier(FunctionId functionId, BoundSignature boundSignature, FunctionDependencies functionDependencies);
+
+    TableFunctionProcessorProvider getTableFunctionProcessorProvider(SchemaFunctionName name);
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionDataProcessor.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionDataProcessor.java
@@ -13,14 +13,12 @@
  */
 package io.trino.spi.ptf;
 
-import io.trino.spi.Experimental;
 import io.trino.spi.Page;
 
 import java.util.List;
 import java.util.Optional;
 
-@Experimental(eta = "2023-03-31")
-public interface TableFunctionProcessor
+public interface TableFunctionDataProcessor
 {
     /**
      * This method processes a portion of data. It is called multiple times until the partition is fully processed.
@@ -30,8 +28,8 @@ public interface TableFunctionProcessor
      * A page for an argument consists of columns requested during analysis (see {@link TableFunctionAnalysis#getRequiredColumns()}}.
      * If any of the sources is fully processed, {@code Optional.empty)()} is returned for that source.
      * If all sources are fully processed, the argument is {@code null}.
-     * // TODO what if there are no sources?
      * @return {@link TableFunctionProcessorState} including the processor's state and optionally a portion of result.
+     * After the returned state is {@code FINISHED}, the method will not be called again.
      */
     TableFunctionProcessorState process(List<Optional<Page>> input);
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionProcessor.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionProcessor.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.ptf;
+
+import io.trino.spi.Experimental;
+import io.trino.spi.Page;
+
+import java.util.List;
+import java.util.Optional;
+
+@Experimental(eta = "2023-03-31")
+public interface TableFunctionProcessor
+{
+    /**
+     * This method processes a portion of data. It is called multiple times until the partition is fully processed.
+     *
+     * @param input a tuple of {@link Page} including one page for each table function's input table.
+     * Pages list is ordered according to the corresponding argument specifications in {@link ConnectorTableFunction}.
+     * A page for an argument consists of columns requested during analysis (see {@link TableFunctionAnalysis#getRequiredColumns()}}.
+     * If any of the sources is fully processed, {@code Optional.empty)()} is returned for that source.
+     * If all sources are fully processed, the argument is {@code null}.
+     * // TODO what if there are no sources?
+     * @return {@link TableFunctionProcessorState} including the processor's state and optionally a portion of result.
+     */
+    TableFunctionProcessorState process(List<Optional<Page>> input);
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionProcessorProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionProcessorProvider.java
@@ -19,8 +19,20 @@ import io.trino.spi.Experimental;
 public interface TableFunctionProcessorProvider
 {
     /**
-     * This method returns a {@code TableFunctionProcessor}. All the necessary information collected during analysis is available
+     * This method returns a {@code TableFunctionDataProcessor}. All the necessary information collected during analysis is available
      * in the form of {@link ConnectorTableFunctionHandle}. It is called once per each partition processed by the table function.
      */
-    TableFunctionProcessor get(ConnectorTableFunctionHandle handle);
+    default TableFunctionDataProcessor getDataProcessor(ConnectorTableFunctionHandle handle)
+    {
+        throw new UnsupportedOperationException("this table function does not process input data");
+    }
+
+    /**
+     * This method returns a {@code TableFunctionSplitProcessor}. All the necessary information collected during analysis is available
+     * in the form of {@link ConnectorTableFunctionHandle}. It is called once per each split processed by the table function.
+     */
+    default TableFunctionSplitProcessor getSplitProcessor(ConnectorTableFunctionHandle handle)
+    {
+        throw new UnsupportedOperationException("this table function does not process splits");
+    }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionProcessorProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionProcessorProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.ptf;
+
+import io.trino.spi.Experimental;
+
+@Experimental(eta = "2023-03-31")
+public interface TableFunctionProcessorProvider
+{
+    /**
+     * This method returns a {@code TableFunctionProcessor}. All the necessary information collected during analysis is available
+     * in the form of {@link ConnectorTableFunctionHandle}. It is called once per each partition processed by the table function.
+     */
+    TableFunctionProcessor get(ConnectorTableFunctionHandle handle);
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionProcessorState.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionProcessorState.java
@@ -23,7 +23,7 @@ import java.util.concurrent.CompletableFuture;
 import static java.util.Objects.requireNonNull;
 
 /**
- * The result of processing input by {@link TableFunctionProcessor}.
+ * The result of processing input by {@link TableFunctionDataProcessor} or {@link TableFunctionSplitProcessor}.
  * It can optionally include a portion of output data in the form of {@link Page}
  * The returned {@link Page} should consist of:
  * - proper columns produced by the table function

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionProcessorState.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionProcessorState.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.ptf;
+
+import io.trino.spi.Experimental;
+import io.trino.spi.Page;
+
+import javax.annotation.Nullable;
+
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * The result of processing input by {@link TableFunctionProcessor}.
+ * It can optionally include a portion of output data in the form of {@link Page}
+ * The returned {@link Page} should consist of:
+ * - proper columns produced by the table function
+ * - one column of type {@code BIGINT} for each table function's input table having the pass-through property (see {@link TableArgumentSpecification#isPassThroughColumns}),
+ * in order of the corresponding argument specifications. Entries in these columns are the indexes of input rows (from partition start) to be attached to output,
+ * or null to indicate that a row of nulls should be attached instead of an input row. The indexes are validated to be within the portion of the partition
+ * provided to the function so far.
+ * Note: when the input is empty, the only valid index value is null, because there are no input rows that could be attached to output. In such case, for performance
+ * reasons, the validation of indexes is skipped, and all pass-through columns are filled with nulls.
+ */
+@Experimental(eta = "2023-03-31")
+public sealed interface TableFunctionProcessorState
+        permits TableFunctionProcessorState.Blocked, TableFunctionProcessorState.Finished, TableFunctionProcessorState.Processed
+{
+    final class Blocked
+            implements TableFunctionProcessorState
+    {
+        private final CompletableFuture<Void> future;
+
+        private Blocked(CompletableFuture<Void> future)
+        {
+            this.future = requireNonNull(future, "future is null");
+        }
+
+        public static Blocked blocked(CompletableFuture<Void> future)
+        {
+            return new Blocked(future);
+        }
+
+        public CompletableFuture<Void> getFuture()
+        {
+            return future;
+        }
+    }
+
+    final class Finished
+            implements TableFunctionProcessorState
+    {
+        public static final Finished FINISHED = new Finished();
+
+        private Finished() {}
+    }
+
+    final class Processed
+            implements TableFunctionProcessorState
+    {
+        private final boolean usedInput;
+        private final Page result;
+
+        private Processed(boolean usedInput, @Nullable Page result)
+        {
+            this.usedInput = usedInput;
+            this.result = result;
+        }
+
+        public static Processed usedInput()
+        {
+            return new Processed(true, null);
+        }
+
+        public static Processed produced(Page result)
+        {
+            requireNonNull(result, "result is null");
+            return new Processed(false, result);
+        }
+
+        public static Processed usedInputAndProduced(Page result)
+        {
+            requireNonNull(result, "result is null");
+            return new Processed(true, result);
+        }
+
+        public boolean isUsedInput()
+        {
+            return usedInput;
+        }
+
+        public Page getResult()
+        {
+            return result;
+        }
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionSplitProcessor.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionSplitProcessor.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.ptf;
+
+import io.trino.spi.connector.ConnectorSplit;
+
+public interface TableFunctionSplitProcessor
+{
+    /**
+     * This method processes a split. It is called multiple times until the whole output for the split is produced.
+     *
+     * @param split a {@link ConnectorSplit} representing a subtask.
+     * @return {@link TableFunctionProcessorState} including the processor's state and optionally a portion of result.
+     * After the returned state is {@code FINISHED}, the method will not be called again.
+     */
+    TableFunctionProcessorState process(ConnectorSplit split);
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorSplitManager.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorSplitManager.java
@@ -21,6 +21,8 @@ import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.function.SchemaFunctionName;
+import io.trino.spi.ptf.ConnectorTableFunctionHandle;
 
 import javax.inject.Inject;
 
@@ -49,6 +51,18 @@ public final class ClassLoaderSafeConnectorSplitManager
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.getSplits(transaction, session, table, dynamicFilter, constraint);
+        }
+    }
+
+    @Override
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            SchemaFunctionName name,
+            ConnectorTableFunctionHandle function)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getSplits(transaction, session, name, function);
         }
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMockConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMockConnector.java
@@ -235,7 +235,7 @@ public class TestMockConnector
     public void testTableFunction()
     {
         assertThatThrownBy(() -> assertUpdate("SELECT * FROM TABLE(mock.system.simple_table_function())"))
-                .hasMessage("execution by operator is not yet implemented for table function simple_table_function");
+                .hasMessage("missing ConnectorSplitSource for table function system.simple_table_function");
         assertThatThrownBy(() -> assertUpdate("SELECT * FROM TABLE(mock.system.non_existing_table_function())"))
                 .hasMessageContaining("Table function mock.system.non_existing_table_function not registered");
     }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestTableFunctionInvocation.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestTableFunctionInvocation.java
@@ -16,9 +16,38 @@ package io.trino.tests;
 import com.google.common.collect.ImmutableSet;
 import io.trino.connector.MockConnectorFactory;
 import io.trino.connector.MockConnectorPlugin;
+import io.trino.connector.TestingTableFunctions.EmptyOutputFunction;
+import io.trino.connector.TestingTableFunctions.EmptyOutputFunction.EmptyOutputProcessorProvider;
+import io.trino.connector.TestingTableFunctions.EmptyOutputWithPassThroughFunction;
+import io.trino.connector.TestingTableFunctions.EmptyOutputWithPassThroughFunction.EmptyOutputWithPassThroughProcessorProvider;
+import io.trino.connector.TestingTableFunctions.IdentityFunction;
+import io.trino.connector.TestingTableFunctions.IdentityFunction.IdentityFunctionProcessorProvider;
+import io.trino.connector.TestingTableFunctions.IdentityPassThroughFunction;
+import io.trino.connector.TestingTableFunctions.IdentityPassThroughFunction.IdentityPassThroughFunctionProcessorProvider;
+import io.trino.connector.TestingTableFunctions.PassThroughInputFunction;
+import io.trino.connector.TestingTableFunctions.PassThroughInputFunction.PassThroughInputProcessorProvider;
+import io.trino.connector.TestingTableFunctions.RepeatFunction;
+import io.trino.connector.TestingTableFunctions.RepeatFunction.RepeatFunctionProcessorProvider;
 import io.trino.connector.TestingTableFunctions.SimpleTableFunction;
 import io.trino.connector.TestingTableFunctions.SimpleTableFunction.SimpleTableFunctionHandle;
+import io.trino.connector.TestingTableFunctions.TestInputFunction;
+import io.trino.connector.TestingTableFunctions.TestInputFunction.TestInputProcessorProvider;
+import io.trino.connector.TestingTableFunctions.TestInputsFunction;
+import io.trino.connector.TestingTableFunctions.TestInputsFunction.TestInputsFunctionProcessorProvider;
+import io.trino.connector.TestingTableFunctions.TestSingleInputRowSemanticsFunction;
+import io.trino.connector.TestingTableFunctions.TestSingleInputRowSemanticsFunction.TestSingleInputFunctionProcessorProvider;
+import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.spi.connector.TableFunctionApplicationResult;
+import io.trino.spi.function.AggregationImplementation;
+import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionDependencies;
+import io.trino.spi.function.FunctionId;
+import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.function.InvocationConvention;
+import io.trino.spi.function.ScalarFunctionImplementation;
+import io.trino.spi.function.SchemaFunctionName;
+import io.trino.spi.function.WindowFunctionSupplier;
+import io.trino.spi.ptf.TableFunctionProcessorProvider;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -53,15 +82,82 @@ public class TestTableFunctionInvocation
         DistributedQueryRunner queryRunner = getDistributedQueryRunner();
 
         queryRunner.installPlugin(new MockConnectorPlugin(MockConnectorFactory.builder()
-                .withTableFunctions(ImmutableSet.of(new SimpleTableFunction()))
+                .withTableFunctions(ImmutableSet.of(
+                        new SimpleTableFunction(),
+                        new IdentityFunction(),
+                        new IdentityPassThroughFunction(),
+                        new RepeatFunction(),
+                        new EmptyOutputFunction(),
+                        new EmptyOutputWithPassThroughFunction(),
+                        new TestInputsFunction(),
+                        new PassThroughInputFunction(),
+                        new TestInputFunction(),
+                        new TestSingleInputRowSemanticsFunction()))
                 .withApplyTableFunction((session, handle) -> {
                     if (handle instanceof SimpleTableFunctionHandle functionHandle) {
                         return Optional.of(new TableFunctionApplicationResult<>(functionHandle.getTableHandle(), functionHandle.getTableHandle().getColumns().orElseThrow()));
                     }
-                    throw new IllegalStateException("Unsupported table function handle: " + handle.getClass().getSimpleName());
+                    return Optional.empty();
                 })
+                .withFunctionProvider(Optional.of(new FunctionProvider()
+                {
+                    @Override
+                    public ScalarFunctionImplementation getScalarFunctionImplementation(FunctionId functionId, BoundSignature boundSignature, FunctionDependencies functionDependencies, InvocationConvention invocationConvention)
+                    {
+                        return null;
+                    }
+
+                    @Override
+                    public AggregationImplementation getAggregationImplementation(FunctionId functionId, BoundSignature boundSignature, FunctionDependencies functionDependencies)
+                    {
+                        return null;
+                    }
+
+                    @Override
+                    public WindowFunctionSupplier getWindowFunctionSupplier(FunctionId functionId, BoundSignature boundSignature, FunctionDependencies functionDependencies)
+                    {
+                        return null;
+                    }
+
+                    @Override
+                    public TableFunctionProcessorProvider getTableFunctionProcessorProvider(SchemaFunctionName name)
+                    {
+                        if (name.equals(new SchemaFunctionName("system", "identity_function"))) {
+                            return new IdentityFunctionProcessorProvider();
+                        }
+                        else if (name.equals(new SchemaFunctionName("system", "identity_pass_through_function"))) {
+                            return new IdentityPassThroughFunctionProcessorProvider();
+                        }
+                        else if (name.equals(new SchemaFunctionName("system", "repeat"))) {
+                            return new RepeatFunctionProcessorProvider();
+                        }
+                        else if (name.equals(new SchemaFunctionName("system", "empty_output"))) {
+                            return new EmptyOutputProcessorProvider();
+                        }
+                        else if (name.equals(new SchemaFunctionName("system", "empty_output_with_pass_through"))) {
+                            return new EmptyOutputWithPassThroughProcessorProvider();
+                        }
+                        else if (name.equals(new SchemaFunctionName("system", "test_inputs_function"))) {
+                            return new TestInputsFunctionProcessorProvider();
+                        }
+                        else if (name.equals(new SchemaFunctionName("system", "pass_through"))) {
+                            return new PassThroughInputProcessorProvider();
+                        }
+                        else if (name.equals(new SchemaFunctionName("system", "test_input"))) {
+                            return new TestInputProcessorProvider();
+                        }
+                        else if (name.equals(new SchemaFunctionName("system", "test_single_input_function"))) {
+                            return new TestSingleInputFunctionProcessorProvider();
+                        }
+
+                        return null;
+                    }
+                }))
                 .build()));
         queryRunner.createCatalog(TESTING_CATALOG, "mock");
+
+        queryRunner.installPlugin(new TpchPlugin());
+        queryRunner.createCatalog("tpch", "tpch");
     }
 
     @Test
@@ -80,5 +176,512 @@ public class TestTableFunctionInvocation
     {
         assertThat(query("SELECT col FROM TABLE(system.simple_table_function())"))
                 .matches("SELECT true WHERE false");
+    }
+
+    @Test
+    public void testIdentityFunction()
+    {
+        assertThat(query("SELECT b, a FROM TABLE(system.identity_function(input => TABLE(VALUES (1, 2), (3, 4), (5, 6)) T(a, b)))"))
+                .matches("VALUES (2, 1), (4, 3), (6, 5)");
+
+        assertThat(query("SELECT b, a FROM TABLE(system.identity_pass_through_function(input => TABLE(VALUES (1, 2), (3, 4), (5, 6)) T(a, b)))"))
+                .matches("VALUES (2, 1), (4, 3), (6, 5)");
+
+        // null partitioning value
+        assertThat(query("SELECT i.b, a FROM TABLE(system.identity_function(input => TABLE(VALUES ('x', 1), ('y', 2), ('z', null)) T(a, b) PARTITION BY b)) i"))
+                .matches("VALUES (1, 'x'), (2, 'y'), (null, 'z')");
+
+        assertThat(query("SELECT b, a FROM TABLE(system.identity_pass_through_function(input => TABLE(VALUES ('x', 1), ('y', 2), ('z', null)) T(a, b) PARTITION BY b))"))
+                .matches("VALUES (1, 'x'), (2, 'y'), (null, 'z')");
+
+        // the identity_function copies all input columns and outputs them as proper columns.
+        // the table tpch.tiny.orders has a hidden column row_number, which is not exposed to the function.
+        assertThat(query("SELECT * FROM TABLE(system.identity_function(input => TABLE(tpch.tiny.orders)))"))
+                .matches("SELECT * FROM tpch.tiny.orders");
+
+        // the identity_pass_through_function passes all input columns on output using the pass-through mechanism (as opposed to producing proper columns).
+        // the table tpch.tiny.orders has a hidden column row_number, which is exposed to the pass-through mechanism.
+        // the passed-through column row_number preserves its hidden property.
+        assertThat(query("SELECT row_number, * FROM TABLE(system.identity_pass_through_function(input => TABLE(tpch.tiny.orders)))"))
+                .matches("SELECT row_number, * FROM tpch.tiny.orders");
+    }
+
+    @Test
+    public void testRepeatFunction()
+    {
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.repeat(TABLE(VALUES (1, 2), (3, 4), (5, 6))))
+                """))
+                .matches("VALUES (1, 2), (1, 2), (3, 4), (3, 4), (5, 6), (5, 6)");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.repeat(
+                                        TABLE(VALUES ('a', true), ('b', false)),
+                                        4))
+                """))
+                .matches("VALUES ('a', true), ('b', false), ('a', true), ('b', false), ('a', true), ('b', false), ('a', true), ('b', false)");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.repeat(
+                                        TABLE(VALUES ('a', true), ('b', false)) t(x, y) PARTITION BY x,
+                                        4))
+                """))
+                .matches("VALUES ('a', true), ('b', false), ('a', true), ('b', false), ('a', true), ('b', false), ('a', true), ('b', false)");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.repeat(
+                                        TABLE(VALUES ('a', true), ('b', false)) t(x, y) ORDER BY y,
+                                        4))
+                """))
+                .matches("VALUES ('a', true), ('b', false), ('a', true), ('b', false), ('a', true), ('b', false), ('a', true), ('b', false)");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.repeat(
+                                        TABLE(VALUES ('a', true), ('b', false)) t(x, y) PARTITION BY x ORDER BY y,
+                                        4))
+                """))
+                .matches("VALUES ('a', true), ('b', false), ('a', true), ('b', false), ('a', true), ('b', false), ('a', true), ('b', false)");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.repeat(TABLE(tpch.tiny.part), 3))
+                """))
+                .matches("SELECT * FROM tpch.tiny.part UNION ALL TABLE tpch.tiny.part UNION ALL TABLE tpch.tiny.part");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.repeat(TABLE(tpch.tiny.part) PARTITION BY type, 3))
+                """))
+                .matches("SELECT * FROM tpch.tiny.part UNION ALL TABLE tpch.tiny.part UNION ALL TABLE tpch.tiny.part");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.repeat(TABLE(tpch.tiny.part) ORDER BY size, 3))
+                """))
+                .matches("SELECT * FROM tpch.tiny.part UNION ALL TABLE tpch.tiny.part UNION ALL TABLE tpch.tiny.part");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.repeat(TABLE(tpch.tiny.part) PARTITION BY type ORDER BY size, 3))
+                """))
+                .matches("SELECT * FROM tpch.tiny.part UNION ALL TABLE tpch.tiny.part UNION ALL TABLE tpch.tiny.part");
+    }
+
+    @Test
+    public void testFunctionsReturningEmptyPages()
+    {
+        // the functions empty_output and empty_output_with_pass_through return an empty Page for each processed input Page. the argument has KEEP WHEN EMPTY property
+
+        // non-empty input, no pass-trough columns
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.empty_output(TABLE(tpch.tiny.orders)))
+                """))
+                .matches("SELECT true WHERE false");
+
+        // non-empty input, pass-through partitioning column
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.empty_output(TABLE(tpch.tiny.orders) PARTITION BY orderstatus))
+                """))
+                .matches("SELECT true, 'X' WHERE false");
+
+        // non-empty input, argument has pass-trough columns
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.empty_output_with_pass_through(TABLE(tpch.tiny.orders)))
+                """))
+                .matches("SELECT true, * FROM tpch.tiny.orders WHERE false");
+
+        // non-empty input, argument has pass-trough columns, partitioning column present
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.empty_output_with_pass_through(TABLE(tpch.tiny.orders) PARTITION BY orderstatus))
+                """))
+                .matches("SELECT true, * FROM tpch.tiny.orders WHERE false");
+
+        // empty input, no pass-trough columns
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.empty_output(TABLE(SELECT * FROM tpch.tiny.orders WHERE false)))
+                """))
+                .matches("SELECT true WHERE false");
+
+        // empty input, pass-through partitioning column
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.empty_output(TABLE(SELECT * FROM tpch.tiny.orders WHERE false) PARTITION BY orderstatus))
+                """))
+                .matches("SELECT true, 'X' WHERE false");
+
+        // empty input, argument has pass-trough columns
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.empty_output_with_pass_through(TABLE(SELECT * FROM tpch.tiny.orders WHERE false)))
+                """))
+                .matches("SELECT true, * FROM tpch.tiny.orders WHERE false");
+
+        // empty input, argument has pass-trough columns, partitioning column present
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.empty_output_with_pass_through(TABLE(SELECT * FROM tpch.tiny.orders WHERE false) PARTITION BY orderstatus))
+                """))
+                .matches("SELECT true, * FROM tpch.tiny.orders WHERE false");
+    }
+
+    @Test
+    public void testInputPartitioning()
+    {
+        // table function test_inputs_function has four table arguments. input_1 has row semantics. input_2, input_3 and input_4 have set semantics.
+        // the function outputs one row per each tuple of partition it processes. The row includes a true value, and partitioning values.
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(VALUES 1, 2, 3),
+                               input_2 => TABLE(VALUES 4, 5, 4, 5, 4) t2(x2) PARTITION BY x2,
+                               input_3 => TABLE(VALUES 6, 7, 6) t3(x3) PARTITION BY x3,
+                               input_4 => TABLE(VALUES 8, 9)))
+                """))
+                .matches("VALUES (true, 4, 6), (true, 4, 7), (true, 5, 6), (true, 5, 7)");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(VALUES 1, 2, 3),
+                               input_2 => TABLE(VALUES 4, 5, 4, 5, 4) t2(x2) PARTITION BY x2,
+                               input_3 => TABLE(VALUES 6, 7, 6) t3(x3) PARTITION BY x3,
+                               input_4 => TABLE(VALUES 8, 9) t4(x4) PARTITION BY x4))
+                """))
+                .matches("VALUES (true, 4, 6, 8), (true, 4, 6, 9), (true, 4, 7, 8), (true, 4, 7, 9), (true, 5, 6, 8), (true, 5, 6, 9), (true, 5, 7, 8), (true, 5, 7, 9)");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(VALUES 1, 2, 3),
+                               input_2 => TABLE(VALUES 4, 5, 4, 5, 4) t2(x2) PARTITION BY x2,
+                               input_3 => TABLE(VALUES 6, 7, 6) t3(x3) PARTITION BY x3,
+                               input_4 => TABLE(VALUES 8, 8) t4(x4) PARTITION BY x4))
+                """))
+                .matches("VALUES (true, 4, 6, 8), (true, 4, 7, 8), (true, 5, 6, 8), (true, 5, 7, 8)");
+
+        // null partitioning values
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(VALUES 1, null),
+                               input_2 => TABLE(VALUES 2, null, 2, null) t2(x2) PARTITION BY x2,
+                               input_3 => TABLE(VALUES 3, null, 3, null) t3(x3) PARTITION BY x3,
+                               input_4 => TABLE(VALUES null, null) t4(x4) PARTITION BY x4))
+                """))
+                .matches("VALUES (true, 2, 3, null), (true, 2, null, null), (true, null, 3, null), (true, null, null, null)");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(VALUES 1, 2, 3),
+                               input_2 => TABLE(VALUES 4, 5, 4, 5, 4),
+                               input_3 => TABLE(VALUES 6, 7, 6),
+                               input_4 => TABLE(VALUES 8, 9)))
+                """))
+                .matches("VALUES true");
+
+        assertThat(query("""
+                SELECT DISTINCT regionkey, nationkey
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(tpch.tiny.nation),
+                               input_2 => TABLE(tpch.tiny.nation) PARTITION BY regionkey ORDER BY name,
+                               input_3 => TABLE(tpch.tiny.customer) PARTITION BY nationkey,
+                               input_4 => TABLE(tpch.tiny.customer)))
+                """))
+                .matches("SELECT DISTINCT n.regionkey, c.nationkey FROM tpch.tiny.nation n, tpch.tiny.customer c");
+    }
+
+    @Test
+    public void testEmptyPartitions()
+    {
+        // input_1 has row semantics, so it is prune when empty. input_2, input_3 and input_4 have set semantics, and are keep when empty by default
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(VALUES 1, 2, 3),
+                               input_2 => TABLE(SELECT 2 WHERE false),
+                               input_3 => TABLE(SELECT 3 WHERE false),
+                               input_4 => TABLE(SELECT 4 WHERE false)))
+                """))
+                .matches("VALUES true");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(SELECT 1 WHERE false),
+                               input_2 => TABLE(VALUES 2),
+                               input_3 => TABLE(VALUES 3),
+                               input_4 => TABLE(VALUES 4)))
+                """))
+                .returnsEmptyResult();
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(VALUES 1, 2, 3),
+                               input_2 => TABLE(SELECT 2 WHERE false) t2(x2) PARTITION BY x2,
+                               input_3 => TABLE(SELECT 3 WHERE false) t3(x3) PARTITION BY x3,
+                               input_4 => TABLE(SELECT 4 WHERE false) t4(x4) PARTITION BY x4))
+                """))
+                .matches("VALUES (true, CAST(null AS integer), CAST(null AS integer), CAST(null AS integer))");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(VALUES 1, 2, 3),
+                               input_2 => TABLE(SELECT 2 WHERE false) t2(x2) PARTITION BY x2,
+                               input_3 => TABLE(VALUES 3, 4, 4) t3(x3) PARTITION BY x3,
+                               input_4 => TABLE(VALUES 4, 4, 4, 5, 5, 5, 5) t4(x4) PARTITION BY x4))
+                """))
+                .matches("VALUES (true, CAST(null AS integer), 3, 4), (true, null, 4, 4), (true, null, 4, 5), (true, null, 3, 5)");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(VALUES 1, 2, 3),
+                               input_2 => TABLE(SELECT 2 WHERE false) t2(x2) PARTITION BY x2,
+                               input_3 => TABLE(SELECT 3 WHERE false) t3(x3) PARTITION BY x3,
+                               input_4 => TABLE(VALUES 4, 5) t4(x4) PARTITION BY x4))
+                """))
+                .matches("VALUES (true, CAST(null AS integer), CAST(null AS integer), 4), (true, null, null, 5)");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(VALUES 1, 2, 3),
+                               input_2 => TABLE(SELECT 2 WHERE false) t2(x2) PARTITION BY x2 PRUNE WHEN EMPTY,
+                               input_3 => TABLE(SELECT 3 WHERE false) t3(x3) PARTITION BY x3,
+                               input_4 => TABLE(VALUES 4, 5) t4(x4) PARTITION BY x4))
+                """))
+                .returnsEmptyResult();
+    }
+
+    @Test
+    public void testCopartitioning()
+    {
+        // all tanbles are by default KEEP WHEN EMPTY. If there is no matching partition, it is null-completed
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(VALUES 1, 2, 3),
+                               input_2 => TABLE(VALUES 1, 1, 2, 2) t2(x2) PARTITION BY x2,
+                               input_3 => TABLE(VALUES 4, 5) t3(x3),
+                               input_4 => TABLE(VALUES 2, 2, 2, 3) t4(x4) PARTITION BY x4
+                               COPARTITION (t2, t4)))
+                """))
+                .matches("VALUES (true, 1, null), (true, 2, 2), (true, null, 3)");
+
+        // partition `3` from input_4 is pruned because there is no matching partition in input_2
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(VALUES 1, 2, 3),
+                               input_2 => TABLE(VALUES 1, 1, 2, 2) t2(x2) PARTITION BY x2 PRUNE WHEN EMPTY,
+                               input_3 => TABLE(VALUES 4, 5) t3(x3),
+                               input_4 => TABLE(VALUES 2, 2, 2, 3) t4(x4) PARTITION BY x4
+                               COPARTITION (t2, t4)))
+                """))
+                .matches("VALUES (true, 1, null), (true, 2, 2)");
+
+        // partition `1` from input_2 is pruned because there is no matching partition in input_4
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(VALUES 1, 2, 3),
+                               input_2 => TABLE(VALUES 1, 1, 2, 2) t2(x2) PARTITION BY x2,
+                               input_3 => TABLE(VALUES 4, 5) t3(x3),
+                               input_4 => TABLE(VALUES 2, 2, 2, 3) t4(x4) PARTITION BY x4 PRUNE WHEN EMPTY
+                               COPARTITION (t2, t4)))
+                """))
+                .matches("VALUES (true, 2, 2), (true, null, 3)");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(VALUES 1, 2, 3),
+                               input_2 => TABLE(VALUES 1, 1, 2, 2) t2(x2) PARTITION BY x2 PRUNE WHEN EMPTY,
+                               input_3 => TABLE(VALUES 4, 5) t3(x3),
+                               input_4 => TABLE(VALUES 2, 2, 2, 3) t4(x4) PARTITION BY x4 PRUNE WHEN EMPTY
+                               COPARTITION (t2, t4)))
+                """))
+                .matches("VALUES (true, 2, 2)");
+
+        // null partitioning values
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(VALUES 1, 2, 3),
+                               input_2 => TABLE(VALUES 1, 1, null, null, 2, 2) t2(x2) PARTITION BY x2,
+                               input_3 => TABLE(VALUES 4, 5) t3(x3),
+                               input_4 => TABLE(VALUES null, 2, 2, 2, 3) t4(x4) PARTITION BY x4
+                               COPARTITION (t2, t4)))
+                """))
+                .matches("VALUES (true, 1, null), (true, 2, 2), (true, null, null), (true, null, 3)");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(VALUES 1, 2, 3),
+                               input_2 => TABLE(VALUES 1, 1, null, null, 2, 2) t2(x2) PARTITION BY x2 PRUNE WHEN EMPTY,
+                               input_3 => TABLE(VALUES 4, 5) t3(x3),
+                               input_4 => TABLE(VALUES null, 2, 2, 2, 3) t4(x4) PARTITION BY x4 PRUNE WHEN EMPTY
+                               COPARTITION (t2, t4)))
+                """))
+                .matches("VALUES (true, 2, 2), (true, null, null)");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(VALUES 1, 2, 3),
+                               input_2 => TABLE(VALUES 1, 1, null, null) t2(x2) PARTITION BY x2,
+                               input_3 => TABLE(VALUES 2, 2, null) t3(x3) PARTITION BY x3,
+                               input_4 => TABLE(VALUES 2, 3, 3) t4(x4) PARTITION BY x4
+                               COPARTITION (t2, t4, t3)))
+                """))
+                .matches("VALUES (true, 1, null, null), (true, null, null, null), (true, null, 2, 2), (true, null, null, 3)");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(VALUES 1, 2, 3),
+                               input_2 => TABLE(VALUES 1, 1, null, null) t2(x2) PARTITION BY x2,
+                               input_3 => TABLE(VALUES 2, 2, null) t3(x3) PARTITION BY x3 PRUNE WHEN EMPTY,
+                               input_4 => TABLE(VALUES 2, 3, 3) t4(x4) PARTITION BY x4
+                               COPARTITION (t2, t4, t3)))
+                """))
+                .matches("VALUES (true, CAST(null AS integer), null, null), (true, null, 2, 2)");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(VALUES 1, 2, 3),
+                               input_2 => TABLE(VALUES 1, 1, null, null) t2(x2) PARTITION BY x2 PRUNE WHEN EMPTY,
+                               input_3 => TABLE(VALUES 2, 2, null) t3(x3) PARTITION BY x3,
+                               input_4 => TABLE(VALUES 2, 3, 3) t4(x4) PARTITION BY x4
+                               COPARTITION (t2, t4, t3)))
+                """))
+                .matches("VALUES (true, 1, CAST(null AS integer), CAST(null AS integer)), (true, null, null, null)");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_inputs_function(
+                               input_1 => TABLE(VALUES 1, 2, 3),
+                               input_2 => TABLE(VALUES 1, 1, null, null) t2(x2) PARTITION BY x2 PRUNE WHEN EMPTY,
+                               input_3 => TABLE(VALUES 2, 2, null) t3(x3) PARTITION BY x3,
+                               input_4 => TABLE(VALUES 2, 3, 3) t4(x4) PARTITION BY x4 PRUNE WHEN EMPTY
+                               COPARTITION (t2, t4, t3)))
+                """))
+                .returnsEmptyResult();
+    }
+
+    @Test
+    public void testPassThroughWithEmptyPartitions()
+    {
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.pass_through(
+                                            TABLE(VALUES (1, 'a'), (2, 'b')) t1(a1, b1) PARTITION BY a1,
+                                            TABLE(VALUES (2, 'x'), (3, 'y')) t2(a2, b2) PARTITION BY a2
+                                            COPARTITION (t1, t2)))
+                """))
+                .matches("VALUES (true, false, 1, 'a', null, null), (true, true, 2, 'b', 2, 'x'), (false, true, null, null, 3, 'y')");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.pass_through(
+                                            TABLE(VALUES (1, 'a'), (2, 'b')) t1(a1, b1) PARTITION BY a1,
+                                            TABLE(SELECT 2, 'x' WHERE false) t2(a2, b2) PARTITION BY a2
+                                            COPARTITION (t1, t2)))
+                """))
+                .matches("VALUES (true, false, 1, 'a', CAST(null AS integer), CAST(null AS VARCHAR(1))), (true, false, 2, 'b', null, null)");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.pass_through(
+                                            TABLE(VALUES (1, 'a'), (2, 'b')) t1(a1, b1) PARTITION BY a1,
+                                            TABLE(SELECT 2, 'x' WHERE false) t2(a2, b2) PARTITION BY a2))
+                """))
+                .matches("VALUES (true, false, 1, 'a', CAST(null AS integer), CAST(null AS VARCHAR(1))), (true, false, 2, 'b', null, null)");
+    }
+
+    @Test
+    public void testPassThroughWithEmptyInput()
+    {
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.pass_through(
+                                            TABLE(SELECT 1, 'x' WHERE false) t1(a1, b1) PARTITION BY a1,
+                                            TABLE(SELECT 2, 'y' WHERE false) t2(a2, b2) PARTITION BY a2
+                                            COPARTITION (t1, t2)))
+                """))
+                .matches("VALUES (false, false, CAST(null AS integer), CAST(null AS VARCHAR(1)), CAST(null AS integer), CAST(null AS VARCHAR(1)))");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.pass_through(
+                                            TABLE(SELECT 1, 'x' WHERE false) t1(a1, b1) PARTITION BY a1,
+                                            TABLE(SELECT 2, 'y' WHERE false) t2(a2, b2) PARTITION BY a2))
+                """))
+                .matches("VALUES (false, false, CAST(null AS integer), CAST(null AS VARCHAR(1)), CAST(null AS integer), CAST(null AS VARCHAR(1)))");
+    }
+
+    @Test
+    public void testInput()
+    {
+        assertThat(query("""
+                SELECT got_input
+                FROM TABLE(system.test_input(TABLE(VALUES 1)))
+                """))
+                .matches("VALUES true");
+
+        assertThat(query("""
+                SELECT got_input
+                FROM TABLE(system.test_input(TABLE(VALUES 1, 2, 3) t(a) PARTITION BY a))
+                """))
+                .matches("VALUES true, true, true");
+
+        assertThat(query("""
+                SELECT got_input
+                FROM TABLE(system.test_input(TABLE(SELECT 1 WHERE false)))
+                """))
+                .matches("VALUES false");
+
+        assertThat(query("""
+                SELECT got_input
+                FROM TABLE(system.test_input(TABLE(SELECT 1 WHERE false) t(a) PARTITION BY a))
+                """))
+                .matches("VALUES false");
+
+        assertThat(query("""
+                SELECT got_input
+                FROM TABLE(system.test_input(TABLE(SELECT * FROM tpch.tiny.orders WHERE false)))
+                """))
+                .matches("VALUES false");
+
+        assertThat(query("""
+                SELECT got_input
+                FROM TABLE(system.test_input(TABLE(SELECT * FROM tpch.tiny.orders WHERE false) PARTITION BY orderstatus ORDER BY orderkey))
+                """))
+                .matches("VALUES false");
+    }
+
+    @Test
+    public void testSingleSourceWithRowSemantics()
+    {
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.test_single_input_function(TABLE(VALUES (true), (false), (true))))
+                """))
+                .matches("VALUES true");
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestTableFunctionInvocation.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestTableFunctionInvocation.java
@@ -757,4 +757,119 @@ public class TestTableFunctionInvocation
                 """))
                 .matches("VALUES (BIGINT '1000000', BIGINT '1', 2)");
     }
+
+    @Test
+    public void testPruneAllColumns()
+    {
+        // function identity_pass_through_function has no proper outputs. It outputs input columns using the pass-through mechanism.
+        // in this case, no pass-through columns are referenced, so they are all pruned. The function effectively produces no columns.
+        assertThat(query("SELECT 'a' FROM TABLE(system.identity_pass_through_function(input => TABLE(VALUES 1, 2, 3)))"))
+                .matches("VALUES 'a', 'a', 'a'");
+
+        // all pass-through columns are pruned. Also, the input is empty, and it has KEEP WHEN EMPTY property, so the function is executed on empty partition.
+        assertThat(query("SELECT 'a' FROM TABLE(system.identity_pass_through_function(input => TABLE(SELECT 1 WHERE false)))"))
+                .matches("SELECT 'a' WHERE false");
+
+        // all pass-through columns are pruned. Also, the input is empty, and it has PRUNE WHEN EMPTY property, so the function is pruned out.
+        assertThat(query("SELECT 'a' FROM TABLE(system.identity_pass_through_function(input => TABLE(SELECT 1 WHERE false) PRUNE WHEN EMPTY))"))
+                .matches("SELECT 'a' WHERE false");
+    }
+
+    @Test
+    public void testPrunePassThroughColumns()
+    {
+        // function pass_through has 2 proper columns, and it outputs all columns from both inputs using the pass-through mechanism.
+        // all columns are referenced
+        assertThat(query("""
+                SELECT p1, p2, x1, x2, y1, y2
+                FROM TABLE(system.pass_through(
+                                            TABLE(VALUES (1, 'a'), (2, 'b'), (3, 'c')) t1(x1, x2),
+                                            TABLE(VALUES (4, 'd'), (5, 'e')) t2(y1, y2))) t(p1, p2)
+                """))
+                .matches("VALUES (true, true, 3, 'c', 5, 'e')");
+
+        // all pass-through columns are referenced. Proper columns are not referenced, but they are not pruned.
+        assertThat(query("""
+                SELECT x1, x2, y1, y2
+                FROM TABLE(system.pass_through(
+                                            TABLE(VALUES (1, 'a'), (2, 'b'), (3, 'c')) t1(x1, x2),
+                                            TABLE(VALUES (4, 'd'), (5, 'e')) t2(y1, y2))) t(p1, p2)
+                """))
+                .matches("VALUES (3, 'c', 5, 'e')");
+
+        // some pass-through columns are referenced. Unreferenced pass-through columns are pruned.
+        assertThat(query("""
+                SELECT x2, y2
+                FROM TABLE(system.pass_through(
+                                            TABLE(VALUES (1, 'a'), (2, 'b'), (3, 'c')) t1(x1, x2),
+                                            TABLE(VALUES (4, 'd'), (5, 'e')) t2(y1, y2))) t(p1, p2)
+                """))
+                .matches("VALUES ('c', 'e')");
+
+        assertThat(query("""
+                SELECT y1, y2
+                FROM TABLE(system.pass_through(
+                                            TABLE(VALUES (1, 'a'), (2, 'b'), (3, 'c')) t1(x1, x2),
+                                            TABLE(VALUES (4, 'd'), (5, 'e')) t2(y1, y2))) t(p1, p2)
+                """))
+                .matches("VALUES (5, 'e')");
+
+        // no pass-through columns are referenced. Unreferenced pass-through columns are pruned.
+        assertThat(query("""
+                SELECT 'x'
+                FROM TABLE(system.pass_through(
+                                            TABLE(VALUES (1, 'a'), (2, 'b'), (3, 'c')) t1(x1, x2),
+                                            TABLE(VALUES (4, 'd'), (5, 'e')) t2(y1, y2))) t(p1, p2)
+                """))
+                .matches("VALUES ('x')");
+    }
+
+    @Test
+    public void testPrunePassThroughColumnsWithEmptyInput()
+    {
+        // function pass_through has 2 proper columns, and it outputs all columns from both inputs using the pass-through mechanism.
+        // all columns are referenced
+        assertThat(query("""
+                SELECT p1, p2, x1, x2, y1, y2
+                FROM TABLE(system.pass_through(
+                                            TABLE(SELECT 1, 'a' WHERE FALSE) t1(x1, x2),
+                                            TABLE(SELECT 4, 'd' WHERE FALSE) t2(y1, y2))) t(p1, p2)
+                """))
+                .matches("VALUES (false, false, CAST(null AS integer), CAST(null AS varchar(1)), CAST(null AS integer), CAST(null AS varchar(1)))");
+
+        // all pass-through columns are referenced. Proper columns are not referenced, but they are not pruned.
+        assertThat(query("""
+                SELECT x1, x2, y1, y2
+                FROM TABLE(system.pass_through(
+                                            TABLE(SELECT 1, 'a' WHERE FALSE) t1(x1, x2),
+                                            TABLE(SELECT 4, 'd' WHERE FALSE) t2(y1, y2))) t(p1, p2)
+                """))
+                .matches("VALUES (CAST(null AS integer), CAST(null AS varchar(1)), CAST(null AS integer), CAST(null AS varchar(1)))");
+
+        // some pass-through columns are referenced. Unreferenced pass-through columns are pruned.
+        assertThat(query("""
+                SELECT x2, y2
+                FROM TABLE(system.pass_through(
+                                            TABLE(SELECT 1, 'a' WHERE FALSE) t1(x1, x2),
+                                            TABLE(SELECT 4, 'd' WHERE FALSE) t2(y1, y2))) t(p1, p2)
+                """))
+                .matches("VALUES (CAST(null AS varchar(1)), CAST(null AS varchar(1)))");
+
+        assertThat(query("""
+                SELECT y1, y2
+                FROM TABLE(system.pass_through(
+                                            TABLE(SELECT 1, 'a' WHERE FALSE) t1(x1, x2),
+                                            TABLE(SELECT 4, 'd' WHERE FALSE) t2(y1, y2))) t(p1, p2)
+                """))
+                .matches("VALUES (CAST(null AS integer), CAST(null AS varchar(1)))");
+
+        // no pass-through columns are referenced. Unreferenced pass-through columns are pruned.
+        assertThat(query("""
+                SELECT 'x'
+                FROM TABLE(system.pass_through(
+                                            TABLE(SELECT 1, 'a' WHERE FALSE) t1(x1, x2),
+                                            TABLE(SELECT 4, 'd' WHERE FALSE) t2(y1, y2))) t(p1, p2)
+                """))
+                .matches("VALUES ('x')");
+    }
 }


### PR DESCRIPTION
Based on https://github.com/trinodb/trino/pull/15575 (operator) and https://github.com/trinodb/trino/pull/16012 (optimizations).
Adds more tests involving the execution by operator of table functions optimized by the column pruning rules.

No docs or release notes needed.