### PR TITLE
Do not inline non-deterministic expressions as projection

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -546,7 +546,7 @@ public class PlanOptimizers
                                 new TransformCorrelatedSingleRowSubqueryToProject(),
                                 new RemoveAggregationInSemiJoin(),
                                 new MergeProjectWithValues(metadata),
-                                new ReplaceJoinOverConstantWithProject())),
+                                new ReplaceJoinOverConstantWithProject(metadata))),
                 new CheckSubqueryNodesAreRewritten(),
                 simplifyOptimizer, // Should run after MergeProjectWithValues
                 new StatsRecordingPlanOptimizer(

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReplaceJoinOverConstantWithProject.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReplaceJoinOverConstantWithProject.java
@@ -15,6 +15,7 @@ package io.trino.sql.planner.iterative.rule;
 
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.metadata.Metadata;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.Rule;
@@ -32,9 +33,11 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
 import static io.trino.sql.planner.optimizations.QueryCardinalityUtil.extractCardinality;
 import static io.trino.sql.planner.plan.Patterns.join;
 import static io.trino.sql.tree.BooleanLiteral.TRUE_LITERAL;
+import static java.util.Objects.requireNonNull;
 
 /**
  * This rule transforms plans with join where one of the sources is
@@ -49,11 +52,12 @@ import static io.trino.sql.tree.BooleanLiteral.TRUE_LITERAL;
  * be done, because the result of the transformation would be possibly
  * empty, while the single constant row should be preserved on output.
  * <p>
- * Note 2: The transformation is valid when the ValuesNode contains
- * non-deterministic expressions. This is because any expression from
- * the ValuesNode can only be used once. Assignments.Builder deduplicates
- * them in case when the JoinNode produces any of the input symbols
- * more than once.
+ * Note 2: The transformation is not valid when the ValuesNode contains
+ * a non-deterministic expression. According to the semantics of the
+ * original plan, such expression should be evaluated once, and the value
+ * should be appended to each row of the other join source. Inlining the
+ * expression would result in evaluating it for each row to a potentially
+ * different value.
  * <p>
  * Note 3: The transformation is valid when the ValuesNode contains
  * expressions using correlation symbols. They are constant from the
@@ -78,6 +82,13 @@ public class ReplaceJoinOverConstantWithProject
 {
     private static final Pattern<JoinNode> PATTERN = join()
             .matching(ReplaceJoinOverConstantWithProject::isUnconditional);
+
+    private final Metadata metadata;
+
+    public ReplaceJoinOverConstantWithProject(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
 
     @Override
     public Pattern<JoinNode> getPattern()
@@ -169,6 +180,10 @@ public class ReplaceJoinOverConstantWithProject
         }
 
         Expression row = getOnlyElement(values.getRows().get());
+
+        if (!isDeterministic(row, metadata)) {
+            return false;
+        }
 
         return row instanceof Row;
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestReplaceJoinOverConstantWithProject.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestReplaceJoinOverConstantWithProject.java
@@ -18,6 +18,9 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.plan.JoinNode.EquiJoinClause;
+import io.trino.sql.tree.FunctionCall;
+import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.Row;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
@@ -37,7 +40,7 @@ public class TestReplaceJoinOverConstantWithProject
     @Test
     public void testDoesNotFireOnJoinWithEmptySource()
     {
-        tester().assertThat(new ReplaceJoinOverConstantWithProject())
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
                 .on(p ->
                         p.join(
                                 INNER,
@@ -45,7 +48,7 @@ public class TestReplaceJoinOverConstantWithProject
                                 p.values(0, p.symbol("b"))))
                 .doesNotFire();
 
-        tester().assertThat(new ReplaceJoinOverConstantWithProject())
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
                 .on(p ->
                         p.join(
                                 INNER,
@@ -57,7 +60,7 @@ public class TestReplaceJoinOverConstantWithProject
     @Test
     public void testDoesNotFireOnJoinWithCondition()
     {
-        tester().assertThat(new ReplaceJoinOverConstantWithProject())
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
                 .on(p ->
                         p.join(
                                 INNER,
@@ -66,7 +69,7 @@ public class TestReplaceJoinOverConstantWithProject
                                 new EquiJoinClause(p.symbol("a"), p.symbol("b"))))
                 .doesNotFire();
 
-        tester().assertThat(new ReplaceJoinOverConstantWithProject())
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
                 .on(p ->
                         p.join(
                                 INNER,
@@ -79,7 +82,7 @@ public class TestReplaceJoinOverConstantWithProject
     @Test
     public void testDoesNotFireOnValuesWithMultipleRows()
     {
-        tester().assertThat(new ReplaceJoinOverConstantWithProject())
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
                 .on(p ->
                         p.join(
                                 INNER,
@@ -91,7 +94,7 @@ public class TestReplaceJoinOverConstantWithProject
     @Test
     public void testDoesNotFireOnValuesWithNoOutputs()
     {
-        tester().assertThat(new ReplaceJoinOverConstantWithProject())
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
                 .on(p ->
                         p.join(
                                 INNER,
@@ -103,7 +106,7 @@ public class TestReplaceJoinOverConstantWithProject
     @Test
     public void testDoesNotFireOnValuesWithNonRowExpression()
     {
-        tester().assertThat(new ReplaceJoinOverConstantWithProject())
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
                 .on(p ->
                         p.join(
                                 INNER,
@@ -115,7 +118,7 @@ public class TestReplaceJoinOverConstantWithProject
     @Test
     public void testDoesNotFireOnOuterJoinWhenSourcePossiblyEmpty()
     {
-        tester().assertThat(new ReplaceJoinOverConstantWithProject())
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
                 .on(p ->
                         p.join(
                                 LEFT,
@@ -125,7 +128,7 @@ public class TestReplaceJoinOverConstantWithProject
                                         p.values(10, p.symbol("b")))))
                 .doesNotFire();
 
-        tester().assertThat(new ReplaceJoinOverConstantWithProject())
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
                 .on(p ->
                         p.join(
                                 RIGHT,
@@ -135,7 +138,7 @@ public class TestReplaceJoinOverConstantWithProject
                                 p.values(1, p.symbol("b"))))
                 .doesNotFire();
 
-        tester().assertThat(new ReplaceJoinOverConstantWithProject())
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
                 .on(p ->
                         p.join(
                                 FULL,
@@ -145,7 +148,7 @@ public class TestReplaceJoinOverConstantWithProject
                                         p.values(10, p.symbol("b")))))
                 .doesNotFire();
 
-        tester().assertThat(new ReplaceJoinOverConstantWithProject())
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
                 .on(p ->
                         p.join(
                                 FULL,
@@ -159,7 +162,7 @@ public class TestReplaceJoinOverConstantWithProject
     @Test
     public void testReplaceInnerJoinWithProject()
     {
-        tester().assertThat(new ReplaceJoinOverConstantWithProject())
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
                 .on(p ->
                         p.join(
                                 INNER,
@@ -173,7 +176,7 @@ public class TestReplaceJoinOverConstantWithProject
                                         "c", PlanMatchPattern.expression("c")),
                                 values("c")));
 
-        tester().assertThat(new ReplaceJoinOverConstantWithProject())
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
                 .on(p ->
                         p.join(
                                 INNER,
@@ -191,7 +194,7 @@ public class TestReplaceJoinOverConstantWithProject
     @Test
     public void testReplaceLeftJoinWithProject()
     {
-        tester().assertThat(new ReplaceJoinOverConstantWithProject())
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
                 .on(p ->
                         p.join(
                                 LEFT,
@@ -205,7 +208,7 @@ public class TestReplaceJoinOverConstantWithProject
                                         "c", PlanMatchPattern.expression("c")),
                                 values("c")));
 
-        tester().assertThat(new ReplaceJoinOverConstantWithProject())
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
                 .on(p ->
                         p.join(
                                 LEFT,
@@ -223,7 +226,7 @@ public class TestReplaceJoinOverConstantWithProject
     @Test
     public void testReplaceRightJoinWithProject()
     {
-        tester().assertThat(new ReplaceJoinOverConstantWithProject())
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
                 .on(p ->
                         p.join(
                                 RIGHT,
@@ -237,7 +240,7 @@ public class TestReplaceJoinOverConstantWithProject
                                         "c", PlanMatchPattern.expression("c")),
                                 values("c")));
 
-        tester().assertThat(new ReplaceJoinOverConstantWithProject())
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
                 .on(p ->
                         p.join(
                                 RIGHT,
@@ -255,7 +258,7 @@ public class TestReplaceJoinOverConstantWithProject
     @Test
     public void testReplaceFullJoinWithProject()
     {
-        tester().assertThat(new ReplaceJoinOverConstantWithProject())
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
                 .on(p ->
                         p.join(
                                 FULL,
@@ -269,7 +272,7 @@ public class TestReplaceJoinOverConstantWithProject
                                         "c", PlanMatchPattern.expression("c")),
                                 values("c")));
 
-        tester().assertThat(new ReplaceJoinOverConstantWithProject())
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
                 .on(p ->
                         p.join(
                                 FULL,
@@ -287,7 +290,7 @@ public class TestReplaceJoinOverConstantWithProject
     @Test
     public void testRemoveOutputDuplicates()
     {
-        tester().assertThat(new ReplaceJoinOverConstantWithProject())
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
                 .on(p ->
                         p.join(
                                 INNER,
@@ -309,17 +312,28 @@ public class TestReplaceJoinOverConstantWithProject
     @Test
     public void testNonDeterministicValues()
     {
-        tester().assertThat(new ReplaceJoinOverConstantWithProject())
+        FunctionCall randomFunction = new FunctionCall(
+                tester().getMetadata().resolveFunction(tester().getSession(), QualifiedName.of("random"), ImmutableList.of()).toQualifiedName(),
+                ImmutableList.of());
+
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
                 .on(p ->
                         p.join(
                                 INNER,
-                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a")), ImmutableList.of(expression("ROW(rand())"))),
+                                p.valuesOfExpressions(ImmutableList.of(p.symbol("rand")), ImmutableList.of(new Row(ImmutableList.of(randomFunction)))),
                                 p.values(5, p.symbol("b"))))
-                .matches(
-                        strictProject(
-                                ImmutableMap.of(
-                                        "a", PlanMatchPattern.expression("rand()"),
-                                        "b", PlanMatchPattern.expression("b")),
-                                values("b")));
+                .doesNotFire();
+
+        FunctionCall uuidFunction = new FunctionCall(
+                tester().getMetadata().resolveFunction(tester().getSession(), QualifiedName.of("uuid"), ImmutableList.of()).toQualifiedName(),
+                ImmutableList.of());
+
+        tester().assertThat(new ReplaceJoinOverConstantWithProject(tester().getMetadata()))
+                .on(p ->
+                        p.join(
+                                INNER,
+                                p.valuesOfExpressions(ImmutableList.of(p.symbol("uuid")), ImmutableList.of(new Row(ImmutableList.of(uuidFunction)))),
+                                p.values(5, p.symbol("b"))))
+                .doesNotFire();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJoin.java
@@ -73,6 +73,18 @@ public class TestJoin
     }
 
     @Test
+    public void testSingleRowNonDeterministicSource()
+    {
+        assertThat(assertions.query("""
+                WITH data(id) AS (SELECT uuid())
+                SELECT COUNT(DISTINCT id)
+                FROM (VALUES 1, 2, 3, 4, 5, 6, 7, 8)
+                CROSS JOIN data
+                """))
+                .matches("VALUES BIGINT '1'");
+    }
+
+    @Test
     public void testJoinOnNan()
     {
         assertThat(assertions.query("""


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

fixes https://github.com/trinodb/trino/issues/16512

The incorrect result was caused by the Optimizer rule `ReplaceJoinOverConstantWithProject`, which inlined a non-deterministic expression (in this case, `uuid()`), causing it to be evaluated separately for every row.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# General
* Fix potential incorrect result in queries involving join and a non-deterministic value. ({issue}`16512`)
```
