### PR TITLE
Fix wrong class name in `TestConstraintExtractor` comment

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestConstraintExtractor.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestConstraintExtractor.java
@@ -173,7 +173,7 @@ public class TestConstraintExtractor
 
     /**
      * Test equivalent of {@link UnwrapDateTruncInComparison} for {@link TimestampWithTimeZoneType}.
-     * {@link UnwrapCastInComparison} handles {@link DateType} and {@link TimestampType}, but cannot handle
+     * {@link UnwrapDateTruncInComparison} handles {@link DateType} and {@link TimestampType}, but cannot handle
      * {@link TimestampWithTimeZoneType}. Such unwrap would not be monotonic. Within Iceberg, we know
      * that {@link TimestampWithTimeZoneType} is always in UTC zone (point in time, with no time zone information),
      * so we can unwrap.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fix wrong class name in `TestConstraintExtractor` comment

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
