### PR TITLE
Added jdbc fetch size config for pg/oracle/redshift

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -1064,7 +1064,7 @@ public abstract class BaseJdbcClient
     }
 
     @Override
-    public PreparedStatement getPreparedStatement(Connection connection, String sql)
+    public PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
             throws SQLException
     {
         return connection.prepareStatement(sql);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -350,10 +350,10 @@ public class CachingJdbcClient
     }
 
     @Override
-    public PreparedStatement getPreparedStatement(Connection connection, String sql)
+    public PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
             throws SQLException
     {
-        return delegate.getPreparedStatement(connection, sql);
+        return delegate.getPreparedStatement(session, connection, sql);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
@@ -176,7 +176,7 @@ public class DefaultQueryBuilder
     {
         String modifiedQuery = queryModifier.apply(session, preparedQuery.getQuery());
         log.debug("Preparing query: %s", modifiedQuery);
-        PreparedStatement statement = client.getPreparedStatement(connection, modifiedQuery);
+        PreparedStatement statement = client.getPreparedStatement(session, connection, modifiedQuery);
 
         List<QueryParameter> parameters = preparedQuery.getParameters();
         for (int i = 0; i < parameters.size(); i++) {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -240,10 +240,10 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
-    public PreparedStatement getPreparedStatement(Connection connection, String sql)
+    public PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
             throws SQLException
     {
-        return delegate().getPreparedStatement(connection, sql);
+        return delegate().getPreparedStatement(session, connection, sql);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
@@ -177,7 +177,7 @@ public interface JdbcClient
     Connection getConnection(ConnectorSession session, JdbcOutputTableHandle handle)
             throws SQLException;
 
-    PreparedStatement getPreparedStatement(Connection connection, String sql)
+    PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
             throws SQLException;
 
     /**

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -320,10 +320,10 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
-    public PreparedStatement getPreparedStatement(Connection connection, String sql)
+    public PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
             throws SQLException
     {
-        return stats.getGetPreparedStatement().wrap(() -> delegate().getPreparedStatement(connection, sql));
+        return stats.getGetPreparedStatement().wrap(() -> delegate().getPreparedStatement(session, connection, sql));
     }
 
     @Override

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -294,7 +294,7 @@ public class MySqlClient
     }
 
     @Override
-    public PreparedStatement getPreparedStatement(Connection connection, String sql)
+    public PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
             throws SQLException
     {
         PreparedStatement statement = connection.prepareStatement(sql);
@@ -472,7 +472,8 @@ public class MySqlClient
 
     private LongWriteFunction mySqlDateWriteFunctionUsingLocalDate()
     {
-        return new LongWriteFunction() {
+        return new LongWriteFunction()
+        {
             @Override
             public String getBindExpression()
             {

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
@@ -105,6 +105,7 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.varbinaryWriteFunction
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
 import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.getUnsupportedTypeHandling;
 import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
+import static io.trino.plugin.oracle.OracleSessionProperties.getJdbcFetchSize;
 import static io.trino.plugin.oracle.OracleSessionProperties.getNumberDefaultScale;
 import static io.trino.plugin.oracle.OracleSessionProperties.getNumberRoundingMode;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -257,11 +258,11 @@ public class OracleClient
     }
 
     @Override
-    public PreparedStatement getPreparedStatement(Connection connection, String sql)
+    public PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
             throws SQLException
     {
         PreparedStatement statement = connection.prepareStatement(sql);
-        statement.setFetchSize(1000);
+        statement.setFetchSize(getJdbcFetchSize(session));
         return statement;
     }
 

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleConfig.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleConfig.java
@@ -37,6 +37,7 @@ public class OracleConfig
     private int connectionPoolMinSize = 1;
     private int connectionPoolMaxSize = 30;
     private Duration inactiveConnectionTimeout = new Duration(20, MINUTES);
+    private int jdbcFetchSize = 1000;
 
     @NotNull
     public boolean isSynonymsEnabled()
@@ -146,5 +147,17 @@ public class OracleConfig
     public boolean isPoolSizedProperly()
     {
         return getConnectionPoolMaxSize() >= getConnectionPoolMinSize();
+    }
+
+    public int getJdbcFetchSize()
+    {
+        return jdbcFetchSize;
+    }
+
+    @Config("oracle.jdbc-fetch-size")
+    public OracleConfig setJdbcFetchSize(int jdbcFetchSize)
+    {
+        this.jdbcFetchSize = jdbcFetchSize;
+        return this;
     }
 }

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleSessionProperties.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleSessionProperties.java
@@ -32,6 +32,7 @@ public final class OracleSessionProperties
 {
     public static final String NUMBER_ROUNDING_MODE = "number_rounding_mode";
     public static final String NUMBER_DEFAULT_SCALE = "number_default_scale";
+    public static final String JDBC_FETCH_SIZE = "jdbc_fetch_size";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -50,6 +51,11 @@ public final class OracleSessionProperties
                         "Default scale for Oracle Number data type",
                         config.getDefaultNumberScale().orElse(null),
                         false))
+                .add(integerProperty(
+                        JDBC_FETCH_SIZE,
+                        "A hit number for oracle JDBC driver for fetching the result rows",
+                        config.getJdbcFetchSize(),
+                        false))
                 .build();
     }
 
@@ -67,5 +73,10 @@ public final class OracleSessionProperties
     public static Optional<Integer> getNumberDefaultScale(ConnectorSession session)
     {
         return Optional.ofNullable(session.getProperty(NUMBER_DEFAULT_SCALE, Integer.class));
+    }
+
+    public static int getJdbcFetchSize(ConnectorSession session)
+    {
+        return session.getProperty(JDBC_FETCH_SIZE, Integer.class);
     }
 }

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConfig.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConfig.java
@@ -43,7 +43,8 @@ public class TestOracleConfig
                 .setConnectionPoolEnabled(true)
                 .setConnectionPoolMinSize(1)
                 .setConnectionPoolMaxSize(30)
-                .setInactiveConnectionTimeout(new Duration(20, MINUTES)));
+                .setInactiveConnectionTimeout(new Duration(20, MINUTES))
+                .setJdbcFetchSize(1000));
     }
 
     @Test
@@ -58,6 +59,7 @@ public class TestOracleConfig
                 .put("oracle.connection-pool.min-size", "10")
                 .put("oracle.connection-pool.max-size", "20")
                 .put("oracle.connection-pool.inactive-timeout", "30s")
+                .put("oracle.jdbc-fetch-size", "2000")
                 .buildOrThrow();
 
         OracleConfig expected = new OracleConfig()
@@ -68,7 +70,8 @@ public class TestOracleConfig
                 .setConnectionPoolEnabled(false)
                 .setConnectionPoolMinSize(10)
                 .setConnectionPoolMaxSize(20)
-                .setInactiveConnectionTimeout(new Duration(30, SECONDS));
+                .setInactiveConnectionTimeout(new Duration(30, SECONDS))
+                .setJdbcFetchSize(2000);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -184,6 +184,7 @@ import static io.trino.plugin.postgresql.PostgreSqlConfig.ArrayMapping.AS_ARRAY;
 import static io.trino.plugin.postgresql.PostgreSqlConfig.ArrayMapping.AS_JSON;
 import static io.trino.plugin.postgresql.PostgreSqlConfig.ArrayMapping.DISABLED;
 import static io.trino.plugin.postgresql.PostgreSqlSessionProperties.getArrayMapping;
+import static io.trino.plugin.postgresql.PostgreSqlSessionProperties.getJdbcFetchSize;
 import static io.trino.plugin.postgresql.PostgreSqlSessionProperties.isEnableStringPushdownWithCollate;
 import static io.trino.plugin.postgresql.TypeUtils.arrayDepth;
 import static io.trino.plugin.postgresql.TypeUtils.getArrayElementPgTypeName;
@@ -378,13 +379,13 @@ public class PostgreSqlClient
     }
 
     @Override
-    public PreparedStatement getPreparedStatement(Connection connection, String sql)
+    public PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
             throws SQLException
     {
         // fetch-size is ignored when connection is in auto-commit
         connection.setAutoCommit(false);
         PreparedStatement statement = connection.prepareStatement(sql);
-        statement.setFetchSize(1000);
+        statement.setFetchSize(getJdbcFetchSize(session));
         return statement;
     }
 

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlConfig.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlConfig.java
@@ -23,6 +23,7 @@ public class PostgreSqlConfig
     private ArrayMapping arrayMapping = ArrayMapping.DISABLED;
     private boolean includeSystemTables;
     private boolean enableStringPushdownWithCollate;
+    private int jdbcFetchSize = 1000;
 
     public enum ArrayMapping
     {
@@ -66,6 +67,18 @@ public class PostgreSqlConfig
     public PostgreSqlConfig setEnableStringPushdownWithCollate(boolean enableStringPushdownWithCollate)
     {
         this.enableStringPushdownWithCollate = enableStringPushdownWithCollate;
+        return this;
+    }
+
+    public int getJdbcFetchSize()
+    {
+        return jdbcFetchSize;
+    }
+
+    @Config("postgresql.jdbc-fetch-size")
+    public PostgreSqlConfig setJdbcFetchSize(int jdbcFetchSize)
+    {
+        this.jdbcFetchSize = jdbcFetchSize;
         return this;
     }
 }

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlSessionProperties.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlSessionProperties.java
@@ -25,12 +25,14 @@ import java.util.List;
 
 import static io.trino.spi.session.PropertyMetadata.booleanProperty;
 import static io.trino.spi.session.PropertyMetadata.enumProperty;
+import static io.trino.spi.session.PropertyMetadata.integerProperty;
 
 public final class PostgreSqlSessionProperties
         implements SessionPropertiesProvider
 {
     public static final String ARRAY_MAPPING = "array_mapping";
     public static final String ENABLE_STRING_PUSHDOWN_WITH_COLLATE = "enable_string_pushdown_with_collate";
+    public static final String JDBC_FETCH_SIZE = "jdbc_fetch_size";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -48,6 +50,11 @@ public final class PostgreSqlSessionProperties
                         ENABLE_STRING_PUSHDOWN_WITH_COLLATE,
                         "Enable string pushdown with collate (experimental)",
                         postgreSqlConfig.isEnableStringPushdownWithCollate(),
+                        false),
+                integerProperty(
+                        JDBC_FETCH_SIZE,
+                        "A hit number for postgresql JDBC driver for fetching the result rows",
+                        postgreSqlConfig.getJdbcFetchSize(),
                         false));
     }
 
@@ -65,5 +72,10 @@ public final class PostgreSqlSessionProperties
     public static boolean isEnableStringPushdownWithCollate(ConnectorSession session)
     {
         return session.getProperty(ENABLE_STRING_PUSHDOWN_WITH_COLLATE, Boolean.class);
+    }
+
+    public static int getJdbcFetchSize(ConnectorSession session)
+    {
+        return session.getProperty(JDBC_FETCH_SIZE, Integer.class);
     }
 }

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConfig.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConfig.java
@@ -30,7 +30,8 @@ public class TestPostgreSqlConfig
         assertRecordedDefaults(recordDefaults(PostgreSqlConfig.class)
                 .setArrayMapping(PostgreSqlConfig.ArrayMapping.DISABLED)
                 .setIncludeSystemTables(false)
-                .setEnableStringPushdownWithCollate(false));
+                .setEnableStringPushdownWithCollate(false)
+                .setJdbcFetchSize(1000));
     }
 
     @Test
@@ -40,12 +41,14 @@ public class TestPostgreSqlConfig
                 .put("postgresql.array-mapping", "AS_ARRAY")
                 .put("postgresql.include-system-tables", "true")
                 .put("postgresql.experimental.enable-string-pushdown-with-collate", "true")
+                .put("postgresql.jdbc-fetch-size", "2000")
                 .buildOrThrow();
 
         PostgreSqlConfig expected = new PostgreSqlConfig()
                 .setArrayMapping(PostgreSqlConfig.ArrayMapping.AS_ARRAY)
                 .setIncludeSystemTables(true)
-                .setEnableStringPushdownWithCollate(true);
+                .setEnableStringPushdownWithCollate(true)
+                .setJdbcFetchSize(2000);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
@@ -404,7 +404,7 @@ public class RedshiftClient
     }
 
     @Override
-    public PreparedStatement getPreparedStatement(Connection connection, String sql)
+    public PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
             throws SQLException
     {
         // In PostgreSQL, fetch-size is ignored when connection is in auto-commit. Redshift JDBC documentation does not state this requirement

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftConfig.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftConfig.java
@@ -18,6 +18,7 @@ import io.airlift.configuration.Config;
 public class RedshiftConfig
 {
     private boolean legacyTypeMapping;
+    private int jdbcFetchSize = 1000;
 
     public boolean isLegacyTypeMapping()
     {
@@ -28,6 +29,18 @@ public class RedshiftConfig
     public RedshiftConfig setLegacyTypeMapping(boolean legacyTypeMapping)
     {
         this.legacyTypeMapping = legacyTypeMapping;
+        return this;
+    }
+
+    public int getJdbcFetchSize()
+    {
+        return jdbcFetchSize;
+    }
+
+    @Config("redshift.jdbc-fetch-size")
+    public RedshiftConfig setJdbcFetchSize(int jdbcFetchSize)
+    {
+        this.jdbcFetchSize = jdbcFetchSize;
         return this;
     }
 }

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConfig.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConfig.java
@@ -28,7 +28,8 @@ public class TestRedshiftConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(RedshiftConfig.class)
-                .setLegacyTypeMapping(false));
+                .setLegacyTypeMapping(false)
+                .setJdbcFetchSize(1000));
     }
 
     @Test
@@ -36,10 +37,12 @@ public class TestRedshiftConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("redshift.use-legacy-type-mapping", "true")
+                .put("redshift.jdbc-fetch-size", "2000")
                 .buildOrThrow();
 
         RedshiftConfig expected = new RedshiftConfig()
-                .setLegacyTypeMapping(true);
+                .setLegacyTypeMapping(true)
+                .setJdbcFetchSize(2000);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Solve https://github.com/trinodb/trino/issues/16153
Removed the magic number `1000` in the pg/oracle/redshift client.
Added `jdbc-fetch-size` configuration for pg/oracle/redshift connector. 


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
() Release notes are required, with the following suggested text:

```markdown
# Section
* Allow Postgresql, Oracle, Redshift set jdbc fetch size. ({issue}`16153`)
```
