### PR TITLE
Close the idle connections in the JDBC driver's HTTP connection pool

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
@@ -269,6 +269,8 @@ public class TrinoConnection
             }
         }
         finally {
+            httpClient.dispatcher().executorService().shutdown();
+            httpClient.connectionPool().evictAll();
             closed.set(true);
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
When connecting to Trino cluster through JDBC, below code takes 5 mins to shutdown the JVM after the statement has been successfully executed. Process hangs for around 5 mins before it completes.

``` tsx
try (Connection connection = DriverManager.getConnection("url", "user", "password")) {
    try (Statement statement = connection.createStatement()) {
        statement.execute("SELECT 1");
    }
}
```


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
