### PR TITLE
Allow different jdbc metadata cache ttls for schema and tables lists

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcConfig.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcConfig.java
@@ -20,7 +20,7 @@ import io.airlift.configuration.ConfigDescription;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
 
-import javax.annotation.PostConstruct;
+import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
@@ -28,7 +28,6 @@ import javax.validation.constraints.Pattern;
 import java.util.Set;
 
 import static com.google.common.base.Strings.nullToEmpty;
-import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static javax.validation.constraints.Pattern.Flag.CASE_INSENSITIVE;
 
@@ -114,12 +113,9 @@ public class BaseJdbcConfig
         return this;
     }
 
-    @PostConstruct
-    public void validate()
+    @AssertTrue(message = METADATA_CACHE_TTL + " must be set to a non-zero value when " + METADATA_CACHE_MAXIMUM_SIZE + " is set")
+    public boolean isCacheMaximumSizeConsistent()
     {
-        if (metadataCacheTtl.equals(CACHING_DISABLED) && cacheMaximumSize != BaseJdbcConfig.DEFAULT_METADATA_CACHE_SIZE) {
-            throw new IllegalArgumentException(
-                    format("%s must be set to a non-zero value when %s is set", METADATA_CACHE_TTL, METADATA_CACHE_MAXIMUM_SIZE));
-        }
+        return !metadataCacheTtl.equals(CACHING_DISABLED) || cacheMaximumSize == BaseJdbcConfig.DEFAULT_METADATA_CACHE_SIZE;
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcConfig.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcConfig.java
@@ -25,6 +25,7 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
+import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Strings.nullToEmpty;
@@ -34,12 +35,16 @@ import static javax.validation.constraints.Pattern.Flag.CASE_INSENSITIVE;
 public class BaseJdbcConfig
 {
     public static final String METADATA_CACHE_TTL = "metadata.cache-ttl";
+    public static final String METADATA_SCHEMAS_CACHE_TTL = "metadata.schemas.cache-ttl";
+    public static final String METADATA_TABLES_CACHE_TTL = "metadata.tables.cache-ttl";
     public static final String METADATA_CACHE_MAXIMUM_SIZE = "metadata.cache-maximum-size";
 
     private String connectionUrl;
     private Set<String> jdbcTypesMappedToVarchar = ImmutableSet.of();
     public static final Duration CACHING_DISABLED = new Duration(0, MILLISECONDS);
     private Duration metadataCacheTtl = CACHING_DISABLED;
+    private Optional<Duration> schemaNamesCacheTtl = Optional.empty();
+    private Optional<Duration> tableNamesCacheTtl = Optional.empty();
     private boolean cacheMissing;
     public static final long DEFAULT_METADATA_CACHE_SIZE = 10000;
     private long cacheMaximumSize = DEFAULT_METADATA_CACHE_SIZE;
@@ -86,6 +91,34 @@ public class BaseJdbcConfig
         return this;
     }
 
+    @NotNull
+    public Duration getSchemaNamesCacheTtl()
+    {
+        return schemaNamesCacheTtl.orElse(metadataCacheTtl);
+    }
+
+    @Config(METADATA_SCHEMAS_CACHE_TTL)
+    @ConfigDescription("Determines how long schema names list information will be cached")
+    public BaseJdbcConfig setSchemaNamesCacheTtl(Duration schemaNamesCacheTtl)
+    {
+        this.schemaNamesCacheTtl = Optional.ofNullable(schemaNamesCacheTtl);
+        return this;
+    }
+
+    @NotNull
+    public Duration getTableNamesCacheTtl()
+    {
+        return tableNamesCacheTtl.orElse(metadataCacheTtl);
+    }
+
+    @Config(METADATA_TABLES_CACHE_TTL)
+    @ConfigDescription("Determines how long table names list information will be cached")
+    public BaseJdbcConfig setTableNamesCacheTtl(Duration tableNamesCacheTtl)
+    {
+        this.tableNamesCacheTtl = Optional.ofNullable(tableNamesCacheTtl);
+        return this;
+    }
+
     public boolean isCacheMissing()
     {
         return cacheMissing;
@@ -117,5 +150,17 @@ public class BaseJdbcConfig
     public boolean isCacheMaximumSizeConsistent()
     {
         return !metadataCacheTtl.equals(CACHING_DISABLED) || cacheMaximumSize == BaseJdbcConfig.DEFAULT_METADATA_CACHE_SIZE;
+    }
+
+    @AssertTrue(message = METADATA_SCHEMAS_CACHE_TTL + " must not be set when " + METADATA_CACHE_TTL + " is not set")
+    public boolean isSchemaNamesCacheTtlConsistent()
+    {
+        return !metadataCacheTtl.equals(CACHING_DISABLED) || schemaNamesCacheTtl.isEmpty();
+    }
+
+    @AssertTrue(message = METADATA_TABLES_CACHE_TTL + " must not be set when " + METADATA_CACHE_TTL + " is not set")
+    public boolean isTableNamesCacheTtlConsistent()
+    {
+        return !metadataCacheTtl.equals(CACHING_DISABLED) || tableNamesCacheTtl.isEmpty();
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -584,6 +584,12 @@ public class CachingJdbcClient
     }
 
     @VisibleForTesting
+    CacheStats getSchemaNamesCacheStats()
+    {
+        return schemaNamesCache.stats();
+    }
+
+    @VisibleForTesting
     CacheStats getTableNamesCacheStats()
     {
         return tableNamesCache.stats();

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -93,7 +93,15 @@ public class CachingJdbcClient
             IdentityCacheMapping identityMapping,
             BaseJdbcConfig config)
     {
-        this(delegate, sessionPropertiesProviders, identityMapping, config.getMetadataCacheTtl(), config.isCacheMissing(), config.getCacheMaximumSize());
+        this(
+                delegate,
+                sessionPropertiesProviders,
+                identityMapping,
+                config.getMetadataCacheTtl(),
+                config.getSchemaNamesCacheTtl(),
+                config.getTableNamesCacheTtl(),
+                config.isCacheMissing(),
+                config.getCacheMaximumSize());
     }
 
     public CachingJdbcClient(
@@ -104,6 +112,26 @@ public class CachingJdbcClient
             boolean cacheMissing,
             long cacheMaximumSize)
     {
+        this(delegate,
+                sessionPropertiesProviders,
+                identityMapping,
+                metadataCachingTtl,
+                metadataCachingTtl,
+                metadataCachingTtl,
+                cacheMissing,
+                cacheMaximumSize);
+    }
+
+    public CachingJdbcClient(
+            JdbcClient delegate,
+            Set<SessionPropertiesProvider> sessionPropertiesProviders,
+            IdentityCacheMapping identityMapping,
+            Duration metadataCachingTtl,
+            Duration schemaNamesCachingTtl,
+            Duration tableNamesCachingTtl,
+            boolean cacheMissing,
+            long cacheMaximumSize)
+    {
         this.delegate = requireNonNull(delegate, "delegate is null");
         this.sessionProperties = sessionPropertiesProviders.stream()
                 .flatMap(provider -> provider.getSessionProperties().stream())
@@ -111,25 +139,27 @@ public class CachingJdbcClient
         this.cacheMissing = cacheMissing;
         this.identityMapping = requireNonNull(identityMapping, "identityMapping is null");
 
-        EvictableCacheBuilder<Object, Object> cacheBuilder = EvictableCacheBuilder.newBuilder()
-                .expireAfterWrite(metadataCachingTtl.toMillis(), MILLISECONDS)
+        long cacheSize = metadataCachingTtl.equals(CACHING_DISABLED)
+                // Disables the cache entirely
+                ? 0
+                : cacheMaximumSize;
+
+        schemaNamesCache = buildCache(cacheSize, schemaNamesCachingTtl);
+        tableNamesCache = buildCache(cacheSize, tableNamesCachingTtl);
+        tableHandlesByNameCache = buildCache(cacheSize, metadataCachingTtl);
+        tableHandlesByQueryCache = buildCache(cacheSize, metadataCachingTtl);
+        columnsCache = buildCache(cacheSize, metadataCachingTtl);
+        statisticsCache = buildCache(cacheSize, metadataCachingTtl);
+    }
+
+    private static <K, V> Cache<K, V> buildCache(long cacheSize, Duration cachingTtl)
+    {
+        return EvictableCacheBuilder.newBuilder()
+                .maximumSize(cacheSize)
+                .expireAfterWrite(cachingTtl.toMillis(), MILLISECONDS)
                 .shareNothingWhenDisabled()
-                .recordStats();
-
-        if (metadataCachingTtl.equals(CACHING_DISABLED)) {
-            // Disables the cache entirely
-            cacheBuilder.maximumSize(0);
-        }
-        else {
-            cacheBuilder.maximumSize(cacheMaximumSize);
-        }
-
-        schemaNamesCache = cacheBuilder.build();
-        tableNamesCache = cacheBuilder.build();
-        tableHandlesByNameCache = cacheBuilder.build();
-        tableHandlesByQueryCache = cacheBuilder.build();
-        columnsCache = cacheBuilder.build();
-        statisticsCache = cacheBuilder.build();
+                .recordStats()
+                .build();
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestBaseJdbcConfig.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestBaseJdbcConfig.java
@@ -44,6 +44,8 @@ public class TestBaseJdbcConfig
                 .setConnectionUrl(null)
                 .setJdbcTypesMappedToVarchar("")
                 .setMetadataCacheTtl(ZERO)
+                .setSchemaNamesCacheTtl(null)
+                .setTableNamesCacheTtl(null)
                 .setCacheMissing(false)
                 .setCacheMaximumSize(10000));
     }
@@ -55,6 +57,8 @@ public class TestBaseJdbcConfig
                 .put("connection-url", "jdbc:h2:mem:config")
                 .put("jdbc-types-mapped-to-varchar", "mytype,struct_type1")
                 .put("metadata.cache-ttl", "1s")
+                .put("metadata.schemas.cache-ttl", "2s")
+                .put("metadata.tables.cache-ttl", "3s")
                 .put("metadata.cache-missing", "true")
                 .put("metadata.cache-maximum-size", "5000")
                 .buildOrThrow();
@@ -63,6 +67,8 @@ public class TestBaseJdbcConfig
                 .setConnectionUrl("jdbc:h2:mem:config")
                 .setJdbcTypesMappedToVarchar("mytype, struct_type1")
                 .setMetadataCacheTtl(new Duration(1, SECONDS))
+                .setSchemaNamesCacheTtl(new Duration(2, SECONDS))
+                .setTableNamesCacheTtl(new Duration(3, SECONDS))
                 .setCacheMissing(true)
                 .setCacheMaximumSize(5000);
 
@@ -88,6 +94,8 @@ public class TestBaseJdbcConfig
         assertValidates(new BaseJdbcConfig()
                 .setConnectionUrl("jdbc:h2:mem:config")
                 .setMetadataCacheTtl(new Duration(1, SECONDS))
+                .setSchemaNamesCacheTtl(new Duration(2, SECONDS))
+                .setTableNamesCacheTtl(new Duration(3, SECONDS))
                 .setCacheMaximumSize(5000));
 
         assertValidates(new BaseJdbcConfig()
@@ -98,6 +106,18 @@ public class TestBaseJdbcConfig
                 .setCacheMaximumSize(5000),
                 "cacheMaximumSizeConsistent",
                 "metadata.cache-ttl must be set to a non-zero value when metadata.cache-maximum-size is set",
+                AssertTrue.class);
+
+        assertFailsValidation(new BaseJdbcConfig()
+                .setSchemaNamesCacheTtl(new Duration(1, SECONDS)),
+                "schemaNamesCacheTtlConsistent",
+                "metadata.schemas.cache-ttl must not be set when metadata.cache-ttl is not set",
+                AssertTrue.class);
+
+        assertFailsValidation(new BaseJdbcConfig()
+                .setTableNamesCacheTtl(new Duration(1, SECONDS)),
+                "tableNamesCacheTtlConsistent",
+                "metadata.tables.cache-ttl must not be set when metadata.cache-ttl is not set",
                 AssertTrue.class);
     }
 

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestCachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestCachingJdbcClient.java
@@ -161,11 +161,20 @@ public class TestCachingJdbcClient
         SchemaTableName phantomTable = new SchemaTableName(schema, "phantom_table");
 
         createTable(phantomTable);
-        assertThat(cachingJdbcClient.getTableNames(SESSION, Optional.of(schema))).contains(phantomTable);
+        assertTableNamesCache(cachingJdbcClient)
+                .misses(1)
+                .loads(1)
+                .afterRunning(() -> {
+                    assertThat(cachingJdbcClient.getTableNames(SESSION, Optional.of(schema))).contains(phantomTable);
+                });
         dropTable(phantomTable);
 
         assertThat(jdbcClient.getTableNames(SESSION, Optional.of(schema))).doesNotContain(phantomTable);
-        assertThat(cachingJdbcClient.getTableNames(SESSION, Optional.of(schema))).contains(phantomTable);
+        assertTableNamesCache(cachingJdbcClient)
+                .hits(1)
+                .afterRunning(() -> {
+                    assertThat(cachingJdbcClient.getTableNames(SESSION, Optional.of(schema))).contains(phantomTable);
+                });
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Missing table metadata can be configured to not get cached (`cacheMissing`), but that doesn't apply to schema and table name lists.

In certain cases it might be beneficial to shorten the list cache ttl for them to reflect the added schemas/tables faster, while specific table caches will automatically reload tables that were missing before.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
