### PR TITLE
Remove support for legacy hive-hadoop2 connector name

### DIFF
--- a/plugin/trino-hive-hadoop2/pom.xml
+++ b/plugin/trino-hive-hadoop2/pom.xml
@@ -24,11 +24,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>log</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/plugin/trino-hive-hadoop2/src/main/java/io/trino/plugin/hive/HivePlugin.java
+++ b/plugin/trino-hive-hadoop2/src/main/java/io/trino/plugin/hive/HivePlugin.java
@@ -15,45 +15,23 @@ package io.trino.plugin.hive;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import io.airlift.log.Logger;
 import io.trino.spi.Plugin;
-import io.trino.spi.connector.Connector;
-import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
 
-import java.util.Map;
 import java.util.Set;
 
 public class HivePlugin
         implements Plugin
 {
-    private static final Logger log = Logger.get(HivePlugin.class);
-
     @Override
     public Iterable<ConnectorFactory> getConnectorFactories()
     {
-        return ImmutableList.of(new HiveConnectorFactory("hive"), new LegacyHiveConnectorFactory());
+        return ImmutableList.of(new HiveConnectorFactory("hive"));
     }
 
     @Override
     public Set<Class<?>> getFunctions()
     {
         return ImmutableSet.of(CanonicalizeHiveTimezoneId.class);
-    }
-
-    private static class LegacyHiveConnectorFactory
-            extends HiveConnectorFactory
-    {
-        public LegacyHiveConnectorFactory()
-        {
-            super("hive-hadoop2");
-        }
-
-        @Override
-        public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
-        {
-            log.warn("Connector name 'hive-hadoop2' is deprecated. Use 'hive' instead.");
-            return super.create(catalogName, config, context);
-        }
     }
 }

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHivePlugin.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHivePlugin.java
@@ -79,19 +79,6 @@ public class TestHivePlugin
     }
 
     @Test
-    public void testCreateConnectorLegacyName()
-    {
-        Plugin plugin = new HivePlugin();
-        ConnectorFactory factory = stream(plugin.getConnectorFactories())
-                .filter(x -> x.getName().equals("hive-hadoop2"))
-                .collect(toOptional())
-                .orElseThrow();
-
-        // simplest possible configuration
-        factory.create("test", ImmutableMap.of("hive.metastore.uri", "thrift://foo:1234"), new TestingConnectorContext()).shutdown();
-    }
-
-    @Test
     public void testThriftMetastore()
     {
         ConnectorFactory factory = getHiveConnectorFactory();

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeCompatibility.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeCompatibility.java
@@ -75,7 +75,7 @@ public class EnvSinglenodeCompatibility
                 .withExposedLogPaths("/var/trino/var/log", "/var/log/container-health.log")
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/presto/etc/jvm.config")), containerConfigDir + "jvm.config")
                 .withCopyFileToContainer(forHostPath(configDir.getPath(getConfigFileFor(dockerImage))), containerConfigDir + "config.properties")
-                .withCopyFileToContainer(forHostPath(configDir.getPath("hive.properties")), containerConfigDir + "catalog/hive.properties")
+                .withCopyFileToContainer(forHostPath(configDir.getPath(getHiveConfigFor(dockerImage))), containerConfigDir + "catalog/hive.properties")
                 .withCopyFileToContainer(forHostPath(configDir.getPath("iceberg.properties")), containerConfigDir + "catalog/iceberg.properties")
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath()), "/docker/presto-product-tests")
                 .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
@@ -109,6 +109,14 @@ public class EnvSinglenodeCompatibility
             return "config-with-system-memory.properties";
         }
         return "config.properties";
+    }
+
+    private String getHiveConfigFor(String dockerImage)
+    {
+        if (getVersionFromDockerImageName(dockerImage) < 359) {
+            return "hive-hadoop2.properties";
+        }
+        return "hive.properties";
     }
 
     private void configureTestsContainer(Environment.Builder builder, Config config)

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-compatibility/hive-hadoop2.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-compatibility/hive-hadoop2.properties
@@ -1,2 +1,2 @@
-connector.name=hive
+connector.name=hive-hadoop2
 hive.metastore.uri=thrift://hadoop-master:9083


### PR DESCRIPTION
## Description

Drop support for deprected `hive-hadoop2` connector name.  This name has been deprecated since June 2021.

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# Hive
* Drop support for deprected `hive-hadoop2` connector name. ({issue}`16166`)
```
