### PR TITLE
Add black scholes

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathFunctions.java
@@ -3573,4 +3573,25 @@ public class TestMathFunctions
         assertThat(assertions.function("wilson_interval_upper", "1250", "1310", "1.96e0"))
                 .isEqualTo(0.9642524717143908);
     }
+
+    @Test
+    public void testBSEuropeanOption() {
+        assertThat(assertions.function("bs_european_option", "500", "450", "1", ".05", ".15", "call"))
+                .isEqualTo(77.33579531627726);
+
+        assertThat(assertions.function("bs_european_option", "450", "500", "1", ".05", ".15", "put"))
+                .isEqualTo(42.335680830637045);
+
+        assertTrinoExceptionThrownBy(() -> assertions.function("bs_european_option", "0", "500", "1", ".05", ".15", "put").evaluate())
+                .hasMessage("stockPrice must be > 0");
+
+        assertTrinoExceptionThrownBy(() -> assertions.function("bs_european_option", "450", "0", "1", ".05", ".15", "put").evaluate())
+                .hasMessage("strikePrice must be > 0");
+
+        assertTrinoExceptionThrownBy(() -> assertions.function("bs_european_option", "450", "500", "0", ".05", ".15", "put").evaluate())
+                .hasMessage("timeToExpiration must be > 0");
+
+        assertTrinoExceptionThrownBy(() -> assertions.function("bs_european_option", "450", "500", "1", ".05", ".15", "foo").evaluate())
+                .hasMessage("optionType must be call or put");
+    }
 }

--- a/docs/src/main/sphinx/functions.rst
+++ b/docs/src/main/sphinx/functions.rst
@@ -28,6 +28,7 @@ and the :doc:`SQL statement and syntax reference</sql>`.
     Conversion          <functions/conversion>
     Date and time       <functions/datetime>
     Decimal             <functions/decimal>
+    Financial           <functions/financial>
     Geospatial          <functions/geospatial>
     HyperLogLog         <functions/hyperloglog>
     IP Address          <functions/ipaddress>

--- a/docs/src/main/sphinx/functions/Financial.rst
+++ b/docs/src/main/sphinx/functions/Financial.rst
@@ -1,0 +1,28 @@
+==============================
+Financial Functions and Models
+==============================
+
+Functions and models providing financial calculations and analysis. Intended for
+educational and illustrative purposes only and should not be used for making
+investment decisions. Models may not accurately reflect actual market prices or the
+behavior of stock prices in the real world.
+
+Black-Scholes Model
+-------------------
+
+.. function:: bsEuropeanOption(stockPrice, strikePrice, timeToExpiration, riskFreeRate, volatility, optionType) -> double
+
+    Returns a numeric expression representing the theoretical price of the option,
+    based on the Black-Scholes model.
+
+        SELECT bsEuropeanOption(100, 110, 1, 0.05, 0.2, 'call');
+        -- 5.94327393259265
+        SELECT bsEuropeanOption(100, 90, 0.5, 0.02, 0.3, 'put');
+        -- 5.48771157975784
+
+    ``stockPrice``: A numeric expression representing the current stock price.
+    ``strikePrice``: A numeric expression representing the strike price of the option.
+    ``timeToExpiration``: A numeric expression representing the time in until expiration of the option, in years.
+    ``riskFreeRate``: A numeric expression representing the risk-free interest rate, expressed as a decimal.
+    ``volatility``: A numeric expression representing the annualized volatility of the stock, expressed as a decimal.
+    ``optionType``: A string expression representing the type of option, either "call" or "put".


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Adds a functions [bsEuropeanOption()] in mathfunctions.java. This function is given by: 

<img width="355" alt="Screen Shot 2023-02-26 at 1 20 56 PM" src="https://user-images.githubusercontent.com/4753829/221437980-83a96ca7-70cb-4454-bf30-8430733f85a9.png">

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

These functions are used for options valuation. They are useful for any quantitative finance analyst. I have checked return values and added tests. 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
