### PR TITLE
Update documentation for table functions

### DIFF
--- a/docs/src/main/sphinx/develop/table-functions.rst
+++ b/docs/src/main/sphinx/develop/table-functions.rst
@@ -84,14 +84,30 @@ invocation:
 
 - **returned row type**
 
+It describes the row type produced by the table function.
+
+If a table function takes table arguments, it can additionally pass the columns
+of the input tables to output using the *pass-through mechanism*. The returned
+row type is supposed to describe only the columns produced by the function, as
+opposed to the pass-through columns.
+
 In the example, the returned row type is ``GENERIC_TABLE``, which means that
 the row type is not known statically, and it is determined dynamically based on
-the passed arguments. When the returned row type is known statically, you can
-declare it using:
+the passed arguments.
+
+When the returned row type is known statically, you can declare it using:
 
 .. code-block:: java
 
     new DescribedTable(descriptor)
+
+If a table function does not produce any columns, and it only outputs the
+pass-through columns, use ``ONLY_PASS_THROUGH`` as the returned row type.
+
+.. note::
+
+    A table function must return at least one column. It can either be a proper
+    column, i.e. produced by the function, or a pass-through column.
 
 The ``analyze()`` method
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/src/main/sphinx/develop/table-functions.rst
+++ b/docs/src/main/sphinx/develop/table-functions.rst
@@ -226,6 +226,7 @@ is also the place to perform custom checks on the arguments:
 
         return TableFunctionAnalysis.builder()
                 .returnedType(returnedType)
+                .handle(new MyHandle(columnCount, rowCount))
                 .build();
     }
 

--- a/docs/src/main/sphinx/develop/table-functions.rst
+++ b/docs/src/main/sphinx/develop/table-functions.rst
@@ -163,6 +163,8 @@ value for a table argument.
             .passThroughColumns()
             .build()
 
+.. _tf_set_or_row_semantics:
+
 Set or row semantics
 ====================
 

--- a/docs/src/main/sphinx/develop/table-functions.rst
+++ b/docs/src/main/sphinx/develop/table-functions.rst
@@ -49,7 +49,7 @@ The constructor
 
 The constructor takes the following arguments:
 
-- schema name
+- **schema name**
 
 The schema name helps you organize functions, and it is used for function
 resolution. When a table function is invoked, the right implementation is
@@ -58,8 +58,8 @@ identified by the catalog name, the schema name, and the function name.
 The function can use the schema name, for example to use data from the
 indicated schema, or ignore it.
 
-- function name
-- list of expected arguments
+- **function name**
+- **list of expected arguments**
 
 You can specify default values for some arguments, and those arguments can be
 skipped during invocation:
@@ -82,7 +82,7 @@ invocation:
             .type(INTEGER)
             .build()
 
-- returned row type
+- **returned row type**
 
 In the example, the returned row type is ``GENERIC_TABLE``, which means that
 the row type is not known statically, and it is determined dynamically based on

--- a/docs/src/main/sphinx/functions/table.rst
+++ b/docs/src/main/sphinx/functions/table.rst
@@ -47,6 +47,55 @@ by the specified catalog, the query fails.
 The table function name is resolved case-insensitive, analogically to scalar
 function and table resolution in Trino.
 
+Arguments
+^^^^^^^^^
+
+There are three types of arguments.
+
+1. Scalar arguments
+
+They must be constant expressions, and they can be of any SQL type, which is
+compatible with the declared argument type::
+
+    factor => 42
+
+2. Descriptor arguments
+
+Descriptors consist of fields with names and optional data types::
+
+    schema => DESCRIPTOR(id BIGINT, name VARCHAR)
+    columns => DESCRIPTOR(date, status, comment)
+
+To pass ``null`` for a descriptor, use::
+
+    schema => CAST(null AS DESCRIPTOR)
+
+3. Table arguments
+
+You can pass a table name, or a query. Use the keyword ``TABLE``::
+
+    input => TABLE(orders)
+    data => TABLE(SELECT * FROM region, nation WHERE region.regionkey = nation.regionkey)
+
+If the table argument is declared as :ref:`set semantics<tf_set_or_row_semantics>`,
+you can specify partitioning and ordering. Each partition is processed
+independently by the table function. If you do not specify partitioning, the
+argument is processed as a single partition. You can also specify
+``PRUNE WHEN EMPTY`` or ``KEEP WHEN EMPTY``. With ``PRUNE WHEN EMPTY`` you
+declare that you are not interested in the function result if the argument is
+empty. This information is used by the Trino engine to optimize the query. The
+``KEEP WHEN EMPTY`` option indicates that the function should be executed even
+if the table argument is empty. Note that by specifying ``KEEP WHEN EMPTY`` or
+``PRUNE WHEN EMPTY``, you override the property set for the argument by the
+function author.
+
+The following example shows how the table argument properties should be ordered::
+
+    input => TABLE(orders)
+                        PARTITION BY orderstatus
+                        KEEP WHEN EMPTY
+                        ORDER BY orderdate
+
 Argument passing conventions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -70,9 +119,7 @@ skipped arguments are declared with default values.
 
 You cannot mix the argument conventions in one invocation.
 
-All arguments must be constant expressions, and they can be of any SQL type,
-which is compatible with the declared argument type. You can also use
-parameters in arguments::
+You can also use parameters in arguments::
 
     PREPARE stmt FROM
     SELECT * FROM TABLE(my_function(row_count => ? + 1, column_count => ?));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This change adds information about all types of arguments supported by table functions to both developer guide and user guide. Also, the developer guide is updated with the new way of executing table functions involving the operator.

Follow-up to: https://github.com/trinodb/trino/pull/15575

No release notes required. Only docs change.