### PR TITLE
Make JDBC write parallelism configurable

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -61,6 +61,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -81,6 +82,7 @@ import static io.trino.plugin.jdbc.CaseSensitivity.CASE_INSENSITIVE;
 import static io.trino.plugin.jdbc.CaseSensitivity.CASE_SENSITIVE;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static io.trino.plugin.jdbc.JdbcWriteSessionProperties.getWriteBatchSize;
+import static io.trino.plugin.jdbc.JdbcWriteSessionProperties.getWriteParallelism;
 import static io.trino.plugin.jdbc.JdbcWriteSessionProperties.isNonTransactionalInsert;
 import static io.trino.plugin.jdbc.PredicatePushdownController.DISABLE_PUSHDOWN;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharReadFunction;
@@ -1340,6 +1342,12 @@ public abstract class BaseJdbcClient
         verify(handle.getAuthorization().isEmpty(), "Unexpected authorization is required for table: %s".formatted(handle));
         String sql = "TRUNCATE TABLE " + quoted(handle.asPlainTable().getRemoteTableName());
         execute(session, sql);
+    }
+
+    @Override
+    public OptionalInt getMaxWriteParallelism(ConnectorSession session)
+    {
+        return OptionalInt.of(getWriteParallelism(session));
     }
 
     protected void verifySchemaName(DatabaseMetaData databaseMetadata, String schemaName)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -54,6 +54,7 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -563,6 +564,12 @@ public class CachingJdbcClient
     public Optional<TableScanRedirectApplicationResult> getTableScanRedirection(ConnectorSession session, JdbcTableHandle tableHandle)
     {
         return delegate.getTableScanRedirection(session, tableHandle);
+    }
+
+    @Override
+    public OptionalInt getMaxWriteParallelism(ConnectorSession session)
+    {
+        return delegate.getMaxWriteParallelism(session);
     }
 
     public void onDataChanged(SchemaTableName table)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -72,6 +72,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -992,6 +993,12 @@ public class DefaultJdbcMetadata
     public void renameSchema(ConnectorSession session, String schemaName, String newSchemaName)
     {
         jdbcClient.renameSchema(session, schemaName, newSchemaName);
+    }
+
+    @Override
+    public OptionalInt getMaxWriterTasks(ConnectorSession session)
+    {
+        return jdbcClient.getMaxWriteParallelism(session);
     }
 
     private static boolean isTableHandleForProcedure(ConnectorTableHandle tableHandle)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -39,6 +39,7 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -430,5 +431,11 @@ public abstract class ForwardingJdbcClient
     public void truncateTable(ConnectorSession session, JdbcTableHandle handle)
     {
         delegate().truncateTable(session, handle);
+    }
+
+    @Override
+    public OptionalInt getMaxWriteParallelism(ConnectorSession session)
+    {
+        return delegate().getMaxWriteParallelism(session);
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
@@ -40,6 +40,7 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 
@@ -229,4 +230,6 @@ public interface JdbcClient
     OptionalLong delete(ConnectorSession session, JdbcTableHandle handle);
 
     void truncateTable(ConnectorSession session, JdbcTableHandle handle);
+
+    OptionalInt getMaxWriteParallelism(ConnectorSession session);
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcWriteConfig.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcWriteConfig.java
@@ -22,8 +22,10 @@ import javax.validation.constraints.Min;
 public class JdbcWriteConfig
 {
     public static final int MAX_ALLOWED_WRITE_BATCH_SIZE = 10_000_000;
+    static final int DEFAULT_WRITE_PARALELLISM = 8;
 
     private int writeBatchSize = 1000;
+    private int writeParallelism = DEFAULT_WRITE_PARALELLISM;
 
     // Do not create temporary table during insert.
     // This means that the write operation can fail and leave the table in an inconsistent state.
@@ -55,6 +57,21 @@ public class JdbcWriteConfig
     public JdbcWriteConfig setNonTransactionalInsert(boolean nonTransactionalInsert)
     {
         this.nonTransactionalInsert = nonTransactionalInsert;
+        return this;
+    }
+
+    @Min(1)
+    @Max(128)
+    public int getWriteParallelism()
+    {
+        return writeParallelism;
+    }
+
+    @Config("write.parallelism")
+    @ConfigDescription("Maximum number of parallel write tasks")
+    public JdbcWriteConfig setWriteParallelism(int writeParallelism)
+    {
+        this.writeParallelism = writeParallelism;
         return this;
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcWriteSessionProperties.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcWriteSessionProperties.java
@@ -33,6 +33,7 @@ public class JdbcWriteSessionProperties
 {
     public static final String WRITE_BATCH_SIZE = "write_batch_size";
     public static final String NON_TRANSACTIONAL_INSERT = "non_transactional_insert";
+    public static final String WRITE_PARALLELISM = "write_parallelism";
 
     private final List<PropertyMetadata<?>> properties;
 
@@ -51,6 +52,11 @@ public class JdbcWriteSessionProperties
                         "Do not use temporary table on insert to table",
                         writeConfig.isNonTransactionalInsert(),
                         false))
+                .add(integerProperty(
+                        WRITE_PARALLELISM,
+                        "Maximum number of parallel write tasks",
+                        writeConfig.getWriteParallelism(),
+                        false))
                 .build();
     }
 
@@ -63,6 +69,11 @@ public class JdbcWriteSessionProperties
     public static int getWriteBatchSize(ConnectorSession session)
     {
         return session.getProperty(WRITE_BATCH_SIZE, Integer.class);
+    }
+
+    public static int getWriteParallelism(ConnectorSession session)
+    {
+        return session.getProperty(WRITE_PARALLELISM, Integer.class);
     }
 
     public static boolean isNonTransactionalInsert(ConnectorSession session)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -56,6 +56,7 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 
@@ -450,5 +451,11 @@ public final class StatisticsAwareJdbcClient
     public void truncateTable(ConnectorSession session, JdbcTableHandle handle)
     {
         stats.getTruncateTable().wrap(() -> delegate().truncateTable(session, handle));
+    }
+
+    @Override
+    public OptionalInt getMaxWriteParallelism(ConnectorSession session)
+    {
+        return delegate().getMaxWriteParallelism(session);
     }
 }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcWriteConfig.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcWriteConfig.java
@@ -33,6 +33,7 @@ public class TestJdbcWriteConfig
     {
         assertRecordedDefaults(recordDefaults(JdbcWriteConfig.class)
                 .setWriteBatchSize(1000)
+                .setWriteParallelism(8)
                 .setNonTransactionalInsert(false));
     }
 
@@ -42,11 +43,13 @@ public class TestJdbcWriteConfig
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("write.batch-size", "24")
                 .put("insert.non-transactional-insert.enabled", "true")
+                .put("write.parallelism", "16")
                 .buildOrThrow();
 
         JdbcWriteConfig expected = new JdbcWriteConfig()
                 .setWriteBatchSize(24)
-                .setNonTransactionalInsert(true);
+                .setNonTransactionalInsert(true)
+                .setWriteParallelism(16);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Added an option query.max-writer-nodes-count to QueryManagerConfig and
a session option that limits number of tasks that take part in writing
nodes.<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
