### PR TITLE
Support writing NUMERIC and BIGNUMERIC types in BigQuery

### DIFF
--- a/docs/src/main/sphinx/connector/bigquery.rst
+++ b/docs/src/main/sphinx/connector/bigquery.rst
@@ -259,6 +259,9 @@ to the following table:
     - ``INT64``
     - ``INT``, ``SMALLINT``, ``INTEGER``, ``BIGINT``, ``TINYINT``, and
       ``BYTEINT`` are aliases for ``INT64`` in BigQuery.
+  * - ``DECIMAL(P,S)``
+    - ``NUMERIC``
+    - The default precision and scale of ``NUMERIC`` is ``(38, 9)``.
   * - ``VARCHAR``
     - ``STRING``
     -

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTypeUtils.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTypeUtils.java
@@ -19,6 +19,7 @@ import com.google.common.primitives.SignedBytes;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
@@ -38,6 +39,7 @@ import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.Decimals.readBigDecimal;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.SmallintType.SMALLINT;
@@ -66,7 +68,7 @@ public final class BigQueryTypeUtils
             return null;
         }
 
-        // TODO https://github.com/trinodb/trino/issues/13741 Add support for decimal, time, timestamp with time zone, geography, map type
+        // TODO https://github.com/trinodb/trino/issues/13741 Add support for time, timestamp with time zone, geography, map type
         if (type.equals(BOOLEAN)) {
             return type.getBoolean(block, position);
         }
@@ -84,6 +86,9 @@ public final class BigQueryTypeUtils
         }
         if (type.equals(DOUBLE)) {
             return type.getDouble(block, position);
+        }
+        if (type instanceof DecimalType) {
+            return readBigDecimal((DecimalType) type, block, position).toString();
         }
         if (type instanceof VarcharType) {
             return type.getSlice(block, position).toStringUtf8();

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -223,8 +223,6 @@ public abstract class BaseBigQueryConnectorTest
         switch (dataMappingTestSetup.getTrinoTypeName()) {
             case "real":
             case "char(3)":
-            case "decimal(5,3)":
-            case "decimal(15,3)":
             case "time":
             case "time(3)":
             case "time(6)":

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryTypeMapping.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryTypeMapping.java
@@ -20,6 +20,7 @@ import io.trino.spi.type.RowType;
 import io.trino.spi.type.RowType.Field;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.datatype.CreateAndInsertDataSetup;
+import io.trino.testing.datatype.CreateAndTrinoInsertDataSetup;
 import io.trino.testing.datatype.CreateAsSelectDataSetup;
 import io.trino.testing.datatype.DataSetup;
 import io.trino.testing.datatype.SqlDataTypeTest;
@@ -235,6 +236,36 @@ public abstract class BaseBigQueryTypeMapping
     }
 
     @Test
+    public void testNumericWriteMapping()
+    {
+        // Max precision is 29 when the scale is 0 in BigQuery
+        // Valid scale range is between 0 and 9 in BigQuery
+
+        SqlDataTypeTest.create()
+                .addRoundTrip("NUMERIC(3, 0)", "CAST(193 AS DECIMAL(3, 0))", createDecimalType(3, 0), "CAST(193 AS DECIMAL(3, 0))")
+                .addRoundTrip("NUMERIC(3, 0)", "CAST(19 AS DECIMAL(3, 0))", createDecimalType(3, 0), "CAST(19 AS DECIMAL(3, 0))")
+                .addRoundTrip("NUMERIC(3, 0)", "CAST(-193 AS DECIMAL(3, 0))", createDecimalType(3, 0), "CAST(-193 AS DECIMAL(3, 0))")
+                .addRoundTrip("NUMERIC(3, 1)", "CAST(10.0 AS DECIMAL(3, 1))", createDecimalType(3, 1), "CAST(10.0 AS DECIMAL(3, 1))")
+                .addRoundTrip("NUMERIC(3, 1)", "CAST(10.1 AS DECIMAL(3, 1))", createDecimalType(3, 1), "CAST(10.1 AS DECIMAL(3, 1))")
+                .addRoundTrip("NUMERIC(3, 1)", "CAST(-10.1 AS DECIMAL(3, 1))", createDecimalType(3, 1), "CAST(-10.1 AS DECIMAL(3, 1))")
+                .addRoundTrip("NUMERIC(4, 2)", "CAST(2 AS DECIMAL(4, 2))", createDecimalType(4, 2), "CAST(2 AS DECIMAL(4, 2))")
+                .addRoundTrip("NUMERIC(4, 2)", "CAST(2.3 AS DECIMAL(4, 2))", createDecimalType(4, 2), "CAST(2.3 AS DECIMAL(4, 2))")
+                .addRoundTrip("NUMERIC(24, 2)", "CAST(2 AS DECIMAL(24, 2))", createDecimalType(24, 2), "CAST(2 AS DECIMAL(24, 2))")
+                .addRoundTrip("NUMERIC(24, 2)", "CAST(2.3 AS DECIMAL(24, 2))", createDecimalType(24, 2), "CAST(2.3 AS DECIMAL(24, 2))")
+                .addRoundTrip("NUMERIC(24, 2)", "CAST(123456789.3 AS DECIMAL(24, 2))", createDecimalType(24, 2), "CAST(123456789.3 AS DECIMAL(24, 2))")
+                .addRoundTrip("NUMERIC(24, 4)", "CAST(12345678901234567890.31 AS DECIMAL(24, 4))", createDecimalType(24, 4), "CAST(12345678901234567890.31 AS DECIMAL(24, 4))")
+                .addRoundTrip("NUMERIC(29, 0)", "CAST('27182818284590452353602874713' AS DECIMAL(29, 0))", createDecimalType(29, 0), "CAST('27182818284590452353602874713' AS DECIMAL(29, 0))")
+                .addRoundTrip("NUMERIC(29, 0)", "CAST('-27182818284590452353602874713' AS DECIMAL(29, 0))", createDecimalType(29, 0), "CAST('-27182818284590452353602874713' AS DECIMAL(29, 0))")
+                .addRoundTrip("NUMERIC(30, 5)", "CAST(3141592653589793238462643.38327 AS DECIMAL(30, 5))", createDecimalType(30, 5), "CAST(3141592653589793238462643.38327 AS DECIMAL(30, 5))")
+                .addRoundTrip("NUMERIC(30, 5)", "CAST(-3141592653589793238462643.38327 AS DECIMAL(30, 5))", createDecimalType(30, 5), "CAST(-3141592653589793238462643.38327 AS DECIMAL(30, 5))")
+                .addRoundTrip("NUMERIC(38, 9)", "CAST(100000000020000000001234567.123456789 AS DECIMAL(38, 9))", createDecimalType(38, 9), "CAST(100000000020000000001234567.123456789 AS DECIMAL(38, 9))")
+                .addRoundTrip("NUMERIC(38, 9)", "CAST(-100000000020000000001234567.123456789 AS DECIMAL(38, 9))", createDecimalType(38, 9), "CAST(-100000000020000000001234567.123456789 AS DECIMAL(38, 9))")
+                .addRoundTrip("NUMERIC(10, 3)", "CAST(NULL AS DECIMAL(10, 3))", createDecimalType(10, 3), "CAST(NULL AS DECIMAL(10, 3))")
+                .addRoundTrip("NUMERIC(38, 9)", "CAST(NULL AS DECIMAL(38, 9))", createDecimalType(38, 9), "CAST(NULL AS DECIMAL(38, 9))")
+                .execute(getQueryRunner(), bigqueryCreateAndTrinoInsert("test.writenumeric"));
+    }
+
+    @Test
     public void testNumericMappingView()
     {
         // BigQuery views always return DECIMAL(38, 9)
@@ -305,6 +336,35 @@ public abstract class BaseBigQueryTypeMapping
                 .addRoundTrip("BIGNUMERIC(38)", "BIGNUMERIC '-10000000002000000000300000000012345678'", createDecimalType(38, 0), "CAST('-10000000002000000000300000000012345678' AS DECIMAL(38, 0))")
                 .execute(getQueryRunner(), bigqueryCreateAndInsert("test.bignumeric"));
         // TODO (https://github.com/trinodb/trino/pull/12210) Add support for bigquery type in views
+    }
+
+    @Test
+    public void testBigNumericWriteMapping()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("BIGNUMERIC(3, 0)", "CAST(193 AS DECIMAL(3, 0))", createDecimalType(3, 0), "CAST(193 AS DECIMAL(3, 0))")
+                .addRoundTrip("BIGNUMERIC(3, 0)", "CAST(19 AS DECIMAL(3, 0))", createDecimalType(3, 0), "CAST(19 AS DECIMAL(3, 0))")
+                .addRoundTrip("BIGNUMERIC(3, 0)", "CAST(-193 AS DECIMAL(3, 0))", createDecimalType(3, 0), "CAST(-193 AS DECIMAL(3, 0))")
+                .addRoundTrip("BIGNUMERIC(3, 1)", "CAST(10.0 AS DECIMAL(3, 1))", createDecimalType(3, 1), "CAST(10.0 AS DECIMAL(3, 1))")
+                .addRoundTrip("BIGNUMERIC(3, 1)", "CAST(10.1 AS DECIMAL(3, 1))", createDecimalType(3, 1), "CAST(10.1 AS DECIMAL(3, 1))")
+                .addRoundTrip("BIGNUMERIC(3, 1)", "CAST(-10.1 AS DECIMAL(3, 1))", createDecimalType(3, 1), "CAST(-10.1 AS DECIMAL(3, 1))")
+                .addRoundTrip("BIGNUMERIC(4, 2)", "CAST(2 AS DECIMAL(4, 2))", createDecimalType(4, 2), "CAST(2 AS DECIMAL(4, 2))")
+                .addRoundTrip("BIGNUMERIC(4, 2)", "CAST(2.3 AS DECIMAL(4, 2))", createDecimalType(4, 2), "CAST(2.3 AS DECIMAL(4, 2))")
+                .addRoundTrip("BIGNUMERIC(24, 2)", "CAST(2 AS DECIMAL(24, 2))", createDecimalType(24, 2), "CAST(2 AS DECIMAL(24, 2))")
+                .addRoundTrip("BIGNUMERIC(24, 2)", "CAST(2.3 AS DECIMAL(24, 2))", createDecimalType(24, 2), "CAST(2.3 AS DECIMAL(24, 2))")
+                .addRoundTrip("BIGNUMERIC(24, 2)", "CAST(123456789.3 AS DECIMAL(24, 2))", createDecimalType(24, 2), "CAST(123456789.3 AS DECIMAL(24, 2))")
+                .addRoundTrip("BIGNUMERIC(24, 4)", "CAST(12345678901234567890.31 AS DECIMAL(24, 4))", createDecimalType(24, 4), "CAST(12345678901234567890.31 AS DECIMAL(24, 4))")
+                .addRoundTrip("BIGNUMERIC(29, 0)", "CAST('27182818284590452353602874713' AS DECIMAL(29, 0))", createDecimalType(29, 0), "CAST('27182818284590452353602874713' AS DECIMAL(29, 0))")
+                .addRoundTrip("BIGNUMERIC(29, 0)", "CAST('-27182818284590452353602874713' AS DECIMAL(29, 0))", createDecimalType(29, 0), "CAST('-27182818284590452353602874713' AS DECIMAL(29, 0))")
+                .addRoundTrip("BIGNUMERIC(30, 5)", "CAST(3141592653589793238462643.38327 AS DECIMAL(30, 5))", createDecimalType(30, 5), "CAST(3141592653589793238462643.38327 AS DECIMAL(30, 5))")
+                .addRoundTrip("BIGNUMERIC(30, 5)", "CAST(-3141592653589793238462643.38327 AS DECIMAL(30, 5))", createDecimalType(30, 5), "CAST(-3141592653589793238462643.38327 AS DECIMAL(30, 5))")
+                .addRoundTrip("BIGNUMERIC(38, 9)", "CAST(100000000020000000001234567.123456789 AS DECIMAL(38, 9))", createDecimalType(38, 9), "CAST(100000000020000000001234567.123456789 AS DECIMAL(38, 9))")
+                .addRoundTrip("BIGNUMERIC(38, 9)", "CAST(-100000000020000000001234567.123456789 AS DECIMAL(38, 9))", createDecimalType(38, 9), "CAST(-100000000020000000001234567.123456789 AS DECIMAL(38, 9))")
+                .addRoundTrip("BIGNUMERIC(10, 3)", "CAST(NULL AS DECIMAL(10, 3))", createDecimalType(10, 3), "CAST(NULL AS DECIMAL(10, 3))")
+                .addRoundTrip("BIGNUMERIC(38, 9)", "CAST(NULL AS DECIMAL(38, 9))", createDecimalType(38, 9), "CAST(NULL AS DECIMAL(38, 9))")
+                .addRoundTrip("BIGNUMERIC(1)", "CAST(1 AS DECIMAL(1, 0))", createDecimalType(1, 0), "CAST(1 AS DECIMAL(1, 0))")
+                .addRoundTrip("BIGNUMERIC(1)", "CAST(-1 AS DECIMAL(1, 0))", createDecimalType(1, 0), "CAST(-1 AS DECIMAL(1, 0))")
+                .execute(getQueryRunner(), bigqueryCreateAndTrinoInsert("test.writebignumeric"));
     }
 
     @Test
@@ -649,6 +709,11 @@ public abstract class BaseBigQueryTypeMapping
     private DataSetup bigqueryCreateAndInsert(String tableNamePrefix)
     {
         return new CreateAndInsertDataSetup(getBigQuerySqlExecutor(), tableNamePrefix);
+    }
+
+    private DataSetup bigqueryCreateAndTrinoInsert(String tableNamePrefix)
+    {
+        return new CreateAndTrinoInsertDataSetup(getBigQuerySqlExecutor(), new TrinoSqlExecutor(getQueryRunner()), tableNamePrefix);
     }
 
     private DataSetup bigqueryViewCreateAndInsert(String tableNamePrefix)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Support writing NUMERIC and BIGNUMERIC types in BigQuery

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# BigQuery
* Add support for writing BigQuery `numeric` and `bignumeric` types. ({issue}`16145`)
```
