### PR TITLE
Run Docker architecture check on CI only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ env:
   # the Docker daemon only downloads 3 layers concurrently which prevents the other pull from making any progress.
   # This value should be greater than the time taken for the longest image pull.
   TESTCONTAINERS_PULL_PAUSE_TIMEOUT: 600
+  # CI should never run "wrong" images (images with architecture different than host's), as they are slow to run
   TESTCONTAINERS_SKIP_ARCHITECTURE_CHECK: false
   TEST_REPORT_RETENTION_DAYS: 5
   HEAP_DUMP_RETENTION_DAYS: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ env:
   # the Docker daemon only downloads 3 layers concurrently which prevents the other pull from making any progress.
   # This value should be greater than the time taken for the longest image pull.
   TESTCONTAINERS_PULL_PAUSE_TIMEOUT: 600
-  TESTCONTAINERS_SKIP_ARCHITECTURE_CHECK: true
+  TESTCONTAINERS_SKIP_ARCHITECTURE_CHECK: false
   TEST_REPORT_RETENTION_DAYS: 5
   HEAP_DUMP_RETENTION_DAYS: 14
   # used by actions/cache to retry the download after this time: https://github.com/actions/cache/blob/main/workarounds.md#cache-segment-restore-timeout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -985,7 +985,10 @@ jobs:
           DATABRICKS_TOKEN:
           GCP_CREDENTIALS_KEY:
           GCP_STORAGE_BUCKET:
+          # Preventing pulling images. Otherwise all images would get downloaded (and not used).
           TESTCONTAINERS_NEVER_PULL: true
+          # The architecture check pulls images.
+          TESTCONTAINERS_SKIP_ARCHITECTURE_CHECK: true
         run: |
           # converts filtered YAML file into JSON
           ./.github/bin/build-pt-matrix-from-impacted-connectors.py -v -m .github/test-pt-matrix.yaml -i impacted-features.log -o matrix.json


### PR DESCRIPTION
CI should not run images with wrong architecture.
Engineers may end up running a test using a docker image with a wrong architecture. In such case, test may fail, but it's very common engineers will want to try it anyway. This is because there is no practical alternative.
