### PR TITLE
Support creating a table with `change_data_feed_enabled` table property

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.rst
+++ b/docs/src/main/sphinx/connector/delta-lake.rst
@@ -540,7 +540,7 @@ in the metastore. As a result, any Databricks engine can write to the table::
 The Delta Lake connector also supports creating tables using the :doc:`CREATE
 TABLE AS </sql/create-table-as>` syntax.
 
-There are three table properties available for use in table creation.
+The following properties are available for use:
 
 .. list-table:: Delta Lake table properties
   :widths: 40, 60
@@ -554,14 +554,17 @@ There are three table properties available for use in table creation.
     - Set partition columns.
   * - ``checkpoint_interval``
     - Set the checkpoint interval in seconds.
+  * - ``change_data_feed_enabled``
+    - Enables storing change data feed entries.
 
-The following example uses all three table properties::
+The following example uses all four table properties::
 
   CREATE TABLE example.default.example_partitioned_table
   WITH (
     location = 's3://my-bucket/a/path',
     partitioned_by = ARRAY['regionkey'],
-    checkpoint_interval = 5
+    checkpoint_interval = 5,
+    change_data_feed_enabled = true
   )
   AS SELECT name, comment, regionkey FROM tpch.tiny.nation;
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputTableHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputTableHandle.java
@@ -36,6 +36,7 @@ public class DeltaLakeOutputTableHandle
     private final Optional<Long> checkpointInterval;
     private final boolean external;
     private final Optional<String> comment;
+    private final Optional<Boolean> changeDataFeedEnabled;
 
     @JsonCreator
     public DeltaLakeOutputTableHandle(
@@ -45,7 +46,8 @@ public class DeltaLakeOutputTableHandle
             @JsonProperty("location") String location,
             @JsonProperty("checkpointInterval") Optional<Long> checkpointInterval,
             @JsonProperty("external") boolean external,
-            @JsonProperty("comment") Optional<String> comment)
+            @JsonProperty("comment") Optional<String> comment,
+            @JsonProperty("changeDataFeedEnabled") Optional<Boolean> changeDataFeedEnabled)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -54,6 +56,7 @@ public class DeltaLakeOutputTableHandle
         this.checkpointInterval = checkpointInterval;
         this.external = external;
         this.comment = requireNonNull(comment, "comment is null");
+        this.changeDataFeedEnabled = requireNonNull(changeDataFeedEnabled, "changeDataFeedEnabled is null");
     }
 
     @JsonProperty
@@ -105,5 +108,11 @@ public class DeltaLakeOutputTableHandle
     public Optional<String> getComment()
     {
         return comment;
+    }
+
+    @JsonProperty
+    public Optional<Boolean> getChangeDataFeedEnabled()
+    {
+        return changeDataFeedEnabled;
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableProperties.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableProperties.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
+import static io.trino.spi.session.PropertyMetadata.booleanProperty;
 import static io.trino.spi.session.PropertyMetadata.longProperty;
 import static io.trino.spi.session.PropertyMetadata.stringProperty;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -38,6 +39,7 @@ public class DeltaLakeTableProperties
     public static final String LOCATION_PROPERTY = "location";
     public static final String PARTITIONED_BY_PROPERTY = "partitioned_by";
     public static final String CHECKPOINT_INTERVAL_PROPERTY = "checkpoint_interval";
+    public static final String CHANGE_DATA_FEED_ENABLED_PROPERTY = "change_data_feed_enabled";
 
     private final List<PropertyMetadata<?>> tableProperties;
 
@@ -65,6 +67,11 @@ public class DeltaLakeTableProperties
                 .add(longProperty(
                         CHECKPOINT_INTERVAL_PROPERTY,
                         "Checkpoint interval",
+                        null,
+                        false))
+                .add(booleanProperty(
+                        CHANGE_DATA_FEED_ENABLED_PROPERTY,
+                        "Enables storing change data feed entries",
                         null,
                         false))
                 .build();
@@ -96,5 +103,10 @@ public class DeltaLakeTableProperties
         });
 
         return checkpointInterval;
+    }
+
+    public static Optional<Boolean> getChangeDataFeedEnabled(Map<String, Object> tableProperties)
+    {
+        return Optional.ofNullable((Boolean) tableProperties.get(CHANGE_DATA_FEED_ENABLED_PROPERTY));
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/MetadataEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/MetadataEntry.java
@@ -36,6 +36,7 @@ public class MetadataEntry
     public static final String DELTA_CHECKPOINT_WRITE_STATS_AS_STRUCT_PROPERTY = "delta.checkpoint.writeStatsAsStruct";
 
     private static final String DELTA_CHECKPOINT_INTERVAL_PROPERTY = "delta.checkpointInterval";
+    private static final String DELTA_CHANGE_DATA_FEED_ENABLED_PROPERTY = "delta.enableChangeDataFeed";
 
     private final String id;
     private final String name;
@@ -156,11 +157,28 @@ public class MetadataEntry
         }
     }
 
-    public static Map<String, String> configurationForNewTable(Optional<Long> checkpointInterval)
+    @JsonIgnore
+    public Optional<Boolean> isChangeDataFeedEnabled()
     {
-        return checkpointInterval
-                .map(value -> ImmutableMap.of(DELTA_CHECKPOINT_INTERVAL_PROPERTY, String.valueOf(value)))
-                .orElseGet(ImmutableMap::of);
+        if (this.getConfiguration() == null) {
+            return Optional.empty();
+        }
+
+        String value = this.getConfiguration().get(DELTA_CHANGE_DATA_FEED_ENABLED_PROPERTY);
+        if (value == null) {
+            return Optional.empty();
+        }
+
+        boolean changeDataFeedEnabled = Boolean.parseBoolean(value);
+        return Optional.of(changeDataFeedEnabled);
+    }
+
+    public static Map<String, String> configurationForNewTable(Optional<Long> checkpointInterval, Optional<Boolean> changeDataFeedEnabled)
+    {
+        ImmutableMap.Builder<String, String> configurationMapBuilder = ImmutableMap.builder();
+        checkpointInterval.ifPresent(interval -> configurationMapBuilder.put(DELTA_CHECKPOINT_INTERVAL_PROPERTY, String.valueOf(interval)));
+        changeDataFeedEnabled.ifPresent(enabled -> configurationMapBuilder.put(DELTA_CHANGE_DATA_FEED_ENABLED_PROPERTY, String.valueOf(enabled)));
+        return configurationMapBuilder.buildOrThrow();
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
@@ -851,6 +851,17 @@ public abstract class BaseDeltaLakeMinioConnectorTest
         assertQuery("SELECT * FROM " + tableName, "VALUES(1, null, 100), (2, null, 200)");
     }
 
+    @Test
+    public void testThatEnableCdfTablePropertyIsShownForCtasTables()
+    {
+        String tableName = "test_show_create_show_property_for_table_created_with_ctas_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + "(page_url, views)" +
+                "WITH (change_data_feed_enabled = true) " +
+                "AS VALUES ('url1', 1), ('url2', 2)", 2);
+        assertThat((String) computeScalar("SHOW CREATE TABLE " + tableName))
+                .contains("change_data_feed_enabled = true");
+    }
+
     @Override
     protected void verifyAddNotNullColumnToNonEmptyTableFailurePermissible(Throwable e)
     {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
@@ -158,7 +158,8 @@ public class TestDeltaLakePageSink
                 outputPath.toString(),
                 Optional.of(deltaLakeConfig.getDefaultCheckpointWritingInterval()),
                 true,
-                Optional.empty());
+                Optional.empty(),
+                Optional.of(false));
 
         DeltaLakePageSinkProvider provider = new DeltaLakePageSinkProvider(
                 new GroupByHashPageIndexerFactory(new JoinCompiler(new TypeOperators()), new BlockTypeOperators()),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
https://github.com/trinodb/trino/issues/16129
enable_change_data_feed table property enables writing delta lake CDF entries.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Support creating a table with `change_data_feed_enabled` table property. ({issue}`16129`)
```
