### PR TITLE
Improve error message for catalog errors when listing metadata

### DIFF
--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -89,6 +89,7 @@ import io.trino.spi.metrics.Metrics;
 import io.trino.spi.procedure.Procedure;
 import io.trino.spi.ptf.ConnectorTableFunction;
 import io.trino.spi.ptf.ConnectorTableFunctionHandle;
+import io.trino.spi.security.GrantInfo;
 import io.trino.spi.security.Privilege;
 import io.trino.spi.security.RoleGrant;
 import io.trino.spi.security.TrinoPrincipal;
@@ -152,6 +153,7 @@ public class MockConnector
     private final BiFunction<ConnectorSession, SchemaTableName, Optional<ConnectorTableLayout>> getInsertLayout;
     private final BiFunction<ConnectorSession, ConnectorTableMetadata, Optional<ConnectorTableLayout>> getNewTableLayout;
     private final BiFunction<ConnectorSession, ConnectorTableHandle, ConnectorTableProperties> getTableProperties;
+    private final BiFunction<ConnectorSession, SchemaTablePrefix, List<GrantInfo>> listTablePrivileges;
     private final Supplier<Iterable<EventListener>> eventListeners;
     private final MockConnectorFactory.ListRoleGrants roleGrants;
     private final Optional<ConnectorNodePartitioningProvider> partitioningProvider;
@@ -196,6 +198,7 @@ public class MockConnector
             BiFunction<ConnectorSession, SchemaTableName, Optional<ConnectorTableLayout>> getInsertLayout,
             BiFunction<ConnectorSession, ConnectorTableMetadata, Optional<ConnectorTableLayout>> getNewTableLayout,
             BiFunction<ConnectorSession, ConnectorTableHandle, ConnectorTableProperties> getTableProperties,
+            BiFunction<ConnectorSession, SchemaTablePrefix, List<GrantInfo>> listTablePrivileges,
             Supplier<Iterable<EventListener>> eventListeners,
             ListRoleGrants roleGrants,
             Optional<ConnectorNodePartitioningProvider> partitioningProvider,
@@ -238,6 +241,7 @@ public class MockConnector
         this.getInsertLayout = requireNonNull(getInsertLayout, "getInsertLayout is null");
         this.getNewTableLayout = requireNonNull(getNewTableLayout, "getNewTableLayout is null");
         this.getTableProperties = requireNonNull(getTableProperties, "getTableProperties is null");
+        this.listTablePrivileges = requireNonNull(listTablePrivileges, "listTablePrivileges is null");
         this.eventListeners = requireNonNull(eventListeners, "eventListeners is null");
         this.roleGrants = requireNonNull(roleGrants, "roleGrants is null");
         this.partitioningProvider = requireNonNull(partitioningProvider, "partitioningProvider is null");
@@ -785,6 +789,12 @@ public class MockConnector
         public Set<String> listEnabledRoles(ConnectorSession session)
         {
             return listRoles(session);
+        }
+
+        @Override
+        public List<GrantInfo> listTablePrivileges(ConnectorSession session, SchemaTablePrefix prefix)
+        {
+            return listTablePrivileges.apply(session, prefix);
         }
 
         @Override

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseCaseInsensitiveMappingTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseCaseInsensitiveMappingTest.java
@@ -145,7 +145,7 @@ public abstract class BaseCaseInsensitiveMappingTest
                         AutoCloseable ignore4 = withSchema("some_schema");
                         AutoCloseable ignore5 = withTable("some_schema", "some_table", "(c int)")) {
                     assertThat(computeActual("SHOW SCHEMAS").getOnlyColumn().filter("casesensitivename"::equals)).hasSize(1); // TODO change io.trino.plugin.jdbc.JdbcClient.getSchemaNames to return a List
-                    assertQueryFails("SHOW TABLES FROM casesensitivename", "Failed to find remote schema name: Ambiguous name: casesensitivename");
+                    assertQueryFails("SHOW TABLES FROM casesensitivename", "Error listing tables for catalog \\w+: Failed to find remote schema name: Ambiguous name: casesensitivename");
                     assertQueryFails("SELECT * FROM casesensitivename.some_table_name", "Failed to find remote schema name: Ambiguous name: casesensitivename");
                     assertQuery("SHOW TABLES FROM some_schema", "VALUES 'some_table'");
                     assertQueryReturnsEmptyResult("SELECT * FROM some_schema.some_table");

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
@@ -919,7 +919,7 @@ public class TestCassandraConnectorTest
         // There is no way to figure out what the exactly keyspace we want to retrieve tables from
         assertQueryFailsEventually(
                 "SHOW TABLES FROM cassandra.keyspace_3",
-                "More than one keyspace has been found for the case insensitive schema name: keyspace_3 -> \\(KeYsPaCe_3, kEySpAcE_3\\)",
+                "Error listing tables for catalog cassandra: More than one keyspace has been found for the case insensitive schema name: keyspace_3 -> \\(KeYsPaCe_3, kEySpAcE_3\\)",
                 new Duration(1, MINUTES));
 
         session.execute("DROP KEYSPACE \"KeYsPaCe_3\"");

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/BasePinotIntegrationConnectorSmokeTest.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/BasePinotIntegrationConnectorSmokeTest.java
@@ -1229,7 +1229,7 @@ public abstract class BasePinotIntegrationConnectorSmokeTest
         assertQueryFails("SELECT * FROM " + DUPLICATE_TABLE_MIXED_CASE, "Ambiguous table names: (" + DUPLICATE_TABLE_LOWERCASE + ", " + DUPLICATE_TABLE_MIXED_CASE + "|" + DUPLICATE_TABLE_MIXED_CASE + ", " + DUPLICATE_TABLE_LOWERCASE + ")");
         assertQueryFails("SELECT * FROM \"SELECT * FROM " + DUPLICATE_TABLE_LOWERCASE + "\"", "Ambiguous table names: (" + DUPLICATE_TABLE_LOWERCASE + ", " + DUPLICATE_TABLE_MIXED_CASE + "|" + DUPLICATE_TABLE_MIXED_CASE + ", " + DUPLICATE_TABLE_LOWERCASE + ")");
         assertQueryFails("SELECT * FROM \"SELECT * FROM " + DUPLICATE_TABLE_MIXED_CASE + "\"", "Ambiguous table names: (" + DUPLICATE_TABLE_LOWERCASE + ", " + DUPLICATE_TABLE_MIXED_CASE + "|" + DUPLICATE_TABLE_MIXED_CASE + ", " + DUPLICATE_TABLE_LOWERCASE + ")");
-        assertQueryFails("SELECT * FROM information_schema.columns", "Ambiguous table names: (" + DUPLICATE_TABLE_LOWERCASE + ", " + DUPLICATE_TABLE_MIXED_CASE + "|" + DUPLICATE_TABLE_MIXED_CASE + ", " + DUPLICATE_TABLE_LOWERCASE + ")");
+        assertQueryFails("SELECT * FROM information_schema.columns", "Error listing table columns for catalog pinot: Ambiguous table names: (" + DUPLICATE_TABLE_LOWERCASE + ", " + DUPLICATE_TABLE_MIXED_CASE + "|" + DUPLICATE_TABLE_MIXED_CASE + ", " + DUPLICATE_TABLE_LOWERCASE + ")");
     }
 
     @Test

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestInformationSchemaConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestInformationSchemaConnector.java
@@ -13,15 +13,21 @@
  */
 package io.trino.tests;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
+import io.trino.connector.MockConnectorFactory;
 import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.spi.Plugin;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorFactory;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.CountingMockConnector;
 import io.trino.testing.CountingMockConnector.MetadataCallsCount;
 import io.trino.testing.DistributedQueryRunner;
 import org.testng.annotations.Test;
 
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static org.testng.Assert.assertEquals;
 
@@ -218,6 +224,30 @@ public class TestInformationSchemaConnector
                         .withListSchemasCount(1));
     }
 
+    @Test
+    public void testMetadataListingExceptionHandling()
+    {
+        assertQueryFails(
+                "SELECT * FROM broken_catalog.information_schema.schemata",
+                "Error listing schemas for catalog broken_catalog: Catalog is broken");
+
+        assertQueryFails(
+                "SELECT * FROM broken_catalog.information_schema.tables",
+                "Error listing tables for catalog broken_catalog: Catalog is broken");
+
+        assertQueryFails(
+                "SELECT * FROM broken_catalog.information_schema.views",
+                "Error listing views for catalog broken_catalog: Catalog is broken");
+
+        assertQueryFails(
+                "SELECT * FROM broken_catalog.information_schema.table_privileges",
+                "Error listing table privileges for catalog broken_catalog: Catalog is broken");
+
+        assertQueryFails(
+                "SELECT * FROM broken_catalog.information_schema.columns",
+                "Error listing table columns for catalog broken_catalog: Catalog is broken");
+    }
+
     @Override
     protected DistributedQueryRunner createQueryRunner()
             throws Exception
@@ -232,6 +262,9 @@ public class TestInformationSchemaConnector
 
             queryRunner.installPlugin(countingMockConnector.getPlugin());
             queryRunner.createCatalog("test_catalog", "mock", ImmutableMap.of());
+
+            queryRunner.installPlugin(new FailingMockConnectorPlugin());
+            queryRunner.createCatalog("broken_catalog", "failing_mock", ImmutableMap.of());
             return queryRunner;
         }
         catch (Exception e) {
@@ -248,5 +281,36 @@ public class TestInformationSchemaConnector
         });
 
         assertEquals(actualMetadataCallsCount, expectedMetadataCallsCount);
+    }
+
+    private static final class FailingMockConnectorPlugin
+            implements Plugin
+    {
+        @Override
+        public Iterable<ConnectorFactory> getConnectorFactories()
+        {
+            return ImmutableList.of(
+                    MockConnectorFactory.builder()
+                            .withName("failing_mock")
+                            .withListSchemaNames(session -> {
+                                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Catalog is broken");
+                            })
+                            .withListTables((session, schema) -> {
+                                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Catalog is broken");
+                            })
+                            .withGetViews((session, prefix) -> {
+                                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Catalog is broken");
+                            })
+                            .withGetMaterializedViews((session, prefix) -> {
+                                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Catalog is broken");
+                            })
+                            .withListTablePrivileges((session, prefix) -> {
+                                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Catalog is broken");
+                            })
+                            .withStreamTableColumns((session, prefix) -> {
+                                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Catalog is broken");
+                            })
+                            .build());
+        }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Depending on the client that initiated a metadata query, error messages returned from `ConnectorMetadata` can be confusing for users. For example, a query to `system.jdbc` tables with no catalog predicate, on exceptions in the catalog, will propagate those exceptions, with no way for the user to know which catalog has thrown that exception.

When there are a lot of catalogs, this makes investigating the issue very hard for Trino admins. We can make it easier by always including the problematic catalog's name in the error message.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Improve error message on exceptions thrown by connector while querying metadata. ({issue}`issuenumber`)
```
