### PR TITLE
Replace usage of hadoop.fs.Path with String in Delta Lake

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -332,7 +332,7 @@ public class DeltaLakeMergeSink
             DeltaLakeWriter writer = new DeltaLakeWriter(
                     fileSystem,
                     fileWriter,
-                    rootTablePath,
+                    rootTableLocation,
                     targetRelativePath,
                     deletion.partitionValues(),
                     writerStats,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -693,14 +693,13 @@ public class DeltaLakeMetadata
             checkPathContainsNoFiles(session, new Path(location));
             external = false;
         }
-        Path targetPath = new Path(location);
-        Path deltaLogDirectory = getTransactionLogDir(targetPath);
+        String deltaLogDirectory = getTransactionLogDir(location);
         Optional<Long> checkpointInterval = getCheckpointInterval(tableMetadata.getProperties());
         Optional<Boolean> changeDataFeedEnabled = getChangeDataFeedEnabled(tableMetadata.getProperties());
 
         try {
             TrinoFileSystem fileSystem = fileSystemFactory.create(session);
-            if (!fileSystem.listFiles(deltaLogDirectory.toString()).hasNext()) {
+            if (!fileSystem.listFiles(deltaLogDirectory).hasNext()) {
                 validateTableColumns(tableMetadata);
 
                 List<String> partitionColumns = getPartitionedBy(tableMetadata.getProperties());
@@ -713,7 +712,7 @@ public class DeltaLakeMetadata
                         .collect(toImmutableMap(ColumnMetadata::getName, ColumnMetadata::getComment));
                 Map<String, Boolean> columnsNullability = tableMetadata.getColumns().stream()
                         .collect(toImmutableMap(ColumnMetadata::getName, ColumnMetadata::isNullable));
-                TransactionLogWriter transactionLogWriter = transactionLogWriterFactory.newWriterWithoutTransactionIsolation(session, targetPath.toString());
+                TransactionLogWriter transactionLogWriter = transactionLogWriterFactory.newWriterWithoutTransactionIsolation(session, location);
 
                 appendTableEntries(
                         0,
@@ -825,7 +824,7 @@ public class DeltaLakeMetadata
         Path targetPath = new Path(location);
         checkPathContainsNoFiles(session, targetPath);
 
-        setRollback(() -> deleteRecursivelyIfExists(fileSystemFactory.create(session), targetPath));
+        setRollback(() -> deleteRecursivelyIfExists(fileSystemFactory.create(session), targetPath.toString()));
 
         return new DeltaLakeOutputTableHandle(
                 schemaName,
@@ -890,10 +889,10 @@ public class DeltaLakeMetadata
         }
     }
 
-    private static void deleteRecursivelyIfExists(TrinoFileSystem fileSystem, Path path)
+    private static void deleteRecursivelyIfExists(TrinoFileSystem fileSystem, String path)
     {
         try {
-            fileSystem.deleteDirectory(path.toString());
+            fileSystem.deleteDirectory(path);
         }
         catch (IOException e) {
             LOG.warn(e, "IOException while trying to delete '%s'", path);
@@ -980,9 +979,9 @@ public class DeltaLakeMetadata
         catch (Exception e) {
             // Remove the transaction log entry if the table creation fails
             try {
-                Path transactionLogLocation = getTransactionLogDir(new Path(handle.getLocation()));
+                String transactionLogLocation = getTransactionLogDir(handle.getLocation());
                 TrinoFileSystem fileSystem = fileSystemFactory.create(session);
-                fileSystem.deleteDirectory(transactionLogLocation.toString());
+                fileSystem.deleteDirectory(transactionLogLocation);
             }
             catch (IOException ioException) {
                 // Nothing to do, the IOException is probably the same reason why the initial write failed
@@ -1241,7 +1240,7 @@ public class DeltaLakeMetadata
                     tableLocation,
                     table.getMetadataEntry(),
                     inputColumns,
-                    getMandatoryCurrentVersion(fileSystem, new Path(tableLocation)),
+                    getMandatoryCurrentVersion(fileSystem, tableLocation),
                     retryMode != NO_RETRIES);
         }
         catch (IOException e) {
@@ -1288,7 +1287,7 @@ public class DeltaLakeMetadata
             long createdTime = Instant.now().toEpochMilli();
 
             TrinoFileSystem fileSystem = fileSystemFactory.create(session);
-            long commitVersion = getMandatoryCurrentVersion(fileSystem, new Path(handle.getLocation())) + 1;
+            long commitVersion = getMandatoryCurrentVersion(fileSystem, handle.getLocation()) + 1;
             if (commitVersion != handle.getReadVersion() + 1) {
                 throw new TransactionConflictException(format("Conflicting concurrent writes found. Expected transaction log version: %s, actual version: %s",
                         handle.getReadVersion(),
@@ -1425,7 +1424,7 @@ public class DeltaLakeMetadata
             long createdTime = Instant.now().toEpochMilli();
 
             TrinoFileSystem fileSystem = fileSystemFactory.create(session);
-            long currentVersion = getMandatoryCurrentVersion(fileSystem, new Path(tableLocation));
+            long currentVersion = getMandatoryCurrentVersion(fileSystem, tableLocation);
             if (currentVersion != handle.getReadVersion()) {
                 throw new TransactionConflictException(format("Conflicting concurrent writes found. Expected transaction log version: %s, actual version: %s", handle.getReadVersion(), currentVersion));
             }
@@ -2555,7 +2554,7 @@ public class DeltaLakeMetadata
     {
         TrinoFileSystem fileSystem = fileSystemFactory.create(session);
         try {
-            return TransactionLogTail.loadNewTail(fileSystem, new Path(metastore.getTableLocation(table, session)), Optional.empty()).getFileEntries().stream()
+            return TransactionLogTail.loadNewTail(fileSystem, metastore.getTableLocation(table, session), Optional.empty()).getFileEntries().stream()
                     .map(DeltaLakeTransactionLogEntry::getCommitInfo)
                     .filter(Objects::nonNull)
                     .collect(toImmutableList());

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
@@ -34,7 +34,6 @@ import io.trino.spi.block.LazyBlockLoader;
 import io.trino.spi.block.LongArrayBlock;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
-import org.apache.hadoop.fs.Path;
 import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
@@ -54,6 +53,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.filesystem.Locations.appendPath;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeParquetStatisticsUtils.hasInvalidStatistics;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeParquetStatisticsUtils.jsonEncodeMax;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeParquetStatisticsUtils.jsonEncodeMin;
@@ -68,7 +68,7 @@ public class DeltaLakeWriter
 {
     private final TrinoFileSystem fileSystem;
     private final FileWriter fileWriter;
-    private final Path rootTableLocation;
+    private final String rootTableLocation;
     private final String relativeFilePath;
     private final List<String> partitionValues;
     private final DeltaLakeWriterStats stats;
@@ -83,7 +83,7 @@ public class DeltaLakeWriter
     public DeltaLakeWriter(
             TrinoFileSystem fileSystem,
             FileWriter fileWriter,
-            Path rootTableLocation,
+            String rootTableLocation,
             String relativeFilePath,
             List<String> partitionValues,
             DeltaLakeWriterStats stats,
@@ -186,7 +186,7 @@ public class DeltaLakeWriter
 
     private static DeltaLakeJsonFileStatistics readStatistics(
             TrinoFileSystem fileSystem,
-            Path tableLocation,
+            String tableLocation,
             List<String> dataColumnNames,
             List<Type> dataColumnTypes,
             String relativeFilePath,
@@ -198,7 +198,7 @@ public class DeltaLakeWriter
             typeForColumn.put(dataColumnNames.get(i), dataColumnTypes.get(i));
         }
 
-        TrinoInputFile inputFile = fileSystem.newInputFile(new Path(tableLocation, relativeFilePath).toString());
+        TrinoInputFile inputFile = fileSystem.newInputFile(appendPath(tableLocation, relativeFilePath));
         try (TrinoParquetDataSource trinoParquetDataSource = new TrinoParquetDataSource(
                 inputFile,
                 new ParquetReaderOptions(),

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -41,7 +41,6 @@ import io.trino.spi.statistics.DoubleRange;
 import io.trino.spi.statistics.Estimate;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.spi.type.TypeManager;
-import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -153,7 +152,7 @@ public class HiveMetastoreBackedDeltaLakeMetastore
         statisticsAccess.invalidateCache(tableLocation);
         transactionLogAccess.invalidateCaches(tableLocation);
         try {
-            TableSnapshot tableSnapshot = transactionLogAccess.loadSnapshot(table.getSchemaTableName(), new Path(tableLocation), session);
+            TableSnapshot tableSnapshot = transactionLogAccess.loadSnapshot(table.getSchemaTableName(), tableLocation, session);
             Optional<MetadataEntry> maybeMetadata = transactionLogAccess.getMetadataEntry(tableSnapshot, session);
             if (maybeMetadata.isEmpty()) {
                 throw new TrinoException(DELTA_LAKE_INVALID_TABLE, "Provided location did not contain a valid Delta Lake table: " + tableLocation);
@@ -219,7 +218,7 @@ public class HiveMetastoreBackedDeltaLakeMetastore
     public TableSnapshot getSnapshot(SchemaTableName table, ConnectorSession session)
     {
         try {
-            return transactionLogAccess.loadSnapshot(table, new Path(getTableLocation(table, session)), session);
+            return transactionLogAccess.loadSnapshot(table, getTableLocation(table, session), session);
         }
         catch (NotADeltaLakeTableException e) {
             throw e;

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/RegisterTableProcedure.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/RegisterTableProcedure.java
@@ -27,7 +27,6 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.procedure.Procedure;
-import org.apache.hadoop.fs.Path;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -131,8 +130,8 @@ public class RegisterTableProcedure
 
         TrinoFileSystem fileSystem = fileSystemFactory.create(session);
         try {
-            Path transactionLogDir = getTransactionLogDir(new Path(tableLocation));
-            if (!fileSystem.listFiles(transactionLogDir.toString()).hasNext()) {
+            String transactionLogDir = getTransactionLogDir(tableLocation);
+            if (!fileSystem.listFiles(transactionLogDir).hasNext()) {
                 throw new TrinoException(GENERIC_USER_ERROR, format("No transaction log found in location %s", transactionLogDir));
             }
         }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/VacuumProcedure.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/VacuumProcedure.java
@@ -38,7 +38,6 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.procedure.Procedure;
 import io.trino.spi.procedure.Procedure.Argument;
-import org.apache.hadoop.fs.Path;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -169,9 +168,9 @@ public class VacuumProcedure
         accessControl.checkCanInsertIntoTable(null, tableName);
         accessControl.checkCanDeleteFromTable(null, tableName);
 
-        TableSnapshot tableSnapshot = transactionLogAccess.loadSnapshot(tableName, new Path(handle.getLocation()), session);
-        Path tableLocation = tableSnapshot.getTableLocation();
-        Path transactionLogDir = getTransactionLogDir(tableLocation);
+        TableSnapshot tableSnapshot = transactionLogAccess.loadSnapshot(tableName, handle.getLocation(), session);
+        String tableLocation = tableSnapshot.getTableLocation();
+        String transactionLogDir = getTransactionLogDir(tableLocation);
         TrinoFileSystem fileSystem = fileSystemFactory.create(session);
         String commonPathPrefix = tableLocation + "/";
         String queryId = session.getQueryId();

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/MissingTransactionLogException.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/MissingTransactionLogException.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.deltalake.transactionlog;
 
 import io.trino.spi.TrinoException;
-import org.apache.hadoop.fs.Path;
 
 import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_INVALID_TABLE;
 import static java.lang.String.format;
@@ -22,7 +21,7 @@ import static java.lang.String.format;
 public class MissingTransactionLogException
         extends TrinoException
 {
-    public MissingTransactionLogException(Path transactionLogPath)
+    public MissingTransactionLogException(String transactionLogPath)
     {
         super(DELTA_LAKE_INVALID_TABLE, format("The transaction log file %s was not found", transactionLogPath));
     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogUtil.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogUtil.java
@@ -13,8 +13,7 @@
  */
 package io.trino.plugin.deltalake.transactionlog;
 
-import org.apache.hadoop.fs.Path;
-
+import static io.trino.filesystem.Locations.appendPath;
 import static java.lang.String.format;
 
 public final class TransactionLogUtil
@@ -23,13 +22,13 @@ public final class TransactionLogUtil
 
     public static final String TRANSACTION_LOG_DIRECTORY = "_delta_log";
 
-    public static Path getTransactionLogDir(Path tableLocation)
+    public static String getTransactionLogDir(String tableLocation)
     {
-        return new Path(tableLocation, TRANSACTION_LOG_DIRECTORY);
+        return appendPath(tableLocation, TRANSACTION_LOG_DIRECTORY);
     }
 
-    public static Path getTransactionLogJsonEntryPath(Path transactionLogDir, long entryNumber)
+    public static String getTransactionLogJsonEntryPath(String transactionLogDir, long entryNumber)
     {
-        return new Path(transactionLogDir, format("%020d.json", entryNumber));
+        return appendPath(transactionLogDir, format("%020d.json", entryNumber));
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/TransactionLogWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/TransactionLogWriter.java
@@ -96,9 +96,9 @@ public class TransactionLogWriter
     {
         checkState(commitInfoEntry.isPresent(), "commitInfo not set");
 
-        Path transactionLogLocation = getTransactionLogDir(new Path(tableLocation));
+        String transactionLogLocation = getTransactionLogDir(tableLocation);
         CommitInfoEntry commitInfo = requireNonNull(commitInfoEntry.get().getCommitInfo(), "commitInfoEntry.get().getCommitInfo() is null");
-        Path logEntry = getTransactionLogJsonEntryPath(transactionLogLocation, commitInfo.getVersion());
+        String logEntry = getTransactionLogJsonEntryPath(transactionLogLocation, commitInfo.getVersion());
 
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         writeEntry(bos, commitInfoEntry.get());
@@ -107,7 +107,7 @@ public class TransactionLogWriter
         }
 
         String clusterId = commitInfoEntry.get().getCommitInfo().getClusterId();
-        logSynchronizer.write(session, clusterId, logEntry, bos.toByteArray());
+        logSynchronizer.write(session, clusterId, new Path(logEntry), bos.toByteArray());
     }
 
     private void writeEntry(OutputStream outputStream, DeltaLakeTransactionLogEntry deltaLakeTransactionLogEntry)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeRegisterTableProcedureTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeRegisterTableProcedureTest.java
@@ -226,9 +226,9 @@ public abstract class BaseDeltaLakeRegisterTableProcedureTest
         String tableNameNew = "test_register_table_with_no_transaction_log_new_" + randomNameSuffix();
 
         // Delete files under transaction log directory and put an invalid log file to verify register_table call fails
-        String transactionLogDir = new URI(getTransactionLogDir(new org.apache.hadoop.fs.Path(tableLocation)).toString()).getPath();
+        String transactionLogDir = new URI(getTransactionLogDir(tableLocation)).getPath();
         deleteDirectoryContents(Path.of(transactionLogDir), ALLOW_INSECURE);
-        new File(getTransactionLogJsonEntryPath(new org.apache.hadoop.fs.Path(transactionLogDir), 0).toString()).createNewFile();
+        new File(getTransactionLogJsonEntryPath(transactionLogDir, 0)).createNewFile();
 
         assertQueryFails(format("CALL system.register_table('%s', '%s', '%s')", SCHEMA, tableNameNew, tableLocation),
                 ".*Failed to access table location: (.*)");
@@ -250,7 +250,7 @@ public abstract class BaseDeltaLakeRegisterTableProcedureTest
         String tableNameNew = "test_register_table_with_no_transaction_log_new_" + randomNameSuffix();
 
         // Delete files under transaction log directory to verify register_table call fails
-        deleteDirectoryContents(Path.of(new URI(getTransactionLogDir(new org.apache.hadoop.fs.Path(tableLocation)).toString()).getPath()), ALLOW_INSECURE);
+        deleteDirectoryContents(Path.of(new URI(getTransactionLogDir(tableLocation)).getPath()), ALLOW_INSECURE);
 
         assertQueryFails(format("CALL system.register_table('%s', '%s', '%s')", SCHEMA, tableNameNew, tableLocation),
                 ".*No transaction log found in location (.*)");

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
@@ -36,7 +36,6 @@ import io.trino.tpch.LineItemColumn;
 import io.trino.tpch.LineItemGenerator;
 import io.trino.tpch.TpchColumnType;
 import io.trino.type.BlockTypeOperators;
-import org.apache.hadoop.fs.Path;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -83,7 +82,7 @@ public class TestDeltaLakePageSink
         try {
             DeltaLakeWriterStats stats = new DeltaLakeWriterStats();
             String tablePath = tempDir.getAbsolutePath() + "/test_table";
-            ConnectorPageSink pageSink = createPageSink(new Path(tablePath), stats);
+            ConnectorPageSink pageSink = createPageSink(tablePath, stats);
 
             List<LineItemColumn> columns = ImmutableList.copyOf(LineItemColumn.values());
             List<Type> columnTypes = columns.stream()
@@ -150,7 +149,7 @@ public class TestDeltaLakePageSink
         }
     }
 
-    private static ConnectorPageSink createPageSink(Path outputPath, DeltaLakeWriterStats stats)
+    private static ConnectorPageSink createPageSink(String outputPath, DeltaLakeWriterStats stats)
     {
         HiveTransactionHandle transaction = new HiveTransactionHandle(false);
         DeltaLakeConfig deltaLakeConfig = new DeltaLakeConfig();
@@ -158,7 +157,7 @@ public class TestDeltaLakePageSink
                 SCHEMA_NAME,
                 TABLE_NAME,
                 getColumnHandles(),
-                outputPath.toString(),
+                outputPath,
                 Optional.of(deltaLakeConfig.getDefaultCheckpointWritingInterval()),
                 true,
                 Optional.empty(),

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestingDeltaLakeUtils.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestingDeltaLakeUtils.java
@@ -21,7 +21,6 @@ import io.trino.plugin.hive.FileFormatDataSourceStats;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.testing.TestingConnectorContext;
-import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
 import java.util.List;
@@ -47,6 +46,6 @@ public final class TestingDeltaLakeUtils
                 new HdfsFileSystemFactory(HDFS_ENVIRONMENT),
                 new ParquetReaderConfig());
 
-        return transactionLogAccess.getActiveFiles(transactionLogAccess.loadSnapshot(dummyTable, new Path(tableLocation), SESSION), SESSION);
+        return transactionLogAccess.getActiveFiles(transactionLogAccess.loadSnapshot(dummyTable, tableLocation, SESSION), SESSION);
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestTableSnapshot.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestTableSnapshot.java
@@ -24,12 +24,10 @@ import io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointSchemaManag
 import io.trino.plugin.hive.FileFormatDataSourceStats;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.spi.connector.SchemaTableName;
-import org.apache.hadoop.fs.Path;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.List;
@@ -55,15 +53,14 @@ public class TestTableSnapshot
     private CheckpointSchemaManager checkpointSchemaManager;
     private AccessTrackingFileSystemFactory accessTrackingFileSystemFactory;
     private TrinoFileSystem accessTrackingFileSystem;
-    private Path tableLocation;
+    private String tableLocation;
 
     @BeforeMethod
     public void setUp()
             throws URISyntaxException
     {
         checkpointSchemaManager = new CheckpointSchemaManager(TESTING_TYPE_MANAGER);
-        URI deltaLogPath = getClass().getClassLoader().getResource("databricks/person").toURI();
-        tableLocation = new Path(deltaLogPath);
+        tableLocation = getClass().getClassLoader().getResource("databricks/person").toURI().toString();
 
         accessTrackingFileSystemFactory = new AccessTrackingFileSystemFactory(new HdfsFileSystemFactory(HDFS_ENVIRONMENT));
         accessTrackingFileSystem = accessTrackingFileSystemFactory.create(SESSION);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestTransactionLogParser.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestTransactionLogParser.java
@@ -16,9 +16,9 @@ package io.trino.plugin.deltalake.transactionlog;
 
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
-import org.apache.hadoop.fs.Path;
 import org.testng.annotations.Test;
 
+import static io.trino.filesystem.Locations.appendPath;
 import static io.trino.plugin.deltalake.DeltaTestingConnectorSession.SESSION;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogParser.getMandatoryCurrentVersion;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
@@ -32,10 +32,10 @@ public class TestTransactionLogParser
     {
         TrinoFileSystem fileSystem = new HdfsFileSystemFactory(HDFS_ENVIRONMENT).create(SESSION);
 
-        Path basePath = new Path(getClass().getClassLoader().getResource("databricks").toURI());
+        String basePath = getClass().getClassLoader().getResource("databricks").toURI().toString();
 
-        assertEquals(getMandatoryCurrentVersion(fileSystem, new Path(basePath, "simple_table_without_checkpoint")), 9);
-        assertEquals(getMandatoryCurrentVersion(fileSystem, new Path(basePath, "simple_table_ending_on_checkpoint")), 10);
-        assertEquals(getMandatoryCurrentVersion(fileSystem, new Path(basePath, "simple_table_past_checkpoint")), 11);
+        assertEquals(getMandatoryCurrentVersion(fileSystem, appendPath(basePath, "simple_table_without_checkpoint")), 9);
+        assertEquals(getMandatoryCurrentVersion(fileSystem, appendPath(basePath, "simple_table_ending_on_checkpoint")), 10);
+        assertEquals(getMandatoryCurrentVersion(fileSystem, appendPath(basePath, "simple_table_past_checkpoint")), 11);
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointWriter.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointWriter.java
@@ -41,7 +41,6 @@ import io.trino.spi.type.Int128;
 import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.TypeManager;
 import io.trino.util.DateTimeUtils;
-import org.apache.hadoop.fs.Path;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -197,7 +196,7 @@ public class TestCheckpointWriter
         File targetFile = File.createTempFile("testCheckpointWriteReadRoundtrip-", ".checkpoint.parquet");
         targetFile.deleteOnExit();
 
-        Path targetPath = new Path("file://" + targetFile.getAbsolutePath());
+        String targetPath = "file://" + targetFile.getAbsolutePath();
         targetFile.delete(); // file must not exist when writer is called
         writer.write(entries, createOutputFile(targetPath));
 
@@ -333,7 +332,7 @@ public class TestCheckpointWriter
         File targetFile = File.createTempFile("testCheckpointWriteReadRoundtrip-", ".checkpoint.parquet");
         targetFile.deleteOnExit();
 
-        Path targetPath = new Path("file://" + targetFile.getAbsolutePath());
+        String targetPath = "file://" + targetFile.getAbsolutePath();
         targetFile.delete(); // file must not exist when writer is called
         writer.write(entries, createOutputFile(targetPath));
 
@@ -404,7 +403,7 @@ public class TestCheckpointWriter
         File targetFile = File.createTempFile("testCheckpointWriteReadRoundtrip-", ".checkpoint.parquet");
         targetFile.deleteOnExit();
 
-        Path targetPath = new Path("file://" + targetFile.getAbsolutePath());
+        String targetPath = "file://" + targetFile.getAbsolutePath();
         targetFile.delete(); // file must not exist when writer is called
         writer.write(entries, createOutputFile(targetPath));
 
@@ -476,11 +475,11 @@ public class TestCheckpointWriter
         return Optional.of(comparableStats.buildOrThrow());
     }
 
-    private CheckpointEntries readCheckpoint(Path checkpointPath, MetadataEntry metadataEntry, boolean rowStatisticsEnabled)
+    private CheckpointEntries readCheckpoint(String checkpointPath, MetadataEntry metadataEntry, boolean rowStatisticsEnabled)
             throws IOException
     {
         TrinoFileSystem fileSystem = new HdfsFileSystemFactory(HDFS_ENVIRONMENT).create(SESSION);
-        TrinoInputFile checkpointFile = fileSystem.newInputFile(checkpointPath.toString());
+        TrinoInputFile checkpointFile = fileSystem.newInputFile(checkpointPath);
 
         Iterator<DeltaLakeTransactionLogEntry> checkpointEntryIterator = new CheckpointEntryIterator(
                 checkpointFile,
@@ -504,8 +503,8 @@ public class TestCheckpointWriter
         return checkpointBuilder.build();
     }
 
-    private static TrinoOutputFile createOutputFile(Path path)
+    private static TrinoOutputFile createOutputFile(String path)
     {
-        return new HdfsFileSystemFactory(HDFS_ENVIRONMENT).create(SESSION).newOutputFile(path.toString());
+        return new HdfsFileSystemFactory(HDFS_ENVIRONMENT).create(SESSION).newOutputFile(path);
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestTransactionLogTail.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestTransactionLogTail.java
@@ -16,7 +16,6 @@ package io.trino.plugin.deltalake.transactionlog.checkpoint;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
 import io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry;
-import org.apache.hadoop.fs.Path;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -53,9 +52,8 @@ public class TestTransactionLogTail
             throws Exception
     {
         TrinoFileSystem fileSystem = new HdfsFileSystemFactory(HDFS_ENVIRONMENT).create(SESSION);
-        Path tablePath = new Path(tableLocation);
-        TransactionLogTail transactionLogTail = TransactionLogTail.loadNewTail(fileSystem, tablePath, Optional.of(10L), Optional.of(12L));
-        Optional<TransactionLogTail> updatedLogTail = transactionLogTail.getUpdatedTail(fileSystem, tablePath);
+        TransactionLogTail transactionLogTail = TransactionLogTail.loadNewTail(fileSystem, tableLocation, Optional.of(10L), Optional.of(12L));
+        Optional<TransactionLogTail> updatedLogTail = transactionLogTail.getUpdatedTail(fileSystem, tableLocation);
         assertTrue(updatedLogTail.isPresent());
         return updatedLogTail.get().getFileEntries();
     }
@@ -64,8 +62,7 @@ public class TestTransactionLogTail
             throws Exception
     {
         TrinoFileSystem fileSystem = new HdfsFileSystemFactory(HDFS_ENVIRONMENT).create(SESSION);
-        Path tablePath = new Path(tableLocation);
-        TransactionLogTail transactionLogTail = TransactionLogTail.loadNewTail(fileSystem, tablePath, Optional.of(10L));
+        TransactionLogTail transactionLogTail = TransactionLogTail.loadNewTail(fileSystem, tableLocation, Optional.of(10L));
         return transactionLogTail.getFileEntries();
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestTransactionLogTail.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestTransactionLogTail.java
@@ -20,7 +20,6 @@ import org.apache.hadoop.fs.Path;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
@@ -36,7 +35,7 @@ public class TestTransactionLogTail
     public void testTail(String dataSource)
             throws Exception
     {
-        String tableLocation = format("%s/person", dataSource);
+        String tableLocation = getClass().getClassLoader().getResource(format("%s/person", dataSource)).toURI().toString();
         assertEquals(readJsonTransactionLogTails(tableLocation).size(), 7);
         assertEquals(updateJsonTransactionLogTails(tableLocation).size(), 7);
     }
@@ -54,8 +53,7 @@ public class TestTransactionLogTail
             throws Exception
     {
         TrinoFileSystem fileSystem = new HdfsFileSystemFactory(HDFS_ENVIRONMENT).create(SESSION);
-        URI resource = getClass().getClassLoader().getResource(tableLocation).toURI();
-        Path tablePath = new Path(resource);
+        Path tablePath = new Path(tableLocation);
         TransactionLogTail transactionLogTail = TransactionLogTail.loadNewTail(fileSystem, tablePath, Optional.of(10L), Optional.of(12L));
         Optional<TransactionLogTail> updatedLogTail = transactionLogTail.getUpdatedTail(fileSystem, tablePath);
         assertTrue(updatedLogTail.isPresent());
@@ -66,8 +64,7 @@ public class TestTransactionLogTail
             throws Exception
     {
         TrinoFileSystem fileSystem = new HdfsFileSystemFactory(HDFS_ENVIRONMENT).create(SESSION);
-        URI resource = getClass().getClassLoader().getResource(tableLocation).toURI();
-        Path tablePath = new Path(resource);
+        Path tablePath = new Path(tableLocation);
         TransactionLogTail transactionLogTail = TransactionLogTail.loadNewTail(fileSystem, tablePath, Optional.of(10L));
         return transactionLogTail.getFileEntries();
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Origin of this change is to migrate to TrinoFileSystem
Relates to https://github.com/trinodb/trino/issues/16020

Some hadoop.fs.Path will be migrated in following PR as it needs some additional path resolution functions.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
