### PR TITLE
Fix iceberg $files metadata table not show delete files

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -1561,7 +1561,7 @@ public abstract class BaseIcebergConnectorTest
             assertQuery(
                     "SELECT custkey, name, address, nationkey, phone, acctbal, mktsegment, comment FROM " + table.getName(),
                     "SELECT custkey, name, address, nationkey, phone, acctbal, mktsegment, substring(comment, 2) FROM customer");
-            for (Object filePath : computeActual("SELECT file_path from \"" + table.getName() + "$files\"").getOnlyColumnAsSet()) {
+            for (Object filePath : computeActual("SELECT file_path from \"" + table.getName() + "$files\" where content != 1").getOnlyColumnAsSet()) {
                 assertThat(isFileSorted((String) filePath, "comment")).isTrue();
             }
         }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
@@ -20,6 +20,7 @@ import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.MaterializedRow;
 import io.trino.testing.QueryRunner;
+import org.apache.iceberg.FileContent;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -96,6 +97,13 @@ public abstract class BaseIcebergSystemTables
         assertUpdate("DELETE FROM test_schema.test_table_with_dml WHERE _date = DATE '2022-02-02' AND _varchar = 'b2'", 1);
         assertUpdate("INSERT INTO test_schema.test_table_with_dml VALUES ('c3', DATE '2022-03-03'), ('d1', DATE '2022-04-04')", 2);
         assertQuery("SELECT count(*) FROM test_schema.test_table_with_dml", "VALUES 7");
+
+        assertUpdate("CREATE TABLE test_schema.test_table_with_delete (_bigint BIGINT, _date DATE) WITH (partitioning = ARRAY['_date'])");
+        assertUpdate("INSERT INTO test_schema.test_table_with_delete VALUES (0, CAST('2019-09-08' AS DATE)), (1, CAST('2019-09-09' AS DATE)), (2, CAST('2019-09-09' AS DATE))", 3);
+        assertUpdate("INSERT INTO test_schema.test_table_with_delete VALUES (3, CAST('2019-09-09' AS DATE)), (4, CAST('2019-09-10' AS DATE)), (5, CAST('2019-09-10' AS DATE))", 3);
+        assertUpdate("DELETE FROM test_schema.test_table_with_delete WHERE _bigint = 5", 1);
+        assertUpdate("DELETE FROM test_schema.test_table_with_delete WHERE _bigint = 2", 1);
+        assertQuery("SELECT count(*) FROM test_schema.test_table_with_delete", "VALUES 4");
     }
 
     @AfterAll
@@ -107,6 +115,7 @@ public abstract class BaseIcebergSystemTables
         assertUpdate("DROP TABLE IF EXISTS test_schema.test_table_nan");
         assertUpdate("DROP TABLE IF EXISTS test_schema.test_table_with_dml");
         assertUpdate("DROP TABLE IF EXISTS test_schema.test_metadata_log_entries");
+        assertUpdate("DROP TABLE IF EXISTS test_schema.test_table_with_delete");
         assertUpdate("DROP SCHEMA IF EXISTS test_schema");
     }
 
@@ -361,6 +370,14 @@ public abstract class BaseIcebergSystemTables
                         .row(ImmutableList.of(offset))
                         .row(ImmutableList.of(offset))
                         .build());
+    }
+
+    @Test
+    public void testFilesTableWithDelete()
+    {
+        assertQuery("SELECT count(*) FROM test_schema.\"test_table_with_delete$files\" WHERE content = " + FileContent.DATA.id(), "VALUES 4");
+        assertQuery("SELECT count(*) FROM test_schema.\"test_table_with_delete$files\" WHERE content = " + FileContent.POSITION_DELETES.id(), "VALUES 2");
+        assertQuery("SELECT count(*) FROM test_schema.\"test_table_with_delete$files\" WHERE content = " + FileContent.EQUALITY_DELETES.id(), "VALUES 0");
     }
 
     private Long nanCount(long value)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -41,6 +41,7 @@ import io.trino.testing.sql.TestTable;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileContent;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
@@ -216,6 +217,11 @@ public class TestIcebergV2
         assertQuery("SELECT * FROM " + tableName, "SELECT * FROM nation WHERE regionkey != 1");
         // nationkey is before the equality delete column in the table schema, comment is after
         assertQuery("SELECT nationkey, comment FROM " + tableName, "SELECT nationkey, comment FROM nation WHERE regionkey != 1");
+
+        assertUpdate("INSERT INTO " + tableName + " SELECT * FROM tpch.tiny.nation", 25);
+        writeEqualityDeleteToNationTable(icebergTable, Optional.of(icebergTable.spec()), Optional.of(new PartitionData(new Long[] {2L})), ImmutableMap.of("regionkey", 2L));
+        // the equality delete file is applied to 2 data files
+        assertQuery("SELECT count(*) FROM \"" + tableName + "$files\" WHERE content = " + FileContent.EQUALITY_DELETES.id(), "VALUES 2");
     }
 
     @Test
@@ -869,8 +875,6 @@ public class TestIcebergV2
                 .withEncryptionKeyMetadata(ByteBuffer.wrap("Trino".getBytes(UTF_8)))
                 .build();
         table.newAppend().appendFile(dataFile).commit();
-        // TODO Currently, Trino does not include equality delete files stats in the $files table.
-        //  Once it is fixed by https://github.com/trinodb/trino/pull/16232, include equality delete output in the test.
         writeEqualityDeleteToNationTable(table);
         assertQuery(
                 "SELECT " +
@@ -912,7 +916,19 @@ public class TestIcebergV2
                                         JSON '{"1":"4"}',
                                         X'54 72 69 6e 6f',
                                         ARRAY[4L],
-                                        null)
+                                        null),
+                                        (2,
+                                        'PARQUET',
+                                        1L,
+                                        JSON '{"3":46}',
+                                        JSON '{"3":1}',
+                                        JSON '{"3":0}',
+                                        JSON '{}',
+                                        JSON '{"3":"1"}',
+                                        JSON '{"3":"1"}',
+                                        null,
+                                        ARRAY[4],
+                                        ARRAY[3])
                         """);
     }
 
@@ -1331,7 +1347,7 @@ public class TestIcebergV2
 
     private List<String> getActiveFiles(String tableName)
     {
-        return computeActual(format("SELECT file_path FROM \"%s$files\"", tableName)).getOnlyColumn()
+        return computeActual(format("SELECT file_path FROM \"%s$files\" WHERE content = %d", tableName, FileContent.DATA.id())).getOnlyColumn()
                 .map(String.class::cast)
                 .collect(toImmutableList());
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR is aimed to fix `$files` table not showing delete files for iceberg v2 format. https://github.com/trinodb/trino/issues/16233


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix `$files` table not showing delete files for iceberg v2 format. ({issue}`[16233]`)
```
