### PR TITLE
Skip non-comparable & non-orderable field when extracting VALUES predicate

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/EffectivePredicateExtractor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/EffectivePredicateExtractor.java
@@ -386,6 +386,9 @@ public class EffectivePredicateExtractor
                             }
                             else {
                                 Type type = types.get(node.getOutputSymbols().get(i));
+                                if (!type.isComparable() && !type.isOrderable()) {
+                                    return TRUE_LITERAL;
+                                }
                                 if (hasNestedNulls(type, item)) {
                                     // Workaround solution to deal with array and row comparisons don't support null elements currently.
                                     // TODO: remove when comparisons are fixed
@@ -415,6 +418,9 @@ public class EffectivePredicateExtractor
                             hasNull[i] = true;
                         }
                         else {
+                            if (!type.isComparable() && !type.isOrderable()) {
+                                return TRUE_LITERAL;
+                            }
                             if (hasNestedNulls(type, item)) {
                                 // Workaround solution to deal with array and row comparisons don't support null elements currently.
                                 // TODO: remove when comparisons are fixed

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestEffectivePredicateExtractor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestEffectivePredicateExtractor.java
@@ -113,6 +113,7 @@ import static io.trino.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static io.trino.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static io.trino.sql.tree.ComparisonExpression.Operator.EQUAL;
 import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
+import static io.trino.tests.BogusType.BOGUS;
 import static io.trino.transaction.TransactionBuilder.transaction;
 import static io.trino.type.UnknownType.UNKNOWN;
 import static org.testng.Assert.assertEquals;
@@ -568,6 +569,7 @@ public class TestEffectivePredicateExtractor
                 .put(A, BIGINT)
                 .put(B, BIGINT)
                 .put(D, DOUBLE)
+                .put(G, BOGUS)
                 .put(R, RowType.anonymous(ImmutableList.of(BIGINT, BIGINT)))
                 .buildOrThrow());
 
@@ -745,6 +747,20 @@ public class TestEffectivePredicateExtractor
                                 ImmutableList.of(
                                         new Row(ImmutableList.of(bigintLiteral(1))),
                                         new Row(ImmutableList.of(BE)))),
+                        types,
+                        typeAnalyzer),
+                TRUE_LITERAL);
+
+        // non-comparable and non-orderable
+        assertEquals(
+                effectivePredicateExtractor.extract(
+                        SESSION,
+                        new ValuesNode(
+                                newId(),
+                                ImmutableList.of(G),
+                                ImmutableList.of(
+                                        new Row(ImmutableList.of(bigintLiteral(1))),
+                                        new Row(ImmutableList.of(bigintLiteral(2))))),
                         types,
                         typeAnalyzer),
                 TRUE_LITERAL);


### PR DESCRIPTION
Repro
```
CREATE TABLE t1 (coordinates row(x double, y double))

-- Fails with "Cannot create discrete ValueSet with non-comparable type: Geometry"
WITH ZONE (polygon) AS
    (VALUES (ST_POLYGON('polygon((0.0 0.0))')),
            (ST_POLYGON('polygon((0.0 0.0))')))
SELECT *
FROM t1
CROSS JOIN ZONE
WHERE ST_WITHIN(ST_POINT(coordinates.x, coordinates.y), polygon)
```

Related to #743 @martint 

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(X) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
