### PR TITLE
Add regex to Hive table properties format row

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -1033,10 +1033,11 @@ to the connector using a :doc:`WITH </sql/create-table-as>` clause::
       :ref:`hive_examples` for more information.
     -
   * - ``format``
-    - The table file format. Valid values include ``ORC``, ``PARQUET``, ``AVRO``,
-      ``RCBINARY``, ``RCTEXT``, ``SEQUENCEFILE``, ``JSON``, ``TEXTFILE``, and
-      ``CSV``. The catalog property ``hive.storage-format`` sets the default
-      value and can change it to a different default.
+    - The table file format. Valid values include ``ORC``, ``PARQUET``,
+      ``AVRO``, ``RCBINARY``, ``RCTEXT``, ``SEQUENCEFILE``, ``JSON``,
+      ``TEXTFILE``, ``CSV``, and ``REGEX``. The catalog property
+      ``hive.storage-format`` sets the default value and can change it to a
+      different default.
     -
   * - ``null_format``
     - The serialization format for ``NULL`` value. Requires TextFile, RCText,


### PR DESCRIPTION
## Description

Add REGEX to Hive table properties format row.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/trinodb/trino/pull/16271/files Release note already present for Trino 409.
