### PR TITLE
[trino-ignite] Ensure primary_key columns exist while creating table

### DIFF
--- a/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
+++ b/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
@@ -109,6 +109,7 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.varbinaryWriteFunction
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharReadFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
 import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
+import static io.trino.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -366,14 +367,25 @@ public class IgniteClient
 
         int expectedSize = tableMetadata.getColumns().size();
         ImmutableList.Builder<String> columns = ImmutableList.builderWithExpectedSize(expectedSize);
-        ImmutableList.Builder<String> columnNames = ImmutableList.builderWithExpectedSize(expectedSize);
+        ImmutableList.Builder<String> columnNamesBuilder = ImmutableList.builderWithExpectedSize(expectedSize);
         ImmutableList.Builder<Type> columnTypes = ImmutableList.builderWithExpectedSize(expectedSize);
         for (ColumnMetadata columnMetadata : tableMetadata.getColumns()) {
             columns.add(getColumnDefinitionSql(session, columnMetadata, columnMetadata.getName()));
-            columnNames.add(columnMetadata.getName());
+            columnNamesBuilder.add(columnMetadata.getName());
             columnTypes.add(columnMetadata.getType());
         }
-        String sql = buildCreateSql(schemaTableName, columns.build(), tableMetadata.getProperties());
+
+        List<String> columnNames = columnNamesBuilder.build();
+        List<String> primaryKeys = IgniteTableProperties.getPrimaryKey(tableMetadata.getProperties());
+
+        for (String primaryKey : primaryKeys) {
+            if (!columnNames.contains(primaryKey)) {
+                throw new TrinoException(INVALID_TABLE_PROPERTY,
+                        format("Column '%s' specified in property '%s' doesn't exist in table", primaryKey, PRIMARY_KEY_PROPERTY));
+            }
+        }
+
+        String sql = buildCreateSql(schemaTableName, columns.build(), primaryKeys);
 
         try (Connection connection = connectionFactory.openConnection(session)) {
             execute(session, connection, sql);
@@ -381,22 +393,21 @@ public class IgniteClient
             return new IgniteOutputTableHandle(
                     schemaTableName.getSchemaName(),
                     schemaTableName.getTableName(),
-                    columnNames.build(),
+                    columnNames,
                     columnTypes.build(),
                     Optional.empty(),
-                    IgniteTableProperties.getPrimaryKey(tableMetadata.getProperties()).isEmpty() ? Optional.of(IGNITE_DUMMY_ID) : Optional.empty());
+                    primaryKeys.isEmpty() ? Optional.of(IGNITE_DUMMY_ID) : Optional.empty());
         }
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);
         }
     }
 
-    private String buildCreateSql(SchemaTableName schemaTableName, List<String> columns, Map<String, Object> tableProperties)
+    private String buildCreateSql(SchemaTableName schemaTableName, List<String> columns, List<String> primaryKeys)
     {
         ImmutableList.Builder<String> columnDefinitions = ImmutableList.builder();
         columnDefinitions.addAll(columns);
 
-        List<String> primaryKeys = IgniteTableProperties.getPrimaryKey(tableProperties);
         checkArgument(primaryKeys.size() < columns.size(), "Ignite table must have at least one non PRIMARY KEY column.");
         if (primaryKeys.isEmpty()) {
             columnDefinitions.add(quoted(IGNITE_DUMMY_ID) + " VARCHAR NOT NULL");

--- a/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
+++ b/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
@@ -404,13 +404,6 @@ public class IgniteClient
         }
         columnDefinitions.add("PRIMARY KEY (" + join(", ", primaryKeys.stream().map(this::quoted).collect(joining(", "))) + ")");
 
-        for (Map.Entry<String, Object> propertyEntry : tableProperties.entrySet()) {
-            String propertyKey = propertyEntry.getKey();
-            if (!PRIMARY_KEY_PROPERTY.equalsIgnoreCase(propertyKey)) {
-                throw new UnsupportedOperationException("Not support table property " + propertyKey);
-            }
-        }
-
         String remoteTableName = quoted(null, schemaTableName.getSchemaName(), schemaTableName.getTableName());
         return format("CREATE TABLE %s (%s) ", remoteTableName, join(", ", columnDefinitions.build()));
     }

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteConnectorTest.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteConnectorTest.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 
 import static com.google.common.base.Strings.nullToEmpty;
 import static io.trino.plugin.ignite.IgniteQueryRunner.createIgniteQueryRunner;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -145,6 +146,20 @@ public class TestIgniteConnectorTest
             assertThat((String) computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue())
                     .isEqualTo(format(pattern, catalog, schema, tableName));
         }
+    }
+
+    @Test
+    public void testCreateTableWithNonExistingPrimaryKey()
+    {
+        String tableName = "test_invalid_primary_key" + randomNameSuffix();
+        assertQueryFails("CREATE TABLE " + tableName + "(a bigint) WITH (primary_key = ARRAY['not_existing_column'])",
+                "Column 'not_existing_column' specified in property 'primary_key' doesn't exist in table");
+
+        assertQueryFails("CREATE TABLE " + tableName + "(a bigint) WITH (primary_key = ARRAY['dummy_id'])",
+                "Column 'dummy_id' specified in property 'primary_key' doesn't exist in table");
+
+        assertQueryFails("CREATE TABLE " + tableName + "(a bigint) WITH (primary_key = ARRAY['A'])",
+                "Column 'A' specified in property 'primary_key' doesn't exist in table");
     }
 
     @Test


### PR DESCRIPTION
## Description

Adds a check to validate that the column names defined in primary_key table property exists as column names in the table definition.

Fixes #16215

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
