### PR TITLE
Improve check-commits and decrease build times

### DIFF
--- a/.github/actions/compile-commit/action.yml
+++ b/.github/actions/compile-commit/action.yml
@@ -50,7 +50,7 @@ runs:
     - name: Mark this workspace as successfully compiled
       if: steps.check-compile-commit-success.outputs.cache-hit != 'true'
       shell: bash
-      run: touch compile-commit-success.txt
+      run: echo "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" > compile-commit-success.txt
     - name: Clean local Maven repo
       # Avoid creating a cache entry because this job doesn't download all dependencies
       if: steps.check-compile-commit-success.outputs.cache-hit != 'true' && steps.cache.outputs.cache-hit != 'true'

--- a/.github/actions/compile-commit/action.yml
+++ b/.github/actions/compile-commit/action.yml
@@ -7,9 +7,24 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Get the hash of the tree at HEAD
+      id: repo-hash
+      shell: bash
+      run: |
+        TREE_HASH=$( git rev-parse HEAD: )
+        echo "tree-hash=${TREE_HASH}" >> $GITHUB_OUTPUT
+    - name: Cache compile-commit action success
+      id: check-compile-commit-success
+      uses: actions/cache@v3
+      with:
+        path: compile-commit-success.txt
+        # use tree hashes instead of commit hashes to reuse cache when changes in commits are reorganized without changing the workspace
+        key: compile-commit-success-${{ github.event.pull_request.head.repo.full_name }}-${{ steps.repo-hash.outputs.tree-hash }}
     - uses: ./.github/actions/setup
+      if: steps.check-compile-commit-success.outputs.cache-hit != 'true'
     - name: Check if a specified commit compiles
       shell: bash
+      if: steps.check-compile-commit-success.outputs.cache-hit != 'true'
       run: |
         set -x
 
@@ -32,8 +47,12 @@ runs:
           ${MAVEN_COMPILE_COMMITS} `# defaults, kept in sync with ci.yml` \
           -Dair.check.skip-all=false -Dair.check.skip-basic=true -Dair.check.skip-extended=true -Dair.check.skip-checkstyle=false \
           ${MAVEN_GIB}
+    - name: Mark this workspace as successfully compiled
+      if: steps.check-compile-commit-success.outputs.cache-hit != 'true'
+      shell: bash
+      run: touch compile-commit-success.txt
     - name: Clean local Maven repo
       # Avoid creating a cache entry because this job doesn't download all dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.check-compile-commit-success.outputs.cache-hit != 'true' && steps.cache.outputs.cache-hit != 'true'
       shell: bash
       run: rm -rf ~/.m2/repository

--- a/.github/bin/prepare-check-commits-matrix.py
+++ b/.github/bin/prepare-check-commits-matrix.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import logging
+import sys
+import tempfile
+import unittest
+
+import csv
+import json
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Choose commits to compile using their CSV descriptions."
+    )
+    parser.add_argument(
+        "-i",
+        "--input",
+        type=argparse.FileType("r"),
+        default=sys.stdin,
+        help="A CSV file in <commit hash>,<tree hash>,<commit subject>",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=argparse.FileType("w"),
+        default=sys.stdout,
+        help="Filename to write chosen commit hashes to",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_const",
+        dest="loglevel",
+        const=logging.INFO,
+        default=logging.WARNING,
+        help="Print info level logs",
+    )
+    parser.add_argument(
+        "-t",
+        "--test",
+        action='store_true',
+        help="test this script instead of executing it",
+    )
+
+    args = parser.parse_args()
+    logging.basicConfig(level=args.loglevel)
+    if args.test:
+        sys.argv = [sys.argv[0]]
+        unittest.main()
+        return
+    build(args.input, args.output)
+
+
+def build(input_file, output_file):
+    logging.info("input_file: %s", input_file)
+    logging.info("output_file: %s", output_file)
+    reader = csv.reader(input_file)
+    entries = list(reader)
+    logging.info("entries: %s", entries)
+    commits = []
+    for i, entry in enumerate(entries):
+        try:
+            commit_hash, _, subject = entry
+            # TODO: add filtering based on GitHub Actions cache entries
+            if not has_followup(entries, i, commit_hash, subject):
+                commits.append(commit_hash)
+        except ValueError:
+            # ignore lines which don't match the expected CSV pattern
+            pass
+    if len(commits) > 0:
+        json.dump({'include': [{'commit': commit} for commit in commits]}, output_file, separators=(',', ':'), sort_keys=True)
+
+
+def has_followup(entries, i, commit_hash, subject):
+    for later_entry in entries[i+1:]:
+        _, _, later_subject = later_entry
+        if later_subject.startswith(('fixup! ', 'squash! ', 'amend! ')) and (subject in later_subject or commit_hash in later_subject):
+            return True
+    return False
+
+
+class TestBuild(unittest.TestCase):
+    PERFORMANCE_TEST_SIZE = 1000
+
+    def test_build(self):
+        cases = [
+            (
+                "Empty test",
+                (),
+                []
+            ),
+            (
+                "Malformed input test",
+                (
+                    "c1,t1\n"
+                ),
+                []
+            ),
+            (
+                "Basic test",
+                (
+                    "c1,t1,Hello World\n",
+                ),
+                ['{"include":[{"commit":"c1"}]}']
+            ),
+            (
+                "Add a new entry",
+                (
+                    "c1,t1,Hello World\n",
+                    "c2,t2,Quick brown fox\n",
+                ),
+                ['{"include":[{"commit":"c1"},{"commit":"c2"}]}']
+            ),
+            (
+                "Add a fixup",
+                (
+                    "c1,t1,Hello World\n",
+                    "c2,t2,Quick brown fox\n",
+                    "c3,t3,fixup! Hello World - fixed a bug\n",
+                ),
+                ['{"include":[{"commit":"c2"},{"commit":"c3"}]}']
+            ),
+            (
+                "Add a floating fixup",
+                (
+                    "c1,t1,Hello World\n",
+                    "c2,t2,Quick brown fox\n",
+                    "c3,t3,fixup! Unknown commits are fun!\n",
+                ),
+                ['{"include":[{"commit":"c1"},{"commit":"c2"},{"commit":"c3"}]}']
+            ),
+            (
+                "Add a squash",
+                (
+                    "c1,t1,Hello World\n",
+                    "c2,t2,Quick brown fox\n",
+                    "c3,t3,fixup! Hello World - fixed a bug\n",
+                    "c4,t4,squash! Quick brown fox - refactoring\n",
+                ),
+                ['{"include":[{"commit":"c3"},{"commit":"c4"}]}']
+            ),
+            (
+                "Add an amend",
+                (
+                    "c1,t1,Hello World\n",
+                    "c2,t2,Quick brown fox\n",
+                    "c3,t3,fixup! Hello World - fixed a bug\n",
+                    "c4,t4,squash! Quick brown fox - refactoring\n",
+                    "c5,t5,amend! fixup! Hello World - fixed a bug\n",
+                ),
+                ['{"include":[{"commit":"c4"},{"commit":"c5"}]}']
+            ),
+            (
+                "Add a fixup using commit hash",
+                (
+                    "c1,t1,Hello World\n",
+                    "c2,t2,Quick brown fox\n",
+                    "c3,t3,fixup! Hello World - fixed a bug\n",
+                    "c4,t4,squash! Quick brown fox - refactoring\n",
+                    "c5,t5,amend! fixup! Hello World - fixed a bug\n",
+                    "c6,t6,fixup! c3\n",
+                ),
+                ['{"include":[{"commit":"c4"},{"commit":"c5"},{"commit":"c6"}]}']
+            ),
+            (
+                "Add a squash using commit hash",
+                (
+                    "c1,t1,Hello World\n",
+                    "c2,t2,Quick brown fox\n",
+                    "c3,t3,fixup! Hello World - fixed a bug\n",
+                    "c4,t4,squash! Quick brown fox - refactoring\n",
+                    "c5,t5,amend! fixup! Hello World - fixed a bug\n",
+                    "c6,t6,fixup! c3\n",
+                    "c7,t7,squash! c4\n",
+                ),
+                ['{"include":[{"commit":"c5"},{"commit":"c6"},{"commit":"c7"}]}']
+            ),
+            (
+                "Add an amend using commit hash",
+                (
+                    "c1,t1,Hello World\n",
+                    "c2,t2,Quick brown fox\n",
+                    "c3,t3,fixup! Hello World - fixed a bug\n",
+                    "c4,t4,squash! Quick brown fox - refactoring\n",
+                    "c5,t5,amend! fixup! Hello World - fixed a bug\n",
+                    "c6,t6,fixup! c3\n",
+                    "c7,t7,squash! c4\n",
+                    "c8,t8,amend! c5\n",
+                ),
+                ['{"include":[{"commit":"c6"},{"commit":"c7"},{"commit":"c8"}]}']
+            ),
+            (
+                "Quoted newline test",
+                (
+                    'c1,t1,"Hello\nWorld"\n',
+                    'c2,t2,"fixup! Hello\nWorld"\n'
+                ),
+                ['{"include":[{"commit":"c2"}]}']
+            ),
+            (
+                "Quoted quote test",
+                (
+                    'c1,t1,""Hello"World"\n',
+                    'c2,t2,"fixup! "Hello"World"\n'
+                ),
+                ['{"include":[{"commit":"c2"}]}']
+            ),
+            (
+                "Performance test",
+                # O(n^2) case for our algorithm is a list of commits where the last commit is the fixup to the first one, the second last to the second, etc.
+                # Generate the commits that will be fixed later
+                [f"c{i},t{i},Fix me\n" for i in range(self.PERFORMANCE_TEST_SIZE)] +
+                    # Followed by fixups
+                    [f"c{self.PERFORMANCE_TEST_SIZE + i},t{self.PERFORMANCE_TEST_SIZE + i},fixup! c{self.PERFORMANCE_TEST_SIZE - (i + 1)}\n" for i in range(self.PERFORMANCE_TEST_SIZE)],
+                # Expect fixups to survive
+                [f'{{"include":[{self.calculate_expected(range(self.PERFORMANCE_TEST_SIZE, 2 * self.PERFORMANCE_TEST_SIZE))}]}}']
+            ),
+        ]
+        for test_name, input_lines, expected in cases:
+            with self.subTest(test_name), tempfile.TemporaryFile("w+") as input_file, tempfile.TemporaryFile("w+") as output_file:
+                # given
+                input_file.writelines(input_lines)
+                input_file.seek(0)
+                # when
+                build(input_file, output_file)
+                output_file.seek(0)
+                output = [line.rstrip() for line in output_file.readlines()]    # Remove trailing newlines
+                # then
+                self.assertEqual(output, expected)
+
+    def calculate_expected(self, seq):
+        return ",".join([f'{{"commit":"c{i}"}}' for i in seq])
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/bin/prepare-check-commits-matrix.py
+++ b/.github/bin/prepare-check-commits-matrix.py
@@ -1,20 +1,16 @@
 #!/usr/bin/env python3
 
 import argparse
+import csv
 import json
 import logging
 import sys
 import tempfile
 import unittest
 
-import csv
-import json
-
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Choose commits to compile using their CSV descriptions."
-    )
+    parser = argparse.ArgumentParser(description="Choose commits to compile using their CSV descriptions.")
     parser.add_argument(
         "-i",
         "--input",
@@ -41,7 +37,7 @@ def main():
     parser.add_argument(
         "-t",
         "--test",
-        action='store_true',
+        action="store_true",
         help="test this script instead of executing it",
     )
 
@@ -71,13 +67,17 @@ def build(input_file, output_file):
             # ignore lines which don't match the expected CSV pattern
             pass
     if len(commits) > 0:
-        json.dump({'include': [{'commit': commit} for commit in commits]}, output_file, separators=(',', ':'), sort_keys=True)
+        json.dump(
+            {"include": [{"commit": commit} for commit in commits]}, output_file, separators=(",", ":"), sort_keys=True
+        )
 
 
 def has_followup(entries, i, commit_hash, subject):
-    for later_entry in entries[i+1:]:
+    for later_entry in entries[i + 1 :]:
         _, _, later_subject = later_entry
-        if later_subject.startswith(('fixup! ', 'squash! ', 'amend! ')) and (subject in later_subject or commit_hash in later_subject):
+        if later_subject.startswith(("fixup! ", "squash! ", "amend! ")) and (
+            subject in later_subject
+        ):
             return True
     return False
 
@@ -87,32 +87,16 @@ class TestBuild(unittest.TestCase):
 
     def test_build(self):
         cases = [
-            (
-                "Empty test",
-                (),
-                []
-            ),
-            (
-                "Malformed input test",
-                (
-                    "c1,t1\n"
-                ),
-                []
-            ),
-            (
-                "Basic test",
-                (
-                    "c1,t1,Hello World\n",
-                ),
-                ['{"include":[{"commit":"c1"}]}']
-            ),
+            ("Empty test", (), []),
+            ("Malformed input test", ("c1,t1\n"), []),
+            ("Basic test", ("c1,t1,Hello World\n",), ['{"include":[{"commit":"c1"}]}']),
             (
                 "Add a new entry",
                 (
                     "c1,t1,Hello World\n",
                     "c2,t2,Quick brown fox\n",
                 ),
-                ['{"include":[{"commit":"c1"},{"commit":"c2"}]}']
+                ['{"include":[{"commit":"c1"},{"commit":"c2"}]}'],
             ),
             (
                 "Add a fixup",
@@ -121,7 +105,7 @@ class TestBuild(unittest.TestCase):
                     "c2,t2,Quick brown fox\n",
                     "c3,t3,fixup! Hello World - fixed a bug\n",
                 ),
-                ['{"include":[{"commit":"c2"},{"commit":"c3"}]}']
+                ['{"include":[{"commit":"c2"},{"commit":"c3"}]}'],
             ),
             (
                 "Add a floating fixup",
@@ -130,7 +114,7 @@ class TestBuild(unittest.TestCase):
                     "c2,t2,Quick brown fox\n",
                     "c3,t3,fixup! Unknown commits are fun!\n",
                 ),
-                ['{"include":[{"commit":"c1"},{"commit":"c2"},{"commit":"c3"}]}']
+                ['{"include":[{"commit":"c1"},{"commit":"c2"},{"commit":"c3"}]}'],
             ),
             (
                 "Add a squash",
@@ -140,7 +124,7 @@ class TestBuild(unittest.TestCase):
                     "c3,t3,fixup! Hello World - fixed a bug\n",
                     "c4,t4,squash! Quick brown fox - refactoring\n",
                 ),
-                ['{"include":[{"commit":"c3"},{"commit":"c4"}]}']
+                ['{"include":[{"commit":"c3"},{"commit":"c4"}]}'],
             ),
             (
                 "Add an amend",
@@ -151,83 +135,45 @@ class TestBuild(unittest.TestCase):
                     "c4,t4,squash! Quick brown fox - refactoring\n",
                     "c5,t5,amend! fixup! Hello World - fixed a bug\n",
                 ),
-                ['{"include":[{"commit":"c4"},{"commit":"c5"}]}']
-            ),
-            (
-                "Add a fixup using commit hash",
-                (
-                    "c1,t1,Hello World\n",
-                    "c2,t2,Quick brown fox\n",
-                    "c3,t3,fixup! Hello World - fixed a bug\n",
-                    "c4,t4,squash! Quick brown fox - refactoring\n",
-                    "c5,t5,amend! fixup! Hello World - fixed a bug\n",
-                    "c6,t6,fixup! c3\n",
-                ),
-                ['{"include":[{"commit":"c4"},{"commit":"c5"},{"commit":"c6"}]}']
-            ),
-            (
-                "Add a squash using commit hash",
-                (
-                    "c1,t1,Hello World\n",
-                    "c2,t2,Quick brown fox\n",
-                    "c3,t3,fixup! Hello World - fixed a bug\n",
-                    "c4,t4,squash! Quick brown fox - refactoring\n",
-                    "c5,t5,amend! fixup! Hello World - fixed a bug\n",
-                    "c6,t6,fixup! c3\n",
-                    "c7,t7,squash! c4\n",
-                ),
-                ['{"include":[{"commit":"c5"},{"commit":"c6"},{"commit":"c7"}]}']
-            ),
-            (
-                "Add an amend using commit hash",
-                (
-                    "c1,t1,Hello World\n",
-                    "c2,t2,Quick brown fox\n",
-                    "c3,t3,fixup! Hello World - fixed a bug\n",
-                    "c4,t4,squash! Quick brown fox - refactoring\n",
-                    "c5,t5,amend! fixup! Hello World - fixed a bug\n",
-                    "c6,t6,fixup! c3\n",
-                    "c7,t7,squash! c4\n",
-                    "c8,t8,amend! c5\n",
-                ),
-                ['{"include":[{"commit":"c6"},{"commit":"c7"},{"commit":"c8"}]}']
+                ['{"include":[{"commit":"c4"},{"commit":"c5"}]}'],
             ),
             (
                 "Quoted newline test",
-                (
-                    'c1,t1,"Hello\nWorld"\n',
-                    'c2,t2,"fixup! Hello\nWorld"\n'
-                ),
-                ['{"include":[{"commit":"c2"}]}']
+                ('c1,t1,"Hello\nWorld"\n', 'c2,t2,"fixup! Hello\nWorld"\n'),
+                ['{"include":[{"commit":"c2"}]}'],
             ),
             (
                 "Quoted quote test",
-                (
-                    'c1,t1,""Hello"World"\n',
-                    'c2,t2,"fixup! "Hello"World"\n'
-                ),
-                ['{"include":[{"commit":"c2"}]}']
+                ('c1,t1,""Hello"World"\n', 'c2,t2,"fixup! "Hello"World"\n'),
+                ['{"include":[{"commit":"c2"}]}'],
             ),
             (
                 "Performance test",
                 # O(n^2) case for our algorithm is a list of commits where the last commit is the fixup to the first one, the second last to the second, etc.
                 # Generate the commits that will be fixed later
-                [f"c{i},t{i},Fix me\n" for i in range(self.PERFORMANCE_TEST_SIZE)] +
-                    # Followed by fixups
-                    [f"c{self.PERFORMANCE_TEST_SIZE + i},t{self.PERFORMANCE_TEST_SIZE + i},fixup! c{self.PERFORMANCE_TEST_SIZE - (i + 1)}\n" for i in range(self.PERFORMANCE_TEST_SIZE)],
+                [f"c{i},t{i},title{i}\n" for i in range(self.PERFORMANCE_TEST_SIZE)] +
+                # Followed by fixups
+                [
+                    f"c{self.PERFORMANCE_TEST_SIZE + i},t{self.PERFORMANCE_TEST_SIZE + i},fixup! title{self.PERFORMANCE_TEST_SIZE - (i + 1)}\n"
+                    for i in range(self.PERFORMANCE_TEST_SIZE)
+                ],
                 # Expect fixups to survive
-                [f'{{"include":[{self.calculate_expected(range(self.PERFORMANCE_TEST_SIZE, 2 * self.PERFORMANCE_TEST_SIZE))}]}}']
+                [
+                    f'{{"include":[{self.calculate_expected(range(self.PERFORMANCE_TEST_SIZE, 2 * self.PERFORMANCE_TEST_SIZE))}]}}'
+                ],
             ),
         ]
         for test_name, input_lines, expected in cases:
-            with self.subTest(test_name), tempfile.TemporaryFile("w+") as input_file, tempfile.TemporaryFile("w+") as output_file:
+            with self.subTest(test_name), tempfile.TemporaryFile("w+") as input_file, tempfile.TemporaryFile(
+                "w+"
+            ) as output_file:
                 # given
                 input_file.writelines(input_lines)
                 input_file.seek(0)
                 # when
                 build(input_file, output_file)
                 output_file.seek(0)
-                output = [line.rstrip() for line in output_file.readlines()]    # Remove trailing newlines
+                output = [line.rstrip() for line in output_file.readlines()]  # Remove trailing newlines
                 # then
                 self.assertEqual(output, expected)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,12 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.check-commits-dispatcher.outputs.matrix) }}
     steps:
+      - name: Verify args
+        shell: bash
+        if: matrix.commit == ''
+        run: |
+          echo >&2 "Required 'commit' argument not provided"
+          exit 1
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # checkout all commits to be able to determine merge base

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
           then
             # The HEAD commit of the PR can be safely ignored since it's already compiled in other jobs
             # This is achieved by adding a tilde (~) after the HEAD sha
-            git rev-list refs/remotes/origin/${{ github.event.pull_request.base.ref }}..${{ github.event.pull_request.head.sha }}~ | jq --raw-input --slurp "$JQ_PIPELINE" > commit-matrix.json
+            git rev-list --reverse refs/remotes/origin/${{ github.event.pull_request.base.ref }}..${{ github.event.pull_request.head.sha }}~ | jq --raw-input --slurp "$JQ_PIPELINE" > commit-matrix.json
           else
             echo -n '' > commit-matrix.json
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,15 +105,12 @@ jobs:
       - name: Set matrix (dispatch commit checks)
         id: set-matrix
         run: |
-          # The output from rev-list ends with a newline, so we have to filter out index -1 in jq since it's an empty string
-          JQ_PIPELINE='split("\n") | .[0:-1] | map({commit: .}) | select(length > 0) | {include: .}'
-
           # Make sure the PR branch contains the compile-commit composite job
           if git merge-base --is-ancestor $( git rev-list HEAD -- .github/actions/compile-commit/action.yml | tail -n 1 ) ${{ github.event.pull_request.head.sha }}
           then
             # The HEAD commit of the PR can be safely ignored since it's already compiled in other jobs
             # This is achieved by adding a tilde (~) after the HEAD sha
-            git rev-list --reverse refs/remotes/origin/${{ github.event.pull_request.base.ref }}..${{ github.event.pull_request.head.sha }}~ | jq --raw-input --slurp "$JQ_PIPELINE" > commit-matrix.json
+            git log --reverse --pretty=format:'%H,%T,"%s"' refs/remotes/origin/${{ github.event.pull_request.base.ref }}..${{ github.event.pull_request.head.sha }}~ | ./.github/bin/prepare-check-commits-matrix.py > commit-matrix.json
           else
             echo -n '' > commit-matrix.json
           fi


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Use GitHub cache to mark which workspace states compiled successfully.

For each successfully compiled tree hash we create a GH cache entry.

We use tree hashes instead of commit hashes to reuse cache when changes in commits are reorganized without changing the workspace.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This is the same as #15966

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
