### PR TITLE
Avoid materializing all results in Iceberg `$files` system table at once

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/InMemoryRecordSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/InMemoryRecordSet.java
@@ -68,15 +68,15 @@ public class InMemoryRecordSet
         return new InMemoryRecordCursor(types, records.iterator());
     }
 
-    private static class InMemoryRecordCursor
+    public static class InMemoryRecordCursor<T extends Iterator<? extends List<?>>>
             implements RecordCursor
     {
         private final List<Type> types;
-        private final Iterator<? extends List<?>> records;
+        protected T records;
         private List<?> record;
         private long completedBytes;
 
-        private InMemoryRecordCursor(List<Type> types, Iterator<? extends List<?>> records)
+        protected InMemoryRecordCursor(List<Type> types, T records)
         {
             this.types = types;
             this.records = records;

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/FilesTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/FilesTable.java
@@ -15,34 +15,41 @@ package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.airlift.slice.Slices;
-import io.trino.plugin.iceberg.util.PageListBuilder;
-import io.trino.spi.Page;
+import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.ColumnMetadata;
-import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTransactionHandle;
-import io.trino.spi.connector.FixedPageSource;
+import io.trino.spi.connector.InMemoryRecordSet;
+import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.TypeManager;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
+import org.apache.iceberg.io.CloseableGroup;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -55,12 +62,14 @@ public class FilesTable
         implements SystemTable
 {
     private final ConnectorTableMetadata tableMetadata;
+    private final TypeManager typeManager;
     private final Table icebergTable;
     private final Optional<Long> snapshotId;
 
     public FilesTable(SchemaTableName tableName, TypeManager typeManager, Table icebergTable, Optional<Long> snapshotId)
     {
         this.icebergTable = requireNonNull(icebergTable, "icebergTable is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
 
         tableMetadata = new ConnectorTableMetadata(requireNonNull(tableName, "tableName is null"),
                 ImmutableList.<ColumnMetadata>builder()
@@ -95,82 +104,157 @@ public class FilesTable
     }
 
     @Override
-    public ConnectorPageSource pageSource(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
+    public RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
     {
+        List<io.trino.spi.type.Type> types = tableMetadata.getColumns().stream()
+                .map(ColumnMetadata::getType)
+                .collect(toImmutableList());
         if (snapshotId.isEmpty()) {
-            return new FixedPageSource(ImmutableList.of());
+            return InMemoryRecordSet.builder(types).build().cursor();
         }
-        return new FixedPageSource(buildPages(tableMetadata, icebergTable, snapshotId.get()));
-    }
 
-    private static List<Page> buildPages(ConnectorTableMetadata tableMetadata, Table icebergTable, long snapshotId)
-    {
-        PageListBuilder pagesBuilder = PageListBuilder.forTable(tableMetadata);
         Map<Integer, Type> idToTypeMapping = getIcebergIdToTypeMapping(icebergTable.schema());
-
         TableScan tableScan = icebergTable.newScan()
-                .useSnapshot(snapshotId)
+                .useSnapshot(snapshotId.get())
                 .includeColumnStats();
 
-        tableScan.planFiles().forEach(fileScanTask -> {
-            DataFile dataFile = fileScanTask.file();
-
-            pagesBuilder.beginRow();
-            pagesBuilder.appendInteger(dataFile.content().id());
-            pagesBuilder.appendVarchar(dataFile.path().toString());
-            pagesBuilder.appendVarchar(dataFile.format().name());
-            pagesBuilder.appendBigint(dataFile.recordCount());
-            pagesBuilder.appendBigint(dataFile.fileSizeInBytes());
-            if (checkNonNull(dataFile.columnSizes(), pagesBuilder)) {
-                pagesBuilder.appendIntegerBigintMap(dataFile.columnSizes());
-            }
-            if (checkNonNull(dataFile.valueCounts(), pagesBuilder)) {
-                pagesBuilder.appendIntegerBigintMap(dataFile.valueCounts());
-            }
-            if (checkNonNull(dataFile.nullValueCounts(), pagesBuilder)) {
-                pagesBuilder.appendIntegerBigintMap(dataFile.nullValueCounts());
-            }
-            if (checkNonNull(dataFile.nanValueCounts(), pagesBuilder)) {
-                pagesBuilder.appendIntegerBigintMap(dataFile.nanValueCounts());
-            }
-            if (checkNonNull(dataFile.lowerBounds(), pagesBuilder)) {
-                pagesBuilder.appendIntegerVarcharMap(dataFile.lowerBounds().entrySet().stream()
-                        .filter(entry -> idToTypeMapping.containsKey(entry.getKey()))
-                        .collect(toImmutableMap(
-                                Map.Entry<Integer, ByteBuffer>::getKey,
-                                entry -> Transforms.identity().toHumanString(
-                                        idToTypeMapping.get(entry.getKey()), Conversions.fromByteBuffer(idToTypeMapping.get(entry.getKey()), entry.getValue())))));
-            }
-            if (checkNonNull(dataFile.upperBounds(), pagesBuilder)) {
-                pagesBuilder.appendIntegerVarcharMap(dataFile.upperBounds().entrySet().stream()
-                        .filter(entry -> idToTypeMapping.containsKey(entry.getKey()))
-                        .collect(toImmutableMap(
-                                Map.Entry<Integer, ByteBuffer>::getKey,
-                                entry -> Transforms.identity().toHumanString(
-                                        idToTypeMapping.get(entry.getKey()), Conversions.fromByteBuffer(idToTypeMapping.get(entry.getKey()), entry.getValue())))));
-            }
-            if (checkNonNull(dataFile.keyMetadata(), pagesBuilder)) {
-                pagesBuilder.appendVarbinary(Slices.wrappedBuffer(dataFile.keyMetadata()));
-            }
-            if (checkNonNull(dataFile.splitOffsets(), pagesBuilder)) {
-                pagesBuilder.appendBigintArray(dataFile.splitOffsets());
-            }
-            if (checkNonNull(dataFile.equalityFieldIds(), pagesBuilder)) {
-                pagesBuilder.appendIntegerArray(dataFile.equalityFieldIds());
-            }
-            pagesBuilder.endRow();
-        });
-
-        return pagesBuilder.build();
+        PlanFilesIterable planFilesIterable = new PlanFilesIterable(tableScan.planFiles(), idToTypeMapping, types, typeManager);
+        return planFilesIterable.cursor();
     }
 
-    private static boolean checkNonNull(Object object, PageListBuilder pagesBuilder)
+    private static class PlanFilesIterable
+            extends CloseableGroup
+            implements Iterable<List<Object>>
     {
-        if (object == null) {
-            pagesBuilder.appendNull();
-            return false;
+        private final CloseableIterable<FileScanTask> planFiles;
+        private final Map<Integer, Type> idToTypeMapping;
+        private final List<io.trino.spi.type.Type> types;
+        private boolean closed;
+        private final io.trino.spi.type.Type integerToBigintMapType;
+        private final io.trino.spi.type.Type integerToVarcharMapType;
+
+        public PlanFilesIterable(CloseableIterable<FileScanTask> planFiles, Map<Integer, Type> idToTypeMapping, List<io.trino.spi.type.Type> types, TypeManager typeManager)
+        {
+            this.planFiles = requireNonNull(planFiles, "planFiles is null");
+            this.idToTypeMapping = ImmutableMap.copyOf(requireNonNull(idToTypeMapping, "idToTypeMapping is null"));
+            this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
+            this.integerToBigintMapType = typeManager.getType(mapType(INTEGER.getTypeSignature(), BIGINT.getTypeSignature()));
+            this.integerToVarcharMapType = typeManager.getType(mapType(INTEGER.getTypeSignature(), VARCHAR.getTypeSignature()));
+            addCloseable(planFiles);
         }
-        return true;
+
+        public RecordCursor cursor()
+        {
+            return new InMemoryRecordSet.InMemoryRecordCursor<CloseableIterator<? extends List<?>>>(types, this.iterator()) {
+                @Override
+                public void close()
+                {
+                    try {
+                        records.close();
+                        records = null;
+                    }
+                    catch (IOException e) {
+                        throw new UncheckedIOException("Failed to close cursor", e);
+                    }
+                }
+            };
+        }
+
+        @Override
+        public CloseableIterator<List<Object>> iterator()
+        {
+            final CloseableIterator<FileScanTask> planFilesIterator = planFiles.iterator();
+            addCloseable(planFilesIterator);
+
+            return new CloseableIterator<>() {
+                @Override
+                public boolean hasNext()
+                {
+                    return !closed && planFilesIterator.hasNext();
+                }
+
+                @Override
+                public List<Object> next()
+                {
+                    return getRecord(planFilesIterator.next().file());
+                }
+
+                @Override
+                public void close()
+                        throws IOException
+                {
+                    PlanFilesIterable.super.close();
+                    closed = true;
+                }
+            };
+        }
+
+        private List<Object> getRecord(DataFile dataFile)
+        {
+            List<Object> columns = new ArrayList<>();
+            columns.add(dataFile.content().id());
+            columns.add(dataFile.path().toString());
+            columns.add(dataFile.format().name());
+            columns.add(dataFile.recordCount());
+            columns.add(dataFile.fileSizeInBytes());
+            columns.add(getIntegerBigintMapBlock(dataFile.columnSizes()));
+            columns.add(getIntegerBigintMapBlock(dataFile.valueCounts()));
+            columns.add(getIntegerBigintMapBlock(dataFile.nullValueCounts()));
+            columns.add(getIntegerBigintMapBlock(dataFile.nanValueCounts()));
+            columns.add(getIntegerVarcharMapBlock(dataFile.lowerBounds()));
+            columns.add(getIntegerVarcharMapBlock(dataFile.upperBounds()));
+            columns.add(dataFile.keyMetadata());
+            columns.add(dataFile.splitOffsets());
+            columns.add(dataFile.equalityFieldIds());
+            checkArgument(columns.size() == types.size(), "Expected %s types in row, but got %s values", types.size(), columns.size());
+            return columns;
+        }
+
+        private Object getIntegerBigintMapBlock(Map<Integer, Long> value)
+        {
+            if (value == null) {
+                return null;
+            }
+            return toIntegerBigintMapBlock(value);
+        }
+
+        private Object getIntegerVarcharMapBlock(Map<Integer, ByteBuffer> value)
+        {
+            if (value == null) {
+                return null;
+            }
+            return toIntegerVarcharMapBlock(
+                    value.entrySet().stream()
+                            .filter(entry -> idToTypeMapping.containsKey(entry.getKey()))
+                            .collect(toImmutableMap(
+                                    Map.Entry<Integer, ByteBuffer>::getKey,
+                                    entry -> Transforms.identity().toHumanString(
+                                            idToTypeMapping.get(entry.getKey()), Conversions.fromByteBuffer(idToTypeMapping.get(entry.getKey()), entry.getValue())))));
+        }
+
+        private Object toIntegerBigintMapBlock(Map<Integer, Long> values)
+        {
+            BlockBuilder blockBuilder = integerToBigintMapType.createBlockBuilder(null, 1);
+            BlockBuilder singleMapBlockBuilder = blockBuilder.beginBlockEntry();
+            values.forEach((key, value) -> {
+                INTEGER.writeLong(singleMapBlockBuilder, key);
+                BIGINT.writeLong(singleMapBlockBuilder, value);
+            });
+            blockBuilder.closeEntry();
+            return integerToBigintMapType.getObject(blockBuilder, 0);
+        }
+
+        private Object toIntegerVarcharMapBlock(Map<Integer, String> values)
+        {
+            BlockBuilder blockBuilder = integerToVarcharMapType.createBlockBuilder(null, 1);
+            BlockBuilder singleMapBlockBuilder = blockBuilder.beginBlockEntry();
+            values.forEach((key, value) -> {
+                INTEGER.writeLong(singleMapBlockBuilder, key);
+                VARCHAR.writeString(singleMapBlockBuilder, value);
+            });
+            blockBuilder.closeEntry();
+            return integerToVarcharMapType.getObject(blockBuilder, 0);
+        }
     }
 
     private static Map<Integer, Type> getIcebergIdToTypeMapping(Schema schema)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fixes https://github.com/trinodb/trino/issues/15991

The RR is an alternative approach to fix https://github.com/trinodb/trino/issues/15991. another approach https://github.com/trinodb/trino/pull/16063 to fix https://github.com/trinodb/trino/issues/15991

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Reduce memory usage when reading `$files` system tables. ({issue}`16112`)
```
