### PR TITLE
Fix indent formatting in a printed plan

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -584,7 +584,7 @@ public class PlanPrinter
                     hashColumn));
         }
 
-        fragment.getPartitionCount().ifPresent(partitionCount -> builder.append(format("Partition count: %s\n", partitionCount)));
+        fragment.getPartitionCount().ifPresent(partitionCount -> builder.append(format("%sPartition count: %s\n", indentString(1), partitionCount)));
 
         builder.append(
                         new PlanPrinter(


### PR DESCRIPTION
## Description
There is incorrect indentation when there is  a `partitionCount` in a printed plan (look at screen). This PR addresses it. 
![Screenshot 2023-02-23 at 09 07 29](https://user-images.githubusercontent.com/94364205/220855226-4ebdc0f0-2391-429c-a2b2-3b7ea5d79a19.png)
