### PR TITLE
Allow for Custom OkHTTPClient in NonRegisteringTrinoDriver

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/NonRegisteringTrinoDriver.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/NonRegisteringTrinoDriver.java
@@ -33,7 +33,17 @@ import static io.trino.jdbc.DriverInfo.DRIVER_VERSION_MINOR;
 public class NonRegisteringTrinoDriver
         implements Driver, Closeable
 {
-    private final OkHttpClient httpClient = newHttpClient();
+    private final OkHttpClient httpClient;
+
+    public NonRegisteringTrinoDriver()
+    {
+        this(new OkHttpClient());
+    }
+
+    public NonRegisteringTrinoDriver(OkHttpClient httpClient)
+    {
+        this.httpClient = addDriverUserAgent(httpClient);
+    }
 
     @Override
     public void close()
@@ -117,10 +127,9 @@ public class NonRegisteringTrinoDriver
         throw new SQLFeatureNotSupportedException();
     }
 
-    private static OkHttpClient newHttpClient()
+    private static OkHttpClient addDriverUserAgent(OkHttpClient httpClient)
     {
-        OkHttpClient.Builder builder = new OkHttpClient.Builder()
-                .addInterceptor(userAgent(DRIVER_NAME + "/" + DRIVER_VERSION));
-        return builder.build();
+        return httpClient.newBuilder()
+                .addInterceptor(userAgent(DRIVER_NAME + "/" + DRIVER_VERSION)).build();
     }
 }

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestNonRegisteringTrinoDriver.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestNonRegisteringTrinoDriver.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.jdbc;
+
+import io.airlift.log.Logging;
+import io.trino.server.testing.TestingTrinoServer;
+import okhttp3.OkHttpClient;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.lang.String.format;
+import static org.testng.Assert.assertTrue;
+
+public class TestNonRegisteringTrinoDriver
+{
+    private TestingTrinoServer server;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        Logging.initialize();
+        server = TestingTrinoServer.create();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+            throws Exception
+    {
+        server.close();
+        server = null;
+    }
+
+    @Test
+    public void testDriverWithCustomOkHttpClient()
+            throws Exception
+    {
+        AtomicBoolean customClientInvoked = new AtomicBoolean(false);
+
+        OkHttpClient client = new OkHttpClient.Builder()
+                .addInterceptor(chain -> {
+                    customClientInvoked.getAndSet(true);
+                    return chain.proceed(chain.request());
+                })
+                .build();
+
+        NonRegisteringTrinoDriver driverWithCustomHttpClient = new NonRegisteringTrinoDriver(client);
+        DriverManager.registerDriver(driverWithCustomHttpClient);
+
+        try (Connection connection = createConnection()) {
+            try (Statement statement = connection.createStatement()) {
+                statement.executeQuery("SELECT 123");
+                assertTrue(customClientInvoked.get());
+            }
+        }
+    }
+
+    private Connection createConnection()
+            throws SQLException
+    {
+        String url = format("jdbc:trino://%s", server.getAddress());
+        return DriverManager.getConnection(url, "test", null);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
In order to allow for greater flexibility when working with the Trino JDBC driver, we are proposing to allow for developers to create their own OkHttpClient instance to pass into the constructor for NonRegisteringTrinoDriver.



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Examples of greater flexibility would be providing custom DNS resolvers, connection pooling properties, and connection timeouts.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

