### PR TITLE
Allow product tests' framework to use more memory

### DIFF
--- a/testing/trino-product-tests-launcher/pom.xml
+++ b/testing/trino-product-tests-launcher/pom.xml
@@ -218,7 +218,7 @@
                 <artifactId>really-executable-jar-maven-plugin</artifactId>
                 <configuration>
                     <!-- Force Parallel GC to ensure MaxHeapFreeRatio is respected -->
-                    <flags>-Xmx256m -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=10</flags>
+                    <flags>-Xmx256m -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=50</flags>
                     <classifier>executable</classifier>
                 </configuration>
                 <executions>

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/TestRun.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/TestRun.java
@@ -349,7 +349,7 @@ public final class TestRun
                                         // Force Parallel GC to ensure MaxHeapFreeRatio is respected
                                         "-XX:+UseParallelGC",
                                         "-XX:MinHeapFreeRatio=10",
-                                        "-XX:MaxHeapFreeRatio=10",
+                                        "-XX:MaxHeapFreeRatio=50",
                                         "-Djava.util.logging.config.file=/docker/presto-product-tests/conf/tempto/logging.properties",
                                         "-Duser.timezone=Asia/Kathmandu",
                                         // Tempto has progress logging built in


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

After #15833 we saw a big increase in the duration of product tests jobs. Starting tests got stuck for 2–3 minutes before loading the tempto configuration. This only happens on amd64 hosts with 7 GB of memory. I found this section that explains why we set it to 10% before: https://docs.oracle.com/en/java/javase/17/gctuning/factors-affecting-garbage-collection-performance.html#GUID-7FB2D1D5-D75F-4AA1-A3B1-4A17F8FF97D0

I chose to increase `MaxHeapFreeRatio` to 50% because this is the lowest value when tests didn't get stuck. 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: