### PR TITLE
Don't check SPI dependencies when downloading dependencies

### DIFF
--- a/.github/bin/download-maven-dependencies.sh
+++ b/.github/bin/download-maven-dependencies.sh
@@ -13,9 +13,9 @@ $RETRY $MAVEN_ONLINE -B de.qaware.maven:go-offline-maven-plugin:resolve-dependen
 
 # Enable common profiles to make sure their plugin dependencies are downloaded as well
 # GIB should be disabled even though it's profile is active, to make sure it doesn't skip any submodules
-$RETRY $MAVEN_ONLINE -B -P ci,errorprone-compiler ${MAVEN_GIB} -Dgib.disable dependency:go-offline
-$RETRY $MAVEN_ONLINE -B -P ci,errorprone-compiler ${MAVEN_GIB} -Dgib.disable de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+$RETRY $MAVEN_ONLINE -B -P ci,errorprone-compiler,disable-check-spi-dependencies ${MAVEN_GIB} -Dgib.disable dependency:go-offline
+$RETRY $MAVEN_ONLINE -B -P ci,errorprone-compiler,disable-check-spi-dependencies ${MAVEN_GIB} -Dgib.disable de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
 
 # TODO: Remove next step once https://github.com/qaware/go-offline-maven-plugin/issues/28 is fixed
 # trino-pinot overrides some common dependency versions, focus on it to make sure those overrides are downloaded as well
-$RETRY $MAVEN_ONLINE -B -P ci,errorprone-compiler ${MAVEN_GIB} -Dgib.disable de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -pl ':trino-pinot'
+$RETRY $MAVEN_ONLINE -B -P ci,errorprone-compiler,disable-check-spi-dependencies ${MAVEN_GIB} -Dgib.disable de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -pl ':trino-pinot'


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

I noticed there are some errors in the setup step, but the job doesn't fail. This should address these issues and possibly download missing dependencies.

SPI dependencies require local packages to be built, but it's too early for that.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
