### PR TITLE
Add deflate codec to Hive formats

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/compression/CompressionKind.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/compression/CompressionKind.java
@@ -20,6 +20,7 @@ import io.airlift.compress.lz4.Lz4Codec;
 import io.airlift.compress.lzo.LzoCodec;
 import io.airlift.compress.lzo.LzopCodec;
 import io.airlift.compress.snappy.SnappyCodec;
+import org.apache.hadoop.io.compress.DefaultCodec;
 
 import java.util.Arrays;
 import java.util.List;
@@ -66,6 +67,15 @@ public enum CompressionKind
         public Codec createCodec()
         {
             return new AircompressorCodec(new JdkGzipCodec());
+        }
+    },
+    DEFLATE(".deflate", "org.apache.hadoop.io.compress.DefaultCodec") {
+        @Override
+        public Codec createCodec()
+        {
+            DefaultCodec codec = new DefaultCodec();
+            codec.setConf(newEmptyConfiguration());
+            return new HadoopCodec(codec);
         }
     },
     ZSTD(".zst", "org.apache.hadoop.io.compress.ZStandardCodec") {

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/FormatTestUtils.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/FormatTestUtils.java
@@ -129,6 +129,7 @@ public final class FormatTestUtils
             .add(Optional.of(CompressionKind.SNAPPY))
             .add(Optional.of(CompressionKind.LZ4))
             .add(Optional.of(CompressionKind.GZIP))
+            .add(Optional.of(CompressionKind.DEFLATE))
             .add(Optional.of(CompressionKind.ZSTD))
             .add(Optional.of(CompressionKind.LZO))
             .add(Optional.of(CompressionKind.LZOP))


### PR DESCRIPTION
## Description
Add missing support for Hadoop `DefaultCodec` (a.k.a., `DEFLATE`) to Hive formats.

Fixes #16250

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Add support for Hadoop `DefaultCodec` to Hive formats. ({issue}`16250`)
```
