### PR TITLE
Add CLI options for history file and pager

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -136,6 +136,9 @@ public class ClientOptions
     @Option(names = "--debug", paramLabel = "<debug>", description = "Enable debug information")
     public boolean debug;
 
+    @Option(names = "--history-file", paramLabel = "<historyFile>", defaultValue = "${env:TRINO_HISTORY_FILE:-${sys:user.home}/.trino_history}", description = "Path to the history file " + DEFAULT_VALUE)
+    public String historyFile;
+
     @Option(names = "--network-logging", paramLabel = "<level>", defaultValue = "NONE", description = "Network logging level [${COMPLETION-CANDIDATES}] " + DEFAULT_VALUE)
     public HttpLoggingInterceptor.Level networkLogging;
 
@@ -150,6 +153,9 @@ public class ClientOptions
 
     @Option(names = "--output-format-interactive", paramLabel = "<format>", defaultValue = "ALIGNED", description = "Output format for interactive mode [${COMPLETION-CANDIDATES}] " + DEFAULT_VALUE)
     public OutputFormat outputFormatInteractive;
+
+    @Option(names = "--pager", paramLabel = "<pager>", defaultValue = "${env:TRINO_PAGER}", description = "Path to the pager program used to display the query results")
+    public Optional<String> pager;
 
     @Option(names = "--resource-estimate", paramLabel = "<estimate>", description = "Resource estimate (property can be used multiple times; format is key=value)")
     public final List<ClientResourceEstimate> resourceEstimates = new ArrayList<>();

--- a/client/trino-cli/src/main/java/io/trino/cli/Pager.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Pager.java
@@ -21,6 +21,7 @@ import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -28,7 +29,6 @@ import static com.google.common.base.Preconditions.checkState;
 public class Pager
         extends FilterOutputStream
 {
-    public static final String ENV_PAGER = "TRINO_PAGER";
     public static final List<String> LESS = ImmutableList.of("less", "-FXRSn");
 
     private final Process process;
@@ -131,17 +131,10 @@ public class Pager
         throw e;
     }
 
-    public static Pager create()
+    public static Pager create(Optional<String> pagerName)
     {
-        String pager = System.getenv(ENV_PAGER);
-        if (pager == null) {
-            return create(LESS);
-        }
-        pager = pager.trim();
-        if (pager.isEmpty()) {
-            return createNullPager();
-        }
-        return create(ImmutableList.of("/bin/sh", "-c", pager));
+        return pagerName.map(name -> create(ImmutableList.of("/bin/sh", "-c", name)))
+                .orElseGet(() -> create(LESS));
     }
 
     public static Pager create(List<String> command)

--- a/client/trino-cli/src/main/java/io/trino/cli/Query.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Query.java
@@ -126,7 +126,7 @@ public class Query
         return client.isClearTransactionId();
     }
 
-    public boolean renderOutput(Terminal terminal, PrintStream out, PrintStream errorChannel, OutputFormat outputFormat, boolean usePager, boolean showProgress)
+    public boolean renderOutput(Terminal terminal, PrintStream out, PrintStream errorChannel, OutputFormat outputFormat, Optional<String> pager, boolean showProgress)
     {
         Thread clientThread = Thread.currentThread();
         SignalHandler oldHandler = terminal.handle(Signal.INT, signal -> {
@@ -137,7 +137,7 @@ public class Query
             clientThread.interrupt();
         });
         try {
-            return renderQueryOutput(terminal, out, errorChannel, outputFormat, usePager, showProgress);
+            return renderQueryOutput(terminal, out, errorChannel, outputFormat, pager, showProgress);
         }
         finally {
             terminal.handle(Signal.INT, oldHandler);
@@ -145,13 +145,13 @@ public class Query
         }
     }
 
-    private boolean renderQueryOutput(Terminal terminal, PrintStream out, PrintStream errorChannel, OutputFormat outputFormat, boolean usePager, boolean showProgress)
+    private boolean renderQueryOutput(Terminal terminal, PrintStream out, PrintStream errorChannel, OutputFormat outputFormat, Optional<String> pager, boolean showProgress)
     {
         StatusPrinter statusPrinter = null;
         WarningsPrinter warningsPrinter = new PrintStreamWarningsPrinter(errorChannel);
 
         if (showProgress) {
-            statusPrinter = new StatusPrinter(client, errorChannel, debug, usePager);
+            statusPrinter = new StatusPrinter(client, errorChannel, debug, isInteractive(pager));
             statusPrinter.printInitialStatusUpdates(terminal);
         }
         else {
@@ -162,7 +162,7 @@ public class Query
         if (client.isRunning() || (client.isFinished() && client.finalStatusInfo().getError() == null)) {
             QueryStatusInfo results = client.isRunning() ? client.currentStatusInfo() : client.finalStatusInfo();
             if (results.getUpdateType() != null) {
-                renderUpdate(terminal, errorChannel, results, outputFormat, usePager);
+                renderUpdate(terminal, errorChannel, results, outputFormat, pager);
             }
             // TODO once https://github.com/trinodb/trino/issues/14253 is done this else here should be needed
             // and should be replaced with just simple:
@@ -173,7 +173,7 @@ public class Query
                 return false;
             }
             else {
-                renderResults(terminal, out, outputFormat, usePager, results.getColumns());
+                renderResults(terminal, out, outputFormat, pager, results.getColumns());
             }
         }
 
@@ -203,6 +203,11 @@ public class Query
         return true;
     }
 
+    private boolean isInteractive(Optional<String> pager)
+    {
+        return pager.map(name -> name.trim().length() != 0).orElse(true);
+    }
+
     private void processInitialStatusUpdates(WarningsPrinter warningsPrinter)
     {
         while (client.isRunning() && (client.currentData().getData() == null)) {
@@ -224,7 +229,7 @@ public class Query
         warningsPrinter.print(warnings, false, true);
     }
 
-    private void renderUpdate(Terminal terminal, PrintStream out, QueryStatusInfo results, OutputFormat outputFormat, boolean usePager)
+    private void renderUpdate(Terminal terminal, PrintStream out, QueryStatusInfo results, OutputFormat outputFormat, Optional<String> pager)
     {
         String status = results.getUpdateType();
         if (results.getUpdateCount() != null) {
@@ -234,7 +239,7 @@ public class Query
         }
         else if (results.getColumns() != null && !results.getColumns().isEmpty()) {
             out.println(status);
-            renderResults(terminal, out, outputFormat, usePager, results.getColumns());
+            renderResults(terminal, out, outputFormat, pager, results.getColumns());
         }
         else {
             out.println(status);
@@ -252,10 +257,10 @@ public class Query
         }
     }
 
-    private void renderResults(Terminal terminal, PrintStream out, OutputFormat outputFormat, boolean interactive, List<Column> columns)
+    private void renderResults(Terminal terminal, PrintStream out, OutputFormat outputFormat, Optional<String> pager, List<Column> columns)
     {
         try {
-            doRenderResults(terminal, out, outputFormat, interactive, columns);
+            doRenderResults(terminal, out, outputFormat, pager, columns);
         }
         catch (QueryAbortedException e) {
             System.out.println("(query aborted by user)");
@@ -266,21 +271,21 @@ public class Query
         }
     }
 
-    private void doRenderResults(Terminal terminal, PrintStream out, OutputFormat format, boolean interactive, List<Column> columns)
+    private void doRenderResults(Terminal terminal, PrintStream out, OutputFormat format, Optional<String> pager, List<Column> columns)
             throws IOException
     {
-        if (interactive) {
-            pageOutput(format, terminal.getWidth(), columns);
+        if (isInteractive(pager)) {
+            pageOutput(pager, format, terminal.getWidth(), columns);
         }
         else {
             sendOutput(out, format, terminal.getWidth(), columns);
         }
     }
 
-    private void pageOutput(OutputFormat format, int maxWidth, List<Column> columns)
+    private void pageOutput(Optional<String> pagerName, OutputFormat format, int maxWidth, List<Column> columns)
             throws IOException
     {
-        try (Pager pager = Pager.create();
+        try (Pager pager = Pager.create(pagerName);
                 ThreadInterruptor clientThread = new ThreadInterruptor();
                 Writer writer = createWriter(pager);
                 OutputHandler handler = createOutputHandler(format, maxWidth, writer, columns)) {

--- a/client/trino-cli/src/test/java/io/trino/cli/TestInsecureQueryRunner.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestInsecureQueryRunner.java
@@ -26,6 +26,7 @@ import javax.net.ssl.TrustManagerFactory;
 import java.io.InputStream;
 import java.security.KeyStore;
 import java.security.SecureRandom;
+import java.util.Optional;
 
 import static com.google.common.io.Resources.getResource;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
@@ -74,7 +75,7 @@ public class TestInsecureQueryRunner
         QueryRunner queryRunner = createQueryRunner(createClientSession(server), true);
 
         try (Query query = queryRunner.startQuery("query with insecure mode")) {
-            query.renderOutput(getTerminal(), nullPrintStream(), nullPrintStream(), CSV, false, false);
+            query.renderOutput(getTerminal(), nullPrintStream(), nullPrintStream(), CSV, Optional.of(""), false);
         }
 
         assertEquals(server.takeRequest().getPath(), "/v1/statement");

--- a/client/trino-cli/src/test/java/io/trino/cli/TestQueryRunner.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestQueryRunner.java
@@ -88,10 +88,10 @@ public class TestQueryRunner
         QueryRunner queryRunner = createQueryRunner(createClientSession(server), false);
 
         try (Query query = queryRunner.startQuery("first query will introduce a cookie")) {
-            query.renderOutput(getTerminal(), nullPrintStream(), nullPrintStream(), CSV, false, false);
+            query.renderOutput(getTerminal(), nullPrintStream(), nullPrintStream(), CSV, Optional.of(""), false);
         }
         try (Query query = queryRunner.startQuery("second query should carry the cookie")) {
-            query.renderOutput(getTerminal(), nullPrintStream(), nullPrintStream(), CSV, false, false);
+            query.renderOutput(getTerminal(), nullPrintStream(), nullPrintStream(), CSV, Optional.of(""), false);
         }
 
         assertNull(server.takeRequest().getHeader("Cookie"));

--- a/docs/src/main/sphinx/client/cli.rst
+++ b/docs/src/main/sphinx/client/cli.rst
@@ -161,6 +161,8 @@ mode:
       EMACS editors. Defaults to ``EMACS``.
   * - ``--http-proxy``
     - Configures the URL of the HTTP proxy to connect to Trino.
+  * - ``--history-file``
+    - Path to the :ref:`history file <cli-history>`. Defaults to ``~/.trino_history``.
   * - ``--network-logging``
     - Configures the level of detail provided for network logging of the CLI.
       Defaults to ``NONE``, other options are ``BASIC``, ``HEADERS``, or
@@ -168,6 +170,10 @@ mode:
   * - ``--output-format-interactive=<format>``
     - Specify the :ref:`format <cli-output-format>` to use
       for printing query results. Defaults to ``ALIGNED``.
+  * - ``--pager=<pager>``
+    - Path to the pager program used to display the query results. Set to
+      an empty value to completely disable pagination. Defaults to ``less``
+      with a carefully selected set of options.
   * - ``--no-progress``
     - Do not show query processing progress.
   * - ``--password``
@@ -423,9 +429,12 @@ Pagination
 
 By default, the results of queries are paginated using the ``less`` program
 which is configured with a carefully selected set of options. This behavior
-can be overridden by setting the environment variable ``TRINO_PAGER`` to the
-name of a different program such as ``more`` or `pspg <https://github.com/okbob/pspg>`_,
+can be overridden by setting the ``--pager`` option or
+the ``TRINO_PAGER`` environment variable to the name of a different program
+such as ``more`` or `pspg <https://github.com/okbob/pspg>`_,
 or it can be set to an empty value to completely disable pagination.
+
+.. _cli-history:
 
 History
 -------
@@ -436,7 +445,8 @@ history by scrolling or searching. Use the up and down arrows to scroll and
 press :kbd:`Enter`.
 
 By default, you can locate the Trino history file in ``~/.trino_history``.
-Use the ``TRINO_HISTORY_FILE`` environment variable to change the default.
+Use the ``--history-file`` option or the ```TRINO_HISTORY_FILE`` environment variable
+to change the default.
 
 Auto suggestion
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Add CLI options for pager and history file, which previously could only be set using environmental variables. Having them available as options allows setting them in the configuration file.

Extracted from #12208 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
