### PR TITLE
Fix failure when query table function contains column alias in JDBC connectors

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
@@ -439,6 +439,16 @@ public class QueryAssertions
         }
 
         @CanIgnoreReturnValue
+        public QueryAssert hasColumnNames(String... expectedColumnNames)
+        {
+            return satisfies(actual -> {
+                assertThat(actual.getColumnNames())
+                        .as("Column names for query [%s]", query)
+                        .containsExactly(expectedColumnNames);
+            });
+        }
+
+        @CanIgnoreReturnValue
         public QueryAssert hasOutputTypes(List<Type> expectedTypes)
         {
             return satisfies(actual -> {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -253,7 +253,8 @@ public abstract class BaseJdbcClient
                 throw new UnsupportedOperationException("Query not supported: ResultSetMetaData not available for query: " + preparedQuery.getQuery());
             }
             for (int column = 1; column <= metadata.getColumnCount(); column++) {
-                String name = metadata.getColumnName(column);
+                // Use getColumnLabel method because query pass-through table function may contain column aliases
+                String name = metadata.getColumnLabel(column);
                 JdbcTypeHandle jdbcTypeHandle = new JdbcTypeHandle(
                         metadata.getColumnType(column),
                         Optional.ofNullable(metadata.getColumnTypeName(column)),

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectorTest.java
@@ -257,6 +257,19 @@ public class TestJdbcConnectorTest
     }
 
     @Override
+    public void testNativeQueryColumnAlias()
+    {
+        // override because H2 uppercase column names by default
+        assertThat(query(format("SELECT * FROM TABLE(system.query(query => 'SELECT name AS region_name FROM %s.region WHERE regionkey = 0'))", getSession().getSchema().orElseThrow())))
+                .hasColumnNames("REGION_NAME")
+                .matches("VALUES CAST('AFRICA' AS VARCHAR(25))");
+
+        assertThat(query(format("SELECT region_name FROM TABLE(system.query(query => 'SELECT name AS region_name FROM %s.region WHERE regionkey = 0'))", getSession().getSchema().orElseThrow())))
+                .hasColumnNames("region_name")
+                .matches("VALUES CAST('AFRICA' AS VARCHAR(25))");
+    }
+
+    @Override
     protected String errorMessageForInsertIntoNotNullColumn(String columnName)
     {
         return format("NULL not allowed for column \"%s\"(?s).*", columnName.toUpperCase(ENGLISH));

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -719,6 +719,29 @@ public abstract class BaseBigQueryConnectorTest
     }
 
     @Test
+    public void testNativeQueryColumnAlias()
+    {
+        assertThat(query("SELECT * FROM TABLE(system.query(query => 'SELECT name AS region_name FROM tpch.region WHERE regionkey = 0'))"))
+                .hasColumnNames("region_name")
+                .matches("VALUES CAST('AFRICA' AS VARCHAR)");
+
+        assertThat(query("SELECT region_name FROM TABLE(system.query(query => 'SELECT name AS region_name FROM tpch.region WHERE regionkey = 0'))"))
+                .hasColumnNames("region_name")
+                .matches("VALUES CAST('AFRICA' AS VARCHAR)");
+    }
+
+    @Test
+    public void testNativeQueryColumnAliasNotFound()
+    {
+        assertQueryFails(
+                "SELECT name FROM TABLE(system.query(query => 'SELECT name AS region_name FROM tpch.region'))",
+                ".* Column 'name' cannot be resolved");
+        assertQueryFails(
+                "SELECT column_not_found FROM TABLE(system.query(query => 'SELECT name AS region_name FROM tpch.region'))",
+                ".* Column 'column_not_found' cannot be resolved");
+    }
+
+    @Test
     public void testNativeQuerySelectFromTestTable()
     {
         String tableName = "test.test_select" + randomNameSuffix();

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
@@ -1406,6 +1406,29 @@ public class TestCassandraConnectorTest
     }
 
     @Test
+    public void testNativeQueryColumnAlias()
+    {
+        assertThat(query("SELECT * FROM TABLE(system.query(query => 'SELECT name AS region_name FROM tpch.region WHERE regionkey = 0 ALLOW FILTERING'))"))
+                .hasColumnNames("region_name")
+                .matches("VALUES CAST('AFRICA' AS VARCHAR)");
+
+        assertThat(query("SELECT region_name FROM TABLE(system.query(query => 'SELECT name AS region_name FROM tpch.region WHERE regionkey = 0 ALLOW FILTERING'))"))
+                .hasColumnNames("region_name")
+                .matches("VALUES CAST('AFRICA' AS VARCHAR)");
+    }
+
+    @Test
+    public void testNativeQueryColumnAliasNotFound()
+    {
+        assertQueryFails(
+                "SELECT name FROM TABLE(system.query(query => 'SELECT name AS region_name FROM tpch.region'))",
+                ".* Column 'name' cannot be resolved");
+        assertQueryFails(
+                "SELECT column_not_found FROM TABLE(system.query(query => 'SELECT name AS region_name FROM tpch.region'))",
+                ".* Column 'column_not_found' cannot be resolved");
+    }
+
+    @Test
     public void testNativeQuerySelectFromTestTable()
     {
         String tableName = "tpch.test_select" + randomNameSuffix();

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorTest.java
@@ -722,6 +722,24 @@ public abstract class BaseClickHouseConnectorTest
     }
 
     @Override
+    public void testNativeQueryColumnAlias()
+    {
+        // table function disabled for ClickHouse, because it doesn't provide ResultSetMetaData, so the result relation type cannot be determined
+        assertQueryFails(
+                "SELECT * FROM TABLE(system.query(query => 'SELECT name AS region_name FROM tpch.region WHERE regionkey = 0'))",
+                ".* Table function system.query not registered");
+    }
+
+    @Override
+    public void testNativeQueryColumnAliasNotFound()
+    {
+        // table function disabled for ClickHouse, because it doesn't provide ResultSetMetaData, so the result relation type cannot be determined
+        assertQueryFails(
+                "SELECT name FROM TABLE(system.query(query => 'SELECT name AS region_name FROM tpch.region'))",
+                ".* Table function system.query not registered");
+    }
+
+    @Override
     public void testNativeQuerySelectUnsupportedType()
     {
         // table function disabled for ClickHouse, because it doesn't provide ResultSetMetaData, so the result relation type cannot be determined

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteConnectorTest.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteConnectorTest.java
@@ -292,6 +292,24 @@ public class TestIgniteConnectorTest
     }
 
     @Override
+    public void testNativeQueryColumnAlias()
+    {
+        // table function disabled for Ignite, because it doesn't provide ResultSetMetaData, so the result relation type cannot be determined
+        assertQueryFails(
+                "SELECT * FROM TABLE(system.query(query => 'SELECT name AS region_name FROM public.region WHERE regionkey = 0'))",
+                ".* Table function system.query not registered");
+    }
+
+    @Override
+    public void testNativeQueryColumnAliasNotFound()
+    {
+        // table function disabled for Ignite, because it doesn't provide ResultSetMetaData, so the result relation type cannot be determined
+        assertQueryFails(
+                "SELECT name FROM TABLE(system.query(query => 'SELECT name AS region_name FROM public.region'))",
+                ".* Table function system.query not registered");
+    }
+
+    @Override
     public void testNativeQuerySelectUnsupportedType()
     {
         // table function disabled for Ignite, because it doesn't provide ResultSetMetaData, so the result relation type cannot be determined

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
@@ -447,6 +447,19 @@ public abstract class BaseOracleConnectorTest
     }
 
     @Override
+    public void testNativeQueryColumnAlias()
+    {
+        // override because Oracle uppercase column names by default
+        assertThat(query(format("SELECT * FROM TABLE(system.query(query => 'SELECT name AS region_name FROM %s.region WHERE regionkey = 0'))", getSession().getSchema().orElseThrow())))
+                .hasColumnNames("REGION_NAME")
+                .matches("VALUES CAST('AFRICA' AS VARCHAR(25))");
+
+        assertThat(query(format("SELECT region_name FROM TABLE(system.query(query => 'SELECT name AS region_name FROM %s.region WHERE regionkey = 0'))", getSession().getSchema().orElseThrow())))
+                .hasColumnNames("region_name")
+                .matches("VALUES CAST('AFRICA' AS VARCHAR(25))");
+    }
+
+    @Override
     public void testNativeQueryParameters()
     {
         // override because Oracle requires the FROM clause, and it needs explicit type

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
@@ -609,6 +609,24 @@ public class TestPhoenixConnectorTest
     }
 
     @Override
+    public void testNativeQueryColumnAlias()
+    {
+        // not implemented
+        assertQueryFails(
+                "SELECT * FROM TABLE(system.query(query => 'SELECT name AS region_name FROM tpch.region WHERE regionkey = 0'))",
+                ".* Table function system.query not registered");
+    }
+
+    @Override
+    public void testNativeQueryColumnAliasNotFound()
+    {
+        // not implemented
+        assertQueryFails(
+                "SELECT name FROM TABLE(system.query(query => 'SELECT name AS region_name FROM tpch.region'))",
+                ".* Table function system.query not registered");
+    }
+
+    @Override
     public void testNativeQueryCreateStatement()
     {
         // not implemented


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fixes #16225

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# MySQL, Druid, MariaDB, SingleStore
* Fix failure when `query` table function contains column alias. ({issue}`16225`)
```
