### PR TITLE
add header authentication support for the web-ui

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/HeaderAuthenticatorManager.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/HeaderAuthenticatorManager.java
@@ -13,6 +13,7 @@
  */
 package io.trino.server.security;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
@@ -114,5 +115,13 @@ public class HeaderAuthenticatorManager
     public boolean isLoaded()
     {
         return authenticators.get() != null;
+    }
+
+    @VisibleForTesting
+    public void setAuthenticators(HeaderAuthenticator... authenticators)
+    {
+        if (!this.authenticators.compareAndSet(null, ImmutableList.copyOf(authenticators))) {
+            throw new IllegalStateException("authenticators already loaded");
+        }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/ui/WebUiAuthenticationModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/WebUiAuthenticationModule.java
@@ -21,6 +21,9 @@ import io.airlift.http.server.HttpServer.ClientCertificate;
 import io.trino.server.security.Authenticator;
 import io.trino.server.security.CertificateAuthenticator;
 import io.trino.server.security.CertificateConfig;
+import io.trino.server.security.HeaderAuthenticator;
+import io.trino.server.security.HeaderAuthenticatorConfig;
+import io.trino.server.security.HeaderAuthenticatorManager;
 import io.trino.server.security.KerberosAuthenticator;
 import io.trino.server.security.KerberosConfig;
 import io.trino.server.security.SecurityConfig;
@@ -58,6 +61,11 @@ public class WebUiAuthenticationModule
         }));
         installWebUiAuthenticator("kerberos", KerberosAuthenticator.class, KerberosConfig.class);
         install(webUiAuthenticator("jwt", JwtAuthenticator.class, new JwtAuthenticatorSupportModule()));
+        install(webUiAuthenticator("header", HeaderAuthenticator.class, headerBinder -> {
+            newOptionalBinder(headerBinder, HeaderAuthenticatorManager.class);
+            configBinder(headerBinder).bindConfig(HeaderAuthenticatorConfig.class);
+            headerBinder.bind(HeaderAuthenticatorManager.class).in(SINGLETON);
+        }));
     }
 
     private void installWebUiAuthenticator(String type, Module module)

--- a/docs/src/main/sphinx/admin/properties-web-interface.md
+++ b/docs/src/main/sphinx/admin/properties-web-interface.md
@@ -5,7 +5,7 @@ The following properties can be used to configure the {doc}`web-interface`.
 ## `web-ui.authentication.type`
 
 - **Type:** {ref}`prop-type-string`
-- **Allowed values:** `FORM`, `FIXED`, `CERTIFICATE`, `KERBEROS`, `JWT`, `OAUTH2`
+- **Allowed values:** `FORM`, `FIXED`, `CERTIFICATE`, `KERBEROS`, `JWT`, `OAUTH2`, `HEADER`
 - **Default value:** `FORM`
 
 The authentication mechanism to allow user access to the Web UI. See

--- a/docs/src/main/sphinx/admin/web-interface.md
+++ b/docs/src/main/sphinx/admin/web-interface.md
@@ -46,6 +46,7 @@ The following Web UI authentication types are also supported:
 - `KERBEROS`, see details in {doc}`/security/kerberos`
 - `JWT`, see details in {doc}`/security/jwt`
 - `OAUTH2`, see details in {doc}`/security/oauth2`
+- `HEADER`, see details in {doc}`/develop/header-authenticator`
 
 For these authentication types, the username is defined by {doc}`/security/user-mapping`.
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Installs the header authenticator and header authenticator manager modules in the web UI authentication module

relevant configuration

``web-ui.authentication.type=header``

in place of https://github.com/trinodb/trino/pull/14450

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
