### PR TITLE
Support DML operations on Delta tables with `name` column mapping

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
@@ -162,8 +162,8 @@ public abstract class AbstractDeltaLakePageSink
                 case REGULAR:
                     dataColumnHandles.add(column);
                     dataColumnsInputIndex.add(inputIndex);
-                    dataColumnNames.add(column.getName());
-                    dataColumnTypes.add(column.getType());
+                    dataColumnNames.add(column.getPhysicalName());
+                    dataColumnTypes.add(column.getPhysicalType());
                     break;
                 case SYNTHESIZED:
                     processSynthesizedColumn(column);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -364,11 +364,10 @@ public class DeltaLakeMergeSink
             Closeable rollbackAction = () -> fileSystem.deleteFile(path);
 
             List<Type> parquetTypes = dataColumns.stream()
-                    .map(column -> toParquetType(typeOperators, column.getType()))
+                    .map(column -> toParquetType(typeOperators, column.getPhysicalType()))
                     .collect(toImmutableList());
-
             List<String> dataColumnNames = dataColumns.stream()
-                    .map(DeltaLakeColumnHandle::getName)
+                    .map(DeltaLakeColumnHandle::getPhysicalName)
                     .collect(toImmutableList());
             ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(
                     parquetTypes,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -138,7 +138,6 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -256,6 +255,7 @@ import static java.lang.String.format;
 import static java.time.Instant.EPOCH;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableMap;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 import static java.util.function.Function.identity;
@@ -1598,7 +1598,7 @@ public class DeltaLakeMetadata
             return Optional.empty();
         }
         Map<String, DeltaLakeColumnHandle> columnsByName = optimizeHandle.getTableColumns().stream()
-                .collect(toImmutableMap(columnHandle -> columnHandle.getName().toLowerCase(Locale.ENGLISH), identity()));
+                .collect(toImmutableMap(columnHandle -> columnHandle.getName().toLowerCase(ENGLISH), identity()));
         ImmutableList.Builder<DeltaLakeColumnHandle> partitioningColumns = ImmutableList.builder();
         for (String columnName : partitionColumnNames) {
             partitioningColumns.add(columnsByName.get(columnName));

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
@@ -185,8 +185,8 @@ public class DeltaLakeWriter
     public DataFileInfo getDataFileInfo()
             throws IOException
     {
-        List<String> dataColumnNames = columnHandles.stream().map(DeltaLakeColumnHandle::getName).collect(toImmutableList());
-        List<Type> dataColumnTypes = columnHandles.stream().map(DeltaLakeColumnHandle::getType).collect(toImmutableList());
+        List<String> dataColumnNames = columnHandles.stream().map(DeltaLakeColumnHandle::getPhysicalName).collect(toImmutableList());
+        List<Type> dataColumnTypes = columnHandles.stream().map(DeltaLakeColumnHandle::getPhysicalType).collect(toImmutableList());
         return new DataFileInfo(
                 relativeFilePath,
                 getWrittenBytes(),

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -375,7 +375,7 @@ public class HiveMetastoreBackedDeltaLakeMetastore
                 columnStatsBuilder.setDistinctValuesCount(Estimate.of(partitioningColumnsDistinctValues.get(column).size()));
             }
             if (statistics.isPresent()) {
-                DeltaLakeColumnStatistics deltaLakeColumnStatistics = statistics.get().getColumnStatistics().get(column.getName());
+                DeltaLakeColumnStatistics deltaLakeColumnStatistics = statistics.get().getColumnStatistics().get(column.getPhysicalName());
                 if (deltaLakeColumnStatistics != null && column.getColumnType() != PARTITION_KEY) {
                     deltaLakeColumnStatistics.getTotalSizeInBytes().ifPresent(size -> columnStatsBuilder.setDataSize(Estimate.of(size)));
                     columnStatsBuilder.setDistinctValuesCount(Estimate.of(deltaLakeColumnStatistics.getNdvSummary().cardinality()));

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
@@ -257,7 +257,7 @@ public class CheckpointWriter
     private Map<String, Type> getColumnTypeMapping(MetadataEntry deltaMetadata)
     {
         return extractSchema(deltaMetadata, typeManager).stream()
-                .collect(toImmutableMap(DeltaLakeColumnMetadata::getName, DeltaLakeColumnMetadata::getType));
+                .collect(toImmutableMap(DeltaLakeColumnMetadata::getPhysicalName, DeltaLakeColumnMetadata::getPhysicalColumnType));
     }
 
     private Optional<String> getStatsString(DeltaLakeJsonFileStatistics parsedStats)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeColumnMappingMode.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeColumnMappingMode.java
@@ -24,8 +24,11 @@ import java.util.List;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
+import static io.trino.testing.DataProviders.cartesianProduct;
+import static io.trino.testing.DataProviders.trueFalse;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_DATABRICKS;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_EXCLUDE_104;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_EXCLUDE_73;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_EXCLUDE_91;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_OSS;
@@ -328,9 +331,146 @@ public class TestDeltaLakeColumnMappingMode
         }
     }
 
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, DELTA_LAKE_EXCLUDE_73, DELTA_LAKE_EXCLUDE_91, DELTA_LAKE_EXCLUDE_104, PROFILE_SPECIFIC_TESTS}, dataProvider = "columnMappingDataProvider")
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testDropAndAddColumnShowStatsForColumnMappingMode(String mode)
+    {
+        String tableName = "test_dl_drop_add_column_show_stats_for_column_mapping_mode_" + randomNameSuffix();
+
+        onDelta().executeQuery("" +
+                "CREATE TABLE default." + tableName +
+                " (a_number INT, b_number INT)" +
+                " USING delta " +
+                " LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
+                " TBLPROPERTIES (" +
+                " 'delta.columnMapping.mode' = '" + mode + "'" +
+                ")");
+        try {
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES (1, 10), (2, 20), (null, null)");
+            onTrino().executeQuery("ANALYZE delta.default." + tableName);
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(ImmutableList.of(
+                            row("a_number", null, 2.0, 0.33333333333, null, "1", "2"),
+                            row("b_number", null, 2.0, 0.33333333333, null, "10", "20"),
+                            row(null, null, null, null, 3.0, null, null)));
+
+            // Ensure SHOW STATS doesn't return stats for the restored column
+            onDelta().executeQuery("ALTER TABLE default." + tableName + " DROP COLUMN b_number");
+            onDelta().executeQuery("ALTER TABLE default." + tableName + " ADD COLUMN b_number INT");
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(ImmutableList.of(
+                            row("a_number", null, 2.0, 0.33333333333, null, "1", "2"),
+                            row("b_number", null, null, null, null, null, null),
+                            row(null, null, null, null, 3.0, null, null)));
+
+            // SHOW STATS returns the expected stats after executing ANALYZE
+            onTrino().executeQuery("ANALYZE delta.default." + tableName);
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(ImmutableList.of(
+                            row("a_number", null, 2.0, 0.33333333333, null, "1", "2"),
+                            row("b_number", 0.0, 0.0, 1.0, null, null, null),
+                            row(null, null, null, null, 3.0, null, null)));
+        }
+        finally {
+            dropDeltaTableWithRetry("default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, DELTA_LAKE_EXCLUDE_73, DELTA_LAKE_EXCLUDE_91, DELTA_LAKE_EXCLUDE_104, PROFILE_SPECIFIC_TESTS})
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testChangeColumnMappingAndShowStatsForColumnMappingMode()
+    {
+        String tableName = "test_dl_change_column_mapping_and_show_stats_for_column_mapping_mode_" + randomNameSuffix();
+
+        onDelta().executeQuery("" +
+                "CREATE TABLE default." + tableName +
+                " (a_number INT, b_number INT)" +
+                " USING delta " +
+                " LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
+                " TBLPROPERTIES (" +
+                " 'delta.columnMapping.mode'='none'," +
+                " 'delta.minReaderVersion'='2'," +
+                " 'delta.minWriterVersion'='5')");
+        try {
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES (1, 10), (2, 20), (null, null)");
+            onTrino().executeQuery("ANALYZE delta.default." + tableName);
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(
+                            row("a_number", null, 2.0, 0.33333333333, null, "1", "2"),
+                            row("b_number", null, 2.0, 0.33333333333, null, "10", "20"),
+                            row(null, null, null, null, 3.0, null, null));
+
+            onDelta().executeQuery("ALTER TABLE default." + tableName + " SET TBLPROPERTIES('delta.columnMapping.mode'='name')");
+            onDelta().executeQuery("ALTER TABLE default." + tableName + " DROP COLUMN b_number");
+            onDelta().executeQuery("ALTER TABLE default." + tableName + " ADD COLUMN b_number INT");
+
+            // Ensure SHOW STATS doesn't return stats for the restored column
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(
+                            row("a_number", null, 2.0, 0.33333333333, null, "1", "2"),
+                            row("b_number", null, null, null, null, null, null),
+                            row(null, null, null, null, 3.0, null, null));
+
+            // SHOW STATS returns the expected stats after executing ANALYZE
+            onTrino().executeQuery("ANALYZE delta.default." + tableName);
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(
+                            row("a_number", null, 2.0, 0.33333333333, null, "1", "2"),
+                            row("b_number", 0.0, 0.0, 1.0, null, null, null),
+                            row(null, null, null, null, 3.0, null, null));
+        }
+        finally {
+            dropDeltaTableWithRetry("default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, DELTA_LAKE_EXCLUDE_73, DELTA_LAKE_EXCLUDE_91, PROFILE_SPECIFIC_TESTS}, dataProvider = "changeColumnMappingDataProvider")
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testChangeColumnMappingMode(String sourceMappingMode, String targetMappingMode, boolean supported)
+    {
+        String tableName = "test_dl_change_column_mapping_mode_" + randomNameSuffix();
+
+        onDelta().executeQuery("" +
+                "CREATE TABLE default." + tableName +
+                " (a_number INT)" +
+                " USING delta " +
+                " LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
+                " TBLPROPERTIES (" +
+                " 'delta.columnMapping.mode'='" + sourceMappingMode + "'," +
+                " 'delta.minReaderVersion'='2'," +
+                " 'delta.minWriterVersion'='5')");
+        try {
+            if (supported) {
+                onDelta().executeQuery("ALTER TABLE default." + tableName + " SET TBLPROPERTIES('delta.columnMapping.mode'='" + targetMappingMode + "')");
+            }
+            else {
+                assertQueryFailure(() -> onDelta().executeQuery("ALTER TABLE default." + tableName + " SET TBLPROPERTIES('delta.columnMapping.mode'='" + targetMappingMode + "')"))
+                        .hasMessageContaining("Changing column mapping mode from '%s' to '%s' is not supported".formatted(sourceMappingMode, targetMappingMode));
+            }
+        }
+        finally {
+            dropDeltaTableWithRetry("default." + tableName);
+        }
+    }
+
+    @DataProvider
+    public Object[][] changeColumnMappingDataProvider()
+    {
+        // Update testChangeColumnMappingAndShowStatsForColumnMappingMode if Delta Lake changes their behavior
+        return new Object[][] {
+                // sourceMappingMode targetMappingMode supported
+                {"none", "id", false},
+                {"none", "name", true},
+                {"id", "none", false},
+                {"id", "name", false},
+                {"name", "none", false},
+                {"name", "id", false},
+        };
+    }
+
     @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, DELTA_LAKE_EXCLUDE_73, DELTA_LAKE_EXCLUDE_91, PROFILE_SPECIFIC_TESTS}, dataProvider = "columnMappingDataProvider")
     @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
-    public void testUnsupportedOperationsColumnMappingModeName(String mode)
+    public void testUnsupportedOperationsColumnMappingMode(String mode)
     {
         String tableName = "test_dl_unsupported_column_mapping_mode_" + randomNameSuffix();
 
@@ -345,19 +485,33 @@ public class TestDeltaLakeColumnMappingMode
                 " 'delta.minWriterVersion'='5')");
 
         try {
-            assertQueryFailure(() -> onTrino().executeQuery("INSERT INTO default." + tableName + " VALUES (1, 'one'), (2, 'two')"))
-                    .hasMessageContaining("Delta Lake writer version 5 which is not supported");
-            assertQueryFailure(() -> onTrino().executeQuery("DELETE FROM default." + tableName))
-                    .hasMessageContaining("Delta Lake writer version 5 which is not supported");
-            assertQueryFailure(() -> onTrino().executeQuery("UPDATE default." + tableName + " SET a_string = 'test'"))
-                    .hasMessageContaining("Delta Lake writer version 5 which is not supported");
-            assertQueryFailure(() -> onTrino().executeQuery("ALTER TABLE default." + tableName + " EXECUTE OPTIMIZE"))
-                    .hasMessageContaining("Delta Lake writer version 5 which is not supported");
-            assertQueryFailure(() -> onTrino().executeQuery("ALTER TABLE default." + tableName + " ADD COLUMN new_col varchar"))
-                    .hasMessageContaining("Delta Lake writer version 5 which is not supported");
-            assertQueryFailure(() -> onTrino().executeQuery("ALTER TABLE default." + tableName + " RENAME COLUMN a_number TO renamed_column"))
+            if (!mode.equals("id")) {
+                assertThat(onTrino().executeQuery("INSERT INTO delta.default." + tableName + " VALUES (1, 'one'), (2, 'two')"))
+                        .updatedRowsCountIsEqualTo(2);
+                assertThat(onTrino().executeQuery("DELETE FROM delta.default." + tableName))
+                        .updatedRowsCountIsEqualTo(2);
+                assertThat(onTrino().executeQuery("UPDATE delta.default." + tableName + " SET a_string = 'test'"))
+                        .updatedRowsCountIsEqualTo(0);
+            }
+            else {
+                assertQueryFailure(() -> onTrino().executeQuery("INSERT INTO delta.default." + tableName + " VALUES (1, 'one'), (2, 'two')"))
+                        .hasMessageContaining("Writing with column mapping id is not supported");
+                assertQueryFailure(() -> onTrino().executeQuery("DELETE FROM delta.default." + tableName))
+                        .hasMessageContaining("Writing with column mapping id is not supported");
+                assertQueryFailure(() -> onTrino().executeQuery("UPDATE delta.default." + tableName + " SET a_string = 'test'"))
+                        .hasMessageContaining("Writing with column mapping id is not supported");
+            }
+            assertQueryFailure(() -> onTrino().executeQuery("COMMENT ON TABLE delta.default." + tableName + " IS 'test comment'"))
+                    .hasMessageContaining("Setting a table comment with column mapping %s is not supported".formatted(mode));
+            assertQueryFailure(() -> onTrino().executeQuery("COMMENT ON COLUMN delta.default." + tableName + ".a_number IS 'test comment'"))
+                    .hasMessageContaining("Setting a column comment with column mapping %s is not supported".formatted(mode));
+            assertQueryFailure(() -> onTrino().executeQuery("ALTER TABLE delta.default." + tableName + " EXECUTE OPTIMIZE"))
+                    .hasMessageContaining("Executing 'optimize' procedure with column mapping %s is not supported".formatted(mode));
+            assertQueryFailure(() -> onTrino().executeQuery("ALTER TABLE delta.default." + tableName + " ADD COLUMN new_col varchar"))
+                    .hasMessageContaining("Adding a column with column mapping %s is not supported".formatted(mode));
+            assertQueryFailure(() -> onTrino().executeQuery("ALTER TABLE delta.default." + tableName + " RENAME COLUMN a_number TO renamed_column"))
                     .hasMessageContaining("This connector does not support renaming columns");
-            assertQueryFailure(() -> onTrino().executeQuery("ALTER TABLE default." + tableName + " DROP COLUMN a_number"))
+            assertQueryFailure(() -> onTrino().executeQuery("ALTER TABLE delta.default." + tableName + " DROP COLUMN a_number"))
                     .hasMessageContaining("This connector does not support dropping columns");
         }
         finally {
@@ -396,11 +550,365 @@ public class TestDeltaLakeColumnMappingMode
         }
     }
 
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, DELTA_LAKE_EXCLUDE_73, DELTA_LAKE_EXCLUDE_91, PROFILE_SPECIFIC_TESTS}, dataProvider = "columnMappingWithTrueAndFalseDataProvider")
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testSupportedNonPartitionedColumnMappingWrites(String mode, boolean statsAsJsonEnabled)
+    {
+        String tableName = "test_dl_dml_column_mapping_mode_" + mode + randomNameSuffix();
+
+        onDelta().executeQuery("" +
+                "CREATE TABLE default." + tableName +
+                " (a_number INT, a_string STRING, array_col ARRAY<STRUCT<array_struct_element: STRING>>, nested STRUCT<field1: STRING>)" +
+                " USING delta " +
+                " LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
+                " TBLPROPERTIES (" +
+                " 'delta.checkpointInterval' = 1, " +
+                " 'delta.checkpoint.writeStatsAsJson' = " + statsAsJsonEnabled + ", " +
+                " 'delta.checkpoint.writeStatsAsStruct' = " + !statsAsJsonEnabled + ", " +
+                " 'delta.columnMapping.mode' = '" + mode + "'" +
+                ")");
+
+        try {
+            String trinoColumns = "a_number, a_string, array_col[1].array_struct_element, nested.field1";
+            String deltaColumns = "a_number, a_string, array_col[0].array_struct_element, nested.field1";
+
+            onTrino().executeQuery("INSERT INTO delta.default." + tableName +
+                    " VALUES (1, 'first value', ARRAY[ROW('nested 1')], ROW('databricks 1'))," +
+                    "        (2, 'two', ARRAY[ROW('nested 2')], ROW('databricks 2'))," +
+                    "        (3, 'third value', ARRAY[ROW('nested 3')], ROW('databricks 3'))," +
+                    "        (4, 'four', ARRAY[ROW('nested 4')], ROW('databricks 4'))");
+            assertDeltaTrinoTableEquals(tableName, trinoColumns, deltaColumns, ImmutableList.of(
+                    row(1, "first value", "nested 1", "databricks 1"),
+                    row(2, "two", "nested 2", "databricks 2"),
+                    row(3, "third value", "nested 3", "databricks 3"),
+                    row(4, "four", "nested 4", "databricks 4")));
+
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(ImmutableList.of(
+                            row("a_number", null, 4.0, 0.0, null, "1", "4"),
+                            row("a_string", 29.0, 4.0, 0.0, null, null, null),
+                            row("array_col", null, null, null, null, null, null),
+                            row("nested", null, null, null, null, null, null),
+                            row(null, null, null, null, 4.0, null, null)));
+
+            onTrino().executeQuery("UPDATE delta.default." + tableName + " SET a_number = a_number + 10 WHERE a_number in (3, 4)");
+            onDelta().executeQuery("UPDATE default." + tableName + " SET a_number = a_number + 20 WHERE a_number in (1, 2)");
+            assertDeltaTrinoTableEquals(tableName, trinoColumns, deltaColumns, ImmutableList.of(
+                    row(21, "first value", "nested 1", "databricks 1"),
+                    row(22, "two", "nested 2", "databricks 2"),
+                    row(13, "third value", "nested 3", "databricks 3"),
+                    row(14, "four", "nested 4", "databricks 4")));
+
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(ImmutableList.of(
+                            row("a_number", null, 4.0, 0.0, null, "13", "22"),
+                            row("a_string", 29.0, 4.0, 0.0, null, null, null),
+                            row("array_col", null, null, null, null, null, null),
+                            row("nested", null, null, null, null, null, null),
+                            row(null, null, null, null, 4.0, null, null)));
+
+            onTrino().executeQuery("DELETE FROM delta.default." + tableName + " WHERE a_number = 22");
+            onTrino().executeQuery("DELETE FROM delta.default." + tableName + " WHERE a_number = 13");
+            onDelta().executeQuery("DELETE FROM default." + tableName + " WHERE a_number = 21");
+            assertDeltaTrinoTableEquals(tableName, trinoColumns, deltaColumns, ImmutableList.of(
+                    row(14, "four", "nested 4", "databricks 4")));
+
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(ImmutableList.of(
+                            row("a_number", null, 1.0, 0.0, null, "14", "14"),
+                            row("a_string", 29.0, 1.0, 0.0, null, null, null),
+                            row("array_col", null, null, null, null, null, null),
+                            row("nested", null, null, null, null, null, null),
+                            row(null, null, null, null, 1.0, null, null)));
+        }
+        finally {
+            dropDeltaTableWithRetry("default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, DELTA_LAKE_EXCLUDE_73, DELTA_LAKE_EXCLUDE_91, PROFILE_SPECIFIC_TESTS}, dataProvider = "columnMappingWithTrueAndFalseDataProvider")
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testSupportedPartitionedColumnMappingWrites(String mode, boolean statsAsJsonEnabled)
+    {
+        String tableName = "test_dl_dml_column_mapping_mode_" + mode + randomNameSuffix();
+
+        onDelta().executeQuery("" +
+                "CREATE TABLE default." + tableName +
+                " (a_number INT, a_string STRING, array_col ARRAY<STRUCT<array_struct_element: STRING>>, nested STRUCT<field1: STRING>)" +
+                " USING delta " +
+                " PARTITIONED BY (a_string)" +
+                " LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
+                " TBLPROPERTIES (" +
+                " 'delta.checkpointInterval' = 1, " +
+                " 'delta.checkpoint.writeStatsAsJson' = " + statsAsJsonEnabled + ", " +
+                " 'delta.checkpoint.writeStatsAsStruct' = " + !statsAsJsonEnabled + ", " +
+                " 'delta.columnMapping.mode' = '" + mode + "'" +
+                ")");
+
+        try {
+            String trinoColumns = "a_number, a_string, array_col[1].array_struct_element, nested.field1";
+            String deltaColumns = "a_number, a_string, array_col[0].array_struct_element, nested.field1";
+
+            onTrino().executeQuery("INSERT INTO delta.default." + tableName +
+                    " VALUES (1, 'first value', ARRAY[ROW('nested 1')], ROW('databricks 1'))," +
+                    "        (2, 'two', ARRAY[ROW('nested 2')], ROW('databricks 2'))," +
+                    "        (3, 'third value', ARRAY[ROW('nested 3')], ROW('databricks 3'))," +
+                    "        (4, 'four', ARRAY[ROW('nested 4')], ROW('databricks 4'))");
+
+            assertDeltaTrinoTableEquals(tableName, trinoColumns, deltaColumns, ImmutableList.of(
+                    row(1, "first value", "nested 1", "databricks 1"),
+                    row(2, "two", "nested 2", "databricks 2"),
+                    row(3, "third value", "nested 3", "databricks 3"),
+                    row(4, "four", "nested 4", "databricks 4")));
+
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(ImmutableList.of(
+                            row("a_number", null, 4.0, 0.0, null, "1", "4"),
+                            row("a_string", null, 4.0, 0.0, null, null, null),
+                            row("array_col", null, null, null, null, null, null),
+                            row("nested", null, null, null, null, null, null),
+                            row(null, null, null, null, 4.0, null, null)));
+
+            onTrino().executeQuery("UPDATE delta.default." + tableName + " SET a_number = a_number + 10 WHERE a_number in (3, 4)");
+            onDelta().executeQuery("UPDATE default." + tableName + " SET a_number = a_number + 20 WHERE a_number in (1, 2)");
+            assertDeltaTrinoTableEquals(tableName, trinoColumns, deltaColumns, ImmutableList.of(
+                    row(21, "first value", "nested 1", "databricks 1"),
+                    row(22, "two", "nested 2", "databricks 2"),
+                    row(13, "third value", "nested 3", "databricks 3"),
+                    row(14, "four", "nested 4", "databricks 4")));
+
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(ImmutableList.of(
+                            row("a_number", null, 4.0, 0.0, null, "13", "22"),
+                            row("a_string", null, 4.0, 0.0, null, null, null),
+                            row("array_col", null, null, null, null, null, null),
+                            row("nested", null, null, null, null, null, null),
+                            row(null, null, null, null, 4.0, null, null)));
+
+            onTrino().executeQuery("DELETE FROM delta.default." + tableName + " WHERE a_number = 22");
+            onTrino().executeQuery("DELETE FROM delta.default." + tableName + " WHERE a_number = 13");
+            onDelta().executeQuery("DELETE FROM default." + tableName + " WHERE a_number = 21");
+            assertDeltaTrinoTableEquals(tableName, trinoColumns, deltaColumns, ImmutableList.of(
+                    row(14, "four", "nested 4", "databricks 4")));
+
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(ImmutableList.of(
+                            row("a_number", null, 1.0, 0.0, null, "14", "14"),
+                            row("a_string", null, 1.0, 0.0, null, null, null),
+                            row("array_col", null, null, null, null, null, null),
+                            row("nested", null, null, null, null, null, null),
+                            row(null, null, null, null, 1.0, null, null)));
+        }
+        finally {
+            dropDeltaTableWithRetry("default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, DELTA_LAKE_EXCLUDE_73, DELTA_LAKE_EXCLUDE_91, PROFILE_SPECIFIC_TESTS}, dataProvider = "supportedColumnMappingForDmlDataProvider")
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testMergeUpdateWithColumnMapping(String mode)
+    {
+        String sourceTableName = "test_merge_update_source_column_mapping_mode_" + randomNameSuffix();
+        String targetTableName = "test_merge_update_target_column_mapping_mode_" + randomNameSuffix();
+
+        onDelta().executeQuery("CREATE TABLE default." + targetTableName + " (nationkey INT, name STRING, regionkey INT) " +
+                "USING DELTA " +
+                "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + targetTableName + "'" +
+                "TBLPROPERTIES ('delta.columnMapping.mode' = '" + mode + "')");
+        onDelta().executeQuery("CREATE TABLE default." + sourceTableName + " (nationkey INT, name STRING, regionkey INT) " +
+                "USING DELTA " +
+                "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + sourceTableName + "'");
+        try {
+            onDelta().executeQuery("INSERT INTO default." + targetTableName + " VALUES (1, 'nation1', 100), (2, 'nation2', 200), (3, 'nation3', 300)");
+            onDelta().executeQuery("INSERT INTO default." + sourceTableName + " VALUES (1000, 'nation1000', 1000), (2, 'nation2', 20000), (3000, 'nation3000', 3000)");
+
+            onTrino().executeQuery("MERGE INTO delta.default." + targetTableName + " target USING delta.default." + sourceTableName + " source " +
+                    "ON (target.nationkey = source.nationkey) " +
+                    "WHEN MATCHED " +
+                    "THEN UPDATE SET nationkey = (target.nationkey + source.nationkey + source.regionkey) " +
+                    "WHEN NOT MATCHED " +
+                    "THEN INSERT (nationkey, name, regionkey) VALUES (source.nationkey, source.name, source.regionkey)");
+
+            assertThat(onDelta().executeQuery("SELECT * FROM " + targetTableName))
+                    .containsOnly(
+                            row(1000, "nation1000", 1000),
+                            row(3000, "nation3000", 3000),
+                            row(1, "nation1", 100),
+                            row(3, "nation3", 300),
+                            row(20004, "nation2", 200));
+        }
+        finally {
+            dropDeltaTableWithRetry("default." + targetTableName);
+            dropDeltaTableWithRetry("default." + sourceTableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, DELTA_LAKE_EXCLUDE_73, DELTA_LAKE_EXCLUDE_91, PROFILE_SPECIFIC_TESTS}, dataProvider = "supportedColumnMappingForDmlDataProvider")
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testMergeDeleteWithColumnMapping(String mode)
+    {
+        String sourceTableName = "test_dl_merge_delete_source_column_mapping_mode_" + mode + randomNameSuffix();
+        String targetTableName = "test_dl_merge_delete_target_column_mapping_mode_" + mode + randomNameSuffix();
+
+        onDelta().executeQuery("" +
+                "CREATE TABLE default." + sourceTableName +
+                " (a_number INT, a_string STRING, array_col ARRAY<STRUCT<array_struct_element: STRING>>, nested STRUCT<field1: STRING>)" +
+                " USING delta " +
+                " PARTITIONED BY (a_string)" +
+                " LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + sourceTableName + "'" +
+                " TBLPROPERTIES (" +
+                " 'delta.columnMapping.mode' ='" + mode + "')");
+
+        onDelta().executeQuery("" +
+                "CREATE TABLE default." + targetTableName +
+                " (a_number INT, a_string STRING, array_col ARRAY<STRUCT<array_struct_element: STRING>>, nested STRUCT<field1: STRING>)" +
+                " USING delta " +
+                " PARTITIONED BY (a_string)" +
+                " LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + targetTableName + "'" +
+                " TBLPROPERTIES (" +
+                " 'delta.columnMapping.mode' ='" + mode + "')");
+        try {
+            onTrino().executeQuery("INSERT INTO delta.default." + sourceTableName +
+                    " VALUES (1, 'first value', ARRAY[ROW('nested 1')], ROW('databricks 1'))," +
+                    "        (2, 'two', ARRAY[ROW('nested 2')], ROW('databricks 2'))," +
+                    "        (3, 'third value', ARRAY[ROW('nested 3')], ROW('databricks 3'))," +
+                    "        (4, 'four', ARRAY[ROW('nested 4')], ROW('databricks 4'))");
+
+            String trinoColumns = "a_number, a_string, array_col[1].array_struct_element, nested.field1";
+            String deltaColumns = "a_number, a_string, array_col[0].array_struct_element, nested.field1";
+            assertDeltaTrinoTableEquals(sourceTableName, trinoColumns, deltaColumns, ImmutableList.of(
+                    row(1, "first value", "nested 1", "databricks 1"),
+                    row(2, "two", "nested 2", "databricks 2"),
+                    row(3, "third value", "nested 3", "databricks 3"),
+                    row(4, "four", "nested 4", "databricks 4")));
+
+            onTrino().executeQuery("INSERT INTO delta.default." + targetTableName +
+                    " VALUES (1000, '1000 value', ARRAY[ROW('nested 1000')], ROW('databricks 1000'))," +
+                    "        (2, 'two', ARRAY[ROW('nested 2')], ROW('databricks 2'))");
+            onDelta().executeQuery("INSERT INTO default." + targetTableName +
+                    " VALUES (3000, '3000 value', array(struct('nested 3000')), struct('databricks 3000'))," +
+                    "        (4, 'four', array(struct('nested 4')), struct('databricks 4'))");
+
+            assertDeltaTrinoTableEquals(targetTableName, trinoColumns, deltaColumns, ImmutableList.of(
+                    row(1000, "1000 value", "nested 1000", "databricks 1000"),
+                    row(2, "two", "nested 2", "databricks 2"),
+                    row(3000, "3000 value", "nested 3000", "databricks 3000"),
+                    row(4, "four", "nested 4", "databricks 4")));
+
+            onTrino().executeQuery("MERGE INTO delta.default." + targetTableName + " t USING delta.default." + sourceTableName + " s " +
+                    "ON (t.a_number = s.a_number) " +
+                    "WHEN MATCHED " +
+                    "THEN DELETE " +
+                    "WHEN NOT MATCHED " +
+                    "THEN INSERT (a_number, a_string, array_col, nested) VALUES (s.a_number, s.a_string, s.array_col, s.nested)");
+
+            assertDeltaTrinoTableEquals(targetTableName, trinoColumns, deltaColumns, ImmutableList.of(
+                    row(1000, "1000 value", "nested 1000", "databricks 1000"),
+                    row(3000, "3000 value", "nested 3000", "databricks 3000"),
+                    row(1, "first value", "nested 1", "databricks 1"),
+                    row(3, "third value", "nested 3", "databricks 3")));
+        }
+        finally {
+            dropDeltaTableWithRetry("default." + sourceTableName);
+            dropDeltaTableWithRetry("default." + targetTableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, DELTA_LAKE_EXCLUDE_91, PROFILE_SPECIFIC_TESTS}, dataProvider = "columnMappingDataProvider")
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testUnsupportedColumnMappingModeChangeDataFeed(String mode)
+    {
+        String sourceTableName = "test_dl_cdf_target_column_mapping_mode_" + randomNameSuffix();
+        String targetTableName = "test_dl_cdf_source_column_mapping_mode_" + randomNameSuffix();
+
+        onDelta().executeQuery("" +
+                "CREATE TABLE default." + targetTableName +
+                " (nationkey INT, name STRING, regionkey INT)" +
+                " USING delta " +
+                " LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + targetTableName + "'" +
+                " TBLPROPERTIES (" +
+                " 'delta.columnMapping.mode'='" + mode + "'," +
+                " 'delta.enableChangeDataFeed' = true" +
+                ")");
+        onDelta().executeQuery("CREATE TABLE default." + sourceTableName + " (nationkey INT, name STRING, regionkey INT) " +
+                " USING DELTA" +
+                " LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + sourceTableName + "'");
+
+        try {
+            onDelta().executeQuery("INSERT INTO default." + targetTableName + " VALUES (1, 'nation1', 100)");
+            onDelta().executeQuery("INSERT INTO default." + targetTableName + " VALUES (2, 'nation2', 200)");
+            onDelta().executeQuery("INSERT INTO default." + targetTableName + " VALUES (3, 'nation3', 300)");
+
+            // Column mapping mode 'none' is tested in TestDeltaLakeDatabricksChangeDataFeedCompatibility
+            // TODO: Remove these failure check and update TestDeltaLakeDatabricksChangeDataFeedCompatibility when adding support the column mapping mode
+            if (mode.equals("id")) {
+                assertQueryFailure(() -> onTrino().executeQuery("UPDATE delta.default." + targetTableName + " SET regionkey = 10"))
+                        .hasMessageContaining("Unsupported column mapping mode for tables with change data feed enabled: id");
+                assertQueryFailure(() -> onTrino().executeQuery("DELETE FROM delta.default." + targetTableName))
+                        .hasMessageContaining("Unsupported column mapping mode for tables with change data feed enabled: id");
+                assertQueryFailure(() -> onTrino().executeQuery("MERGE INTO delta.default." + targetTableName + " cdf USING delta.default." + sourceTableName + " n " +
+                        "ON (cdf.nationkey = n.nationkey) " +
+                        "WHEN MATCHED " +
+                        "THEN UPDATE SET nationkey = (cdf.nationkey + n.nationkey + n.regionkey) " +
+                        "WHEN NOT MATCHED " +
+                        "THEN INSERT (nationkey, name, regionkey) VALUES (n.nationkey, n.name, n.regionkey)"))
+                        .hasMessageContaining("Unsupported column mapping mode for tables with change data feed enabled: id");
+            }
+            else if (mode.equals("name")) {
+                assertQueryFailure(() -> onTrino().executeQuery("UPDATE delta.default." + targetTableName + " SET regionkey = 10"))
+                        .hasMessageContaining("Unsupported column mapping mode for tables with change data feed enabled: " + mode);
+                assertQueryFailure(() -> onTrino().executeQuery("DELETE FROM delta.default." + targetTableName))
+                        .hasMessageContaining("Unsupported column mapping mode for tables with change data feed enabled: " + mode);
+                assertQueryFailure(() -> onTrino().executeQuery("MERGE INTO delta.default." + targetTableName + " cdf USING delta.default." + sourceTableName + " n " +
+                        "ON (cdf.nationkey = n.nationkey) " +
+                        "WHEN MATCHED " +
+                        "THEN UPDATE SET nationkey = (cdf.nationkey + n.nationkey + n.regionkey) " +
+                        "WHEN NOT MATCHED " +
+                        "THEN INSERT (nationkey, name, regionkey) VALUES (n.nationkey, n.name, n.regionkey)"))
+                        .hasMessageContaining("Unsupported column mapping mode for tables with change data feed enabled: " + mode);
+            }
+
+            assertThat(onDelta().executeQuery("SELECT nationkey, name, regionkey, _change_type, _commit_version " +
+                    "FROM table_changes('default." + targetTableName + "', 0)"))
+                    .containsOnly(
+                            row(1, "nation1", 100, "insert", 1),
+                            row(2, "nation2", 200, "insert", 2),
+                            row(3, "nation3", 300, "insert", 3));
+        }
+        finally {
+            dropDeltaTableWithRetry("default." + targetTableName);
+        }
+    }
+
+    private void assertDeltaTrinoTableEquals(String tableName, String trinoQuery, String deltaQuery, List<Row> expectedRows)
+    {
+        assertThat(onDelta().executeQuery("SELECT " + deltaQuery + " FROM default." + tableName))
+                .containsOnly(expectedRows);
+        assertThat(onTrino().executeQuery("SELECT " + trinoQuery + " FROM delta.default." + tableName))
+                .containsOnly(expectedRows);
+    }
+
+    @DataProvider
+    public Object[][] columnMappingWithTrueAndFalseDataProvider()
+    {
+        return cartesianProduct(supportedColumnMappingForDmlDataProvider(), trueFalse());
+    }
+
     @DataProvider
     public Object[][] columnMappingDataProvider()
     {
         return new Object[][] {
                 {"id"},
+                {"name"},
+        };
+    }
+
+    @DataProvider
+    public Object[][] supportedColumnMappingForDmlDataProvider()
+    {
+        // TODO: Support 'id' column mapping
+        return new Object[][] {
+                {"none"},
                 {"name"},
         };
     }


### PR DESCRIPTION
## Description

Relates to #12638

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Add support for DML operations on tables with `name` column mapping. ({issue}`12638`)
```
