### PR TITLE
HIVE connector off by +1 _ or . causes files to be skipped

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/HiveFileIterator.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/HiveFileIterator.java
@@ -150,7 +150,7 @@ public class HiveFileIterator
     {
         String pathString = path.toUri().getPath();
         checkArgument(pathString.startsWith(prefix), "path %s does not start with prefix %s", pathString, prefix);
-        return containsHiddenPathPartAfterIndex(pathString, prefix.length() + 1);
+        return containsHiddenPathPartAfterIndex(pathString, prefix.endsWith("/") ? prefix.length() : prefix.length() + 1);
     }
 
     @VisibleForTesting

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestHiveFileIterator.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestHiveFileIterator.java
@@ -30,6 +30,9 @@ public class TestHiveFileIterator
         String root = new Path("file:///root-path").toUri().getPath();
         assertTrue(isHiddenOrWithinHiddenParentDirectory(new Path(root, ".hidden/child"), root));
         assertTrue(isHiddenOrWithinHiddenParentDirectory(new Path(root, "_hidden.txt"), root));
+        String rootWithSlash = new Path("file:///root-path/").toUri().getPath();
+        assertTrue(isHiddenOrWithinHiddenParentDirectory(new Path(rootWithSlash, ".hidden/child"), rootWithSlash));
+        assertTrue(isHiddenOrWithinHiddenParentDirectory(new Path(rootWithSlash, "_hidden.txt"), rootWithSlash));
         String rootWithinHidden = new Path("file:///root/.hidden/listing-root").toUri().getPath();
         assertFalse(isHiddenOrWithinHiddenParentDirectory(new Path(rootWithinHidden, "file.txt"), rootWithinHidden));
         String rootHiddenEnding = new Path("file:///root/hidden-ending_").toUri().getPath();


### PR DESCRIPTION
Fixes #16386

The +1 causes the 1st character of the filename to be skipped.

So, in the case of the below files stored in s3
p_file1.parquet
p_file2.parquet

The 2nd character "_", not the 1st p is viewed and thus marked as a hidden file.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
