### PR TITLE
Get stats from hive metastore only for the necessary columns 

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -279,6 +279,7 @@ import static io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore.Part
 import static io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore.cleanExtraOutputFiles;
 import static io.trino.plugin.hive.metastore.StorageFormat.VIEW_STORAGE_FORMAT;
 import static io.trino.plugin.hive.metastore.StorageFormat.fromHiveStorageFormat;
+import static io.trino.plugin.hive.type.Category.PRIMITIVE;
 import static io.trino.plugin.hive.util.AcidTables.deltaSubdir;
 import static io.trino.plugin.hive.util.AcidTables.isFullAcidTable;
 import static io.trino.plugin.hive.util.AcidTables.isTransactionalTable;
@@ -838,10 +839,14 @@ public class HiveMetadata
             return TableStatistics.empty();
         }
         HiveTableHandle hiveTableHandle = (HiveTableHandle) tableHandle;
-        Map<String, ColumnHandle> columns = getColumnHandles(session, tableHandle)
-                .entrySet().stream()
-                .filter(entry -> !((HiveColumnHandle) entry.getValue()).isHidden())
-                .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+        Set<ColumnHandle> projectedColumns = hiveTableHandle.getProjectedColumns();
+        // Return column statistics only for projectedColumns
+        // plus, since column statistics are not supported for non-primitive types in hive, filter those out
+        Map<String, ColumnHandle> columns = projectedColumns.stream()
+                .map(columnHandle -> (HiveColumnHandle) columnHandle)
+                .filter(entry -> !entry.isHidden() && entry.getHiveType().getCategory().equals(PRIMITIVE))
+                .collect(toImmutableMap(HiveColumnHandle::getName, Function.identity()));
+
         Map<String, Type> columnTypes = columns.entrySet().stream()
                 .collect(toImmutableMap(Map.Entry::getKey, entry -> getColumnMetadata(session, tableHandle, entry.getValue()).getType()));
         HivePartitionResult partitionResult = partitionManager.getPartitions(metastore, tableHandle, new Constraint(hiveTableHandle.getEnforcedConstraint()));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
@@ -18,6 +18,7 @@ import io.trino.hive.thrift.metastore.DataOperationType;
 import io.trino.plugin.hive.acid.AcidOperation;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.AcidTransactionOwner;
+import io.trino.plugin.hive.metastore.Column;
 import io.trino.plugin.hive.metastore.Database;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.HivePrincipal;
@@ -87,13 +88,39 @@ public class HiveMetastoreClosure
 
     public PartitionStatistics getTableStatistics(String databaseName, String tableName)
     {
-        return delegate.getTableStatistics(getExistingTable(databaseName, tableName));
+        return getTableStatistics(databaseName, tableName, Optional.empty());
+    }
+
+    public PartitionStatistics getTableStatistics(String databaseName, String tableName, Optional<Set<String>> columns)
+    {
+        Table table = getExistingTable(databaseName, tableName);
+        if (columns.isPresent()) {
+            Set<String> requestedColumnNames = columns.get();
+            List<Column> requestedColumns = table.getDataColumns().stream()
+                    .filter(column -> requestedColumnNames.contains(column.getName()))
+                    .collect(toImmutableList());
+            table = Table.builder(table).setDataColumns(requestedColumns).build();
+        }
+        return delegate.getTableStatistics(table);
     }
 
     public Map<String, PartitionStatistics> getPartitionStatistics(String databaseName, String tableName, Set<String> partitionNames)
     {
+        return getPartitionStatistics(databaseName, tableName, partitionNames, Optional.empty());
+    }
+
+    public Map<String, PartitionStatistics> getPartitionStatistics(String databaseName, String tableName, Set<String> partitionNames, Optional<Set<String>> columns)
+    {
         Table table = getExistingTable(databaseName, tableName);
         List<Partition> partitions = getExistingPartitionsByNames(table, ImmutableList.copyOf(partitionNames));
+        if (columns.isPresent()) {
+            Set<String> requestedColumnNames = columns.get();
+            List<Column> requestedColumns = table.getDataColumns().stream()
+                    .filter(column -> requestedColumnNames.contains(column.getName()))
+                    .collect(toImmutableList());
+            table = Table.builder(table).setDataColumns(requestedColumns).build();
+            partitions = partitions.stream().map(partition -> Partition.builder(partition).setColumns(requestedColumns).build()).collect(toImmutableList());
+        }
         return delegate.getPartitionStatistics(table, partitions);
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableHandle.java
@@ -150,7 +150,7 @@ public class HiveTableHandle
                 bucketFilter,
                 analyzePartitionValues,
                 constraintColumns,
-                ImmutableSet.of(),
+                ImmutableSet.<ColumnHandle>builder().addAll(partitionColumns).addAll(dataColumns).build(),
                 transaction,
                 recordScannedFiles,
                 maxSplitFileSize);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableHandle.java
@@ -86,7 +86,6 @@ public class HiveTableHandle
                 bucketFilter,
                 analyzePartitionValues,
                 ImmutableSet.of(),
-                ImmutableSet.of(),
                 transaction,
                 false,
                 Optional.empty());
@@ -114,10 +113,47 @@ public class HiveTableHandle
                 Optional.empty(),
                 Optional.empty(),
                 ImmutableSet.of(),
-                ImmutableSet.of(),
                 NO_ACID_TRANSACTION,
                 false,
                 Optional.empty());
+    }
+
+    private HiveTableHandle(
+            String schemaName,
+            String tableName,
+            Optional<Map<String, String>> tableParameters,
+            List<HiveColumnHandle> partitionColumns,
+            List<HiveColumnHandle> dataColumns,
+            Optional<List<String>> partitionNames,
+            Optional<List<HivePartition>> partitions,
+            TupleDomain<HiveColumnHandle> compactEffectivePredicate,
+            TupleDomain<ColumnHandle> enforcedConstraint,
+            Optional<HiveBucketHandle> bucketHandle,
+            Optional<HiveBucketFilter> bucketFilter,
+            Optional<List<List<String>>> analyzePartitionValues,
+            Set<ColumnHandle> constraintColumns,
+            AcidTransaction transaction,
+            boolean recordScannedFiles,
+            Optional<Long> maxSplitFileSize)
+    {
+        this(
+                schemaName,
+                tableName,
+                tableParameters,
+                partitionColumns,
+                dataColumns,
+                partitionNames,
+                partitions,
+                compactEffectivePredicate,
+                enforcedConstraint,
+                bucketHandle,
+                bucketFilter,
+                analyzePartitionValues,
+                constraintColumns,
+                ImmutableSet.of(),
+                transaction,
+                recordScannedFiles,
+                maxSplitFileSize);
     }
 
     public HiveTableHandle(

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
@@ -19,10 +19,13 @@ import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
+import io.trino.hive.thrift.metastore.ColumnStatisticsData;
+import io.trino.hive.thrift.metastore.LongColumnStatsData;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HiveMetastoreClosure;
 import io.trino.plugin.hive.PartitionStatistics;
 import io.trino.plugin.hive.metastore.Column;
+import io.trino.plugin.hive.metastore.HiveColumnStatistics;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.HivePrincipal;
 import io.trino.plugin.hive.metastore.Partition;
@@ -68,11 +71,13 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static io.trino.plugin.hive.HiveColumnHandle.createBaseColumn;
 import static io.trino.plugin.hive.HiveStorageFormat.TEXTFILE;
+import static io.trino.plugin.hive.HiveType.HIVE_LONG;
 import static io.trino.plugin.hive.HiveType.HIVE_STRING;
 import static io.trino.plugin.hive.HiveType.toHiveType;
 import static io.trino.plugin.hive.TestingThriftHiveMetastoreBuilder.testingThriftHiveMetastoreBuilder;
 import static io.trino.plugin.hive.metastore.HiveColumnStatistics.createIntegerColumnStatistics;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.computePartitionKeyFilter;
+import static io.trino.plugin.hive.metastore.MetastoreUtil.makePartitionName;
 import static io.trino.plugin.hive.metastore.StorageFormat.fromHiveStorageFormat;
 import static io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.memoizeMetastore;
 import static io.trino.plugin.hive.metastore.cache.TestCachingHiveMetastore.PartitionCachingAssertions.assertThatCachingWithDisabledPartitionCache;
@@ -84,7 +89,10 @@ import static io.trino.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TE
 import static io.trino.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_PARTITION1;
 import static io.trino.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_PARTITION1_VALUE;
 import static io.trino.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_PARTITION2;
+import static io.trino.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_PARTITION3;
 import static io.trino.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_PARTITION_VALUES1;
+import static io.trino.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_PARTITION_VALUES2;
+import static io.trino.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_PARTITION_VALUES3;
 import static io.trino.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_ROLES;
 import static io.trino.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_TABLE;
 import static io.trino.spi.predicate.TupleDomain.withColumnDomains;
@@ -290,7 +298,7 @@ public class TestCachingHiveMetastore
     @Test
     public void testGetPartitionNames()
     {
-        ImmutableList<String> expectedPartitions = ImmutableList.of(TEST_PARTITION1, TEST_PARTITION2);
+        ImmutableList<String> expectedPartitions = ImmutableList.of(TEST_PARTITION1, TEST_PARTITION2, TEST_PARTITION3);
         assertEquals(mockClient.getAccessCount(), 0);
         assertEquals(metastore.getPartitionNamesByFilter(TEST_DATABASE, TEST_TABLE, PARTITION_COLUMN_NAMES, TupleDomain.all()).orElseThrow(), expectedPartitions);
         assertEquals(mockClient.getAccessCount(), 1);
@@ -377,7 +385,7 @@ public class TestCachingHiveMetastore
     @Test
     public void testGetPartitionNamesByParts()
     {
-        ImmutableList<String> expectedPartitions = ImmutableList.of(TEST_PARTITION1, TEST_PARTITION2);
+        ImmutableList<String> expectedPartitions = ImmutableList.of(TEST_PARTITION1, TEST_PARTITION2, TEST_PARTITION3);
 
         assertEquals(mockClient.getAccessCount(), 0);
         assertEquals(metastore.getPartitionNamesByFilter(TEST_DATABASE, TEST_TABLE, PARTITION_COLUMN_NAMES, TupleDomain.all()).orElseThrow(), expectedPartitions);
@@ -513,6 +521,27 @@ public class TestCachingHiveMetastore
 
         assertEquals(metastore.getTableStats().getRequestCount(), 1);
         assertEquals(metastore.getTableStats().getHitRate(), 0.0);
+
+        // check empty column list does not trigger the call
+        Table emptyColumnListTable = Table.builder(table).setDataColumns(ImmutableList.of()).build();
+        assertThat(metastore.getTableStatistics(emptyColumnListTable).getBasicStatistics()).isEqualTo(TEST_STATS.getBasicStatistics());
+        assertEquals(metastore.getTableStatisticsStats().getRequestCount(), 3);
+        assertEquals(metastore.getTableStatisticsStats().getHitRate(), 2.0 / 3);
+
+        mockClient.mockColumnStats(TEST_DATABASE, TEST_TABLE, ImmutableMap.of(
+                "col1", ColumnStatisticsData.longStats(new LongColumnStatsData().setNumNulls(1)),
+                "col2", ColumnStatisticsData.longStats(new LongColumnStatsData().setNumNulls(2)),
+                "col3", ColumnStatisticsData.longStats(new LongColumnStatsData().setNumNulls(3))));
+        Table tableCol1 = Table.builder(table).setDataColumns(ImmutableList.of(new Column("col1", HIVE_LONG, Optional.empty()))).build();
+        assertThat(metastore.getTableStatistics(tableCol1).getColumnStatistics()).containsEntry("col1", intColumnStats(1));
+        Table tableCol2 = Table.builder(table).setDataColumns(ImmutableList.of(new Column("col2", HIVE_LONG, Optional.empty()))).build();
+        assertThat(metastore.getTableStatistics(tableCol2).getColumnStatistics()).containsEntry("col2", intColumnStats(2));
+        Table tableCol23 = Table.builder(table)
+                .setDataColumns(ImmutableList.of(new Column("col2", HIVE_LONG, Optional.empty()), new Column("col3", HIVE_LONG, Optional.empty())))
+                .build();
+        assertThat(metastore.getTableStatistics(tableCol23).getColumnStatistics())
+                .containsEntry("col2", intColumnStats(2))
+                .containsEntry("col3", intColumnStats(3));
     }
 
     @Test
@@ -545,22 +574,83 @@ public class TestCachingHiveMetastore
         assertEquals(mockClient.getAccessCount(), 1);
 
         Partition partition = metastore.getPartition(table, TEST_PARTITION_VALUES1).orElseThrow();
-        assertEquals(mockClient.getAccessCount(), 2);
+        String partitionName = makePartitionName(table, partition);
+        Partition partition2 = metastore.getPartition(table, TEST_PARTITION_VALUES2).orElseThrow();
+        String partition2Name = makePartitionName(table, partition2);
+        Partition partition3 = metastore.getPartition(table, TEST_PARTITION_VALUES3).orElseThrow();
+        String partition3Name = makePartitionName(table, partition3);
+        assertEquals(mockClient.getAccessCount(), 4);
 
         assertEquals(metastore.getPartitionStatistics(table, ImmutableList.of(partition)), ImmutableMap.of(TEST_PARTITION1, TEST_STATS));
-        assertEquals(mockClient.getAccessCount(), 3);
+        assertEquals(mockClient.getAccessCount(), 5);
 
         assertEquals(metastore.getPartitionStatistics(table, ImmutableList.of(partition)), ImmutableMap.of(TEST_PARTITION1, TEST_STATS));
-        assertEquals(mockClient.getAccessCount(), 3);
+        assertEquals(mockClient.getAccessCount(), 5);
 
-        assertEquals(metastore.getPartitionStatisticsStats().getRequestCount(), 2);
-        assertEquals(metastore.getPartitionStatisticsStats().getHitRate(), 0.5);
+        assertEquals(metastore.getPartitionStatisticsStats().getRequestCount(), 3);
+        assertEquals(metastore.getPartitionStatisticsStats().getHitRate(), 2.0 / 3);
 
         assertEquals(metastore.getTableStats().getRequestCount(), 1);
         assertEquals(metastore.getTableStats().getHitRate(), 0.0);
 
-        assertEquals(metastore.getPartitionStats().getRequestCount(), 1);
+        assertEquals(metastore.getPartitionStats().getRequestCount(), 3);
         assertEquals(metastore.getPartitionStats().getHitRate(), 0.0);
+
+        // check empty column list does not trigger the call
+        Table emptyColumnListTable = Table.builder(table).setDataColumns(ImmutableList.of()).build();
+        Map<String, PartitionStatistics> partitionStatistics = metastore.getPartitionStatistics(emptyColumnListTable, ImmutableList.of(partition));
+        assertThat(partitionStatistics).containsOnlyKeys(TEST_PARTITION1);
+        assertThat(partitionStatistics.get(TEST_PARTITION1).getBasicStatistics()).isEqualTo(TEST_STATS.getBasicStatistics());
+        assertEquals(metastore.getPartitionStatisticsStats().getRequestCount(), 4);
+        assertEquals(metastore.getPartitionStatisticsStats().getHitRate(), 3.0 / 4);
+
+        mockClient.mockPartitionColumnStats(TEST_DATABASE, TEST_TABLE, TEST_PARTITION1, ImmutableMap.of(
+                "col1", ColumnStatisticsData.longStats(new LongColumnStatsData().setNumNulls(1)),
+                "col2", ColumnStatisticsData.longStats(new LongColumnStatsData().setNumNulls(2)),
+                "col3", ColumnStatisticsData.longStats(new LongColumnStatsData().setNumNulls(3))));
+
+        Table tableCol1 = Table.builder(table).setDataColumns(ImmutableList.of(new Column("col1", HIVE_LONG, Optional.empty()))).build();
+        Map<String, PartitionStatistics> tableCol1PartitionStatistics = metastore.getPartitionStatistics(tableCol1, ImmutableList.of(partition));
+        assertThat(tableCol1PartitionStatistics).containsOnlyKeys(partitionName);
+        assertThat(tableCol1PartitionStatistics.get(partitionName).getColumnStatistics()).containsEntry("col1", intColumnStats(1));
+        Table tableCol2 = Table.builder(table).setDataColumns(ImmutableList.of(new Column("col2", HIVE_LONG, Optional.empty()))).build();
+        Map<String, PartitionStatistics> tableCol2PartitionStatistics = metastore.getPartitionStatistics(tableCol2, ImmutableList.of(partition));
+        assertThat(tableCol2PartitionStatistics).containsOnlyKeys(partitionName);
+        assertThat(tableCol2PartitionStatistics.get(partitionName).getColumnStatistics()).containsEntry("col2", intColumnStats(2));
+        Table tableCol23 = Table.builder(table)
+                .setDataColumns(ImmutableList.of(new Column("col2", HIVE_LONG, Optional.empty()), new Column("col3", HIVE_LONG, Optional.empty())))
+                .build();
+        Map<String, PartitionStatistics> tableCol23PartitionStatistics = metastore.getPartitionStatistics(tableCol23, ImmutableList.of(partition));
+        assertThat(tableCol23PartitionStatistics).containsOnlyKeys(partitionName);
+        assertThat(tableCol23PartitionStatistics.get(partitionName).getColumnStatistics())
+                .containsEntry("col2", intColumnStats(2))
+                .containsEntry("col3", intColumnStats(3));
+
+        mockClient.mockPartitionColumnStats(TEST_DATABASE, TEST_TABLE, TEST_PARTITION2, ImmutableMap.of(
+                "col1", ColumnStatisticsData.longStats(new LongColumnStatsData().setNumNulls(21)),
+                "col2", ColumnStatisticsData.longStats(new LongColumnStatsData().setNumNulls(22)),
+                "col3", ColumnStatisticsData.longStats(new LongColumnStatsData().setNumNulls(23))));
+
+        mockClient.mockPartitionColumnStats(TEST_DATABASE, TEST_TABLE, TEST_PARTITION3, ImmutableMap.of(
+                "col1", ColumnStatisticsData.longStats(new LongColumnStatsData().setNumNulls(31)),
+                "col2", ColumnStatisticsData.longStats(new LongColumnStatsData().setNumNulls(32)),
+                "col3", ColumnStatisticsData.longStats(new LongColumnStatsData().setNumNulls(33))));
+
+        Map<String, PartitionStatistics> tableCol2Partition2Statistics = metastore.getPartitionStatistics(tableCol2, ImmutableList.of(partition2));
+        assertThat(tableCol2Partition2Statistics).containsOnlyKeys(partition2Name);
+        assertThat(tableCol2Partition2Statistics.get(partition2Name).getColumnStatistics()).containsEntry("col2", intColumnStats(22));
+
+        Map<String, PartitionStatistics> tableCol23Partition123Statistics = metastore.getPartitionStatistics(tableCol23, ImmutableList.of(partition, partition2, partition3));
+        assertThat(tableCol23Partition123Statistics).containsOnlyKeys(partitionName, partition2Name, partition3Name);
+        assertThat(tableCol23Partition123Statistics.get(partitionName).getColumnStatistics())
+                .containsEntry("col2", intColumnStats(2))
+                .containsEntry("col3", intColumnStats(3));
+        assertThat(tableCol23Partition123Statistics.get(partition2Name).getColumnStatistics())
+                .containsEntry("col2", intColumnStats(22))
+                .containsEntry("col3", intColumnStats(23));
+        assertThat(tableCol23Partition123Statistics.get(partition3Name).getColumnStatistics())
+                .containsEntry("col2", intColumnStats(32))
+                .containsEntry("col3", intColumnStats(33));
     }
 
     @Test
@@ -580,8 +670,8 @@ public class TestCachingHiveMetastore
         assertEquals(statsCacheMetastore.getPartitionStatistics(table, ImmutableList.of(partition)), ImmutableMap.of(TEST_PARTITION1, TEST_STATS));
         assertEquals(mockClient.getAccessCount(), 3);
 
-        assertEquals(statsCacheMetastore.getPartitionStatisticsStats().getRequestCount(), 2);
-        assertEquals(statsCacheMetastore.getPartitionStatisticsStats().getHitRate(), 0.5);
+        assertEquals(statsCacheMetastore.getPartitionStatisticsStats().getRequestCount(), 3);
+        assertEquals(statsCacheMetastore.getPartitionStatisticsStats().getHitRate(), 2.0 / 3);
 
         assertEquals(statsCacheMetastore.getTableStats().getRequestCount(), 0);
         assertEquals(statsCacheMetastore.getTableStats().getHitRate(), 1.0);
@@ -848,6 +938,11 @@ public class TestCachingHiveMetastore
         assertEquals(mockClient.getAccessCount(), 4);
         assertNotNull(metastore.getPartition(table, TEST_PARTITION_VALUES1));
         assertEquals(mockClient.getAccessCount(), 5);
+    }
+
+    private static HiveColumnStatistics intColumnStats(int nullsCount)
+    {
+        return createIntegerColumnStatistics(OptionalLong.empty(), OptionalLong.empty(), OptionalLong.of(nullsCount), OptionalLong.empty());
     }
 
     private static void await(CountDownLatch latch, long timeout, TimeUnit unit)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/statistics/TestMetastoreHiveStatisticsProvider.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/statistics/TestMetastoreHiveStatisticsProvider.java
@@ -630,7 +630,7 @@ public class TestMetastoreHiveStatisticsProvider
                 .setBasicStatistics(new HiveBasicStatistics(OptionalLong.empty(), OptionalLong.of(1000), OptionalLong.empty(), OptionalLong.empty()))
                 .setColumnStatistics(ImmutableMap.of(COLUMN, createIntegerColumnStatistics(OptionalLong.of(-100), OptionalLong.of(100), OptionalLong.of(500), OptionalLong.of(300))))
                 .build();
-        MetastoreHiveStatisticsProvider statisticsProvider = new MetastoreHiveStatisticsProvider((session, table, hivePartitions) -> ImmutableMap.of(partitionName, statistics));
+        MetastoreHiveStatisticsProvider statisticsProvider = new MetastoreHiveStatisticsProvider((session, table, hivePartitions, columns) -> ImmutableMap.of(partitionName, statistics));
         HiveColumnHandle columnHandle = createBaseColumn(COLUMN, 2, HIVE_LONG, BIGINT, REGULAR, Optional.empty());
         TableStatistics expected = TableStatistics.builder()
                 .setRowCount(Estimate.of(1000))
@@ -679,7 +679,7 @@ public class TestMetastoreHiveStatisticsProvider
                 .setBasicStatistics(new HiveBasicStatistics(OptionalLong.empty(), OptionalLong.of(1000), OptionalLong.empty(), OptionalLong.empty()))
                 .setColumnStatistics(ImmutableMap.of(COLUMN, createIntegerColumnStatistics(OptionalLong.of(-100), OptionalLong.of(100), OptionalLong.of(500), OptionalLong.of(300))))
                 .build();
-        MetastoreHiveStatisticsProvider statisticsProvider = new MetastoreHiveStatisticsProvider((session, table, hivePartitions) -> ImmutableMap.of(UNPARTITIONED_ID, statistics));
+        MetastoreHiveStatisticsProvider statisticsProvider = new MetastoreHiveStatisticsProvider((session, table, hivePartitions, columns) -> ImmutableMap.of(UNPARTITIONED_ID, statistics));
 
         HiveColumnHandle columnHandle = createBaseColumn(COLUMN, 2, HIVE_LONG, BIGINT, REGULAR, Optional.empty());
 
@@ -707,7 +707,7 @@ public class TestMetastoreHiveStatisticsProvider
     public void testGetTableStatisticsEmpty()
     {
         String partitionName = "p1=string1/p2=1234";
-        MetastoreHiveStatisticsProvider statisticsProvider = new MetastoreHiveStatisticsProvider((session, table, hivePartitions) -> ImmutableMap.of(partitionName, PartitionStatistics.empty()));
+        MetastoreHiveStatisticsProvider statisticsProvider = new MetastoreHiveStatisticsProvider((session, table, hivePartitions, columns) -> ImmutableMap.of(partitionName, PartitionStatistics.empty()));
         assertEquals(
                 statisticsProvider.getTableStatistics(
                         SESSION,
@@ -721,7 +721,7 @@ public class TestMetastoreHiveStatisticsProvider
     @Test
     public void testGetTableStatisticsSampling()
     {
-        MetastoreHiveStatisticsProvider statisticsProvider = new MetastoreHiveStatisticsProvider((session, table, hivePartitions) -> {
+        MetastoreHiveStatisticsProvider statisticsProvider = new MetastoreHiveStatisticsProvider((session, table, hivePartitions, columns) -> {
             assertEquals(table, TABLE);
             assertEquals(hivePartitions.size(), 1);
             return ImmutableMap.of();
@@ -743,7 +743,7 @@ public class TestMetastoreHiveStatisticsProvider
                 .setBasicStatistics(new HiveBasicStatistics(-1, 0, 0, 0))
                 .build();
         String partitionName = "p1=string1/p2=1234";
-        MetastoreHiveStatisticsProvider statisticsProvider = new MetastoreHiveStatisticsProvider((session, table, hivePartitions) -> ImmutableMap.of(partitionName, corruptedStatistics));
+        MetastoreHiveStatisticsProvider statisticsProvider = new MetastoreHiveStatisticsProvider((session, table, hivePartitions, columns) -> ImmutableMap.of(partitionName, corruptedStatistics));
         assertThatThrownBy(() -> statisticsProvider.getTableStatistics(
                 getHiveSession(new HiveConfig().setIgnoreCorruptedStatistics(false)),
                 TABLE,
@@ -766,7 +766,7 @@ public class TestMetastoreHiveStatisticsProvider
     public void testEmptyTableStatisticsForPartitionColumnsWhenStatsAreEmpty()
     {
         MetastoreHiveStatisticsProvider statisticsProvider = new MetastoreHiveStatisticsProvider(
-                (session, table, hivePartitions) -> ImmutableMap.of("p1=string1/p2=1234", PartitionStatistics.empty()));
+                (session, table, hivePartitions, columns) -> ImmutableMap.of("p1=string1/p2=1234", PartitionStatistics.empty()));
         testEmptyTableStatisticsForPartitionColumns(statisticsProvider);
     }
 
@@ -774,7 +774,7 @@ public class TestMetastoreHiveStatisticsProvider
     public void testEmptyTableStatisticsForPartitionColumnsWhenStatsAreMissing()
     {
         MetastoreHiveStatisticsProvider statisticsProvider = new MetastoreHiveStatisticsProvider(
-                (session, table, hivePartitions) -> ImmutableMap.of());
+                (session, table, hivePartitions, columns) -> ImmutableMap.of());
         testEmptyTableStatisticsForPartitionColumns(statisticsProvider);
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
`HiveTableHandle` contains the list of projected columns. Since only projected columns will be available to the engine, `HiveMetadata.getTableStatistics` can return statistics limited to those columns.
This also requires `CachingHiveMetastore` to support caching statistics for a subset of table columns.

#### Benchmarks
I tested the change on the glue metastore and table with 100 columns (details below) with caching stats disabled (`hive.metastore-stats-cache-ttl=0s)` and a simple query (`select count(c1)  from test_col_stats_part`) where planning dominates.

There is a difference of about 20% for planning time/elapsed (so visible)

baseline 2.251s on average and only required stats 1.853s

This would have a potentially higher impact on a metastore under heavy load.

The table used:
```
create table test_col_stats_part (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50, c51, c52, c53, c54, c55, c56, c57, c58, c59, c60, c61, c62, c63, c64, c65, c66, c67, c68, c69, c70, c71, c72, c73, c74, c75, c76, c77, c78, c79, c80, c81, c82, c83, c84, c85, c86, c87, c88, c89, c90, c91, c92, c93, c94, c95, c96, c97, c98, c99, c100, shipdate)
 WITH (                                              
    format = 'ORC',                                  
    partitioned_by = ARRAY['shipdate']               
 )
 as select 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, shipdate from hive.tpch_sf10_dec_orc.lineitem;
```

I also ran standard tpch/tpcds on scale factor 1000, orc, partitioned. The results show mostly no change (except for some variability)

![image](https://user-images.githubusercontent.com/8080198/221212069-a202034c-d5dc-4fcd-9b1c-a78eadb90014.png)

[sf1k-orc-part-240223.pdf](https://github.com/trinodb/trino/files/10825537/sf1k-orc-part-240223.pdf)


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Improve query planning performance for queries scanning tables with a larger number of columns. ({issue}`16203`)
```
