### PR TITLE
Add `sinh` function to return hyperbolic sine

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
@@ -1155,6 +1155,14 @@ public final class MathFunctions
         return Math.sin(num);
     }
 
+    @Description("Hyperbolic sine")
+    @ScalarFunction
+    @SqlType(StandardTypes.DOUBLE)
+    public static double sinh(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return Math.sinh(num);
+    }
+
     @Description("Square root")
     @ScalarFunction
     @SqlType(StandardTypes.DOUBLE)

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathFunctions.java
@@ -2501,6 +2501,21 @@ public class TestMathFunctions
     }
 
     @Test
+    public void testSinh()
+    {
+        for (double doubleValue : DOUBLE_VALUES) {
+            assertThat(assertions.function("sinh", Double.toString(doubleValue)))
+                    .isEqualTo(Math.sinh(doubleValue));
+
+            assertThat(assertions.function("sinh", "REAL '%s'".formatted((float) doubleValue)))
+                    .isEqualTo(Math.sinh((float) doubleValue));
+        }
+
+        assertThat(assertions.function("sinh", "NULL"))
+                .isNull(DOUBLE);
+    }
+
+    @Test
     public void testSqrt()
     {
         for (double doubleValue : DOUBLE_VALUES) {

--- a/docs/src/main/sphinx/functions/list-by-topic.rst
+++ b/docs/src/main/sphinx/functions/list-by-topic.rst
@@ -412,6 +412,7 @@ For more details, see :doc:`math`
 * :func:`round`
 * :func:`sign`
 * :func:`sin`
+* :func:`sinh`
 * :func:`sqrt`
 * :func:`tan`
 * :func:`tanh`

--- a/docs/src/main/sphinx/functions/list.rst
+++ b/docs/src/main/sphinx/functions/list.rst
@@ -386,6 +386,7 @@ S
 - :func:`sign`
 - :func:`simplify_geometry`
 - :func:`sin`
+- :func:`sinh`
 - :func:`skewness`
 - :func:`slice`
 - :ref:`SOME <quantified_comparison_predicates>`

--- a/docs/src/main/sphinx/functions/math.rst
+++ b/docs/src/main/sphinx/functions/math.rst
@@ -186,6 +186,10 @@ See unit conversion functions :func:`degrees` and :func:`radians`.
 
     Returns the sine of ``x``.
 
+.. function:: sinh(x) -> double
+
+    Returns the hyperbolic sine of ``x``.
+
 .. function:: tan(x) -> double
 
     Returns the tangent of ``x``.

--- a/testing/trino-product-tests/src/main/resources/sql-tests/testcases/math_functions/checkMathFunctionsRegistered.result
+++ b/testing/trino-product-tests/src/main/resources/sql-tests/testcases/math_functions/checkMathFunctionsRegistered.result
@@ -71,6 +71,7 @@
  round | double | double, integer | scalar | true | Round to given number of decimal places |
  row_number | bigint | | window | true | |
  sin | double | double | scalar | true | Sine |
+ sinh | double | double | scalar | true | Hyperbolic sine |
  sqrt | double | double | scalar | true | Square root |
  stddev | double | bigint | aggregate | true | Returns the sample standard deviation of the argument |
  stddev | double | double | aggregate | true | Returns the sample standard deviation of the argument |


### PR DESCRIPTION
## Description

Fixes #16494

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Add {func}`sinh` function. ({issue}`16494`)
```
