### PR TITLE
Add max-outstanding-splits-size to Hive configuration doc

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -1465,6 +1465,10 @@ connector.
       - The target number of buffered splits for each table scan in a query,
         before the scheduler tries to pause.
       - ``1000``
+    * - ``hive.max-outstanding-splits-size``
+      - The maximum size allowed for buffered splits for each table scan
+        in a query, before the query fails.
+      - ``256 MB``
     * - ``hive.max-splits-per-second``
       - The maximum number of splits generated per second per table scan. This
         can be used to reduce the load on the storage system. By default, there


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Per issue #16240, queries where getting the error HIVE_EXCEEDED_SPLIT_BUFFERING_LIMIT (256MB). Changing the limit through hive.max-outstanding-splits-size resolved this. The hive.max-outstanding-splits-size property was not in the Performance Tuning Configuration Properties section of the Hive documentation, however. 


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
