### PR TITLE
Do not use materialized view in information schema

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -1031,12 +1031,12 @@ public abstract class BaseConnectorTest
                 "SELECT table_name, table_type FROM information_schema.tables " +
                         "WHERE table_schema = '" + view.getSchemaName() + "'"))
                 .skippingTypesCheck()
-                .containsAll("VALUES ('" + view.getObjectName() + "', 'MATERIALIZED VIEW')");
+                .containsAll("VALUES ('" + view.getObjectName() + "', 'BASE TABLE')"); // TODO table_type should probably be "* VIEW"
         // information_schema.tables with table_name filter
         assertQuery(
                 "SELECT table_name, table_type FROM information_schema.tables " +
                         "WHERE table_schema = '" + view.getSchemaName() + "' and table_name = '" + view.getObjectName() + "'",
-                "VALUES ('" + view.getObjectName() + "', 'MATERIALIZED VIEW')");
+                "VALUES ('" + view.getObjectName() + "', 'BASE TABLE')");
 
         // system.jdbc.tables without filter
         assertThat(query("SELECT table_schem, table_name, table_type FROM system.jdbc.tables"))


### PR DESCRIPTION
This reverts commit ba5beab7003f54d21d11c6c4037f8ebe8aa9e257, which introduces a change that's incompatible with the SQL specification. It's unclear why this is needed and no conclusion was reached on other possible alternatives. It needs further analysis and consideration.

## Release notes

(x) This is not user-visible or docs only and no release notes are required -- it reverts an unreleased change.
