### PR TITLE
Fix disabling cache in the setup action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -37,7 +37,7 @@ runs:
           java-version: ${{ inputs.java-version }}
       - name: Cache local Maven repo
         id: cache
-        if: ${{ inputs.cache }}
+        if: ${{ format('{0}', inputs.cache) == 'true' }}
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,6 +7,9 @@ inputs:
   cache:
     description: "Cache Maven repo"
     default: true
+  download_dependencies:
+    description: "Download all Maven dependencies so Maven can work in offline mode"
+    default: true
 
 runs:
   using: composite
@@ -46,6 +49,7 @@ runs:
             ${{ runner.os }}-maven-
       - name: Fetch any missing dependencies
         shell: bash
+        if: ${{ format('{0}', inputs.download_dependencies) == 'true' }}
         run: ./.github/bin/download-maven-dependencies.sh
       - name: Configure Problem Matchers
         if: ${{ inputs.java-version != '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -977,6 +977,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache: false
+          download_dependencies: false
       - name: Product tests artifact
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Cache should not be restored in the `pt` job, since it doesn't build anything with Maven, and it makes it unnecessary longer by 2–3 minutes. The issue is caused by a boolean input actually being a string: https://github.com/actions/runner/issues/1483

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
