### PR TITLE
Don't pull PT env images in build-pt job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ env:
   # the Docker daemon only downloads 3 layers concurrently which prevents the other pull from making any progress.
   # This value should be greater than the time taken for the longest image pull.
   TESTCONTAINERS_PULL_PAUSE_TIMEOUT: 600
+  TESTCONTAINERS_SKIP_ARCHITECTURE_CHECK: true
   TEST_REPORT_RETENTION_DAYS: 5
   HEAP_DUMP_RETENTION_DAYS: 14
   # used by actions/cache to retry the download after this time: https://github.com/actions/cache/blob/main/workarounds.md#cache-segment-restore-timeout
@@ -951,6 +952,7 @@ jobs:
           DATABRICKS_TOKEN:
           GCP_CREDENTIALS_KEY:
           GCP_STORAGE_BUCKET:
+          TESTCONTAINERS_NEVER_PULL: true
         run: |
           # converts filtered YAML file into JSON
           ./.github/bin/build-pt-matrix-from-impacted-connectors.py -v -m .github/test-pt-matrix.yaml -i impacted-features.log -o matrix.json

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/ConditionalPullPolicy.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/ConditionalPullPolicy.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing.containers;
+
+import org.testcontainers.images.ImagePullPolicy;
+import org.testcontainers.images.PullPolicy;
+import org.testcontainers.utility.DockerImageName;
+
+import static java.lang.System.getenv;
+
+public class ConditionalPullPolicy
+        implements ImagePullPolicy
+{
+    private static final boolean TESTCONTAINERS_NEVER_PULL = "true".equalsIgnoreCase(getenv("TESTCONTAINERS_NEVER_PULL"));
+    private static final ImagePullPolicy defaultPolicy = PullPolicy.defaultPolicy();
+
+    @Override
+    public boolean shouldPull(DockerImageName imageName)
+    {
+        if (TESTCONTAINERS_NEVER_PULL) {
+            return false;
+        }
+        return defaultPolicy.shouldPull(imageName);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The `build-pt` job needs to run `ptl suite describe` for all test suites to get a complete list of features used in every test environment. This does not require pulling all Docker images, but `testcontainers` do so by default. This PR allows to disable pulling images before starting containers. It should reduce the run time of the `build-pt` job by ~2 minutes and avoid running out of disk space on the node. No other PT job downloads all images.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
