### PR TITLE
Use parent partitioning for aggregations

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -862,7 +862,7 @@ public class PlanOptimizers
             // unalias symbols before adding exchanges to use same partitioning symbols in joins, aggregations and other
             // operators that require node partitioning
             builder.add(new UnaliasSymbolReferences(metadata));
-            builder.add(new StatsRecordingPlanOptimizer(optimizerStats, new AddExchanges(plannerContext, typeAnalyzer, statsCalculator)));
+            builder.add(new StatsRecordingPlanOptimizer(optimizerStats, new AddExchanges(plannerContext, typeAnalyzer, statsCalculator, taskCountEstimator)));
             // It can only run after AddExchanges since it estimates the hash partition count for all remote exchanges
             builder.add(new StatsRecordingPlanOptimizer(optimizerStats, new DeterminePartitionCount(statsCalculator)));
         }

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -703,6 +703,11 @@ public class LocalQueryRunner
         return estimatedExchangesCostCalculator;
     }
 
+    public TaskCountEstimator getTaskCountEstimator()
+    {
+        return taskCountEstimator;
+    }
+
     @Override
     public TestingGroupProviderManager getGroupProvider()
     {

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestEliminateSorts.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestEliminateSorts.java
@@ -100,7 +100,7 @@ public class TestEliminateSorts
                         ImmutableSet.of(
                                 new RemoveRedundantIdentityProjections(),
                                 new DetermineTableScanNodePartitioning(getQueryRunner().getMetadata(), getQueryRunner().getNodePartitioningManager(), new TaskCountEstimator(() -> 10)))),
-                new AddExchanges(getQueryRunner().getPlannerContext(), typeAnalyzer, getQueryRunner().getStatsCalculator()));
+                new AddExchanges(getQueryRunner().getPlannerContext(), typeAnalyzer, getQueryRunner().getStatsCalculator(), getQueryRunner().getTaskCountEstimator()));
 
         assertPlan(sql, pattern, optimizers);
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestWindow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestWindow.java
@@ -207,11 +207,10 @@ public class TestWindow
                         window(pattern -> pattern
                                         .specification(specification(ImmutableList.of("custkey"), ImmutableList.of(), ImmutableMap.of()))
                                         .addFunction(functionCall("rank", Optional.empty(), ImmutableList.of())),
-                                exchange(LOCAL, GATHER,
-                                        exchange(REMOTE, REPARTITION,
-                                                project(aggregation(singleGroupingSet("shippriority", "custkey"), ImmutableMap.of(), Optional.empty(), FINAL,
-                                                        exchange(LOCAL, GATHER,
-                                                                exchange(REMOTE, REPARTITION,
-                                                                        anyTree(tableScan("orders", ImmutableMap.of("custkey", "custkey", "shippriority", "shippriority"))))))))))));
+                                project(aggregation(singleGroupingSet("shippriority", "custkey"), ImmutableMap.of(), Optional.empty(), FINAL,
+                                        exchange(LOCAL, GATHER,
+                                                project(
+                                                        exchange(REMOTE, REPARTITION,
+                                                                anyTree(tableScan("orders", ImmutableMap.of("custkey", "custkey", "shippriority", "shippriority")))))))))));
     }
 }

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q02.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q02.plan.txt
@@ -3,42 +3,36 @@ remote exchange (GATHER, SINGLE, [])
         remote exchange (REPARTITION, ROUND_ROBIN, [])
             join (INNER, PARTITIONED):
                 join (INNER, PARTITIONED):
-                    final aggregation over (d_week_seq)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["d_week_seq"])
-                                partial aggregation over (d_week_seq)
-                                    final aggregation over (d_day_name, d_week_seq)
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["d_day_name", "d_week_seq"])
-                                                partial aggregation over (d_day_name, d_week_seq)
-                                                    join (INNER, REPLICATED):
-                                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                                            scan web_sales
-                                                            scan catalog_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                    single aggregation over (d_week_seq)
+                        final aggregation over (d_day_name, d_week_seq)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["d_week_seq"])
+                                    partial aggregation over (d_day_name, d_week_seq)
+                                        join (INNER, REPLICATED):
+                                            remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                scan web_sales
+                                                scan catalog_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["d_week_seq_23"])
                             scan date_dim
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["expr_229"])
                         join (INNER, PARTITIONED):
-                            final aggregation over (d_week_seq_132)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["d_week_seq_132"])
-                                        partial aggregation over (d_week_seq_132)
-                                            final aggregation over (d_day_name_142, d_week_seq_132)
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["d_day_name_142", "d_week_seq_132"])
-                                                        partial aggregation over (d_day_name_142, d_week_seq_132)
-                                                            join (INNER, REPLICATED):
-                                                                remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                                                    scan web_sales
-                                                                    scan catalog_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan date_dim
+                            single aggregation over (d_week_seq_132)
+                                final aggregation over (d_day_name_142, d_week_seq_132)
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["d_week_seq_132"])
+                                            partial aggregation over (d_day_name_142, d_week_seq_132)
+                                                join (INNER, REPLICATED):
+                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                        scan web_sales
+                                                        scan catalog_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["d_week_seq_178"])
                                     scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q04.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q04.plan.txt
@@ -2,101 +2,90 @@ local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
             join (INNER, PARTITIONED):
-                remote exchange (REPARTITION, HASH, ["c_customer_id"])
-                    final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["c_birth_country", "c_customer_id", "c_email_address", "c_first_name", "c_last_name", "c_login", "c_preferred_cust_flag", "d_year"])
-                                partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                scan customer
-                local exchange (GATHER, SINGLE, [])
-                    join (INNER, PARTITIONED):
-                        join (INNER, PARTITIONED):
-                            remote exchange (REPARTITION, HASH, ["c_customer_id_574"])
-                                final aggregation over (c_birth_country_587, c_customer_id_574, c_email_address_589, c_first_name_581, c_last_name_582, c_login_588, c_preferred_cust_flag_583, d_year_638)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["c_birth_country_587", "c_customer_id_574", "c_email_address_589", "c_first_name_581", "c_last_name_582", "c_login_588", "c_preferred_cust_flag_583", "d_year_638"])
-                                            partial aggregation over (c_birth_country_587, c_customer_id_574, c_email_address_589, c_first_name_581, c_last_name_582, c_login_588, c_preferred_cust_flag_583, d_year_638)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_573"])
-                                                        scan customer
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_596"])
-                                                            join (INNER, REPLICATED):
-                                                                scan catalog_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan date_dim
-                            local exchange (GATHER, SINGLE, [])
+                final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id"])
+                            partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
                                 join (INNER, PARTITIONED):
-                                    remote exchange (REPARTITION, HASH, ["c_customer_id_1611"])
-                                        final aggregation over (c_birth_country_1624, c_customer_id_1611, c_email_address_1626, c_first_name_1618, c_last_name_1619, c_login_1625, c_preferred_cust_flag_1620, d_year_1675)
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_birth_country_1624", "c_customer_id_1611", "c_email_address_1626", "c_first_name_1618", "c_last_name_1619", "c_login_1625", "c_preferred_cust_flag_1620", "d_year_1675"])
-                                                    partial aggregation over (c_birth_country_1624, c_customer_id_1611, c_email_address_1626, c_first_name_1618, c_last_name_1619, c_login_1625, c_preferred_cust_flag_1620, d_year_1675)
-                                                        join (INNER, PARTITIONED):
-                                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_1610"])
-                                                                scan customer
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1634"])
-                                                                    join (INNER, REPLICATED):
-                                                                        scan web_sales
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan date_dim
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
                                     local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["c_customer_id_1299"])
-                                            final aggregation over (c_birth_country_1312, c_customer_id_1299, c_email_address_1314, c_first_name_1306, c_last_name_1307, c_login_1313, c_preferred_cust_flag_1308, d_year_1363)
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                                            scan customer
+                join (INNER, PARTITIONED):
+                    join (INNER, PARTITIONED):
+                        final aggregation over (c_birth_country_587, c_customer_id_574, c_email_address_589, c_first_name_581, c_last_name_582, c_login_588, c_preferred_cust_flag_583, d_year_638)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["c_customer_id_574"])
+                                    partial aggregation over (c_birth_country_587, c_customer_id_574, c_email_address_589, c_first_name_581, c_last_name_582, c_login_588, c_preferred_cust_flag_583, d_year_638)
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_573"])
+                                                scan customer
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_596"])
+                                                    join (INNER, REPLICATED):
+                                                        scan catalog_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
+                        join (INNER, PARTITIONED):
+                            final aggregation over (c_birth_country_1624, c_customer_id_1611, c_email_address_1626, c_first_name_1618, c_last_name_1619, c_login_1625, c_preferred_cust_flag_1620, d_year_1675)
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPARTITION, HASH, ["c_customer_id_1611"])
+                                        partial aggregation over (c_birth_country_1624, c_customer_id_1611, c_email_address_1626, c_first_name_1618, c_last_name_1619, c_login_1625, c_preferred_cust_flag_1620, d_year_1675)
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_1610"])
+                                                    scan customer
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_birth_country_1312", "c_customer_id_1299", "c_email_address_1314", "c_first_name_1306", "c_last_name_1307", "c_login_1313", "c_preferred_cust_flag_1308", "d_year_1363"])
-                                                        partial aggregation over (c_birth_country_1312, c_customer_id_1299, c_email_address_1314, c_first_name_1306, c_last_name_1307, c_login_1313, c_preferred_cust_flag_1308, d_year_1363)
-                                                            join (INNER, PARTITIONED):
-                                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_1298"])
-                                                                    scan customer
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1322"])
-                                                                        join (INNER, REPLICATED):
-                                                                            scan web_sales
-                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan date_dim
+                                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1634"])
+                                                        join (INNER, REPLICATED):
+                                                            scan web_sales
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan date_dim
+                            final aggregation over (c_birth_country_1312, c_customer_id_1299, c_email_address_1314, c_first_name_1306, c_last_name_1307, c_login_1313, c_preferred_cust_flag_1308, d_year_1363)
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPARTITION, HASH, ["c_customer_id_1299"])
+                                        partial aggregation over (c_birth_country_1312, c_customer_id_1299, c_email_address_1314, c_first_name_1306, c_last_name_1307, c_login_1313, c_preferred_cust_flag_1308, d_year_1363)
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_1298"])
+                                                    scan customer
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1322"])
+                                                        join (INNER, REPLICATED):
+                                                            scan web_sales
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan date_dim
+                    final aggregation over (c_birth_country_899, c_customer_id_886, c_email_address_901, c_first_name_893, c_last_name_894, c_login_900, c_preferred_cust_flag_895, d_year_950)
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["c_customer_id_886"])
-                                final aggregation over (c_birth_country_899, c_customer_id_886, c_email_address_901, c_first_name_893, c_last_name_894, c_login_900, c_preferred_cust_flag_895, d_year_950)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["c_birth_country_899", "c_customer_id_886", "c_email_address_901", "c_first_name_893", "c_last_name_894", "c_login_900", "c_preferred_cust_flag_895", "d_year_950"])
-                                            partial aggregation over (c_birth_country_899, c_customer_id_886, c_email_address_901, c_first_name_893, c_last_name_894, c_login_900, c_preferred_cust_flag_895, d_year_950)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_885"])
-                                                        scan customer
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_908"])
-                                                            join (INNER, REPLICATED):
-                                                                scan catalog_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan date_dim
-            local exchange (GATHER, SINGLE, [])
-                remote exchange (REPARTITION, HASH, ["c_customer_id_172"])
-                    final aggregation over (c_birth_country_185, c_customer_id_172, c_email_address_187, c_first_name_179, c_last_name_180, c_login_186, c_preferred_cust_flag_181, d_year_225)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["c_birth_country_185", "c_customer_id_172", "c_email_address_187", "c_first_name_179", "c_last_name_180", "c_login_186", "c_preferred_cust_flag_181", "d_year_225"])
-                                partial aggregation over (c_birth_country_185, c_customer_id_172, c_email_address_187, c_first_name_179, c_last_name_180, c_login_186, c_preferred_cust_flag_181, d_year_225)
+                                partial aggregation over (c_birth_country_899, c_customer_id_886, c_email_address_901, c_first_name_893, c_last_name_894, c_login_900, c_preferred_cust_flag_895, d_year_950)
                                     join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["ss_customer_sk_194"])
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_885"])
+                                            scan customer
                                         local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_171"])
-                                                scan customer
+                                            remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_908"])
+                                                join (INNER, REPLICATED):
+                                                    scan catalog_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
+            final aggregation over (c_birth_country_185, c_customer_id_172, c_email_address_187, c_first_name_179, c_last_name_180, c_login_186, c_preferred_cust_flag_181, d_year_225)
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPARTITION, HASH, ["c_customer_id_172"])
+                        partial aggregation over (c_birth_country_185, c_customer_id_172, c_email_address_187, c_first_name_179, c_last_name_180, c_login_186, c_preferred_cust_flag_181, d_year_225)
+                            join (INNER, PARTITIONED):
+                                remote exchange (REPARTITION, HASH, ["ss_customer_sk_194"])
+                                    join (INNER, REPLICATED):
+                                        scan store_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_171"])
+                                        scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q11.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q11.plan.txt
@@ -1,68 +1,61 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
-            remote exchange (REPARTITION, HASH, ["c_customer_id_85"])
-                final aggregation over (c_birth_country_98, c_customer_id_85, c_email_address_100, c_first_name_92, c_last_name_93, c_login_99, c_preferred_cust_flag_94, d_year_138)
+            final aggregation over (c_birth_country_98, c_customer_id_85, c_email_address_100, c_first_name_92, c_last_name_93, c_login_99, c_preferred_cust_flag_94, d_year_138)
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPARTITION, HASH, ["c_customer_id_85"])
+                        partial aggregation over (c_birth_country_98, c_customer_id_85, c_email_address_100, c_first_name_92, c_last_name_93, c_login_99, c_preferred_cust_flag_94, d_year_138)
+                            join (INNER, PARTITIONED):
+                                remote exchange (REPARTITION, HASH, ["c_customer_sk_84"])
+                                    scan customer
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk_107"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+            join (INNER, PARTITIONED):
+                final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
                     local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["c_birth_country_98", "c_customer_id_85", "c_email_address_100", "c_first_name_92", "c_last_name_93", "c_login_99", "c_preferred_cust_flag_94", "d_year_138"])
-                            partial aggregation over (c_birth_country_98, c_customer_id_85, c_email_address_100, c_first_name_92, c_last_name_93, c_login_99, c_preferred_cust_flag_94, d_year_138)
+                        remote exchange (REPARTITION, HASH, ["c_customer_id"])
+                            partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
                                 join (INNER, PARTITIONED):
-                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_84"])
+                                    remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                                         scan customer
                                     local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ss_customer_sk_107"])
+                                        remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
                                             join (INNER, REPLICATED):
                                                 scan store_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         scan date_dim
-            local exchange (GATHER, SINGLE, [])
                 join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id"])
-                        final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_birth_country", "c_customer_id", "c_email_address", "c_first_name", "c_last_name", "c_login", "c_preferred_cust_flag", "d_year"])
-                                    partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                scan customer
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan store_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
-                    local exchange (GATHER, SINGLE, [])
-                        join (INNER, PARTITIONED):
+                    final aggregation over (c_birth_country_590, c_customer_id_577, c_email_address_592, c_first_name_584, c_last_name_585, c_login_591, c_preferred_cust_flag_586, d_year_641)
+                        local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["c_customer_id_577"])
-                                final aggregation over (c_birth_country_590, c_customer_id_577, c_email_address_592, c_first_name_584, c_last_name_585, c_login_591, c_preferred_cust_flag_586, d_year_641)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["c_birth_country_590", "c_customer_id_577", "c_email_address_592", "c_first_name_584", "c_last_name_585", "c_login_591", "c_preferred_cust_flag_586", "d_year_641"])
-                                            partial aggregation over (c_birth_country_590, c_customer_id_577, c_email_address_592, c_first_name_584, c_last_name_585, c_login_591, c_preferred_cust_flag_586, d_year_641)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_576"])
-                                                        scan customer
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_600"])
-                                                            join (INNER, REPLICATED):
-                                                                scan web_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan date_dim
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_customer_id_376"])
-                                    final aggregation over (c_birth_country_389, c_customer_id_376, c_email_address_391, c_first_name_383, c_last_name_384, c_login_390, c_preferred_cust_flag_385, d_year_440)
+                                partial aggregation over (c_birth_country_590, c_customer_id_577, c_email_address_592, c_first_name_584, c_last_name_585, c_login_591, c_preferred_cust_flag_586, d_year_641)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_576"])
+                                            scan customer
                                         local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["c_birth_country_389", "c_customer_id_376", "c_email_address_391", "c_first_name_383", "c_last_name_384", "c_login_390", "c_preferred_cust_flag_385", "d_year_440"])
-                                                partial aggregation over (c_birth_country_389, c_customer_id_376, c_email_address_391, c_first_name_383, c_last_name_384, c_login_390, c_preferred_cust_flag_385, d_year_440)
-                                                    join (INNER, PARTITIONED):
-                                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_375"])
-                                                            scan customer
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_399"])
-                                                                join (INNER, REPLICATED):
-                                                                    scan web_sales
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
+                                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_600"])
+                                                join (INNER, REPLICATED):
+                                                    scan web_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
+                    final aggregation over (c_birth_country_389, c_customer_id_376, c_email_address_391, c_first_name_383, c_last_name_384, c_login_390, c_preferred_cust_flag_385, d_year_440)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["c_customer_id_376"])
+                                partial aggregation over (c_birth_country_389, c_customer_id_376, c_email_address_391, c_first_name_383, c_last_name_384, c_login_390, c_preferred_cust_flag_385, d_year_440)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_375"])
+                                            scan customer
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_399"])
+                                                join (INNER, REPLICATED):
+                                                    scan web_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q23.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q23.plan.txt
@@ -5,23 +5,20 @@ final aggregation over ()
                 join (INNER, PARTITIONED):
                     remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
                         join (INNER, PARTITIONED):
-                            final aggregation over (ss_item_sk)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ss_item_sk"])
-                                        partial aggregation over (ss_item_sk)
-                                            final aggregation over (d_date_9, ss_item_sk, substr$gid)
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["d_date_9", "ss_item_sk", "substr$gid"])
-                                                        partial aggregation over (d_date_9, ss_item_sk, substr$gid)
-                                                            join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    scan store_sales
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan item
+                            single aggregation over (ss_item_sk)
+                                final aggregation over (d_date_9, ss_item_sk, substr$gid)
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["ss_item_sk"])
+                                            partial aggregation over (d_date_9, ss_item_sk, substr$gid)
+                                                join (INNER, REPLICATED):
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["cs_item_sk"])
                                     join (INNER, REPLICATED):
@@ -63,23 +60,20 @@ final aggregation over ()
                 join (INNER, PARTITIONED):
                     remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk"])
                         join (INNER, PARTITIONED):
-                            final aggregation over (ss_item_sk_199)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ss_item_sk_199"])
-                                        partial aggregation over (ss_item_sk_199)
-                                            final aggregation over (d_date_227, ss_item_sk_199, substr$gid_284)
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["d_date_227", "ss_item_sk_199", "substr$gid_284"])
-                                                        partial aggregation over (d_date_227, ss_item_sk_199, substr$gid_284)
-                                                            join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    scan store_sales
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan item
+                            single aggregation over (ss_item_sk_199)
+                                final aggregation over (d_date_227, ss_item_sk_199, substr$gid_284)
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["ss_item_sk_199"])
+                                            partial aggregation over (d_date_227, ss_item_sk_199, substr$gid_284)
+                                                join (INNER, REPLICATED):
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["ws_item_sk"])
                                     join (INNER, REPLICATED):

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q30.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q30.plan.txt
@@ -9,22 +9,20 @@ local exchange (GATHER, SINGLE, [])
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
                                     scan customer_address
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["wr_returning_customer_sk"])
-                            final aggregation over (ca_state, wr_returning_customer_sk)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ca_state", "wr_returning_customer_sk"])
-                                        partial aggregation over (ca_state, wr_returning_customer_sk)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                    scan customer_address
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["wr_returning_addr_sk"])
-                                                        join (INNER, REPLICATED):
-                                                            scan web_returns
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
+                    final aggregation over (ca_state, wr_returning_customer_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["wr_returning_customer_sk"])
+                                partial aggregation over (ca_state, wr_returning_customer_sk)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                            scan customer_address
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["wr_returning_addr_sk"])
+                                                join (INNER, REPLICATED):
+                                                    scan web_returns
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPLICATE, BROADCAST, [])
                         final aggregation over (ca_state_92)

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q31.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q31.plan.txt
@@ -6,7 +6,7 @@ remote exchange (GATHER, SINGLE, [])
                     join (INNER, PARTITIONED):
                         final aggregation over (ca_county_71, d_qoy_43, d_year_39)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_county_71", "d_qoy_43", "d_year_39"])
+                                remote exchange (REPARTITION, HASH, ["ca_county_71"])
                                     partial aggregation over (ca_county_71, d_qoy_43, d_year_39)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["ss_addr_sk_11"])
@@ -18,26 +18,24 @@ remote exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["ca_address_sk_64"])
                                                     scan customer_address
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ca_county_149", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
-                                final aggregation over (ca_county_149, d_qoy_121, d_year_117)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_county_149", "d_qoy_121", "d_year_117"])
-                                            partial aggregation over (ca_county_149, d_qoy_121, d_year_117)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["ss_addr_sk_89"])
-                                                        join (INNER, REPLICATED):
-                                                            scan store_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
+                        final aggregation over (ca_county_149, d_qoy_121, d_year_117)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["ca_county_149"])
+                                    partial aggregation over (ca_county_149, d_qoy_121, d_year_117)
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["ss_addr_sk_89"])
+                                                join (INNER, REPLICATED):
+                                                    scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["ca_address_sk_142"])
-                                                            scan customer_address
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["ca_address_sk_142"])
+                                                    scan customer_address
                     join (INNER, PARTITIONED):
                         final aggregation over (ca_county_293, d_qoy_265, d_year_261)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_county_293", "d_qoy_265", "d_year_261"])
+                                remote exchange (REPARTITION, HASH, ["ca_county_293"])
                                     partial aggregation over (ca_county_293, d_qoy_265, d_year_261)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["ca_address_sk_286"])
@@ -49,50 +47,46 @@ remote exchange (GATHER, SINGLE, [])
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                 scan date_dim
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ca_county_382", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
-                                final aggregation over (ca_county_382, d_qoy_354, d_year_350)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_county_382", "d_qoy_354", "d_year_350"])
-                                            partial aggregation over (ca_county_382, d_qoy_354, d_year_350)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["ca_address_sk_375"])
-                                                        scan customer_address
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk_312"])
-                                                            join (INNER, REPLICATED):
-                                                                scan web_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan date_dim
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["ca_county", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
-                        join (INNER, PARTITIONED):
-                            final aggregation over (ca_county, d_qoy, d_year)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ca_county", "d_qoy", "d_year"])
-                                        partial aggregation over (ca_county, d_qoy, d_year)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
+                        final aggregation over (ca_county_382, d_qoy_354, d_year_350)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["ca_county_382"])
+                                    partial aggregation over (ca_county_382, d_qoy_354, d_year_350)
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["ca_address_sk_375"])
+                                                scan customer_address
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk_312"])
                                                     join (INNER, REPLICATED):
-                                                        scan store_sales
+                                                        scan web_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                 scan date_dim
+                join (INNER, PARTITIONED):
+                    final aggregation over (ca_county, d_qoy, d_year)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ca_county"])
+                                partial aggregation over (ca_county, d_qoy, d_year)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
+                                            join (INNER, REPLICATED):
+                                                scan store_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                        scan customer_address
-                            final aggregation over (ca_county_204, d_qoy_176, d_year_172)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ca_county_204", "d_qoy_176", "d_year_172"])
-                                        partial aggregation over (ca_county_204, d_qoy_176, d_year_172)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ca_address_sk_197"])
-                                                    scan customer_address
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk"])
-                                                        join (INNER, REPLICATED):
-                                                            scan web_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                scan customer_address
+                    final aggregation over (ca_county_204, d_qoy_176, d_year_172)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ca_county_204"])
+                                partial aggregation over (ca_county_204, d_qoy_176, d_year_172)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ca_address_sk_197"])
+                                            scan customer_address
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk"])
+                                                join (INNER, REPLICATED):
+                                                    scan web_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q51.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q51.plan.txt
@@ -3,25 +3,21 @@ local exchange (GATHER, SINGLE, [])
         local exchange (GATHER, SINGLE, [])
             remote exchange (REPARTITION, HASH, ["expr"])
                 join (FULL, PARTITIONED):
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["ws_item_sk"])
-                            final aggregation over (d_date, ws_item_sk)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["d_date", "ws_item_sk"])
-                                        partial aggregation over (d_date, ws_item_sk)
-                                            join (INNER, REPLICATED):
-                                                scan web_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["ss_item_sk"])
-                            final aggregation over (d_date_10, ss_item_sk)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["d_date_10", "ss_item_sk"])
-                                        partial aggregation over (d_date_10, ss_item_sk)
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
+                    final aggregation over (d_date, ws_item_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ws_item_sk"])
+                                partial aggregation over (d_date, ws_item_sk)
+                                    join (INNER, REPLICATED):
+                                        scan web_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
+                    final aggregation over (d_date_10, ss_item_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ss_item_sk"])
+                                partial aggregation over (d_date_10, ss_item_sk)
+                                    join (INNER, REPLICATED):
+                                        scan store_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q54.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q54.plan.txt
@@ -22,27 +22,25 @@ local exchange (GATHER, SINGLE, [])
                                                                             local exchange (GATHER, SINGLE, [])
                                                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                                                     scan store
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
-                                                                            final aggregation over (c_current_addr_sk, c_customer_sk)
-                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                    remote exchange (REPARTITION, HASH, ["c_current_addr_sk", "c_customer_sk"])
-                                                                                        partial aggregation over (c_current_addr_sk, c_customer_sk)
-                                                                                            join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                scan customer
-                                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                        join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                            join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                                remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                                                                                                    scan catalog_sales
-                                                                                                                    scan web_sales
-                                                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                                        scan item
-                                                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                                    scan date_dim
+                                                                    final aggregation over (c_current_addr_sk, c_customer_sk)
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
+                                                                                partial aggregation over (c_current_addr_sk, c_customer_sk)
+                                                                                    join (INNER, REPLICATED, can skip output duplicates):
+                                                                                        scan customer
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                join (INNER, REPLICATED, can skip output duplicates):
+                                                                                                    join (INNER, REPLICATED, can skip output duplicates):
+                                                                                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                                                            scan catalog_sales
+                                                                                                            scan web_sales
+                                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                                scan item
+                                                                                                    local exchange (GATHER, SINGLE, [])
+                                                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                            scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
                                                             scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q74.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q74.plan.txt
@@ -1,68 +1,61 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
-            remote exchange (REPARTITION, HASH, ["c_customer_id_75"])
-                final aggregation over (c_customer_id_75, c_first_name_82, c_last_name_83, d_year_128)
+            final aggregation over (c_customer_id_75, c_first_name_82, c_last_name_83, d_year_128)
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPARTITION, HASH, ["c_customer_id_75"])
+                        partial aggregation over (c_customer_id_75, c_first_name_82, c_last_name_83, d_year_128)
+                            join (INNER, PARTITIONED):
+                                remote exchange (REPARTITION, HASH, ["ss_customer_sk_97"])
+                                    join (INNER, REPLICATED):
+                                        scan store_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_74"])
+                                        scan customer
+            join (INNER, PARTITIONED):
+                final aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
                     local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["c_customer_id_75", "c_first_name_82", "c_last_name_83", "d_year_128"])
-                            partial aggregation over (c_customer_id_75, c_first_name_82, c_last_name_83, d_year_128)
+                        remote exchange (REPARTITION, HASH, ["c_customer_id"])
+                            partial aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
                                 join (INNER, PARTITIONED):
-                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk_97"])
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
                                         join (INNER, REPLICATED):
                                             scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     scan date_dim
                                     local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_74"])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                                             scan customer
-            local exchange (GATHER, SINGLE, [])
                 join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id"])
-                        final aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_customer_id", "c_first_name", "c_last_name", "d_year"])
-                                    partial aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                    final aggregation over (c_customer_id_534, c_first_name_541, c_last_name_542, d_year_598)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["c_customer_id_534"])
+                                partial aggregation over (c_customer_id_534, c_first_name_541, c_last_name_542, d_year_598)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_533"])
+                                            scan customer
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_557"])
                                                 join (INNER, REPLICATED):
-                                                    scan store_sales
+                                                    scan web_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
                                                             scan date_dim
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                    scan customer
-                    local exchange (GATHER, SINGLE, [])
-                        join (INNER, PARTITIONED):
-                            remote exchange (REPARTITION, HASH, ["c_customer_id_534"])
-                                final aggregation over (c_customer_id_534, c_first_name_541, c_last_name_542, d_year_598)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["c_customer_id_534", "c_first_name_541", "c_last_name_542", "d_year_598"])
-                                            partial aggregation over (c_customer_id_534, c_first_name_541, c_last_name_542, d_year_598)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_533"])
-                                                        scan customer
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_557"])
-                                                            join (INNER, REPLICATED):
-                                                                scan web_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan date_dim
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_customer_id_347"])
-                                    final aggregation over (c_customer_id_347, c_first_name_354, c_last_name_355, d_year_411)
+                    final aggregation over (c_customer_id_347, c_first_name_354, c_last_name_355, d_year_411)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["c_customer_id_347"])
+                                partial aggregation over (c_customer_id_347, c_first_name_354, c_last_name_355, d_year_411)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_346"])
+                                            scan customer
                                         local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["c_customer_id_347", "c_first_name_354", "c_last_name_355", "d_year_411"])
-                                                partial aggregation over (c_customer_id_347, c_first_name_354, c_last_name_355, d_year_411)
-                                                    join (INNER, PARTITIONED):
-                                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_346"])
-                                                            scan customer
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_370"])
-                                                                join (INNER, REPLICATED):
-                                                                    scan web_sales
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
+                                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_370"])
+                                                join (INNER, REPLICATED):
+                                                    scan web_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q78.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q78.plan.txt
@@ -32,17 +32,19 @@ local exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     scan date_dim
-                        final aggregation over (d_year_24, ws_bill_customer_sk, ws_item_sk)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["d_year_24", "ws_bill_customer_sk", "ws_item_sk"])
-                                    partial aggregation over (d_year_24, ws_bill_customer_sk, ws_item_sk)
-                                        join (INNER, REPLICATED):
-                                            join (LEFT, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ws_item_sk", "ws_order_number"])
-                                                    scan web_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["wr_item_sk", "wr_order_number"])
-                                                        scan web_returns
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk", "ws_item_sk", NullableValue{type=integer, value=2000}])
+                                final aggregation over (d_year_24, ws_bill_customer_sk, ws_item_sk)
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk", "ws_item_sk"])
+                                            partial aggregation over (d_year_24, ws_bill_customer_sk, ws_item_sk)
+                                                join (INNER, REPLICATED):
+                                                    join (LEFT, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, ["ws_item_sk", "ws_order_number"])
+                                                            scan web_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPARTITION, HASH, ["wr_item_sk", "wr_order_number"])
+                                                                scan web_returns
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q79.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q79.plan.txt
@@ -1,24 +1,23 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
-            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                final aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["s_city", "ss_addr_sk", "ss_customer_sk", "ss_ticket_number"])
-                            partial aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
+            final aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                        partial aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
+                            join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
-                                        join (INNER, REPLICATED):
-                                            scan store_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
+                                        scan store_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan household_demographics
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan store
+                                            scan household_demographics
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPLICATE, BROADCAST, [])
+                                        scan store
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                     scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q81.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q81.plan.txt
@@ -3,21 +3,20 @@ local exchange (GATHER, SINGLE, [])
         cross join:
             join (LEFT, REPLICATED):
                 join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["cr_returning_customer_sk"])
-                        final aggregation over (ca_state, cr_returning_customer_sk)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_state", "cr_returning_customer_sk"])
-                                    partial aggregation over (ca_state, cr_returning_customer_sk)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                scan customer_address
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["cr_returning_addr_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan catalog_returns
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                    final aggregation over (ca_state, cr_returning_customer_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["cr_returning_customer_sk"])
+                                partial aggregation over (ca_state, cr_returning_customer_sk)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                            scan customer_address
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["cr_returning_addr_sk"])
+                                                join (INNER, REPLICATED):
+                                                    scan catalog_returns
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                             join (INNER, REPLICATED):

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q02.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q02.plan.txt
@@ -3,42 +3,36 @@ remote exchange (GATHER, SINGLE, [])
         remote exchange (REPARTITION, ROUND_ROBIN, [])
             join (INNER, PARTITIONED):
                 join (INNER, PARTITIONED):
-                    final aggregation over (d_week_seq)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["d_week_seq"])
-                                partial aggregation over (d_week_seq)
-                                    final aggregation over (d_day_name, d_week_seq)
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["d_day_name", "d_week_seq"])
-                                                partial aggregation over (d_day_name, d_week_seq)
-                                                    join (INNER, REPLICATED):
-                                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                                            scan web_sales
-                                                            scan catalog_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                    single aggregation over (d_week_seq)
+                        final aggregation over (d_day_name, d_week_seq)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["d_week_seq"])
+                                    partial aggregation over (d_day_name, d_week_seq)
+                                        join (INNER, REPLICATED):
+                                            remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                scan web_sales
+                                                scan catalog_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["d_week_seq_22"])
                             scan date_dim
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["expr_226"])
                         join (INNER, PARTITIONED):
-                            final aggregation over (d_week_seq_129)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["d_week_seq_129"])
-                                        partial aggregation over (d_week_seq_129)
-                                            final aggregation over (d_day_name_139, d_week_seq_129)
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["d_day_name_139", "d_week_seq_129"])
-                                                        partial aggregation over (d_day_name_139, d_week_seq_129)
-                                                            join (INNER, REPLICATED):
-                                                                remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                                                    scan web_sales
-                                                                    scan catalog_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan date_dim
+                            single aggregation over (d_week_seq_129)
+                                final aggregation over (d_day_name_139, d_week_seq_129)
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["d_week_seq_129"])
+                                            partial aggregation over (d_day_name_139, d_week_seq_129)
+                                                join (INNER, REPLICATED):
+                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                        scan web_sales
+                                                        scan catalog_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["d_week_seq_175"])
                                     scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q04.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q04.plan.txt
@@ -3,100 +3,89 @@ local exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
             join (INNER, PARTITIONED):
                 join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id_877"])
-                        final aggregation over (c_birth_country_890, c_customer_id_877, c_email_address_892, c_first_name_884, c_last_name_885, c_login_891, c_preferred_cust_flag_886, d_year_940)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_birth_country_890", "c_customer_id_877", "c_email_address_892", "c_first_name_884", "c_last_name_885", "c_login_891", "c_preferred_cust_flag_886", "d_year_940"])
-                                    partial aggregation over (c_birth_country_890, c_customer_id_877, c_email_address_892, c_first_name_884, c_last_name_885, c_login_891, c_preferred_cust_flag_886, d_year_940)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_900"])
-                                                join (INNER, REPLICATED):
-                                                    scan catalog_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_876"])
-                                                    scan customer
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["c_customer_id_1595"])
-                            final aggregation over (c_birth_country_1608, c_customer_id_1595, c_email_address_1610, c_first_name_1602, c_last_name_1603, c_login_1609, c_preferred_cust_flag_1604, d_year_1658)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_birth_country_1608", "c_customer_id_1595", "c_email_address_1610", "c_first_name_1602", "c_last_name_1603", "c_login_1609", "c_preferred_cust_flag_1604", "d_year_1658"])
-                                        partial aggregation over (c_birth_country_1608, c_customer_id_1595, c_email_address_1610, c_first_name_1602, c_last_name_1603, c_login_1609, c_preferred_cust_flag_1604, d_year_1658)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1619"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                    final aggregation over (c_birth_country_890, c_customer_id_877, c_email_address_892, c_first_name_884, c_last_name_885, c_login_891, c_preferred_cust_flag_886, d_year_940)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["c_customer_id_877"])
+                                partial aggregation over (c_birth_country_890, c_customer_id_877, c_email_address_892, c_first_name_884, c_last_name_885, c_login_891, c_preferred_cust_flag_886, d_year_940)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_900"])
+                                            join (INNER, REPLICATED):
+                                                scan catalog_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_1594"])
-                                                        scan customer
-                local exchange (GATHER, SINGLE, [])
-                    join (INNER, PARTITIONED):
-                        remote exchange (REPARTITION, HASH, ["c_customer_id_568"])
-                            final aggregation over (c_birth_country_581, c_customer_id_568, c_email_address_583, c_first_name_575, c_last_name_576, c_login_582, c_preferred_cust_flag_577, d_year_631)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_birth_country_581", "c_customer_id_568", "c_email_address_583", "c_first_name_575", "c_last_name_576", "c_login_582", "c_preferred_cust_flag_577", "d_year_631"])
-                                        partial aggregation over (c_birth_country_581, c_customer_id_568, c_email_address_583, c_first_name_575, c_last_name_576, c_login_582, c_preferred_cust_flag_577, d_year_631)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_591"])
-                                                    join (INNER, REPLICATED):
-                                                        scan catalog_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_876"])
+                                                scan customer
+                    final aggregation over (c_birth_country_1608, c_customer_id_1595, c_email_address_1610, c_first_name_1602, c_last_name_1603, c_login_1609, c_preferred_cust_flag_1604, d_year_1658)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["c_customer_id_1595"])
+                                partial aggregation over (c_birth_country_1608, c_customer_id_1595, c_email_address_1610, c_first_name_1602, c_last_name_1603, c_login_1609, c_preferred_cust_flag_1604, d_year_1658)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1619"])
+                                            join (INNER, REPLICATED):
+                                                scan web_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_567"])
-                                                        scan customer
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_1594"])
+                                                scan customer
+                join (INNER, PARTITIONED):
+                    final aggregation over (c_birth_country_581, c_customer_id_568, c_email_address_583, c_first_name_575, c_last_name_576, c_login_582, c_preferred_cust_flag_577, d_year_631)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["c_customer_id_568"])
+                                partial aggregation over (c_birth_country_581, c_customer_id_568, c_email_address_583, c_first_name_575, c_last_name_576, c_login_582, c_preferred_cust_flag_577, d_year_631)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_591"])
+                                            join (INNER, REPLICATED):
+                                                scan catalog_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_567"])
+                                                scan customer
+                    final aggregation over (c_birth_country_1299, c_customer_id_1286, c_email_address_1301, c_first_name_1293, c_last_name_1294, c_login_1300, c_preferred_cust_flag_1295, d_year_1349)
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["c_customer_id_1286"])
-                                final aggregation over (c_birth_country_1299, c_customer_id_1286, c_email_address_1301, c_first_name_1293, c_last_name_1294, c_login_1300, c_preferred_cust_flag_1295, d_year_1349)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["c_birth_country_1299", "c_customer_id_1286", "c_email_address_1301", "c_first_name_1293", "c_last_name_1294", "c_login_1300", "c_preferred_cust_flag_1295", "d_year_1349"])
-                                            partial aggregation over (c_birth_country_1299, c_customer_id_1286, c_email_address_1301, c_first_name_1293, c_last_name_1294, c_login_1300, c_preferred_cust_flag_1295, d_year_1349)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1310"])
-                                                        join (INNER, REPLICATED):
-                                                            scan web_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_1285"])
-                                                            scan customer
-            local exchange (GATHER, SINGLE, [])
-                join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id_170"])
-                        final aggregation over (c_birth_country_183, c_customer_id_170, c_email_address_185, c_first_name_177, c_last_name_178, c_login_184, c_preferred_cust_flag_179, d_year_222)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_birth_country_183", "c_customer_id_170", "c_email_address_185", "c_first_name_177", "c_last_name_178", "c_login_184", "c_preferred_cust_flag_179", "d_year_222"])
-                                    partial aggregation over (c_birth_country_183, c_customer_id_170, c_email_address_185, c_first_name_177, c_last_name_178, c_login_184, c_preferred_cust_flag_179, d_year_222)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ss_customer_sk_193"])
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                partial aggregation over (c_birth_country_1299, c_customer_id_1286, c_email_address_1301, c_first_name_1293, c_last_name_1294, c_login_1300, c_preferred_cust_flag_1295, d_year_1349)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1310"])
+                                            join (INNER, REPLICATED):
+                                                scan web_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_1285"])
+                                                scan customer
+            join (INNER, PARTITIONED):
+                final aggregation over (c_birth_country_183, c_customer_id_170, c_email_address_185, c_first_name_177, c_last_name_178, c_login_184, c_preferred_cust_flag_179, d_year_222)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_170"])
+                            partial aggregation over (c_birth_country_183, c_customer_id_170, c_email_address_185, c_first_name_177, c_last_name_178, c_login_184, c_preferred_cust_flag_179, d_year_222)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk_193"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_169"])
-                                                    scan customer
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_169"])
+                                            scan customer
+                final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_id"])
-                            final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_birth_country", "c_customer_id", "c_email_address", "c_first_name", "c_last_name", "c_login", "c_preferred_cust_flag", "d_year"])
-                                        partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan store_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                        scan customer
+                            partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                                            scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q11.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q11.plan.txt
@@ -2,67 +2,60 @@ local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
             join (INNER, PARTITIONED):
-                remote exchange (REPARTITION, HASH, ["c_customer_id_84"])
-                    final aggregation over (c_birth_country_97, c_customer_id_84, c_email_address_99, c_first_name_91, c_last_name_92, c_login_98, c_preferred_cust_flag_93, d_year_136)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["c_birth_country_97", "c_customer_id_84", "c_email_address_99", "c_first_name_91", "c_last_name_92", "c_login_98", "c_preferred_cust_flag_93", "d_year_136"])
-                                partial aggregation over (c_birth_country_97, c_customer_id_84, c_email_address_99, c_first_name_91, c_last_name_92, c_login_98, c_preferred_cust_flag_93, d_year_136)
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["ss_customer_sk_107"])
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_83"])
-                                                scan customer
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["c_customer_id_372"])
-                        final aggregation over (c_birth_country_385, c_customer_id_372, c_email_address_387, c_first_name_379, c_last_name_380, c_login_386, c_preferred_cust_flag_381, d_year_435)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_birth_country_385", "c_customer_id_372", "c_email_address_387", "c_first_name_379", "c_last_name_380", "c_login_386", "c_preferred_cust_flag_381", "d_year_435"])
-                                    partial aggregation over (c_birth_country_385, c_customer_id_372, c_email_address_387, c_first_name_379, c_last_name_380, c_login_386, c_preferred_cust_flag_381, d_year_435)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_396"])
-                                                join (INNER, REPLICATED):
-                                                    scan web_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                final aggregation over (c_birth_country_97, c_customer_id_84, c_email_address_99, c_first_name_91, c_last_name_92, c_login_98, c_preferred_cust_flag_93, d_year_136)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_84"])
+                            partial aggregation over (c_birth_country_97, c_customer_id_84, c_email_address_99, c_first_name_91, c_last_name_92, c_login_98, c_preferred_cust_flag_93, d_year_136)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk_107"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_371"])
-                                                    scan customer
-            local exchange (GATHER, SINGLE, [])
-                join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id"])
-                        final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_birth_country", "c_customer_id", "c_email_address", "c_first_name", "c_last_name", "c_login", "c_preferred_cust_flag", "d_year"])
-                                    partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_83"])
+                                            scan customer
+                final aggregation over (c_birth_country_385, c_customer_id_372, c_email_address_387, c_first_name_379, c_last_name_380, c_login_386, c_preferred_cust_flag_381, d_year_435)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_372"])
+                            partial aggregation over (c_birth_country_385, c_customer_id_372, c_email_address_387, c_first_name_379, c_last_name_380, c_login_386, c_preferred_cust_flag_381, d_year_435)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_396"])
+                                        join (INNER, REPLICATED):
+                                            scan web_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                    scan customer
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_371"])
+                                            scan customer
+            join (INNER, PARTITIONED):
+                final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id"])
+                            partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                                            scan customer
+                final aggregation over (c_birth_country_584, c_customer_id_571, c_email_address_586, c_first_name_578, c_last_name_579, c_login_585, c_preferred_cust_flag_580, d_year_634)
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_id_571"])
-                            final aggregation over (c_birth_country_584, c_customer_id_571, c_email_address_586, c_first_name_578, c_last_name_579, c_login_585, c_preferred_cust_flag_580, d_year_634)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_birth_country_584", "c_customer_id_571", "c_email_address_586", "c_first_name_578", "c_last_name_579", "c_login_585", "c_preferred_cust_flag_580", "d_year_634"])
-                                        partial aggregation over (c_birth_country_584, c_customer_id_571, c_email_address_586, c_first_name_578, c_last_name_579, c_login_585, c_preferred_cust_flag_580, d_year_634)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_595"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_570"])
-                                                        scan customer
+                            partial aggregation over (c_birth_country_584, c_customer_id_571, c_email_address_586, c_first_name_578, c_last_name_579, c_login_585, c_preferred_cust_flag_580, d_year_634)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_595"])
+                                        join (INNER, REPLICATED):
+                                            scan web_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_570"])
+                                            scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q16.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q16.plan.txt
@@ -9,26 +9,24 @@ final aggregation over ()
                                 remote exchange (REPARTITION, HASH, ["cr_order_number"])
                                     partial aggregation over (cr_order_number)
                                         scan catalog_returns
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["cs_order_number_26"])
-                                final aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number_26, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_state", "cc_county", "cs_call_center_sk", "cs_ext_ship_cost", "cs_net_profit", "cs_order_number_26", "cs_ship_addr_sk", "cs_ship_date_sk", "cs_warehouse_sk", "d_date", "unique"])
-                                            partial aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number_26, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
-                                                join (INNER, REPLICATED, can skip output duplicates):
-                                                    scan catalog_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
+                        final aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number_26, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["cs_order_number_26"])
+                                    partial aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number_26, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
+                                        join (INNER, REPLICATED, can skip output duplicates):
+                                            scan catalog_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    join (INNER, REPLICATED):
+                                                        join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    join (INNER, REPLICATED):
-                                                                        scan catalog_sales
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan customer_address
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
+                                                                scan catalog_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan call_center
+                                                                        scan customer_address
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan date_dim
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan call_center

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q23.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q23.plan.txt
@@ -5,23 +5,20 @@ final aggregation over ()
                 join (INNER, PARTITIONED):
                     remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
                         join (INNER, PARTITIONED):
-                            final aggregation over (ss_item_sk)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ss_item_sk"])
-                                        partial aggregation over (ss_item_sk)
-                                            final aggregation over (d_date_8, ss_item_sk, substr$gid)
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["d_date_8", "ss_item_sk", "substr$gid"])
-                                                        partial aggregation over (d_date_8, ss_item_sk, substr$gid)
-                                                            join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    scan store_sales
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan item
+                            single aggregation over (ss_item_sk)
+                                final aggregation over (d_date_8, ss_item_sk, substr$gid)
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["ss_item_sk"])
+                                            partial aggregation over (d_date_8, ss_item_sk, substr$gid)
+                                                join (INNER, REPLICATED):
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["cs_item_sk"])
                                     join (INNER, REPLICATED):
@@ -63,23 +60,20 @@ final aggregation over ()
                 join (INNER, PARTITIONED):
                     remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk"])
                         join (INNER, PARTITIONED):
-                            final aggregation over (ss_item_sk_196)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ss_item_sk_196"])
-                                        partial aggregation over (ss_item_sk_196)
-                                            final aggregation over (d_date_222, ss_item_sk_196, substr$gid_279)
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["d_date_222", "ss_item_sk_196", "substr$gid_279"])
-                                                        partial aggregation over (d_date_222, ss_item_sk_196, substr$gid_279)
-                                                            join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    scan store_sales
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan item
+                            single aggregation over (ss_item_sk_196)
+                                final aggregation over (d_date_222, ss_item_sk_196, substr$gid_279)
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["ss_item_sk_196"])
+                                            partial aggregation over (d_date_222, ss_item_sk_196, substr$gid_279)
+                                                join (INNER, REPLICATED):
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["ws_item_sk"])
                                     join (INNER, REPLICATED):

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q30.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q30.plan.txt
@@ -3,21 +3,20 @@ local exchange (GATHER, SINGLE, [])
         cross join:
             join (LEFT, REPLICATED):
                 join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["wr_returning_customer_sk"])
-                        final aggregation over (ca_state, wr_returning_customer_sk)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_state", "wr_returning_customer_sk"])
-                                    partial aggregation over (ca_state, wr_returning_customer_sk)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["wr_returning_addr_sk"])
-                                                join (INNER, REPLICATED):
-                                                    scan web_returns
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                    scan customer_address
+                    final aggregation over (ca_state, wr_returning_customer_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["wr_returning_customer_sk"])
+                                partial aggregation over (ca_state, wr_returning_customer_sk)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["wr_returning_addr_sk"])
+                                            join (INNER, REPLICATED):
+                                                scan web_returns
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                scan customer_address
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                             join (INNER, REPLICATED):

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q31.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q31.plan.txt
@@ -6,7 +6,7 @@ remote exchange (GATHER, SINGLE, [])
                     join (INNER, PARTITIONED):
                         final aggregation over (ca_county_70, d_qoy_42, d_year_38)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_county_70", "d_qoy_42", "d_year_38"])
+                                remote exchange (REPARTITION, HASH, ["ca_county_70"])
                                     partial aggregation over (ca_county_70, d_qoy_42, d_year_38)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["ss_addr_sk_12"])
@@ -18,26 +18,24 @@ remote exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["ca_address_sk_63"])
                                                     scan customer_address
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ca_county_147", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
-                                final aggregation over (ca_county_147, d_qoy_119, d_year_115)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_county_147", "d_qoy_119", "d_year_115"])
-                                            partial aggregation over (ca_county_147, d_qoy_119, d_year_115)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["ss_addr_sk_89"])
-                                                        join (INNER, REPLICATED):
-                                                            scan store_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
+                        final aggregation over (ca_county_147, d_qoy_119, d_year_115)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["ca_county_147"])
+                                    partial aggregation over (ca_county_147, d_qoy_119, d_year_115)
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["ss_addr_sk_89"])
+                                                join (INNER, REPLICATED):
+                                                    scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["ca_address_sk_140"])
-                                                            scan customer_address
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["ca_address_sk_140"])
+                                                    scan customer_address
                     join (INNER, PARTITIONED):
                         final aggregation over (ca_county_289, d_qoy_261, d_year_257)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_county_289", "d_qoy_261", "d_year_257"])
+                                remote exchange (REPARTITION, HASH, ["ca_county_289"])
                                     partial aggregation over (ca_county_289, d_qoy_261, d_year_257)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk_221"])
@@ -49,50 +47,46 @@ remote exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["ca_address_sk_282"])
                                                     scan customer_address
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ca_county_377", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
-                                final aggregation over (ca_county_377, d_qoy_349, d_year_345)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_county_377", "d_qoy_349", "d_year_345"])
-                                            partial aggregation over (ca_county_377, d_qoy_349, d_year_345)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk_309"])
-                                                        join (INNER, REPLICATED):
-                                                            scan web_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
+                        final aggregation over (ca_county_377, d_qoy_349, d_year_345)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["ca_county_377"])
+                                    partial aggregation over (ca_county_377, d_qoy_349, d_year_345)
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk_309"])
+                                                join (INNER, REPLICATED):
+                                                    scan web_sales
                                                     local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["ca_address_sk_370"])
-                                                            scan customer_address
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["ca_county", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
-                        join (INNER, PARTITIONED):
-                            final aggregation over (ca_county, d_qoy, d_year)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ca_county", "d_qoy", "d_year"])
-                                        partial aggregation over (ca_county, d_qoy, d_year)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan store_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["ca_address_sk_370"])
+                                                    scan customer_address
+                join (INNER, PARTITIONED):
+                    final aggregation over (ca_county, d_qoy, d_year)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ca_county"])
+                                partial aggregation over (ca_county, d_qoy, d_year)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
+                                            join (INNER, REPLICATED):
+                                                scan store_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                        scan customer_address
-                            final aggregation over (ca_county_201, d_qoy_173, d_year_169)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ca_county_201", "d_qoy_173", "d_year_169"])
-                                        partial aggregation over (ca_county_201, d_qoy_173, d_year_169)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                scan customer_address
+                    final aggregation over (ca_county_201, d_qoy_173, d_year_169)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ca_county_201"])
+                                partial aggregation over (ca_county_201, d_qoy_173, d_year_169)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk"])
+                                            join (INNER, REPLICATED):
+                                                scan web_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["ca_address_sk_194"])
-                                                        scan customer_address
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ca_address_sk_194"])
+                                                scan customer_address

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q34.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q34.plan.txt
@@ -4,22 +4,20 @@ remote exchange (GATHER, SINGLE, [])
             join (INNER, PARTITIONED):
                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                     scan customer
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                        final aggregation over (ss_customer_sk, ss_ticket_number)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_ticket_number"])
-                                    partial aggregation over (ss_customer_sk, ss_ticket_number)
+                final aggregation over (ss_customer_sk, ss_ticket_number)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                            partial aggregation over (ss_customer_sk, ss_ticket_number)
+                                join (INNER, REPLICATED):
+                                    join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan store
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan household_demographics
+                                                    scan store
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            scan household_demographics

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q51.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q51.plan.txt
@@ -3,25 +3,21 @@ local exchange (GATHER, SINGLE, [])
         local exchange (GATHER, SINGLE, [])
             remote exchange (REPARTITION, HASH, ["expr"])
                 join (FULL, PARTITIONED):
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["ws_item_sk"])
-                            final aggregation over (d_date, ws_item_sk)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["d_date", "ws_item_sk"])
-                                        partial aggregation over (d_date, ws_item_sk)
-                                            join (INNER, REPLICATED):
-                                                scan web_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["ss_item_sk"])
-                            final aggregation over (d_date_9, ss_item_sk)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["d_date_9", "ss_item_sk"])
-                                        partial aggregation over (d_date_9, ss_item_sk)
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
+                    final aggregation over (d_date, ws_item_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ws_item_sk"])
+                                partial aggregation over (d_date, ws_item_sk)
+                                    join (INNER, REPLICATED):
+                                        scan web_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
+                    final aggregation over (d_date_9, ss_item_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ss_item_sk"])
+                                partial aggregation over (d_date_9, ss_item_sk)
+                                    join (INNER, REPLICATED):
+                                        scan store_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q54.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q54.plan.txt
@@ -22,27 +22,25 @@ local exchange (GATHER, SINGLE, [])
                                                                             local exchange (GATHER, SINGLE, [])
                                                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                                                     scan store
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
-                                                                            final aggregation over (c_current_addr_sk, c_customer_sk)
-                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                    remote exchange (REPARTITION, HASH, ["c_current_addr_sk", "c_customer_sk"])
-                                                                                        partial aggregation over (c_current_addr_sk, c_customer_sk)
-                                                                                            join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                scan customer
-                                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                        join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                            join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                                remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                                                                                                    scan catalog_sales
-                                                                                                                    scan web_sales
-                                                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                                        scan item
-                                                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                                    scan date_dim
+                                                                    final aggregation over (c_current_addr_sk, c_customer_sk)
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
+                                                                                partial aggregation over (c_current_addr_sk, c_customer_sk)
+                                                                                    join (INNER, REPLICATED, can skip output duplicates):
+                                                                                        scan customer
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                join (INNER, REPLICATED, can skip output duplicates):
+                                                                                                    join (INNER, REPLICATED, can skip output duplicates):
+                                                                                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                                                            scan catalog_sales
+                                                                                                            scan web_sales
+                                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                                scan item
+                                                                                                    local exchange (GATHER, SINGLE, [])
+                                                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                            scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
                                                             scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q73.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q73.plan.txt
@@ -4,22 +4,20 @@ remote exchange (GATHER, SINGLE, [])
             join (INNER, PARTITIONED):
                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                     scan customer
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                        final aggregation over (ss_customer_sk, ss_ticket_number)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_ticket_number"])
-                                    partial aggregation over (ss_customer_sk, ss_ticket_number)
+                final aggregation over (ss_customer_sk, ss_ticket_number)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                            partial aggregation over (ss_customer_sk, ss_ticket_number)
+                                join (INNER, REPLICATED):
+                                    join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan household_demographics
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan store
+                                                    scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan household_demographics
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            scan store

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q74.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q74.plan.txt
@@ -2,67 +2,60 @@ local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
             join (INNER, PARTITIONED):
-                remote exchange (REPARTITION, HASH, ["c_customer_id_74"])
-                    final aggregation over (c_customer_id_74, c_first_name_81, c_last_name_82, d_year_126)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["c_customer_id_74", "c_first_name_81", "c_last_name_82", "d_year_126"])
-                                partial aggregation over (c_customer_id_74, c_first_name_81, c_last_name_82, d_year_126)
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["ss_customer_sk_97"])
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_73"])
-                                                scan customer
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["c_customer_id_343"])
-                        final aggregation over (c_customer_id_343, c_first_name_350, c_last_name_351, d_year_406)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_customer_id_343", "c_first_name_350", "c_last_name_351", "d_year_406"])
-                                    partial aggregation over (c_customer_id_343, c_first_name_350, c_last_name_351, d_year_406)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_367"])
-                                                join (INNER, REPLICATED):
-                                                    scan web_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                final aggregation over (c_customer_id_74, c_first_name_81, c_last_name_82, d_year_126)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_74"])
+                            partial aggregation over (c_customer_id_74, c_first_name_81, c_last_name_82, d_year_126)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk_97"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_342"])
-                                                    scan customer
-            local exchange (GATHER, SINGLE, [])
-                join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id"])
-                        final aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_customer_id", "c_first_name", "c_last_name", "d_year"])
-                                    partial aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_73"])
+                                            scan customer
+                final aggregation over (c_customer_id_343, c_first_name_350, c_last_name_351, d_year_406)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_343"])
+                            partial aggregation over (c_customer_id_343, c_first_name_350, c_last_name_351, d_year_406)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_367"])
+                                        join (INNER, REPLICATED):
+                                            scan web_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                    scan customer
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_342"])
+                                            scan customer
+            join (INNER, PARTITIONED):
+                final aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id"])
+                            partial aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                                            scan customer
+                final aggregation over (c_customer_id_528, c_first_name_535, c_last_name_536, d_year_591)
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_id_528"])
-                            final aggregation over (c_customer_id_528, c_first_name_535, c_last_name_536, d_year_591)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_customer_id_528", "c_first_name_535", "c_last_name_536", "d_year_591"])
-                                        partial aggregation over (c_customer_id_528, c_first_name_535, c_last_name_536, d_year_591)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_552"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_527"])
-                                                        scan customer
+                            partial aggregation over (c_customer_id_528, c_first_name_535, c_last_name_536, d_year_591)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_552"])
+                                        join (INNER, REPLICATED):
+                                            scan web_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_527"])
+                                            scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q78.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q78.plan.txt
@@ -5,7 +5,7 @@ local exchange (GATHER, SINGLE, [])
                 join (INNER, PARTITIONED):
                     final aggregation over (d_year, ss_customer_sk, ss_item_sk)
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["d_year", "ss_customer_sk", "ss_item_sk"])
+                            remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_item_sk"])
                                 partial aggregation over (d_year, ss_customer_sk, ss_item_sk)
                                     join (INNER, REPLICATED):
                                         join (LEFT, PARTITIONED):
@@ -19,7 +19,7 @@ local exchange (GATHER, SINGLE, [])
                                                 scan date_dim
                     final aggregation over (d_year_21, ws_bill_customer_sk, ws_item_sk)
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["d_year_21", "ws_bill_customer_sk", "ws_item_sk"])
+                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk", "ws_item_sk"])
                                 partial aggregation over (d_year_21, ws_bill_customer_sk, ws_item_sk)
                                     join (INNER, REPLICATED):
                                         join (LEFT, PARTITIONED):
@@ -31,19 +31,17 @@ local exchange (GATHER, SINGLE, [])
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
                                                 scan date_dim
-            local exchange (GATHER, SINGLE, [])
-                remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
-                    final aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_63)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk", "cs_item_sk", "d_year_63"])
-                                partial aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_63)
-                                    join (INNER, REPLICATED):
-                                        join (LEFT, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["cs_item_sk", "cs_order_number"])
-                                                scan catalog_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["cr_item_sk", "cr_order_number"])
-                                                    scan catalog_returns
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                scan date_dim
+            final aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_63)
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
+                        partial aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_63)
+                            join (INNER, REPLICATED):
+                                join (LEFT, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["cs_item_sk", "cs_order_number"])
+                                        scan catalog_sales
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["cr_item_sk", "cr_order_number"])
+                                            scan catalog_returns
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPLICATE, BROADCAST, [])
+                                        scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q79.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q79.plan.txt
@@ -1,24 +1,23 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
-            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                final aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["s_city", "ss_addr_sk", "ss_customer_sk", "ss_ticket_number"])
-                            partial aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
+            final aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                        partial aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
+                            join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
-                                        join (INNER, REPLICATED):
-                                            scan store_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
+                                        scan store_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan household_demographics
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan store
+                                            scan household_demographics
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPLICATE, BROADCAST, [])
+                                        scan store
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                     scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q94.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q94.plan.txt
@@ -9,26 +9,24 @@ final aggregation over ()
                                 remote exchange (REPARTITION, HASH, ["wr_order_number"])
                                     partial aggregation over (wr_order_number)
                                         scan web_returns
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ws_order_number_26"])
-                                final aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number_26, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_state", "d_date", "unique", "web_company_name", "ws_ext_ship_cost", "ws_net_profit", "ws_order_number_26", "ws_ship_addr_sk", "ws_ship_date_sk", "ws_warehouse_sk", "ws_web_site_sk"])
-                                            partial aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number_26, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
-                                                join (INNER, REPLICATED, can skip output duplicates):
-                                                    scan web_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
+                        final aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number_26, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["ws_order_number_26"])
+                                    partial aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number_26, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
+                                        join (INNER, REPLICATED, can skip output duplicates):
+                                            scan web_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    join (INNER, REPLICATED):
+                                                        join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    join (INNER, REPLICATED):
-                                                                        scan web_sales
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan customer_address
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
+                                                                scan web_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan web_site
+                                                                        scan customer_address
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan date_dim
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan web_site

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q02.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q02.plan.txt
@@ -3,42 +3,36 @@ remote exchange (GATHER, SINGLE, [])
         remote exchange (REPARTITION, ROUND_ROBIN, [])
             join (INNER, PARTITIONED):
                 join (INNER, PARTITIONED):
-                    final aggregation over (d_week_seq)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["d_week_seq"])
-                                partial aggregation over (d_week_seq)
-                                    final aggregation over (d_day_name, d_week_seq)
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["d_day_name", "d_week_seq"])
-                                                partial aggregation over (d_day_name, d_week_seq)
-                                                    join (INNER, REPLICATED):
-                                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                                            scan web_sales
-                                                            scan catalog_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                    single aggregation over (d_week_seq)
+                        final aggregation over (d_day_name, d_week_seq)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["d_week_seq"])
+                                    partial aggregation over (d_day_name, d_week_seq)
+                                        join (INNER, REPLICATED):
+                                            remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                scan web_sales
+                                                scan catalog_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["d_week_seq_20"])
                             scan date_dim
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["expr_219"])
                         join (INNER, PARTITIONED):
-                            final aggregation over (d_week_seq_124)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["d_week_seq_124"])
-                                        partial aggregation over (d_week_seq_124)
-                                            final aggregation over (d_day_name_134, d_week_seq_124)
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["d_day_name_134", "d_week_seq_124"])
-                                                        partial aggregation over (d_day_name_134, d_week_seq_124)
-                                                            join (INNER, REPLICATED):
-                                                                remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                                                    scan web_sales
-                                                                    scan catalog_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan date_dim
+                            single aggregation over (d_week_seq_124)
+                                final aggregation over (d_day_name_134, d_week_seq_124)
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["d_week_seq_124"])
+                                            partial aggregation over (d_day_name_134, d_week_seq_124)
+                                                join (INNER, REPLICATED):
+                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                        scan web_sales
+                                                        scan catalog_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["d_week_seq_169"])
                                     scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q04.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q04.plan.txt
@@ -3,100 +3,89 @@ local exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
             join (INNER, PARTITIONED):
                 join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id_848"])
-                        final aggregation over (c_birth_country_861, c_customer_id_848, c_email_address_863, c_first_name_855, c_last_name_856, c_login_862, c_preferred_cust_flag_857, d_year_909)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_birth_country_861", "c_customer_id_848", "c_email_address_863", "c_first_name_855", "c_last_name_856", "c_login_862", "c_preferred_cust_flag_857", "d_year_909"])
-                                    partial aggregation over (c_birth_country_861, c_customer_id_848, c_email_address_863, c_first_name_855, c_last_name_856, c_login_862, c_preferred_cust_flag_857, d_year_909)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_869"])
-                                                join (INNER, REPLICATED):
-                                                    scan catalog_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_847"])
-                                                    scan customer
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["c_customer_id_1545"])
-                            final aggregation over (c_birth_country_1558, c_customer_id_1545, c_email_address_1560, c_first_name_1552, c_last_name_1553, c_login_1559, c_preferred_cust_flag_1554, d_year_1606)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_birth_country_1558", "c_customer_id_1545", "c_email_address_1560", "c_first_name_1552", "c_last_name_1553", "c_login_1559", "c_preferred_cust_flag_1554", "d_year_1606"])
-                                        partial aggregation over (c_birth_country_1558, c_customer_id_1545, c_email_address_1560, c_first_name_1552, c_last_name_1553, c_login_1559, c_preferred_cust_flag_1554, d_year_1606)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1567"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                    final aggregation over (c_birth_country_861, c_customer_id_848, c_email_address_863, c_first_name_855, c_last_name_856, c_login_862, c_preferred_cust_flag_857, d_year_909)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["c_customer_id_848"])
+                                partial aggregation over (c_birth_country_861, c_customer_id_848, c_email_address_863, c_first_name_855, c_last_name_856, c_login_862, c_preferred_cust_flag_857, d_year_909)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_869"])
+                                            join (INNER, REPLICATED):
+                                                scan catalog_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_1544"])
-                                                        scan customer
-                local exchange (GATHER, SINGLE, [])
-                    join (INNER, PARTITIONED):
-                        remote exchange (REPARTITION, HASH, ["c_customer_id_548"])
-                            final aggregation over (c_birth_country_561, c_customer_id_548, c_email_address_563, c_first_name_555, c_last_name_556, c_login_562, c_preferred_cust_flag_557, d_year_609)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_birth_country_561", "c_customer_id_548", "c_email_address_563", "c_first_name_555", "c_last_name_556", "c_login_562", "c_preferred_cust_flag_557", "d_year_609"])
-                                        partial aggregation over (c_birth_country_561, c_customer_id_548, c_email_address_563, c_first_name_555, c_last_name_556, c_login_562, c_preferred_cust_flag_557, d_year_609)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_569"])
-                                                    join (INNER, REPLICATED):
-                                                        scan catalog_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_847"])
+                                                scan customer
+                    final aggregation over (c_birth_country_1558, c_customer_id_1545, c_email_address_1560, c_first_name_1552, c_last_name_1553, c_login_1559, c_preferred_cust_flag_1554, d_year_1606)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["c_customer_id_1545"])
+                                partial aggregation over (c_birth_country_1558, c_customer_id_1545, c_email_address_1560, c_first_name_1552, c_last_name_1553, c_login_1559, c_preferred_cust_flag_1554, d_year_1606)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1567"])
+                                            join (INNER, REPLICATED):
+                                                scan web_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_547"])
-                                                        scan customer
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_1544"])
+                                                scan customer
+                join (INNER, PARTITIONED):
+                    final aggregation over (c_birth_country_561, c_customer_id_548, c_email_address_563, c_first_name_555, c_last_name_556, c_login_562, c_preferred_cust_flag_557, d_year_609)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["c_customer_id_548"])
+                                partial aggregation over (c_birth_country_561, c_customer_id_548, c_email_address_563, c_first_name_555, c_last_name_556, c_login_562, c_preferred_cust_flag_557, d_year_609)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_569"])
+                                            join (INNER, REPLICATED):
+                                                scan catalog_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_547"])
+                                                scan customer
+                    final aggregation over (c_birth_country_1258, c_customer_id_1245, c_email_address_1260, c_first_name_1252, c_last_name_1253, c_login_1259, c_preferred_cust_flag_1254, d_year_1306)
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["c_customer_id_1245"])
-                                final aggregation over (c_birth_country_1258, c_customer_id_1245, c_email_address_1260, c_first_name_1252, c_last_name_1253, c_login_1259, c_preferred_cust_flag_1254, d_year_1306)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["c_birth_country_1258", "c_customer_id_1245", "c_email_address_1260", "c_first_name_1252", "c_last_name_1253", "c_login_1259", "c_preferred_cust_flag_1254", "d_year_1306"])
-                                            partial aggregation over (c_birth_country_1258, c_customer_id_1245, c_email_address_1260, c_first_name_1252, c_last_name_1253, c_login_1259, c_preferred_cust_flag_1254, d_year_1306)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1267"])
-                                                        join (INNER, REPLICATED):
-                                                            scan web_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_1244"])
-                                                            scan customer
-            local exchange (GATHER, SINGLE, [])
-                join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id_162"])
-                        final aggregation over (c_birth_country_175, c_customer_id_162, c_email_address_177, c_first_name_169, c_last_name_170, c_login_176, c_preferred_cust_flag_171, d_year_212)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_birth_country_175", "c_customer_id_162", "c_email_address_177", "c_first_name_169", "c_last_name_170", "c_login_176", "c_preferred_cust_flag_171", "d_year_212"])
-                                    partial aggregation over (c_birth_country_175, c_customer_id_162, c_email_address_177, c_first_name_169, c_last_name_170, c_login_176, c_preferred_cust_flag_171, d_year_212)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ss_customer_sk_183"])
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                partial aggregation over (c_birth_country_1258, c_customer_id_1245, c_email_address_1260, c_first_name_1252, c_last_name_1253, c_login_1259, c_preferred_cust_flag_1254, d_year_1306)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1267"])
+                                            join (INNER, REPLICATED):
+                                                scan web_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_1244"])
+                                                scan customer
+            join (INNER, PARTITIONED):
+                final aggregation over (c_birth_country_175, c_customer_id_162, c_email_address_177, c_first_name_169, c_last_name_170, c_login_176, c_preferred_cust_flag_171, d_year_212)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_162"])
+                            partial aggregation over (c_birth_country_175, c_customer_id_162, c_email_address_177, c_first_name_169, c_last_name_170, c_login_176, c_preferred_cust_flag_171, d_year_212)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk_183"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_161"])
-                                                    scan customer
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_161"])
+                                            scan customer
+                final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_id"])
-                            final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_birth_country", "c_customer_id", "c_email_address", "c_first_name", "c_last_name", "c_login", "c_preferred_cust_flag", "d_year"])
-                                        partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan store_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                        scan customer
+                            partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                                            scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q11.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q11.plan.txt
@@ -2,67 +2,60 @@ local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
             join (INNER, PARTITIONED):
-                remote exchange (REPARTITION, HASH, ["c_customer_id_79"])
-                    final aggregation over (c_birth_country_92, c_customer_id_79, c_email_address_94, c_first_name_86, c_last_name_87, c_login_93, c_preferred_cust_flag_88, d_year_129)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["c_birth_country_92", "c_customer_id_79", "c_email_address_94", "c_first_name_86", "c_last_name_87", "c_login_93", "c_preferred_cust_flag_88", "d_year_129"])
-                                partial aggregation over (c_birth_country_92, c_customer_id_79, c_email_address_94, c_first_name_86, c_last_name_87, c_login_93, c_preferred_cust_flag_88, d_year_129)
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["ss_customer_sk_100"])
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_78"])
-                                                scan customer
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["c_customer_id_358"])
-                        final aggregation over (c_birth_country_371, c_customer_id_358, c_email_address_373, c_first_name_365, c_last_name_366, c_login_372, c_preferred_cust_flag_367, d_year_419)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_birth_country_371", "c_customer_id_358", "c_email_address_373", "c_first_name_365", "c_last_name_366", "c_login_372", "c_preferred_cust_flag_367", "d_year_419"])
-                                    partial aggregation over (c_birth_country_371, c_customer_id_358, c_email_address_373, c_first_name_365, c_last_name_366, c_login_372, c_preferred_cust_flag_367, d_year_419)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_380"])
-                                                join (INNER, REPLICATED):
-                                                    scan web_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                final aggregation over (c_birth_country_92, c_customer_id_79, c_email_address_94, c_first_name_86, c_last_name_87, c_login_93, c_preferred_cust_flag_88, d_year_129)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_79"])
+                            partial aggregation over (c_birth_country_92, c_customer_id_79, c_email_address_94, c_first_name_86, c_last_name_87, c_login_93, c_preferred_cust_flag_88, d_year_129)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk_100"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_357"])
-                                                    scan customer
-            local exchange (GATHER, SINGLE, [])
-                join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id"])
-                        final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_birth_country", "c_customer_id", "c_email_address", "c_first_name", "c_last_name", "c_login", "c_preferred_cust_flag", "d_year"])
-                                    partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_78"])
+                                            scan customer
+                final aggregation over (c_birth_country_371, c_customer_id_358, c_email_address_373, c_first_name_365, c_last_name_366, c_login_372, c_preferred_cust_flag_367, d_year_419)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_358"])
+                            partial aggregation over (c_birth_country_371, c_customer_id_358, c_email_address_373, c_first_name_365, c_last_name_366, c_login_372, c_preferred_cust_flag_367, d_year_419)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_380"])
+                                        join (INNER, REPLICATED):
+                                            scan web_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                    scan customer
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_357"])
+                                            scan customer
+            join (INNER, PARTITIONED):
+                final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id"])
+                            partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                                            scan customer
+                final aggregation over (c_birth_country_564, c_customer_id_551, c_email_address_566, c_first_name_558, c_last_name_559, c_login_565, c_preferred_cust_flag_560, d_year_612)
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_id_551"])
-                            final aggregation over (c_birth_country_564, c_customer_id_551, c_email_address_566, c_first_name_558, c_last_name_559, c_login_565, c_preferred_cust_flag_560, d_year_612)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_birth_country_564", "c_customer_id_551", "c_email_address_566", "c_first_name_558", "c_last_name_559", "c_login_565", "c_preferred_cust_flag_560", "d_year_612"])
-                                        partial aggregation over (c_birth_country_564, c_customer_id_551, c_email_address_566, c_first_name_558, c_last_name_559, c_login_565, c_preferred_cust_flag_560, d_year_612)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_573"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_550"])
-                                                        scan customer
+                            partial aggregation over (c_birth_country_564, c_customer_id_551, c_email_address_566, c_first_name_558, c_last_name_559, c_login_565, c_preferred_cust_flag_560, d_year_612)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_573"])
+                                        join (INNER, REPLICATED):
+                                            scan web_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_550"])
+                                            scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q16.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q16.plan.txt
@@ -9,26 +9,24 @@ final aggregation over ()
                                 remote exchange (REPARTITION, HASH, ["cr_order_number"])
                                     partial aggregation over (cr_order_number)
                                         scan catalog_returns
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["cs_order_number_22"])
-                                final aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number_22, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_state", "cc_county", "cs_call_center_sk", "cs_ext_ship_cost", "cs_net_profit", "cs_order_number_22", "cs_ship_addr_sk", "cs_ship_date_sk", "cs_warehouse_sk", "d_date", "unique"])
-                                            partial aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number_22, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
-                                                join (INNER, REPLICATED, can skip output duplicates):
-                                                    scan catalog_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
+                        final aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number_22, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["cs_order_number_22"])
+                                    partial aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number_22, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
+                                        join (INNER, REPLICATED, can skip output duplicates):
+                                            scan catalog_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    join (INNER, REPLICATED):
+                                                        join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    join (INNER, REPLICATED):
-                                                                        scan catalog_sales
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan date_dim
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan customer_address
+                                                                scan catalog_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan call_center
+                                                                        scan date_dim
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan customer_address
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan call_center

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q23.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q23.plan.txt
@@ -5,23 +5,20 @@ final aggregation over ()
                 join (INNER, PARTITIONED):
                     remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
                         join (INNER, PARTITIONED):
-                            final aggregation over (ss_item_sk)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ss_item_sk"])
-                                        partial aggregation over (ss_item_sk)
-                                            final aggregation over (d_date_6, ss_item_sk, substr$gid)
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["d_date_6", "ss_item_sk", "substr$gid"])
-                                                        partial aggregation over (d_date_6, ss_item_sk, substr$gid)
-                                                            join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    scan store_sales
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan item
+                            single aggregation over (ss_item_sk)
+                                final aggregation over (d_date_6, ss_item_sk, substr$gid)
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["ss_item_sk"])
+                                            partial aggregation over (d_date_6, ss_item_sk, substr$gid)
+                                                join (INNER, REPLICATED):
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["cs_item_sk"])
                                     join (INNER, REPLICATED):
@@ -63,23 +60,20 @@ final aggregation over ()
                 join (INNER, PARTITIONED):
                     remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk"])
                         join (INNER, PARTITIONED):
-                            final aggregation over (ss_item_sk_184)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ss_item_sk_184"])
-                                        partial aggregation over (ss_item_sk_184)
-                                            final aggregation over (d_date_210, ss_item_sk_184, substr$gid_265)
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["d_date_210", "ss_item_sk_184", "substr$gid_265"])
-                                                        partial aggregation over (d_date_210, ss_item_sk_184, substr$gid_265)
-                                                            join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    scan store_sales
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan item
+                            single aggregation over (ss_item_sk_184)
+                                final aggregation over (d_date_210, ss_item_sk_184, substr$gid_265)
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["ss_item_sk_184"])
+                                            partial aggregation over (d_date_210, ss_item_sk_184, substr$gid_265)
+                                                join (INNER, REPLICATED):
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["ws_item_sk"])
                                     join (INNER, REPLICATED):

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q30.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q30.plan.txt
@@ -3,21 +3,20 @@ local exchange (GATHER, SINGLE, [])
         cross join:
             join (LEFT, REPLICATED):
                 join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["wr_returning_customer_sk"])
-                        final aggregation over (ca_state, wr_returning_customer_sk)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_state", "wr_returning_customer_sk"])
-                                    partial aggregation over (ca_state, wr_returning_customer_sk)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                scan customer_address
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["wr_returning_addr_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_returns
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                    final aggregation over (ca_state, wr_returning_customer_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["wr_returning_customer_sk"])
+                                partial aggregation over (ca_state, wr_returning_customer_sk)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                            scan customer_address
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["wr_returning_addr_sk"])
+                                                join (INNER, REPLICATED):
+                                                    scan web_returns
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                             join (INNER, REPLICATED):

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q31.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q31.plan.txt
@@ -6,7 +6,7 @@ remote exchange (GATHER, SINGLE, [])
                     join (INNER, PARTITIONED):
                         final aggregation over (ca_county_66, d_qoy_39, d_year_35)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_county_66", "d_qoy_39", "d_year_35"])
+                                remote exchange (REPARTITION, HASH, ["ca_county_66"])
                                     partial aggregation over (ca_county_66, d_qoy_39, d_year_35)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["ss_addr_sk_9"])
@@ -18,26 +18,24 @@ remote exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["ca_address_sk_59"])
                                                     scan customer_address
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ca_county_140", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
-                                final aggregation over (ca_county_140, d_qoy_113, d_year_109)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_county_140", "d_qoy_113", "d_year_109"])
-                                            partial aggregation over (ca_county_140, d_qoy_113, d_year_109)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["ss_addr_sk_83"])
-                                                        join (INNER, REPLICATED):
-                                                            scan store_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
+                        final aggregation over (ca_county_140, d_qoy_113, d_year_109)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["ca_county_140"])
+                                    partial aggregation over (ca_county_140, d_qoy_113, d_year_109)
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["ss_addr_sk_83"])
+                                                join (INNER, REPLICATED):
+                                                    scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["ca_address_sk_133"])
-                                                            scan customer_address
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["ca_address_sk_133"])
+                                                    scan customer_address
                     join (INNER, PARTITIONED):
                         final aggregation over (ca_county_276, d_qoy_249, d_year_245)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_county_276", "d_qoy_249", "d_year_245"])
+                                remote exchange (REPARTITION, HASH, ["ca_county_276"])
                                     partial aggregation over (ca_county_276, d_qoy_249, d_year_245)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk_209"])
@@ -49,50 +47,46 @@ remote exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["ca_address_sk_269"])
                                                     scan customer_address
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ca_county_361", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
-                                final aggregation over (ca_county_361, d_qoy_334, d_year_330)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_county_361", "d_qoy_334", "d_year_330"])
-                                            partial aggregation over (ca_county_361, d_qoy_334, d_year_330)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk_294"])
-                                                        join (INNER, REPLICATED):
-                                                            scan web_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
+                        final aggregation over (ca_county_361, d_qoy_334, d_year_330)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["ca_county_361"])
+                                    partial aggregation over (ca_county_361, d_qoy_334, d_year_330)
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk_294"])
+                                                join (INNER, REPLICATED):
+                                                    scan web_sales
                                                     local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["ca_address_sk_354"])
-                                                            scan customer_address
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["ca_county", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
-                        join (INNER, PARTITIONED):
-                            final aggregation over (ca_county, d_qoy, d_year)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ca_county", "d_qoy", "d_year"])
-                                        partial aggregation over (ca_county, d_qoy, d_year)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan store_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["ca_address_sk_354"])
+                                                    scan customer_address
+                join (INNER, PARTITIONED):
+                    final aggregation over (ca_county, d_qoy, d_year)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ca_county"])
+                                partial aggregation over (ca_county, d_qoy, d_year)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
+                                            join (INNER, REPLICATED):
+                                                scan store_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                        scan customer_address
-                            final aggregation over (ca_county_191, d_qoy_164, d_year_160)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ca_county_191", "d_qoy_164", "d_year_160"])
-                                        partial aggregation over (ca_county_191, d_qoy_164, d_year_160)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                scan customer_address
+                    final aggregation over (ca_county_191, d_qoy_164, d_year_160)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ca_county_191"])
+                                partial aggregation over (ca_county_191, d_qoy_164, d_year_160)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk"])
+                                            join (INNER, REPLICATED):
+                                                scan web_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["ca_address_sk_184"])
-                                                        scan customer_address
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ca_address_sk_184"])
+                                                scan customer_address

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q34.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q34.plan.txt
@@ -4,22 +4,20 @@ remote exchange (GATHER, SINGLE, [])
             join (INNER, PARTITIONED):
                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                     scan customer
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                        final aggregation over (ss_customer_sk, ss_ticket_number)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_ticket_number"])
-                                    partial aggregation over (ss_customer_sk, ss_ticket_number)
+                final aggregation over (ss_customer_sk, ss_ticket_number)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                            partial aggregation over (ss_customer_sk, ss_ticket_number)
+                                join (INNER, REPLICATED):
+                                    join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan store
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan household_demographics
+                                                    scan store
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            scan household_demographics

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q51.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q51.plan.txt
@@ -3,25 +3,21 @@ local exchange (GATHER, SINGLE, [])
         local exchange (GATHER, SINGLE, [])
             remote exchange (REPARTITION, HASH, ["expr"])
                 join (FULL, PARTITIONED):
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["ws_item_sk"])
-                            final aggregation over (d_date, ws_item_sk)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["d_date", "ws_item_sk"])
-                                        partial aggregation over (d_date, ws_item_sk)
-                                            join (INNER, REPLICATED):
-                                                scan web_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["ss_item_sk"])
-                            final aggregation over (d_date_7, ss_item_sk)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["d_date_7", "ss_item_sk"])
-                                        partial aggregation over (d_date_7, ss_item_sk)
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
+                    final aggregation over (d_date, ws_item_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ws_item_sk"])
+                                partial aggregation over (d_date, ws_item_sk)
+                                    join (INNER, REPLICATED):
+                                        scan web_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
+                    final aggregation over (d_date_7, ss_item_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ss_item_sk"])
+                                partial aggregation over (d_date_7, ss_item_sk)
+                                    join (INNER, REPLICATED):
+                                        scan store_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q54.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q54.plan.txt
@@ -22,27 +22,25 @@ local exchange (GATHER, SINGLE, [])
                                                                             local exchange (GATHER, SINGLE, [])
                                                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                                                     scan store
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
-                                                                            final aggregation over (c_current_addr_sk, c_customer_sk)
-                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                    remote exchange (REPARTITION, HASH, ["c_current_addr_sk", "c_customer_sk"])
-                                                                                        partial aggregation over (c_current_addr_sk, c_customer_sk)
-                                                                                            join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                scan customer
-                                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                        join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                            join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                                remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                                                                                                    scan catalog_sales
-                                                                                                                    scan web_sales
-                                                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                                        scan item
-                                                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                                    scan date_dim
+                                                                    final aggregation over (c_current_addr_sk, c_customer_sk)
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
+                                                                                partial aggregation over (c_current_addr_sk, c_customer_sk)
+                                                                                    join (INNER, REPLICATED, can skip output duplicates):
+                                                                                        scan customer
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                join (INNER, REPLICATED, can skip output duplicates):
+                                                                                                    join (INNER, REPLICATED, can skip output duplicates):
+                                                                                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                                                            scan catalog_sales
+                                                                                                            scan web_sales
+                                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                                scan item
+                                                                                                    local exchange (GATHER, SINGLE, [])
+                                                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                            scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
                                                             scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q73.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q73.plan.txt
@@ -4,22 +4,20 @@ remote exchange (GATHER, SINGLE, [])
             join (INNER, PARTITIONED):
                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                     scan customer
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                        final aggregation over (ss_customer_sk, ss_ticket_number)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_ticket_number"])
-                                    partial aggregation over (ss_customer_sk, ss_ticket_number)
+                final aggregation over (ss_customer_sk, ss_ticket_number)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                            partial aggregation over (ss_customer_sk, ss_ticket_number)
+                                join (INNER, REPLICATED):
+                                    join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan household_demographics
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan store
+                                                    scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan household_demographics
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            scan store

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q74.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q74.plan.txt
@@ -2,67 +2,60 @@ local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
             join (INNER, PARTITIONED):
-                remote exchange (REPARTITION, HASH, ["c_customer_id_69"])
-                    final aggregation over (c_customer_id_69, c_first_name_76, c_last_name_77, d_year_119)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["c_customer_id_69", "c_first_name_76", "c_last_name_77", "d_year_119"])
-                                partial aggregation over (c_customer_id_69, c_first_name_76, c_last_name_77, d_year_119)
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["ss_customer_sk_90"])
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_68"])
-                                                scan customer
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["c_customer_id_329"])
-                        final aggregation over (c_customer_id_329, c_first_name_336, c_last_name_337, d_year_390)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_customer_id_329", "c_first_name_336", "c_last_name_337", "d_year_390"])
-                                    partial aggregation over (c_customer_id_329, c_first_name_336, c_last_name_337, d_year_390)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_351"])
-                                                join (INNER, REPLICATED):
-                                                    scan web_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                final aggregation over (c_customer_id_69, c_first_name_76, c_last_name_77, d_year_119)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_69"])
+                            partial aggregation over (c_customer_id_69, c_first_name_76, c_last_name_77, d_year_119)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk_90"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_328"])
-                                                    scan customer
-            local exchange (GATHER, SINGLE, [])
-                join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id"])
-                        final aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_customer_id", "c_first_name", "c_last_name", "d_year"])
-                                    partial aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_68"])
+                                            scan customer
+                final aggregation over (c_customer_id_329, c_first_name_336, c_last_name_337, d_year_390)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_329"])
+                            partial aggregation over (c_customer_id_329, c_first_name_336, c_last_name_337, d_year_390)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_351"])
+                                        join (INNER, REPLICATED):
+                                            scan web_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                    scan customer
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_328"])
+                                            scan customer
+            join (INNER, PARTITIONED):
+                final aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id"])
+                            partial aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                                            scan customer
+                final aggregation over (c_customer_id_508, c_first_name_515, c_last_name_516, d_year_569)
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_id_508"])
-                            final aggregation over (c_customer_id_508, c_first_name_515, c_last_name_516, d_year_569)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_customer_id_508", "c_first_name_515", "c_last_name_516", "d_year_569"])
-                                        partial aggregation over (c_customer_id_508, c_first_name_515, c_last_name_516, d_year_569)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_530"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_507"])
-                                                        scan customer
+                            partial aggregation over (c_customer_id_508, c_first_name_515, c_last_name_516, d_year_569)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_530"])
+                                        join (INNER, REPLICATED):
+                                            scan web_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_507"])
+                                            scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q78.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q78.plan.txt
@@ -5,7 +5,7 @@ local exchange (GATHER, SINGLE, [])
                 join (INNER, PARTITIONED):
                     final aggregation over (d_year, ss_customer_sk, ss_item_sk)
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["d_year", "ss_customer_sk", "ss_item_sk"])
+                            remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_item_sk"])
                                 partial aggregation over (d_year, ss_customer_sk, ss_item_sk)
                                     join (INNER, REPLICATED):
                                         join (LEFT, PARTITIONED):
@@ -19,7 +19,7 @@ local exchange (GATHER, SINGLE, [])
                                                 scan date_dim
                     final aggregation over (d_year_17, ws_bill_customer_sk, ws_item_sk)
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["d_year_17", "ws_bill_customer_sk", "ws_item_sk"])
+                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk", "ws_item_sk"])
                                 partial aggregation over (d_year_17, ws_bill_customer_sk, ws_item_sk)
                                     join (INNER, REPLICATED):
                                         join (LEFT, PARTITIONED):
@@ -31,19 +31,17 @@ local exchange (GATHER, SINGLE, [])
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
                                                 scan date_dim
-            local exchange (GATHER, SINGLE, [])
-                remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
-                    final aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_56)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk", "cs_item_sk", "d_year_56"])
-                                partial aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_56)
-                                    join (INNER, REPLICATED):
-                                        join (LEFT, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["cs_item_sk", "cs_order_number"])
-                                                scan catalog_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["cr_item_sk", "cr_order_number"])
-                                                    scan catalog_returns
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                scan date_dim
+            final aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_56)
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
+                        partial aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_56)
+                            join (INNER, REPLICATED):
+                                join (LEFT, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["cs_item_sk", "cs_order_number"])
+                                        scan catalog_sales
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["cr_item_sk", "cr_order_number"])
+                                            scan catalog_returns
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPLICATE, BROADCAST, [])
+                                        scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q79.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q79.plan.txt
@@ -1,24 +1,23 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
-            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                final aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["s_city", "ss_addr_sk", "ss_customer_sk", "ss_ticket_number"])
-                            partial aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
+            final aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                        partial aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
+                            join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
-                                        join (INNER, REPLICATED):
-                                            scan store_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
+                                        scan store_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan household_demographics
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan store
+                                            scan household_demographics
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPLICATE, BROADCAST, [])
+                                        scan store
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                     scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q81.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q81.plan.txt
@@ -3,21 +3,20 @@ local exchange (GATHER, SINGLE, [])
         cross join:
             join (LEFT, REPLICATED):
                 join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["cr_returning_customer_sk"])
-                        final aggregation over (ca_state, cr_returning_customer_sk)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_state", "cr_returning_customer_sk"])
-                                    partial aggregation over (ca_state, cr_returning_customer_sk)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["cr_returning_addr_sk"])
-                                                join (INNER, REPLICATED):
-                                                    scan catalog_returns
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                    scan customer_address
+                    final aggregation over (ca_state, cr_returning_customer_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["cr_returning_customer_sk"])
+                                partial aggregation over (ca_state, cr_returning_customer_sk)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["cr_returning_addr_sk"])
+                                            join (INNER, REPLICATED):
+                                                scan catalog_returns
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                scan customer_address
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                             join (INNER, REPLICATED):

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q94.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q94.plan.txt
@@ -9,26 +9,24 @@ final aggregation over ()
                                 remote exchange (REPARTITION, HASH, ["wr_order_number"])
                                     partial aggregation over (wr_order_number)
                                         scan web_returns
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ws_order_number_22"])
-                                final aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number_22, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_state", "d_date", "unique", "web_company_name", "ws_ext_ship_cost", "ws_net_profit", "ws_order_number_22", "ws_ship_addr_sk", "ws_ship_date_sk", "ws_warehouse_sk", "ws_web_site_sk"])
-                                            partial aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number_22, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
-                                                join (INNER, REPLICATED, can skip output duplicates):
-                                                    scan web_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
+                        final aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number_22, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["ws_order_number_22"])
+                                    partial aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number_22, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
+                                        join (INNER, REPLICATED, can skip output duplicates):
+                                            scan web_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    join (INNER, REPLICATED):
+                                                        join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    join (INNER, REPLICATED):
-                                                                        scan web_sales
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan date_dim
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan customer_address
+                                                                scan web_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan web_site
+                                                                        scan date_dim
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan customer_address
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan web_site

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q02.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q02.plan.txt
@@ -3,42 +3,36 @@ remote exchange (GATHER, SINGLE, [])
         remote exchange (REPARTITION, ROUND_ROBIN, [])
             join (INNER, PARTITIONED):
                 join (INNER, PARTITIONED):
-                    final aggregation over (d_week_seq)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["d_week_seq"])
-                                partial aggregation over (d_week_seq)
-                                    final aggregation over (d_day_name, d_week_seq)
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["d_day_name", "d_week_seq"])
-                                                partial aggregation over (d_day_name, d_week_seq)
-                                                    join (INNER, REPLICATED):
-                                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                                            scan web_sales
-                                                            scan catalog_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                    single aggregation over (d_week_seq)
+                        final aggregation over (d_day_name, d_week_seq)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["d_week_seq"])
+                                    partial aggregation over (d_day_name, d_week_seq)
+                                        join (INNER, REPLICATED):
+                                            remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                scan web_sales
+                                                scan catalog_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["d_week_seq_20"])
                             scan date_dim
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["expr_219"])
                         join (INNER, PARTITIONED):
-                            final aggregation over (d_week_seq_124)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["d_week_seq_124"])
-                                        partial aggregation over (d_week_seq_124)
-                                            final aggregation over (d_day_name_134, d_week_seq_124)
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["d_day_name_134", "d_week_seq_124"])
-                                                        partial aggregation over (d_day_name_134, d_week_seq_124)
-                                                            join (INNER, REPLICATED):
-                                                                remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                                                    scan web_sales
-                                                                    scan catalog_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan date_dim
+                            single aggregation over (d_week_seq_124)
+                                final aggregation over (d_day_name_134, d_week_seq_124)
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["d_week_seq_124"])
+                                            partial aggregation over (d_day_name_134, d_week_seq_124)
+                                                join (INNER, REPLICATED):
+                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                        scan web_sales
+                                                        scan catalog_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["d_week_seq_169"])
                                     scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q04.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q04.plan.txt
@@ -3,100 +3,89 @@ local exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
             join (INNER, PARTITIONED):
                 join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id_848"])
-                        final aggregation over (c_birth_country_861, c_customer_id_848, c_email_address_863, c_first_name_855, c_last_name_856, c_login_862, c_preferred_cust_flag_857, d_year_909)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_birth_country_861", "c_customer_id_848", "c_email_address_863", "c_first_name_855", "c_last_name_856", "c_login_862", "c_preferred_cust_flag_857", "d_year_909"])
-                                    partial aggregation over (c_birth_country_861, c_customer_id_848, c_email_address_863, c_first_name_855, c_last_name_856, c_login_862, c_preferred_cust_flag_857, d_year_909)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_870"])
-                                                join (INNER, REPLICATED):
-                                                    scan catalog_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_847"])
-                                                    scan customer
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["c_customer_id_1545"])
-                            final aggregation over (c_birth_country_1558, c_customer_id_1545, c_email_address_1560, c_first_name_1552, c_last_name_1553, c_login_1559, c_preferred_cust_flag_1554, d_year_1606)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_birth_country_1558", "c_customer_id_1545", "c_email_address_1560", "c_first_name_1552", "c_last_name_1553", "c_login_1559", "c_preferred_cust_flag_1554", "d_year_1606"])
-                                        partial aggregation over (c_birth_country_1558, c_customer_id_1545, c_email_address_1560, c_first_name_1552, c_last_name_1553, c_login_1559, c_preferred_cust_flag_1554, d_year_1606)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1568"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                    final aggregation over (c_birth_country_861, c_customer_id_848, c_email_address_863, c_first_name_855, c_last_name_856, c_login_862, c_preferred_cust_flag_857, d_year_909)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["c_customer_id_848"])
+                                partial aggregation over (c_birth_country_861, c_customer_id_848, c_email_address_863, c_first_name_855, c_last_name_856, c_login_862, c_preferred_cust_flag_857, d_year_909)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_870"])
+                                            join (INNER, REPLICATED):
+                                                scan catalog_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_1544"])
-                                                        scan customer
-                local exchange (GATHER, SINGLE, [])
-                    join (INNER, PARTITIONED):
-                        remote exchange (REPARTITION, HASH, ["c_customer_id_548"])
-                            final aggregation over (c_birth_country_561, c_customer_id_548, c_email_address_563, c_first_name_555, c_last_name_556, c_login_562, c_preferred_cust_flag_557, d_year_609)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_birth_country_561", "c_customer_id_548", "c_email_address_563", "c_first_name_555", "c_last_name_556", "c_login_562", "c_preferred_cust_flag_557", "d_year_609"])
-                                        partial aggregation over (c_birth_country_561, c_customer_id_548, c_email_address_563, c_first_name_555, c_last_name_556, c_login_562, c_preferred_cust_flag_557, d_year_609)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_570"])
-                                                    join (INNER, REPLICATED):
-                                                        scan catalog_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_847"])
+                                                scan customer
+                    final aggregation over (c_birth_country_1558, c_customer_id_1545, c_email_address_1560, c_first_name_1552, c_last_name_1553, c_login_1559, c_preferred_cust_flag_1554, d_year_1606)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["c_customer_id_1545"])
+                                partial aggregation over (c_birth_country_1558, c_customer_id_1545, c_email_address_1560, c_first_name_1552, c_last_name_1553, c_login_1559, c_preferred_cust_flag_1554, d_year_1606)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1568"])
+                                            join (INNER, REPLICATED):
+                                                scan web_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_547"])
-                                                        scan customer
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_1544"])
+                                                scan customer
+                join (INNER, PARTITIONED):
+                    final aggregation over (c_birth_country_561, c_customer_id_548, c_email_address_563, c_first_name_555, c_last_name_556, c_login_562, c_preferred_cust_flag_557, d_year_609)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["c_customer_id_548"])
+                                partial aggregation over (c_birth_country_561, c_customer_id_548, c_email_address_563, c_first_name_555, c_last_name_556, c_login_562, c_preferred_cust_flag_557, d_year_609)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_570"])
+                                            join (INNER, REPLICATED):
+                                                scan catalog_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_547"])
+                                                scan customer
+                    final aggregation over (c_birth_country_1258, c_customer_id_1245, c_email_address_1260, c_first_name_1252, c_last_name_1253, c_login_1259, c_preferred_cust_flag_1254, d_year_1306)
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["c_customer_id_1245"])
-                                final aggregation over (c_birth_country_1258, c_customer_id_1245, c_email_address_1260, c_first_name_1252, c_last_name_1253, c_login_1259, c_preferred_cust_flag_1254, d_year_1306)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["c_birth_country_1258", "c_customer_id_1245", "c_email_address_1260", "c_first_name_1252", "c_last_name_1253", "c_login_1259", "c_preferred_cust_flag_1254", "d_year_1306"])
-                                            partial aggregation over (c_birth_country_1258, c_customer_id_1245, c_email_address_1260, c_first_name_1252, c_last_name_1253, c_login_1259, c_preferred_cust_flag_1254, d_year_1306)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1268"])
-                                                        join (INNER, REPLICATED):
-                                                            scan web_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_1244"])
-                                                            scan customer
-            local exchange (GATHER, SINGLE, [])
-                join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id_162"])
-                        final aggregation over (c_birth_country_175, c_customer_id_162, c_email_address_177, c_first_name_169, c_last_name_170, c_login_176, c_preferred_cust_flag_171, d_year_212)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_birth_country_175", "c_customer_id_162", "c_email_address_177", "c_first_name_169", "c_last_name_170", "c_login_176", "c_preferred_cust_flag_171", "d_year_212"])
-                                    partial aggregation over (c_birth_country_175, c_customer_id_162, c_email_address_177, c_first_name_169, c_last_name_170, c_login_176, c_preferred_cust_flag_171, d_year_212)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ss_customer_sk_184"])
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                partial aggregation over (c_birth_country_1258, c_customer_id_1245, c_email_address_1260, c_first_name_1252, c_last_name_1253, c_login_1259, c_preferred_cust_flag_1254, d_year_1306)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1268"])
+                                            join (INNER, REPLICATED):
+                                                scan web_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_1244"])
+                                                scan customer
+            join (INNER, PARTITIONED):
+                final aggregation over (c_birth_country_175, c_customer_id_162, c_email_address_177, c_first_name_169, c_last_name_170, c_login_176, c_preferred_cust_flag_171, d_year_212)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_162"])
+                            partial aggregation over (c_birth_country_175, c_customer_id_162, c_email_address_177, c_first_name_169, c_last_name_170, c_login_176, c_preferred_cust_flag_171, d_year_212)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk_184"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_161"])
-                                                    scan customer
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_161"])
+                                            scan customer
+                final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_id"])
-                            final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_birth_country", "c_customer_id", "c_email_address", "c_first_name", "c_last_name", "c_login", "c_preferred_cust_flag", "d_year"])
-                                        partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan store_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                        scan customer
+                            partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                                            scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q11.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q11.plan.txt
@@ -2,67 +2,60 @@ local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
             join (INNER, PARTITIONED):
-                remote exchange (REPARTITION, HASH, ["c_customer_id_79"])
-                    final aggregation over (c_birth_country_92, c_customer_id_79, c_email_address_94, c_first_name_86, c_last_name_87, c_login_93, c_preferred_cust_flag_88, d_year_129)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["c_birth_country_92", "c_customer_id_79", "c_email_address_94", "c_first_name_86", "c_last_name_87", "c_login_93", "c_preferred_cust_flag_88", "d_year_129"])
-                                partial aggregation over (c_birth_country_92, c_customer_id_79, c_email_address_94, c_first_name_86, c_last_name_87, c_login_93, c_preferred_cust_flag_88, d_year_129)
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["ss_customer_sk_101"])
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_78"])
-                                                scan customer
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["c_customer_id_358"])
-                        final aggregation over (c_birth_country_371, c_customer_id_358, c_email_address_373, c_first_name_365, c_last_name_366, c_login_372, c_preferred_cust_flag_367, d_year_419)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_birth_country_371", "c_customer_id_358", "c_email_address_373", "c_first_name_365", "c_last_name_366", "c_login_372", "c_preferred_cust_flag_367", "d_year_419"])
-                                    partial aggregation over (c_birth_country_371, c_customer_id_358, c_email_address_373, c_first_name_365, c_last_name_366, c_login_372, c_preferred_cust_flag_367, d_year_419)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_381"])
-                                                join (INNER, REPLICATED):
-                                                    scan web_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                final aggregation over (c_birth_country_92, c_customer_id_79, c_email_address_94, c_first_name_86, c_last_name_87, c_login_93, c_preferred_cust_flag_88, d_year_129)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_79"])
+                            partial aggregation over (c_birth_country_92, c_customer_id_79, c_email_address_94, c_first_name_86, c_last_name_87, c_login_93, c_preferred_cust_flag_88, d_year_129)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk_101"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_357"])
-                                                    scan customer
-            local exchange (GATHER, SINGLE, [])
-                join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id"])
-                        final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_birth_country", "c_customer_id", "c_email_address", "c_first_name", "c_last_name", "c_login", "c_preferred_cust_flag", "d_year"])
-                                    partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_78"])
+                                            scan customer
+                final aggregation over (c_birth_country_371, c_customer_id_358, c_email_address_373, c_first_name_365, c_last_name_366, c_login_372, c_preferred_cust_flag_367, d_year_419)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_358"])
+                            partial aggregation over (c_birth_country_371, c_customer_id_358, c_email_address_373, c_first_name_365, c_last_name_366, c_login_372, c_preferred_cust_flag_367, d_year_419)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_381"])
+                                        join (INNER, REPLICATED):
+                                            scan web_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                    scan customer
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_357"])
+                                            scan customer
+            join (INNER, PARTITIONED):
+                final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id"])
+                            partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                                            scan customer
+                final aggregation over (c_birth_country_564, c_customer_id_551, c_email_address_566, c_first_name_558, c_last_name_559, c_login_565, c_preferred_cust_flag_560, d_year_612)
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_id_551"])
-                            final aggregation over (c_birth_country_564, c_customer_id_551, c_email_address_566, c_first_name_558, c_last_name_559, c_login_565, c_preferred_cust_flag_560, d_year_612)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_birth_country_564", "c_customer_id_551", "c_email_address_566", "c_first_name_558", "c_last_name_559", "c_login_565", "c_preferred_cust_flag_560", "d_year_612"])
-                                        partial aggregation over (c_birth_country_564, c_customer_id_551, c_email_address_566, c_first_name_558, c_last_name_559, c_login_565, c_preferred_cust_flag_560, d_year_612)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_574"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_550"])
-                                                        scan customer
+                            partial aggregation over (c_birth_country_564, c_customer_id_551, c_email_address_566, c_first_name_558, c_last_name_559, c_login_565, c_preferred_cust_flag_560, d_year_612)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_574"])
+                                        join (INNER, REPLICATED):
+                                            scan web_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_550"])
+                                            scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q16.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q16.plan.txt
@@ -9,26 +9,24 @@ final aggregation over ()
                                 remote exchange (REPARTITION, HASH, ["cr_order_number"])
                                     partial aggregation over (cr_order_number)
                                         scan catalog_returns
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["cs_order_number_23"])
-                                final aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number_23, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_state", "cc_county", "cs_call_center_sk", "cs_ext_ship_cost", "cs_net_profit", "cs_order_number_23", "cs_ship_addr_sk", "cs_ship_date_sk", "cs_warehouse_sk", "d_date", "unique"])
-                                            partial aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number_23, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
-                                                join (INNER, REPLICATED, can skip output duplicates):
-                                                    scan catalog_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
+                        final aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number_23, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["cs_order_number_23"])
+                                    partial aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number_23, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
+                                        join (INNER, REPLICATED, can skip output duplicates):
+                                            scan catalog_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    join (INNER, REPLICATED):
+                                                        join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    join (INNER, REPLICATED):
-                                                                        scan catalog_sales
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan date_dim
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan customer_address
+                                                                scan catalog_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan call_center
+                                                                        scan date_dim
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan customer_address
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan call_center

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q23.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q23.plan.txt
@@ -5,23 +5,20 @@ final aggregation over ()
                 join (INNER, PARTITIONED):
                     remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
                         join (INNER, PARTITIONED):
-                            final aggregation over (ss_item_sk)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ss_item_sk"])
-                                        partial aggregation over (ss_item_sk)
-                                            final aggregation over (d_date_6, ss_item_sk, substr$gid)
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["d_date_6", "ss_item_sk", "substr$gid"])
-                                                        partial aggregation over (d_date_6, ss_item_sk, substr$gid)
-                                                            join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    scan store_sales
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan item
+                            single aggregation over (ss_item_sk)
+                                final aggregation over (d_date_6, ss_item_sk, substr$gid)
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["ss_item_sk"])
+                                            partial aggregation over (d_date_6, ss_item_sk, substr$gid)
+                                                join (INNER, REPLICATED):
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["cs_item_sk"])
                                     join (INNER, REPLICATED):
@@ -63,23 +60,20 @@ final aggregation over ()
                 join (INNER, PARTITIONED):
                     remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk"])
                         join (INNER, PARTITIONED):
-                            final aggregation over (ss_item_sk_185)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ss_item_sk_185"])
-                                        partial aggregation over (ss_item_sk_185)
-                                            final aggregation over (d_date_210, ss_item_sk_185, substr$gid_265)
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["d_date_210", "ss_item_sk_185", "substr$gid_265"])
-                                                        partial aggregation over (d_date_210, ss_item_sk_185, substr$gid_265)
-                                                            join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    scan store_sales
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan item
+                            single aggregation over (ss_item_sk_185)
+                                final aggregation over (d_date_210, ss_item_sk_185, substr$gid_265)
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["ss_item_sk_185"])
+                                            partial aggregation over (d_date_210, ss_item_sk_185, substr$gid_265)
+                                                join (INNER, REPLICATED):
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["ws_item_sk"])
                                     join (INNER, REPLICATED):

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q30.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q30.plan.txt
@@ -3,21 +3,20 @@ local exchange (GATHER, SINGLE, [])
         cross join:
             join (LEFT, REPLICATED):
                 join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["wr_returning_customer_sk"])
-                        final aggregation over (ca_state, wr_returning_customer_sk)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_state", "wr_returning_customer_sk"])
-                                    partial aggregation over (ca_state, wr_returning_customer_sk)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                scan customer_address
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["wr_returning_addr_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_returns
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                    final aggregation over (ca_state, wr_returning_customer_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["wr_returning_customer_sk"])
+                                partial aggregation over (ca_state, wr_returning_customer_sk)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                            scan customer_address
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["wr_returning_addr_sk"])
+                                                join (INNER, REPLICATED):
+                                                    scan web_returns
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                             join (INNER, REPLICATED):

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q31.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q31.plan.txt
@@ -6,7 +6,7 @@ remote exchange (GATHER, SINGLE, [])
                     join (INNER, PARTITIONED):
                         final aggregation over (ca_county_66, d_qoy_39, d_year_35)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_county_66", "d_qoy_39", "d_year_35"])
+                                remote exchange (REPARTITION, HASH, ["ca_county_66"])
                                     partial aggregation over (ca_county_66, d_qoy_39, d_year_35)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["ss_addr_sk_10"])
@@ -18,26 +18,24 @@ remote exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["ca_address_sk_59"])
                                                     scan customer_address
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ca_county_140", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
-                                final aggregation over (ca_county_140, d_qoy_113, d_year_109)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_county_140", "d_qoy_113", "d_year_109"])
-                                            partial aggregation over (ca_county_140, d_qoy_113, d_year_109)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["ss_addr_sk_84"])
-                                                        join (INNER, REPLICATED):
-                                                            scan store_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
+                        final aggregation over (ca_county_140, d_qoy_113, d_year_109)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["ca_county_140"])
+                                    partial aggregation over (ca_county_140, d_qoy_113, d_year_109)
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["ss_addr_sk_84"])
+                                                join (INNER, REPLICATED):
+                                                    scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["ca_address_sk_133"])
-                                                            scan customer_address
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["ca_address_sk_133"])
+                                                    scan customer_address
                     join (INNER, PARTITIONED):
                         final aggregation over (ca_county_276, d_qoy_249, d_year_245)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_county_276", "d_qoy_249", "d_year_245"])
+                                remote exchange (REPARTITION, HASH, ["ca_county_276"])
                                     partial aggregation over (ca_county_276, d_qoy_249, d_year_245)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk_210"])
@@ -49,50 +47,46 @@ remote exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["ca_address_sk_269"])
                                                     scan customer_address
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ca_county_361", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
-                                final aggregation over (ca_county_361, d_qoy_334, d_year_330)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_county_361", "d_qoy_334", "d_year_330"])
-                                            partial aggregation over (ca_county_361, d_qoy_334, d_year_330)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk_295"])
-                                                        join (INNER, REPLICATED):
-                                                            scan web_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
+                        final aggregation over (ca_county_361, d_qoy_334, d_year_330)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["ca_county_361"])
+                                    partial aggregation over (ca_county_361, d_qoy_334, d_year_330)
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk_295"])
+                                                join (INNER, REPLICATED):
+                                                    scan web_sales
                                                     local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["ca_address_sk_354"])
-                                                            scan customer_address
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["ca_county", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
-                        join (INNER, PARTITIONED):
-                            final aggregation over (ca_county, d_qoy, d_year)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ca_county", "d_qoy", "d_year"])
-                                        partial aggregation over (ca_county, d_qoy, d_year)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan store_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["ca_address_sk_354"])
+                                                    scan customer_address
+                join (INNER, PARTITIONED):
+                    final aggregation over (ca_county, d_qoy, d_year)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ca_county"])
+                                partial aggregation over (ca_county, d_qoy, d_year)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
+                                            join (INNER, REPLICATED):
+                                                scan store_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                        scan customer_address
-                            final aggregation over (ca_county_191, d_qoy_164, d_year_160)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ca_county_191", "d_qoy_164", "d_year_160"])
-                                        partial aggregation over (ca_county_191, d_qoy_164, d_year_160)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                scan customer_address
+                    final aggregation over (ca_county_191, d_qoy_164, d_year_160)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ca_county_191"])
+                                partial aggregation over (ca_county_191, d_qoy_164, d_year_160)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk"])
+                                            join (INNER, REPLICATED):
+                                                scan web_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["ca_address_sk_184"])
-                                                        scan customer_address
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ca_address_sk_184"])
+                                                scan customer_address

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q34.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q34.plan.txt
@@ -4,22 +4,20 @@ remote exchange (GATHER, SINGLE, [])
             join (INNER, PARTITIONED):
                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                     scan customer
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                        final aggregation over (ss_customer_sk, ss_ticket_number)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_ticket_number"])
-                                    partial aggregation over (ss_customer_sk, ss_ticket_number)
+                final aggregation over (ss_customer_sk, ss_ticket_number)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                            partial aggregation over (ss_customer_sk, ss_ticket_number)
+                                join (INNER, REPLICATED):
+                                    join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan store
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan household_demographics
+                                                    scan store
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            scan household_demographics

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q51.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q51.plan.txt
@@ -3,25 +3,21 @@ local exchange (GATHER, SINGLE, [])
         local exchange (GATHER, SINGLE, [])
             remote exchange (REPARTITION, HASH, ["expr"])
                 join (FULL, PARTITIONED):
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["ws_item_sk"])
-                            final aggregation over (d_date, ws_item_sk)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["d_date", "ws_item_sk"])
-                                        partial aggregation over (d_date, ws_item_sk)
-                                            join (INNER, REPLICATED):
-                                                scan web_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["ss_item_sk"])
-                            final aggregation over (d_date_7, ss_item_sk)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["d_date_7", "ss_item_sk"])
-                                        partial aggregation over (d_date_7, ss_item_sk)
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
+                    final aggregation over (d_date, ws_item_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ws_item_sk"])
+                                partial aggregation over (d_date, ws_item_sk)
+                                    join (INNER, REPLICATED):
+                                        scan web_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
+                    final aggregation over (d_date_7, ss_item_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ss_item_sk"])
+                                partial aggregation over (d_date_7, ss_item_sk)
+                                    join (INNER, REPLICATED):
+                                        scan store_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q54.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q54.plan.txt
@@ -22,27 +22,25 @@ local exchange (GATHER, SINGLE, [])
                                                                             local exchange (GATHER, SINGLE, [])
                                                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                                                     scan store
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
-                                                                            final aggregation over (c_current_addr_sk, c_customer_sk)
-                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                    remote exchange (REPARTITION, HASH, ["c_current_addr_sk", "c_customer_sk"])
-                                                                                        partial aggregation over (c_current_addr_sk, c_customer_sk)
-                                                                                            join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                scan customer
-                                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                        join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                            join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                                remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                                                                                                    scan catalog_sales
-                                                                                                                    scan web_sales
-                                                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                                        scan item
-                                                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                                    scan date_dim
+                                                                    final aggregation over (c_current_addr_sk, c_customer_sk)
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
+                                                                                partial aggregation over (c_current_addr_sk, c_customer_sk)
+                                                                                    join (INNER, REPLICATED, can skip output duplicates):
+                                                                                        scan customer
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                join (INNER, REPLICATED, can skip output duplicates):
+                                                                                                    join (INNER, REPLICATED, can skip output duplicates):
+                                                                                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                                                            scan catalog_sales
+                                                                                                            scan web_sales
+                                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                                scan item
+                                                                                                    local exchange (GATHER, SINGLE, [])
+                                                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                            scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
                                                             scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q73.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q73.plan.txt
@@ -4,22 +4,20 @@ remote exchange (GATHER, SINGLE, [])
             join (INNER, PARTITIONED):
                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                     scan customer
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                        final aggregation over (ss_customer_sk, ss_ticket_number)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_ticket_number"])
-                                    partial aggregation over (ss_customer_sk, ss_ticket_number)
+                final aggregation over (ss_customer_sk, ss_ticket_number)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                            partial aggregation over (ss_customer_sk, ss_ticket_number)
+                                join (INNER, REPLICATED):
+                                    join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan household_demographics
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan store
+                                                    scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan household_demographics
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            scan store

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q74.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q74.plan.txt
@@ -2,67 +2,60 @@ local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
             join (INNER, PARTITIONED):
-                remote exchange (REPARTITION, HASH, ["c_customer_id_69"])
-                    final aggregation over (c_customer_id_69, c_first_name_76, c_last_name_77, d_year_119)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["c_customer_id_69", "c_first_name_76", "c_last_name_77", "d_year_119"])
-                                partial aggregation over (c_customer_id_69, c_first_name_76, c_last_name_77, d_year_119)
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["ss_customer_sk_91"])
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_68"])
-                                                scan customer
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["c_customer_id_329"])
-                        final aggregation over (c_customer_id_329, c_first_name_336, c_last_name_337, d_year_390)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_customer_id_329", "c_first_name_336", "c_last_name_337", "d_year_390"])
-                                    partial aggregation over (c_customer_id_329, c_first_name_336, c_last_name_337, d_year_390)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_352"])
-                                                join (INNER, REPLICATED):
-                                                    scan web_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                final aggregation over (c_customer_id_69, c_first_name_76, c_last_name_77, d_year_119)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_69"])
+                            partial aggregation over (c_customer_id_69, c_first_name_76, c_last_name_77, d_year_119)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk_91"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_328"])
-                                                    scan customer
-            local exchange (GATHER, SINGLE, [])
-                join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id"])
-                        final aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_customer_id", "c_first_name", "c_last_name", "d_year"])
-                                    partial aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_68"])
+                                            scan customer
+                final aggregation over (c_customer_id_329, c_first_name_336, c_last_name_337, d_year_390)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_329"])
+                            partial aggregation over (c_customer_id_329, c_first_name_336, c_last_name_337, d_year_390)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_352"])
+                                        join (INNER, REPLICATED):
+                                            scan web_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                    scan customer
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_328"])
+                                            scan customer
+            join (INNER, PARTITIONED):
+                final aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id"])
+                            partial aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                                            scan customer
+                final aggregation over (c_customer_id_508, c_first_name_515, c_last_name_516, d_year_569)
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_id_508"])
-                            final aggregation over (c_customer_id_508, c_first_name_515, c_last_name_516, d_year_569)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_customer_id_508", "c_first_name_515", "c_last_name_516", "d_year_569"])
-                                        partial aggregation over (c_customer_id_508, c_first_name_515, c_last_name_516, d_year_569)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_531"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_507"])
-                                                        scan customer
+                            partial aggregation over (c_customer_id_508, c_first_name_515, c_last_name_516, d_year_569)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_531"])
+                                        join (INNER, REPLICATED):
+                                            scan web_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_507"])
+                                            scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q78.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q78.plan.txt
@@ -5,7 +5,7 @@ local exchange (GATHER, SINGLE, [])
                 join (INNER, PARTITIONED):
                     final aggregation over (d_year, ss_customer_sk, ss_item_sk)
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["d_year", "ss_customer_sk", "ss_item_sk"])
+                            remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_item_sk"])
                                 partial aggregation over (d_year, ss_customer_sk, ss_item_sk)
                                     join (INNER, REPLICATED):
                                         join (LEFT, PARTITIONED):
@@ -19,7 +19,7 @@ local exchange (GATHER, SINGLE, [])
                                                 scan date_dim
                     final aggregation over (d_year_17, ws_bill_customer_sk, ws_item_sk)
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["d_year_17", "ws_bill_customer_sk", "ws_item_sk"])
+                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk", "ws_item_sk"])
                                 partial aggregation over (d_year_17, ws_bill_customer_sk, ws_item_sk)
                                     join (INNER, REPLICATED):
                                         join (LEFT, PARTITIONED):
@@ -31,19 +31,17 @@ local exchange (GATHER, SINGLE, [])
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
                                                 scan date_dim
-            local exchange (GATHER, SINGLE, [])
-                remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
-                    final aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_56)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk", "cs_item_sk", "d_year_56"])
-                                partial aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_56)
-                                    join (INNER, REPLICATED):
-                                        join (LEFT, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["cs_item_sk", "cs_order_number"])
-                                                scan catalog_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["cr_item_sk", "cr_order_number"])
-                                                    scan catalog_returns
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                scan date_dim
+            final aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_56)
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
+                        partial aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_56)
+                            join (INNER, REPLICATED):
+                                join (LEFT, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["cs_item_sk", "cs_order_number"])
+                                        scan catalog_sales
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["cr_item_sk", "cr_order_number"])
+                                            scan catalog_returns
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPLICATE, BROADCAST, [])
+                                        scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q79.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q79.plan.txt
@@ -1,24 +1,23 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
-            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                final aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["s_city", "ss_addr_sk", "ss_customer_sk", "ss_ticket_number"])
-                            partial aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
+            final aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                        partial aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
+                            join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
-                                        join (INNER, REPLICATED):
-                                            scan store_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
+                                        scan store_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan household_demographics
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan store
+                                            scan household_demographics
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPLICATE, BROADCAST, [])
+                                        scan store
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                     scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q81.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q81.plan.txt
@@ -3,21 +3,20 @@ local exchange (GATHER, SINGLE, [])
         cross join:
             join (LEFT, REPLICATED):
                 join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["cr_returning_customer_sk"])
-                        final aggregation over (ca_state, cr_returning_customer_sk)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_state", "cr_returning_customer_sk"])
-                                    partial aggregation over (ca_state, cr_returning_customer_sk)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["cr_returning_addr_sk"])
-                                                join (INNER, REPLICATED):
-                                                    scan catalog_returns
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                    scan customer_address
+                    final aggregation over (ca_state, cr_returning_customer_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["cr_returning_customer_sk"])
+                                partial aggregation over (ca_state, cr_returning_customer_sk)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["cr_returning_addr_sk"])
+                                            join (INNER, REPLICATED):
+                                                scan catalog_returns
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                scan customer_address
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                             join (INNER, REPLICATED):

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q94.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q94.plan.txt
@@ -9,26 +9,24 @@ final aggregation over ()
                                 remote exchange (REPARTITION, HASH, ["wr_order_number"])
                                     partial aggregation over (wr_order_number)
                                         scan web_returns
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ws_order_number_23"])
-                                final aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number_23, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_state", "d_date", "unique", "web_company_name", "ws_ext_ship_cost", "ws_net_profit", "ws_order_number_23", "ws_ship_addr_sk", "ws_ship_date_sk", "ws_warehouse_sk", "ws_web_site_sk"])
-                                            partial aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number_23, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
-                                                join (INNER, REPLICATED, can skip output duplicates):
-                                                    scan web_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
+                        final aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number_23, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["ws_order_number_23"])
+                                    partial aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number_23, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
+                                        join (INNER, REPLICATED, can skip output duplicates):
+                                            scan web_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    join (INNER, REPLICATED):
+                                                        join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    join (INNER, REPLICATED):
-                                                                        scan web_sales
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan date_dim
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan customer_address
+                                                                scan web_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan web_site
+                                                                        scan date_dim
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan customer_address
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan web_site

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q02.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q02.plan.txt
@@ -3,42 +3,36 @@ remote exchange (GATHER, SINGLE, [])
         remote exchange (REPARTITION, ROUND_ROBIN, [])
             join (INNER, PARTITIONED):
                 join (INNER, PARTITIONED):
-                    final aggregation over (d_week_seq)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["d_week_seq"])
-                                partial aggregation over (d_week_seq)
-                                    final aggregation over (d_day_name, d_week_seq)
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["d_day_name", "d_week_seq"])
-                                                partial aggregation over (d_day_name, d_week_seq)
-                                                    join (INNER, REPLICATED):
-                                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                                            scan web_sales
-                                                            scan catalog_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                    single aggregation over (d_week_seq)
+                        final aggregation over (d_day_name, d_week_seq)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["d_week_seq"])
+                                    partial aggregation over (d_day_name, d_week_seq)
+                                        join (INNER, REPLICATED):
+                                            remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                scan web_sales
+                                                scan catalog_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["d_week_seq_20"])
                             scan date_dim
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["expr_219"])
                         join (INNER, PARTITIONED):
-                            final aggregation over (d_week_seq_124)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["d_week_seq_124"])
-                                        partial aggregation over (d_week_seq_124)
-                                            final aggregation over (d_day_name_134, d_week_seq_124)
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["d_day_name_134", "d_week_seq_124"])
-                                                        partial aggregation over (d_day_name_134, d_week_seq_124)
-                                                            join (INNER, REPLICATED):
-                                                                remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                                                    scan web_sales
-                                                                    scan catalog_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan date_dim
+                            single aggregation over (d_week_seq_124)
+                                final aggregation over (d_day_name_134, d_week_seq_124)
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["d_week_seq_124"])
+                                            partial aggregation over (d_day_name_134, d_week_seq_124)
+                                                join (INNER, REPLICATED):
+                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                        scan web_sales
+                                                        scan catalog_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["d_week_seq_169"])
                                     scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q04.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q04.plan.txt
@@ -3,100 +3,89 @@ local exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
             join (INNER, PARTITIONED):
                 join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id_848"])
-                        final aggregation over (c_birth_country_861, c_customer_id_848, c_email_address_863, c_first_name_855, c_last_name_856, c_login_862, c_preferred_cust_flag_857, d_year_909)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_birth_country_861", "c_customer_id_848", "c_email_address_863", "c_first_name_855", "c_last_name_856", "c_login_862", "c_preferred_cust_flag_857", "d_year_909"])
-                                    partial aggregation over (c_birth_country_861, c_customer_id_848, c_email_address_863, c_first_name_855, c_last_name_856, c_login_862, c_preferred_cust_flag_857, d_year_909)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_869"])
-                                                join (INNER, REPLICATED):
-                                                    scan catalog_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_847"])
-                                                    scan customer
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["c_customer_id_1545"])
-                            final aggregation over (c_birth_country_1558, c_customer_id_1545, c_email_address_1560, c_first_name_1552, c_last_name_1553, c_login_1559, c_preferred_cust_flag_1554, d_year_1606)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_birth_country_1558", "c_customer_id_1545", "c_email_address_1560", "c_first_name_1552", "c_last_name_1553", "c_login_1559", "c_preferred_cust_flag_1554", "d_year_1606"])
-                                        partial aggregation over (c_birth_country_1558, c_customer_id_1545, c_email_address_1560, c_first_name_1552, c_last_name_1553, c_login_1559, c_preferred_cust_flag_1554, d_year_1606)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1567"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                    final aggregation over (c_birth_country_861, c_customer_id_848, c_email_address_863, c_first_name_855, c_last_name_856, c_login_862, c_preferred_cust_flag_857, d_year_909)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["c_customer_id_848"])
+                                partial aggregation over (c_birth_country_861, c_customer_id_848, c_email_address_863, c_first_name_855, c_last_name_856, c_login_862, c_preferred_cust_flag_857, d_year_909)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_869"])
+                                            join (INNER, REPLICATED):
+                                                scan catalog_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_1544"])
-                                                        scan customer
-                local exchange (GATHER, SINGLE, [])
-                    join (INNER, PARTITIONED):
-                        remote exchange (REPARTITION, HASH, ["c_customer_id_548"])
-                            final aggregation over (c_birth_country_561, c_customer_id_548, c_email_address_563, c_first_name_555, c_last_name_556, c_login_562, c_preferred_cust_flag_557, d_year_609)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_birth_country_561", "c_customer_id_548", "c_email_address_563", "c_first_name_555", "c_last_name_556", "c_login_562", "c_preferred_cust_flag_557", "d_year_609"])
-                                        partial aggregation over (c_birth_country_561, c_customer_id_548, c_email_address_563, c_first_name_555, c_last_name_556, c_login_562, c_preferred_cust_flag_557, d_year_609)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_569"])
-                                                    join (INNER, REPLICATED):
-                                                        scan catalog_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_847"])
+                                                scan customer
+                    final aggregation over (c_birth_country_1558, c_customer_id_1545, c_email_address_1560, c_first_name_1552, c_last_name_1553, c_login_1559, c_preferred_cust_flag_1554, d_year_1606)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["c_customer_id_1545"])
+                                partial aggregation over (c_birth_country_1558, c_customer_id_1545, c_email_address_1560, c_first_name_1552, c_last_name_1553, c_login_1559, c_preferred_cust_flag_1554, d_year_1606)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1567"])
+                                            join (INNER, REPLICATED):
+                                                scan web_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_547"])
-                                                        scan customer
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_1544"])
+                                                scan customer
+                join (INNER, PARTITIONED):
+                    final aggregation over (c_birth_country_561, c_customer_id_548, c_email_address_563, c_first_name_555, c_last_name_556, c_login_562, c_preferred_cust_flag_557, d_year_609)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["c_customer_id_548"])
+                                partial aggregation over (c_birth_country_561, c_customer_id_548, c_email_address_563, c_first_name_555, c_last_name_556, c_login_562, c_preferred_cust_flag_557, d_year_609)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_569"])
+                                            join (INNER, REPLICATED):
+                                                scan catalog_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_547"])
+                                                scan customer
+                    final aggregation over (c_birth_country_1258, c_customer_id_1245, c_email_address_1260, c_first_name_1252, c_last_name_1253, c_login_1259, c_preferred_cust_flag_1254, d_year_1306)
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["c_customer_id_1245"])
-                                final aggregation over (c_birth_country_1258, c_customer_id_1245, c_email_address_1260, c_first_name_1252, c_last_name_1253, c_login_1259, c_preferred_cust_flag_1254, d_year_1306)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["c_birth_country_1258", "c_customer_id_1245", "c_email_address_1260", "c_first_name_1252", "c_last_name_1253", "c_login_1259", "c_preferred_cust_flag_1254", "d_year_1306"])
-                                            partial aggregation over (c_birth_country_1258, c_customer_id_1245, c_email_address_1260, c_first_name_1252, c_last_name_1253, c_login_1259, c_preferred_cust_flag_1254, d_year_1306)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1267"])
-                                                        join (INNER, REPLICATED):
-                                                            scan web_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_1244"])
-                                                            scan customer
-            local exchange (GATHER, SINGLE, [])
-                join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id_162"])
-                        final aggregation over (c_birth_country_175, c_customer_id_162, c_email_address_177, c_first_name_169, c_last_name_170, c_login_176, c_preferred_cust_flag_171, d_year_212)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_birth_country_175", "c_customer_id_162", "c_email_address_177", "c_first_name_169", "c_last_name_170", "c_login_176", "c_preferred_cust_flag_171", "d_year_212"])
-                                    partial aggregation over (c_birth_country_175, c_customer_id_162, c_email_address_177, c_first_name_169, c_last_name_170, c_login_176, c_preferred_cust_flag_171, d_year_212)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ss_customer_sk_183"])
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                partial aggregation over (c_birth_country_1258, c_customer_id_1245, c_email_address_1260, c_first_name_1252, c_last_name_1253, c_login_1259, c_preferred_cust_flag_1254, d_year_1306)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1267"])
+                                            join (INNER, REPLICATED):
+                                                scan web_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_1244"])
+                                                scan customer
+            join (INNER, PARTITIONED):
+                final aggregation over (c_birth_country_175, c_customer_id_162, c_email_address_177, c_first_name_169, c_last_name_170, c_login_176, c_preferred_cust_flag_171, d_year_212)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_162"])
+                            partial aggregation over (c_birth_country_175, c_customer_id_162, c_email_address_177, c_first_name_169, c_last_name_170, c_login_176, c_preferred_cust_flag_171, d_year_212)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk_183"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_161"])
-                                                    scan customer
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_161"])
+                                            scan customer
+                final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_id"])
-                            final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_birth_country", "c_customer_id", "c_email_address", "c_first_name", "c_last_name", "c_login", "c_preferred_cust_flag", "d_year"])
-                                        partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan store_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                        scan customer
+                            partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                                            scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q11.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q11.plan.txt
@@ -2,67 +2,60 @@ local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
             join (INNER, PARTITIONED):
-                remote exchange (REPARTITION, HASH, ["c_customer_id_79"])
-                    final aggregation over (c_birth_country_92, c_customer_id_79, c_email_address_94, c_first_name_86, c_last_name_87, c_login_93, c_preferred_cust_flag_88, d_year_129)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["c_birth_country_92", "c_customer_id_79", "c_email_address_94", "c_first_name_86", "c_last_name_87", "c_login_93", "c_preferred_cust_flag_88", "d_year_129"])
-                                partial aggregation over (c_birth_country_92, c_customer_id_79, c_email_address_94, c_first_name_86, c_last_name_87, c_login_93, c_preferred_cust_flag_88, d_year_129)
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["ss_customer_sk_100"])
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_78"])
-                                                scan customer
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["c_customer_id_358"])
-                        final aggregation over (c_birth_country_371, c_customer_id_358, c_email_address_373, c_first_name_365, c_last_name_366, c_login_372, c_preferred_cust_flag_367, d_year_419)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_birth_country_371", "c_customer_id_358", "c_email_address_373", "c_first_name_365", "c_last_name_366", "c_login_372", "c_preferred_cust_flag_367", "d_year_419"])
-                                    partial aggregation over (c_birth_country_371, c_customer_id_358, c_email_address_373, c_first_name_365, c_last_name_366, c_login_372, c_preferred_cust_flag_367, d_year_419)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_380"])
-                                                join (INNER, REPLICATED):
-                                                    scan web_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                final aggregation over (c_birth_country_92, c_customer_id_79, c_email_address_94, c_first_name_86, c_last_name_87, c_login_93, c_preferred_cust_flag_88, d_year_129)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_79"])
+                            partial aggregation over (c_birth_country_92, c_customer_id_79, c_email_address_94, c_first_name_86, c_last_name_87, c_login_93, c_preferred_cust_flag_88, d_year_129)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk_100"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_357"])
-                                                    scan customer
-            local exchange (GATHER, SINGLE, [])
-                join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id"])
-                        final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_birth_country", "c_customer_id", "c_email_address", "c_first_name", "c_last_name", "c_login", "c_preferred_cust_flag", "d_year"])
-                                    partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_78"])
+                                            scan customer
+                final aggregation over (c_birth_country_371, c_customer_id_358, c_email_address_373, c_first_name_365, c_last_name_366, c_login_372, c_preferred_cust_flag_367, d_year_419)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_358"])
+                            partial aggregation over (c_birth_country_371, c_customer_id_358, c_email_address_373, c_first_name_365, c_last_name_366, c_login_372, c_preferred_cust_flag_367, d_year_419)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_380"])
+                                        join (INNER, REPLICATED):
+                                            scan web_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                    scan customer
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_357"])
+                                            scan customer
+            join (INNER, PARTITIONED):
+                final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id"])
+                            partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                                            scan customer
+                final aggregation over (c_birth_country_564, c_customer_id_551, c_email_address_566, c_first_name_558, c_last_name_559, c_login_565, c_preferred_cust_flag_560, d_year_612)
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_id_551"])
-                            final aggregation over (c_birth_country_564, c_customer_id_551, c_email_address_566, c_first_name_558, c_last_name_559, c_login_565, c_preferred_cust_flag_560, d_year_612)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_birth_country_564", "c_customer_id_551", "c_email_address_566", "c_first_name_558", "c_last_name_559", "c_login_565", "c_preferred_cust_flag_560", "d_year_612"])
-                                        partial aggregation over (c_birth_country_564, c_customer_id_551, c_email_address_566, c_first_name_558, c_last_name_559, c_login_565, c_preferred_cust_flag_560, d_year_612)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_573"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_550"])
-                                                        scan customer
+                            partial aggregation over (c_birth_country_564, c_customer_id_551, c_email_address_566, c_first_name_558, c_last_name_559, c_login_565, c_preferred_cust_flag_560, d_year_612)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_573"])
+                                        join (INNER, REPLICATED):
+                                            scan web_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_550"])
+                                            scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q16.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q16.plan.txt
@@ -9,26 +9,24 @@ final aggregation over ()
                                 remote exchange (REPARTITION, HASH, ["cr_order_number"])
                                     partial aggregation over (cr_order_number)
                                         scan catalog_returns
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["cs_order_number_22"])
-                                final aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number_22, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_state", "cc_county", "cs_call_center_sk", "cs_ext_ship_cost", "cs_net_profit", "cs_order_number_22", "cs_ship_addr_sk", "cs_ship_date_sk", "cs_warehouse_sk", "d_date", "unique"])
-                                            partial aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number_22, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
-                                                join (INNER, REPLICATED, can skip output duplicates):
-                                                    scan catalog_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
+                        final aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number_22, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["cs_order_number_22"])
+                                    partial aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number_22, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
+                                        join (INNER, REPLICATED, can skip output duplicates):
+                                            scan catalog_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    join (INNER, REPLICATED):
+                                                        join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    join (INNER, REPLICATED):
-                                                                        scan catalog_sales
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan customer_address
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
+                                                                scan catalog_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan call_center
+                                                                        scan customer_address
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan date_dim
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan call_center

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q23.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q23.plan.txt
@@ -5,23 +5,20 @@ final aggregation over ()
                 join (INNER, PARTITIONED):
                     remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
                         join (INNER, PARTITIONED):
-                            final aggregation over (ss_item_sk)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ss_item_sk"])
-                                        partial aggregation over (ss_item_sk)
-                                            final aggregation over (d_date_6, ss_item_sk, substr$gid)
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["d_date_6", "ss_item_sk", "substr$gid"])
-                                                        partial aggregation over (d_date_6, ss_item_sk, substr$gid)
-                                                            join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    scan store_sales
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan item
+                            single aggregation over (ss_item_sk)
+                                final aggregation over (d_date_6, ss_item_sk, substr$gid)
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["ss_item_sk"])
+                                            partial aggregation over (d_date_6, ss_item_sk, substr$gid)
+                                                join (INNER, REPLICATED):
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["cs_item_sk"])
                                     join (INNER, REPLICATED):
@@ -63,23 +60,20 @@ final aggregation over ()
                 join (INNER, PARTITIONED):
                     remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk"])
                         join (INNER, PARTITIONED):
-                            final aggregation over (ss_item_sk_184)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ss_item_sk_184"])
-                                        partial aggregation over (ss_item_sk_184)
-                                            final aggregation over (d_date_210, ss_item_sk_184, substr$gid_265)
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["d_date_210", "ss_item_sk_184", "substr$gid_265"])
-                                                        partial aggregation over (d_date_210, ss_item_sk_184, substr$gid_265)
-                                                            join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    scan store_sales
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan item
+                            single aggregation over (ss_item_sk_184)
+                                final aggregation over (d_date_210, ss_item_sk_184, substr$gid_265)
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["ss_item_sk_184"])
+                                            partial aggregation over (d_date_210, ss_item_sk_184, substr$gid_265)
+                                                join (INNER, REPLICATED):
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["ws_item_sk"])
                                     join (INNER, REPLICATED):

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q30.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q30.plan.txt
@@ -3,21 +3,20 @@ local exchange (GATHER, SINGLE, [])
         cross join:
             join (LEFT, REPLICATED):
                 join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["wr_returning_customer_sk"])
-                        final aggregation over (ca_state, wr_returning_customer_sk)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_state", "wr_returning_customer_sk"])
-                                    partial aggregation over (ca_state, wr_returning_customer_sk)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["wr_returning_addr_sk"])
-                                                join (INNER, REPLICATED):
-                                                    scan web_returns
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                    scan customer_address
+                    final aggregation over (ca_state, wr_returning_customer_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["wr_returning_customer_sk"])
+                                partial aggregation over (ca_state, wr_returning_customer_sk)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["wr_returning_addr_sk"])
+                                            join (INNER, REPLICATED):
+                                                scan web_returns
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                scan customer_address
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                             join (INNER, REPLICATED):

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q31.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q31.plan.txt
@@ -6,7 +6,7 @@ remote exchange (GATHER, SINGLE, [])
                     join (INNER, PARTITIONED):
                         final aggregation over (ca_county_66, d_qoy_39, d_year_35)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_county_66", "d_qoy_39", "d_year_35"])
+                                remote exchange (REPARTITION, HASH, ["ca_county_66"])
                                     partial aggregation over (ca_county_66, d_qoy_39, d_year_35)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["ss_addr_sk_9"])
@@ -18,26 +18,24 @@ remote exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["ca_address_sk_59"])
                                                     scan customer_address
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ca_county_140", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
-                                final aggregation over (ca_county_140, d_qoy_113, d_year_109)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_county_140", "d_qoy_113", "d_year_109"])
-                                            partial aggregation over (ca_county_140, d_qoy_113, d_year_109)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["ss_addr_sk_83"])
-                                                        join (INNER, REPLICATED):
-                                                            scan store_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
+                        final aggregation over (ca_county_140, d_qoy_113, d_year_109)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["ca_county_140"])
+                                    partial aggregation over (ca_county_140, d_qoy_113, d_year_109)
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["ss_addr_sk_83"])
+                                                join (INNER, REPLICATED):
+                                                    scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["ca_address_sk_133"])
-                                                            scan customer_address
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["ca_address_sk_133"])
+                                                    scan customer_address
                     join (INNER, PARTITIONED):
                         final aggregation over (ca_county_276, d_qoy_249, d_year_245)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_county_276", "d_qoy_249", "d_year_245"])
+                                remote exchange (REPARTITION, HASH, ["ca_county_276"])
                                     partial aggregation over (ca_county_276, d_qoy_249, d_year_245)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk_209"])
@@ -49,50 +47,46 @@ remote exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["ca_address_sk_269"])
                                                     scan customer_address
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ca_county_361", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
-                                final aggregation over (ca_county_361, d_qoy_334, d_year_330)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_county_361", "d_qoy_334", "d_year_330"])
-                                            partial aggregation over (ca_county_361, d_qoy_334, d_year_330)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk_294"])
-                                                        join (INNER, REPLICATED):
-                                                            scan web_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
+                        final aggregation over (ca_county_361, d_qoy_334, d_year_330)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["ca_county_361"])
+                                    partial aggregation over (ca_county_361, d_qoy_334, d_year_330)
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk_294"])
+                                                join (INNER, REPLICATED):
+                                                    scan web_sales
                                                     local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["ca_address_sk_354"])
-                                                            scan customer_address
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["ca_county", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
-                        join (INNER, PARTITIONED):
-                            final aggregation over (ca_county, d_qoy, d_year)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ca_county", "d_qoy", "d_year"])
-                                        partial aggregation over (ca_county, d_qoy, d_year)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan store_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["ca_address_sk_354"])
+                                                    scan customer_address
+                join (INNER, PARTITIONED):
+                    final aggregation over (ca_county, d_qoy, d_year)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ca_county"])
+                                partial aggregation over (ca_county, d_qoy, d_year)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
+                                            join (INNER, REPLICATED):
+                                                scan store_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                        scan customer_address
-                            final aggregation over (ca_county_191, d_qoy_164, d_year_160)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ca_county_191", "d_qoy_164", "d_year_160"])
-                                        partial aggregation over (ca_county_191, d_qoy_164, d_year_160)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                scan customer_address
+                    final aggregation over (ca_county_191, d_qoy_164, d_year_160)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ca_county_191"])
+                                partial aggregation over (ca_county_191, d_qoy_164, d_year_160)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk"])
+                                            join (INNER, REPLICATED):
+                                                scan web_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["ca_address_sk_184"])
-                                                        scan customer_address
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ca_address_sk_184"])
+                                                scan customer_address

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q34.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q34.plan.txt
@@ -4,22 +4,20 @@ remote exchange (GATHER, SINGLE, [])
             join (INNER, PARTITIONED):
                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                     scan customer
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                        final aggregation over (ss_customer_sk, ss_ticket_number)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_ticket_number"])
-                                    partial aggregation over (ss_customer_sk, ss_ticket_number)
+                final aggregation over (ss_customer_sk, ss_ticket_number)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                            partial aggregation over (ss_customer_sk, ss_ticket_number)
+                                join (INNER, REPLICATED):
+                                    join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan store
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan household_demographics
+                                                    scan store
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            scan household_demographics

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q51.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q51.plan.txt
@@ -3,25 +3,21 @@ local exchange (GATHER, SINGLE, [])
         local exchange (GATHER, SINGLE, [])
             remote exchange (REPARTITION, HASH, ["expr"])
                 join (FULL, PARTITIONED):
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["ws_item_sk"])
-                            final aggregation over (d_date, ws_item_sk)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["d_date", "ws_item_sk"])
-                                        partial aggregation over (d_date, ws_item_sk)
-                                            join (INNER, REPLICATED):
-                                                scan web_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["ss_item_sk"])
-                            final aggregation over (d_date_7, ss_item_sk)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["d_date_7", "ss_item_sk"])
-                                        partial aggregation over (d_date_7, ss_item_sk)
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
+                    final aggregation over (d_date, ws_item_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ws_item_sk"])
+                                partial aggregation over (d_date, ws_item_sk)
+                                    join (INNER, REPLICATED):
+                                        scan web_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
+                    final aggregation over (d_date_7, ss_item_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ss_item_sk"])
+                                partial aggregation over (d_date_7, ss_item_sk)
+                                    join (INNER, REPLICATED):
+                                        scan store_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q54.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q54.plan.txt
@@ -22,27 +22,25 @@ local exchange (GATHER, SINGLE, [])
                                                                             local exchange (GATHER, SINGLE, [])
                                                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                                                     scan store
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
-                                                                            final aggregation over (c_current_addr_sk, c_customer_sk)
-                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                    remote exchange (REPARTITION, HASH, ["c_current_addr_sk", "c_customer_sk"])
-                                                                                        partial aggregation over (c_current_addr_sk, c_customer_sk)
-                                                                                            join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                scan customer
-                                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                        join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                            join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                                remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                                                                                                    scan catalog_sales
-                                                                                                                    scan web_sales
-                                                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                                        scan item
-                                                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                                    scan date_dim
+                                                                    final aggregation over (c_current_addr_sk, c_customer_sk)
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
+                                                                                partial aggregation over (c_current_addr_sk, c_customer_sk)
+                                                                                    join (INNER, REPLICATED, can skip output duplicates):
+                                                                                        scan customer
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                join (INNER, REPLICATED, can skip output duplicates):
+                                                                                                    join (INNER, REPLICATED, can skip output duplicates):
+                                                                                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                                                            scan catalog_sales
+                                                                                                            scan web_sales
+                                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                                scan item
+                                                                                                    local exchange (GATHER, SINGLE, [])
+                                                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                            scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
                                                             scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q73.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q73.plan.txt
@@ -4,22 +4,20 @@ remote exchange (GATHER, SINGLE, [])
             join (INNER, PARTITIONED):
                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                     scan customer
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                        final aggregation over (ss_customer_sk, ss_ticket_number)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_ticket_number"])
-                                    partial aggregation over (ss_customer_sk, ss_ticket_number)
+                final aggregation over (ss_customer_sk, ss_ticket_number)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                            partial aggregation over (ss_customer_sk, ss_ticket_number)
+                                join (INNER, REPLICATED):
+                                    join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan household_demographics
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan store
+                                                    scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan household_demographics
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            scan store

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q74.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q74.plan.txt
@@ -2,67 +2,60 @@ local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
             join (INNER, PARTITIONED):
-                remote exchange (REPARTITION, HASH, ["c_customer_id_69"])
-                    final aggregation over (c_customer_id_69, c_first_name_76, c_last_name_77, d_year_119)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["c_customer_id_69", "c_first_name_76", "c_last_name_77", "d_year_119"])
-                                partial aggregation over (c_customer_id_69, c_first_name_76, c_last_name_77, d_year_119)
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["ss_customer_sk_90"])
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_68"])
-                                                scan customer
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["c_customer_id_329"])
-                        final aggregation over (c_customer_id_329, c_first_name_336, c_last_name_337, d_year_390)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_customer_id_329", "c_first_name_336", "c_last_name_337", "d_year_390"])
-                                    partial aggregation over (c_customer_id_329, c_first_name_336, c_last_name_337, d_year_390)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_351"])
-                                                join (INNER, REPLICATED):
-                                                    scan web_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                final aggregation over (c_customer_id_69, c_first_name_76, c_last_name_77, d_year_119)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_69"])
+                            partial aggregation over (c_customer_id_69, c_first_name_76, c_last_name_77, d_year_119)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk_90"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_328"])
-                                                    scan customer
-            local exchange (GATHER, SINGLE, [])
-                join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id"])
-                        final aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_customer_id", "c_first_name", "c_last_name", "d_year"])
-                                    partial aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_68"])
+                                            scan customer
+                final aggregation over (c_customer_id_329, c_first_name_336, c_last_name_337, d_year_390)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_329"])
+                            partial aggregation over (c_customer_id_329, c_first_name_336, c_last_name_337, d_year_390)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_351"])
+                                        join (INNER, REPLICATED):
+                                            scan web_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                    scan customer
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_328"])
+                                            scan customer
+            join (INNER, PARTITIONED):
+                final aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id"])
+                            partial aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                                            scan customer
+                final aggregation over (c_customer_id_508, c_first_name_515, c_last_name_516, d_year_569)
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_id_508"])
-                            final aggregation over (c_customer_id_508, c_first_name_515, c_last_name_516, d_year_569)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_customer_id_508", "c_first_name_515", "c_last_name_516", "d_year_569"])
-                                        partial aggregation over (c_customer_id_508, c_first_name_515, c_last_name_516, d_year_569)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_530"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_507"])
-                                                        scan customer
+                            partial aggregation over (c_customer_id_508, c_first_name_515, c_last_name_516, d_year_569)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_530"])
+                                        join (INNER, REPLICATED):
+                                            scan web_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_507"])
+                                            scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q78.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q78.plan.txt
@@ -5,7 +5,7 @@ local exchange (GATHER, SINGLE, [])
                 join (INNER, PARTITIONED):
                     final aggregation over (d_year, ss_customer_sk, ss_item_sk)
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["d_year", "ss_customer_sk", "ss_item_sk"])
+                            remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_item_sk"])
                                 partial aggregation over (d_year, ss_customer_sk, ss_item_sk)
                                     join (INNER, REPLICATED):
                                         join (LEFT, PARTITIONED):
@@ -19,7 +19,7 @@ local exchange (GATHER, SINGLE, [])
                                                 scan date_dim
                     final aggregation over (d_year_17, ws_bill_customer_sk, ws_item_sk)
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["d_year_17", "ws_bill_customer_sk", "ws_item_sk"])
+                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk", "ws_item_sk"])
                                 partial aggregation over (d_year_17, ws_bill_customer_sk, ws_item_sk)
                                     join (INNER, REPLICATED):
                                         join (LEFT, PARTITIONED):
@@ -31,19 +31,17 @@ local exchange (GATHER, SINGLE, [])
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
                                                 scan date_dim
-            local exchange (GATHER, SINGLE, [])
-                remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
-                    final aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_56)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk", "cs_item_sk", "d_year_56"])
-                                partial aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_56)
-                                    join (INNER, REPLICATED):
-                                        join (LEFT, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["cs_item_sk", "cs_order_number"])
-                                                scan catalog_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["cr_item_sk", "cr_order_number"])
-                                                    scan catalog_returns
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                scan date_dim
+            final aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_56)
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
+                        partial aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_56)
+                            join (INNER, REPLICATED):
+                                join (LEFT, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["cs_item_sk", "cs_order_number"])
+                                        scan catalog_sales
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["cr_item_sk", "cr_order_number"])
+                                            scan catalog_returns
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPLICATE, BROADCAST, [])
+                                        scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q79.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q79.plan.txt
@@ -1,24 +1,23 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
-            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                final aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["s_city", "ss_addr_sk", "ss_customer_sk", "ss_ticket_number"])
-                            partial aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
+            final aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                        partial aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
+                            join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
-                                        join (INNER, REPLICATED):
-                                            scan store_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
+                                        scan store_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan household_demographics
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan store
+                                            scan household_demographics
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPLICATE, BROADCAST, [])
+                                        scan store
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                     scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q94.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q94.plan.txt
@@ -9,26 +9,24 @@ final aggregation over ()
                                 remote exchange (REPARTITION, HASH, ["wr_order_number"])
                                     partial aggregation over (wr_order_number)
                                         scan web_returns
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ws_order_number_22"])
-                                final aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number_22, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_state", "d_date", "unique", "web_company_name", "ws_ext_ship_cost", "ws_net_profit", "ws_order_number_22", "ws_ship_addr_sk", "ws_ship_date_sk", "ws_warehouse_sk", "ws_web_site_sk"])
-                                            partial aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number_22, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
-                                                join (INNER, REPLICATED, can skip output duplicates):
-                                                    scan web_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
+                        final aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number_22, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["ws_order_number_22"])
+                                    partial aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number_22, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
+                                        join (INNER, REPLICATED, can skip output duplicates):
+                                            scan web_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    join (INNER, REPLICATED):
+                                                        join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    join (INNER, REPLICATED):
-                                                                        scan web_sales
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan customer_address
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
+                                                                scan web_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan web_site
+                                                                        scan customer_address
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan date_dim
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan web_site

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q02.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q02.plan.txt
@@ -3,42 +3,36 @@ remote exchange (GATHER, SINGLE, [])
         remote exchange (REPARTITION, ROUND_ROBIN, [])
             join (INNER, PARTITIONED):
                 join (INNER, PARTITIONED):
-                    final aggregation over (d_week_seq)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["d_week_seq"])
-                                partial aggregation over (d_week_seq)
-                                    final aggregation over (d_day_name, d_week_seq)
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["d_day_name", "d_week_seq"])
-                                                partial aggregation over (d_day_name, d_week_seq)
-                                                    join (INNER, REPLICATED):
-                                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                                            scan web_sales
-                                                            scan catalog_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                    single aggregation over (d_week_seq)
+                        final aggregation over (d_day_name, d_week_seq)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["d_week_seq"])
+                                    partial aggregation over (d_day_name, d_week_seq)
+                                        join (INNER, REPLICATED):
+                                            remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                scan web_sales
+                                                scan catalog_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["d_week_seq_20"])
                             scan date_dim
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["expr_219"])
                         join (INNER, PARTITIONED):
-                            final aggregation over (d_week_seq_124)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["d_week_seq_124"])
-                                        partial aggregation over (d_week_seq_124)
-                                            final aggregation over (d_day_name_134, d_week_seq_124)
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["d_day_name_134", "d_week_seq_124"])
-                                                        partial aggregation over (d_day_name_134, d_week_seq_124)
-                                                            join (INNER, REPLICATED):
-                                                                remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                                                    scan web_sales
-                                                                    scan catalog_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan date_dim
+                            single aggregation over (d_week_seq_124)
+                                final aggregation over (d_day_name_134, d_week_seq_124)
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["d_week_seq_124"])
+                                            partial aggregation over (d_day_name_134, d_week_seq_124)
+                                                join (INNER, REPLICATED):
+                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                        scan web_sales
+                                                        scan catalog_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["d_week_seq_169"])
                                     scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q04.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q04.plan.txt
@@ -3,100 +3,89 @@ local exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
             join (INNER, PARTITIONED):
                 join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id_848"])
-                        final aggregation over (c_birth_country_861, c_customer_id_848, c_email_address_863, c_first_name_855, c_last_name_856, c_login_862, c_preferred_cust_flag_857, d_year_909)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_birth_country_861", "c_customer_id_848", "c_email_address_863", "c_first_name_855", "c_last_name_856", "c_login_862", "c_preferred_cust_flag_857", "d_year_909"])
-                                    partial aggregation over (c_birth_country_861, c_customer_id_848, c_email_address_863, c_first_name_855, c_last_name_856, c_login_862, c_preferred_cust_flag_857, d_year_909)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_870"])
-                                                join (INNER, REPLICATED):
-                                                    scan catalog_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_847"])
-                                                    scan customer
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["c_customer_id_1545"])
-                            final aggregation over (c_birth_country_1558, c_customer_id_1545, c_email_address_1560, c_first_name_1552, c_last_name_1553, c_login_1559, c_preferred_cust_flag_1554, d_year_1606)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_birth_country_1558", "c_customer_id_1545", "c_email_address_1560", "c_first_name_1552", "c_last_name_1553", "c_login_1559", "c_preferred_cust_flag_1554", "d_year_1606"])
-                                        partial aggregation over (c_birth_country_1558, c_customer_id_1545, c_email_address_1560, c_first_name_1552, c_last_name_1553, c_login_1559, c_preferred_cust_flag_1554, d_year_1606)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1568"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                    final aggregation over (c_birth_country_861, c_customer_id_848, c_email_address_863, c_first_name_855, c_last_name_856, c_login_862, c_preferred_cust_flag_857, d_year_909)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["c_customer_id_848"])
+                                partial aggregation over (c_birth_country_861, c_customer_id_848, c_email_address_863, c_first_name_855, c_last_name_856, c_login_862, c_preferred_cust_flag_857, d_year_909)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_870"])
+                                            join (INNER, REPLICATED):
+                                                scan catalog_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_1544"])
-                                                        scan customer
-                local exchange (GATHER, SINGLE, [])
-                    join (INNER, PARTITIONED):
-                        remote exchange (REPARTITION, HASH, ["c_customer_id_548"])
-                            final aggregation over (c_birth_country_561, c_customer_id_548, c_email_address_563, c_first_name_555, c_last_name_556, c_login_562, c_preferred_cust_flag_557, d_year_609)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_birth_country_561", "c_customer_id_548", "c_email_address_563", "c_first_name_555", "c_last_name_556", "c_login_562", "c_preferred_cust_flag_557", "d_year_609"])
-                                        partial aggregation over (c_birth_country_561, c_customer_id_548, c_email_address_563, c_first_name_555, c_last_name_556, c_login_562, c_preferred_cust_flag_557, d_year_609)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_570"])
-                                                    join (INNER, REPLICATED):
-                                                        scan catalog_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_847"])
+                                                scan customer
+                    final aggregation over (c_birth_country_1558, c_customer_id_1545, c_email_address_1560, c_first_name_1552, c_last_name_1553, c_login_1559, c_preferred_cust_flag_1554, d_year_1606)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["c_customer_id_1545"])
+                                partial aggregation over (c_birth_country_1558, c_customer_id_1545, c_email_address_1560, c_first_name_1552, c_last_name_1553, c_login_1559, c_preferred_cust_flag_1554, d_year_1606)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1568"])
+                                            join (INNER, REPLICATED):
+                                                scan web_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_547"])
-                                                        scan customer
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_1544"])
+                                                scan customer
+                join (INNER, PARTITIONED):
+                    final aggregation over (c_birth_country_561, c_customer_id_548, c_email_address_563, c_first_name_555, c_last_name_556, c_login_562, c_preferred_cust_flag_557, d_year_609)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["c_customer_id_548"])
+                                partial aggregation over (c_birth_country_561, c_customer_id_548, c_email_address_563, c_first_name_555, c_last_name_556, c_login_562, c_preferred_cust_flag_557, d_year_609)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_570"])
+                                            join (INNER, REPLICATED):
+                                                scan catalog_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_547"])
+                                                scan customer
+                    final aggregation over (c_birth_country_1258, c_customer_id_1245, c_email_address_1260, c_first_name_1252, c_last_name_1253, c_login_1259, c_preferred_cust_flag_1254, d_year_1306)
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["c_customer_id_1245"])
-                                final aggregation over (c_birth_country_1258, c_customer_id_1245, c_email_address_1260, c_first_name_1252, c_last_name_1253, c_login_1259, c_preferred_cust_flag_1254, d_year_1306)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["c_birth_country_1258", "c_customer_id_1245", "c_email_address_1260", "c_first_name_1252", "c_last_name_1253", "c_login_1259", "c_preferred_cust_flag_1254", "d_year_1306"])
-                                            partial aggregation over (c_birth_country_1258, c_customer_id_1245, c_email_address_1260, c_first_name_1252, c_last_name_1253, c_login_1259, c_preferred_cust_flag_1254, d_year_1306)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1268"])
-                                                        join (INNER, REPLICATED):
-                                                            scan web_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_1244"])
-                                                            scan customer
-            local exchange (GATHER, SINGLE, [])
-                join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id_162"])
-                        final aggregation over (c_birth_country_175, c_customer_id_162, c_email_address_177, c_first_name_169, c_last_name_170, c_login_176, c_preferred_cust_flag_171, d_year_212)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_birth_country_175", "c_customer_id_162", "c_email_address_177", "c_first_name_169", "c_last_name_170", "c_login_176", "c_preferred_cust_flag_171", "d_year_212"])
-                                    partial aggregation over (c_birth_country_175, c_customer_id_162, c_email_address_177, c_first_name_169, c_last_name_170, c_login_176, c_preferred_cust_flag_171, d_year_212)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ss_customer_sk_184"])
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                partial aggregation over (c_birth_country_1258, c_customer_id_1245, c_email_address_1260, c_first_name_1252, c_last_name_1253, c_login_1259, c_preferred_cust_flag_1254, d_year_1306)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1268"])
+                                            join (INNER, REPLICATED):
+                                                scan web_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_1244"])
+                                                scan customer
+            join (INNER, PARTITIONED):
+                final aggregation over (c_birth_country_175, c_customer_id_162, c_email_address_177, c_first_name_169, c_last_name_170, c_login_176, c_preferred_cust_flag_171, d_year_212)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_162"])
+                            partial aggregation over (c_birth_country_175, c_customer_id_162, c_email_address_177, c_first_name_169, c_last_name_170, c_login_176, c_preferred_cust_flag_171, d_year_212)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk_184"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_161"])
-                                                    scan customer
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_161"])
+                                            scan customer
+                final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_id"])
-                            final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_birth_country", "c_customer_id", "c_email_address", "c_first_name", "c_last_name", "c_login", "c_preferred_cust_flag", "d_year"])
-                                        partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan store_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                        scan customer
+                            partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                                            scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q11.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q11.plan.txt
@@ -2,67 +2,60 @@ local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
             join (INNER, PARTITIONED):
-                remote exchange (REPARTITION, HASH, ["c_customer_id_79"])
-                    final aggregation over (c_birth_country_92, c_customer_id_79, c_email_address_94, c_first_name_86, c_last_name_87, c_login_93, c_preferred_cust_flag_88, d_year_129)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["c_birth_country_92", "c_customer_id_79", "c_email_address_94", "c_first_name_86", "c_last_name_87", "c_login_93", "c_preferred_cust_flag_88", "d_year_129"])
-                                partial aggregation over (c_birth_country_92, c_customer_id_79, c_email_address_94, c_first_name_86, c_last_name_87, c_login_93, c_preferred_cust_flag_88, d_year_129)
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["ss_customer_sk_101"])
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_78"])
-                                                scan customer
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["c_customer_id_358"])
-                        final aggregation over (c_birth_country_371, c_customer_id_358, c_email_address_373, c_first_name_365, c_last_name_366, c_login_372, c_preferred_cust_flag_367, d_year_419)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_birth_country_371", "c_customer_id_358", "c_email_address_373", "c_first_name_365", "c_last_name_366", "c_login_372", "c_preferred_cust_flag_367", "d_year_419"])
-                                    partial aggregation over (c_birth_country_371, c_customer_id_358, c_email_address_373, c_first_name_365, c_last_name_366, c_login_372, c_preferred_cust_flag_367, d_year_419)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_381"])
-                                                join (INNER, REPLICATED):
-                                                    scan web_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                final aggregation over (c_birth_country_92, c_customer_id_79, c_email_address_94, c_first_name_86, c_last_name_87, c_login_93, c_preferred_cust_flag_88, d_year_129)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_79"])
+                            partial aggregation over (c_birth_country_92, c_customer_id_79, c_email_address_94, c_first_name_86, c_last_name_87, c_login_93, c_preferred_cust_flag_88, d_year_129)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk_101"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_357"])
-                                                    scan customer
-            local exchange (GATHER, SINGLE, [])
-                join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id"])
-                        final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_birth_country", "c_customer_id", "c_email_address", "c_first_name", "c_last_name", "c_login", "c_preferred_cust_flag", "d_year"])
-                                    partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_78"])
+                                            scan customer
+                final aggregation over (c_birth_country_371, c_customer_id_358, c_email_address_373, c_first_name_365, c_last_name_366, c_login_372, c_preferred_cust_flag_367, d_year_419)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_358"])
+                            partial aggregation over (c_birth_country_371, c_customer_id_358, c_email_address_373, c_first_name_365, c_last_name_366, c_login_372, c_preferred_cust_flag_367, d_year_419)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_381"])
+                                        join (INNER, REPLICATED):
+                                            scan web_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                    scan customer
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_357"])
+                                            scan customer
+            join (INNER, PARTITIONED):
+                final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id"])
+                            partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                                            scan customer
+                final aggregation over (c_birth_country_564, c_customer_id_551, c_email_address_566, c_first_name_558, c_last_name_559, c_login_565, c_preferred_cust_flag_560, d_year_612)
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_id_551"])
-                            final aggregation over (c_birth_country_564, c_customer_id_551, c_email_address_566, c_first_name_558, c_last_name_559, c_login_565, c_preferred_cust_flag_560, d_year_612)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_birth_country_564", "c_customer_id_551", "c_email_address_566", "c_first_name_558", "c_last_name_559", "c_login_565", "c_preferred_cust_flag_560", "d_year_612"])
-                                        partial aggregation over (c_birth_country_564, c_customer_id_551, c_email_address_566, c_first_name_558, c_last_name_559, c_login_565, c_preferred_cust_flag_560, d_year_612)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_574"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_550"])
-                                                        scan customer
+                            partial aggregation over (c_birth_country_564, c_customer_id_551, c_email_address_566, c_first_name_558, c_last_name_559, c_login_565, c_preferred_cust_flag_560, d_year_612)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_574"])
+                                        join (INNER, REPLICATED):
+                                            scan web_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_550"])
+                                            scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q16.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q16.plan.txt
@@ -9,26 +9,24 @@ final aggregation over ()
                                 remote exchange (REPARTITION, HASH, ["cr_order_number"])
                                     partial aggregation over (cr_order_number)
                                         scan catalog_returns
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["cs_order_number_23"])
-                                final aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number_23, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_state", "cc_county", "cs_call_center_sk", "cs_ext_ship_cost", "cs_net_profit", "cs_order_number_23", "cs_ship_addr_sk", "cs_ship_date_sk", "cs_warehouse_sk", "d_date", "unique"])
-                                            partial aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number_23, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
-                                                join (INNER, REPLICATED, can skip output duplicates):
-                                                    scan catalog_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
+                        final aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number_23, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["cs_order_number_23"])
+                                    partial aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number_23, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
+                                        join (INNER, REPLICATED, can skip output duplicates):
+                                            scan catalog_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    join (INNER, REPLICATED):
+                                                        join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    join (INNER, REPLICATED):
-                                                                        scan catalog_sales
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan customer_address
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
+                                                                scan catalog_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan call_center
+                                                                        scan customer_address
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan date_dim
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan call_center

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q23.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q23.plan.txt
@@ -5,23 +5,20 @@ final aggregation over ()
                 join (INNER, PARTITIONED):
                     remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
                         join (INNER, PARTITIONED):
-                            final aggregation over (ss_item_sk)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ss_item_sk"])
-                                        partial aggregation over (ss_item_sk)
-                                            final aggregation over (d_date_6, ss_item_sk, substr$gid)
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["d_date_6", "ss_item_sk", "substr$gid"])
-                                                        partial aggregation over (d_date_6, ss_item_sk, substr$gid)
-                                                            join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    scan store_sales
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan item
+                            single aggregation over (ss_item_sk)
+                                final aggregation over (d_date_6, ss_item_sk, substr$gid)
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["ss_item_sk"])
+                                            partial aggregation over (d_date_6, ss_item_sk, substr$gid)
+                                                join (INNER, REPLICATED):
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["cs_item_sk"])
                                     join (INNER, REPLICATED):
@@ -63,23 +60,20 @@ final aggregation over ()
                 join (INNER, PARTITIONED):
                     remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk"])
                         join (INNER, PARTITIONED):
-                            final aggregation over (ss_item_sk_185)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ss_item_sk_185"])
-                                        partial aggregation over (ss_item_sk_185)
-                                            final aggregation over (d_date_210, ss_item_sk_185, substr$gid_265)
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["d_date_210", "ss_item_sk_185", "substr$gid_265"])
-                                                        partial aggregation over (d_date_210, ss_item_sk_185, substr$gid_265)
-                                                            join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    scan store_sales
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan item
+                            single aggregation over (ss_item_sk_185)
+                                final aggregation over (d_date_210, ss_item_sk_185, substr$gid_265)
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["ss_item_sk_185"])
+                                            partial aggregation over (d_date_210, ss_item_sk_185, substr$gid_265)
+                                                join (INNER, REPLICATED):
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["ws_item_sk"])
                                     join (INNER, REPLICATED):

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q30.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q30.plan.txt
@@ -3,21 +3,20 @@ local exchange (GATHER, SINGLE, [])
         cross join:
             join (LEFT, REPLICATED):
                 join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["wr_returning_customer_sk"])
-                        final aggregation over (ca_state, wr_returning_customer_sk)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_state", "wr_returning_customer_sk"])
-                                    partial aggregation over (ca_state, wr_returning_customer_sk)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["wr_returning_addr_sk"])
-                                                join (INNER, REPLICATED):
-                                                    scan web_returns
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                    scan customer_address
+                    final aggregation over (ca_state, wr_returning_customer_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["wr_returning_customer_sk"])
+                                partial aggregation over (ca_state, wr_returning_customer_sk)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["wr_returning_addr_sk"])
+                                            join (INNER, REPLICATED):
+                                                scan web_returns
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                scan customer_address
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                             join (INNER, REPLICATED):

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q31.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q31.plan.txt
@@ -6,7 +6,7 @@ remote exchange (GATHER, SINGLE, [])
                     join (INNER, PARTITIONED):
                         final aggregation over (ca_county_66, d_qoy_39, d_year_35)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_county_66", "d_qoy_39", "d_year_35"])
+                                remote exchange (REPARTITION, HASH, ["ca_county_66"])
                                     partial aggregation over (ca_county_66, d_qoy_39, d_year_35)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["ss_addr_sk_10"])
@@ -18,26 +18,24 @@ remote exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["ca_address_sk_59"])
                                                     scan customer_address
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ca_county_140", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
-                                final aggregation over (ca_county_140, d_qoy_113, d_year_109)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_county_140", "d_qoy_113", "d_year_109"])
-                                            partial aggregation over (ca_county_140, d_qoy_113, d_year_109)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["ss_addr_sk_84"])
-                                                        join (INNER, REPLICATED):
-                                                            scan store_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
+                        final aggregation over (ca_county_140, d_qoy_113, d_year_109)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["ca_county_140"])
+                                    partial aggregation over (ca_county_140, d_qoy_113, d_year_109)
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["ss_addr_sk_84"])
+                                                join (INNER, REPLICATED):
+                                                    scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["ca_address_sk_133"])
-                                                            scan customer_address
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["ca_address_sk_133"])
+                                                    scan customer_address
                     join (INNER, PARTITIONED):
                         final aggregation over (ca_county_276, d_qoy_249, d_year_245)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_county_276", "d_qoy_249", "d_year_245"])
+                                remote exchange (REPARTITION, HASH, ["ca_county_276"])
                                     partial aggregation over (ca_county_276, d_qoy_249, d_year_245)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk_210"])
@@ -49,50 +47,46 @@ remote exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["ca_address_sk_269"])
                                                     scan customer_address
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ca_county_361", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
-                                final aggregation over (ca_county_361, d_qoy_334, d_year_330)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_county_361", "d_qoy_334", "d_year_330"])
-                                            partial aggregation over (ca_county_361, d_qoy_334, d_year_330)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk_295"])
-                                                        join (INNER, REPLICATED):
-                                                            scan web_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
+                        final aggregation over (ca_county_361, d_qoy_334, d_year_330)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["ca_county_361"])
+                                    partial aggregation over (ca_county_361, d_qoy_334, d_year_330)
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk_295"])
+                                                join (INNER, REPLICATED):
+                                                    scan web_sales
                                                     local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["ca_address_sk_354"])
-                                                            scan customer_address
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["ca_county", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
-                        join (INNER, PARTITIONED):
-                            final aggregation over (ca_county, d_qoy, d_year)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ca_county", "d_qoy", "d_year"])
-                                        partial aggregation over (ca_county, d_qoy, d_year)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan store_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["ca_address_sk_354"])
+                                                    scan customer_address
+                join (INNER, PARTITIONED):
+                    final aggregation over (ca_county, d_qoy, d_year)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ca_county"])
+                                partial aggregation over (ca_county, d_qoy, d_year)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
+                                            join (INNER, REPLICATED):
+                                                scan store_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                        scan customer_address
-                            final aggregation over (ca_county_191, d_qoy_164, d_year_160)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["ca_county_191", "d_qoy_164", "d_year_160"])
-                                        partial aggregation over (ca_county_191, d_qoy_164, d_year_160)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                scan customer_address
+                    final aggregation over (ca_county_191, d_qoy_164, d_year_160)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ca_county_191"])
+                                partial aggregation over (ca_county_191, d_qoy_164, d_year_160)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["ws_bill_addr_sk"])
+                                            join (INNER, REPLICATED):
+                                                scan web_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["ca_address_sk_184"])
-                                                        scan customer_address
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ca_address_sk_184"])
+                                                scan customer_address

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q34.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q34.plan.txt
@@ -4,22 +4,20 @@ remote exchange (GATHER, SINGLE, [])
             join (INNER, PARTITIONED):
                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                     scan customer
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                        final aggregation over (ss_customer_sk, ss_ticket_number)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_ticket_number"])
-                                    partial aggregation over (ss_customer_sk, ss_ticket_number)
+                final aggregation over (ss_customer_sk, ss_ticket_number)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                            partial aggregation over (ss_customer_sk, ss_ticket_number)
+                                join (INNER, REPLICATED):
+                                    join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan store
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan household_demographics
+                                                    scan store
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            scan household_demographics

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q51.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q51.plan.txt
@@ -3,25 +3,21 @@ local exchange (GATHER, SINGLE, [])
         local exchange (GATHER, SINGLE, [])
             remote exchange (REPARTITION, HASH, ["expr"])
                 join (FULL, PARTITIONED):
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["ws_item_sk"])
-                            final aggregation over (d_date, ws_item_sk)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["d_date", "ws_item_sk"])
-                                        partial aggregation over (d_date, ws_item_sk)
-                                            join (INNER, REPLICATED):
-                                                scan web_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["ss_item_sk"])
-                            final aggregation over (d_date_7, ss_item_sk)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["d_date_7", "ss_item_sk"])
-                                        partial aggregation over (d_date_7, ss_item_sk)
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
+                    final aggregation over (d_date, ws_item_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ws_item_sk"])
+                                partial aggregation over (d_date, ws_item_sk)
+                                    join (INNER, REPLICATED):
+                                        scan web_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
+                    final aggregation over (d_date_7, ss_item_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ss_item_sk"])
+                                partial aggregation over (d_date_7, ss_item_sk)
+                                    join (INNER, REPLICATED):
+                                        scan store_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q54.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q54.plan.txt
@@ -22,27 +22,25 @@ local exchange (GATHER, SINGLE, [])
                                                                             local exchange (GATHER, SINGLE, [])
                                                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                                                     scan store
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
-                                                                            final aggregation over (c_current_addr_sk, c_customer_sk)
-                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                    remote exchange (REPARTITION, HASH, ["c_current_addr_sk", "c_customer_sk"])
-                                                                                        partial aggregation over (c_current_addr_sk, c_customer_sk)
-                                                                                            join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                scan customer
-                                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                        join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                            join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                                remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                                                                                                    scan catalog_sales
-                                                                                                                    scan web_sales
-                                                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                                        scan item
-                                                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                                    scan date_dim
+                                                                    final aggregation over (c_current_addr_sk, c_customer_sk)
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
+                                                                                partial aggregation over (c_current_addr_sk, c_customer_sk)
+                                                                                    join (INNER, REPLICATED, can skip output duplicates):
+                                                                                        scan customer
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                join (INNER, REPLICATED, can skip output duplicates):
+                                                                                                    join (INNER, REPLICATED, can skip output duplicates):
+                                                                                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                                                            scan catalog_sales
+                                                                                                            scan web_sales
+                                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                                scan item
+                                                                                                    local exchange (GATHER, SINGLE, [])
+                                                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                            scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
                                                             scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q73.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q73.plan.txt
@@ -4,22 +4,20 @@ remote exchange (GATHER, SINGLE, [])
             join (INNER, PARTITIONED):
                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                     scan customer
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                        final aggregation over (ss_customer_sk, ss_ticket_number)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_ticket_number"])
-                                    partial aggregation over (ss_customer_sk, ss_ticket_number)
+                final aggregation over (ss_customer_sk, ss_ticket_number)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                            partial aggregation over (ss_customer_sk, ss_ticket_number)
+                                join (INNER, REPLICATED):
+                                    join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan household_demographics
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan store
+                                                    scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan household_demographics
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            scan store

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q74.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q74.plan.txt
@@ -2,67 +2,60 @@ local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
             join (INNER, PARTITIONED):
-                remote exchange (REPARTITION, HASH, ["c_customer_id_69"])
-                    final aggregation over (c_customer_id_69, c_first_name_76, c_last_name_77, d_year_119)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["c_customer_id_69", "c_first_name_76", "c_last_name_77", "d_year_119"])
-                                partial aggregation over (c_customer_id_69, c_first_name_76, c_last_name_77, d_year_119)
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["ss_customer_sk_91"])
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["c_customer_sk_68"])
-                                                scan customer
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["c_customer_id_329"])
-                        final aggregation over (c_customer_id_329, c_first_name_336, c_last_name_337, d_year_390)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_customer_id_329", "c_first_name_336", "c_last_name_337", "d_year_390"])
-                                    partial aggregation over (c_customer_id_329, c_first_name_336, c_last_name_337, d_year_390)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_352"])
-                                                join (INNER, REPLICATED):
-                                                    scan web_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                final aggregation over (c_customer_id_69, c_first_name_76, c_last_name_77, d_year_119)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_69"])
+                            partial aggregation over (c_customer_id_69, c_first_name_76, c_last_name_77, d_year_119)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk_91"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk_328"])
-                                                    scan customer
-            local exchange (GATHER, SINGLE, [])
-                join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, ["c_customer_id"])
-                        final aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["c_customer_id", "c_first_name", "c_last_name", "d_year"])
-                                    partial aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_68"])
+                                            scan customer
+                final aggregation over (c_customer_id_329, c_first_name_336, c_last_name_337, d_year_390)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id_329"])
+                            partial aggregation over (c_customer_id_329, c_first_name_336, c_last_name_337, d_year_390)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_352"])
+                                        join (INNER, REPLICATED):
+                                            scan web_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                    scan customer
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_328"])
+                                            scan customer
+            join (INNER, PARTITIONED):
+                final aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["c_customer_id"])
+                            partial aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                                            scan customer
+                final aggregation over (c_customer_id_508, c_first_name_515, c_last_name_516, d_year_569)
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_id_508"])
-                            final aggregation over (c_customer_id_508, c_first_name_515, c_last_name_516, d_year_569)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["c_customer_id_508", "c_first_name_515", "c_last_name_516", "d_year_569"])
-                                        partial aggregation over (c_customer_id_508, c_first_name_515, c_last_name_516, d_year_569)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_531"])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_507"])
-                                                        scan customer
+                            partial aggregation over (c_customer_id_508, c_first_name_515, c_last_name_516, d_year_569)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_531"])
+                                        join (INNER, REPLICATED):
+                                            scan web_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["c_customer_sk_507"])
+                                            scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q78.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q78.plan.txt
@@ -5,7 +5,7 @@ local exchange (GATHER, SINGLE, [])
                 join (INNER, PARTITIONED):
                     final aggregation over (d_year, ss_customer_sk, ss_item_sk)
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["d_year", "ss_customer_sk", "ss_item_sk"])
+                            remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_item_sk"])
                                 partial aggregation over (d_year, ss_customer_sk, ss_item_sk)
                                     join (INNER, REPLICATED):
                                         join (LEFT, PARTITIONED):
@@ -19,7 +19,7 @@ local exchange (GATHER, SINGLE, [])
                                                 scan date_dim
                     final aggregation over (d_year_17, ws_bill_customer_sk, ws_item_sk)
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["d_year_17", "ws_bill_customer_sk", "ws_item_sk"])
+                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk", "ws_item_sk"])
                                 partial aggregation over (d_year_17, ws_bill_customer_sk, ws_item_sk)
                                     join (INNER, REPLICATED):
                                         join (LEFT, PARTITIONED):
@@ -31,19 +31,17 @@ local exchange (GATHER, SINGLE, [])
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
                                                 scan date_dim
-            local exchange (GATHER, SINGLE, [])
-                remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
-                    final aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_56)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk", "cs_item_sk", "d_year_56"])
-                                partial aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_56)
-                                    join (INNER, REPLICATED):
-                                        join (LEFT, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["cs_item_sk", "cs_order_number"])
-                                                scan catalog_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["cr_item_sk", "cr_order_number"])
-                                                    scan catalog_returns
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                scan date_dim
+            final aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_56)
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
+                        partial aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_56)
+                            join (INNER, REPLICATED):
+                                join (LEFT, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["cs_item_sk", "cs_order_number"])
+                                        scan catalog_sales
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["cr_item_sk", "cr_order_number"])
+                                            scan catalog_returns
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPLICATE, BROADCAST, [])
+                                        scan date_dim

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q79.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q79.plan.txt
@@ -1,24 +1,23 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
-            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                final aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["s_city", "ss_addr_sk", "ss_customer_sk", "ss_ticket_number"])
-                            partial aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
+            final aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                        partial aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
+                            join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
-                                        join (INNER, REPLICATED):
-                                            scan store_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
+                                        scan store_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan household_demographics
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan store
+                                            scan household_demographics
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPLICATE, BROADCAST, [])
+                                        scan store
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                     scan customer

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q94.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q94.plan.txt
@@ -9,26 +9,24 @@ final aggregation over ()
                                 remote exchange (REPARTITION, HASH, ["wr_order_number"])
                                     partial aggregation over (wr_order_number)
                                         scan web_returns
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ws_order_number_23"])
-                                final aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number_23, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ca_state", "d_date", "unique", "web_company_name", "ws_ext_ship_cost", "ws_net_profit", "ws_order_number_23", "ws_ship_addr_sk", "ws_ship_date_sk", "ws_warehouse_sk", "ws_web_site_sk"])
-                                            partial aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number_23, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
-                                                join (INNER, REPLICATED, can skip output duplicates):
-                                                    scan web_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
+                        final aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number_23, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["ws_order_number_23"])
+                                    partial aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number_23, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
+                                        join (INNER, REPLICATED, can skip output duplicates):
+                                            scan web_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    join (INNER, REPLICATED):
+                                                        join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    join (INNER, REPLICATED):
-                                                                        scan web_sales
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan customer_address
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
+                                                                scan web_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan web_site
+                                                                        scan customer_address
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan date_dim
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan web_site


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
If parent partitioning provides enough parallelism, and is a subset of the current node preferred
partitioning (grouping keys for the aggregation) we can use the parent partitioning to skip data shuffle required by the parent.

#### Benchmarks
tpch/tpcds orc part sf1K benchmarks show mostly no change. This is because even though several tpcds queries are affected by this change, the difference in perf is small because the partitioned exchange is already quite optimized, and the reduction of data that is sent across the network is somehow small (e.g. 2GB out of 118GB for tpcds q04).

![image](https://user-images.githubusercontent.com/8080198/223066038-226e0999-c8ef-45de-8258-91caba7224a8.png)


[trino-sf1k-orc-part-use-parent-part.pdf](https://github.com/trinodb/trino/files/10896236/trino-sf1k-orc-part-use-parent-part.pdf)

For a sample query where this gives visible improvements let's look at:
```
select (orderkey_expr, suppkey, sum(count))
from (
    select orderkey % 30000 as orderkey_expr, partkey,suppkey, count(*) as count
    from lineitem
    group by orderkey % 30000, partkey, suppkey)
group by orderkey_expr, suppkey;
```

running this on `tpch sf 100` I get ~19.5s duration, 1150s CPU, and 45GB internal network with the preferred parent partitioning and ~21.5s duration, 1320s CPU, and 59GB of the internal network without it, so around 10% of duration and CPU improvement and 23% for the network.
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X ) Release notes are required, with the following suggested text:

```markdown
# Section
* Reduce redundant data exchanges for queries with multiple aggregations
```
