### PR TITLE
Remove limits on dynamic-filtering.large-*.max-size-per-driver

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/DynamicFilterConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DynamicFilterConfig.java
@@ -230,7 +230,6 @@ public class DynamicFilterConfig
         return this;
     }
 
-    @MaxDataSize("50MB")
     public DataSize getLargeBroadcastMaxSizePerDriver()
     {
         return largeBroadcastMaxSizePerDriver;
@@ -282,7 +281,6 @@ public class DynamicFilterConfig
         return this;
     }
 
-    @MaxDataSize("5MB")
     public DataSize getLargePartitionedMaxSizePerDriver()
     {
         return largePartitionedMaxSizePerDriver;

--- a/core/trino-main/src/main/java/io/trino/operator/DynamicFilterSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DynamicFilterSourceOperator.java
@@ -16,6 +16,7 @@ package io.trino.operator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
+import io.trino.memory.context.LocalMemoryContext;
 import io.trino.operator.aggregation.TypedSet;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
@@ -177,6 +178,7 @@ public class DynamicFilterSourceOperator
     }
 
     private final OperatorContext context;
+    private final LocalMemoryContext userMemoryContext;
     private boolean finished;
     private Page current;
     private final DynamicFilterSourceConsumer dynamicPredicateConsumer;
@@ -198,6 +200,7 @@ public class DynamicFilterSourceOperator
             BlockTypeOperators blockTypeOperators)
     {
         this.context = requireNonNull(context, "context is null");
+        this.userMemoryContext = context.localUserMemoryContext();
         this.minMaxCollectionLimit = minMaxCollectionLimit;
         this.dynamicPredicateConsumer = requireNonNull(dynamicPredicateConsumer, "dynamicPredicateConsumer is null");
         this.channels = requireNonNull(channels, "channels is null");
@@ -248,10 +251,12 @@ public class DynamicFilterSourceOperator
         }
 
         // Collect only the columns which are relevant for the JOIN.
+        long filterSizeInBytes = 0;
         for (int channelIndex = 0; channelIndex < channels.size(); ++channelIndex) {
             Block block = page.getBlock(channels.get(channelIndex).index);
-            channelFilters[channelIndex].process(block);
+            filterSizeInBytes += channelFilters[channelIndex].process(block);
         }
+        userMemoryContext.setBytes(filterSizeInBytes);
     }
 
     @Override
@@ -281,12 +286,20 @@ public class DynamicFilterSourceOperator
             domainsBuilder.put(filterId, channelFilters[channelIndex].getDomain());
         }
         dynamicPredicateConsumer.addPartition(TupleDomain.withColumnDomains(domainsBuilder.buildOrThrow()));
+        userMemoryContext.setBytes(0);
     }
 
     @Override
     public boolean isFinished()
     {
         return current == null && finished;
+    }
+
+    @Override
+    public void close()
+            throws Exception
+    {
+        userMemoryContext.setBytes(0);
     }
 
     private void finishDomainCollectionIfNecessary()
@@ -409,9 +422,9 @@ public class DynamicFilterSourceOperator
                     format("DynamicFilterSourceOperator_%s_%d", planNodeId, channel.index));
         }
 
-        private void process(Block block)
+        private long process(Block block)
         {
-            // TODO: we should account for the memory used for collecting build-side values using MemoryContext
+            long retainedSizeInBytes = 0;
             switch (state) {
                 case SET:
                     for (int position = 0; position < block.getPositionCount(); ++position) {
@@ -429,6 +442,9 @@ public class DynamicFilterSourceOperator
                         valueSet = null;
                         blockBuilder = null;
                     }
+                    else {
+                        retainedSizeInBytes = valueSet.getRetainedSizeInBytes();
+                    }
                     break;
                 case MIN_MAX:
                     updateMinMaxValues(block, minMaxComparison);
@@ -436,6 +452,7 @@ public class DynamicFilterSourceOperator
                 case NONE:
                     break;
             }
+            return retainedSizeInBytes;
         }
 
         private Domain getDomain()
@@ -480,6 +497,8 @@ public class DynamicFilterSourceOperator
                 }
             }
 
+            valueSet = null;
+            blockBuilder = null;
             // Inner and right join doesn't match rows with null key column values.
             return Domain.create(ValueSet.copyOf(type, values.build()), false);
         }


### PR DESCRIPTION
## Description
Implemented memory accounting in DynamicFilterSourceOperator.
With memory accounting added to DynamicFilterSourceOperator there
is no longer a reason to put a limit on the max size per driver
allowed in config.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/16100

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Improved memory usage accounting for queries with dynamic filters. ({issue}`16110`)
```
