### PR TITLE
Attempt to evaluate the value of `TryFunction` in `ExpressionInterpreter`

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
@@ -17,6 +17,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.trino.operator.scalar.TryFunction;
 import io.trino.security.AllowAllAccessControl;
 import io.trino.spi.type.Int128;
 import io.trino.spi.type.SqlTimestampWithTimeZone;
@@ -373,6 +374,22 @@ public class TestExpressionInterpreter
         assertOptimizedEquals("abs(-bound_long)", "1234");
         assertOptimizedEquals("abs(unbound_long)", "abs(unbound_long)");
         assertOptimizedEquals("abs(unbound_long + 1)", "abs(unbound_long + 1)");
+    }
+
+    @Test
+    public void testTryFunction()
+    {
+        assertOptimizedEquals("\"" + TryFunction.NAME + "\"(() -> CAST('123' as BIGINT))", "123");
+        assertOptimizedEquals("\"" + TryFunction.NAME + "\"(() -> CAST('abc' as BIGINT))",
+                "\"" + TryFunction.NAME + "\"(() -> CAST('abc' as BIGINT))");
+        assertOptimizedEquals("\"" + TryFunction.NAME + "\"(() -> 0 / 0)",
+                "\"" + TryFunction.NAME + "\"(() -> 0 / 0)");
+        assertOptimizedEquals("\"" + TryFunction.NAME + "\"(() -> bound_long)", "bound_long");
+        assertOptimizedEquals("\"" + TryFunction.NAME + "\"(() -> 1 / (bound_long - 1234))",
+                "\"" + TryFunction.NAME + "\"(() -> 1 / (bound_long - 1234))");
+        assertOptimizedEquals("\"" + TryFunction.NAME + "\"(() -> NULL)", "NULL");
+        assertOptimizedEquals("\"" + TryFunction.NAME + "\"(() -> INTEGER '2147483647' * 2)",
+                "\"" + TryFunction.NAME + "\"(() -> INTEGER '2147483647' * 2)");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR aims to evaluate the value of TryFunction in ExpressionInterpreter. Before that, any expression wrapped in Try must be computed through Runner. This PR solves those try expressions that can actually be inferred as constants, so that these expressions can be replaced during the execution plan optimization phase.

A simple example:
```sql
select count(*) from table where dt = try(cast(20230303 as VARCHAR))
```

Before, partition filtering pushdown cannot be performed on this query. This PR can fix this example.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
