### PR TITLE
Support coercing char types of different lengths in hive

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CharCoercer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CharCoercer.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.coercions;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.CharType;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.plugin.hive.HivePageSource.narrowerThan;
+import static io.trino.spi.type.Chars.truncateToLengthAndTrimSpaces;
+
+public class CharCoercer
+        extends TypeCoercer<CharType, CharType>
+{
+    public CharCoercer(CharType fromType, CharType toType)
+    {
+        super(fromType, toType);
+        checkArgument(narrowerThan(toType, fromType), "Coercer to a wider char type should not be required");
+    }
+
+    @Override
+    protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+    {
+        Slice value = fromType.getSlice(block, position);
+        toType.writeSlice(blockBuilder, truncateToLengthAndTrimSpaces(value, toType));
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
@@ -19,6 +19,7 @@ import io.trino.plugin.hive.type.Category;
 import io.trino.plugin.hive.type.ListTypeInfo;
 import io.trino.plugin.hive.type.MapTypeInfo;
 import io.trino.plugin.hive.type.StructTypeInfo;
+import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
@@ -62,6 +63,9 @@ public final class HiveCoercionPolicy
                     toHiveType.equals(HIVE_SHORT) ||
                     toHiveType.equals(HIVE_INT) ||
                     toHiveType.equals(HIVE_LONG);
+        }
+        if (fromType instanceof CharType) {
+            return toType instanceof CharType;
         }
         if (toType instanceof VarcharType) {
             return fromHiveType.equals(HIVE_BYTE) || fromHiveType.equals(HIVE_SHORT) || fromHiveType.equals(HIVE_INT) || fromHiveType.equals(HIVE_LONG) || fromType instanceof DecimalType;

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestHiveCoercion.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestHiveCoercion.java
@@ -210,7 +210,7 @@ public abstract class BaseTestHiveCoercion
         }
 
         return ImmutableMap.<String, List<Object>>builder()
-                .put("row_to_row", Arrays.asList(
+                .put("row_to_row", ImmutableList.of(
                         engine == Engine.TRINO ?
                                 rowBuilder()
                                         .addField("keep", "as is")
@@ -232,7 +232,7 @@ public abstract class BaseTestHiveCoercion
                                         .addField("lower2uppercase", 2L)
                                         .build() :
                                 String.format("{\"keep\":null,\"ti2si\":1,\"si2int\":-100,\"int2bi\":-2323,\"bi2vc\":\"-12345\",%s}", hiveValueForCaseChangeField)))
-                .put("list_to_list", Arrays.asList(
+                .put("list_to_list", ImmutableList.of(
                         engine == Engine.TRINO ?
                                 ImmutableList.of(rowBuilder()
                                         .addField("ti2int", 2)
@@ -247,7 +247,7 @@ public abstract class BaseTestHiveCoercion
                                         .addField("bi2vc", "-12345")
                                         .build()) :
                                 "[{\"ti2int\":-2,\"si2bi\":101,\"bi2vc\":\"-12345\"}]"))
-                .put("map_to_map", Arrays.asList(
+                .put("map_to_map", ImmutableList.of(
                         engine == Engine.TRINO ?
                                 ImmutableMap.of(2, rowBuilder()
                                         .addField("ti2bi", -3L)
@@ -264,70 +264,70 @@ public abstract class BaseTestHiveCoercion
                                         .addField("add", null)
                                         .build()) :
                                 "{-2:{\"ti2bi\":null,\"int2bi\":-2323,\"float2double\":-1.5,\"add\":null}}"))
-                .put("tinyint_to_smallint", Arrays.asList(
+                .put("tinyint_to_smallint", ImmutableList.of(
                         -1,
                         1))
-                .put("tinyint_to_int", Arrays.asList(
+                .put("tinyint_to_int", ImmutableList.of(
                         2,
                         -2))
                 .put("tinyint_to_bigint", Arrays.asList(
                         -3L,
                         null))
-                .put("smallint_to_int", Arrays.asList(
+                .put("smallint_to_int", ImmutableList.of(
                         100,
                         -100))
-                .put("smallint_to_bigint", Arrays.asList(
+                .put("smallint_to_bigint", ImmutableList.of(
                         -101L,
                         101L))
-                .put("int_to_bigint", Arrays.asList(
+                .put("int_to_bigint", ImmutableList.of(
                         2323L,
                         -2323L))
-                .put("bigint_to_varchar", Arrays.asList(
+                .put("bigint_to_varchar", ImmutableList.of(
                         "12345",
                         "-12345"))
-                .put("float_to_double", Arrays.asList(
+                .put("float_to_double", ImmutableList.of(
                         0.5,
                         -1.5))
-                .put("double_to_float", Arrays.asList(0.5, -1.5))
-                .put("shortdecimal_to_shortdecimal", Arrays.asList(
+                .put("double_to_float", ImmutableList.of(0.5, -1.5))
+                .put("shortdecimal_to_shortdecimal", ImmutableList.of(
                         new BigDecimal("12345678.1200"),
                         new BigDecimal("-12345678.1200")))
-                .put("shortdecimal_to_longdecimal", Arrays.asList(
+                .put("shortdecimal_to_longdecimal", ImmutableList.of(
                         new BigDecimal("12345678.1200"),
                         new BigDecimal("-12345678.1200")))
-                .put("longdecimal_to_shortdecimal", Arrays.asList(
+                .put("longdecimal_to_shortdecimal", ImmutableList.of(
                         new BigDecimal("12345678.12"),
                         new BigDecimal("-12345678.12")))
-                .put("longdecimal_to_longdecimal", Arrays.asList(
+                .put("longdecimal_to_longdecimal", ImmutableList.of(
                         new BigDecimal("12345678.12345612345600"),
                         new BigDecimal("-12345678.12345612345600")))
-                .put("float_to_decimal", Arrays.asList(new BigDecimal(floatToDecimalVal), new BigDecimal("-" + floatToDecimalVal)))
-                .put("double_to_decimal", Arrays.asList(new BigDecimal("12345.12345"), new BigDecimal("-12345.12345")))
-                .put("decimal_to_float", Arrays.asList(
+                .put("float_to_decimal", ImmutableList.of(new BigDecimal(floatToDecimalVal), new BigDecimal("-" + floatToDecimalVal)))
+                .put("double_to_decimal", ImmutableList.of(new BigDecimal("12345.12345"), new BigDecimal("-12345.12345")))
+                .put("decimal_to_float", ImmutableList.of(
                         Float.parseFloat(decimalToFloatVal),
                         -Float.parseFloat(decimalToFloatVal)))
-                .put("decimal_to_double", Arrays.asList(
+                .put("decimal_to_double", ImmutableList.of(
                         12345.12345,
                         -12345.12345))
-                .put("short_decimal_to_varchar", Arrays.asList(
+                .put("short_decimal_to_varchar", ImmutableList.of(
                         "12345.12345",
                         "-12345.12345"))
-                .put("long_decimal_to_varchar", Arrays.asList(
+                .put("long_decimal_to_varchar", ImmutableList.of(
                         "12345678.123456123456",
                         "-12345678.123456123456"))
-                .put("short_decimal_to_bounded_varchar", Arrays.asList(
+                .put("short_decimal_to_bounded_varchar", ImmutableList.of(
                         "12345.12345",
                         "12345.12345"))
-                .put("long_decimal_to_bounded_varchar", Arrays.asList(
+                .put("long_decimal_to_bounded_varchar", ImmutableList.of(
                         "12345678.123456123456",
                         "-12345678.123456123456"))
-                .put("varchar_to_bigger_varchar", Arrays.asList(
+                .put("varchar_to_bigger_varchar", ImmutableList.of(
                         "abc",
                         "\uD83D\uDCB0\uD83D\uDCB0\uD83D\uDCB0"))
-                .put("varchar_to_smaller_varchar", Arrays.asList(
+                .put("varchar_to_smaller_varchar", ImmutableList.of(
                         "ab",
                         "\uD83D\uDCB0\uD83D\uDCB0"))
-                .put("id", Arrays.asList(
+                .put("id", ImmutableList.of(
                         1,
                         1))
                 .buildOrThrow();
@@ -689,7 +689,7 @@ public abstract class BaseTestHiveCoercion
     private static List<List<?>> extract(List<TrinoArray> arrays)
     {
         return arrays.stream()
-                .map(trinoArray -> Arrays.asList((Object[]) trinoArray.getArray()))
+                .map(trinoArray -> ImmutableList.copyOf((Object[]) trinoArray.getArray()))
                 .collect(toImmutableList());
     }
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestHiveCoercion.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestHiveCoercion.java
@@ -50,6 +50,7 @@ import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 import static java.sql.JDBCType.ARRAY;
 import static java.sql.JDBCType.BIGINT;
+import static java.sql.JDBCType.CHAR;
 import static java.sql.JDBCType.DECIMAL;
 import static java.sql.JDBCType.DOUBLE;
 import static java.sql.JDBCType.FLOAT;
@@ -108,6 +109,8 @@ public abstract class BaseTestHiveCoercion
                 "long_decimal_to_bounded_varchar",
                 "varchar_to_bigger_varchar",
                 "varchar_to_smaller_varchar",
+                "char_to_bigger_char",
+                "char_to_smaller_char",
                 "id");
 
         Function<Engine, Map<String, List<Object>>> expected = engine -> expectedValuesForEngineProvider(engine, tableName, decimalToFloatVal, floatToDecimalVal);
@@ -162,6 +165,8 @@ public abstract class BaseTestHiveCoercion
                         "  DECIMAL '12345678.123456123456', " +
                         "  'abc', " +
                         "  'abc', " +
+                        "  'abc', " +
+                        "  'abc', " +
                         "  1), " +
                         "(" +
                         "  CAST(ROW (NULL, 1, -100, -2323, -12345, 2) AS ROW(keep VARCHAR, ti2si TINYINT, si2int SMALLINT, int2bi INTEGER, bi2vc BIGINT, lower2uppercase BIGINT)), " +
@@ -188,6 +193,8 @@ public abstract class BaseTestHiveCoercion
                         "  DECIMAL '-12345678.123456123456', " +
                         "  DECIMAL '-12345.12345', " +
                         "  DECIMAL '-12345678.123456123456', " +
+                        "  '\uD83D\uDCB0\uD83D\uDCB0\uD83D\uDCB0', " +
+                        "  '\uD83D\uDCB0\uD83D\uDCB0\uD83D\uDCB0', " +
                         "  '\uD83D\uDCB0\uD83D\uDCB0\uD83D\uDCB0', " +
                         "  '\uD83D\uDCB0\uD83D\uDCB0\uD83D\uDCB0', " +
                         "  1)",
@@ -325,6 +332,12 @@ public abstract class BaseTestHiveCoercion
                         "abc",
                         "\uD83D\uDCB0\uD83D\uDCB0\uD83D\uDCB0"))
                 .put("varchar_to_smaller_varchar", ImmutableList.of(
+                        "ab",
+                        "\uD83D\uDCB0\uD83D\uDCB0"))
+                .put("char_to_bigger_char", ImmutableList.of(
+                        "abc ",
+                        "\uD83D\uDCB0\uD83D\uDCB0\uD83D\uDCB0 "))
+                .put("char_to_smaller_char", ImmutableList.of(
                         "ab",
                         "\uD83D\uDCB0\uD83D\uDCB0"))
                 .put("id", ImmutableList.of(
@@ -549,6 +562,8 @@ public abstract class BaseTestHiveCoercion
                 row("long_decimal_to_bounded_varchar", "varchar(30)"),
                 row("varchar_to_bigger_varchar", "varchar(4)"),
                 row("varchar_to_smaller_varchar", "varchar(2)"),
+                row("char_to_bigger_char", "char(4)"),
+                row("char_to_smaller_char", "char(2)"),
                 row("id", "bigint"));
     }
 
@@ -593,6 +608,8 @@ public abstract class BaseTestHiveCoercion
                 .put("long_decimal_to_bounded_varchar", VARCHAR)
                 .put("varchar_to_bigger_varchar", VARCHAR)
                 .put("varchar_to_smaller_varchar", VARCHAR)
+                .put("char_to_bigger_char", CHAR)
+                .put("char_to_smaller_char", CHAR)
                 .put("id", BIGINT)
                 .put("nested_field", BIGINT)
                 .buildOrThrow();
@@ -631,6 +648,8 @@ public abstract class BaseTestHiveCoercion
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN long_decimal_to_bounded_varchar long_decimal_to_bounded_varchar varchar(30)", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN varchar_to_bigger_varchar varchar_to_bigger_varchar varchar(4)", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN varchar_to_smaller_varchar varchar_to_smaller_varchar varchar(2)", tableName));
+        onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN char_to_bigger_char char_to_bigger_char char(4)", tableName));
+        onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN char_to_smaller_char char_to_smaller_char char(2)", tableName));
     }
 
     protected static TableInstance<?> mutableTableInstanceOf(TableDefinition tableDefinition)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnPartitionedTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnPartitionedTable.java
@@ -96,7 +96,9 @@ public class TestHiveCoercionOnPartitionedTable
                         "    short_decimal_to_bounded_varchar   DECIMAL(10,5)," +
                         "    long_decimal_to_bounded_varchar    DECIMAL(20,12)," +
                         "    varchar_to_bigger_varchar          VARCHAR(3)," +
-                        "    varchar_to_smaller_varchar         VARCHAR(3)" +
+                        "    varchar_to_smaller_varchar         VARCHAR(3)," +
+                        "    char_to_bigger_char                CHAR(3)," +
+                        "    char_to_smaller_char               CHAR(3)" +
                         ") " +
                         "PARTITIONED BY (id BIGINT) " +
                         rowFormat.map(s -> format("ROW FORMAT %s ", s)).orElse("") +

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
@@ -70,6 +70,8 @@ public class TestHiveCoercionOnUnpartitionedTable
                             long_decimal_to_bounded_varchar    DECIMAL(20,12),
                             varchar_to_bigger_varchar          VARCHAR(3),
                             varchar_to_smaller_varchar         VARCHAR(3),
+                            char_to_bigger_char                CHAR(3),
+                            char_to_smaller_char               CHAR(3),
                             id                                 BIGINT)
                        STORED AS\s""" + fileFormat);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Add support  for coercing from 
- char to bigger char
- char to smaller char


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Similar to #5530


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes
 (x) Release notes are required, with the following suggested text:
```
## Hive Connector Changes
* Support coercion between `char` types of different lengths.
```
