### PR TITLE
Enforce `Locale.ENGLISH` instead of `Locale.ROOT`

### DIFF
--- a/.mvn/modernizer/violations.xml
+++ b/.mvn/modernizer/violations.xml
@@ -277,4 +277,10 @@
         <version>1.8</version>
         <comment>Use io.airlift.slice.SizeOf.instanceSize</comment>
     </violation>
+
+    <violation>
+        <name>java/util/Locale.ROOT:Ljava/util/Locale;</name>
+        <version>1.6</version>
+        <comment>Use java.util.Locale.ENGLISH</comment>
+    </violation>
 </modernizer>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/CatalogHandle.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/CatalogHandle.java
@@ -24,7 +24,7 @@ import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.connector.CatalogHandle.CatalogHandleType.INFORMATION_SCHEMA;
 import static io.trino.spi.connector.CatalogHandle.CatalogHandleType.NORMAL;
 import static io.trino.spi.connector.CatalogHandle.CatalogHandleType.SYSTEM;
-import static java.util.Locale.ROOT;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 @Experimental(eta = "2023-02-01")
@@ -68,7 +68,7 @@ public final class CatalogHandle
         }
 
         String catalogName = id.substring(0, typeSplit);
-        CatalogHandleType type = CatalogHandleType.valueOf(id.substring(typeSplit + 1, versionSplit).toUpperCase(ROOT));
+        CatalogHandleType type = CatalogHandleType.valueOf(id.substring(typeSplit + 1, versionSplit).toUpperCase(ENGLISH));
         CatalogVersion version = new CatalogVersion(id.substring(versionSplit + 1));
         return new CatalogHandle(catalogName, type, version);
     }
@@ -94,7 +94,7 @@ public final class CatalogHandle
     @JsonValue
     public String getId()
     {
-        return catalogName + ":" + type.toString().toLowerCase(ROOT) + ":" + version;
+        return catalogName + ":" + type.toString().toLowerCase(ENGLISH) + ":" + version;
     }
 
     /**

--- a/core/trino-spi/src/main/java/io/trino/spi/security/AccessDeniedException.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/AccessDeniedException.java
@@ -18,12 +18,12 @@ import io.trino.spi.function.FunctionKind;
 
 import java.security.Principal;
 import java.util.Collection;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 
 import static io.trino.spi.StandardErrorCode.PERMISSION_DENIED;
 import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 
 public class AccessDeniedException
         extends TrinoException
@@ -692,7 +692,7 @@ public class AccessDeniedException
 
     public static void denyExecuteFunction(String functionName, FunctionKind functionKind, String extraInfo)
     {
-        throw new AccessDeniedException(format("Cannot execute %s function %s%s", functionKind.name().toLowerCase(Locale.ROOT), functionName, formatExtraInfo(extraInfo)));
+        throw new AccessDeniedException(format("Cannot execute %s function %s%s", functionKind.name().toLowerCase(ENGLISH), functionName, formatExtraInfo(extraInfo)));
     }
 
     public static void denyExecuteTableProcedure(String tableName, String procedureName)

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonDeserializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonDeserializer.java
@@ -49,7 +49,6 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.IntFunction;
@@ -85,6 +84,7 @@ import static java.lang.Float.floatToRawIntBits;
 import static java.lang.StrictMath.toIntExact;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Locale.ENGLISH;
 import static org.joda.time.DateTimeZone.UTC;
 
 /**
@@ -130,7 +130,7 @@ public class JsonDeserializer
 
         rowDecoder = new RowDecoder(
                 RowType.from(columns.stream()
-                        .map(column -> field(column.name().toLowerCase(Locale.ROOT), column.type()))
+                        .map(column -> field(column.name().toLowerCase(ENGLISH), column.type()))
                         .collect(toImmutableList())),
                 columns.stream()
                         .map(Column::type)
@@ -670,7 +670,7 @@ public class JsonDeserializer
             super(rowType);
             this.fieldNames = rowType.getFields().stream()
                     .map(field -> field.getName().orElseThrow())
-                    .map(fieldName -> fieldName.toLowerCase(Locale.ROOT))
+                    .map(fieldName -> fieldName.toLowerCase(ENGLISH))
                     .collect(toImmutableList());
             this.fieldDecoders = fieldDecoders;
             this.ordinalToFieldPosition = ordinalToFieldPosition;
@@ -763,7 +763,7 @@ public class JsonDeserializer
 
         private int getFieldPosition(String fieldName)
         {
-            int fieldPosition = fieldNames.indexOf(fieldName.toLowerCase(Locale.ROOT));
+            int fieldPosition = fieldNames.indexOf(fieldName.toLowerCase(ENGLISH));
             if (fieldPosition >= 0) {
                 return fieldPosition;
             }

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonSerializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonSerializer.java
@@ -36,7 +36,6 @@ import io.trino.spi.type.VarcharType;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
-import java.util.Locale;
 import java.util.function.IntFunction;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -52,6 +51,7 @@ import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.Float.intBitsToFloat;
+import static java.util.Locale.ENGLISH;
 
 /**
  * Deserializer that is bug for bug compatible with Hive JsonSerDe.
@@ -65,7 +65,7 @@ public class JsonSerializer
     public JsonSerializer(List<Column> columns)
     {
         this.type = RowType.from(columns.stream()
-                .map(column -> field(column.name().toLowerCase(Locale.ROOT), column.type()))
+                .map(column -> field(column.name().toLowerCase(ENGLISH), column.type()))
                 .collect(toImmutableList()));
 
         jsonFactory = new JsonFactory();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -78,7 +78,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -8280,7 +8279,7 @@ public abstract class BaseHiveConnectorTest
     @Test(dataProvider = "legalUseColumnNamesProvider")
     public void testUseColumnNames(HiveStorageFormat format, boolean formatUseColumnNames)
     {
-        String lowerCaseFormat = format.name().toLowerCase(Locale.ROOT);
+        String lowerCaseFormat = format.name().toLowerCase(ENGLISH);
         Session.SessionBuilder builder = Session.builder(getSession());
         if (format == HiveStorageFormat.ORC || format == HiveStorageFormat.PARQUET) {
             builder.setCatalogSessionProperty(catalog, lowerCaseFormat + "_use_column_names", String.valueOf(formatUseColumnNames));
@@ -8335,7 +8334,7 @@ public abstract class BaseHiveConnectorTest
     @Test(dataProvider = "legalUseColumnNamesProvider")
     public void testUseColumnAddDrop(HiveStorageFormat format, boolean formatUseColumnNames)
     {
-        String lowerCaseFormat = format.name().toLowerCase(Locale.ROOT);
+        String lowerCaseFormat = format.name().toLowerCase(ENGLISH);
         Session.SessionBuilder builder = Session.builder(getSession());
         if (format == HiveStorageFormat.ORC || format == HiveStorageFormat.PARQUET) {
             builder.setCatalogSessionProperty(catalog, lowerCaseFormat + "_use_column_names", String.valueOf(formatUseColumnNames));

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/testing/ResourceHudiTablesInitializer.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/testing/ResourceHudiTablesInitializer.java
@@ -39,7 +39,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -51,6 +50,7 @@ import static io.trino.plugin.hive.HiveType.HIVE_DOUBLE;
 import static io.trino.plugin.hive.HiveType.HIVE_INT;
 import static io.trino.plugin.hive.HiveType.HIVE_LONG;
 import static io.trino.plugin.hive.HiveType.HIVE_STRING;
+import static java.util.Locale.ENGLISH;
 import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
 import static org.apache.hudi.common.model.HoodieTableType.MERGE_ON_READ;
 
@@ -189,7 +189,7 @@ public class ResourceHudiTablesInitializer
 
         public String getTableName()
         {
-            return name().toLowerCase(Locale.ROOT);
+            return name().toLowerCase(ENGLISH);
         }
 
         public HoodieTableType getTableType()

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableHandle.java
@@ -26,12 +26,12 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
@@ -263,7 +263,7 @@ public class IcebergTableHandle
 
     public SchemaTableName getSchemaTableNameWithType()
     {
-        return new SchemaTableName(schemaName, tableName + "$" + tableType.name().toLowerCase(Locale.ROOT));
+        return new SchemaTableName(schemaName, tableName + "$" + tableType.name().toLowerCase(ENGLISH));
     }
 
     public IcebergTableHandle withProjectedColumns(Set<IcebergColumnHandle> projectedColumns)

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestDenyOnSchema.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestDenyOnSchema.java
@@ -43,7 +43,7 @@ import static io.trino.common.Randoms.randomUsername;
 import static io.trino.spi.security.PrincipalType.USER;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
-import static java.util.Locale.ROOT;
+import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -116,7 +116,7 @@ public class TestDenyOnSchema
             expectedPrivileges = ImmutableSet.copyOf(Privilege.values());
         }
         else {
-            expectedPrivileges = ImmutableSet.of(Privilege.valueOf(privilege.toUpperCase(ROOT)));
+            expectedPrivileges = ImmutableSet.of(Privilege.valueOf(privilege.toUpperCase(ENGLISH)));
         }
         expectedGrantee = new TrinoPrincipal(USER, username);
 


### PR DESCRIPTION
## Description

I didn't touch `Locale.US` in `PemReader.java` (the class is copied from airlift) and `Locale.CHINESE` in `TestJdbc#shouldSetLocale` (the test purpose is setting the locale)

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
