### PR TITLE
Remove unnecessary override test in Phoenix connector

### DIFF
--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
@@ -187,46 +187,6 @@ public class TestPhoenixConnectorTest
     }
 
     @Override
-    public void testInsert()
-    {
-        String query = "SELECT orderdate, orderkey, totalprice FROM orders";
-
-        assertUpdate("CREATE TABLE test_insert WITH (ROWKEYS='orderkey') AS " + query + " WITH NO DATA", 0);
-        assertQuery("SELECT count(*) FROM test_insert", "SELECT 0");
-
-        assertUpdate("INSERT INTO test_insert " + query, "SELECT count(*) FROM orders");
-
-        assertQuery("SELECT * FROM test_insert", query);
-
-        assertUpdate("INSERT INTO test_insert (orderkey) VALUES (-1)", 1);
-        assertUpdate("INSERT INTO test_insert (orderkey) VALUES (-1)", 1); // Phoenix Upsert
-        assertUpdate("INSERT INTO test_insert (orderkey) VALUES (-2)", 1);
-        assertUpdate("INSERT INTO test_insert (orderkey, orderdate) VALUES (-3, DATE '2001-01-01')", 1);
-        assertUpdate("INSERT INTO test_insert (orderkey, orderdate) VALUES (-4, DATE '2001-01-02')", 1);
-        assertUpdate("INSERT INTO test_insert (orderdate, orderkey) VALUES (DATE '2001-01-03', -5)", 1);
-        assertUpdate("INSERT INTO test_insert (orderkey, totalprice) VALUES (-6, 1234)", 1);
-
-        assertQuery("SELECT * FROM test_insert", query
-                + " UNION ALL SELECT null, -1, null"
-                + " UNION ALL SELECT null, -2, null"
-                + " UNION ALL SELECT DATE '2001-01-01', -3, null"
-                + " UNION ALL SELECT DATE '2001-01-02', -4, null"
-                + " UNION ALL SELECT DATE '2001-01-03', -5, null"
-                + " UNION ALL SELECT null, -6, 1234");
-
-        // UNION query produces columns in the opposite order
-        // of how they are declared in the table schema
-        assertUpdate(
-                "INSERT INTO test_insert (orderkey, orderdate, totalprice) " +
-                        "SELECT orderkey, orderdate, totalprice FROM orders " +
-                        "UNION ALL " +
-                        "SELECT orderkey, orderdate, totalprice FROM orders",
-                "SELECT 2 * count(*) FROM orders");
-
-        assertUpdate("DROP TABLE test_insert");
-    }
-
-    @Override
     public void testInsertArray()
     {
         assertThatThrownBy(super::testInsertArray)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Remove unnecessary override test in Phoenix connector test, Phoenix client could handle the `rowkey` by default.
Guess this test is added before the `CTAS` was supported in the client.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
