### PR TITLE
Removed reference to Presto in Hive performance tuning configuration …

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -1467,7 +1467,7 @@ connector.
     * - ``hive.max-splits-per-second``
       - The maximum number of splits generated per second per table scan. This
         can be used to reduce the load on the storage system. By default, there
-        is no limit, which results in Presto maximizing the parallelization of
+        is no limit, which results in Trino maximizing the parallelization of
         data access.
       -
     * - ``hive.max-initial-splits``


### PR DESCRIPTION
…documentation

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Also raised by #16240. In the Performance Tuning Configuration Properties section of the Hive documentation, there was a reference to "Presto" in the description for hive.max-splits-per-second. I changed this to "Trino."


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
