### PR TITLE
Fix Partition Projection storage location

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/aws/athena/PartitionProjectionService.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/aws/athena/PartitionProjectionService.java
@@ -134,7 +134,7 @@ public final class PartitionProjectionService
                 metastoreTablePropertiesBuilder,
                 PARTITION_PROJECTION_LOCATION_TEMPLATE,
                 METASTORE_PROPERTY_PROJECTION_LOCATION_TEMPLATE,
-                value -> value.toString().toLowerCase(Locale.ENGLISH));
+                Object::toString);
 
         // Handle Column Properties
         tableMetadata.getColumns().stream()


### PR DESCRIPTION
## Description
Fix handling of `partition_projection_location_template` table property mapped from `storage.location.template` hive table property.

## Additional context and related issues
When template contained upper case characters S3 List Objects operations was not returning any objects which resulted in 0 results queries. This was caused by lowercasing Trino table property during convertion to Hive table property.

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix handling of `partition_projection_location_template` table property when uppercase characters are used
```
