### PR TITLE
Fix overly restrictive correctness checks in native line readers

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/compression/CompressionKind.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/compression/CompressionKind.java
@@ -95,9 +95,12 @@ public enum CompressionKind
             .filter(codec -> codec.fileExtension != null)
             .collect(toImmutableMap(codec -> codec.fileExtension, Function.identity()));
 
-    public static Optional<Codec> createCodecFromExtension(String extension)
+    public static Optional<CompressionKind> forFile(String fileName)
     {
-        return Optional.ofNullable(CODECS_BY_FILE_EXTENSION.get(extension))
-                .map(CompressionKind::createCodec);
+        int position = fileName.lastIndexOf('.');
+        if (position < 0) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(CODECS_BY_FILE_EXTENSION.get(fileName.substring(position)));
     }
 }

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/text/TextLineReaderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/text/TextLineReaderFactory.java
@@ -65,8 +65,8 @@ public class TextLineReaderFactory
     {
         InputStream inputStream = inputFile.newStream();
         try {
-            Optional<Codec> codec = getExtension(inputFile.location())
-                    .flatMap(CompressionKind::createCodecFromExtension);
+            Optional<Codec> codec = CompressionKind.forFile(inputFile.location())
+                    .map(CompressionKind::createCodec);
             if (codec.isPresent()) {
                 checkArgument(start == 0, "Compressed files are not splittable");
                 // for compressed input, we do not know the length of the uncompressed text
@@ -102,14 +102,5 @@ public class TextLineReaderFactory
                 return;
             }
         }
-    }
-
-    private static Optional<String> getExtension(String location)
-    {
-        int position = location.lastIndexOf('.');
-        if (position < 0) {
-            return Optional.empty();
-        }
-        return Optional.of(location.substring(position));
     }
 }

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/text/TextLineReaderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/text/TextLineReaderFactory.java
@@ -68,7 +68,7 @@ public class TextLineReaderFactory
             Optional<Codec> codec = getExtension(inputFile.location())
                     .flatMap(CompressionKind::createCodecFromExtension);
             if (codec.isPresent()) {
-                checkArgument(start == 0 && length == inputFile.length(), "Compressed files are not splittable");
+                checkArgument(start == 0, "Compressed files are not splittable");
                 // for compressed input, we do not know the length of the uncompressed text
                 length = Long.MAX_VALUE;
                 inputStream = codec.get().createStreamDecompressor(inputStream);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LinePageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LinePageSourceFactory.java
@@ -117,12 +117,12 @@ public abstract class LinePageSourceFactory
 
         // get header and footer count
         int headerCount = getHeaderCount(schema);
-        if (headerCount > 0) {
-            checkArgument(estimatedFileSize == start + length, "Header not supported for a split file");
+        if (headerCount > 1) {
+            checkArgument(start == 0, "Multiple header rows are not supported for a split file");
         }
         int footerCount = getFooterCount(schema);
         if (footerCount > 0) {
-            checkArgument(estimatedFileSize == start + length, "Footer not supported for a split file");
+            checkArgument(start == 0, "Footer not supported for a split file");
         }
 
         // setup projected columns


### PR DESCRIPTION
## Description
Do not verify length when determining if a file is split and instead only check that start offset is zero.  This is because Hive supports replacing files during a query, and users take advantage of this.  This check is still correct, because a split file necessarily has second split that will have a non-zero start offset.

For all native file formats, hardcode the handling of the isSplittable check as it is a behavior of the code and not the file format.

Fixes #16492 
Fixes #16510 

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Hive
* Fix support for text formats with single header row when the file is split. ({issue}`16492`)
* Fix support for reading text formats when the file is replaced during the query. ({issue}`16510`)
```
