### PR TITLE
Extend retry policy for dropping delta tables backed by AWS Glue on Databricks

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/DeltaLakeTestUtils.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/DeltaLakeTestUtils.java
@@ -19,6 +19,7 @@ import dev.failsafe.Failsafe;
 import dev.failsafe.RetryPolicy;
 import io.airlift.log.Logger;
 import io.trino.tempto.query.QueryResult;
+import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.intellij.lang.annotations.Language;
 
 import java.time.temporal.ChronoUnit;
@@ -39,6 +40,7 @@ public final class DeltaLakeTestUtils
             "\\Q[Databricks][DatabricksJDBCDriver](500593) Communication link failure. Failed to connect to server. Reason: HTTP retry after response received with no Retry-After header, error: HTTP Response code: 503, Error message: Unknown.";
     private static final RetryPolicy<QueryResult> CONCURRENT_MODIFICATION_EXCEPTION_RETRY_POLICY = RetryPolicy.<QueryResult>builder()
             .handleIf(throwable -> Throwables.getRootCause(throwable) instanceof ConcurrentModificationException)
+            .handleIf(throwable -> Throwables.getRootCause(throwable) instanceof MetaException metaException && metaException.getMessage() != null && metaException.getMessage().contains("Table being modified concurrently"))
             .withBackoff(1, 10, ChronoUnit.SECONDS)
             .withMaxRetries(3)
             .onRetry(event -> log.warn(event.getLastException(), "Query failed on attempt %d, will retry.", event.getAttemptCount()))


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Extend the retry policy used to drop Delta tables backed by AWS Glue via Databricks JDBC Driver to handle the case described in https://github.com/trinodb/trino/issues/13199#issuecomment-1447787619

Fixes https://github.com/trinodb/trino/issues/13199


## Release notes

(x) This is not user-visible or docs only and no release notes are required.
