### PR TITLE
Fix a dead link in Glossary

### DIFF
--- a/docs/src/main/sphinx/glossary.rst
+++ b/docs/src/main/sphinx/glossary.rst
@@ -64,7 +64,7 @@ Data virtualization
 
 Data source
     A system from which data is retrieved, for example, PostgreSQL or Iceberg on S3
-    data. In Trino, users query data sources with `catalogs <glossCatalog>`_
+    data. In Trino, users query data sources with :ref:`catalogs <glossCatalog>`
     that connect to each source. See :ref:`trino-concept-data-sources` for more
     information.
 


### PR DESCRIPTION
## Description

There is a dead link on the Glossary page here:
https://trino.io/docs/407/glossary#:~:text=data%20sources%20with-,catalogs,-that%20connect%20to

I'm not familiar with the .rst format and just hope this will fix the problem.

## Additional context and related issues


## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
