### PR TITLE
Fix predicate lost during pushdown

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
@@ -18,7 +18,6 @@ import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import io.trino.Session;
 import io.trino.cost.TableStatsProvider;
@@ -1004,10 +1003,6 @@ public class PredicatePushDown
             EqualityInference predicateInference = EqualityInference.newInstance(metadata, inheritedPredicate);
             Expression simplifiedLeftEffectivePredicate = predicateInference.rewrite(leftEffectivePredicate, leftScope);
             Expression simplifiedRightEffectivePredicate = predicateInference.rewrite(rightEffectivePredicate, rightScope);
-
-            // simplify predicate based on known equalities guaranteed by the left/right side
-            EqualityInference assertions = EqualityInference.newInstance(metadata, leftEffectivePredicate, rightEffectivePredicate);
-            inheritedPredicate = assertions.rewrite(inheritedPredicate, Sets.union(leftScope, rightScope));
 
             // Generate equality inferences
             EqualityInference allInference = EqualityInference.newInstance(metadata, inheritedPredicate, leftEffectivePredicate, rightEffectivePredicate, joinPredicate, simplifiedLeftEffectivePredicate, simplifiedRightEffectivePredicate);

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestIssue16101.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestIssue16101.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.plugin.tpch.TpchConnectorFactory;
+import io.trino.testing.LocalQueryRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestIssue16101
+{
+    @Test
+    public void test()
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("local")
+                .setSchema(TINY_SCHEMA_NAME)
+                .build();
+
+        LocalQueryRunner runner = LocalQueryRunner.builder(session).build();
+        runner.createCatalog("local", new TpchConnectorFactory(1), ImmutableMap.of());
+
+        try (QueryAssertions assertions = new QueryAssertions(runner)) {
+            assertThat(assertions.query("""
+                    SELECT orderkey, orderstatus, x
+                    FROM (
+                        SELECT orderkey, orderstatus, orderstatus = 'O' AS x
+                        FROM orders) a
+                    INNER JOIN ( VALUES 1, 2, 3, 4 ) b(k)
+                    ON a.orderkey = b.k
+                    WHERE orderstatus = 'O'
+                    """))
+                    .matches("""
+                            VALUES
+                                (BIGINT '1', 'O', true),
+                                (BIGINT '2', 'O', true),
+                                (BIGINT '4', 'O', true)
+                            """);
+        }
+    }
+}


### PR DESCRIPTION
Given a query such as

    SELECT *
    FROM (
        SELECT k, a = 'X'
        FROM t
    ) a
    INNER JOIN (
        VALUES 1,2,3,4
    ) b (k) ON a.k = b.k
    WHERE a = 'X';

the predicate "a = 'X'" is lost during pushdown.

This happens because an unfortunate combination of conditions.

After inheritedPredicate is rewritten, it turns from an equality into a non-equality expression (a = 'X' turns into expr). This causes the equality to be lost (due to EqualityInference not being smart enought to derive that from other truths) and to not add it to the final set of predicates (left, right, join).

This might not be an issue except for the fact that there's a logical fallacy in how
predicates are inferred and simplified. The code uses information from predicates as
truths to simplify those same predicates. This causes the inheritedPredicate
to be simplified to "true" and, effectively, omitted from the final set.

The fix for this specific issue is simple: avoid rewriting the inheritedPredicate so that any equalities are included in the EqualityInference that's used to generate the conditions in the join, left and right subqueries.

Fixes #16101 

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix incorrect results for queries involving an equality predicate in a `WHERE` clause 
  that is equal to a term of a `SELECT` clause in one of the branches of a `JOIN`. ({issue}`16101`)
```
