### PR TITLE
Show stats in EXPLAIN/EXPLAIN ANALYZE with partial aggregation

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestShowStats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestShowStats.java
@@ -485,8 +485,8 @@ public class TestShowStats
         assertQuery(
                 "SHOW STATS FOR ((SELECT nationkey FROM nation) INTERSECT (SELECT regionkey FROM region))",
                 "VALUES " +
-                        "   ('nationkey', null, null, null, null, null, null), " +
-                        "   (null, null, null, null, null, null, null)");
+                        "   ('nationkey', null, 22.5, 0.0, null, 0, 24), " +
+                        "   (null, null, null, null, 22.5, null, null)");
     }
 
     @Test
@@ -509,12 +509,11 @@ public class TestShowStats
     @Test
     public void testShowStatsWithGroupBy()
     {
-        // TODO calculate row count - https://github.com/trinodb/trino/issues/6323
         assertQuery(
                 "SHOW STATS FOR (SELECT avg(totalprice) AS x FROM orders GROUP BY orderkey)",
                 "VALUES " +
                         "   ('x', null, null, null, null, null, null), " +
-                        "   (null, null, null, null, null, null, null)");
+                        "   (null, null, null, null, 15000.0, null, null)");
 
         assertQuery(
                 sessionWith(getSession(), PREFER_PARTIAL_AGGREGATION, "false"),
@@ -531,7 +530,7 @@ public class TestShowStats
                 "SHOW STATS FOR (SELECT count(nationkey) AS x FROM nation_partitioned GROUP BY regionkey HAVING regionkey > 0)",
                 "VALUES " +
                         "   ('x', null, null, null, null, null, null), " +
-                        "   (null, null, null, null, null, null, null)");
+                        "   (null, null, null, null, 4.0, null, null)");
 
         assertQuery(
                 sessionWith(getSession(), PREFER_PARTIAL_AGGREGATION, "false"),
@@ -544,20 +543,19 @@ public class TestShowStats
     @Test
     public void testShowStatsWithSelectDistinct()
     {
-        // TODO calculate row count - https://github.com/trinodb/trino/issues/6323
         assertQuery(
                 "SHOW STATS FOR (SELECT DISTINCT * FROM orders)",
                 "VALUES " +
-                        "   ('orderkey', null, null, null, null, null, null), " +
-                        "   ('custkey', null, null, null, null, null, null), " +
-                        "   ('orderstatus', null, null, null, null, null, null), " +
-                        "   ('totalprice', null, null, null, null, null, null), " +
-                        "   ('orderdate', null, null, null, null, null, null), " +
-                        "   ('orderpriority', null, null, null, null, null, null), " +
-                        "   ('clerk', null, null, null, null, null, null), " +
-                        "   ('shippriority', null, null, null, null, null, null), " +
-                        "   ('comment', null, null, null, null, null, null), " +
-                        "   (null, null, null, null, null, null, null)");
+                        "   ('orderkey', null, 15000.0, 0.0, null, '1', '60000'), " +
+                        "   ('custkey', null, 990.0, 0.0, null, '1', '1499'), " +
+                        "   ('orderstatus',  15000.0, 3.0, 0.0, null, null, null), " +
+                        "   ('totalprice', null, 15000.0, 0.0, null, '874.89', '466001.28'), " +
+                        "   ('orderdate', null, 2406.0, 0.0, null, '1992-01-01', '1998-08-02'), " +
+                        "   ('orderpriority', 126188.00000000001, 5.0, 0.0, null, null, null), " +
+                        "   ('clerk', 225000.0, 995.0, 0.0, null, null, null), " +
+                        "   ('shippriority', null, 1.0, 0.0, null, '0', '0'), " +
+                        "   ('comment', 727364.0, 15000.0, 0.0, null, null, null), " +
+                        "   (null, null, null, null, 15000.0, null, null)");
 
         assertQuery(
                 sessionWith(getSession(), PREFER_PARTIAL_AGGREGATION, "false"),
@@ -572,12 +570,11 @@ public class TestShowStats
                         "   ('comment', 727364, 15000, 0, null, null, null), " +
                         "   (null, null, null, null, 15000, null, null)");
 
-        // TODO calculate row count - https://github.com/trinodb/trino/issues/6323
         assertQuery(
                 "SHOW STATS FOR (SELECT DISTINCT regionkey FROM region)",
                 "VALUES " +
-                        "   ('regionkey', null, null, null, null, null, null), " +
-                        "   (null, null, null, null, null, null, null)");
+                        "   ('regionkey', null, 5.0, 0.0, null, 0, 4), " +
+                        "   (null, null, null, null, 5.0, null, null)");
 
         assertQuery(
                 sessionWith(getSession(), PREFER_PARTIAL_AGGREGATION, "false"),

--- a/testing/trino-tests/src/test/java/io/trino/tests/tpch/TestTpchDistributedStats.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/tpch/TestTpchDistributedStats.java
@@ -23,7 +23,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static io.trino.SystemSessionProperties.COLLECT_PLAN_STATISTICS_FOR_ALL_QUERIES;
-import static io.trino.SystemSessionProperties.PREFER_PARTIAL_AGGREGATION;
 import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_COLUMN_NAMING_PROPERTY;
 import static io.trino.testing.assertions.Assert.assertEventually;
 import static io.trino.testing.statistics.MetricComparisonStrategies.absoluteError;
@@ -43,8 +42,6 @@ public class TestTpchDistributedStats
     {
         DistributedQueryRunner runner = TpchQueryRunnerBuilder.builder()
                 .amendSession(builder -> builder
-                        // We are not able to calculate stats for PARTIAL aggregations
-                        .setSystemProperty(PREFER_PARTIAL_AGGREGATION, "false")
                         // Stats for non-EXPLAIN queries are not collected by default
                         .setSystemProperty(COLLECT_PLAN_STATISTICS_FOR_ALL_QUERIES, "true"))
                 .buildWithoutCatalogs();

--- a/testing/trino-tests/src/test/java/io/trino/tests/tpch/TestTpchLocalStats.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/tpch/TestTpchLocalStats.java
@@ -24,7 +24,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static io.trino.SystemSessionProperties.COLLECT_PLAN_STATISTICS_FOR_ALL_QUERIES;
-import static io.trino.SystemSessionProperties.PREFER_PARTIAL_AGGREGATION;
 import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_COLUMN_NAMING_PROPERTY;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -48,8 +47,6 @@ public class TestTpchLocalStats
         Session defaultSession = testSessionBuilder()
                 .setCatalog("tpch")
                 .setSchema(TINY_SCHEMA_NAME)
-                // We are not able to calculate stats for PARTIAL aggregations
-                .setSystemProperty(PREFER_PARTIAL_AGGREGATION, "false")
                 // Stats for non-EXPLAIN queries are not collected by default
                 .setSystemProperty(COLLECT_PLAN_STATISTICS_FOR_ALL_QUERIES, "true")
                 .build();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Show stats for final aggregation in EXPLAIN/EXPLAIN ANALYZE when partial aggregation is present.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/6323


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Improve output of EXPLAIN queries to show statistics when the query contains aggregations. ({issue}`16201`)
```
