### PR TITLE
Remove override test 'testAddNotNullColumnToNonEmptyTable' in ClickHouse

### DIFF
--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorTest.java
@@ -196,22 +196,9 @@ public abstract class BaseClickHouseConnectorTest
     }
 
     @Override
-    public void testAddNotNullColumnToNonEmptyTable()
+    protected String tableDefinitionForAddingNotNullColumnToNonEmptyTable()
     {
-        // Override because the default storage type doesn't support adding columns
-        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_add_notnull_col", "(a_varchar varchar NOT NULL)  WITH (engine = 'MergeTree', order_by = ARRAY['a_varchar'])")) {
-            String tableName = table.getName();
-
-            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN b_varchar varchar NOT NULL");
-            assertFalse(columnIsNullable(tableName, "b_varchar"));
-
-            assertUpdate("INSERT INTO " + tableName + " VALUES ('a', 'b')", 1);
-
-            // ClickHouse set an empty character as the default value
-            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN c_varchar varchar NOT NULL");
-            assertFalse(columnIsNullable(tableName, "c_varchar"));
-            assertQuery("SELECT c_varchar FROM " + tableName, "VALUES ''");
-        }
+        return "(a_varchar varchar NOT NULL) WITH (engine = 'MergeTree', order_by = ARRAY['a_varchar'])";
     }
 
     @Test

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -2111,7 +2111,7 @@ public abstract class BaseConnectorTest
             return;
         }
 
-        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_add_notnull_col", "(a_varchar varchar)")) {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_add_notnull_col", tableDefinitionForAddingNotNullColumnToNonEmptyTable())) {
             String tableName = table.getName();
 
             assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN b_varchar varchar NOT NULL");
@@ -2128,6 +2128,14 @@ public abstract class BaseConnectorTest
                 verifyAddNotNullColumnToNonEmptyTableFailurePermissible(e);
             }
         }
+    }
+
+    /**
+     * The table must have only one varchar type column
+     */
+    protected String tableDefinitionForAddingNotNullColumnToNonEmptyTable()
+    {
+        return "(a_varchar varchar)";
     }
 
     protected boolean columnIsNullable(String tableName, String columnName)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Remove the override test 'testAddNotNullColumnToNonEmptyTable' in ClickHouse connector test.
Added 'tableDefinitionForAddingNotNullColumnToNonEmptyTable' and override the method for ClickHouse.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:


