### PR TITLE
Upgrade Confluent version to 7.3.1

### DIFF
--- a/lib/trino-record-decoder/pom.xml
+++ b/lib/trino-record-decoder/pom.xml
@@ -56,7 +56,12 @@
 
         <dependency>
             <groupId>com.squareup.wire</groupId>
-            <artifactId>wire-schema</artifactId>
+            <artifactId>wire-runtime-jvm</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.wire</groupId>
+            <artifactId>wire-schema-jvm</artifactId>
         </dependency>
 
         <dependency>
@@ -83,6 +88,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio-jvm</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/AvroColumnDecoder.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/AvroColumnDecoder.java
@@ -36,6 +36,7 @@ import io.trino.spi.type.TinyintType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
+import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.generic.GenericEnumSymbol;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
@@ -127,7 +128,18 @@ public class AvroColumnDecoder
 
     public FieldValueProvider decodeField(GenericRecord avroRecord)
     {
-        Object avroColumnValue = locateNode(avroRecord, columnMapping);
+        Object avroColumnValue;
+        try {
+            avroColumnValue = locateNode(avroRecord, columnMapping);
+        }
+        catch (AvroRuntimeException e) {
+            if (e.getMessage().contains("Not a valid schema field")) {
+                avroColumnValue = null;
+            }
+            else {
+                throw e;
+            }
+        }
         return new ObjectValueProvider(avroColumnValue, columnType, columnName);
     }
 

--- a/plugin/trino-kafka/pom.xml
+++ b/plugin/trino-kafka/pom.xml
@@ -145,16 +145,23 @@
             <scope>runtime</scope>
         </dependency>
 
-        <!-- used by trino-record-decoder -->
+        <!-- used by kafka-protobuf-provider -->
         <dependency>
-            <groupId>com.squareup.wire</groupId>
-            <artifactId>wire-schema</artifactId>
+            <groupId>com.google.api.grpc</groupId>
+            <artifactId>proto-google-common-protos</artifactId>
+            <version>2.5.1</version>
             <scope>runtime</scope>
         </dependency>
 
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
             <scope>runtime</scope>
         </dependency>
 
@@ -300,6 +307,13 @@
 
         <dependency>
             <groupId>io.confluent</groupId>
+            <artifactId>kafka-protobuf-types</artifactId>
+            <!-- This is under Confluent Community License and it should not be used with compile scope -->
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-serializer</artifactId>
             <scope>test</scope>
         </dependency>
@@ -326,6 +340,7 @@
                 <configuration>
                     <allowedProvidedDependencies>
                         <id>io.confluent:kafka-protobuf-provider</id>
+                        <id>io.confluent:kafka-protobuf-types</id>
                     </allowedProvidedDependencies>
                 </configuration>
             </plugin>

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ClassLoaderSafeSchemaRegistryClient.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ClassLoaderSafeSchemaRegistryClient.java
@@ -87,6 +87,15 @@ public class ClassLoaderSafeSchemaRegistryClient
     }
 
     @Override
+    public int register(String subject, ParsedSchema schema, boolean normalize)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.register(subject, schema, normalize);
+        }
+    }
+
+    @Override
     public Schema getByID(int id)
             throws IOException, RestClientException
     {
@@ -101,6 +110,140 @@ public class ClassLoaderSafeSchemaRegistryClient
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.getById(id);
+        }
+    }
+
+    @Override
+    public int getId(String subject, ParsedSchema schema, boolean normalize)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getId(subject, schema, normalize);
+        }
+    }
+
+    @Override
+    public Optional<ParsedSchema> parseSchema(io.confluent.kafka.schemaregistry.client.rest.entities.Schema schema)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.parseSchema(schema);
+        }
+    }
+
+    @Override
+    public List<ParsedSchema> getSchemas(String subjectPrefix, boolean lookupDeletedSchema, boolean latestOnly)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getSchemas(subjectPrefix, lookupDeletedSchema, latestOnly);
+        }
+    }
+
+    @Override
+    public SchemaMetadata getSchemaMetadata(String subject, int version, boolean lookupDeletedSchema)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getSchemaMetadata(subject, version, lookupDeletedSchema);
+        }
+    }
+
+    @Override
+    public int getVersion(String subject, ParsedSchema schema, boolean normalize)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getVersion(subject, schema, normalize);
+        }
+    }
+
+    @Override
+    public List<Integer> getAllVersions(String subject, boolean lookupDeletedSchema)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getAllVersions(subject, lookupDeletedSchema);
+        }
+    }
+
+    @Override
+    public List<String> testCompatibilityVerbose(String subject, ParsedSchema schema)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.testCompatibilityVerbose(subject, schema);
+        }
+    }
+
+    @Override
+    public void deleteCompatibility(String subject)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            delegate.deleteCompatibility(subject);
+        }
+    }
+
+    @Override
+    public void deleteMode(String subject)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            delegate.deleteMode(subject);
+        }
+    }
+
+    @Override
+    public Collection<String> getAllSubjects(boolean lookupDeletedSubject)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getAllSubjects(lookupDeletedSubject);
+        }
+    }
+
+    @Override
+    public Collection<String> getAllSubjectsByPrefix(String subjectPrefix)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getAllSubjectsByPrefix(subjectPrefix);
+        }
+    }
+
+    @Override
+    public List<Integer> deleteSubject(String subject, boolean isPermanent)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.deleteSubject(subject, isPermanent);
+        }
+    }
+
+    @Override
+    public List<Integer> deleteSubject(Map<String, String> requestProperties, String subject, boolean isPermanent)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.deleteSubject(requestProperties, subject, isPermanent);
+        }
+    }
+
+    @Override
+    public Integer deleteSchemaVersion(String subject, String version, boolean isPermanent)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.deleteSchemaVersion(subject, version, isPermanent);
+        }
+    }
+
+    @Override
+    public Integer deleteSchemaVersion(Map<String, String> requestProperties, String subject, String version, boolean isPermanent)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.deleteSchemaVersion(requestProperties, subject, version, isPermanent);
         }
     }
 

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentModule.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentModule.java
@@ -27,6 +27,7 @@ import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import io.trino.decoder.DispatchingRowDecoderFactory;
@@ -175,9 +176,15 @@ public class ConfluentModule
         }
 
         @Override
-        public Optional<ParsedSchema> parseSchema(String schema, List<SchemaReference> references)
+        public Optional<ParsedSchema> parseSchema(String schema, List<SchemaReference> references, boolean isNew)
         {
-            return delegate.get().parseSchema(schema, references);
+            return delegate.get().parseSchema(schema, references, isNew);
+        }
+
+        @Override
+        public ParsedSchema parseSchemaOrElseThrow(Schema schema, boolean isNew)
+        {
+            return delegate.get().parseSchemaOrElseThrow(schema, isNew);
         }
 
         private SchemaProvider create()

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestConfluentSchemaRegistryTableDescriptionSupplier.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestConfluentSchemaRegistryTableDescriptionSupplier.java
@@ -177,7 +177,7 @@ public class TestConfluentSchemaRegistryTableDescriptionSupplier
                                 .build(),
                         new SchemaTableName(DEFAULT_NAME, format("%s&value-subject=%s", topicName, overriddenSubject))))
                 .isInstanceOf(TrinoException.class)
-                .hasMessage("Subject 'ambiguousoverriddensubject' is ambiguous, and may refer to one of the following: ambiguousOverriddenSubject, AMBIGUOUSOVERRIDDENSUBJECT");
+                .hasMessage("Subject 'ambiguousoverriddensubject' is ambiguous, and may refer to one of the following: AMBIGUOUSOVERRIDDENSUBJECT, ambiguousOverriddenSubject");
     }
 
     private KafkaTopicDescription getKafkaTopicDescription(TableDescriptionSupplier tableDescriptionSupplier, SchemaTableName schemaTableName)

--- a/pom.xml
+++ b/pom.xml
@@ -63,14 +63,16 @@
         <dep.testcontainers.version>1.17.6</dep.testcontainers.version>
         <dep.duct-tape.version>1.0.8</dep.duct-tape.version>
         <dep.coral.version>2.0.77</dep.coral.version>
-        <dep.confluent.version>5.5.2</dep.confluent.version>
+        <dep.confluent.version>7.3.1</dep.confluent.version>
+        <dep.kafka-clients.version>3.3.2</dep.kafka-clients.version>
         <dep.casandra.version>4.14.0</dep.casandra.version>
         <dep.minio.version>7.1.4</dep.minio.version>
         <dep.iceberg.version>1.1.0</dep.iceberg.version>
         <dep.spotbugs-annotations.version>4.7.2</dep.spotbugs-annotations.version>
         <dep.protobuf.version>3.21.6</dep.protobuf.version>
-        <dep.wire.version>3.2.2</dep.wire.version>
-        <dep.kotlin.version>1.4.0</dep.kotlin.version>
+        <dep.wire.version>4.4.3</dep.wire.version>
+        <dep.kotlin.version>1.8.0</dep.kotlin.version>
+        <dep.netty.version>4.1.79.Final</dep.netty.version>
 
         <dep.docker.images.version>77</dep.docker.images.version>
 
@@ -1205,6 +1207,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.github.luben</groupId>
+                <artifactId>zstd-jni</artifactId>
+                <version>1.5.2-3</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.github.oshi</groupId>
                 <artifactId>oshi-core</artifactId>
                 <version>5.8.5</version>
@@ -1361,11 +1369,22 @@
             </dependency>
 
             <dependency>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio-jvm</artifactId>
+                <version>3.3.0</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.squareup.wire</groupId>
-                <artifactId>wire-schema</artifactId>
+                <artifactId>wire-runtime-jvm</artifactId>
                 <version>${dep.wire.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>com.squareup.wire</groupId>
+                <artifactId>wire-schema-jvm</artifactId>
+                <version>${dep.wire.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>com.teradata</groupId>
@@ -1416,6 +1435,10 @@
                         <groupId>commons-cli</groupId>
                         <artifactId>commons-cli</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>com.google.re2j</groupId>
+                        <artifactId>re2j</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -1429,6 +1452,11 @@
                     <exclusion>
                         <groupId>org.apache.kafka</groupId>
                         <artifactId>kafka-clients</artifactId>
+                    </exclusion>
+                    <!-- Brings in a 2.13.4.2 version of databind-->
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>com.google.re2j</groupId>
@@ -1447,6 +1475,13 @@
                 <version>${dep.confluent.version}</version>
                 <!-- This is under Confluent Community License and it should not be used with compile scope -->
                 <scope>provided</scope>
+                <exclusions>
+                    <!-- Brings in a 2.13.4.2 version of databind -->
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -1459,12 +1494,25 @@
 
             <dependency>
                 <groupId>io.confluent</groupId>
+                <artifactId>kafka-protobuf-types</artifactId>
+                <version>${dep.confluent.version}</version>
+                <!-- This is under Confluent Community License and it should not be used with compile scope -->
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>io.confluent</groupId>
                 <artifactId>kafka-schema-registry-client</artifactId>
                 <version>${dep.confluent.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.kafka</groupId>
                         <artifactId>kafka-clients</artifactId>
+                    </exclusion>
+                    <!-- Brings in a 2.13.4.2 version of databind -->
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
                     </exclusion>
                     <!--
                         This library depends on conflicting:
@@ -1520,6 +1568,12 @@
             </dependency>
 
             <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-core</artifactId>
+                <version>4.1.18</version>
+            </dependency>
+
+            <dependency>
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt-api</artifactId>
                 <version>${dep.jsonwebtoken.version}</version>
@@ -1541,6 +1595,14 @@
                 <groupId>io.minio</groupId>
                 <artifactId>minio</artifactId>
                 <version>${dep.minio.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <type>pom</type>
+                <version>${dep.netty.version}</version>
+                <scope>import</scope>
             </dependency>
 
             <!-- io.confluent:kafka-avro-serializer uses multiple versions of this transitive dependency -->
@@ -1652,13 +1714,19 @@
             <dependency>
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro</artifactId>
-                <version>1.9.2</version>
+                <version>1.11.0</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
                 <version>1.22</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.12.0</version>
             </dependency>
 
             <dependency>
@@ -1747,7 +1815,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>2.4.1</version>
+                <version>${dep.kafka-clients.version}</version>
             </dependency>
 
             <dependency>
@@ -1765,7 +1833,7 @@
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
-                <version>3.5.8</version>
+                <version>3.6.3</version>
                 <exclusions>
                     <exclusion>
                         <groupId>log4j</groupId>
@@ -1838,6 +1906,12 @@
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib-common</artifactId>
+                <version>${dep.kotlin.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-jdk8</artifactId>
                 <version>${dep.kotlin.version}</version>
             </dependency>
 

--- a/testing/trino-product-tests-launcher/pom.xml
+++ b/testing/trino-product-tests-launcher/pom.xml
@@ -133,6 +133,32 @@
         </dependency>
 
         <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-protobuf-provider</artifactId>
+            <!-- This is under Confluent Community License and we use it under runtime scope only for tests -->
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-protobuf-types</artifactId>
+            <!-- This is under Confluent Community License and we use it under runtime scope only for tests -->
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-jdbc</artifactId>
             <scope>test</scope>
@@ -204,6 +230,12 @@
                                 <artifactItem>
                                     <groupId>io.confluent</groupId>
                                     <artifactId>kafka-protobuf-provider</artifactId>
+                                    <type>jar</type>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>io.confluent</groupId>
+                                    <artifactId>kafka-protobuf-types</artifactId>
                                     <type>jar</type>
                                     <outputDirectory>${project.build.directory}</outputDirectory>
                                 </artifactItem>

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Kafka.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Kafka.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 import java.io.File;
 import java.time.Duration;
 
+import static io.trino.testing.TestingProperties.getConfluentVersion;
 import static io.trino.tests.product.launcher.docker.ContainerUtil.forSelectedPorts;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.isTrinoContainer;
 import static io.trino.tests.product.launcher.env.common.Standard.CONTAINER_TRINO_ETC;
@@ -38,9 +39,10 @@ import static org.testcontainers.utility.MountableFile.forHostPath;
 public class Kafka
         implements EnvironmentExtender
 {
-    private static final String CONFLUENT_VERSION = "5.5.2";
+    private static final String CONFLUENT_VERSION = "7.3.1";
     private static final int SCHEMA_REGISTRY_PORT = 8081;
-    private static final File KAFKA_PROTOBUF_PROVIDER = new File("testing/trino-product-tests-launcher/target/kafka-protobuf-provider-5.5.2.jar");
+    private static final File KAFKA_PROTOBUF_PROVIDER = new File("testing/trino-product-tests-launcher/target/kafka-protobuf-provider-" + getConfluentVersion() + ".jar");
+    private static final File KAFKA_PROTOBUF_TYPES = new File("testing/trino-product-tests-launcher/target/kafka-protobuf-types-" + getConfluentVersion() + ".jar");
     static final String KAFKA = "kafka";
     static final String SCHEMA_REGISTRY = "schema-registry";
     static final String ZOOKEEPER = "zookeeper";
@@ -70,6 +72,7 @@ public class Kafka
                 container
                         .withCopyFileToContainer(logConfigFile, CONTAINER_TRINO_ETC + "/log.properties")
                         .withCopyFileToContainer(forHostPath(KAFKA_PROTOBUF_PROVIDER.getAbsolutePath()), "/docker/kafka-protobuf-provider/kafka-protobuf-provider.jar")
+                        .withCopyFileToContainer(forHostPath(KAFKA_PROTOBUF_TYPES.getAbsolutePath()), "/docker/kafka-protobuf-provider/kafka-protobuf-types.jar")
                         .withCopyFileToContainer(forClasspathResource("install-kafka-protobuf-provider.sh", 0755), "/docker/presto-init.d/install-kafka-protobuf-provider.sh");
             }
         });

--- a/testing/trino-product-tests/pom.xml
+++ b/testing/trino-product-tests/pom.xml
@@ -48,6 +48,10 @@
                     <groupId>com.squareup.okio</groupId>
                     <artifactId>okio</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.squareup.okhttp</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -164,6 +168,12 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okio</groupId>
+                    <artifactId>okio</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -188,8 +198,8 @@
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>com.squareup.okio</groupId>
-                    <artifactId>okio</artifactId>
+                    <groupId>commons-cli</groupId>
+                    <artifactId>commons-cli</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -257,6 +267,13 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-protobuf-types</artifactId>
+            <!-- This is under Confluent Community License and we use it under runtime scope only for tests -->
             <scope>runtime</scope>
         </dependency>
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/kafka/TestKafkaAvroReadsSmokeTest.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/kafka/TestKafkaAvroReadsSmokeTest.java
@@ -356,9 +356,9 @@ public class TestKafkaAvroReadsSmokeTest
         }
 
         @Override
-        public boolean isBackwardCompatible(ParsedSchema parsedSchema)
+        public List<String> isBackwardCompatible(ParsedSchema parsedSchema)
         {
-            return false;
+            return ImmutableList.of("Is not backward compatible");
         }
 
         @Override

--- a/testing/trino-testing-kafka/pom.xml
+++ b/testing/trino-testing-kafka/pom.xml
@@ -16,6 +16,16 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>io.trino</groupId>

--- a/testing/trino-testing-kafka/src/main/java/io/trino/testing/kafka/TestingKafka.java
+++ b/testing/trino-testing-kafka/src/main/java/io/trino/testing/kafka/TestingKafka.java
@@ -58,7 +58,7 @@ public final class TestingKafka
 {
     private static final Logger log = Logger.get(TestingKafka.class);
 
-    private static final String DEFAULT_CONFLUENT_PLATFORM_VERSION = "5.5.2";
+    private static final String DEFAULT_CONFLUENT_PLATFORM_VERSION = "7.3.1";
     private static final int SCHEMA_REGISTRY_PORT = 8081;
 
     private static final DockerImageName KAFKA_IMAGE_NAME = DockerImageName.parse("confluentinc/cp-kafka");
@@ -190,8 +190,8 @@ public final class TestingKafka
             command.add(Integer.toString(partitions));
             command.add("--replication-factor");
             command.add(Integer.toString(replication));
-            command.add("--zookeeper");
-            command.add("localhost:2181");
+            command.add("--bootstrap-server");
+            command.add("localhost:9092");
             if (enableLogAppendTime) {
                 command.add("--config");
                 command.add("message.timestamp.type=LogAppendTime");

--- a/testing/trino-testing-services/src/main/java/io/trino/testing/TestingProperties.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testing/TestingProperties.java
@@ -44,11 +44,21 @@ public class TestingProperties
 
     public static String getProjectVersion()
     {
-        return requireNonNull(properties.get().getProperty("project.version"), "project.version is null");
+        return getProjectProperty("project.version");
     }
 
     public static String getDockerImagesVersion()
     {
-        return requireNonNull(properties.get().getProperty("docker.images.version"), "docker.images.version is null");
+        return getProjectProperty("docker.images.version");
+    }
+
+    public static String getConfluentVersion()
+    {
+        return getProjectProperty("confluent.version");
+    }
+
+    private static String getProjectProperty(String name)
+    {
+        return requireNonNull(properties.get().getProperty(name), name + " is null");
     }
 }

--- a/testing/trino-testing-services/src/main/resources/trino-testing.properties
+++ b/testing/trino-testing-services/src/main/resources/trino-testing.properties
@@ -1,2 +1,3 @@
 project.version=${project.version}
 docker.images.version=${dep.docker.images.version}
+confluent.version=${dep.confluent.version}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Updates Kafka Confluent version to 7.3.1 and transitive dependencies for Avro, ZooKeeper, and Wire. Wire 4.x is required for Confluent 7.3.1 and is updated in the modules that need it, but leaves Wire at 3.x for the remaining modules to avoid updating OkHttp.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This relates to https://github.com/trinodb/trino/pull/10524 where we are looking to upgrade the Kafka/Confluent stuff first prior to the OkHttp 4.x upgrade (this specific suggestion https://github.com/trinodb/trino/pull/10524#issuecomment-1421477181)


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.