### PR TITLE
Fix BaseFailureRecoveryTest temp table checking flakiness #16277

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
@@ -13,6 +13,7 @@
  */
 package io.trino.testing;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.graph.Traverser;
@@ -30,10 +31,13 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadLocalRandom;
@@ -346,7 +350,8 @@ public abstract class BaseFailureRecoveryTest
                     .withSession(session)
                     .withSetupQuery(setupQuery)
                     .withCleanupQuery(cleanupQuery)
-                    .failsDespiteRetries(failure -> failure.hasMessageMatching("This connector does not support query retries"));
+                    .failsDespiteRetries(failure -> failure.hasMessageMatching("This connector does not support query retries"))
+                    .cleansUpTemporaryTables();
             return;
         }
 
@@ -356,7 +361,8 @@ public abstract class BaseFailureRecoveryTest
                 .withCleanupQuery(cleanupQuery)
                 .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
                 .at(boundaryCoordinatorStage())
-                .failsAlways(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE));
+                .failsAlways(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE))
+                .cleansUpTemporaryTables();
 
         assertThatQuery(query)
                 .withSession(session)
@@ -364,7 +370,8 @@ public abstract class BaseFailureRecoveryTest
                 .withCleanupQuery(cleanupQuery)
                 .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
                 .at(rootStage())
-                .failsAlways(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE));
+                .failsAlways(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE))
+                .cleansUpTemporaryTables();
 
         assertThatQuery(query)
                 .withSession(session)
@@ -373,7 +380,8 @@ public abstract class BaseFailureRecoveryTest
                 .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
                 .at(boundaryDistributedStage())
                 .failsWithoutRetries(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE))
-                .finishesSuccessfully();
+                .finishesSuccessfully()
+                .cleansUpTemporaryTables();
 
         assertThatQuery(query)
                 .withSetupQuery(setupQuery)
@@ -381,7 +389,8 @@ public abstract class BaseFailureRecoveryTest
                 .experiencing(TASK_MANAGEMENT_REQUEST_TIMEOUT)
                 .at(boundaryDistributedStage())
                 .failsWithoutRetries(failure -> failure.hasMessageContaining("Encountered too many errors talking to a worker node"))
-                .finishesSuccessfully();
+                .finishesSuccessfully()
+                .cleansUpTemporaryTables();
 
         if (getRetryPolicy() == RetryPolicy.QUERY) {
             assertThatQuery(query)
@@ -391,7 +400,8 @@ public abstract class BaseFailureRecoveryTest
                     .experiencing(TASK_GET_RESULTS_REQUEST_FAILURE)
                     .at(boundaryDistributedStage())
                     .failsWithoutRetries(failure -> failure.hasMessageFindingMatch("Error 500 Internal Server Error|Error closing remote buffer, expected 204 got 500"))
-                    .finishesSuccessfully();
+                    .finishesSuccessfully()
+                    .cleansUpTemporaryTables();
 
             assertThatQuery(query)
                     .withSetupQuery(setupQuery)
@@ -399,13 +409,53 @@ public abstract class BaseFailureRecoveryTest
                     .experiencing(TASK_GET_RESULTS_REQUEST_TIMEOUT)
                     .at(boundaryDistributedStage())
                     .failsWithoutRetries(failure -> failure.hasMessageFindingMatch("Encountered too many errors talking to a worker node|Error closing remote buffer"))
-                    .finishesSuccessfully();
+                    .finishesSuccessfully()
+                    .cleansUpTemporaryTables();
         }
     }
 
     protected FailureRecoveryAssert assertThatQuery(String query)
     {
         return new FailureRecoveryAssert(query);
+    }
+
+    // Provided as a protected method here in case this is not a one-sized-fits-all solution
+    protected void checkTemporaryTables(Set<String> queryIds)
+    {
+        // queryId -> temporary table names
+        Map<String, Set<String>> remainingTemporaryTables = new HashMap<>();
+        // queryId -> assertion messages
+        Map<String, Set<String>> assertionErrorMessages = new HashMap<>();
+        for (String queryId : queryIds) {
+            String temporaryTablePrefix = temporaryTableNamePrefix(queryId);
+            MaterializedResult temporaryTablesResult = getQueryRunner()
+                    .execute("SHOW TABLES LIKE '%s%%' ESCAPE '\\'".formatted(temporaryTablePrefix.replace("_", "\\_")));
+            // Unfortunately, information_schema is not strictly consistent with recently dropped tables,
+            // and for some connectors, it can return tables that have been recently dropped. Therefore,
+            // we can't rely simply on SHOW TABLES LIKE returning no results - we have to try to query the table
+            for (MaterializedRow temporaryTableRow : temporaryTablesResult.getMaterializedRows()) {
+                String temporaryTableName = (String) temporaryTableRow.getField(0);
+                try {
+                    assertThatThrownBy(() -> getQueryRunner().execute("SELECT 1 FROM %s WHERE 1 = 0".formatted(temporaryTableName)))
+                            .hasMessageContaining("%s does not exist", temporaryTableName);
+                }
+                catch (AssertionError e) {
+                    remainingTemporaryTables.computeIfAbsent(queryId, ignored -> new HashSet<>()).add(temporaryTableName);
+                    assertionErrorMessages.computeIfAbsent(queryId, ignored -> new HashSet<>()).add(e.getMessage());
+                }
+            }
+        }
+
+        assertThat(remainingTemporaryTables.isEmpty())
+                .as("There should be no remaining tmp_trino tables that are queryable. They are:\n%s",
+                        remainingTemporaryTables.entrySet().stream()
+                                .map(entry -> "\tFor queryId [%s] (prefix [%s]) remaining tables: [%s]\n\t\tWith errors: [%s]".formatted(
+                                        entry.getKey(),
+                                        temporaryTableNamePrefix(entry.getKey()),
+                                        Joiner.on(",").join(entry.getValue()),
+                                        Joiner.on("],\n[").join(assertionErrorMessages.get(entry.getKey())).replace("\n", "\n\t\t\t")))
+                                .collect(joining("\n")))
+                .isTrue();
     }
 
     protected class FailureRecoveryAssert
@@ -417,6 +467,7 @@ public abstract class BaseFailureRecoveryTest
         private Optional<ErrorType> errorType = Optional.empty();
         private Optional<String> setup = Optional.empty();
         private Optional<String> cleanup = Optional.empty();
+        private Set<String> queryIds = new HashSet<>();
 
         public FailureRecoveryAssert(String query)
         {
@@ -519,16 +570,7 @@ public abstract class BaseFailureRecoveryTest
             }
 
             if (queryId != null) {
-                String temporaryTablePrefix = temporaryTableNamePrefix(queryId);
-                MaterializedResult temporaryTablesResult = getQueryRunner()
-                        .execute("SHOW TABLES LIKE '%s%%' ESCAPE '\\'".formatted(temporaryTablePrefix.replace("_", "\\_")));
-                assertThat(temporaryTablesResult.getRowCount())
-                        .as("There should be no remaining %s* tables. They are: [%s]",
-                                temporaryTablePrefix,
-                                temporaryTablesResult.getMaterializedRows().stream()
-                                        .map(row -> row.getField(0).toString())
-                                        .collect(joining(",")))
-                        .isEqualTo(0);
+                queryIds.add(queryId);
             }
 
             MaterializedResult result = resultWithQueryId == null ? null : resultWithQueryId.getResult();
@@ -572,22 +614,28 @@ public abstract class BaseFailureRecoveryTest
             assertThat(subStages).isEmpty();
         }
 
-        public void finishesSuccessfully()
+        public FailureRecoveryAssert cleansUpTemporaryTables()
         {
-            finishesSuccessfully(queryId -> {});
+            checkTemporaryTables(queryIds);
+            return this;
         }
 
-        public void finishesSuccessfullyWithoutTaskFailures()
+        public FailureRecoveryAssert finishesSuccessfully()
         {
-            finishesSuccessfully(queryId -> {}, false);
+            return finishesSuccessfully(queryId -> {});
         }
 
-        private void finishesSuccessfully(Consumer<QueryId> queryAssertion)
+        public FailureRecoveryAssert finishesSuccessfullyWithoutTaskFailures()
         {
-            finishesSuccessfully(queryAssertion, true);
+            return finishesSuccessfully(queryId -> {}, false);
         }
 
-        public void finishesSuccessfully(Consumer<QueryId> queryAssertion, boolean expectTaskFailures)
+        private FailureRecoveryAssert finishesSuccessfully(Consumer<QueryId> queryAssertion)
+        {
+            return finishesSuccessfully(queryAssertion, true);
+        }
+
+        public FailureRecoveryAssert finishesSuccessfully(Consumer<QueryId> queryAssertion, boolean expectTaskFailures)
         {
             verifyFailureTypeAndStageSelector();
             ExecutionResult expected = executeExpected();
@@ -657,6 +705,7 @@ public abstract class BaseFailureRecoveryTest
             }
 
             queryAssertion.accept(actual.getQueryId());
+            return this;
         }
 
         public FailureRecoveryAssert failsAlways(Consumer<AbstractThrowableAssert<?, ? extends Throwable>> failureAssertion)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This fixes the issue described in https://github.com/trinodb/trino/issues/16277

Because `information_schema` is not strictly consistent with recently dropped tables among all connectors, but _querying_ recently dropped tables _is_ consistent, this no longer relies on `SHOW TABLES LIKE` returning no results, but instead, actually attempts to query the recently dropped temporary table, and expects there to be a "does not exist" exception.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
