### PR TITLE
Allow the check-commits to be marked as success instead of skipped

### DIFF
--- a/.github/bin/prepare-check-commits-matrix.py
+++ b/.github/bin/prepare-check-commits-matrix.py
@@ -70,6 +70,12 @@ def build(input_file, output_file):
         json.dump(
             {"include": [{"commit": commit} for commit in commits]}, output_file, separators=(",", ":"), sort_keys=True
         )
+    else:
+        # Produce a valid matrix with an empty commit so the check-commit job
+        # can still succeed and not show up as skipped
+        json.dump(
+            {"include": [{"commit": ""}]}, output_file, separators=(",", ":"), sort_keys=True
+        )
 
 
 def has_followup(entries, i, commit_hash, subject):
@@ -87,8 +93,8 @@ class TestBuild(unittest.TestCase):
 
     def test_build(self):
         cases = [
-            ("Empty test", (), []),
-            ("Malformed input test", ("c1,t1\n"), []),
+            ("Empty test", (), ['{"include":[{"commit":""}]}']),
+            ("Malformed input test", ("c1,t1\n"), ['{"include":[{"commit":""}]}']),
             ("Basic test", ("c1,t1,Hello World\n",), ['{"include":[{"commit":"c1"}]}']),
             (
                 "Add a new entry",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,13 +127,8 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.check-commits-dispatcher.outputs.matrix) }}
     steps:
-      - name: Verify args
-        shell: bash
-        if: matrix.commit == ''
-        run: |
-          echo >&2 "Required 'commit' argument not provided"
-          exit 1
       - uses: actions/checkout@v3
+        if: matrix.commit != ''
         with:
           fetch-depth: 0 # checkout all commits to be able to determine merge base
           ref: ${{ matrix.commit }}
@@ -142,6 +137,7 @@ jobs:
       # PR HEAD since that is the commit the workflow is started for. This could lead to problems if those parameters were changed
       # in the middle of a PR branch.
       - uses: ./.github/actions/compile-commit
+        if: matrix.commit != ''
         with:
           base_ref: ${{ github.event.pull_request.base.ref }}
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Allow the check-commits to be marked as success instead of skipped, so the list of checks in the web view of a PR can be collapsed by default.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
