### PR TITLE
Ignore TDigest fields when building QueryCompletedEvent

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -1138,6 +1138,17 @@ public class TestEventListenerBasic
                                 new ColumnDetail("tpch", "sf1", "orders", "custkey"))));
     }
 
+    @Test
+    public void testIgnoreTDigest()
+            throws Exception
+    {
+        String sql = "SELECT COUNT(1) FROM tpch.tiny.nation";
+        QueryEvents queryEvents = runQueryAndWaitForEvents(sql).getQueryEvents();
+        QueryCompletedEvent queryCompletedEvent = queryEvents.getQueryCompletedEvent();
+        String json = JsonCodec.jsonCodec(QueryCompletedEvent.class).toJson(queryCompletedEvent);
+        assertThat(json).doesNotContain("\\\"digest\\\":");
+    }
+
     @DataProvider
     public Object[][] setOperator()
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

`QueryCompletedEvent` includes several `TDigest` fields that serialize to long base 64 strings. They are not human readable and waste space for transport or storage.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
