### PR TITLE
Don't enforce top-level repo name in BaseCostBasedPlanTest

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/sql/planner/BaseCostBasedPlanTest.java
+++ b/testing/trino-tests/src/test/java/io/trino/sql/planner/BaseCostBasedPlanTest.java
@@ -221,15 +221,14 @@ public abstract class BaseCostBasedPlanTest
     {
         Path workingDir = Paths.get(System.getProperty("user.dir"));
         verify(isDirectory(workingDir), "Working directory is not a directory");
-        String topDirectoryName = workingDir.getFileName().toString();
-        switch (topDirectoryName) {
-            case "trino-tests":
-                return workingDir;
-            case "trino":
-                return workingDir.resolve("testing/trino-tests");
-            default:
-                throw new IllegalStateException("This class must be executed from trino-tests or Trino source directory");
+        if (isDirectory(workingDir.resolve(".git"))) {
+            // Top-level of the repo
+            return workingDir.resolve("testing/trino-tests");
         }
+        if (workingDir.getFileName().toString().equals("trino-tests")) {
+            return workingDir;
+        }
+        throw new IllegalStateException("This class must be executed from trino-tests or Trino source directory");
     }
 
     private class JoinOrderPrinter


### PR DESCRIPTION
Engineers will typically check out the repo into a local folder named the same way: `trino`. This, however, doesn't work when an engineer needs to do a second checkout, or wants to make a backup of the repo for whatever purposes. The build and tests should not assume any particular name of the folder the repo is checked out into.
