### PR TITLE
Support reading FIXED_LEN_BYTE_ARRAY as varchar/varbinary columns

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
@@ -44,6 +44,7 @@ import static io.trino.parquet.reader.decoders.PlainByteArrayDecoders.BinaryPlai
 import static io.trino.parquet.reader.decoders.PlainByteArrayDecoders.BoundedVarcharPlainValueDecoder;
 import static io.trino.parquet.reader.decoders.PlainByteArrayDecoders.CharPlainValueDecoder;
 import static io.trino.parquet.reader.decoders.PlainValueDecoders.BooleanPlainValueDecoder;
+import static io.trino.parquet.reader.decoders.PlainValueDecoders.FixedLengthPlainValueDecoder;
 import static io.trino.parquet.reader.decoders.PlainValueDecoders.Int96PlainValueDecoder;
 import static io.trino.parquet.reader.decoders.PlainValueDecoders.IntPlainValueDecoder;
 import static io.trino.parquet.reader.decoders.PlainValueDecoders.IntToBytePlainValueDecoder;
@@ -198,6 +199,15 @@ public final class ValueDecoders
         return switch (encoding) {
             case PLAIN -> new LongDecimalPlainValueDecoder(field.getDescriptor().getPrimitiveType().getTypeLength());
             case DELTA_BYTE_ARRAY -> getDeltaFixedWidthLongDecimalDecoder(encoding, field);
+            default -> throw wrongEncoding(encoding, field);
+        };
+    }
+
+    public static ValueDecoder<BinaryBuffer> getFixedWidthBinaryDecoder(ParquetEncoding encoding, PrimitiveField field)
+    {
+        return switch (encoding) {
+            case PLAIN -> new FixedLengthPlainValueDecoder(field.getDescriptor().getPrimitiveType().getTypeLength());
+            case DELTA_BYTE_ARRAY -> new BinaryDeltaByteArrayDecoder();
             default -> throw wrongEncoding(encoding, field);
         };
     }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestData.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestData.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.Random;
 import java.util.function.IntFunction;
@@ -31,6 +32,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.trino.parquet.ParquetTypeUtils.paddingBigInteger;
 import static java.lang.Math.toIntExact;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public final class TestData
 {
@@ -168,6 +170,20 @@ public final class TestData
             data[i] = value;
         }
 
+        return data;
+    }
+
+    public static byte[][] randomUtf8(int size, int length)
+    {
+        Random random = new Random(Objects.hash(size, length));
+        byte[][] data = new byte[size][];
+        for (int i = 0; i < size; i++) {
+            StringBuilder builder = new StringBuilder();
+            for (int j = 0; j < length; j++) {
+                builder.append((char) random.nextInt(1 << 16));
+            }
+            data[i] = Arrays.copyOf(builder.toString().getBytes(UTF_8), length);
+        }
         return data;
     }
 

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestingColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestingColumnReader.java
@@ -330,6 +330,21 @@ public class TestingColumnReader
         };
     }
 
+    private static Writer<String> writeFixedWidthBinary(int typeLength)
+    {
+        return (writer, values) -> {
+            String[] result = new String[values.length];
+            for (int i = 0; i < values.length; i++) {
+                if (values[i] != null) {
+                    byte[] bytes = Arrays.copyOf(Integer.toString(values[i]).getBytes(UTF_8), typeLength);
+                    writer.writeBytes(Binary.fromConstantByteArray(bytes));
+                    result[i] = new String(bytes, UTF_8);
+                }
+            }
+            return result;
+        };
+    }
+
     private static final Assertion<Number> ASSERT_BYTE = (values, block, offset, blockOffset) -> assertThat(block.getByte(blockOffset, 0)).isEqualTo(values[offset].byteValue());
     private static final Assertion<Number> ASSERT_SHORT = (values, block, offset, blockOffset) -> assertThat(block.getShort(blockOffset, 0)).isEqualTo(values[offset].shortValue());
     private static final Assertion<Number> ASSERT_INT = (values, block, offset, blockOffset) -> assertThat(block.getInt(blockOffset, 0)).isEqualTo(values[offset].intValue());
@@ -641,6 +656,7 @@ public class TestingColumnReader
                 new ColumnReaderFormat<>(INT32, SMALLINT, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_SHORT, ASSERT_SHORT),
                 new ColumnReaderFormat<>(INT32, TINYINT, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_BYTE, ASSERT_BYTE),
                 new ColumnReaderFormat<>(BINARY, VARCHAR, PLAIN_WRITER, DICTIONARY_BINARY_WRITER, WRITE_BINARY, ASSERT_BINARY),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, null, VARCHAR, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, writeFixedWidthBinary(8), ASSERT_BINARY),
                 new ColumnReaderFormat<>(INT64, decimalType(0, 16), createDecimalType(16), PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, ASSERT_LONG),
                 new ColumnReaderFormat<>(INT64, BIGINT, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, ASSERT_LONG),
                 new ColumnReaderFormat<>(INT64, INTEGER, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, ASSERT_INT),

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/BinaryApacheParquetValueDecoder.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/BinaryApacheParquetValueDecoder.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader.decoders;
+
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import io.trino.parquet.reader.flat.BinaryBuffer;
+import org.apache.parquet.column.values.ValuesReader;
+
+import static java.util.Objects.requireNonNull;
+
+final class BinaryApacheParquetValueDecoder
+        implements ValueDecoder<BinaryBuffer>
+{
+    private final ValuesReader delegate;
+
+    public BinaryApacheParquetValueDecoder(ValuesReader delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    public void init(SimpleSliceInputStream input)
+    {
+        AbstractValueDecodersTest.initialize(input, delegate);
+    }
+
+    @Override
+    public void read(BinaryBuffer values, int offsetsIndex, int length)
+    {
+        for (int i = 0; i < length; i++) {
+            byte[] value = delegate.readBytes().getBytes();
+            values.add(value, i + offsetsIndex);
+        }
+    }
+
+    @Override
+    public void skip(int n)
+    {
+        delegate.skip(n);
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestByteArrayValueDecoders.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestByteArrayValueDecoders.java
@@ -370,36 +370,4 @@ public final class TestByteArrayValueDecoders
             delegate.skip(n);
         }
     }
-
-    private static final class BinaryApacheParquetValueDecoder
-            implements ValueDecoder<BinaryBuffer>
-    {
-        private final ValuesReader delegate;
-
-        public BinaryApacheParquetValueDecoder(ValuesReader delegate)
-        {
-            this.delegate = requireNonNull(delegate, "delegate is null");
-        }
-
-        @Override
-        public void init(SimpleSliceInputStream input)
-        {
-            initialize(input, delegate);
-        }
-
-        @Override
-        public void read(BinaryBuffer values, int offsetsIndex, int length)
-        {
-            for (int i = 0; i < length; i++) {
-                byte[] value = delegate.readBytes().getBytes();
-                values.add(value, i + offsetsIndex);
-            }
-        }
-
-        @Override
-        public void skip(int n)
-        {
-            delegate.skip(n);
-        }
-    }
 }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestFixedWidthByteArrayValueDecoders.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestFixedWidthByteArrayValueDecoders.java
@@ -18,6 +18,7 @@ import io.airlift.slice.Slices;
 import io.trino.parquet.ParquetEncoding;
 import io.trino.parquet.PrimitiveField;
 import io.trino.parquet.reader.SimpleSliceInputStream;
+import io.trino.parquet.reader.flat.BinaryBuffer;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Decimals;
 import io.trino.spi.type.Int128;
@@ -32,9 +33,11 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.math.BigInteger;
 import java.nio.ByteOrder;
+import java.util.List;
 import java.util.OptionalInt;
 import java.util.Random;
 import java.util.UUID;
+import java.util.function.BiConsumer;
 import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -46,9 +49,14 @@ import static io.trino.parquet.ParquetTypeUtils.getShortDecimalValue;
 import static io.trino.parquet.ParquetTypeUtils.paddingBigInteger;
 import static io.trino.parquet.reader.TestData.longToBytes;
 import static io.trino.parquet.reader.TestData.maxPrecision;
+import static io.trino.parquet.reader.TestData.randomBinaryData;
+import static io.trino.parquet.reader.TestData.randomUtf8;
 import static io.trino.parquet.reader.TestData.unscaledRandomShortDecimalSupplier;
+import static io.trino.parquet.reader.flat.BinaryColumnAdapter.BINARY_ADAPTER;
 import static io.trino.parquet.reader.flat.Int128ColumnAdapter.INT128_ADAPTER;
 import static io.trino.parquet.reader.flat.LongColumnAdapter.LONG_ADAPTER;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.DataProviders.concat;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
@@ -59,6 +67,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 public final class TestFixedWidthByteArrayValueDecoders
         extends AbstractValueDecodersTest
 {
+    private static final List<ParquetEncoding> ENCODINGS = ImmutableList.of(PLAIN, RLE_DICTIONARY, DELTA_BYTE_ARRAY);
+
+    private static final BiConsumer<BinaryBuffer, BinaryBuffer> BINARY_ASSERT = (actual, expected) -> {
+        assertThat(actual.getOffsets()).containsExactly(expected.getOffsets());
+        assertThat(actual.asSlice()).isEqualTo(expected.asSlice());
+    };
+
     @Override
     protected Object[][] tests()
     {
@@ -69,7 +84,9 @@ public final class TestFixedWidthByteArrayValueDecoders
                 generateLongDecimalTests(PLAIN),
                 generateLongDecimalTests(DELTA_BYTE_ARRAY),
                 generateLongDecimalTests(RLE_DICTIONARY),
-                generateUuidTests());
+                generateUuidTests(),
+                generateVarbinaryTests(),
+                generateVarcharTests());
     }
 
     private static Object[][] generateShortDecimalTests(ParquetEncoding encoding)
@@ -97,11 +114,33 @@ public final class TestFixedWidthByteArrayValueDecoders
 
     private static Object[][] generateUuidTests()
     {
-        return ImmutableList.of(PLAIN, DELTA_BYTE_ARRAY).stream()
+        return ENCODINGS.stream()
                 .map(encoding -> new Object[] {
                         createUuidTestType(),
                         encoding,
                         new UuidInputProvider()})
+                .toArray(Object[][]::new);
+    }
+
+    private static Object[][] generateVarbinaryTests()
+    {
+        int typeLength = 7;
+        return ENCODINGS.stream()
+                .map(encoding -> new Object[] {
+                        createVarbinaryTestType(typeLength),
+                        encoding,
+                        createRandomBinaryInputProvider(typeLength)})
+                .toArray(Object[][]::new);
+    }
+
+    private static Object[][] generateVarcharTests()
+    {
+        int typeLength = 13;
+        return ENCODINGS.stream()
+                .map(encoding -> new Object[] {
+                        createVarcharTestType(typeLength),
+                        encoding,
+                        createRandomUtf8BinaryInputProvider(typeLength)})
                 .toArray(Object[][]::new);
     }
 
@@ -137,6 +176,26 @@ public final class TestFixedWidthByteArrayValueDecoders
                 UuidApacheParquetValueDecoder::new,
                 INT128_ADAPTER,
                 (actual, expected) -> assertThat(actual).isEqualTo(expected));
+    }
+
+    private static TestType<BinaryBuffer> createVarbinaryTestType(int typeLength)
+    {
+        return new TestType<>(
+                createField(FIXED_LEN_BYTE_ARRAY, OptionalInt.of(typeLength), VARBINARY),
+                ValueDecoders::getFixedWidthBinaryDecoder,
+                BinaryApacheParquetValueDecoder::new,
+                BINARY_ADAPTER,
+                BINARY_ASSERT);
+    }
+
+    private static TestType<BinaryBuffer> createVarcharTestType(int typeLength)
+    {
+        return new TestType<>(
+                createField(FIXED_LEN_BYTE_ARRAY, OptionalInt.of(typeLength), VARCHAR),
+                ValueDecoders::getFixedWidthBinaryDecoder,
+                BinaryApacheParquetValueDecoder::new,
+                BINARY_ADAPTER,
+                BINARY_ASSERT);
     }
 
     private static InputDataProvider createShortDecimalInputDataProvider(int typeLength, int precision)
@@ -207,6 +266,42 @@ public final class TestFixedWidthByteArrayValueDecoders
         {
             return "uuid";
         }
+    }
+
+    private static InputDataProvider createRandomBinaryInputProvider(int length)
+    {
+        return new InputDataProvider()
+        {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                return writeBytes(valuesWriter, randomBinaryData(dataSize, length, length));
+            }
+
+            @Override
+            public String toString()
+            {
+                return "random(" + length + ")";
+            }
+        };
+    }
+
+    private static InputDataProvider createRandomUtf8BinaryInputProvider(int length)
+    {
+        return new InputDataProvider()
+        {
+            @Override
+            public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
+            {
+                return writeBytes(valuesWriter, randomUtf8(dataSize, length));
+            }
+
+            @Override
+            public String toString()
+            {
+                return "random utf8(" + length + ")";
+            }
+        };
     }
 
     private static DataBuffer writeBytes(ValuesWriter valuesWriter, byte[][] input)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
@@ -60,6 +60,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Functions.compose;
@@ -1852,6 +1853,27 @@ public abstract class AbstractTestParquetReader
                 writeValues,
                 transform(writeValues, AbstractTestParquetReader::byteArrayToVarbinary),
                 VARBINARY);
+    }
+
+    @Test
+    public void testReadFixedWidthByteArrayAsVarBinary()
+            throws Exception
+    {
+        Random random = new Random(2342890824L);
+        int typeLength = 5;
+        List<byte[]> writeValues = IntStream.range(0, 30_000)
+                .mapToObj(i -> {
+                    byte[] value = new byte[typeLength];
+                    random.nextBytes(value);
+                    return value;
+                })
+                .collect(toImmutableList());
+        tester.testRoundTrip(
+                javaByteArrayObjectInspector,
+                writeValues,
+                transform(writeValues, AbstractTestParquetReader::byteArrayToVarbinary),
+                VARBINARY,
+                Optional.of(parseMessageType(format("message varbinary { optional FIXED_LEN_BYTE_ARRAY(%s) test; }", typeLength))));
     }
 
     @Test


### PR DESCRIPTION
## Description
Parquet files produced by Kafka Connect may contain FIXED_LEN_BYTE_ARRAY parquet type without any logical type annotation due to `org.apache.parquet.avro.AvroSchemaConverter` translating the FIXED Avro type into FIXED_LEN_BYTE_ARRAY.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Reading a FIXED_LEN_BYTE_ARRAY without logical type annotation as string/binary type is already supported in Apache Hive and Apache Spark.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Hudi, Iceberg, Delta
* Fix query failures on reading parquet files generated by Kafka Connect. ({issue}`16264`)
```
