### PR TITLE
Do not mark already closed connection as to be reused

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ReusableConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ReusableConnectionFactory.java
@@ -128,7 +128,7 @@ public final class ReusableConnectionFactory
         delegate.close();
     }
 
-    private final class CachedConnection
+    final class CachedConnection
             extends ForwardingConnection
     {
         private final String queryId;
@@ -176,7 +176,7 @@ public final class ReusableConnectionFactory
             if (dirty) {
                 delegate.close();
             }
-            else {
+            else if (!delegate.isClosed()) {
                 connections.put(queryId, delegate);
             }
         }


### PR DESCRIPTION
It can happen that the connection will be closed during the query execution, either by the JDBC driver or the connection pooling manager. When connection is closed, it shouldn't be available for reuse by the next getConnection caller.

Replaces https://github.com/trinodb/trino/pull/16115