### PR TITLE
Add ability to redefine BaseFailureRecoveryTest's Semaphore

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
@@ -75,14 +75,20 @@ public abstract class BaseFailureRecoveryTest
     protected static final int INVOCATION_COUNT = 1;
     private static final Duration MAX_ERROR_DURATION = new Duration(5, SECONDS);
     private static final Duration REQUEST_TIMEOUT = new Duration(5, SECONDS);
-    private static final int MAX_PARALLEL_TEST_CONCURRENCY = 4;
+    private static final int DEFAULT_PARALLEL_TEST_CONCURRENCY = 4;
 
     private final RetryPolicy retryPolicy;
-    private final Semaphore parallelTestsSemaphore = new Semaphore(MAX_PARALLEL_TEST_CONCURRENCY);
+    private final Semaphore parallelTestsSemaphore;
 
     protected BaseFailureRecoveryTest(RetryPolicy retryPolicy)
     {
         this.retryPolicy = requireNonNull(retryPolicy, "retryPolicy is null");
+        this.parallelTestsSemaphore = createParallelTestsSemaphore();
+    }
+
+    protected Semaphore createParallelTestsSemaphore()
+    {
+        return new Semaphore(DEFAULT_PARALLEL_TEST_CONCURRENCY);
     }
 
     protected RetryPolicy getRetryPolicy()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This allows connectors to redefine the `Semaphore` used to control the parallelism of `BaseFailureRecoveryTest`. This was by request of @anusudarsan 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
