### PR TITLE
Use record-cursor based implementation in Iceberg system tables

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/InMemoryRecordSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/InMemoryRecordSet.java
@@ -76,7 +76,7 @@ public class InMemoryRecordSet
         private List<?> record;
         private long completedBytes;
 
-        protected InMemoryRecordCursor(List<Type> types, Iterator<? extends List<?>> records)
+        public InMemoryRecordCursor(List<Type> types, Iterator<? extends List<?>> records)
         {
             this.types = requireNonNull(types, "types is null");
             this.records = requireNonNull(records, "records is null");

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PropertiesTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PropertiesTable.java
@@ -14,20 +14,16 @@
 package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
-import io.trino.plugin.iceberg.util.PageListBuilder;
-import io.trino.spi.Page;
 import io.trino.spi.connector.ColumnMetadata;
-import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTransactionHandle;
-import io.trino.spi.connector.FixedPageSource;
+import io.trino.spi.connector.InMemoryRecordSet;
+import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
 import org.apache.iceberg.Table;
-
-import java.util.List;
 
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
@@ -62,22 +58,10 @@ public class PropertiesTable
     }
 
     @Override
-    public ConnectorPageSource pageSource(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
+    public RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
     {
-        return new FixedPageSource(buildPages(tableMetadata, icebergTable));
-    }
-
-    private static List<Page> buildPages(ConnectorTableMetadata tableMetadata, Table icebergTable)
-    {
-        PageListBuilder pagesBuilder = PageListBuilder.forTable(tableMetadata);
-
-        icebergTable.properties().entrySet().forEach(prop -> {
-            pagesBuilder.beginRow();
-            pagesBuilder.appendVarchar(prop.getKey());
-            pagesBuilder.appendVarchar(prop.getValue());
-            pagesBuilder.endRow();
-        });
-
-        return pagesBuilder.build();
+        InMemoryRecordSet.Builder table = InMemoryRecordSet.builder(tableMetadata);
+        icebergTable.properties().forEach(table::addRow);
+        return table.build().cursor();
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/SnapshotsTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/SnapshotsTable.java
@@ -14,38 +14,45 @@
 package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
-import io.trino.plugin.iceberg.util.PageListBuilder;
-import io.trino.spi.Page;
+import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.ColumnMetadata;
-import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTransactionHandle;
-import io.trino.spi.connector.FixedPageSource;
+import io.trino.spi.connector.InMemoryRecordSet;
+import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.TimeZoneKey;
+import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
-import io.trino.spi.type.TypeSignature;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.TypeSignature.mapType;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
 
 public class SnapshotsTable
         implements SystemTable
 {
+    private final TypeManager typeManager;
     private final ConnectorTableMetadata tableMetadata;
     private final Table icebergTable;
 
     public SnapshotsTable(SchemaTableName tableName, TypeManager typeManager, Table icebergTable)
     {
-        requireNonNull(typeManager, "typeManager is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
 
         this.icebergTable = requireNonNull(icebergTable, "icebergTable is null");
         tableMetadata = new ConnectorTableMetadata(requireNonNull(tableName, "tableName is null"),
@@ -55,7 +62,7 @@ public class SnapshotsTable
                         .add(new ColumnMetadata("parent_id", BIGINT))
                         .add(new ColumnMetadata("operation", VARCHAR))
                         .add(new ColumnMetadata("manifest_list", VARCHAR))
-                        .add(new ColumnMetadata("summary", typeManager.getType(TypeSignature.mapType(VARCHAR.getTypeSignature(), VARCHAR.getTypeSignature()))))
+                        .add(new ColumnMetadata("summary", typeManager.getType(mapType(VARCHAR.getTypeSignature(), VARCHAR.getTypeSignature()))))
                         .build());
     }
 
@@ -72,44 +79,79 @@ public class SnapshotsTable
     }
 
     @Override
-    public ConnectorPageSource pageSource(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
+    public RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
     {
-        return new FixedPageSource(buildPages(tableMetadata, session, icebergTable));
+        List<io.trino.spi.type.Type> types = tableMetadata.getColumns().stream()
+                .map(ColumnMetadata::getType)
+                .collect(toImmutableList());
+
+        SnapshotsIterable snapshotsIterable = new SnapshotsIterable(icebergTable.snapshots(), types, session.getTimeZoneKey());
+        return snapshotsIterable.cursor();
     }
 
-    private static List<Page> buildPages(ConnectorTableMetadata tableMetadata, ConnectorSession session, Table icebergTable)
+    private class SnapshotsIterable
+            implements Iterable<List<Object>>
     {
-        PageListBuilder pagesBuilder = PageListBuilder.forTable(tableMetadata);
+        private final Iterable<Snapshot> snapshots;
+        private final List<Type> types;
+        private final TimeZoneKey timeZoneKey;
+        private final Type summaryMapType;
 
-        TimeZoneKey timeZoneKey = session.getTimeZoneKey();
-        icebergTable.snapshots().forEach(snapshot -> {
-            pagesBuilder.beginRow();
-            pagesBuilder.appendTimestampTzMillis(snapshot.timestampMillis(), timeZoneKey);
-            pagesBuilder.appendBigint(snapshot.snapshotId());
-            if (checkNonNull(snapshot.parentId(), pagesBuilder)) {
-                pagesBuilder.appendBigint(snapshot.parentId());
-            }
-            if (checkNonNull(snapshot.operation(), pagesBuilder)) {
-                pagesBuilder.appendVarchar(snapshot.operation());
-            }
-            if (checkNonNull(snapshot.manifestListLocation(), pagesBuilder)) {
-                pagesBuilder.appendVarchar(snapshot.manifestListLocation());
-            }
-            if (checkNonNull(snapshot.summary(), pagesBuilder)) {
-                pagesBuilder.appendVarcharVarcharMap(snapshot.summary());
-            }
-            pagesBuilder.endRow();
-        });
-
-        return pagesBuilder.build();
-    }
-
-    private static boolean checkNonNull(Object object, PageListBuilder pagesBuilder)
-    {
-        if (object == null) {
-            pagesBuilder.appendNull();
-            return false;
+        public SnapshotsIterable(Iterable<Snapshot> snapshots, List<Type> types, TimeZoneKey timeZoneKey)
+        {
+            this.snapshots = requireNonNull(snapshots, "snapshots is null");
+            this.types = requireNonNull(types, "types is null");
+            this.timeZoneKey = requireNonNull(timeZoneKey, "timeZoneKey is null");
+            this.summaryMapType = typeManager.getType(mapType(VARCHAR.getTypeSignature(), VARCHAR.getTypeSignature()));
         }
-        return true;
+
+        public RecordCursor cursor()
+        {
+            return new InMemoryRecordSet.InMemoryRecordCursor(types, this.iterator());
+        }
+
+        @Override
+        public Iterator<List<Object>> iterator()
+        {
+            Iterator<Snapshot> snapshotsIterator = snapshots.iterator();
+
+            return new Iterator<>() {
+                @Override
+                public boolean hasNext()
+                {
+                    return snapshotsIterator.hasNext();
+                }
+
+                @Override
+                public List<Object> next()
+                {
+                    return getRecord(snapshotsIterator.next());
+                }
+            };
+        }
+
+        private List<Object> getRecord(Snapshot snapshot)
+        {
+            List<Object> columns = new ArrayList<>();
+            columns.add(packDateTimeWithZone(snapshot.timestampMillis(), timeZoneKey));
+            columns.add(snapshot.snapshotId());
+            columns.add(snapshot.parentId());
+            columns.add(snapshot.operation());
+            columns.add(snapshot.manifestListLocation());
+            columns.add(getSummaryMap(snapshot.summary()));
+            return columns;
+        }
+
+        private Object getSummaryMap(Map<String, String> values)
+        {
+            BlockBuilder blockBuilder = summaryMapType.createBlockBuilder(null, 1);
+            BlockBuilder singleMapBlockBuilder = blockBuilder.beginBlockEntry();
+            values.forEach((key, value) -> {
+                VARCHAR.writeString(singleMapBlockBuilder, key);
+                VARCHAR.writeString(singleMapBlockBuilder, value);
+            });
+            blockBuilder.closeEntry();
+            return summaryMapType.getObject(blockBuilder, 0);
+        }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR covers `$history`, `$manifests`, `$snapshots`, and `$properties` system tables.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Reduce memory usage when reading `$history` system tables. ({issue}`16237`)
* Reduce memory usage when reading `$manifests` system tables. ({issue}`16237`)
* Reduce memory usage when reading `$snapshots` system tables. ({issue}`16237`)
```
