### PR TITLE
Add column test with CTAS in BaseConnectorTest

### DIFF
--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
@@ -112,16 +112,28 @@ public class TestMongoConnectorTest
 
     @Test(dataProvider = "testColumnNameDataProvider")
     @Override
-    public void testColumnName(String columnName)
+    public void testColumnNameWithCreateAndInsert(String columnName)
     {
         if (columnName.equals("a.dot")) {
-            assertThatThrownBy(() -> super.testColumnName(columnName))
+            assertThatThrownBy(() -> super.testColumnNameWithCreateAndInsert(columnName))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessage("Column name must not contain '$' or '.' for INSERT: " + columnName);
             throw new SkipException("Insert would fail");
         }
 
-        super.testColumnName(columnName);
+        super.testColumnNameWithCreateAndInsert(columnName);
+    }
+
+    @Test(dataProvider = "testColumnNameDataProvider")
+    @Override
+    public void testColumnNameWithCreateAsSelect(String columnName)
+    {
+        if (columnName.equals("a.dot")) {
+            // TODO: Enable the test
+            throw new SkipException("Not implement yet");
+        }
+
+        super.testColumnNameWithCreateAsSelect(columnName);
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Add test in BaseConnectorTest for allowing column test with CTAS
`testColumnNameWithCreateAsSelect`

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Renamed the `testColumnName` to `testColumnNameWithCreateAndInsert`

Added a test for allowing the column test with CTAS statement to create test table and data

Remove unnecessary override test `testColumnName`(renamed `testColumnNameWithCreateAndInsert`) by override `createTableByCreateAndInsertForTestingColumnName` method.

Implement the added test `testColumnNameWithCreateAsSelect` for Kudu and Mongodb.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
