### PR TITLE
Fix BigQuery FTE leaving temporary tables behind

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/TemporaryTables.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/TemporaryTables.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base;
+
+import io.trino.spi.connector.ConnectorSession;
+
+import java.util.HexFormat;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static java.util.Objects.requireNonNull;
+
+public class TemporaryTables
+{
+    private static final HexFormat hexFormat = HexFormat.of();
+    public static final String TEMPORARY_TABLE_NAME_PREFIX = "tmp_trino_";
+
+    public static String temporaryTableNamePrefix(String queryId)
+    {
+        requireNonNull(queryId, "queryId is null");
+        return String.format("%s%s_", TEMPORARY_TABLE_NAME_PREFIX, hexFormat.toHexDigits(queryId.hashCode()));
+    }
+
+    public static String generateTemporaryTableName(String queryId)
+    {
+        requireNonNull(queryId, "queryId is null");
+        return temporaryTableNamePrefix(queryId) + hexFormat.toHexDigits(ThreadLocalRandom.current().nextInt());
+    }
+
+    public static String generateTemporaryTableName(ConnectorSession session)
+    {
+        requireNonNull(session, "session is null");
+        return generateTemporaryTableName(session.getQueryId());
+    }
+
+    private TemporaryTables()
+    {
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -60,7 +60,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
-import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -74,6 +73,7 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.plugin.base.TemporaryTables.generateTemporaryTableName;
 import static io.trino.plugin.jdbc.CaseSensitivity.CASE_INSENSITIVE;
 import static io.trino.plugin.jdbc.CaseSensitivity.CASE_SENSITIVE;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
@@ -566,10 +566,10 @@ public abstract class BaseJdbcClient
                 // Create the temporary table
                 ColumnMetadata pageSinkIdColumn = getPageSinkIdColumn(
                         tableMetadata.getColumns().stream().map(ColumnMetadata::getName).toList());
-                return createTable(session, tableMetadata, generateTemporaryTableName(), Optional.of(pageSinkIdColumn));
+                return createTable(session, tableMetadata, generateTemporaryTableName(session), Optional.of(pageSinkIdColumn));
             }
             else {
-                return createTable(session, tableMetadata, generateTemporaryTableName());
+                return createTable(session, tableMetadata, generateTemporaryTableName(session));
             }
         }
         catch (SQLException e) {
@@ -698,7 +698,7 @@ public abstract class BaseJdbcClient
                         Optional.empty());
             }
 
-            String remoteTemporaryTableName = identifierMapping.toRemoteTableName(identity, connection, remoteSchema, generateTemporaryTableName());
+            String remoteTemporaryTableName = identifierMapping.toRemoteTableName(identity, connection, remoteSchema, generateTemporaryTableName(session));
             copyTableSchema(session, connection, catalog, remoteSchema, remoteTable, remoteTemporaryTableName, columnNames.build());
 
             Optional<ColumnMetadata> pageSinkIdColumn = Optional.empty();
@@ -741,11 +741,6 @@ public abstract class BaseJdbcClient
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);
         }
-    }
-
-    protected String generateTemporaryTableName()
-    {
-        return "tmp_trino_" + UUID.randomUUID().toString().replace("-", "");
     }
 
     @Override
@@ -806,7 +801,7 @@ public abstract class BaseJdbcClient
         RemoteTableName pageSinkTable = new RemoteTableName(
                 Optional.ofNullable(handle.getCatalogName()),
                 Optional.ofNullable(handle.getSchemaName()),
-                generateTemporaryTableName());
+                generateTemporaryTableName(session));
 
         int maxBatchSize = getWriteBatchSize(session);
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorModule.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorModule.java
@@ -59,7 +59,8 @@ public class BigQueryConnectorModule
 
             // Connector implementation
             binder.bind(BigQueryConnector.class).in(Scopes.SINGLETON);
-            binder.bind(BigQueryMetadata.class).in(Scopes.SINGLETON);
+            binder.bind(BigQueryMetadataFactory.class).to(DefaultBigQueryMetadataFactory.class).in(Scopes.SINGLETON);
+            binder.bind(BigQueryTransactionManager.class).in(Scopes.SINGLETON);
             binder.bind(BigQuerySplitManager.class).in(Scopes.SINGLETON);
             binder.bind(BigQueryPageSourceProvider.class).in(Scopes.SINGLETON);
             binder.bind(BigQueryPageSinkProvider.class).in(Scopes.SINGLETON);

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadataFactory.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadataFactory.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+public interface BigQueryMetadataFactory
+{
+    BigQueryMetadata create(BigQueryTransactionHandle transaction);
+}

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTransactionHandle.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTransactionHandle.java
@@ -13,10 +13,62 @@
  */
 package io.trino.plugin.bigquery;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 
-public enum BigQueryTransactionHandle
+import java.util.Objects;
+import java.util.UUID;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class BigQueryTransactionHandle
         implements ConnectorTransactionHandle
 {
-    INSTANCE
+    private final UUID uuid;
+
+    public BigQueryTransactionHandle()
+    {
+        this(UUID.randomUUID());
+    }
+
+    @JsonCreator
+    public BigQueryTransactionHandle(@JsonProperty("uuid") UUID uuid)
+    {
+        this.uuid = requireNonNull(uuid, "uuid is null");
+    }
+
+    @JsonProperty
+    public UUID getUuid()
+    {
+        return uuid;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        BigQueryTransactionHandle other = (BigQueryTransactionHandle) obj;
+        return Objects.equals(uuid, other.uuid);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(uuid);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("uuid", uuid)
+                .toString();
+    }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTransactionManager.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTransactionManager.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import io.airlift.log.Logger;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.transaction.IsolationLevel;
+
+import javax.inject.Inject;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.spi.transaction.IsolationLevel.READ_COMMITTED;
+import static io.trino.spi.transaction.IsolationLevel.checkConnectorSupports;
+import static java.util.Objects.requireNonNull;
+
+public class BigQueryTransactionManager
+{
+    private static final Logger log = Logger.get(BigQueryTransactionManager.class);
+
+    private final ConcurrentMap<ConnectorTransactionHandle, BigQueryMetadata> transactions = new ConcurrentHashMap<>();
+    private final BigQueryMetadataFactory metadataFactory;
+
+    @Inject
+    public BigQueryTransactionManager(BigQueryMetadataFactory metadataFactory)
+    {
+        this.metadataFactory = requireNonNull(metadataFactory, "metadataFactory is null");
+    }
+
+    public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit)
+    {
+        log.debug("beginTransaction(isolationLevel=%s, readOnly=%s)", isolationLevel, readOnly);
+        checkConnectorSupports(READ_COMMITTED, isolationLevel);
+        BigQueryTransactionHandle transaction = new BigQueryTransactionHandle();
+        transactions.put(transaction, metadataFactory.create(transaction));
+        return transaction;
+    }
+
+    public BigQueryMetadata getMetadata(ConnectorTransactionHandle transaction)
+    {
+        BigQueryMetadata metadata = transactions.get(transaction);
+        checkArgument(metadata != null, "no such transaction: %s", transaction);
+        return metadata;
+    }
+
+    public void commit(ConnectorTransactionHandle transaction)
+    {
+        checkArgument(transactions.remove(transaction) != null, "no such transaction: %s", transaction);
+    }
+
+    public void rollback(ConnectorTransactionHandle transaction)
+    {
+        BigQueryMetadata metadata = transactions.remove(transaction);
+        checkArgument(metadata != null, "no such transaction: %s", transaction);
+        metadata.rollback();
+    }
+}

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/DefaultBigQueryMetadataFactory.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/DefaultBigQueryMetadataFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class DefaultBigQueryMetadataFactory
+        implements BigQueryMetadataFactory
+{
+    private final BigQueryClientFactory bigQueryClient;
+
+    @Inject
+    public DefaultBigQueryMetadataFactory(BigQueryClientFactory bigQueryClient)
+    {
+        this.bigQueryClient = requireNonNull(bigQueryClient, "bigQueryClient is null");
+    }
+
+    @Override
+    public BigQueryMetadata create(BigQueryTransactionHandle transaction)
+    {
+        return new BigQueryMetadata(bigQueryClient);
+    }
+}

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
@@ -67,7 +67,6 @@ import oracle.jdbc.OracleTypes;
 import javax.inject.Inject;
 
 import java.math.RoundingMode;
-import java.security.SecureRandom;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -130,10 +129,8 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
-import static java.lang.Character.MAX_RADIX;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
-import static java.lang.Math.abs;
 import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
 import static java.lang.Math.max;
@@ -147,10 +144,6 @@ public class OracleClient
         extends BaseJdbcClient
 {
     public static final int ORACLE_MAX_LIST_EXPRESSIONS = 1000;
-
-    // Oracle before 12.2 doesn't allow identifiers over 30 characters
-    private static final int ORACLE_MAX_IDENTIFIER_LENGTH = 30;
-    private static final SecureRandom RANDOM = new SecureRandom();
 
     private static final int MAX_BYTES_PER_CHAR = 4;
 
@@ -263,13 +256,6 @@ public class OracleClient
         PreparedStatement statement = connection.prepareStatement(sql);
         statement.setFetchSize(1000);
         return statement;
-    }
-
-    @Override
-    protected String generateTemporaryTableName()
-    {
-        String tableName = "tmp_trino_" + System.nanoTime() + Long.toString(abs(RANDOM.nextLong()), MAX_RADIX);
-        return tableName.substring(0, min(ORACLE_MAX_IDENTIFIER_LENGTH, tableName.length()));
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

@hashhar discovered that BigQuery tests are leaving behind tmp_trino_* tables.

To start, I'm only pushing the enhancement to BaseFailureRecoveryTest that verifies there are no temporary tables left behind. This is so I can run the BigQuery FTE tests (which require secrets), to verify the test finds the temporary tables left behind, so I can verify the change to the BigQueryConnector fix the problem. I will add more context to this PR when I push that commit.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
