### PR TITLE
Avoid extra allocation in OrderByOperator#getOutput()

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/OrderByOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OrderByOperator.java
@@ -18,7 +18,6 @@ import com.google.common.primitives.Ints;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.memory.context.LocalMemoryContext;
 import io.trino.spi.Page;
-import io.trino.spi.block.Block;
 import io.trino.spi.connector.SortOrder;
 import io.trino.spi.type.Type;
 import io.trino.spiller.Spiller;
@@ -286,11 +285,7 @@ public class OrderByOperator
             return null;
         }
         Page nextPage = next.get();
-        Block[] blocks = new Block[outputChannels.length];
-        for (int i = 0; i < outputChannels.length; i++) {
-            blocks[i] = nextPage.getBlock(outputChannels[i]);
-        }
-        return new Page(nextPage.getPositionCount(), blocks);
+        return nextPage.getColumns(outputChannels);
     }
 
     @Override


### PR DESCRIPTION
## Description
Changes `OrderByOperator#getOutput()` to use `Page#getColumns(outputChannels)` instead of building an array of output blocks itself, which avoids an extra allocation.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
