### PR TITLE
Allow updating `reader_version` and `writer_version` properties for Delta tables

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.rst
+++ b/docs/src/main/sphinx/connector/delta-lake.rst
@@ -563,15 +563,21 @@ The following properties are available for use:
     - Set the checkpoint interval in seconds.
   * - ``change_data_feed_enabled``
     - Enables storing change data feed entries.
+  * - ``reader_version``
+    - Set reader version.
+  * - ``writer_version``
+    - Set writer version.
 
-The following example uses all four table properties::
+The following example uses all six table properties::
 
   CREATE TABLE example.default.example_partitioned_table
   WITH (
     location = 's3://my-bucket/a/path',
     partitioned_by = ARRAY['regionkey'],
     checkpoint_interval = 5,
-    change_data_feed_enabled = true
+    change_data_feed_enabled = true,
+    reader_version = 2,
+    writer_version = 4
   )
   AS SELECT name, comment, regionkey FROM tpch.tiny.nation;
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputTableHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputTableHandle.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
 
 import java.util.List;
@@ -37,6 +38,7 @@ public class DeltaLakeOutputTableHandle
     private final boolean external;
     private final Optional<String> comment;
     private final Optional<Boolean> changeDataFeedEnabled;
+    private final ProtocolEntry protocolEntry;
 
     @JsonCreator
     public DeltaLakeOutputTableHandle(
@@ -47,7 +49,8 @@ public class DeltaLakeOutputTableHandle
             @JsonProperty("checkpointInterval") Optional<Long> checkpointInterval,
             @JsonProperty("external") boolean external,
             @JsonProperty("comment") Optional<String> comment,
-            @JsonProperty("changeDataFeedEnabled") Optional<Boolean> changeDataFeedEnabled)
+            @JsonProperty("changeDataFeedEnabled") Optional<Boolean> changeDataFeedEnabled,
+            @JsonProperty("protocolEntry") ProtocolEntry protocolEntry)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -57,6 +60,7 @@ public class DeltaLakeOutputTableHandle
         this.external = external;
         this.comment = requireNonNull(comment, "comment is null");
         this.changeDataFeedEnabled = requireNonNull(changeDataFeedEnabled, "changeDataFeedEnabled is null");
+        this.protocolEntry = requireNonNull(protocolEntry, "protocolEntry is null");
     }
 
     @JsonProperty
@@ -114,5 +118,11 @@ public class DeltaLakeOutputTableHandle
     public Optional<Boolean> getChangeDataFeedEnabled()
     {
         return changeDataFeedEnabled;
+    }
+
+    @JsonProperty
+    public ProtocolEntry getProtocolEntry()
+    {
+        return protocolEntry;
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -347,7 +347,9 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
                                 ")\n" +
                                 "WITH (\n" +
                                 "   location = '%s',\n" +
-                                "   partitioned_by = ARRAY['age']\n" +
+                                "   partitioned_by = ARRAY['age'],\n" +
+                                "   reader_version = 1,\n" +
+                                "   writer_version = 2\n" +
                                 ")",
                         SCHEMA,
                         getLocationForTable(bucketName, "person")));
@@ -476,7 +478,9 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
                                 ")\n" +
                                 "WITH (\n" +
                                 "   location = '%s',\n" +
-                                "   partitioned_by = ARRAY['regionkey']\n" +
+                                "   partitioned_by = ARRAY['regionkey'],\n" +
+                                "   reader_version = 1,\n" +
+                                "   writer_version = 2\n" +
                                 ")",
                         DELTA_CATALOG, SCHEMA, tableName, getLocationForTable(bucketName, tableName)));
         assertQuery("SELECT * FROM " + tableName, "SELECT name, regionkey, comment FROM nation");
@@ -1347,7 +1351,9 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
                                 ")\n" +
                                 "WITH (\n" +
                                 "   location = '%s',\n" +
-                                "   partitioned_by = ARRAY[%s]\n" +
+                                "   partitioned_by = ARRAY[%s],\n" +
+                                "   reader_version = 1,\n" +
+                                "   writer_version = 2\n" +
                                 ")",
                         getSession().getCatalog().orElseThrow(),
                         SCHEMA,

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
@@ -20,6 +20,7 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
 import io.trino.operator.GroupByHashPageIndexerFactory;
+import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
 import io.trino.plugin.hive.HiveTransactionHandle;
 import io.trino.plugin.hive.NodeVersion;
 import io.trino.spi.Page;
@@ -52,6 +53,8 @@ import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.trino.plugin.deltalake.DeltaLakeColumnType.REGULAR;
+import static io.trino.plugin.deltalake.DeltaLakeMetadata.MIN_READER_VERSION;
+import static io.trino.plugin.deltalake.DeltaLakeMetadata.MIN_WRITER_VERSION;
 import static io.trino.plugin.deltalake.DeltaTestingConnectorSession.SESSION;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -159,7 +162,8 @@ public class TestDeltaLakePageSink
                 Optional.of(deltaLakeConfig.getDefaultCheckpointWritingInterval()),
                 true,
                 Optional.empty(),
-                Optional.of(false));
+                Optional.of(false),
+                new ProtocolEntry(MIN_READER_VERSION, MIN_WRITER_VERSION));
 
         DeltaLakePageSinkProvider provider = new DeltaLakePageSinkProvider(
                 new GroupByHashPageIndexerFactory(new JoinCompiler(new TypeOperators()), new BlockTypeOperators()),

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksCheckpointsCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksCheckpointsCompatibility.java
@@ -158,7 +158,9 @@ public class TestDeltaLakeDatabricksCheckpointsCompatibility
                             "WITH (\n" +
                             "   checkpoint_interval = 5,\n" +
                             "   location = 's3://%s/%s',\n" +
-                            "   partitioned_by = ARRAY['a_number']\n" +
+                            "   partitioned_by = ARRAY['a_number'],\n" +
+                            "   reader_version = 1,\n" +
+                            "   writer_version = 2\n" +
                             ")",
                     tableName,
                     bucketName,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fixes https://github.com/trinodb/trino/issues/15932

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Allow updating `reader_version` and `writer_version` table properties. ({issue}`16165`)
```
