### PR TITLE
Fix FilesTable for non-null key_metadata, split_offsets, equality_ids

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -41,6 +41,9 @@ import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.TestTable;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.Metrics;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -63,6 +66,7 @@ import org.testng.annotations.Test;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
@@ -83,6 +87,9 @@ import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.tpch.TpchTable.NATION;
 import static java.lang.String.format;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.iceberg.FileFormat.ORC;
 import static org.apache.iceberg.TableProperties.SPLIT_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -502,6 +509,79 @@ public class TestIcebergV2
         assertUpdate("DELETE FROM " + tableName + " WHERE regionkey < 10");
         assertThat(query("SELECT * FROM " + tableName)).returnsEmptyResult();
         assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(0);
+    }
+
+    @Test
+    public void testFilesTable()
+            throws Exception
+    {
+        String tableName = "test_files_table_" + randomNameSuffix();
+        String tableLocation = metastoreDir.getPath() + "/" + tableName;
+        assertUpdate("CREATE TABLE " + tableName + " WITH (location = '" + tableLocation + "', format_version = 2) AS SELECT * FROM tpch.tiny.nation", 25);
+        BaseTable table = loadTable(tableName);
+        Metrics metrics = new Metrics(
+                10L,
+                ImmutableMap.of(1, 2L, 2, 3L),
+                ImmutableMap.of(1, 5L, 2, 3L, 3, 2L),
+                ImmutableMap.of(1, 0L, 2, 2L),
+                ImmutableMap.of(4, 1L),
+                ImmutableMap.of(1, ByteBuffer.allocate(8).order(LITTLE_ENDIAN).putLong(0, 0L)),
+                ImmutableMap.of(1, ByteBuffer.allocate(8).order(LITTLE_ENDIAN).putLong(0, 4L)));
+        // Creating a simulated data file to verify the non-null values in the $files table
+        DataFile dataFile = DataFiles.builder(PartitionSpec.unpartitioned())
+                .withFormat(ORC)
+                .withPath(tableLocation + "/data/test_files_table.orc")
+                .withFileSizeInBytes(1234)
+                .withMetrics(metrics)
+                .withSplitOffsets(ImmutableList.of(4L))
+                .withEncryptionKeyMetadata(ByteBuffer.wrap("Trino".getBytes(UTF_8)))
+                .build();
+        table.newAppend().appendFile(dataFile).commit();
+        // TODO Currently, Trino does not include equality delete files stats in the $files table.
+        //  Once it is fixed by https://github.com/trinodb/trino/pull/16232, include equality delete output in the test.
+        writeEqualityDeleteToNationTable(table);
+        assertQuery(
+                "SELECT " +
+                        "content, " +
+                        "file_format, " +
+                        "record_count, " +
+                        "CAST(column_sizes AS JSON), " +
+                        "CAST(value_counts AS JSON), " +
+                        "CAST(null_value_counts AS JSON), " +
+                        "CAST(nan_value_counts AS JSON), " +
+                        "CAST(lower_bounds AS JSON), " +
+                        "CAST(upper_bounds AS JSON), " +
+                        "key_metadata, " +
+                        "split_offsets, " +
+                        "equality_ids " +
+                        "FROM \"" + tableName + "$files\"",
+                """
+                               VALUES
+                                       (0,
+                                        'ORC',
+                                        25L,
+                                        null,
+                                        JSON '{"1":25,"2":25,"3":25,"4":25}',
+                                        JSON '{"1":0,"2":0,"3":0,"4":0}',
+                                        null,
+                                        JSON '{"1":"0","2":"ALGERIA","3":"0","4":" haggle. careful"}',
+                                        JSON '{"1":"24","2":"VIETNAM","3":"4","4":"y final packaget"}',
+                                        null,
+                                        null,
+                                        null),
+                                       (0,
+                                        'ORC',
+                                        10L,
+                                        JSON '{"1":2,"2":3}',
+                                        JSON '{"1":5,"2":3,"3":2}',
+                                        JSON '{"1":0,"2":2}',
+                                        JSON '{"4":1}',
+                                        JSON '{"1":"0"}',
+                                        JSON '{"1":"4"}',
+                                        X'54 72 69 6e 6f',
+                                        ARRAY[4L],
+                                        null)
+                        """);
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fixes https://github.com/trinodb/trino/issues/16473


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Fix failure when `$files` system table contains non-null values on `key_metadata`, `split_offsets`, and `equality_ids` columns. ({issue}`16473`)
```
