### PR TITLE
Expose top level statistics in EXPLAIN ANALYZE

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -446,6 +446,11 @@ public class PlanPrinter
         TypeProvider typeProvider = getTypeProvider(allFragments);
 
         builder.append(format("Trino version: %s\n", version));
+        builder.append(format("Queued: %s, Analysis: %s, Planning: %s, Execution: %s\n",
+                queryStats.getQueuedTime().convertToMostSuccinctTimeUnit(),
+                queryStats.getAnalysisTime().convertToMostSuccinctTimeUnit(),
+                queryStats.getPlanningTime().convertToMostSuccinctTimeUnit(),
+                queryStats.getExecutionTime().convertToMostSuccinctTimeUnit()));
 
         for (StageInfo stageInfo : allStages) {
             builder.append(formatFragment(

--- a/docs/src/main/sphinx/sql/explain-analyze.rst
+++ b/docs/src/main/sphinx/sql/explain-analyze.rst
@@ -41,6 +41,7 @@ when one wants to detect data anomalies for a query (e.g: skewness).
                                               Query Plan
     -----------------------------------------------------------------------------------------------
     Trino version: version
+    Queued: 374.17us, Analysis: 190.96ms, Planning: 179.03ms, Execution: 3.06s
     Fragment 1 [HASH]
         CPU: 22.58ms, Scheduled: 96.72ms, Blocked 46.21s (Input: 23.06s, Output: 0.00ns), Input: 1000 rows (37.11kB); per task: avg.: 1000.00 std.dev.: 0.00, Output: 1000 rows (28.32kB)
         Output layout: [clerk, count]

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractDistributedEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractDistributedEngineOnlyQueries.java
@@ -239,6 +239,14 @@ public abstract class AbstractDistributedEngineOnlyQueries
     }
 
     @Test
+    public void testExplainAnalyzeTopLevelTimes()
+    {
+        assertExplainAnalyze(
+                "EXPLAIN ANALYZE SELECT * FROM nation a",
+                "Queued: .*s, Analysis: .*s, Planning: .*s, Execution: .*s\n");
+    }
+
+    @Test
     public void testInsertWithCoercion()
     {
         String tableName = "test_insert_with_coercion_" + randomNameSuffix();


### PR DESCRIPTION
## Description

Add additional summary statistics on top level of EXPLAIN ANALYZE output

Example:

```
explain analyze select max(extendedprice) from lineitem;
                                    Query Plan
--------------------------------------------------------------------------------------
 Trino version: version
 Queued: 3.00ms, Analysis: 485.81ms, Planning: 268.07ms, Execution: 7.37s
 Fragment 1 [SINGLE]
 (...)
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```
# General
* Show query queued, analysis, planning and execution time in EXPLAIN ANALYZE output. ({issue}`16329`)
```
