### PR TITLE
Reuse AggregtaionAnalyzer when verifying source and orderby aggregations

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
@@ -128,26 +128,30 @@ class AggregationAnalyzer
     public static void verifySourceAggregations(
             List<Expression> groupByExpressions,
             Scope sourceScope,
-            Expression expression,
+            List<Expression> expressions,
             Session session,
             Metadata metadata,
             Analysis analysis)
     {
         AggregationAnalyzer analyzer = new AggregationAnalyzer(groupByExpressions, sourceScope, Optional.empty(), session, metadata, analysis);
-        analyzer.analyze(expression);
+        for (Expression expression : expressions) {
+            analyzer.analyze(expression);
+        }
     }
 
     public static void verifyOrderByAggregations(
             List<Expression> groupByExpressions,
             Scope sourceScope,
             Scope orderByScope,
-            Expression expression,
+            List<Expression> expressions,
             Session session,
             Metadata metadata,
             Analysis analysis)
     {
         AggregationAnalyzer analyzer = new AggregationAnalyzer(groupByExpressions, sourceScope, Optional.of(orderByScope), session, metadata, analysis);
-        analyzer.analyze(expression);
+        for (Expression expression : expressions) {
+            analyzer.analyze(expression);
+        }
     }
 
     private AggregationAnalyzer(

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -4480,12 +4480,9 @@ class StatementAnalyzer
                 //     SELECT a + sum(b) GROUP BY a
                 List<Expression> distinctGroupingColumns = ImmutableSet.copyOf(groupByAnalysis.getOriginalExpressions()).asList();
 
-                for (Expression expression : outputExpressions) {
-                    verifySourceAggregations(distinctGroupingColumns, sourceScope, expression, session, metadata, analysis);
-                }
-
-                for (Expression expression : orderByExpressions) {
-                    verifyOrderByAggregations(distinctGroupingColumns, sourceScope, orderByScope.orElseThrow(), expression, session, metadata, analysis);
+                verifySourceAggregations(distinctGroupingColumns, sourceScope, outputExpressions, session, metadata, analysis);
+                if (!orderByExpressions.isEmpty()) {
+                    verifyOrderByAggregations(distinctGroupingColumns, sourceScope, orderByScope.orElseThrow(), orderByExpressions, session, metadata, analysis);
                 }
             }
         }


### PR DESCRIPTION
## Description
Complementary to https://github.com/trinodb/trino/pull/16198.
Instead of creating `AggregationAnalyzer` for verifying each source column we reuse the analyzer for all source columns. Similar approach has been implemented for orderby column as well.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
