### PR TITLE
Eagerly discard FileSingleStreamSpiller encryption keys

### DIFF
--- a/core/trino-main/src/test/java/io/trino/spiller/TestFileSingleStreamSpiller.java
+++ b/core/trino-main/src/test/java/io/trino/spiller/TestFileSingleStreamSpiller.java
@@ -48,6 +48,7 @@ import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.Double.doubleToLongBits;
 import static java.nio.file.Files.newInputStream;
 import static java.util.concurrent.Executors.newCachedThreadPool;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -150,6 +151,11 @@ public class TestFileSingleStreamSpiller
         for (int i = 0; i < 4; ++i) {
             PageAssertions.assertPageEquals(TYPES, page, spilledPages.get(i));
         }
+
+        // Repeated reads are disallowed
+        assertThatThrownBy(spiller::getSpilledPages)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Repeated reads are disallowed to prevent potential resource leaks");
 
         spiller.close();
         assertEquals(listFiles(spillPath.toPath()).size(), 0);


### PR DESCRIPTION
## Description
Avoids retaining spill to disk encryption keys as part of `FileSingleStreamSpiller` instances after they are closed or the final read-back begins, making them unreachable and eligible for garbage collection sooner.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
