### PR TITLE
Add  for support creating table with comment for more Jdbc based connectors

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -650,8 +650,9 @@ public abstract class BaseJdbcClient
             }
 
             RemoteTableName remoteTableName = new RemoteTableName(Optional.ofNullable(catalog), Optional.ofNullable(remoteSchema), remoteTargetTableName);
-            String sql = createTableSql(remoteTableName, columnList.build(), tableMetadata);
-            execute(session, connection, sql);
+            for (String sql : createTableSqls(remoteTableName, columnList.build(), tableMetadata)) {
+                execute(session, connection, sql);
+            }
 
             return new JdbcOutputTableHandle(
                     catalog,
@@ -665,6 +666,12 @@ public abstract class BaseJdbcClient
         }
     }
 
+    protected List<String> createTableSqls(RemoteTableName remoteTableName, List<String> columns, ConnectorTableMetadata tableMetadata)
+    {
+        return ImmutableList.of(createTableSql(remoteTableName, columns, tableMetadata));
+    }
+
+    @Deprecated
     protected String createTableSql(RemoteTableName remoteTableName, List<String> columns, ConnectorTableMetadata tableMetadata)
     {
         if (tableMetadata.getComment().isPresent()) {

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -124,15 +124,11 @@ public class TestPostgreSqlConnectorTest
             case SUPPORTS_JOIN_PUSHDOWN_WITH_FULL_JOIN:
                 return false;
 
-            case SUPPORTS_CREATE_TABLE_WITH_TABLE_COMMENT:
             case SUPPORTS_CREATE_TABLE_WITH_COLUMN_COMMENT:
             case SUPPORTS_RENAME_TABLE_ACROSS_SCHEMAS:
                 return false;
 
             case SUPPORTS_ADD_COLUMN_WITH_COMMENT:
-                return false;
-
-            case SUPPORTS_COMMENT_ON_TABLE:
                 return false;
 
             case SUPPORTS_ARRAY:


### PR DESCRIPTION
This is a preparation about supporting setting comment for connectors who does not support setting comment directly when creating the table.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Allow the connector that need using extra sql command to set comment by return the list of the extra sql commands in new added method `getExtraTableAndColumnComments`. eg: `Postgresql` can not set command while creating comment, but support `comment on` syntax to set comment on table, but can return the list of `comment on table xxx is 'comments'` to set comment.

In this PR only talking about the table comment, but actually the column comments also can be supported in this way, plan to separate the PR if this get approved.



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes
```
# Postgres
 * Allow to create a table with a comment.
 * Allow to set a comment for table.
``` 

