### PR TITLE
Remove deprecated type methods from HiveUtil

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaHiveTypeTranslator.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaHiveTypeTranslator.java
@@ -18,8 +18,11 @@ import io.trino.plugin.hive.HiveType;
 import io.trino.plugin.hive.type.DecimalTypeInfo;
 import io.trino.plugin.hive.type.TypeInfo;
 import io.trino.spi.TrinoException;
+import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
@@ -46,9 +49,6 @@ import static io.trino.plugin.hive.type.TypeInfoFactory.getMapTypeInfo;
 import static io.trino.plugin.hive.type.TypeInfoFactory.getStructTypeInfo;
 import static io.trino.plugin.hive.type.TypeInfoFactory.getVarcharTypeInfo;
 import static io.trino.plugin.hive.type.VarcharTypeInfo.MAX_VARCHAR_LENGTH;
-import static io.trino.plugin.hive.util.HiveUtil.isArrayType;
-import static io.trino.plugin.hive.util.HiveUtil.isMapType;
-import static io.trino.plugin.hive.util.HiveUtil.isRowType;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -129,16 +129,16 @@ public class DeltaHiveTypeTranslator
         if (type instanceof DecimalType decimalType) {
             return new DecimalTypeInfo(decimalType.getPrecision(), decimalType.getScale());
         }
-        if (isArrayType(type)) {
-            TypeInfo elementType = translate(type.getTypeParameters().get(0));
+        if (type instanceof ArrayType arrayType) {
+            TypeInfo elementType = translate(arrayType.getElementType());
             return getListTypeInfo(elementType);
         }
-        if (isMapType(type)) {
-            TypeInfo keyType = translate(type.getTypeParameters().get(0));
-            TypeInfo valueType = translate(type.getTypeParameters().get(1));
+        if (type instanceof MapType mapType) {
+            TypeInfo keyType = translate(mapType.getKeyType());
+            TypeInfo valueType = translate(mapType.getValueType());
             return getMapTypeInfo(keyType, valueType);
         }
-        if (isRowType(type)) {
+        if (type instanceof RowType) {
             ImmutableList.Builder<String> fieldNames = ImmutableList.builder();
             for (TypeSignatureParameter parameter : type.getTypeSignature().getParameters()) {
                 if (!parameter.isNamedTypeSignature()) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCoercionRecordCursor.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCoercionRecordCursor.java
@@ -25,6 +25,9 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.RecordCursor;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.VarcharType;
@@ -39,9 +42,6 @@ import static io.trino.plugin.hive.HiveType.HIVE_INT;
 import static io.trino.plugin.hive.HiveType.HIVE_LONG;
 import static io.trino.plugin.hive.HiveType.HIVE_SHORT;
 import static io.trino.plugin.hive.util.HiveUtil.extractStructFieldTypes;
-import static io.trino.plugin.hive.util.HiveUtil.isArrayType;
-import static io.trino.plugin.hive.util.HiveUtil.isMapType;
-import static io.trino.plugin.hive.util.HiveUtil.isRowType;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.min;
@@ -277,13 +277,13 @@ public class HiveCoercionRecordCursor
         if (fromHiveType.equals(HIVE_FLOAT) && toHiveType.equals(HIVE_DOUBLE)) {
             return new FloatToDoubleCoercer();
         }
-        if (isArrayType(fromType) && isArrayType(toType)) {
+        if ((fromType instanceof ArrayType) && (toType instanceof ArrayType)) {
             return new ListCoercer(typeManager, fromHiveType, toHiveType, bridgingRecordCursor);
         }
-        if (isMapType(fromType) && isMapType(toType)) {
+        if ((fromType instanceof MapType) && (toType instanceof MapType)) {
             return new MapCoercer(typeManager, fromHiveType, toHiveType, bridgingRecordCursor);
         }
-        if (isRowType(fromType) && isRowType(toType)) {
+        if ((fromType instanceof RowType) && (toType instanceof RowType)) {
             return new StructCoercer(typeManager, fromHiveType, toHiveType, bridgingRecordCursor);
         }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
@@ -42,8 +42,10 @@ import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.metrics.Metrics;
+import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.VarcharType;
@@ -83,9 +85,6 @@ import static io.trino.plugin.hive.coercions.DecimalCoercers.createDoubleToDecim
 import static io.trino.plugin.hive.coercions.DecimalCoercers.createRealToDecimalCoercer;
 import static io.trino.plugin.hive.util.HiveBucketing.getHiveBucket;
 import static io.trino.plugin.hive.util.HiveUtil.extractStructFieldTypes;
-import static io.trino.plugin.hive.util.HiveUtil.isArrayType;
-import static io.trino.plugin.hive.util.HiveUtil.isMapType;
-import static io.trino.plugin.hive.util.HiveUtil.isRowType;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.block.ColumnarArray.toColumnarArray;
 import static io.trino.spi.block.ColumnarMap.toColumnarMap;
@@ -347,13 +346,13 @@ public class HivePageSource
         if (fromType == REAL && toType instanceof DecimalType toDecimalType) {
             return Optional.of(createRealToDecimalCoercer(toDecimalType));
         }
-        if (isArrayType(fromType) && isArrayType(toType)) {
+        if ((fromType instanceof ArrayType) && (toType instanceof ArrayType)) {
             return Optional.of(new ListCoercer(typeManager, fromHiveType, toHiveType));
         }
-        if (isMapType(fromType) && isMapType(toType)) {
+        if ((fromType instanceof MapType) && (toType instanceof MapType)) {
             return Optional.of(new MapCoercer(typeManager, fromHiveType, toHiveType));
         }
-        if (isRowType(fromType) && isRowType(toType)) {
+        if ((fromType instanceof RowType) && (toType instanceof RowType)) {
             HiveType fromHiveTypeStruct = (fromHiveType.getCategory() == Category.UNION) ? HiveType.toHiveType(fromType) : fromHiveType;
             HiveType toHiveTypeStruct = (toHiveType.getCategory() == Category.UNION) ? HiveType.toHiveType(toType) : toHiveType;
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveTypeTranslator.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveTypeTranslator.java
@@ -27,8 +27,11 @@ import io.trino.plugin.hive.type.TypeInfo;
 import io.trino.plugin.hive.type.UnionTypeInfo;
 import io.trino.plugin.hive.type.VarcharTypeInfo;
 import io.trino.spi.TrinoException;
+import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeSignature;
@@ -61,9 +64,6 @@ import static io.trino.plugin.hive.type.TypeInfoFactory.getMapTypeInfo;
 import static io.trino.plugin.hive.type.TypeInfoFactory.getStructTypeInfo;
 import static io.trino.plugin.hive.type.TypeInfoFactory.getVarcharTypeInfo;
 import static io.trino.plugin.hive.type.VarcharTypeInfo.MAX_VARCHAR_LENGTH;
-import static io.trino.plugin.hive.util.HiveUtil.isArrayType;
-import static io.trino.plugin.hive.util.HiveUtil.isMapType;
-import static io.trino.plugin.hive.util.HiveUtil.isRowType;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -147,16 +147,16 @@ public final class HiveTypeTranslator
         if (type instanceof DecimalType decimalType) {
             return new DecimalTypeInfo(decimalType.getPrecision(), decimalType.getScale());
         }
-        if (isArrayType(type)) {
-            TypeInfo elementType = toTypeInfo(type.getTypeParameters().get(0));
+        if (type instanceof ArrayType arrayType) {
+            TypeInfo elementType = toTypeInfo(arrayType.getElementType());
             return getListTypeInfo(elementType);
         }
-        if (isMapType(type)) {
-            TypeInfo keyType = toTypeInfo(type.getTypeParameters().get(0));
-            TypeInfo valueType = toTypeInfo(type.getTypeParameters().get(1));
+        if (type instanceof MapType mapType) {
+            TypeInfo keyType = toTypeInfo(mapType.getKeyType());
+            TypeInfo valueType = toTypeInfo(mapType.getValueType());
             return getMapTypeInfo(keyType, valueType);
         }
-        if (isRowType(type)) {
+        if (type instanceof RowType) {
             ImmutableList.Builder<String> fieldNames = ImmutableList.builder();
             for (TypeSignatureParameter parameter : type.getTypeSignature().getParameters()) {
                 if (!parameter.isNamedTypeSignature()) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
@@ -683,36 +683,9 @@ public final class HiveUtil
         throw new VerifyException(format("Unhandled type [%s] for partition: %s", type, partitionName));
     }
 
-    /**
-     * @deprecated Use {@code instanceof} directly, as that allows variable assignment.
-     */
-    @Deprecated
-    public static boolean isArrayType(Type type)
-    {
-        return type instanceof ArrayType;
-    }
-
-    /**
-     * @deprecated Use {@code instanceof} directly, as that allows variable assignment.
-     */
-    @Deprecated
-    public static boolean isMapType(Type type)
-    {
-        return type instanceof MapType;
-    }
-
-    /**
-     * @deprecated Use {@code instanceof} directly, as that allows variable assignment.
-     */
-    @Deprecated
-    public static boolean isRowType(Type type)
-    {
-        return type instanceof RowType;
-    }
-
     public static boolean isStructuralType(Type type)
     {
-        return isArrayType(type) || isMapType(type) || isRowType(type);
+        return (type instanceof ArrayType) || (type instanceof MapType) || (type instanceof RowType);
     }
 
     public static boolean isStructuralType(HiveType hiveType)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
@@ -115,9 +115,6 @@ import static io.trino.plugin.hive.HiveSessionProperties.getParquetMaxReadBlockS
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_FILE_SYSTEM_FACTORY;
 import static io.trino.plugin.hive.HiveTestUtils.getHiveSession;
-import static io.trino.plugin.hive.util.HiveUtil.isArrayType;
-import static io.trino.plugin.hive.util.HiveUtil.isMapType;
-import static io.trino.plugin.hive.util.HiveUtil.isRowType;
 import static io.trino.plugin.hive.util.HiveUtil.isStructuralType;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -551,15 +548,13 @@ public class ParquetTester
         }
         if (isStructuralType(type)) {
             Block block = (Block) fieldFromCursor;
-            if (isArrayType(type)) {
-                Type elementType = ((ArrayType) type).getElementType();
-                return toArrayValue(block, elementType);
+            if (type instanceof ArrayType arrayType) {
+                return toArrayValue(block, arrayType.getElementType());
             }
-            if (isMapType(type)) {
-                MapType mapType = (MapType) type;
+            if (type instanceof MapType mapType) {
                 return toMapValue(block, mapType.getKeyType(), mapType.getValueType());
             }
-            if (isRowType(type)) {
+            if (type instanceof RowType) {
                 return toRowValue(block, type.getTypeParameters());
             }
         }


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
