### PR TITLE
[FIX] Coerce NullLiteral to boolean in UnwrapCastInComparison

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
@@ -562,11 +562,11 @@ public class UnwrapCastInComparison
 
     public static Expression falseIfNotNull(Expression argument)
     {
-        return and(new IsNullPredicate(argument), new NullLiteral());
+        return and(new IsNullPredicate(argument), new Cast(new NullLiteral(), toSqlType(BOOLEAN), false, true));
     }
 
     public static Expression trueIfNotNull(Expression argument)
     {
-        return or(new IsNotNullPredicate(argument), new NullLiteral());
+        return or(new IsNotNullPredicate(argument), new Cast(new NullLiteral(), toSqlType(BOOLEAN), false, true));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/AbstractPredicatePushdownTest.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/AbstractPredicatePushdownTest.java
@@ -552,6 +552,28 @@ public abstract class AbstractPredicatePushdownTest
                                                 ImmutableMap.of("ORDERSTATUS", "orderstatus"))))));
     }
 
+    @Test
+    public void testOnlyNullPredicateIsPushDownThroughJoinFilters()
+    {
+        assertPlan(
+                """
+                    WITH test_table AS (
+                        SELECT
+                        custkey,
+                        CASE
+                            WHEN name = 'ABC' then 'ABC'
+                            ELSE 'BCD'
+                        END AS new_name
+                        FROM customer)
+                    SELECT orderstatus
+                    FROM orders
+                    JOIN test_table
+                    ON orders.custkey = test_table.custkey
+                    WHERE test_table.new_name = 'TESTING'
+                    """,
+                output(values("orderstatus")));
+    }
+
     private Session noSemiJoinRewrite()
     {
         return Session.builder(getQueryRunner().getDefaultSession())

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapCastInComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapCastInComparison.java
@@ -38,37 +38,37 @@ public class TestUnwrapCastInComparison
         testUnwrap("bigint", "a = DOUBLE '1'", "a = BIGINT '1'");
 
         // non-representable
-        testUnwrap("smallint", "a = DOUBLE '1.1'", "a IS NULL AND NULL");
-        testUnwrap("smallint", "a = DOUBLE '1.9'", "a IS NULL AND NULL");
+        testUnwrap("smallint", "a = DOUBLE '1.1'", "a IS NULL AND CAST(NULL AS BOOLEAN)");
+        testUnwrap("smallint", "a = DOUBLE '1.9'", "a IS NULL AND CAST(NULL AS BOOLEAN)");
 
-        testUnwrap("bigint", "a = DOUBLE '1.1'", "a IS NULL AND NULL");
+        testUnwrap("bigint", "a = DOUBLE '1.1'", "a IS NULL AND CAST(NULL AS BOOLEAN)");
 
         // below top of range
         testUnwrap("smallint", "a = DOUBLE '32766'", "a = SMALLINT '32766'");
 
         // round to top of range
-        testUnwrap("smallint", "a = DOUBLE '32766.9'", "a IS NULL AND NULL");
+        testUnwrap("smallint", "a = DOUBLE '32766.9'", "a IS NULL AND CAST(NULL AS BOOLEAN)");
 
         // top of range
         testUnwrap("smallint", "a = DOUBLE '32767'", "a = SMALLINT '32767'");
 
         // above range
-        testUnwrap("smallint", "a = DOUBLE '32768.1'", "a IS NULL AND NULL");
+        testUnwrap("smallint", "a = DOUBLE '32768.1'", "a IS NULL AND CAST(NULL AS BOOLEAN)");
 
         // above bottom of range
         testUnwrap("smallint", "a = DOUBLE '-32767'", "a = SMALLINT '-32767'");
 
         // round to bottom of range
-        testUnwrap("smallint", "a = DOUBLE '-32767.9'", "a IS NULL AND NULL");
+        testUnwrap("smallint", "a = DOUBLE '-32767.9'", "a IS NULL AND CAST(NULL AS BOOLEAN)");
 
         // bottom of range
         testUnwrap("smallint", "a = DOUBLE '-32768'", "a = SMALLINT '-32768'");
 
         // below range
-        testUnwrap("smallint", "a = DOUBLE '-32768.1'", "a IS NULL AND NULL");
+        testUnwrap("smallint", "a = DOUBLE '-32768.1'", "a IS NULL AND CAST(NULL AS BOOLEAN)");
 
         // -2^64 constant
-        testUnwrap("bigint", "a = DOUBLE '-18446744073709551616'", "a IS NULL AND NULL");
+        testUnwrap("bigint", "a = DOUBLE '-18446744073709551616'", "a IS NULL AND CAST(NULL AS BOOLEAN)");
 
         // shorter varchar and char
         testNoUnwrap("varchar(1)", "= CAST('abc' AS char(3))", "char(3)");
@@ -92,37 +92,37 @@ public class TestUnwrapCastInComparison
         testUnwrap("bigint", "a <> DOUBLE '1'", "a <> BIGINT '1'");
 
         // non-representable
-        testUnwrap("smallint", "a <> DOUBLE '1.1'", "NOT (a IS NULL) OR NULL");
-        testUnwrap("smallint", "a <> DOUBLE '1.9'", "NOT (a IS NULL) OR NULL");
+        testUnwrap("smallint", "a <> DOUBLE '1.1'", "NOT (a IS NULL) OR CAST(NULL AS BOOLEAN)");
+        testUnwrap("smallint", "a <> DOUBLE '1.9'", "NOT (a IS NULL) OR CAST(NULL AS BOOLEAN)");
 
-        testUnwrap("bigint", "a <> DOUBLE '1.1'", "NOT (a IS NULL) OR NULL");
+        testUnwrap("bigint", "a <> DOUBLE '1.1'", "NOT (a IS NULL) OR CAST(NULL AS BOOLEAN)");
 
         // below top of range
         testUnwrap("smallint", "a <> DOUBLE '32766'", "a <> SMALLINT '32766'");
 
         // round to top of range
-        testUnwrap("smallint", "a <> DOUBLE '32766.9'", "NOT (a IS NULL) OR NULL");
+        testUnwrap("smallint", "a <> DOUBLE '32766.9'", "NOT (a IS NULL) OR CAST(NULL AS BOOLEAN)");
 
         // top of range
         testUnwrap("smallint", "a <> DOUBLE '32767'", "a <> SMALLINT '32767'");
 
         // above range
-        testUnwrap("smallint", "a <> DOUBLE '32768.1'", "NOT (a IS NULL) OR NULL");
+        testUnwrap("smallint", "a <> DOUBLE '32768.1'", "NOT (a IS NULL) OR CAST(NULL AS BOOLEAN)");
 
         // 2^64 constant
-        testUnwrap("bigint", "a <> DOUBLE '18446744073709551616'", "NOT (a IS NULL) OR NULL");
+        testUnwrap("bigint", "a <> DOUBLE '18446744073709551616'", "NOT (a IS NULL) OR CAST(NULL AS BOOLEAN)");
 
         // above bottom of range
         testUnwrap("smallint", "a <> DOUBLE '-32767'", "a <> SMALLINT '-32767'");
 
         // round to bottom of range
-        testUnwrap("smallint", "a <> DOUBLE '-32767.9'", "NOT (a IS NULL) OR NULL");
+        testUnwrap("smallint", "a <> DOUBLE '-32767.9'", "NOT (a IS NULL) OR CAST(NULL AS BOOLEAN)");
 
         // bottom of range
         testUnwrap("smallint", "a <> DOUBLE '-32768'", "a <> SMALLINT '-32768'");
 
         // below range
-        testUnwrap("smallint", "a <> DOUBLE '-32768.1'", "NOT (a IS NULL) OR NULL");
+        testUnwrap("smallint", "a <> DOUBLE '-32768.1'", "NOT (a IS NULL) OR CAST(NULL AS BOOLEAN)");
     }
 
     @Test
@@ -150,7 +150,7 @@ public class TestUnwrapCastInComparison
         testUnwrap("smallint", "a < DOUBLE '32767'", "a <> SMALLINT '32767'");
 
         // above range
-        testUnwrap("smallint", "a < DOUBLE '32768.1'", "NOT (a IS NULL) OR NULL");
+        testUnwrap("smallint", "a < DOUBLE '32768.1'", "NOT (a IS NULL) OR CAST(NULL AS BOOLEAN)");
 
         // above bottom of range
         testUnwrap("smallint", "a < DOUBLE '-32767'", "a < SMALLINT '-32767'");
@@ -159,13 +159,13 @@ public class TestUnwrapCastInComparison
         testUnwrap("smallint", "a < DOUBLE '-32767.9'", "a = SMALLINT '-32768'");
 
         // bottom of range
-        testUnwrap("smallint", "a < DOUBLE '-32768'", "a IS NULL AND NULL");
+        testUnwrap("smallint", "a < DOUBLE '-32768'", "a IS NULL AND CAST(NULL AS BOOLEAN)");
 
         // below range
-        testUnwrap("smallint", "a < DOUBLE '-32768.1'", "a IS NULL AND NULL");
+        testUnwrap("smallint", "a < DOUBLE '-32768.1'", "a IS NULL AND CAST(NULL AS BOOLEAN)");
 
         // -2^64 constant
-        testUnwrap("bigint", "a < DOUBLE '-18446744073709551616'", "a IS NULL AND NULL");
+        testUnwrap("bigint", "a < DOUBLE '-18446744073709551616'", "a IS NULL AND CAST(NULL AS BOOLEAN)");
     }
 
     @Test
@@ -190,13 +190,13 @@ public class TestUnwrapCastInComparison
         testUnwrap("smallint", "a <= DOUBLE '32766.9'", "a < SMALLINT '32767'");
 
         // top of range
-        testUnwrap("smallint", "a <= DOUBLE '32767'", "NOT (a IS NULL) OR NULL");
+        testUnwrap("smallint", "a <= DOUBLE '32767'", "NOT (a IS NULL) OR CAST(NULL AS BOOLEAN)");
 
         // above range
-        testUnwrap("smallint", "a <= DOUBLE '32768.1'", "NOT (a IS NULL) OR NULL");
+        testUnwrap("smallint", "a <= DOUBLE '32768.1'", "NOT (a IS NULL) OR CAST(NULL AS BOOLEAN)");
 
         // 2^64 constant
-        testUnwrap("bigint", "a <= DOUBLE '18446744073709551616'", "NOT (a IS NULL) OR NULL");
+        testUnwrap("bigint", "a <= DOUBLE '18446744073709551616'", "NOT (a IS NULL) OR CAST(NULL AS BOOLEAN)");
 
         // above bottom of range
         testUnwrap("smallint", "a <= DOUBLE '-32767'", "a <= SMALLINT '-32767'");
@@ -208,7 +208,7 @@ public class TestUnwrapCastInComparison
         testUnwrap("smallint", "a <= DOUBLE '-32768'", "a = SMALLINT '-32768'");
 
         // below range
-        testUnwrap("smallint", "a <= DOUBLE '-32768.1'", "a IS NULL AND NULL");
+        testUnwrap("smallint", "a <= DOUBLE '-32768.1'", "a IS NULL AND CAST(NULL AS BOOLEAN)");
     }
 
     @Test
@@ -233,13 +233,13 @@ public class TestUnwrapCastInComparison
         testUnwrap("smallint", "a > DOUBLE '32766.9'", "a = SMALLINT '32767'");
 
         // top of range
-        testUnwrap("smallint", "a > DOUBLE '32767'", "a IS NULL AND NULL");
+        testUnwrap("smallint", "a > DOUBLE '32767'", "a IS NULL AND CAST(NULL AS BOOLEAN)");
 
         // above range
-        testUnwrap("smallint", "a > DOUBLE '32768.1'", "a IS NULL AND NULL");
+        testUnwrap("smallint", "a > DOUBLE '32768.1'", "a IS NULL AND CAST(NULL AS BOOLEAN)");
 
         // 2^64 constant
-        testUnwrap("bigint", "a > DOUBLE '18446744073709551616'", "a IS NULL AND NULL");
+        testUnwrap("bigint", "a > DOUBLE '18446744073709551616'", "a IS NULL AND CAST(NULL AS BOOLEAN)");
 
         // above bottom of range
         testUnwrap("smallint", "a > DOUBLE '-32767'", "a > SMALLINT '-32767'");
@@ -251,7 +251,7 @@ public class TestUnwrapCastInComparison
         testUnwrap("smallint", "a > DOUBLE '-32768'", "a <> SMALLINT '-32768'");
 
         // below range
-        testUnwrap("smallint", "a > DOUBLE '-32768.1'", "NOT (a IS NULL) OR NULL");
+        testUnwrap("smallint", "a > DOUBLE '-32768.1'", "NOT (a IS NULL) OR CAST(NULL AS BOOLEAN)");
     }
 
     @Test
@@ -279,7 +279,7 @@ public class TestUnwrapCastInComparison
         testUnwrap("smallint", "a >= DOUBLE '32767'", "a = SMALLINT '32767'");
 
         // above range
-        testUnwrap("smallint", "a >= DOUBLE '32768.1'", "a IS NULL AND NULL");
+        testUnwrap("smallint", "a >= DOUBLE '32768.1'", "a IS NULL AND CAST(NULL AS BOOLEAN)");
 
         // above bottom of range
         testUnwrap("smallint", "a >= DOUBLE '-32767'", "a >= SMALLINT '-32767'");
@@ -288,13 +288,13 @@ public class TestUnwrapCastInComparison
         testUnwrap("smallint", "a >= DOUBLE '-32767.9'", "a > SMALLINT '-32768' ");
 
         // bottom of range
-        testUnwrap("smallint", "a >= DOUBLE '-32768'", "NOT (a IS NULL) OR NULL");
+        testUnwrap("smallint", "a >= DOUBLE '-32768'", "NOT (a IS NULL) OR CAST(NULL AS BOOLEAN)");
 
         // below range
-        testUnwrap("smallint", "a >= DOUBLE '-32768.1'", "NOT (a IS NULL) OR NULL");
+        testUnwrap("smallint", "a >= DOUBLE '-32768.1'", "NOT (a IS NULL) OR CAST(NULL AS BOOLEAN)");
 
         // -2^64 constant
-        testUnwrap("bigint", "a >= DOUBLE '-18446744073709551616'", "NOT (a IS NULL) OR NULL");
+        testUnwrap("bigint", "a >= DOUBLE '-18446744073709551616'", "NOT (a IS NULL) OR CAST(NULL AS BOOLEAN)");
     }
 
     @Test
@@ -365,23 +365,23 @@ public class TestUnwrapCastInComparison
     @Test
     public void testNaN()
     {
-        testUnwrap("smallint", "a = nan()", "a IS NULL AND NULL");
+        testUnwrap("smallint", "a = nan()", "a IS NULL AND CAST(NULL AS BOOLEAN)");
 
-        testUnwrap("bigint", "a = nan()", "a IS NULL AND NULL");
+        testUnwrap("bigint", "a = nan()", "a IS NULL AND CAST(NULL AS BOOLEAN)");
 
-        testUnwrap("smallint", "a < nan()", "a IS NULL AND NULL");
+        testUnwrap("smallint", "a < nan()", "a IS NULL AND CAST(NULL AS BOOLEAN)");
 
-        testUnwrap("smallint", "a <> nan()", "NOT (a IS NULL) OR NULL");
+        testUnwrap("smallint", "a <> nan()", "NOT (a IS NULL) OR CAST(NULL AS BOOLEAN)");
 
         testRemoveFilter("smallint", "a IS DISTINCT FROM nan()");
 
         testRemoveFilter("bigint", "a IS DISTINCT FROM nan()");
 
-        testUnwrap("real", "a = nan()", "a IS NULL AND NULL");
+        testUnwrap("real", "a = nan()", "a IS NULL AND CAST(NULL AS BOOLEAN)");
 
-        testUnwrap("real", "a < nan()", "a IS NULL AND NULL");
+        testUnwrap("real", "a < nan()", "a IS NULL AND CAST(NULL AS BOOLEAN)");
 
-        testUnwrap("real", "a <> nan()", "NOT (a IS NULL) OR NULL");
+        testUnwrap("real", "a <> nan()", "NOT (a IS NULL) OR CAST(NULL AS BOOLEAN)");
 
         testUnwrap("real", "a IS DISTINCT FROM nan()", "a IS DISTINCT FROM CAST(nan() AS REAL)");
     }


### PR DESCRIPTION
Coerce `NullLiteral` to boolean type in `UnwrapCastInComparison` otherwise `PredicatePushDown` rule could throw an error while creating `FilterNode` with `NullLiteral` as a predicate. This is because `FilterNode` cannot be created with just `NullLiteral` without proper coercions.

Steps to reproduce the issue in the current version:
```
CREATE TABLE sample_table_1 (a smallint, b varchar);

CREATE TABLE sample_table_2 (a smallint, b varchar);

WITH t AS (SELECT a,
CASE 
  WHEN b = 'ABCD' THEN 'ABC'
  ELSE 'CDB' END AS channel 
  FROM sample_table_2 t2)
SELECT * FROM sample_table_1 t1 JOIN t ON t1.a = t.a WHERE channel = 'TESTING';
```

Error: `Query 20230308_141912_00008_fy4xb failed: Predicate must be an expression of boolean type: null`

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
