### PR TITLE
Fix RLE support for complex types with null element

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderFactory.java
@@ -40,7 +40,7 @@ public class PositionsAppenderFactory
 
         return new UnnestingPositionsAppender(
                 new RleAwarePositionsAppender(
-                        blockTypeOperators.getEqualOperator(type),
+                        blockTypeOperators.getDistinctFromOperator(type),
                         createPrimitiveAppender(type, expectedPositions, maxPageSizeInBytes)));
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/output/RleAwarePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/RleAwarePositionsAppender.java
@@ -15,7 +15,7 @@ package io.trino.operator.output;
 
 import io.trino.spi.block.Block;
 import io.trino.spi.block.RunLengthEncodedBlock;
-import io.trino.type.BlockTypeOperators.BlockPositionEqual;
+import io.trino.type.BlockTypeOperators.BlockPositionIsDistinctFrom;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -35,7 +35,7 @@ public class RleAwarePositionsAppender
     private static final int INSTANCE_SIZE = toIntExact(ClassLayout.parseClass(RleAwarePositionsAppender.class).instanceSize());
     private static final int NO_RLE = -1;
 
-    private final BlockPositionEqual equalOperator;
+    private final BlockPositionIsDistinctFrom isDistinctFromOperator;
     private final PositionsAppender delegate;
 
     @Nullable
@@ -44,10 +44,10 @@ public class RleAwarePositionsAppender
     // NO_RLE means flat state, 0 means initial empty state, positive means RLE state and the current RLE position count.
     private int rlePositionCount;
 
-    public RleAwarePositionsAppender(BlockPositionEqual equalOperator, PositionsAppender delegate)
+    public RleAwarePositionsAppender(BlockPositionIsDistinctFrom isDistinctFromOperator, PositionsAppender delegate)
     {
         this.delegate = requireNonNull(delegate, "delegate is null");
-        this.equalOperator = requireNonNull(equalOperator, "equalOperator is null");
+        this.isDistinctFromOperator = requireNonNull(isDistinctFromOperator, "isDistinctFromOperator is null");
     }
 
     @Override
@@ -75,7 +75,7 @@ public class RleAwarePositionsAppender
         }
         else if (rleValue != null) {
             // we are in the RLE state
-            if (equalOperator.equalNullSafe(rleValue, 0, value, 0)) {
+            if (!isDistinctFromOperator.isDistinctFrom(rleValue, 0, value, 0)) {
                 // the values match. we can just add positions.
                 this.rlePositionCount += positionCount;
                 return;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

`RleAwarePositionsAppender` uses an equality check to
support producing RLE block if all incoming blocks are RLE with the same value. `BlockPositionEqual`
does not support nested nulls like array
or row with `NULL` elements, so it's both semantically better and avoids potential issues to use the
`NOT DISTINCT FROM` operator.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/16140


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X ) Release notes are required, with the following suggested text:

```markdown
# General
* Fix failures for queries with remote partitioning exchange on a complex type (ROW, ARRAY, MAP) with values containing NULL elements. ({issue}`https://github.com/trinodb/trino/issues/16140`)
```
