### PR TITLE
Support inserting default values in BigQuery

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -540,6 +540,12 @@ public class BigQueryMetadata
     }
 
     @Override
+    public boolean supportsMissingColumnsOnInsert()
+    {
+        return true;
+    }
+
+    @Override
     public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> columns, RetryMode retryMode)
     {
         BigQueryTableHandle table = (BigQueryTableHandle) tableHandle;

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -845,7 +845,14 @@ public abstract class BaseBigQueryConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        throw new SkipException("BigQuery connector does not support column default values");
+        return new TestTable(
+                this::onBigQuery,
+                "test.test_table",
+                "(col_required INT64 NOT NULL," +
+                        "col_nullable INT64," +
+                        "col_default INT64 DEFAULT 43," +
+                        "col_nonnull_default INT64 DEFAULT 42 NOT NULL," +
+                        "col_required2 INT64 NOT NULL)");
     }
 
     @Override


### PR DESCRIPTION
## Description

Support inserting default values in BigQuery

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# BigQuery
* Add support for inserting default values. ({issue}`16327`)
```
