### PR TITLE
Simplify predicates involving year function

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -233,6 +233,7 @@ import io.trino.sql.planner.iterative.rule.UnwrapCastInComparison;
 import io.trino.sql.planner.iterative.rule.UnwrapDateTruncInComparison;
 import io.trino.sql.planner.iterative.rule.UnwrapRowSubscript;
 import io.trino.sql.planner.iterative.rule.UnwrapSingleColumnRowInApply;
+import io.trino.sql.planner.iterative.rule.UnwrapYearInComparison;
 import io.trino.sql.planner.iterative.rule.UseNonPartitionedJoinLookupSource;
 import io.trino.sql.planner.optimizations.AddExchanges;
 import io.trino.sql.planner.optimizations.AddLocalExchanges;
@@ -365,6 +366,7 @@ public class PlanOptimizers
                 .addAll(new PushCastIntoRow().rules())
                 .addAll(new UnwrapCastInComparison(plannerContext, typeAnalyzer).rules())
                 .addAll(new UnwrapDateTruncInComparison(plannerContext, typeAnalyzer).rules())
+                .addAll(new UnwrapYearInComparison(plannerContext, typeAnalyzer).rules())
                 .addAll(new RemoveDuplicateConditions(metadata).rules())
                 .addAll(new CanonicalizeExpressions(plannerContext, typeAnalyzer).rules())
                 .addAll(new RemoveRedundantDateTrunc(plannerContext, typeAnalyzer).rules())

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapYearInComparison.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapYearInComparison.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.trino.Session;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+import io.trino.spi.type.Type;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.planner.ExpressionInterpreter;
+import io.trino.sql.planner.LiteralEncoder;
+import io.trino.sql.planner.NoOpSymbolResolver;
+import io.trino.sql.planner.TypeAnalyzer;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.tree.BetweenPredicate;
+import io.trino.sql.tree.Cast;
+import io.trino.sql.tree.ComparisonExpression;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.ExpressionTreeRewriter;
+import io.trino.sql.tree.FunctionCall;
+import io.trino.sql.tree.IsNotNullPredicate;
+import io.trino.sql.tree.IsNullPredicate;
+import io.trino.sql.tree.NodeRef;
+import io.trino.sql.tree.NotExpression;
+import io.trino.sql.tree.NullLiteral;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.metadata.ResolvedFunction.extractFunctionName;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
+import static io.trino.sql.ExpressionUtils.or;
+import static io.trino.sql.analyzer.TypeSignatureTranslator.toSqlType;
+import static io.trino.sql.tree.ComparisonExpression.Operator.GREATER_THAN;
+import static io.trino.sql.tree.ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL;
+import static io.trino.sql.tree.ComparisonExpression.Operator.LESS_THAN;
+import static io.trino.sql.tree.ComparisonExpression.Operator.LESS_THAN_OR_EQUAL;
+import static io.trino.type.DateTimes.PICOSECONDS_PER_MICROSECOND;
+import static io.trino.type.DateTimes.scaleFactor;
+import static java.lang.Math.multiplyExact;
+import static java.lang.Math.toIntExact;
+import static java.time.ZoneOffset.UTC;
+import static java.time.temporal.TemporalAdjusters.lastDayOfYear;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Transforms a constant date/time expression t
+ * <pre>
+ *     year(date_time) = t
+ * </pre>
+ * <p>
+ * into
+ * <pre>
+ *     date_time BETWEEN (beginning of the year t) AND (end of the year t)
+ * </pre>
+ * <p>
+ *
+ * @see UnwrapCastInComparison
+ */
+public class UnwrapYearInComparison
+        extends ExpressionRewriteRuleSet
+{
+    public UnwrapYearInComparison(PlannerContext plannerContext, TypeAnalyzer typeAnalyzer)
+    {
+        super(createRewrite(plannerContext, typeAnalyzer));
+    }
+
+    private static ExpressionRewriter createRewrite(PlannerContext plannerContext, TypeAnalyzer typeAnalyzer)
+    {
+        requireNonNull(plannerContext, "plannerContext is null");
+        requireNonNull(typeAnalyzer, "typeAnalyzer is null");
+
+        return (expression, context) -> unwrapYear(context.getSession(), plannerContext, typeAnalyzer, context.getSymbolAllocator().getTypes(), expression);
+    }
+
+    private static Expression unwrapYear(Session session,
+            PlannerContext plannerContext,
+            TypeAnalyzer typeAnalyzer,
+            TypeProvider types,
+            Expression expression)
+    {
+        return ExpressionTreeRewriter.rewriteWith(new Visitor(plannerContext, typeAnalyzer, session, types), expression);
+    }
+
+    private static class Visitor
+            extends io.trino.sql.tree.ExpressionRewriter<Void>
+    {
+        private final PlannerContext plannerContext;
+        private final TypeAnalyzer typeAnalyzer;
+        private final Session session;
+        private final TypeProvider types;
+        private final LiteralEncoder literalEncoder;
+
+        public Visitor(PlannerContext plannerContext, TypeAnalyzer typeAnalyzer, Session session, TypeProvider types)
+        {
+            this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+            this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
+            this.session = requireNonNull(session, "session is null");
+            this.types = requireNonNull(types, "types is null");
+            this.literalEncoder = new LiteralEncoder(plannerContext);
+        }
+
+        @Override
+        public Expression rewriteComparisonExpression(ComparisonExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+        {
+            ComparisonExpression expression = (ComparisonExpression) treeRewriter.defaultRewrite((Expression) node, null);
+            return unwrapYear(expression);
+        }
+
+        // Simplify `year(d) ? value`
+        private Expression unwrapYear(ComparisonExpression expression)
+        {
+            // Expect year on the left side and value on the right side of the comparison.
+            // This is provided by CanonicalizeExpressionRewriter.
+            if (!(expression.getLeft() instanceof FunctionCall call) ||
+                    !extractFunctionName(call.getName()).equals("year") ||
+                    call.getArguments().size() != 1) {
+                return expression;
+            }
+
+            Map<NodeRef<Expression>, Type> expressionTypes = typeAnalyzer.getTypes(session, types, expression);
+
+            Expression argument = getOnlyElement(call.getArguments());
+            Type argumentType = expressionTypes.get(NodeRef.of(argument));
+
+            Object right = new ExpressionInterpreter(expression.getRight(), plannerContext, session, expressionTypes)
+                    .optimize(NoOpSymbolResolver.INSTANCE);
+
+            if (right == null || right instanceof NullLiteral) {
+                return switch (expression.getOperator()) {
+                    case EQUAL, NOT_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL -> new Cast(new NullLiteral(), toSqlType(BOOLEAN));
+                    case IS_DISTINCT_FROM -> new IsNotNullPredicate(argument);
+                };
+            }
+
+            if (right instanceof Expression) {
+                return expression;
+            }
+            if (argumentType instanceof TimestampWithTimeZoneType) {
+                // Cannot replace with a range due to how year operates on value's local date/time.
+                // I.e. unwrapping is possible only when values are all of some fixed zone and the zone is known.
+                return expression;
+            }
+            if (argumentType != DATE && !(argumentType instanceof TimestampType)) {
+                // e.g. year(INTERVAL) not handled here
+                return expression;
+            }
+
+            int year = toIntExact((Long) right);
+            return switch (expression.getOperator()) {
+                case EQUAL -> between(argument, argumentType, calculateRangeStartInclusive(year, argumentType), calculateRangeEndInclusive(year, argumentType));
+                case NOT_EQUAL -> new NotExpression(between(argument, argumentType, calculateRangeStartInclusive(year, argumentType), calculateRangeEndInclusive(year, argumentType)));
+                case IS_DISTINCT_FROM -> or(
+                        new IsNullPredicate(argument),
+                        new NotExpression(between(argument, argumentType, calculateRangeStartInclusive(year, argumentType), calculateRangeEndInclusive(year, argumentType))));
+                case LESS_THAN -> new ComparisonExpression(LESS_THAN, argument, toExpression(calculateRangeStartInclusive(year, argumentType), argumentType));
+                case LESS_THAN_OR_EQUAL -> new ComparisonExpression(LESS_THAN_OR_EQUAL, argument, toExpression(calculateRangeEndInclusive(year, argumentType), argumentType));
+                case GREATER_THAN -> new ComparisonExpression(GREATER_THAN, argument, toExpression(calculateRangeEndInclusive(year, argumentType), argumentType));
+                case GREATER_THAN_OR_EQUAL -> new ComparisonExpression(GREATER_THAN_OR_EQUAL, argument, toExpression(calculateRangeStartInclusive(year, argumentType), argumentType));
+            };
+        }
+
+        private BetweenPredicate between(Expression argument, Type type, Object minInclusive, Object maxInclusive)
+        {
+            return new BetweenPredicate(
+                    argument,
+                    toExpression(minInclusive, type),
+                    toExpression(maxInclusive, type));
+        }
+
+        private Expression toExpression(Object value, Type type)
+        {
+            return literalEncoder.toExpression(session, value, type);
+        }
+    }
+
+    private static Object calculateRangeStartInclusive(int year, Type type)
+    {
+        if (type == DATE) {
+            LocalDate firstDay = LocalDate.ofYearDay(year, 1);
+            return firstDay.toEpochDay();
+        }
+        if (type instanceof TimestampType timestampType) {
+            long yearStartEpochSecond = LocalDateTime.of(year, 1, 1, 0, 0).toEpochSecond(UTC);
+            long yearStartEpochMicros = multiplyExact(yearStartEpochSecond, MICROSECONDS_PER_SECOND);
+            if (timestampType.isShort()) {
+                return yearStartEpochMicros;
+            }
+            return new LongTimestamp(yearStartEpochMicros, 0);
+        }
+        throw new UnsupportedOperationException("Unsupported type: " + type);
+    }
+
+    @VisibleForTesting
+    public static Object calculateRangeEndInclusive(int year, Type type)
+    {
+        if (type == DATE) {
+            LocalDate lastDay = LocalDate.ofYearDay(year, 1).with(lastDayOfYear());
+            return lastDay.toEpochDay();
+        }
+        if (type instanceof TimestampType timestampType) {
+            long nextYearStartEpochSecond = LocalDateTime.of(year + 1, 1, 1, 0, 0).toEpochSecond(UTC);
+            long nextYearStartEpochMicros = multiplyExact(nextYearStartEpochSecond, MICROSECONDS_PER_SECOND);
+            if (timestampType.isShort()) {
+                return nextYearStartEpochMicros - scaleFactor(timestampType.getPrecision(), 6);
+            }
+            int picosOfMicro = toIntExact(PICOSECONDS_PER_MICROSECOND - scaleFactor(timestampType.getPrecision(), 12));
+            return new LongTimestamp(nextYearStartEpochMicros - 1, picosOfMicro);
+        }
+        throw new UnsupportedOperationException("Unsupported type: " + type);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapYearInComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapYearInComparison.java
@@ -1,0 +1,341 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import io.trino.spi.type.LongTimestamp;
+import io.trino.sql.planner.assertions.BasePlanTest;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_NANOS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_PICOS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_SECONDS;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
+import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.output;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.iterative.rule.UnwrapYearInComparison.calculateRangeEndInclusive;
+import static java.lang.Math.multiplyExact;
+import static java.lang.String.format;
+import static java.time.ZoneOffset.UTC;
+import static java.util.Arrays.asList;
+import static org.testng.Assert.assertEquals;
+
+public class TestUnwrapYearInComparison
+        extends BasePlanTest
+{
+    @Test
+    public void testEquals()
+    {
+        testUnwrap("date", "year(a) = -0001", "a BETWEEN DATE '-0001-01-01' AND DATE '-0001-12-31'");
+        testUnwrap("date", "year(a) = 1960", "a BETWEEN DATE '1960-01-01' AND DATE '1960-12-31'");
+        testUnwrap("date", "year(a) = 2022", "a BETWEEN DATE '2022-01-01' AND DATE '2022-12-31'");
+        testUnwrap("date", "year(a) = 9999", "a BETWEEN DATE '9999-01-01' AND DATE '9999-12-31'");
+
+        testUnwrap("timestamp", "year(a) = -0001", "a BETWEEN TIMESTAMP '-0001-01-01 00:00:00.000' AND TIMESTAMP '-0001-12-31 23:59:59.999'");
+        testUnwrap("timestamp", "year(a) = 1960", "a BETWEEN TIMESTAMP '1960-01-01 00:00:00.000' AND TIMESTAMP '1960-12-31 23:59:59.999'");
+        testUnwrap("timestamp", "year(a) = 2022", "a BETWEEN TIMESTAMP '2022-01-01 00:00:00.000' AND TIMESTAMP '2022-12-31 23:59:59.999'");
+        testUnwrap("timestamp", "year(a) = 9999", "a BETWEEN TIMESTAMP '9999-01-01 00:00:00.000' AND TIMESTAMP '9999-12-31 23:59:59.999'");
+
+        testUnwrap("timestamp(0)", "year(a) = 2022", "a BETWEEN TIMESTAMP '2022-01-01 00:00:00' AND TIMESTAMP '2022-12-31 23:59:59'");
+        testUnwrap("timestamp(1)", "year(a) = 2022", "a BETWEEN TIMESTAMP '2022-01-01 00:00:00.0' AND TIMESTAMP '2022-12-31 23:59:59.9'");
+        testUnwrap("timestamp(2)", "year(a) = 2022", "a BETWEEN TIMESTAMP '2022-01-01 00:00:00.00' AND TIMESTAMP '2022-12-31 23:59:59.99'");
+        testUnwrap("timestamp(3)", "year(a) = 2022", "a BETWEEN TIMESTAMP '2022-01-01 00:00:00.000' AND TIMESTAMP '2022-12-31 23:59:59.999'");
+        testUnwrap("timestamp(4)", "year(a) = 2022", "a BETWEEN TIMESTAMP '2022-01-01 00:00:00.0000' AND TIMESTAMP '2022-12-31 23:59:59.9999'");
+        testUnwrap("timestamp(5)", "year(a) = 2022", "a BETWEEN TIMESTAMP '2022-01-01 00:00:00.00000' AND TIMESTAMP '2022-12-31 23:59:59.99999'");
+        testUnwrap("timestamp(6)", "year(a) = 2022", "a BETWEEN TIMESTAMP '2022-01-01 00:00:00.000000' AND TIMESTAMP '2022-12-31 23:59:59.999999'");
+        testUnwrap("timestamp(7)", "year(a) = 2022", "a BETWEEN TIMESTAMP '2022-01-01 00:00:00.0000000' AND TIMESTAMP '2022-12-31 23:59:59.9999999'");
+        testUnwrap("timestamp(8)", "year(a) = 2022", "a BETWEEN TIMESTAMP '2022-01-01 00:00:00.00000000' AND TIMESTAMP '2022-12-31 23:59:59.99999999'");
+        testUnwrap("timestamp(9)", "year(a) = 2022", "a BETWEEN TIMESTAMP '2022-01-01 00:00:00.000000000' AND TIMESTAMP '2022-12-31 23:59:59.999999999'");
+        testUnwrap("timestamp(10)", "year(a) = 2022", "a BETWEEN TIMESTAMP '2022-01-01 00:00:00.0000000000' AND TIMESTAMP '2022-12-31 23:59:59.9999999999'");
+        testUnwrap("timestamp(11)", "year(a) = 2022", "a BETWEEN TIMESTAMP '2022-01-01 00:00:00.00000000000' AND TIMESTAMP '2022-12-31 23:59:59.99999999999'");
+        testUnwrap("timestamp(12)", "year(a) = 2022", "a BETWEEN TIMESTAMP '2022-01-01 00:00:00.000000000000' AND TIMESTAMP '2022-12-31 23:59:59.999999999999'");
+    }
+
+    @Test
+    public void testNotEquals()
+    {
+        testUnwrap("date", "year(a) <> -0001", "NOT (a BETWEEN DATE '-0001-01-01' AND DATE '-0001-12-31')");
+        testUnwrap("date", "year(a) <> 1960", "NOT (a BETWEEN DATE '1960-01-01' AND DATE '1960-12-31')");
+        testUnwrap("date", "year(a) <> 2022", "NOT (a BETWEEN DATE '2022-01-01' AND DATE '2022-12-31')");
+        testUnwrap("date", "year(a) <> 9999", "NOT (a BETWEEN DATE '9999-01-01' AND DATE '9999-12-31')");
+
+        testUnwrap("timestamp", "year(a) <> -0001", "NOT (a BETWEEN TIMESTAMP '-0001-01-01 00:00:00.000' AND TIMESTAMP '-0001-12-31 23:59:59.999')");
+        testUnwrap("timestamp", "year(a) <> 1960", "NOT (a BETWEEN TIMESTAMP '1960-01-01 00:00:00.000' AND TIMESTAMP '1960-12-31 23:59:59.999')");
+        testUnwrap("timestamp", "year(a) <> 2022", "NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.000' AND TIMESTAMP '2022-12-31 23:59:59.999')");
+        testUnwrap("timestamp", "year(a) <> 9999", "NOT (a BETWEEN TIMESTAMP '9999-01-01 00:00:00.000' AND TIMESTAMP '9999-12-31 23:59:59.999')");
+
+        testUnwrap("timestamp(0)", "year(a) <> 2022", "NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00' AND TIMESTAMP '2022-12-31 23:59:59')");
+        testUnwrap("timestamp(1)", "year(a) <> 2022", "NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.0' AND TIMESTAMP '2022-12-31 23:59:59.9')");
+        testUnwrap("timestamp(2)", "year(a) <> 2022", "NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.00' AND TIMESTAMP '2022-12-31 23:59:59.99')");
+        testUnwrap("timestamp(3)", "year(a) <> 2022", "NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.000' AND TIMESTAMP '2022-12-31 23:59:59.999')");
+        testUnwrap("timestamp(4)", "year(a) <> 2022", "NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.0000' AND TIMESTAMP '2022-12-31 23:59:59.9999')");
+        testUnwrap("timestamp(5)", "year(a) <> 2022", "NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.00000' AND TIMESTAMP '2022-12-31 23:59:59.99999')");
+        testUnwrap("timestamp(6)", "year(a) <> 2022", "NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.000000' AND TIMESTAMP '2022-12-31 23:59:59.999999')");
+        testUnwrap("timestamp(7)", "year(a) <> 2022", "NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.0000000' AND TIMESTAMP '2022-12-31 23:59:59.9999999')");
+        testUnwrap("timestamp(8)", "year(a) <> 2022", "NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.00000000' AND TIMESTAMP '2022-12-31 23:59:59.99999999')");
+        testUnwrap("timestamp(9)", "year(a) <> 2022", "NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.000000000' AND TIMESTAMP '2022-12-31 23:59:59.999999999')");
+        testUnwrap("timestamp(10)", "year(a) <> 2022", "NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.0000000000' AND TIMESTAMP '2022-12-31 23:59:59.9999999999')");
+        testUnwrap("timestamp(11)", "year(a) <> 2022", "NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.00000000000' AND TIMESTAMP '2022-12-31 23:59:59.99999999999')");
+        testUnwrap("timestamp(12)", "year(a) <> 2022", "NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.000000000000' AND TIMESTAMP '2022-12-31 23:59:59.999999999999')");
+    }
+
+    @Test
+    public void testLessThan()
+    {
+        testUnwrap("date", "year(a) < -0001", "a < DATE '-0001-01-01'");
+        testUnwrap("date", "year(a) < 1960", "a < DATE '1960-01-01'");
+        testUnwrap("date", "year(a) < 2022", "a < DATE '2022-01-01'");
+        testUnwrap("date", "year(a) < 9999", "a < DATE '9999-01-01'");
+
+        testUnwrap("timestamp", "year(a) < -0001", "a < TIMESTAMP '-0001-01-01 00:00:00.000'");
+        testUnwrap("timestamp", "year(a) < 1960", "a < TIMESTAMP '1960-01-01 00:00:00.000'");
+        testUnwrap("timestamp", "year(a) < 2022", "a < TIMESTAMP '2022-01-01 00:00:00.000'");
+        testUnwrap("timestamp", "year(a) < 9999", "a < TIMESTAMP '9999-01-01 00:00:00.000'");
+
+        testUnwrap("timestamp(0)", "year(a) < 2022", "a < TIMESTAMP '2022-01-01 00:00:00'");
+        testUnwrap("timestamp(1)", "year(a) < 2022", "a < TIMESTAMP '2022-01-01 00:00:00.0'");
+        testUnwrap("timestamp(2)", "year(a) < 2022", "a < TIMESTAMP '2022-01-01 00:00:00.00'");
+        testUnwrap("timestamp(3)", "year(a) < 2022", "a < TIMESTAMP '2022-01-01 00:00:00.000'");
+        testUnwrap("timestamp(4)", "year(a) < 2022", "a < TIMESTAMP '2022-01-01 00:00:00.0000'");
+        testUnwrap("timestamp(5)", "year(a) < 2022", "a < TIMESTAMP '2022-01-01 00:00:00.00000'");
+        testUnwrap("timestamp(6)", "year(a) < 2022", "a < TIMESTAMP '2022-01-01 00:00:00.000000'");
+        testUnwrap("timestamp(7)", "year(a) < 2022", "a < TIMESTAMP '2022-01-01 00:00:00.0000000'");
+        testUnwrap("timestamp(8)", "year(a) < 2022", "a < TIMESTAMP '2022-01-01 00:00:00.00000000'");
+        testUnwrap("timestamp(9)", "year(a) < 2022", "a < TIMESTAMP '2022-01-01 00:00:00.000000000'");
+        testUnwrap("timestamp(10)", "year(a) < 2022", "a < TIMESTAMP '2022-01-01 00:00:00.0000000000'");
+        testUnwrap("timestamp(11)", "year(a) < 2022", "a < TIMESTAMP '2022-01-01 00:00:00.00000000000'");
+        testUnwrap("timestamp(12)", "year(a) < 2022", "a < TIMESTAMP '2022-01-01 00:00:00.000000000000'");
+    }
+
+    @Test
+    public void testLessThanOrEqual()
+    {
+        testUnwrap("date", "year(a) <= -0001", "a <= DATE '-0001-12-31'");
+        testUnwrap("date", "year(a) <= 1960", "a <= DATE '1960-12-31'");
+        testUnwrap("date", "year(a) <= 2022", "a <= DATE '2022-12-31'");
+        testUnwrap("date", "year(a) <= 9999", "a <= DATE '9999-12-31'");
+
+        testUnwrap("timestamp", "year(a) <= -0001", "a <= TIMESTAMP '-0001-12-31 23:59:59.999'");
+        testUnwrap("timestamp", "year(a) <= 1960", "a <= TIMESTAMP '1960-12-31 23:59:59.999'");
+        testUnwrap("timestamp", "year(a) <= 2022", "a <= TIMESTAMP '2022-12-31 23:59:59.999'");
+        testUnwrap("timestamp", "year(a) <= 9999", "a <= TIMESTAMP '9999-12-31 23:59:59.999'");
+
+        testUnwrap("timestamp(0)", "year(a) <= 2022", "a <= TIMESTAMP '2022-12-31 23:59:59'");
+        testUnwrap("timestamp(1)", "year(a) <= 2022", "a <= TIMESTAMP '2022-12-31 23:59:59.9'");
+        testUnwrap("timestamp(2)", "year(a) <= 2022", "a <= TIMESTAMP '2022-12-31 23:59:59.99'");
+        testUnwrap("timestamp(3)", "year(a) <= 2022", "a <= TIMESTAMP '2022-12-31 23:59:59.999'");
+        testUnwrap("timestamp(4)", "year(a) <= 2022", "a <= TIMESTAMP '2022-12-31 23:59:59.9999'");
+        testUnwrap("timestamp(5)", "year(a) <= 2022", "a <= TIMESTAMP '2022-12-31 23:59:59.99999'");
+        testUnwrap("timestamp(6)", "year(a) <= 2022", "a <= TIMESTAMP '2022-12-31 23:59:59.999999'");
+        testUnwrap("timestamp(7)", "year(a) <= 2022", "a <= TIMESTAMP '2022-12-31 23:59:59.9999999'");
+        testUnwrap("timestamp(8)", "year(a) <= 2022", "a <= TIMESTAMP '2022-12-31 23:59:59.99999999'");
+        testUnwrap("timestamp(9)", "year(a) <= 2022", "a <= TIMESTAMP '2022-12-31 23:59:59.999999999'");
+        testUnwrap("timestamp(10)", "year(a) <= 2022", "a <= TIMESTAMP '2022-12-31 23:59:59.9999999999'");
+        testUnwrap("timestamp(11)", "year(a) <= 2022", "a <= TIMESTAMP '2022-12-31 23:59:59.99999999999'");
+        testUnwrap("timestamp(12)", "year(a) <= 2022", "a <= TIMESTAMP '2022-12-31 23:59:59.999999999999'");
+    }
+
+    @Test
+    public void testGreaterThan()
+    {
+        testUnwrap("date", "year(a) > -0001", "a > DATE '-0001-12-31'");
+        testUnwrap("date", "year(a) > 1960", "a > DATE '1960-12-31'");
+        testUnwrap("date", "year(a) > 2022", "a > DATE '2022-12-31'");
+        testUnwrap("date", "year(a) > 9999", "a > DATE '9999-12-31'");
+
+        testUnwrap("timestamp", "year(a) > -0001", "a > TIMESTAMP '-0001-12-31 23:59:59.999'");
+        testUnwrap("timestamp", "year(a) > 1960", "a > TIMESTAMP '1960-12-31 23:59:59.999'");
+        testUnwrap("timestamp", "year(a) > 2022", "a > TIMESTAMP '2022-12-31 23:59:59.999'");
+        testUnwrap("timestamp", "year(a) > 9999", "a > TIMESTAMP '9999-12-31 23:59:59.999'");
+
+        testUnwrap("timestamp(0)", "year(a) > 2022", "a > TIMESTAMP '2022-12-31 23:59:59'");
+        testUnwrap("timestamp(1)", "year(a) > 2022", "a > TIMESTAMP '2022-12-31 23:59:59.9'");
+        testUnwrap("timestamp(2)", "year(a) > 2022", "a > TIMESTAMP '2022-12-31 23:59:59.99'");
+        testUnwrap("timestamp(3)", "year(a) > 2022", "a > TIMESTAMP '2022-12-31 23:59:59.999'");
+        testUnwrap("timestamp(4)", "year(a) > 2022", "a > TIMESTAMP '2022-12-31 23:59:59.9999'");
+        testUnwrap("timestamp(5)", "year(a) > 2022", "a > TIMESTAMP '2022-12-31 23:59:59.99999'");
+        testUnwrap("timestamp(6)", "year(a) > 2022", "a > TIMESTAMP '2022-12-31 23:59:59.999999'");
+        testUnwrap("timestamp(7)", "year(a) > 2022", "a > TIMESTAMP '2022-12-31 23:59:59.9999999'");
+        testUnwrap("timestamp(8)", "year(a) > 2022", "a > TIMESTAMP '2022-12-31 23:59:59.99999999'");
+        testUnwrap("timestamp(9)", "year(a) > 2022", "a > TIMESTAMP '2022-12-31 23:59:59.999999999'");
+        testUnwrap("timestamp(10)", "year(a) > 2022", "a > TIMESTAMP '2022-12-31 23:59:59.9999999999'");
+        testUnwrap("timestamp(11)", "year(a) > 2022", "a > TIMESTAMP '2022-12-31 23:59:59.99999999999'");
+        testUnwrap("timestamp(12)", "year(a) > 2022", "a > TIMESTAMP '2022-12-31 23:59:59.999999999999'");
+    }
+
+    @Test
+    public void testGreaterThanOrEqual()
+    {
+        testUnwrap("date", "year(a) >= -0001", "a >= DATE '-0001-01-01'");
+        testUnwrap("date", "year(a) >= 1960", "a >= DATE '1960-01-01'");
+        testUnwrap("date", "year(a) >= 2022", "a >= DATE '2022-01-01'");
+        testUnwrap("date", "year(a) >= 9999", "a >= DATE '9999-01-01'");
+
+        testUnwrap("timestamp", "year(a) >= -0001", "a >= TIMESTAMP '-0001-01-01 00:00:00.000'");
+        testUnwrap("timestamp", "year(a) >= 1960", "a >= TIMESTAMP '1960-01-01 00:00:00.000'");
+        testUnwrap("timestamp", "year(a) >= 2022", "a >= TIMESTAMP '2022-01-01 00:00:00.000'");
+        testUnwrap("timestamp", "year(a) >= 9999", "a >= TIMESTAMP '9999-01-01 00:00:00.000'");
+
+        testUnwrap("timestamp(0)", "year(a) >= 2022", "a >= TIMESTAMP '2022-01-01 00:00:00'");
+        testUnwrap("timestamp(1)", "year(a) >= 2022", "a >= TIMESTAMP '2022-01-01 00:00:00.0'");
+        testUnwrap("timestamp(2)", "year(a) >= 2022", "a >= TIMESTAMP '2022-01-01 00:00:00.00'");
+        testUnwrap("timestamp(3)", "year(a) >= 2022", "a >= TIMESTAMP '2022-01-01 00:00:00.000'");
+        testUnwrap("timestamp(4)", "year(a) >= 2022", "a >= TIMESTAMP '2022-01-01 00:00:00.0000'");
+        testUnwrap("timestamp(5)", "year(a) >= 2022", "a >= TIMESTAMP '2022-01-01 00:00:00.00000'");
+        testUnwrap("timestamp(6)", "year(a) >= 2022", "a >= TIMESTAMP '2022-01-01 00:00:00.000000'");
+        testUnwrap("timestamp(7)", "year(a) >= 2022", "a >= TIMESTAMP '2022-01-01 00:00:00.0000000'");
+        testUnwrap("timestamp(8)", "year(a) >= 2022", "a >= TIMESTAMP '2022-01-01 00:00:00.00000000'");
+        testUnwrap("timestamp(9)", "year(a) >= 2022", "a >= TIMESTAMP '2022-01-01 00:00:00.000000000'");
+        testUnwrap("timestamp(10)", "year(a) >= 2022", "a >= TIMESTAMP '2022-01-01 00:00:00.0000000000'");
+        testUnwrap("timestamp(11)", "year(a) >= 2022", "a >= TIMESTAMP '2022-01-01 00:00:00.00000000000'");
+        testUnwrap("timestamp(12)", "year(a) >= 2022", "a >= TIMESTAMP '2022-01-01 00:00:00.000000000000'");
+    }
+
+    @Test
+    public void testDistinctFrom()
+    {
+        testUnwrap("date", "year(a) IS DISTINCT FROM -0001", "a IS NULL OR NOT (a BETWEEN DATE '-0001-01-01' AND DATE '-0001-12-31')");
+        testUnwrap("date", "year(a) IS DISTINCT FROM 1960", "a IS NULL OR NOT (a BETWEEN DATE '1960-01-01' AND DATE '1960-12-31')");
+        testUnwrap("date", "year(a) IS DISTINCT FROM 2022", "a IS NULL OR NOT (a BETWEEN DATE '2022-01-01' AND DATE '2022-12-31')");
+        testUnwrap("date", "year(a) IS DISTINCT FROM 9999", "a IS NULL OR NOT (a BETWEEN DATE '9999-01-01' AND DATE '9999-12-31')");
+
+        testUnwrap("timestamp", "year(a) IS DISTINCT FROM -0001", "a IS NULL OR NOT (a BETWEEN TIMESTAMP '-0001-01-01 00:00:00.000' AND TIMESTAMP '-0001-12-31 23:59:59.999')");
+        testUnwrap("timestamp", "year(a) IS DISTINCT FROM 1960", "a IS NULL OR NOT (a BETWEEN TIMESTAMP '1960-01-01 00:00:00.000' AND TIMESTAMP '1960-12-31 23:59:59.999')");
+        testUnwrap("timestamp", "year(a) IS DISTINCT FROM 2022", "a IS NULL OR NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.000' AND TIMESTAMP '2022-12-31 23:59:59.999')");
+        testUnwrap("timestamp", "year(a) IS DISTINCT FROM 9999", "a IS NULL OR NOT (a BETWEEN TIMESTAMP '9999-01-01 00:00:00.000' AND TIMESTAMP '9999-12-31 23:59:59.999')");
+
+        testUnwrap("timestamp(0)", "year(a) IS DISTINCT FROM 2022", "a IS NULL OR NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00' AND TIMESTAMP '2022-12-31 23:59:59')");
+        testUnwrap("timestamp(1)", "year(a) IS DISTINCT FROM 2022", "a IS NULL OR NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.0' AND TIMESTAMP '2022-12-31 23:59:59.9')");
+        testUnwrap("timestamp(2)", "year(a) IS DISTINCT FROM 2022", "a IS NULL OR NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.00' AND TIMESTAMP '2022-12-31 23:59:59.99')");
+        testUnwrap("timestamp(3)", "year(a) IS DISTINCT FROM 2022", "a IS NULL OR NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.000' AND TIMESTAMP '2022-12-31 23:59:59.999')");
+        testUnwrap("timestamp(4)", "year(a) IS DISTINCT FROM 2022", "a IS NULL OR NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.0000' AND TIMESTAMP '2022-12-31 23:59:59.9999')");
+        testUnwrap("timestamp(5)", "year(a) IS DISTINCT FROM 2022", "a IS NULL OR NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.00000' AND TIMESTAMP '2022-12-31 23:59:59.99999')");
+        testUnwrap("timestamp(6)", "year(a) IS DISTINCT FROM 2022", "a IS NULL OR NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.000000' AND TIMESTAMP '2022-12-31 23:59:59.999999')");
+        testUnwrap("timestamp(7)", "year(a) IS DISTINCT FROM 2022", "a IS NULL OR NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.0000000' AND TIMESTAMP '2022-12-31 23:59:59.9999999')");
+        testUnwrap("timestamp(8)", "year(a) IS DISTINCT FROM 2022", "a IS NULL OR NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.00000000' AND TIMESTAMP '2022-12-31 23:59:59.99999999')");
+        testUnwrap("timestamp(9)", "year(a) IS DISTINCT FROM 2022", "a IS NULL OR NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.000000000' AND TIMESTAMP '2022-12-31 23:59:59.999999999')");
+        testUnwrap("timestamp(10)", "year(a) IS DISTINCT FROM 2022", "a IS NULL OR NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.0000000000' AND TIMESTAMP '2022-12-31 23:59:59.9999999999')");
+        testUnwrap("timestamp(11)", "year(a) IS DISTINCT FROM 2022", "a IS NULL OR NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.00000000000' AND TIMESTAMP '2022-12-31 23:59:59.99999999999')");
+        testUnwrap("timestamp(12)", "year(a) IS DISTINCT FROM 2022", "a IS NULL OR NOT (a BETWEEN TIMESTAMP '2022-01-01 00:00:00.000000000000' AND TIMESTAMP '2022-12-31 23:59:59.999999999999')");
+    }
+
+    @Test
+    public void testNull()
+    {
+        testUnwrap("date", "year(a) = CAST(NULL AS BIGINT)", "CAST(NULL AS BOOLEAN)");
+        testUnwrap("timestamp", "year(a) = CAST(NULL AS BIGINT)", "CAST(NULL AS BOOLEAN)");
+    }
+
+    @Test
+    public void testNaN()
+    {
+        testUnwrap("date", "year(a) = nan()", "year(a) IS NULL AND CAST(NULL AS BOOLEAN)");
+        testUnwrap("timestamp", "year(a) = nan()", "year(a) IS NULL AND CAST(NULL AS BOOLEAN)");
+    }
+
+    @Test
+    public void smokeTests()
+    {
+        // smoke tests for various type combinations
+        for (String type : asList("SMALLINT", "INTEGER", "BIGINT", "REAL", "DOUBLE")) {
+            testUnwrap("date", format("year(a) = %s '2022'", type), "a BETWEEN DATE '2022-01-01' AND DATE '2022-12-31'");
+        }
+    }
+
+    @Test
+    public void testTermOrder()
+    {
+        // ensure the optimization works when the terms of the comparison are reversed
+        // vs the canonical <expr> <op> <literal> form
+        assertPlan("SELECT * FROM (VALUES DATE '2022-01-01') t(a) WHERE 2022 = year(a)",
+                output(
+                        filter("A BETWEEN DATE '2022-01-01' AND DATE '2022-12-31'",
+                                values("A"))));
+    }
+
+    @Test
+    public void testLeapYear()
+    {
+        testUnwrap("date", "year(a) = 2024", "a BETWEEN DATE '2024-01-01' AND DATE '2024-12-31'");
+        testUnwrap("timestamp", "year(a) = 2024", "a BETWEEN TIMESTAMP '2024-01-01 00:00:00.000' AND TIMESTAMP '2024-12-31 23:59:59.999'");
+    }
+
+    @Test
+    public void testCalculateRangeEndInclusive()
+    {
+        assertEquals(calculateRangeEndInclusive(1960, DATE), LocalDate.of(1960, 12, 31).toEpochDay());
+        assertEquals(calculateRangeEndInclusive(2024, DATE), LocalDate.of(2024, 12, 31).toEpochDay());
+
+        assertEquals(
+                calculateRangeEndInclusive(1960, TIMESTAMP_SECONDS),
+                toEpochMicros(LocalDateTime.of(1960, 12, 31, 23, 59, 59)));
+        assertEquals(
+                calculateRangeEndInclusive(1960, TIMESTAMP_MILLIS),
+                toEpochMicros(LocalDateTime.of(1960, 12, 31, 23, 59, 59, 999_000_000)));
+        assertEquals(
+                calculateRangeEndInclusive(1960, TIMESTAMP_MICROS),
+                toEpochMicros(LocalDateTime.of(1960, 12, 31, 23, 59, 59, 999_999_000)));
+        assertEquals(
+                calculateRangeEndInclusive(1960, TIMESTAMP_NANOS),
+                new LongTimestamp(toEpochMicros(LocalDateTime.of(1960, 12, 31, 23, 59, 59, 999_999_000)), 999_000));
+        assertEquals(
+                calculateRangeEndInclusive(1960, TIMESTAMP_PICOS),
+                new LongTimestamp(toEpochMicros(LocalDateTime.of(1960, 12, 31, 23, 59, 59, 999_999_000)), 999_999));
+        assertEquals(
+                calculateRangeEndInclusive(2024, TIMESTAMP_SECONDS),
+                toEpochMicros(LocalDateTime.of(2024, 12, 31, 23, 59, 59)));
+        assertEquals(
+                calculateRangeEndInclusive(2024, TIMESTAMP_MILLIS),
+                toEpochMicros(LocalDateTime.of(2024, 12, 31, 23, 59, 59, 999_000_000)));
+        assertEquals(
+                calculateRangeEndInclusive(2024, TIMESTAMP_MICROS),
+                toEpochMicros(LocalDateTime.of(2024, 12, 31, 23, 59, 59, 999_999_000)));
+        assertEquals(
+                calculateRangeEndInclusive(2024, TIMESTAMP_NANOS),
+                new LongTimestamp(toEpochMicros(LocalDateTime.of(2024, 12, 31, 23, 59, 59, 999_999_000)), 999_000));
+        assertEquals(
+                calculateRangeEndInclusive(2024, TIMESTAMP_PICOS),
+                new LongTimestamp(toEpochMicros(LocalDateTime.of(2024, 12, 31, 23, 59, 59, 999_999_000)), 999_999));
+    }
+
+    private static long toEpochMicros(LocalDateTime localDateTime)
+    {
+        return multiplyExact(localDateTime.toEpochSecond(UTC), MICROSECONDS_PER_SECOND)
+                + localDateTime.getNano() / NANOSECONDS_PER_MICROSECOND;
+    }
+
+    private void testUnwrap(String inputType, String inputPredicate, String expectedPredicate)
+    {
+        String sql = format("SELECT * FROM (VALUES CAST(NULL AS %s)) t(a) WHERE %s OR rand() = 42", inputType, inputPredicate);
+        try {
+            assertPlan(
+                    sql,
+                    getQueryRunner().getDefaultSession(),
+                    output(
+                            filter(expectedPredicate + " OR rand() = 42e0",
+                                    values("a"))));
+        }
+        catch (Throwable e) {
+            e.addSuppressed(new Exception("Query: " + sql));
+            throw e;
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ConstraintExtractor.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ConstraintExtractor.java
@@ -56,6 +56,7 @@ import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
 import static io.trino.spi.type.Timestamps.MILLISECONDS_PER_DAY;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static java.lang.Math.toIntExact;
 import static java.math.RoundingMode.UNNECESSARY;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.ENGLISH;
@@ -125,6 +126,20 @@ public final class ConstraintExtractor
                         constant,
                         assignments);
             }
+
+            if (firstArgument instanceof Call firstAsCall &&
+                    firstAsCall.getFunctionName().equals(new FunctionName("year")) &&
+                    firstAsCall.getArguments().size() == 1 &&
+                    getOnlyElement(firstAsCall.getArguments()).getType() instanceof TimestampWithTimeZoneType &&
+                    secondArgument instanceof Constant constant &&
+                    // if types do no match, this cannot be a comparison function
+                    firstArgument.getType().equals(secondArgument.getType())) {
+                return unwrapYearInTimestampTzComparison(
+                        call.getFunctionName(),
+                        getOnlyElement(firstAsCall.getArguments()),
+                        constant,
+                        assignments);
+            }
         }
 
         return Optional.empty();
@@ -177,6 +192,26 @@ public final class ConstraintExtractor
         LongTimestampWithTimeZone startOfDate = LongTimestampWithTimeZone.fromEpochMillisAndFraction(date * MILLISECONDS_PER_DAY, 0, UTC_KEY);
         LongTimestampWithTimeZone startOfNextDate = LongTimestampWithTimeZone.fromEpochMillisAndFraction((date + 1) * MILLISECONDS_PER_DAY, 0, UTC_KEY);
 
+        return createDomain(functionName, type, startOfDate, startOfNextDate);
+    }
+
+    private static Optional<Domain> unwrapYearInTimestampTzComparison(FunctionName functionName, Type type, Constant constant)
+    {
+        checkArgument(constant.getValue() != null, "Unexpected constant: %s", constant);
+        checkArgument(type.equals(TIMESTAMP_TZ_MICROS), "Unexpected type: %s", type);
+
+        int year = toIntExact((Long) constant.getValue());
+        ZonedDateTime periodStart = ZonedDateTime.of(year, 1, 1, 0, 0, 0, 0, UTC);
+        ZonedDateTime periodEnd = periodStart.plusYears(1);
+
+        LongTimestampWithTimeZone start = LongTimestampWithTimeZone.fromEpochSecondsAndFraction(periodStart.toEpochSecond(), 0, UTC_KEY);
+        LongTimestampWithTimeZone end = LongTimestampWithTimeZone.fromEpochSecondsAndFraction(periodEnd.toEpochSecond(), 0, UTC_KEY);
+
+        return createDomain(functionName, type, start, end);
+    }
+
+    private static Optional<Domain> createDomain(FunctionName functionName, Type type, LongTimestampWithTimeZone startOfDate, LongTimestampWithTimeZone startOfNextDate)
+    {
         if (functionName.equals(EQUAL_OPERATOR_FUNCTION_NAME)) {
             return Optional.of(Domain.create(ValueSet.ofRanges(Range.range(type, startOfDate, true, startOfNextDate, false)), false));
         }
@@ -314,6 +349,37 @@ public final class ConstraintExtractor
             }
             return Optional.of(Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(type, end)), false));
         }
+        return Optional.empty();
+    }
+
+    private static Optional<TupleDomain<IcebergColumnHandle>> unwrapYearInTimestampTzComparison(
+            // upon invocation, we don't know if this really is a comparison
+            FunctionName functionName,
+            ConnectorExpression yearSource,
+            Constant constant,
+            Map<String, ColumnHandle> assignments)
+    {
+        if (!(yearSource instanceof Variable sourceVariable)) {
+            // Engine unwraps year in comparisons in UnwrapYearInComparison. Within a connector we can do more than
+            // engine only for source columns. We cannot draw many conclusions for intermediate expressions without
+            // knowing them well.
+            return Optional.empty();
+        }
+
+        if (constant.getValue() == null) {
+            // Comparisons with NULL should be simplified by the engine
+            return Optional.empty();
+        }
+
+        IcebergColumnHandle column = resolve(sourceVariable, assignments);
+        if (column.getType() instanceof TimestampWithTimeZoneType type) {
+            // Iceberg supports only timestamp(6) with time zone
+            checkArgument(type.getPrecision() == 6, "Unexpected type: %s", column.getType());
+
+            return unwrapYearInTimestampTzComparison(functionName, type, constant)
+                    .map(domain -> TupleDomain.withColumnDomains(ImmutableMap.of(column, domain)));
+        }
+
         return Optional.empty();
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -1768,7 +1768,7 @@ public abstract class BaseIcebergConnectorTest
 
         // year()
         assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE year(d) = 2015"))
-                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+                .isFullyPushedDown();
 
         // date_trunc
         assertThat(query("SELECT * FROM test_hour_transform_timestamp WHERE date_trunc('hour', d) = TIMESTAMP '2015-05-15 12:00:00'"))
@@ -1874,7 +1874,7 @@ public abstract class BaseIcebergConnectorTest
 
         // year()
         assertThat(query("SELECT * FROM test_hour_transform_timestamptz WHERE year(d) = 2015"))
-                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+                .isFullyPushedDown();
 
         // date_trunc
         assertThat(query("SELECT * FROM test_hour_transform_timestamptz WHERE date_trunc('hour', d) = TIMESTAMP '2015-05-15 12:00:00.000000 UTC'"))
@@ -2015,7 +2015,7 @@ public abstract class BaseIcebergConnectorTest
 
         // year()
         assertThat(query("SELECT * FROM test_day_transform_date WHERE year(d) = 2015"))
-                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+                .isFullyPushedDown();
 
         // date_trunc
         assertThat(query("SELECT * FROM test_day_transform_date WHERE date_trunc('day', d) = DATE '2015-01-13'"))
@@ -2127,7 +2127,7 @@ public abstract class BaseIcebergConnectorTest
 
         // year()
         assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE year(d) = 2015"))
-                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+                .isFullyPushedDown();
 
         // date_trunc
         assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE date_trunc('day', d) = DATE '2015-05-15'"))
@@ -2241,7 +2241,7 @@ public abstract class BaseIcebergConnectorTest
 
         // year()
         assertThat(query("SELECT * FROM test_day_transform_timestamptz WHERE year(d) = 2015"))
-                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+                .isFullyPushedDown();
 
         // date_trunc
         assertThat(query("SELECT * FROM test_day_transform_timestamptz WHERE date_trunc('day', d) = TIMESTAMP '2015-05-15 00:00:00.000000 UTC'"))
@@ -2347,7 +2347,7 @@ public abstract class BaseIcebergConnectorTest
 
         // year()
         assertThat(query("SELECT * FROM test_month_transform_date WHERE year(d) = 2015"))
-                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+                .isFullyPushedDown();
 
         // date_trunc
         assertThat(query("SELECT * FROM test_month_transform_date WHERE date_trunc('month', d) = DATE '2015-01-01'"))
@@ -2471,7 +2471,7 @@ public abstract class BaseIcebergConnectorTest
 
         // year()
         assertThat(query("SELECT * FROM test_month_transform_timestamp WHERE year(d) = 2015"))
-                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+                .isFullyPushedDown();
 
         // date_trunc
         assertThat(query("SELECT * FROM test_month_transform_timestamp WHERE date_trunc('month', d) = DATE '2015-05-01'"))
@@ -2580,7 +2580,7 @@ public abstract class BaseIcebergConnectorTest
 
         // year()
         assertThat(query("SELECT * FROM test_month_transform_timestamptz WHERE year(d) = 2015"))
-                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+                .isFullyPushedDown();
 
         // date_trunc
         assertThat(query("SELECT * FROM test_month_transform_timestamptz WHERE date_trunc('month', d) = TIMESTAMP '2015-05-01 00:00:00.000000 UTC'"))
@@ -2682,7 +2682,7 @@ public abstract class BaseIcebergConnectorTest
 
         // year()
         assertThat(query("SELECT * FROM test_year_transform_date WHERE year(d) = 2015"))
-                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+                .isFullyPushedDown();
 
         // date_trunc
         assertThat(query("SELECT * FROM test_year_transform_date WHERE date_trunc('year', d) = DATE '2015-01-01'"))
@@ -2801,7 +2801,7 @@ public abstract class BaseIcebergConnectorTest
 
         // year()
         assertThat(query("SELECT * FROM test_year_transform_timestamp WHERE year(d) = 2015"))
-                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+                .isFullyPushedDown();
 
         // date_trunc
         assertThat(query("SELECT * FROM test_year_transform_timestamp WHERE date_trunc('year', d) = DATE '2015-01-01'"))
@@ -2905,7 +2905,7 @@ public abstract class BaseIcebergConnectorTest
 
         // year()
         assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE year(d) = 2015"))
-                .isNotFullyPushedDown(FilterNode.class); // TODO convert into range
+                .isFullyPushedDown();
 
         // date_trunc
         assertThat(query("SELECT * FROM test_year_transform_timestamptz WHERE date_trunc('year', d) = TIMESTAMP '2015-01-01 00:00:00.000000 UTC'"))

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestConstraintExtractor.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestConstraintExtractor.java
@@ -35,6 +35,7 @@ import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.iterative.rule.UnwrapCastInComparison;
 import io.trino.sql.planner.iterative.rule.UnwrapDateTruncInComparison;
+import io.trino.sql.planner.iterative.rule.UnwrapYearInComparison;
 import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.ComparisonExpression;
 import io.trino.sql.tree.Expression;
@@ -253,6 +254,80 @@ public class TestConstraintExtractor
                 .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, Domain.create(
                         ValueSet.ofRanges(
                                 Range.lessThan(TIMESTAMP_TZ_MICROS, startOfDateUtc),
+                                Range.greaterThanOrEqual(TIMESTAMP_TZ_MICROS, startOfNextDateUtc)),
+                        true))));
+    }
+
+    /**
+     * Test equivalent of {@link UnwrapYearInComparison} for {@link TimestampWithTimeZoneType}.
+     * {@link UnwrapYearInComparison} handles {@link DateType} and {@link TimestampType}, but cannot handle
+     * {@link TimestampWithTimeZoneType}. Such unwrap would not be monotonic. Within Iceberg, we know
+     * that {@link TimestampWithTimeZoneType} is always in UTC zone (point in time, with no time zone information),
+     * so we can unwrap.
+     */
+    @Test
+    public void testExtractYearTimestampTzComparison()
+    {
+        String timestampTzColumnSymbol = "timestamp_tz_symbol";
+        FunctionCall extractYear = new FunctionCall(
+                QualifiedName.of("year"),
+                List.of(new SymbolReference(timestampTzColumnSymbol)));
+
+        LocalDate someDate = LocalDate.of(2005, 9, 10);
+        Expression yearExpression = LITERAL_ENCODER.toExpression(
+                TEST_SESSION,
+                2005L,
+                BIGINT);
+
+        long startOfYearUtcEpochMillis = someDate.withDayOfYear(1).atStartOfDay().toEpochSecond(UTC) * MILLISECONDS_PER_SECOND;
+        LongTimestampWithTimeZone startOfYearUtc = timestampTzFromEpochMillis(startOfYearUtcEpochMillis);
+        LongTimestampWithTimeZone startOfNextDateUtc = timestampTzFromEpochMillis(someDate.plusYears(1).withDayOfYear(1).atStartOfDay().toEpochSecond(UTC) * MILLISECONDS_PER_SECOND);
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(EQUAL, extractYear, yearExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.range(TIMESTAMP_TZ_MICROS, startOfYearUtc, true, startOfNextDateUtc, false)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(NOT_EQUAL, extractYear, yearExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(
+                        Range.lessThan(TIMESTAMP_TZ_MICROS, startOfYearUtc),
+                        Range.greaterThanOrEqual(TIMESTAMP_TZ_MICROS, startOfNextDateUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(LESS_THAN, extractYear, yearExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.lessThan(TIMESTAMP_TZ_MICROS, startOfYearUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(LESS_THAN_OR_EQUAL, extractYear, yearExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.lessThan(TIMESTAMP_TZ_MICROS, startOfNextDateUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(GREATER_THAN, extractYear, yearExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.greaterThanOrEqual(TIMESTAMP_TZ_MICROS, startOfNextDateUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(GREATER_THAN_OR_EQUAL, extractYear, yearExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.greaterThanOrEqual(TIMESTAMP_TZ_MICROS, startOfYearUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(IS_DISTINCT_FROM, extractYear, yearExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, Domain.create(
+                        ValueSet.ofRanges(
+                                Range.lessThan(TIMESTAMP_TZ_MICROS, startOfYearUtc),
                                 Range.greaterThanOrEqual(TIMESTAMP_TZ_MICROS, startOfNextDateUtc)),
                         true))));
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Simplify predicates involving `year` function likes `UnwrapDateTruncInComparison`. 
Continuation of #15306

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Improve performance of queries that contain predicates involving `year` function. ({issue}`14078`)
```
