### PR TITLE
Fix InterruptedException in miscellaneous connectors

### DIFF
--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduSplitManager.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduSplitManager.java
@@ -123,6 +123,9 @@ public class KuduSplitManager
                 return splitSourceFuture.get().isFinished();
             }
             catch (InterruptedException | ExecutionException e) {
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
                 throw new RuntimeException(e);
             }
         }

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotLegacyDataFetcher.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotLegacyDataFetcher.java
@@ -246,6 +246,7 @@ public class PinotLegacyDataFetcher
                 return pinotDataTableWithSizeBuilder.build().iterator();
             }
             catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new PinotException(PINOT_EXCEPTION, Optional.of(query), "Pinot query execution was interrupted", e);
             }
         }

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/metadata/DatabaseShardManager.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/metadata/DatabaseShardManager.java
@@ -375,6 +375,7 @@ public class DatabaseShardManager
                     SECONDS.sleep(multiplyExact(attempt, 2));
                 }
                 catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
                     throw metadataError(ie);
                 }
             }

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/metadata/DatabaseShardRecorder.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/metadata/DatabaseShardRecorder.java
@@ -58,6 +58,7 @@ public class DatabaseShardRecorder
                     MILLISECONDS.sleep(millis + ThreadLocalRandom.current().nextLong(0, millis));
                 }
                 catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
                     throw metadataError(ie);
                 }
             }


### PR DESCRIPTION
## Description
Ensures that the current thread's interrupted state is reset when an `InterruptedException` is caught and a different exception is re-thrown in `KuduSplitManager`, `PinotLegacyDataFetcher`, and legacy raptor `DatabaseShardManager`/`DatabaseShardRecorder`.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

