### PR TITLE
Disable file system caching when size is set to zero

### DIFF
--- a/lib/trino-hdfs/src/main/java/io/trino/hdfs/HdfsConfig.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/hdfs/HdfsConfig.java
@@ -231,6 +231,7 @@ public class HdfsConfig
         return this;
     }
 
+    @Min(0)
     public int getFileSystemMaxCacheSize()
     {
         return fileSystemMaxCacheSize;

--- a/lib/trino-hdfs/src/main/java/io/trino/hdfs/HdfsFileSystemCacheConfigurationProvider.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/hdfs/HdfsFileSystemCacheConfigurationProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hdfs;
+
+import org.apache.hadoop.conf.Configuration;
+
+import javax.inject.Inject;
+
+import java.net.URI;
+
+public class HdfsFileSystemCacheConfigurationProvider
+        implements DynamicConfigurationProvider
+{
+    private final boolean cachingDisabled;
+
+    @Inject
+    public HdfsFileSystemCacheConfigurationProvider(HdfsConfig hdfsConfig)
+    {
+        this.cachingDisabled = hdfsConfig.getFileSystemMaxCacheSize() == 0;
+    }
+
+    @Override
+    public void updateConfiguration(Configuration configuration, HdfsContext context, URI uri)
+    {
+        if (cachingDisabled) {
+            configuration.setBoolean("fs." + uri.getScheme() + ".impl.disable.cache", true);
+        }
+    }
+}

--- a/lib/trino-hdfs/src/main/java/io/trino/hdfs/HdfsModule.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/hdfs/HdfsModule.java
@@ -33,6 +33,7 @@ public class HdfsModule
 
         binder.bind(HdfsConfigurationInitializer.class).in(Scopes.SINGLETON);
         newSetBinder(binder, ConfigurationInitializer.class);
-        newSetBinder(binder, DynamicConfigurationProvider.class);
+        newSetBinder(binder, DynamicConfigurationProvider.class)
+                .addBinding().to(HdfsFileSystemCacheConfigurationProvider.class).in(Scopes.SINGLETON);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -28,6 +28,7 @@ import io.trino.hdfs.DynamicHdfsConfiguration;
 import io.trino.hdfs.HdfsConfig;
 import io.trino.hdfs.HdfsConfiguration;
 import io.trino.hdfs.HdfsConfigurationInitializer;
+import io.trino.hdfs.HdfsFileSystemCacheConfigurationProvider;
 import io.trino.hdfs.HdfsContext;
 import io.trino.hdfs.HdfsEnvironment;
 import io.trino.hdfs.authentication.NoHdfsAuthentication;
@@ -172,7 +173,7 @@ public class FileHiveMetastore
     public static FileHiveMetastore createTestingFileHiveMetastore(File catalogDirectory)
     {
         HdfsConfig hdfsConfig = new HdfsConfig();
-        HdfsConfiguration hdfsConfiguration = new DynamicHdfsConfiguration(new HdfsConfigurationInitializer(hdfsConfig), ImmutableSet.of());
+        HdfsConfiguration hdfsConfiguration = new DynamicHdfsConfiguration(new HdfsConfigurationInitializer(hdfsConfig), ImmutableSet.of(new HdfsFileSystemCacheConfigurationProvider(hdfsConfig)));
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hdfsConfig, new NoHdfsAuthentication());
         return new FileHiveMetastore(
                 new NodeVersion("testversion"),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -72,6 +72,7 @@ import io.trino.hdfs.DynamicHdfsConfiguration;
 import io.trino.hdfs.HdfsConfig;
 import io.trino.hdfs.HdfsConfiguration;
 import io.trino.hdfs.HdfsConfigurationInitializer;
+import io.trino.hdfs.HdfsFileSystemCacheConfigurationProvider;
 import io.trino.hdfs.HdfsContext;
 import io.trino.hdfs.HdfsEnvironment;
 import io.trino.hdfs.authentication.NoHdfsAuthentication;
@@ -220,7 +221,7 @@ public class GlueHiveMetastore
     public static GlueHiveMetastore createTestingGlueHiveMetastore(String defaultWarehouseDir)
     {
         HdfsConfig hdfsConfig = new HdfsConfig();
-        HdfsConfiguration hdfsConfiguration = new DynamicHdfsConfiguration(new HdfsConfigurationInitializer(hdfsConfig), ImmutableSet.of());
+        HdfsConfiguration hdfsConfiguration = new DynamicHdfsConfiguration(new HdfsConfigurationInitializer(hdfsConfig), ImmutableSet.of(new HdfsFileSystemCacheConfigurationProvider(hdfsConfig)));
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hdfsConfig, new NoHdfsAuthentication());
         GlueMetastoreStats stats = new GlueMetastoreStats();
         GlueHiveMetastoreConfig glueConfig = new GlueHiveMetastoreConfig()


### PR DESCRIPTION
## Description

If the `hive.fs.cache.max-size` property is set to zero the first time a FileSystem is loaded an exception is thrown
"FileSystem max cache size has been reached"

Extracted from: https://github.com/trinodb/trino/pull/16455

I don't expect this to be useful for production but I found it useful for testing the fix in the PR above. The FileSystem cache prevented the tests from hitting the improperly configured FileSystem consistently.

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: