### PR TITLE
Fix jdbc ResultSet getBoolean throw ClassCastException

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/AbstractTrinoResultSet.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/AbstractTrinoResultSet.java
@@ -260,7 +260,13 @@ abstract class AbstractTrinoResultSet
             throws SQLException
     {
         Object value = column(columnIndex);
-        return (value != null) ? (Boolean) value : false;
+        if (value == null) {
+            return false;
+        }
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        throw new SQLException("Value is not a boolean: " + value);
     }
 
     @Override

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/BaseTestJdbcResultSet.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/BaseTestJdbcResultSet.java
@@ -123,6 +123,10 @@ public abstract class BaseTestJdbcResultSet
                         .isInstanceOf(SQLException.class)
                         .hasMessage("Value is not a number: ");
 
+                assertThatThrownBy(() -> rs.getBoolean(column))
+                        .isInstanceOf(SQLException.class)
+                        .hasMessage("Value is not a boolean: ");
+
                 assertThat(rs.getAsciiStream(column)).isEmpty();
             });
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
As JDBC specification, if a data conversion fails, then a SQLException will be raised. But getBoolean will cause a ClassCastException.

Fixes #16296

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
