### PR TITLE
Remove override tests 'testAddColumnWithComment' and 'testAddColumnW…

### DIFF
--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorTest.java
@@ -49,7 +49,6 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 public abstract class BaseClickHouseConnectorTest
@@ -104,16 +103,6 @@ public abstract class BaseClickHouseConnectorTest
     {
         // ClickHouse need resets all data in a column for specified column which to be renamed
         throw new SkipException("TODO: test not implemented yet");
-    }
-
-    @Override
-    public void testAddColumnWithCommentSpecialCharacter(String comment)
-    {
-        // Override because default storage engine doesn't support renaming columns
-        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_add_column_", "(a_varchar varchar NOT NULL) WITH (engine = 'mergetree', order_by = ARRAY['a_varchar'])")) {
-            assertUpdate("ALTER TABLE " + table.getName() + " ADD COLUMN b_varchar varchar COMMENT " + varcharLiteral(comment));
-            assertEquals(getColumnComment(table.getName(), "b_varchar"), comment);
-        }
     }
 
     @Override
@@ -214,20 +203,10 @@ public abstract class BaseClickHouseConnectorTest
         }
     }
 
-    @Test
     @Override
-    public void testAddColumnWithComment()
+    protected String tableDefinitionForAddingColumnWithComment()
     {
-        // Override because the default storage type doesn't support adding columns
-        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_add_col_desc_", "(a_varchar varchar NOT NULL) WITH (engine = 'MergeTree', order_by = ARRAY['a_varchar'])")) {
-            String tableName = table.getName();
-
-            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN b_varchar varchar COMMENT 'test new column comment'");
-            assertThat(getColumnComment(tableName, "b_varchar")).isEqualTo("test new column comment");
-
-            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN empty_comment varchar COMMENT ''");
-            assertNull(getColumnComment(tableName, "empty_comment"));
-        }
+        return "(a_varchar varchar NOT NULL) WITH (engine = 'MergeTree', order_by = ARRAY['a_varchar'])";
     }
 
     @Override

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -2088,15 +2088,23 @@ public abstract class BaseConnectorTest
             return;
         }
 
-        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_add_col_desc_", "(a_varchar varchar)")) {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_add_col_desc_", tableDefinitionForAddingColumnWithComment())) {
             String tableName = table.getName();
 
             assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN b_varchar varchar COMMENT 'test new column comment'");
             assertThat(getColumnComment(tableName, "b_varchar")).isEqualTo("test new column comment");
 
             assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN empty_comment varchar COMMENT ''");
-            assertEquals(getColumnComment(tableName, "empty_comment"), "");
+            assertThat(getColumnComment(tableName, "empty_comment")).isIn("", null); // Some storages do not preserve empty comment
         }
+    }
+
+    /**
+     * The column definition of the table for test adding column with comment, at least contain a varchar type named 'a_varchar'
+     */
+    protected String tableDefinitionForAddingColumnWithComment()
+    {
+        return "(a_varchar varchar)";
     }
 
     @Test
@@ -4615,7 +4623,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_ADD_COLUMN_WITH_COMMENT));
 
-        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_add_col_", "(a_varchar varchar)")) {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_add_col_", tableDefinitionForAddingColumnWithComment())) {
             assertUpdate("ALTER TABLE " + table.getName() + " ADD COLUMN b_varchar varchar COMMENT " + varcharLiteral(comment));
             assertEquals(getColumnComment(table.getName(), "b_varchar"), comment);
         }


### PR DESCRIPTION
…ithCommentSpecialCharacter' in ClickHouse

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Added test method 'tableDefinitionForAddingColumnWithComment' in BaseConnectorTest.
Override the method for ClickHouse connector so we can remove unnecessary override for the tests  'testAddColumnWithComment' and 'testAddColumnWithCommentSpecialCharacter'.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

