### PR TITLE
Make FunctionProvider interface methods optional

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/function/FunctionProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/FunctionProvider.java
@@ -19,15 +19,27 @@ import io.trino.spi.ptf.TableFunctionProcessorProvider;
 @Experimental(eta = "2023-03-31")
 public interface FunctionProvider
 {
-    ScalarFunctionImplementation getScalarFunctionImplementation(
+    default ScalarFunctionImplementation getScalarFunctionImplementation(
             FunctionId functionId,
             BoundSignature boundSignature,
             FunctionDependencies functionDependencies,
-            InvocationConvention invocationConvention);
+            InvocationConvention invocationConvention)
+    {
+        throw new UnsupportedOperationException("%s does not provide scalar functions".formatted(getClass().getName()));
+    }
 
-    AggregationImplementation getAggregationImplementation(FunctionId functionId, BoundSignature boundSignature, FunctionDependencies functionDependencies);
+    default AggregationImplementation getAggregationImplementation(FunctionId functionId, BoundSignature boundSignature, FunctionDependencies functionDependencies)
+    {
+        throw new UnsupportedOperationException("%s does not provide aggregation functions".formatted(getClass().getName()));
+    }
 
-    WindowFunctionSupplier getWindowFunctionSupplier(FunctionId functionId, BoundSignature boundSignature, FunctionDependencies functionDependencies);
+    default WindowFunctionSupplier getWindowFunctionSupplier(FunctionId functionId, BoundSignature boundSignature, FunctionDependencies functionDependencies)
+    {
+        throw new UnsupportedOperationException("%s does not provide window functions".formatted(getClass().getName()));
+    }
 
-    TableFunctionProcessorProvider getTableFunctionProcessorProvider(SchemaFunctionName name);
+    default TableFunctionProcessorProvider getTableFunctionProcessorProvider(SchemaFunctionName name)
+    {
+        throw new UnsupportedOperationException("%s does not provide table functions".formatted(getClass().getName()));
+    }
 }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestTableFunctionInvocation.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestTableFunctionInvocation.java
@@ -112,34 +112,34 @@ public class TestTableFunctionInvocation
                         if (name.equals(new SchemaFunctionName("system", "identity_function"))) {
                             return new IdentityFunctionProcessorProvider();
                         }
-                        else if (name.equals(new SchemaFunctionName("system", "identity_pass_through_function"))) {
+                        if (name.equals(new SchemaFunctionName("system", "identity_pass_through_function"))) {
                             return new IdentityPassThroughFunctionProcessorProvider();
                         }
-                        else if (name.equals(new SchemaFunctionName("system", "repeat"))) {
+                        if (name.equals(new SchemaFunctionName("system", "repeat"))) {
                             return new RepeatFunctionProcessorProvider();
                         }
-                        else if (name.equals(new SchemaFunctionName("system", "empty_output"))) {
+                        if (name.equals(new SchemaFunctionName("system", "empty_output"))) {
                             return new EmptyOutputProcessorProvider();
                         }
-                        else if (name.equals(new SchemaFunctionName("system", "empty_output_with_pass_through"))) {
+                        if (name.equals(new SchemaFunctionName("system", "empty_output_with_pass_through"))) {
                             return new EmptyOutputWithPassThroughProcessorProvider();
                         }
-                        else if (name.equals(new SchemaFunctionName("system", "test_inputs_function"))) {
+                        if (name.equals(new SchemaFunctionName("system", "test_inputs_function"))) {
                             return new TestInputsFunctionProcessorProvider();
                         }
-                        else if (name.equals(new SchemaFunctionName("system", "pass_through"))) {
+                        if (name.equals(new SchemaFunctionName("system", "pass_through"))) {
                             return new PassThroughInputProcessorProvider();
                         }
-                        else if (name.equals(new SchemaFunctionName("system", "test_input"))) {
+                        if (name.equals(new SchemaFunctionName("system", "test_input"))) {
                             return new TestInputProcessorProvider();
                         }
-                        else if (name.equals(new SchemaFunctionName("system", "test_single_input_function"))) {
+                        if (name.equals(new SchemaFunctionName("system", "test_single_input_function"))) {
                             return new TestSingleInputFunctionProcessorProvider();
                         }
-                        else if (name.equals(new SchemaFunctionName("system", "constant"))) {
+                        if (name.equals(new SchemaFunctionName("system", "constant"))) {
                             return new ConstantFunctionProcessorProvider();
                         }
-                        else if (name.equals(new SchemaFunctionName("system", "empty_source"))) {
+                        if (name.equals(new SchemaFunctionName("system", "empty_source"))) {
                             return new EmptySourceFunctionProcessorProvider();
                         }
 

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestTableFunctionInvocation.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestTableFunctionInvocation.java
@@ -45,15 +45,8 @@ import io.trino.connector.TestingTableFunctions.TestSingleInputRowSemanticsFunct
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.spi.connector.FixedSplitSource;
 import io.trino.spi.connector.TableFunctionApplicationResult;
-import io.trino.spi.function.AggregationImplementation;
-import io.trino.spi.function.BoundSignature;
-import io.trino.spi.function.FunctionDependencies;
-import io.trino.spi.function.FunctionId;
 import io.trino.spi.function.FunctionProvider;
-import io.trino.spi.function.InvocationConvention;
-import io.trino.spi.function.ScalarFunctionImplementation;
 import io.trino.spi.function.SchemaFunctionName;
-import io.trino.spi.function.WindowFunctionSupplier;
 import io.trino.spi.ptf.TableFunctionProcessorProvider;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
@@ -113,24 +106,6 @@ public class TestTableFunctionInvocation
                 })
                 .withFunctionProvider(Optional.of(new FunctionProvider()
                 {
-                    @Override
-                    public ScalarFunctionImplementation getScalarFunctionImplementation(FunctionId functionId, BoundSignature boundSignature, FunctionDependencies functionDependencies, InvocationConvention invocationConvention)
-                    {
-                        return null;
-                    }
-
-                    @Override
-                    public AggregationImplementation getAggregationImplementation(FunctionId functionId, BoundSignature boundSignature, FunctionDependencies functionDependencies)
-                    {
-                        return null;
-                    }
-
-                    @Override
-                    public WindowFunctionSupplier getWindowFunctionSupplier(FunctionId functionId, BoundSignature boundSignature, FunctionDependencies functionDependencies)
-                    {
-                        return null;
-                    }
-
                     @Override
                     public TableFunctionProcessorProvider getTableFunctionProcessorProvider(SchemaFunctionName name)
                     {


### PR DESCRIPTION
For example, a connector providing table functions needs to implement only the `FunctionProvider.getTableFunctionProcessorProvider` method.
