### PR TITLE
Add example for TRINO_PASSWORD usage

### DIFF
--- a/docs/src/main/sphinx/client/cli.rst
+++ b/docs/src/main/sphinx/client/cli.rst
@@ -285,7 +285,21 @@ and prompts the CLI for your password:
 
 .. code-block:: text
 
-  ./trino --server https://trino.example.com --user=myusername --password
+  ./trino --server https://trino.example.com --user=exampleusername --password
+
+Alternatively, set the password as the value of the ``TRINO_PASSWORD``
+environment variables. Typically use single quotes to avoid problems with
+special characters such as ``$``:
+
+.. code-block:: text
+
+  export TRINO_PASSWORD='LongSecurePassword123!@#'
+
+The password is automatically used in any following start of the CLI:
+
+.. code-block:: text
+
+  ./trino --server https://trino.example.com --user=exampleusername
 
 .. _cli-external-sso-auth:
 


### PR DESCRIPTION
## Description

Specifically the usage of quotes seems necessary since we hear from users stumbling over password values with $ and other values. 

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
