### PR TITLE
Correct misuse of Description annotation in Config

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/CompilerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/CompilerConfig.java
@@ -14,8 +14,8 @@
 package io.trino.sql.planner;
 
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
-import io.trino.spi.function.Description;
 
 import javax.validation.constraints.Min;
 
@@ -31,7 +31,7 @@ public class CompilerConfig
     }
 
     @Config("compiler.expression-cache-size")
-    @Description("Reuse compiled expressions across multiple queries")
+    @ConfigDescription("Reuse compiled expressions across multiple queries")
     public CompilerConfig setExpressionCacheSize(int expressionCacheSize)
     {
         this.expressionCacheSize = expressionCacheSize;


### PR DESCRIPTION
## Description

- Within Config class, `@ConfigDescription` should be used, not `@Description`

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
