### PR TITLE
Fix typo in access control properties title

### DIFF
--- a/docs/src/main/sphinx/security/kerberos.rst
+++ b/docs/src/main/sphinx/security/kerberos.rst
@@ -133,8 +133,8 @@ Property                                                  Description
 See :ref:`Standards supported <tls-version-and-ciphers>` for a discussion of the
 supported TLS versions and cipher suites.
 
-access-controls.properties
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+access-control.properties
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 At a minimum, an :file:`access-control.properties` file must contain an
 ``access-control.name`` property.  All other configuration is specific for the


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

- Fixes a small typo in the `access-control.properties` title on the Kerberos page

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
