### PR TITLE
Fix OrderByOperator.finish to wait for finishMemoryRevoke

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/Operator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/Operator.java
@@ -62,9 +62,12 @@ public interface Operator
      * Since memory revoking signal is delivered asynchronously to the Operator, implementation
      * must gracefully handle the case when there no longer is any revocable memory allocated.
      * <p>
-     * After this method is called on Operator the Driver is disallowed to call any
-     * processing methods on it (isBlocked/needsInput/addInput/getOutput) until
-     * {@link #finishMemoryRevoke()} is called.
+     * After this method is called on Operator the Driver is disallowed to call most of
+     * processing methods on it
+     * ({@link #isBlocked()}/{@link #needsInput()}/{@link #addInput(Page)}/{@link #getOutput()})
+     * until {@link #finishMemoryRevoke()} is called. {@link #finish()} is the only processing
+     * method that can be called during that time and {@link #close()} remains callable
+     * at any time.
      */
     default ListenableFuture<Void> startMemoryRevoke()
     {


### PR DESCRIPTION
The `Operator.startMemoryRevoke` API promises that no processing methods
are called before memory revoking is done (`finishMemoryRevoke`).  Since
8c9df8268c2fa215ada65c67dad15d22e108871e, 7d1157312873e83d9fa662855416bc21427cdf42 and cf50577d755c943f70dc9de01cfd6c2545c8fb3d `finish` is the only processing
method that can be called between `startMemoryRevoke` and
`finishMemoryRevoke`.

`OrderByOperator` had a concurrency-like bug because it did not handle
well the case when invocation order is `startMemoryRevoke`, spill
completes, `finish`, `finishMemoryRevoke`. During `finish` the operator
gets an iterator over `PagesIndex` which becomes invalidated when
`finishMemoryRevoke` clears the `PagesIndex`.

The commit fixes that by adding explicit wait for `finishMemoryRevoke`
inside `OrderByOperator.finish`. The check is same as in
`HashBuilderOperator`. For consistency with the other operator the
`finishMemoryRevoke` field becomes `Optional`.

Fixes https://github.com/trinodb/trino/issues/16406
