### PR TITLE
Use matching field names in QueryStatistics

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryStatistics.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryStatistics.java
@@ -34,7 +34,7 @@ public class QueryStatistics
     private final Duration queuedTime;
     private final Optional<Duration> scheduledTime;
     private final Optional<Duration> failedScheduledTime;
-    private final Optional<Duration> waitingTime;
+    private final Optional<Duration> resourceWaitingTime;
     private final Optional<Duration> analysisTime;
     private final Optional<Duration> planningTime;
     private final Optional<Duration> executionTime;
@@ -90,7 +90,7 @@ public class QueryStatistics
             Duration queuedTime,
             Optional<Duration> scheduledTime,
             Optional<Duration> failedScheduledTime,
-            Optional<Duration> waitingTime,
+            Optional<Duration> resourceWaitingTime,
             Optional<Duration> analysisTime,
             Optional<Duration> planningTime,
             Optional<Duration> executionTime,
@@ -129,7 +129,7 @@ public class QueryStatistics
         this.queuedTime = requireNonNull(queuedTime, "queuedTime is null");
         this.scheduledTime = requireNonNull(scheduledTime, "scheduledTime is null");
         this.failedScheduledTime = requireNonNull(failedScheduledTime, "failedScheduledTime is null");
-        this.waitingTime = requireNonNull(waitingTime, "waitingTime is null");
+        this.resourceWaitingTime = requireNonNull(resourceWaitingTime, "resourceWaitingTime is null");
         this.analysisTime = requireNonNull(analysisTime, "analysisTime is null");
         this.planningTime = requireNonNull(planningTime, "planningTime is null");
         this.executionTime = requireNonNull(executionTime, "executionTime is null");
@@ -202,7 +202,7 @@ public class QueryStatistics
     @JsonProperty
     public Optional<Duration> getResourceWaitingTime()
     {
-        return waitingTime;
+        return resourceWaitingTime;
     }
 
     @JsonProperty


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Simple clean up to the QueryStatistics class to have the POJO field names match the getters.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
