### PR TITLE
Add ConnectorSession to TableFunctionProcessorProvider#getSplitProcessor

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -1674,7 +1674,12 @@ public class LocalExecutionPlanner
             TableFunctionProcessorProvider processorProvider = plannerContext.getFunctionManager().getTableFunctionProcessorProvider(node.getHandle());
 
             if (node.getSource().isEmpty()) {
-                OperatorFactory operatorFactory = new LeafTableFunctionOperatorFactory(context.getNextOperatorId(), node.getId(), processorProvider, node.getHandle().getFunctionHandle());
+                OperatorFactory operatorFactory = new LeafTableFunctionOperatorFactory(
+                        context.getNextOperatorId(),
+                        node.getId(),
+                        node.getFunctionCatalog(),
+                        processorProvider,
+                        node.getHandle().getFunctionHandle());
                 return new PhysicalOperation(operatorFactory, makeLayout(node), context);
             }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
@@ -468,6 +468,7 @@ class RelationPlanner
         PlanNode root = new TableFunctionNode(
                 idAllocator.getNextId(),
                 functionAnalysis.getFunctionName(),
+                functionAnalysis.getCatalogHandle(),
                 functionAnalysis.getArguments(),
                 properOutputs,
                 sources.build(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ImplementTableFunctionSource.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ImplementTableFunctionSource.java
@@ -161,6 +161,7 @@ public class ImplementTableFunctionSource
             return Result.ofPlanNode(new TableFunctionProcessorNode(
                     node.getId(),
                     node.getName(),
+                    node.getFunctionCatalog(),
                     node.getProperOutputs(),
                     Optional.empty(),
                     false,
@@ -183,6 +184,7 @@ public class ImplementTableFunctionSource
             return Result.ofPlanNode(new TableFunctionProcessorNode(
                     node.getId(),
                     node.getName(),
+                    node.getFunctionCatalog(),
                     node.getProperOutputs(),
                     Optional.of(getOnlyElement(node.getSources())),
                     sourceProperties.isPruneWhenEmpty(),
@@ -278,6 +280,7 @@ public class ImplementTableFunctionSource
         return Result.ofPlanNode(new TableFunctionProcessorNode(
                 node.getId(),
                 node.getName(),
+                node.getFunctionCatalog(),
                 node.getProperOutputs(),
                 Optional.of(marked.node()),
                 pruneWhenEmpty,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
@@ -548,6 +548,7 @@ public class AddLocalExchanges
             TableFunctionProcessorNode result = new TableFunctionProcessorNode(
                     node.getId(),
                     node.getName(),
+                    node.getFunctionCatalog(),
                     node.getProperOutputs(),
                     Optional.of(child.getNode()),
                     node.isPruneWhenEmpty(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
@@ -403,6 +403,7 @@ public class SymbolMapper
         return new TableFunctionProcessorNode(
                 node.getId(),
                 node.getName(),
+                node.getFunctionCatalog(),
                 map(node.getProperOutputs()),
                 Optional.of(source),
                 node.isPruneWhenEmpty(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -359,6 +359,7 @@ public class UnaliasSymbolReferences
                     new TableFunctionNode(
                             node.getId(),
                             node.getName(),
+                            node.getFunctionCatalog(),
                             node.getArguments(),
                             newProperOutputs,
                             newSources.build(),
@@ -378,6 +379,7 @@ public class UnaliasSymbolReferences
                         new TableFunctionProcessorNode(
                                 node.getId(),
                                 node.getName(),
+                                node.getFunctionCatalog(),
                                 mapper.map(node.getProperOutputs()),
                                 Optional.empty(),
                                 node.isPruneWhenEmpty(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableFunctionNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableFunctionNode.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.metadata.TableFunctionHandle;
+import io.trino.spi.connector.CatalogHandle;
 import io.trino.spi.ptf.Argument;
 import io.trino.sql.planner.Symbol;
 
@@ -37,6 +38,7 @@ public class TableFunctionNode
         extends PlanNode
 {
     private final String name;
+    private final CatalogHandle functionCatalog;
     private final Map<String, Argument> arguments;
     private final List<Symbol> properOutputs;
     private final List<PlanNode> sources;
@@ -48,6 +50,7 @@ public class TableFunctionNode
     public TableFunctionNode(
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("name") String name,
+            @JsonProperty("functionCatalog") CatalogHandle functionCatalog,
             @JsonProperty("arguments") Map<String, Argument> arguments,
             @JsonProperty("properOutputs") List<Symbol> properOutputs,
             @JsonProperty("sources") List<PlanNode> sources,
@@ -57,6 +60,7 @@ public class TableFunctionNode
     {
         super(id);
         this.name = requireNonNull(name, "name is null");
+        this.functionCatalog = requireNonNull(functionCatalog, "functionCatalog is null");
         this.arguments = ImmutableMap.copyOf(arguments);
         this.properOutputs = ImmutableList.copyOf(properOutputs);
         this.sources = ImmutableList.copyOf(sources);
@@ -71,6 +75,12 @@ public class TableFunctionNode
     public String getName()
     {
         return name;
+    }
+
+    @JsonProperty
+    public CatalogHandle getFunctionCatalog()
+    {
+        return functionCatalog;
     }
 
     @JsonProperty
@@ -137,7 +147,16 @@ public class TableFunctionNode
     public PlanNode replaceChildren(List<PlanNode> newSources)
     {
         checkArgument(sources.size() == newSources.size(), "wrong number of new children");
-        return new TableFunctionNode(getId(), name, arguments, properOutputs, newSources, tableArgumentProperties, copartitioningLists, handle);
+        return new TableFunctionNode(
+                getId(),
+                name,
+                functionCatalog,
+                arguments,
+                properOutputs,
+                newSources,
+                tableArgumentProperties,
+                copartitioningLists,
+                handle);
     }
 
     public static class TableArgumentProperties

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableFunctionProcessorNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableFunctionProcessorNode.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.metadata.TableFunctionHandle;
+import io.trino.spi.connector.CatalogHandle;
 import io.trino.sql.planner.OrderingScheme;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.plan.TableFunctionNode.PassThroughSpecification;
@@ -38,6 +39,8 @@ public class TableFunctionProcessorNode
         extends PlanNode
 {
     private final String name;
+
+    private final CatalogHandle functionCatalog;
 
     // symbols produced by the function
     private final List<Symbol> properOutputs;
@@ -74,6 +77,7 @@ public class TableFunctionProcessorNode
     public TableFunctionProcessorNode(
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("name") String name,
+            @JsonProperty("functionCatalog") CatalogHandle functionCatalog,
             @JsonProperty("properOutputs") List<Symbol> properOutputs,
             @JsonProperty("source") Optional<PlanNode> source,
             @JsonProperty("pruneWhenEmpty") boolean pruneWhenEmpty,
@@ -88,6 +92,7 @@ public class TableFunctionProcessorNode
     {
         super(id);
         this.name = requireNonNull(name, "name is null");
+        this.functionCatalog = requireNonNull(functionCatalog, "functionCatalog is null");
         this.properOutputs = ImmutableList.copyOf(properOutputs);
         this.source = requireNonNull(source, "source is null");
         this.pruneWhenEmpty = pruneWhenEmpty;
@@ -120,6 +125,12 @@ public class TableFunctionProcessorNode
     public String getName()
     {
         return name;
+    }
+
+    @JsonProperty
+    public CatalogHandle getFunctionCatalog()
+    {
+        return functionCatalog;
     }
 
     @JsonProperty
@@ -221,6 +232,20 @@ public class TableFunctionProcessorNode
     public PlanNode replaceChildren(List<PlanNode> newSources)
     {
         Optional<PlanNode> newSource = newSources.isEmpty() ? Optional.empty() : Optional.of(getOnlyElement(newSources));
-        return new TableFunctionProcessorNode(getId(), name, properOutputs, newSource, pruneWhenEmpty, passThroughSpecifications, requiredSymbols, markerSymbols, specification, prePartitioned, preSorted, hashSymbol, handle);
+        return new TableFunctionProcessorNode(
+                getId(),
+                name,
+                functionCatalog,
+                properOutputs,
+                newSource,
+                pruneWhenEmpty,
+                passThroughSpecifications,
+                requiredSymbols,
+                markerSymbols,
+                specification,
+                prePartitioned,
+                preSorted,
+                hashSymbol,
+                handle);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/connector/TestingTableFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/connector/TestingTableFunctions.java
@@ -1139,7 +1139,7 @@ public class TestingTableFunctions
                 implements TableFunctionProcessorProvider
         {
             @Override
-            public TableFunctionSplitProcessor getSplitProcessor(ConnectorTableFunctionHandle handle)
+            public TableFunctionSplitProcessor getSplitProcessor(ConnectorSession session, ConnectorTableFunctionHandle handle)
             {
                 return new ConstantFunctionProcessor(((ConstantFunctionHandle) handle).getValue());
             }
@@ -1308,7 +1308,7 @@ public class TestingTableFunctions
                 implements TableFunctionProcessorProvider
         {
             @Override
-            public TableFunctionSplitProcessor getSplitProcessor(ConnectorTableFunctionHandle handle)
+            public TableFunctionSplitProcessor getSplitProcessor(ConnectorSession session, ConnectorTableFunctionHandle handle)
             {
                 return new EmptySourceFunctionProcessor();
             }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -1215,6 +1215,7 @@ public class PlanBuilder
         return new TableFunctionNode(
                 idAllocator.getNextId(),
                 name,
+                TEST_CATALOG_HANDLE,
                 ImmutableMap.of(),
                 properOutputs,
                 sources,

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionProcessorProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionProcessorProvider.java
@@ -14,6 +14,7 @@
 package io.trino.spi.ptf;
 
 import io.trino.spi.Experimental;
+import io.trino.spi.connector.ConnectorSession;
 
 @Experimental(eta = "2023-03-31")
 public interface TableFunctionProcessorProvider
@@ -31,7 +32,7 @@ public interface TableFunctionProcessorProvider
      * This method returns a {@code TableFunctionSplitProcessor}. All the necessary information collected during analysis is available
      * in the form of {@link ConnectorTableFunctionHandle}. It is called once per each split processed by the table function.
      */
-    default TableFunctionSplitProcessor getSplitProcessor(ConnectorTableFunctionHandle handle)
+    default TableFunctionSplitProcessor getSplitProcessor(ConnectorSession session, ConnectorTableFunctionHandle handle)
     {
         throw new UnsupportedOperationException("this table function does not process splits");
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Add ConnectorSession as an argument to `TableFunctionProcessorProvider. getSplitProcessor`
and initialize it correctly in `LeafTableFunctionOperator`


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes


(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
