### PR TITLE
Big query PTF queries fails when projection contains now lowercase co…

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -337,7 +337,7 @@ public class BigQueryMetadata
         BigQueryTableHandle table = (BigQueryTableHandle) tableHandle;
         if (table.getProjectedColumns().isPresent()) {
             return table.getProjectedColumns().get().stream()
-                    .collect(toImmutableMap(BigQueryColumnHandle::getName, identity()));
+                    .collect(toImmutableMap(columnHandle -> columnHandle.getColumnMetadata().getName(), identity()));
         }
 
         checkArgument(table.isNamedRelation(), "Cannot get columns for %s", tableHandle);

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.bigquery;
 
+import com.google.common.collect.ImmutableList;
 import io.trino.Session;
 import io.trino.testing.BaseConnectorTest;
 import io.trino.testing.MaterializedResult;
@@ -41,6 +42,7 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public abstract class BaseBigQueryConnectorTest
         extends BaseConnectorTest
@@ -707,6 +709,14 @@ public abstract class BaseBigQueryConnectorTest
         assertQuery(
                 "SELECT * FROM TABLE(bigquery.system.query(query => 'SELECT 1'))",
                 "VALUES 1");
+    }
+
+    @Test
+    public void testNativeQuerySelectForCaseSensitiveColumnNames()
+    {
+        MaterializedResult result = computeActual
+                ("SELECT * FROM TABLE(bigquery.system.query(query => 'select 1 as lower, 2 as UPPER, 3 as miXED'))");
+        assertTrue(result.getColumnNames().containsAll(ImmutableList.of("lower", "UPPER", "miXED")));
     }
 
     @Test


### PR DESCRIPTION
This patch fixes #16075

I have taken the reference from the DefaultJdbcMetadata and it works with that approach.
Another workaround without the fix is always to alias the column names to be lowercase.
