### PR TITLE
Remove assertion restricting hive.max-partitions-per-scan

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
@@ -418,12 +418,6 @@ public class HiveConfig
         return this;
     }
 
-    @AssertTrue(message = "The value of hive.max-partitions-for-eager-load is expected to be less than or equal to hive.max-partitions-per-scan")
-    public boolean isMaxPartitionsForEagerLoadValid()
-    {
-        return maxPartitionsForEagerLoad <= maxPartitionsPerScan;
-    }
-
     @Min(1)
     public int getMaxOutstandingSplits()
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Sometimes it is necessary to allow a higher number of partitions to be loaded eagerly to enable predicate pushdown while the total number of partitions to be scanned might be needed to be restricted.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/trinodb/trino/pull/14225

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(X) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Hive
* Allow setting `hive.max-partitions-per-scan` to a value lover than a value set in `hive.max-partitions-for-eager-load`
```
