### PR TITLE
Make the Adaptive Remote Task Size unit test not flaky

### DIFF
--- a/core/trino-main/src/test/java/io/trino/server/remotetask/TestHttpRemoteTask.java
+++ b/core/trino-main/src/test/java/io/trino/server/remotetask/TestHttpRemoteTask.java
@@ -394,8 +394,8 @@ public class TestHttpRemoteTask
                 .setCatalog("tpch")
                 .setSchema(TINY_SCHEMA_NAME)
                 .setSystemProperty(REMOTE_TASK_ADAPTIVE_UPDATE_REQUEST_SIZE_ENABLED, "true")
-                .setSystemProperty(REMOTE_TASK_MAX_REQUEST_SIZE, "100kB")
-                .setSystemProperty(REMOTE_TASK_REQUEST_SIZE_HEADROOM, "10kB")
+                .setSystemProperty(REMOTE_TASK_MAX_REQUEST_SIZE, "10kB")
+                .setSystemProperty(REMOTE_TASK_REQUEST_SIZE_HEADROOM, "1kB")
                 .setSystemProperty(REMOTE_TASK_GUARANTEED_SPLITS_PER_REQUEST, "1")
                 .build();
         HttpRemoteTaskFactory httpRemoteTaskFactory = createHttpRemoteTaskFactory(testingTaskResource);
@@ -406,14 +406,15 @@ public class TestHttpRemoteTask
         remoteTask.start();
 
         Multimap<PlanNodeId, Split> splits = HashMultimap.create();
-        for (int i = 0; i < 10000; i++) {
+        for (int i = 0; i < 100; i++) {
             splits.put(TABLE_SCAN_NODE_ID, new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit()));
         }
         remoteTask.addSplits(splits);
 
         poll(() -> testingTaskResource.getTaskSplitAssignment(TABLE_SCAN_NODE_ID) != null);
-        poll(() -> testingTaskResource.getTaskSplitAssignment(TABLE_SCAN_NODE_ID).getSplits().size() < 5000); // to check whether the splits are divided or not
-        poll(() -> testingTaskResource.getTaskSplitAssignment(TABLE_SCAN_NODE_ID).getSplits().size() == 10000); // to check whether all the splits are sent or not
+
+        poll(() -> testingTaskResource.getTaskSplitAssignment(TABLE_SCAN_NODE_ID).getSplits().size() == 100); // to check whether all the splits are sent or not
+        assertTrue(testingTaskResource.getCreateOrUpdateCounter() > 1); // to check whether the splits are divided or not
 
         remoteTask.noMoreSplits(TABLE_SCAN_NODE_ID);
         poll(() -> testingTaskResource.getTaskSplitAssignment(TABLE_SCAN_NODE_ID).isNoMoreSplits());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Make the Adaptive Remote Task Size unit test not flaky. Splits can be quickly sent before `poll`.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
