### PR TITLE
Remove flaky test

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/tests/TestDistributedSpilledQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestDistributedSpilledQueries.java
@@ -19,14 +19,12 @@ import io.trino.SystemSessionProperties;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.AbstractTestQueries;
 import io.trino.testing.DistributedQueryRunner;
-import org.testng.annotations.Test;
 
 import java.nio.file.Paths;
 
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.util.UUID.randomUUID;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDistributedSpilledQueries
         extends AbstractTestQueries
@@ -70,13 +68,5 @@ public class TestDistributedSpilledQueries
             queryRunner.close();
             throw e;
         }
-    }
-
-    // The spilling does not happen deterministically. TODO improve query and configuration so that it does.
-    @Test(invocationCount = 10, successPercentage = 20)
-    public void testExplainAnalyzeReportSpilledDataSize()
-    {
-        assertThat((String) computeActual("EXPLAIN ANALYZE SELECT sum(custkey) OVER (PARTITION BY orderkey) FROM orders").getOnlyValue())
-                .containsPattern(", Spilled: [1-9][0-9]*\\wB");
     }
 }


### PR DESCRIPTION
The test is very unreliable when run locally.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
