### PR TITLE
Fix JSON cast parse docs

### DIFF
--- a/docs/src/main/sphinx/functions/json.rst
+++ b/docs/src/main/sphinx/functions/json.rst
@@ -1448,12 +1448,9 @@ the following requirements are met:
 .. note::
 
     Cast operations with supported :ref:`character string types
-    <string-data-types>` treat the input as a string, not validated as JSON.
-    This means that a cast operation with a string-type input of invalid JSON
-    results in a succesful cast to invalid JSON.
-
-    Instead, consider using the :func:`json_parse` function to
-    create validated JSON from a string.
+    <string-data-types>` treat the input as a SQL string, not validated as JSON.
+    This means that a cast operation with a SQL string-type input results in a
+    successful cast to a JSON object with a string value.
 
 The following examples show the behavior of casting to JSON with these types::
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

> Cast operations with supported [character string types](https://trino.io/docs/current/language/types.html#string-data-types) treat the input as a string, not validated as JSON. This means that a cast operation with a string-type input of invalid JSON results in a successful cast to invalid JSON. Instead, consider using the `json_parse()` function to create validated JSON from a string.

“consider” sounds like `json_parse` does basically same thing, but with validation
however, in reality, the cast and the `json_parse` are logically two very different things

`json_parse` and `cast(<varchar> as json)` are two very different things:
* `json_parse` treats the input as a string containing json (numbers, arrays, objects, strings, etc) and creates an equivalent value of type json
* `cast(<varchar> as json)` creates a json value containing a single string (i.e., it creates a json string, in the same way cast(<bigint> as json) creates a json containing a single number)

The statement that "a cast operation with a string type input of invalid JSON results in a successful cast to invalid JSON" is incorrect. The result is valid JSON, but it will be a string JSON value containing such input.

![image](https://user-images.githubusercontent.com/8547669/223336502-93133184-eb69-4895-84c9-31bb9d39bd39.png)


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
