### PR TITLE
Fix generation of JSON path keyvalue() IDs

### DIFF
--- a/core/trino-main/src/main/java/io/trino/json/PathEvaluationVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/json/PathEvaluationVisitor.java
@@ -825,7 +825,8 @@ class PathEvaluationVisitor
                             ImmutableMap.of(
                                     "name", TextNode.valueOf(field.getKey()),
                                     "value", field.getValue(),
-                                    "id", IntNode.valueOf(objectId++)))));
+                                    "id", IntNode.valueOf(objectId)))));
+            objectId++;
         }
 
         return outputSequence.build();

--- a/core/trino-main/src/test/java/io/trino/json/TestJsonPathEvaluator.java
+++ b/core/trino-main/src/test/java/io/trino/json/TestJsonPathEvaluator.java
@@ -683,6 +683,55 @@ public class TestJsonPathEvaluator
                                 "value", NullNode.instance,
                                 "id", IntNode.valueOf(1)))));
 
+        // nested methods
+        assertThat(pathResult(
+                new ArrayNode(
+                        JsonNodeFactory.instance,
+                        ImmutableList.of(
+                                new ObjectNode(JsonNodeFactory.instance, ImmutableMap.of("key1", TextNode.valueOf("first"), "key2", BooleanNode.TRUE)),
+                                new ObjectNode(JsonNodeFactory.instance, ImmutableMap.of("key3", IntNode.valueOf(42))))),
+                path(true, keyValue(keyValue(wildcardArrayAccessor(contextVariable()))))))
+                .isEqualTo(sequence(
+                        // key1
+                        new ObjectNode(JsonNodeFactory.instance, ImmutableMap.of(
+                                "name", TextNode.valueOf("name"),
+                                "value", TextNode.valueOf("key1"),
+                                "id", IntNode.valueOf(2))),
+                        new ObjectNode(JsonNodeFactory.instance, ImmutableMap.of(
+                                "name", TextNode.valueOf("value"),
+                                "value", TextNode.valueOf("first"),
+                                "id", IntNode.valueOf(2))),
+                        new ObjectNode(JsonNodeFactory.instance, ImmutableMap.of(
+                                "name", TextNode.valueOf("id"),
+                                "value", IntNode.valueOf(0),
+                                "id", IntNode.valueOf(2))),
+                        // key2
+                        new ObjectNode(JsonNodeFactory.instance, ImmutableMap.of(
+                                "name", TextNode.valueOf("name"),
+                                "value", TextNode.valueOf("key2"),
+                                "id", IntNode.valueOf(3))),
+                        new ObjectNode(JsonNodeFactory.instance, ImmutableMap.of(
+                                "name", TextNode.valueOf("value"),
+                                "value", BooleanNode.TRUE,
+                                "id", IntNode.valueOf(3))),
+                        new ObjectNode(JsonNodeFactory.instance, ImmutableMap.of(
+                                "name", TextNode.valueOf("id"),
+                                "value", IntNode.valueOf(0),
+                                "id", IntNode.valueOf(3))),
+                        // key3
+                        new ObjectNode(JsonNodeFactory.instance, ImmutableMap.of(
+                                "name", TextNode.valueOf("name"),
+                                "value", TextNode.valueOf("key3"),
+                                "id", IntNode.valueOf(4))),
+                        new ObjectNode(JsonNodeFactory.instance, ImmutableMap.of(
+                                "name", TextNode.valueOf("value"),
+                                "value", IntNode.valueOf(42),
+                                "id", IntNode.valueOf(4))),
+                        new ObjectNode(JsonNodeFactory.instance, ImmutableMap.of(
+                                "name", TextNode.valueOf("id"),
+                                "value", IntNode.valueOf(1),
+                                "id", IntNode.valueOf(4)))));
+
         // type mismatch
         assertThatThrownBy(() -> evaluate(
                 IntNode.valueOf(-5),


### PR DESCRIPTION
## Description

Previously, separate IDs were generated for each member.

Note that the tests pass without this fix due to an AssertJ bug that seems to cause the assertion comparisons not to work. This is fixed by upgrading AssertJ in #16420.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix generation of IDs for `keyvalue()` methods in [JSON path](json-path-language).
  Previously, separate IDs were generated for each member. ({issue}`16482`)
```
