### PR TITLE
Remove unused name customization from HiveConnectorFactory

### DIFF
--- a/plugin/trino-hive-hadoop2/src/main/java/io/trino/plugin/hive/HivePlugin.java
+++ b/plugin/trino-hive-hadoop2/src/main/java/io/trino/plugin/hive/HivePlugin.java
@@ -26,7 +26,7 @@ public class HivePlugin
     @Override
     public Iterable<ConnectorFactory> getConnectorFactories()
     {
-        return ImmutableList.of(new HiveConnectorFactory("hive"));
+        return ImmutableList.of(new HiveConnectorFactory());
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnectorFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnectorFactory.java
@@ -22,8 +22,6 @@ import io.trino.spi.connector.ConnectorFactory;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
@@ -31,25 +29,22 @@ import static java.util.Objects.requireNonNull;
 public class HiveConnectorFactory
         implements ConnectorFactory
 {
-    private final String name;
     private final Class<? extends Module> module;
 
-    public HiveConnectorFactory(String name)
+    public HiveConnectorFactory()
     {
-        this(name, EmptyModule.class);
+        this(EmptyModule.class);
     }
 
-    public HiveConnectorFactory(String name, Class<? extends Module> module)
+    public HiveConnectorFactory(Class<? extends Module> module)
     {
-        checkArgument(!isNullOrEmpty(name), "name is null or empty");
-        this.name = name;
         this.module = requireNonNull(module, "module is null");
     }
 
     @Override
     public String getName()
     {
-        return name;
+        return "hive";
     }
 
     @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorFactory.java
@@ -49,7 +49,7 @@ public class TestHiveConnectorFactory
     {
         Map<String, String> config = ImmutableMap.of("hive.metastore.uri", metastoreUri);
 
-        Connector connector = new HiveConnectorFactory("hive").create("hive-test", config, new TestingConnectorContext());
+        Connector connector = new HiveConnectorFactory().create("hive-test", config, new TestingConnectorContext());
         ConnectorTransactionHandle transaction = connector.beginTransaction(READ_UNCOMMITTED, true, true);
         assertInstanceOf(connector.getMetadata(SESSION, transaction), ClassLoaderSafeConnectorMetadata.class);
         assertInstanceOf(connector.getSplitManager(), ClassLoaderSafeConnectorSplitManager.class);


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
