### PR TITLE
Fix Driver not to finish operator which is revoking memory

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/Operator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/Operator.java
@@ -63,7 +63,7 @@ public interface Operator
      * must gracefully handle the case when there no longer is any revocable memory allocated.
      * <p>
      * After this method is called on Operator the Driver is disallowed to call any
-     * processing methods on it (isBlocked/needsInput/addInput/getOutput) until
+     * processing methods on it (isBlocked/needsInput/addInput/getOutput/finish) until
      * {@link #finishMemoryRevoke()} is called.
      */
     default ListenableFuture<Void> startMemoryRevoke()

--- a/core/trino-main/src/main/java/io/trino/operator/join/HashBuilderOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/HashBuilderOperator.java
@@ -445,9 +445,7 @@ public class HashBuilderOperator
             return;
         }
 
-        if (finishMemoryRevoke.isPresent()) {
-            return;
-        }
+        verify(finishMemoryRevoke.isEmpty(), "finish called between startMemoryRevoke and finishMemoryRevoke");
 
         switch (state) {
             case CONSUMING_INPUT:


### PR DESCRIPTION
The `Operator.startMemoryRevoke` API promises that no processing methods are called before memory revoking is done (`finishMemoryRevoke`). It did not make it whether `finish` can be expected, which introduces concurrency-like challenges to operators. For example, the `OrderByOperator` creates `PagesIndex` iterator in `finish`, but `finishMemoryRevoke` delivered later invalidates the iterator, leading to failures.

One way to fix the problem would be to allow (and document) that `finish` is the only processing method that can be called between `startMemoryRevoke` and `finishMemoryRevoke`. It was rejected as impractical, because it's unclear whether any operator would benefit from such possibility and it would make things more complex.

As a result, the other option was chosen, where `finish` is explicitly forbidden between `startMemoryRevoke` and `finishMemoryRevoke`. This fixes race-y problem in the `OrderByOperator`.

Fixes https://github.com/trinodb/trino/issues/16406