### PR TITLE
Improve BigQuery metadata retrieval performance

### DIFF
--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -77,6 +77,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>configuration</artifactId>
         </dependency>
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
@@ -23,6 +23,7 @@ import io.trino.plugin.base.logging.SessionInterpolatedValues;
 
 import javax.annotation.PostConstruct;
 import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
@@ -59,6 +60,7 @@ public class BigQueryConfig
     private String queryLabelName;
     private String queryLabelFormat;
     private boolean proxyEnabled;
+    private int metadataParallelism = 2;
 
     public Optional<String> getProjectId()
     {
@@ -305,6 +307,21 @@ public class BigQueryConfig
     public BigQueryConfig setProxyEnabled(boolean proxyEnabled)
     {
         this.proxyEnabled = proxyEnabled;
+        return this;
+    }
+
+    @Min(1)
+    @Max(32)
+    public int getMetadataParallelism()
+    {
+        return metadataParallelism;
+    }
+
+    @ConfigDescription("Limits metadata enumeration calls parallelism")
+    @Config("bigquery.metadata.parallelism")
+    public BigQueryConfig setMetadataParallelism(int metadataParallelism)
+    {
+        this.metadataParallelism = metadataParallelism;
         return this;
     }
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryRpcConfig.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryRpcConfig.java
@@ -19,6 +19,8 @@ import io.airlift.units.Duration;
 import io.airlift.units.MaxDuration;
 import io.airlift.units.MinDuration;
 
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
@@ -34,6 +36,7 @@ public class BigQueryRpcConfig
     private int retries;
     private Duration timeout = Duration.valueOf("0s");
     private Duration retryDelay = Duration.valueOf("0s");
+    private double retryMultiplier = 1.0;
 
     @Min(1)
     @Max(MAX_RPC_CONNECTIONS)
@@ -151,5 +154,20 @@ public class BigQueryRpcConfig
     {
         this.retryDelay = retryDelay;
         return this;
+    }
+
+    @ConfigHidden
+    @Config("bigquery.rpc-retry-delay-multiplier")
+    public BigQueryRpcConfig setRetryMultiplier(double retryMultiplier)
+    {
+        this.retryMultiplier = retryMultiplier;
+        return this;
+    }
+
+    @DecimalMin("1.0")
+    @DecimalMax("2.0")
+    public double getRetryMultiplier()
+    {
+        return retryMultiplier;
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/DefaultBigQueryMetadataFactory.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/DefaultBigQueryMetadataFactory.java
@@ -13,24 +13,29 @@
  */
 package io.trino.plugin.bigquery;
 
+import com.google.common.util.concurrent.ListeningExecutorService;
+
 import javax.inject.Inject;
 
+import static io.trino.plugin.bigquery.BigQueryConnectorModule.ForBigQuery;
 import static java.util.Objects.requireNonNull;
 
 public class DefaultBigQueryMetadataFactory
         implements BigQueryMetadataFactory
 {
     private final BigQueryClientFactory bigQueryClient;
+    private final ListeningExecutorService executorService;
 
     @Inject
-    public DefaultBigQueryMetadataFactory(BigQueryClientFactory bigQueryClient)
+    public DefaultBigQueryMetadataFactory(BigQueryClientFactory bigQueryClient, @ForBigQuery ListeningExecutorService executorService)
     {
         this.bigQueryClient = requireNonNull(bigQueryClient, "bigQueryClient is null");
+        this.executorService = requireNonNull(executorService, "executorService is null");
     }
 
     @Override
     public BigQueryMetadata create(BigQueryTransactionHandle transaction)
     {
-        return new BigQueryMetadata(bigQueryClient);
+        return new BigQueryMetadata(bigQueryClient, executorService);
     }
 }

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
@@ -94,6 +94,10 @@ public final class BigQueryQueryRunner
             connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));
             connectorProperties.putIfAbsent("bigquery.views-enabled", "true");
             connectorProperties.putIfAbsent("bigquery.view-expire-duration", "30m");
+            connectorProperties.putIfAbsent("bigquery.rpc-retries", "4");
+            connectorProperties.putIfAbsent("bigquery.rpc-retry-delay", "200ms");
+            connectorProperties.putIfAbsent("bigquery.rpc-retry-delay-multiplier", "1.5");
+            connectorProperties.putIfAbsent("bigquery.rpc-timeout", "8s");
 
             queryRunner.installPlugin(new BigQueryPlugin());
             queryRunner.createCatalog(

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
@@ -51,7 +51,8 @@ public class TestBigQueryConfig
                 .setQueryResultsCacheEnabled(false)
                 .setQueryLabelName(null)
                 .setQueryLabelFormat(null)
-                .setProxyEnabled(false));
+                .setProxyEnabled(false)
+                .setMetadataParallelism(2));
     }
 
     @Test
@@ -76,6 +77,7 @@ public class TestBigQueryConfig
                 .put("bigquery.job.label-name", "trino_job_name")
                 .put("bigquery.job.label-format", "$TRACE_TOKEN")
                 .put("bigquery.rpc-proxy.enabled", "true")
+                .put("bigquery.metadata.parallelism", "31")
                 .buildOrThrow();
 
         BigQueryConfig expected = new BigQueryConfig()
@@ -96,7 +98,8 @@ public class TestBigQueryConfig
                 .setQueryResultsCacheEnabled(true)
                 .setQueryLabelName("trino_job_name")
                 .setQueryLabelFormat("$TRACE_TOKEN")
-                .setProxyEnabled(true);
+                .setProxyEnabled(true)
+                .setMetadataParallelism(31);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryRpcConfig.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryRpcConfig.java
@@ -36,7 +36,8 @@ public class TestBigQueryRpcConfig
                 .setRpcMaxChannelCount(1)
                 .setRetries(0)
                 .setTimeout(Duration.valueOf("0s"))
-                .setRetryDelay(Duration.valueOf("0s")));
+                .setRetryDelay(Duration.valueOf("0s"))
+                .setRetryMultiplier(1.0));
     }
 
     @Test
@@ -51,6 +52,7 @@ public class TestBigQueryRpcConfig
                 .put("bigquery.rpc-retries", "5")
                 .put("bigquery.rpc-timeout", "17s")
                 .put("bigquery.rpc-retry-delay", "10s")
+                .put("bigquery.rpc-retry-delay-multiplier", "1.2")
                 .buildOrThrow();
 
         BigQueryRpcConfig expected = new BigQueryRpcConfig()
@@ -61,7 +63,8 @@ public class TestBigQueryRpcConfig
                 .setMaxRpcPerChannel(15)
                 .setRetries(5)
                 .setTimeout(Duration.valueOf("17s"))
-                .setRetryDelay(Duration.valueOf("10s"));
+                .setRetryDelay(Duration.valueOf("10s"))
+                .setRetryMultiplier(1.2);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
`SELECT * FROM information_schema.columns WHERE table_catalog = 'bigquery'` goes from 17s to 3s in my testing (for just a minor number of tables)

`BaseConnectorTest.testSelectInformationSchemaColumns` completes under 45s instead of 2m

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
