### PR TITLE
Fix failure when non-lowercase column exists in BigQuery query function

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -337,7 +337,7 @@ public class BigQueryMetadata
         BigQueryTableHandle table = (BigQueryTableHandle) tableHandle;
         if (table.getProjectedColumns().isPresent()) {
             return table.getProjectedColumns().get().stream()
-                    .collect(toImmutableMap(BigQueryColumnHandle::getName, identity()));
+                    .collect(toImmutableMap(columnHandle -> columnHandle.getColumnMetadata().getName(), identity()));
         }
 
         checkArgument(table.isNamedRelation(), "Cannot get columns for %s", tableHandle);

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -710,6 +710,35 @@ public abstract class BaseBigQueryConnectorTest
     }
 
     @Test
+    public void testNativeQuerySelectForCaseSensitiveColumnNames()
+    {
+        assertThat(computeActual("SELECT * FROM TABLE(bigquery.system.query(query => 'SELECT 1 AS lower, 2 AS UPPER, 3 AS miXED'))").getColumnNames())
+                .containsExactly("lower", "UPPER", "miXED");
+
+        assertThat(computeActual("SELECT * FROM TABLE(bigquery.system.query(query => 'SELECT 1 AS duplicated, 2 AS duplicated'))").getColumnNames())
+                .containsExactly("duplicated", "duplicated_1");
+
+        String tableName = "test.test_non_lowercase" + randomNameSuffix();
+        onBigQuery("CREATE TABLE " + tableName + " AS SELECT 1 AS lower, 2 AS UPPER, 3 AS miXED");
+        try {
+            assertQuery(
+                    "SELECT * FROM TABLE(bigquery.system.query(query => 'SELECT * FROM " + tableName + "'))",
+                    "VALUES (1, 2, 3)");
+            assertQuery(
+                    "SELECT \"lower\", \"UPPER\", \"miXED\" FROM TABLE(bigquery.system.query(query => 'SELECT * FROM " + tableName + "'))",
+                    "VALUES (1, 2, 3)");
+            assertQuery(
+                    "SELECT * FROM TABLE(bigquery.system.query(query => 'SELECT * FROM " + tableName + "')) WHERE \"UPPER\" = 2",
+                    "VALUES (1, 2, 3)");
+            assertQueryReturnsEmptyResult("SELECT * FROM TABLE(bigquery.system.query(query => 'SELECT * FROM " + tableName + "')) WHERE \"UPPER\" = 100");
+            assertQueryReturnsEmptyResult("SELECT * FROM TABLE(bigquery.system.query(query => 'SELECT * FROM " + tableName + "')) WHERE upper = 100");
+        }
+        finally {
+            onBigQuery("DROP TABLE " + tableName);
+        }
+    }
+
+    @Test
     public void testNativeQuerySelectFromNation()
     {
         assertQuery(


### PR DESCRIPTION
This patch fixes #16075 

I have taken the reference from the DefaultJdbcMetadata and it works with that approach.
Another workaround without the fix is always to alias the column names to be lowercase.