### PR TITLE
Use apt mirrors when building the Docker image

### DIFF
--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -15,6 +15,11 @@ FROM eclipse-temurin:17-jdk AS builder
 
 RUN \
     set -xeu && \
+    index=0 && \
+    for dst in http://mirror.kumi.systems/ubuntu-ports/ http://mirrors.ocf.berkeley.edu/ubuntu-ports/; do \
+    sed "s,http://ports.ubuntu.com/ubuntu-ports/,$dst," /etc/apt/sources.list > /etc/apt/sources.list.d/mirror-$index.list; \
+    index=$((index+1)); \
+    done && \
     echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
     echo 'Acquire::http::Timeout "15";' > /etc/apt/apt.conf.d/80-timeouts && \
     apt-get update -q && \
@@ -26,6 +31,11 @@ FROM eclipse-temurin:17-jdk
 
 RUN \
     set -xeu && \
+    index=0 && \
+    for dst in http://mirror.kumi.systems/ubuntu-ports/ http://mirrors.ocf.berkeley.edu/ubuntu-ports/; do \
+    sed "s,http://ports.ubuntu.com/ubuntu-ports/,$dst," /etc/apt/sources.list > /etc/apt/sources.list.d/mirror-$index.list; \
+    index=$((index+1)); \
+    done && \
     echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
     echo 'Acquire::http::Timeout "15";' > /etc/apt/apt.conf.d/80-timeouts && \
     apt-get update -q && \


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In the last few weeks, we've seen failures in the job that builds the Docker image where it couldn't connect to `ports.ubuntu.com`. Adding mirrors to `apt` should make it more resilient against such failures.

I chose these two mirrors by getting a list of mirrors that include ports using this: https://askubuntu.com/questions/428698/are-there-alternative-repositories-to-ports-ubuntu-com-for-arm
and then checking which ones are the fastest using `netselect`, executed on an ec2 instance in us-east-2:
```
$ sudo netselect -v -s10 -t20 $(cat valid.txt )
Running netselect to choose 10 out of 14 addresses.      
............................................................................................................................................................................................................................
    0 http://mirrors-ca.muzzy.us/ubuntu/
  173 http://mirrors.ocf.berkeley.edu/ubuntu-ports/
  417 http://mirror.kumi.systems/ubuntu-ports/
  621 http://jp.mirror.coganng.com/ubuntu-ports/
  716 http://mirror.deace.id/ubuntu/
 1134 http://mirrors.tuna.tsinghua.edu.cn/ubuntu-ports/
 1155 http://ubuntu-mirror.cloud.mu/ubuntu-ports/
 1281 http://mirror.misakamikoto.network/ubuntu-ports/
 1460 http://in.mirror.coganng.com/ubuntu-ports/
 1550 http://mirror.nishi.network/ubuntu-ports/
```
Out of these, the first one is invalid as it doesn't work over http, returning a 403.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This is related to #15840

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
