### PR TITLE
Do not generate redundant straddling predicates by equality inference

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/EqualityInference.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/EqualityInference.java
@@ -34,11 +34,10 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -215,17 +214,34 @@ public class EqualityInference
                         .forEach(scopeComplementEqualities::add);
             }
 
-            // Compile the scope straddling equality expressions
-            List<Expression> connectingExpressions = new ArrayList<>();
-            connectingExpressions.add(matchingCanonical);
-            connectingExpressions.add(complementCanonical);
-            connectingExpressions.addAll(scopeStraddlingExpressions);
-            connectingExpressions = connectingExpressions.stream()
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toList());
-            Expression connectingCanonical = getCanonical(connectingExpressions.stream());
+            // Compile single equality between matching and complement scope.
+            // Only consider expressions that don't have derived expression in other scope.
+            // Otherwise, redundant equality would be generated.
+            Optional<Expression> matchingConnecting = scopeExpressions.stream()
+                    .filter(expression -> SymbolsExtractor.extractAll(expression).isEmpty() || rewrite(expression, symbol -> !scope.contains(symbol), false) == null)
+                    .min(canonicalComparator);
+            Optional<Expression> complementConnecting = scopeComplementExpressions.stream()
+                    .filter(expression -> SymbolsExtractor.extractAll(expression).isEmpty() || rewrite(expression, scope::contains, false) == null)
+                    .min(canonicalComparator);
+            if (matchingConnecting.isPresent() && complementConnecting.isPresent() && !matchingConnecting.equals(complementConnecting)) {
+                scopeStraddlingEqualities.add(new ComparisonExpression(ComparisonExpression.Operator.EQUAL, matchingConnecting.get(), complementConnecting.get()));
+            }
+
+            // Compile the scope straddling equality expressions.
+            // scopeStraddlingExpressions couldn't be pushed to either side,
+            // therefore there needs to be an equality generated with
+            // one of the scopes (either matching or complement).
+            List<Expression> straddlingExpressions = new ArrayList<>();
+            if (matchingCanonical != null) {
+                straddlingExpressions.add(matchingCanonical);
+            }
+            else if (complementCanonical != null) {
+                straddlingExpressions.add(complementCanonical);
+            }
+            straddlingExpressions.addAll(scopeStraddlingExpressions);
+            Expression connectingCanonical = getCanonical(straddlingExpressions.stream());
             if (connectingCanonical != null) {
-                connectingExpressions.stream()
+                straddlingExpressions.stream()
                         .filter(expression -> !expression.equals(connectingCanonical))
                         .map(expression -> new ComparisonExpression(ComparisonExpression.Operator.EQUAL, connectingCanonical, expression))
                         .forEach(scopeStraddlingEqualities::add);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
@@ -1008,16 +1008,10 @@ public class PredicatePushDown
             ImmutableSet<Symbol> leftScope = ImmutableSet.copyOf(leftSymbols);
             ImmutableSet<Symbol> rightScope = ImmutableSet.copyOf(rightSymbols);
 
-            // Attempt to simplify the effective left/right predicates with the predicate we're pushing down
-            // This, effectively, inlines any constants derived from such predicate
-            EqualityInference predicateInference = new EqualityInference(metadata, inheritedPredicate);
-            Expression simplifiedLeftEffectivePredicate = predicateInference.rewrite(leftEffectivePredicate, leftScope);
-            Expression simplifiedRightEffectivePredicate = predicateInference.rewrite(rightEffectivePredicate, rightScope);
-
             // Generate equality inferences
-            EqualityInference allInference = new EqualityInference(metadata, inheritedPredicate, leftEffectivePredicate, rightEffectivePredicate, joinPredicate, simplifiedLeftEffectivePredicate, simplifiedRightEffectivePredicate);
-            EqualityInference allInferenceWithoutLeftInferred = new EqualityInference(metadata, inheritedPredicate, rightEffectivePredicate, joinPredicate, simplifiedRightEffectivePredicate);
-            EqualityInference allInferenceWithoutRightInferred = new EqualityInference(metadata, inheritedPredicate, leftEffectivePredicate, joinPredicate, simplifiedLeftEffectivePredicate);
+            EqualityInference allInference = new EqualityInference(metadata, inheritedPredicate, leftEffectivePredicate, rightEffectivePredicate, joinPredicate);
+            EqualityInference allInferenceWithoutLeftInferred = new EqualityInference(metadata, inheritedPredicate, rightEffectivePredicate, joinPredicate);
+            EqualityInference allInferenceWithoutRightInferred = new EqualityInference(metadata, inheritedPredicate, leftEffectivePredicate, joinPredicate);
 
             // Add equalities from the inference back in
             leftPushDownConjuncts.addAll(allInferenceWithoutLeftInferred.generateEqualitiesPartitionedBy(leftScope).getScopeEqualities());
@@ -1043,13 +1037,13 @@ public class PredicatePushDown
             });
 
             // See if we can push the right effective predicate to the left side
-            EqualityInference.nonInferrableConjuncts(metadata, simplifiedRightEffectivePredicate)
+            EqualityInference.nonInferrableConjuncts(metadata, rightEffectivePredicate)
                     .map(conjunct -> allInference.rewrite(conjunct, leftScope))
                     .filter(Objects::nonNull)
                     .forEach(leftPushDownConjuncts::add);
 
             // See if we can push the left effective predicate to the right side
-            EqualityInference.nonInferrableConjuncts(metadata, simplifiedLeftEffectivePredicate)
+            EqualityInference.nonInferrableConjuncts(metadata, leftEffectivePredicate)
                     .map(conjunct -> allInference.rewrite(conjunct, rightScope))
                     .filter(Objects::nonNull)
                     .forEach(rightPushDownConjuncts::add);

--- a/core/trino-main/src/test/java/io/trino/sql/planner/AbstractPredicatePushdownTest.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/AbstractPredicatePushdownTest.java
@@ -13,6 +13,7 @@
  */
 package io.trino.sql.planner;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.sql.planner.assertions.BasePlanTest;
@@ -39,6 +40,7 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.semiJoin;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
 import static io.trino.sql.planner.plan.JoinNode.Type.LEFT;
 import static io.trino.sql.tree.BooleanLiteral.TRUE_LITERAL;
 
@@ -463,6 +465,66 @@ public abstract class AbstractPredicatePushdownTest
                         WHERE t1.a = 'aa'
                         """,
                 output(values("field", "field_0")));
+    }
+
+    @Test
+    public void testSimplifyNonInferrableInheritedPredicate()
+    {
+        assertPlan("SELECT * FROM (SELECT * FROM nation WHERE nationkey = regionkey AND regionkey = 5) a, nation b WHERE a.nationkey = b.nationkey AND a.nationkey + 11 > 15",
+                output(
+                        join(INNER, builder -> builder
+                                .equiCriteria(ImmutableList.of())
+                                .left(
+                                        filter("((L_NATIONKEY = L_REGIONKEY) AND (L_REGIONKEY = BIGINT '5'))",
+                                                tableScan("nation", ImmutableMap.of("L_NATIONKEY", "nationkey", "L_REGIONKEY", "regionkey"))))
+                                .right(
+                                        anyTree(
+                                                filter("R_NATIONKEY = BIGINT '5'",
+                                                        tableScan("nation", ImmutableMap.of("R_NATIONKEY", "nationkey"))))))));
+    }
+
+    @Test
+    public void testDoesNotCreatePredicateFromInferredPredicate()
+    {
+        assertPlan("SELECT * FROM (SELECT *, nationkey + 1 as nationkey2 FROM nation) a JOIN nation b ON a.nationkey = b.nationkey",
+                output(
+                        join(INNER, builder -> builder
+                                .equiCriteria("L_NATIONKEY", "R_NATIONKEY")
+                                .left(
+                                        filter("true", // DF filter
+                                                tableScan("nation", ImmutableMap.of("L_NATIONKEY", "nationkey"))))
+                                .right(
+                                        anyTree(
+                                                tableScan("nation", ImmutableMap.of("R_NATIONKEY", "nationkey")))))));
+
+        assertPlan("SELECT * FROM (SELECT * FROM nation WHERE nationkey = 5) a JOIN (SELECT * FROM nation WHERE nationkey = 5) b ON a.nationkey = b.nationkey",
+                output(
+                        join(INNER, builder -> builder
+                                .equiCriteria(ImmutableList.of())
+                                .left(
+                                        filter("L_NATIONKEY = BIGINT '5'",
+                                                tableScan("nation", ImmutableMap.of("L_NATIONKEY", "nationkey"))))
+                                .right(
+                                        anyTree(
+                                                filter("R_NATIONKEY = BIGINT '5'",
+                                                        tableScan("nation", ImmutableMap.of("R_NATIONKEY", "nationkey"))))))));
+    }
+
+    @Test
+    public void testSimplifiesStraddlingPredicate()
+    {
+        assertPlan("SELECT * FROM (SELECT * FROM NATION WHERE nationkey = 5) a JOIN nation b ON a.nationkey = b.nationkey AND a.nationkey = a.regionkey + b.regionkey",
+                output(
+                        filter("L_REGIONKEY + R_REGIONKEY = BIGINT '5'",
+                                join(INNER, builder -> builder
+                                        .equiCriteria(ImmutableList.of())
+                                        .left(
+                                                filter("L_NATIONKEY = BIGINT '5'",
+                                                        tableScan("nation", ImmutableMap.of("L_NATIONKEY", "nationkey", "L_REGIONKEY", "regionkey"))))
+                                        .right(
+                                                anyTree(
+                                                        filter("R_NATIONKEY = BIGINT '5'",
+                                                                tableScan("nation", ImmutableMap.of("R_NATIONKEY", "nationkey", "R_REGIONKEY", "regionkey")))))))));
     }
 
     protected Session noSemiJoinRewrite()

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestPredicatePushdownWithoutDynamicFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestPredicatePushdownWithoutDynamicFilter.java
@@ -13,6 +13,7 @@
  */
 package io.trino.sql.planner;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.sql.planner.plan.ExchangeNode;
@@ -23,6 +24,7 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.output;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.semiJoin;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
@@ -172,5 +174,32 @@ public class TestPredicatePushdownWithoutDynamicFilter
                                 .right(
                                         anyTree(
                                                 tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))))));
+    }
+
+    @Override
+    @Test
+    public void testDoesNotCreatePredicateFromInferredPredicate()
+    {
+        assertPlan("SELECT * FROM (SELECT *, nationkey + 1 as nationkey2 FROM nation) a JOIN nation b ON a.nationkey = b.nationkey",
+                output(
+                        join(INNER, builder -> builder
+                                .equiCriteria("L_NATIONKEY", "R_NATIONKEY")
+                                .left(
+                                        tableScan("nation", ImmutableMap.of("L_NATIONKEY", "nationkey")))
+                                .right(
+                                        anyTree(
+                                                tableScan("nation", ImmutableMap.of("R_NATIONKEY", "nationkey")))))));
+
+        assertPlan("SELECT * FROM (SELECT * FROM nation WHERE nationkey = 5) a JOIN (SELECT * FROM nation WHERE nationkey = 5) b ON a.nationkey = b.nationkey",
+                output(
+                        join(INNER, builder -> builder
+                                .equiCriteria(ImmutableList.of())
+                                .left(
+                                        filter("L_NATIONKEY = BIGINT '5'",
+                                                tableScan("nation", ImmutableMap.of("L_NATIONKEY", "nationkey"))))
+                                .right(
+                                        anyTree(
+                                                filter("R_NATIONKEY = BIGINT '5'",
+                                                        tableScan("nation", ImmutableMap.of("R_NATIONKEY", "nationkey"))))))));
     }
 }


### PR DESCRIPTION
    When there are predicates like a1 = b1 and a2 = a1 + 1, then
    equality inference would derive staddling predicate for
    a2 = b1 + 1, which is redundant to a1 = b1, a2 = a1 + 1.
    This commit makes sure that redundant straddling predicates
    are not generated.

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Improve performance by removing redundant predicates from plan. ({issue}`issuenumber`)
```
