### PR TITLE
Avoid CI log spam when downloading dependencies

### DIFF
--- a/.github/bin/download-maven-dependencies.sh
+++ b/.github/bin/download-maven-dependencies.sh
@@ -6,7 +6,7 @@ RETRY=".github/bin/retry"
 MAVEN_ONLINE="${MAVEN//--offline/}"
 
 # Run download tools without any profiles to use active-by-default profiles
-$RETRY $MAVEN_ONLINE -B dependency:go-offline
+$RETRY $MAVEN_ONLINE -B dependency:go-offline -Dsilent
 $RETRY $MAVEN_ONLINE -B de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
 
 # Downloading dependencies is used to populate the maven cache shared between PRs, so PR-specific GIB state needs to be ignored


### PR DESCRIPTION
## Description

Avoid printing ~130k lines like

```
2023-03-10T03:46:16.0638139Z [INFO] Resolved plugin: maven-compiler-plugin-3.11.0.jar
```

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
