### PR TITLE
Add table function exclude_columns

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/system/GlobalSystemConnector.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/GlobalSystemConnector.java
@@ -21,6 +21,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.procedure.Procedure;
+import io.trino.spi.ptf.ConnectorTableFunction;
 import io.trino.spi.transaction.IsolationLevel;
 import io.trino.transaction.InternalConnector;
 import io.trino.transaction.TransactionId;
@@ -40,12 +41,14 @@ public class GlobalSystemConnector
 
     private final Set<SystemTable> systemTables;
     private final Set<Procedure> procedures;
+    private final Set<ConnectorTableFunction> tableFunctions;
 
     @Inject
-    public GlobalSystemConnector(Set<SystemTable> systemTables, Set<Procedure> procedures)
+    public GlobalSystemConnector(Set<SystemTable> systemTables, Set<Procedure> procedures, Set<ConnectorTableFunction> tableFunctions)
     {
         this.systemTables = ImmutableSet.copyOf(requireNonNull(systemTables, "systemTables is null"));
         this.procedures = ImmutableSet.copyOf(requireNonNull(procedures, "procedures is null"));
+        this.tableFunctions = ImmutableSet.copyOf(requireNonNull(tableFunctions, "tableFunctions is null"));
     }
 
     @Override
@@ -70,5 +73,11 @@ public class GlobalSystemConnector
     public Set<Procedure> getProcedures()
     {
         return procedures;
+    }
+
+    @Override
+    public Set<ConnectorTableFunction> getTableFunctions()
+    {
+        return tableFunctions;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/system/SystemConnectorModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SystemConnectorModule.java
@@ -31,8 +31,12 @@ import io.trino.connector.system.jdbc.TableJdbcTable;
 import io.trino.connector.system.jdbc.TableTypeJdbcTable;
 import io.trino.connector.system.jdbc.TypesJdbcTable;
 import io.trino.connector.system.jdbc.UdtJdbcTable;
+import io.trino.operator.table.ExcludeColumns;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.procedure.Procedure;
+import io.trino.spi.ptf.ConnectorTableFunction;
+
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
 
 public class SystemConnectorModule
         implements Module
@@ -74,6 +78,8 @@ public class SystemConnectorModule
         binder.bind(KillQueryProcedure.class).in(Scopes.SINGLETON);
 
         binder.bind(GlobalSystemConnector.class).in(Scopes.SINGLETON);
+
+        newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(ExcludeColumns.class).in(Scopes.SINGLETON);
     }
 
     @ProvidesIntoSet

--- a/core/trino-main/src/main/java/io/trino/metadata/GlobalFunctionCatalog.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/GlobalFunctionCatalog.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
+import io.trino.operator.table.ExcludeColumns;
 import io.trino.spi.function.AggregationFunctionMetadata;
 import io.trino.spi.function.AggregationImplementation;
 import io.trino.spi.function.BoundSignature;
@@ -47,6 +48,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.metadata.OperatorNameUtil.isOperatorName;
 import static io.trino.metadata.OperatorNameUtil.unmangleOperator;
+import static io.trino.operator.table.ExcludeColumns.getExcludeColumnsFunctionProcessorProvider;
 import static io.trino.spi.function.FunctionKind.AGGREGATE;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -176,6 +178,10 @@ public class GlobalFunctionCatalog
     @Override
     public TableFunctionProcessorProvider getTableFunctionProcessorProvider(SchemaFunctionName name)
     {
+        if (name.equals(new SchemaFunctionName(BUILTIN_SCHEMA, ExcludeColumns.NAME))) {
+            return getExcludeColumnsFunctionProcessorProvider();
+        }
+
         return null;
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/table/ExcludeColumns.java
+++ b/core/trino-main/src/main/java/io/trino/operator/table/ExcludeColumns.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.table;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorTableFunction;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.ptf.AbstractConnectorTableFunction;
+import io.trino.spi.ptf.Argument;
+import io.trino.spi.ptf.ConnectorTableFunction;
+import io.trino.spi.ptf.ConnectorTableFunctionHandle;
+import io.trino.spi.ptf.Descriptor;
+import io.trino.spi.ptf.DescriptorArgument;
+import io.trino.spi.ptf.DescriptorArgumentSpecification;
+import io.trino.spi.ptf.TableArgument;
+import io.trino.spi.ptf.TableArgumentSpecification;
+import io.trino.spi.ptf.TableFunctionAnalysis;
+import io.trino.spi.ptf.TableFunctionDataProcessor;
+import io.trino.spi.ptf.TableFunctionProcessorProvider;
+import io.trino.spi.type.RowType;
+
+import javax.inject.Provider;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.metadata.GlobalFunctionCatalog.BUILTIN_SCHEMA;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.ptf.DescriptorArgument.NULL_DESCRIPTOR;
+import static io.trino.spi.ptf.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
+import static io.trino.spi.ptf.TableFunctionProcessorState.Finished.FINISHED;
+import static io.trino.spi.ptf.TableFunctionProcessorState.Processed.usedInputAndProduced;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
+import static java.util.stream.Collectors.joining;
+
+public class ExcludeColumns
+        implements Provider<ConnectorTableFunction>
+{
+    public static final String NAME = "exclude_columns";
+
+    @Override
+    public ConnectorTableFunction get()
+    {
+        return new ClassLoaderSafeConnectorTableFunction(new ExcludeColumnsFunction(), getClass().getClassLoader());
+    }
+
+    public static class ExcludeColumnsFunction
+            extends AbstractConnectorTableFunction
+    {
+        private static final String TABLE_ARGUMENT_NAME = "INPUT";
+        private static final String DESCRIPTOR_ARGUMENT_NAME = "COLUMNS";
+
+        public ExcludeColumnsFunction()
+        {
+            super(
+                    BUILTIN_SCHEMA,
+                    NAME,
+                    ImmutableList.of(
+                            TableArgumentSpecification.builder()
+                                    .name(TABLE_ARGUMENT_NAME)
+                                    .rowSemantics()
+                                    .build(),
+                            DescriptorArgumentSpecification.builder()
+                                    .name(DESCRIPTOR_ARGUMENT_NAME)
+                                    .build()),
+                    GENERIC_TABLE);
+        }
+
+        @Override
+        public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
+        {
+            DescriptorArgument excludedColumns = (DescriptorArgument) arguments.get(DESCRIPTOR_ARGUMENT_NAME);
+            if (excludedColumns.equals(NULL_DESCRIPTOR)) {
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "COLUMNS descriptor is null");
+            }
+            Descriptor excludedColumnsDescriptor = excludedColumns.getDescriptor().orElseThrow();
+            if (excludedColumnsDescriptor.getFields().stream().anyMatch(field -> field.getType().isPresent())) {
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "COLUMNS descriptor contains types");
+            }
+
+            // column names in DescriptorArgument are canonical wrt SQL identifier semantics.
+            // column names in TableArgument are not canonical wrt SQL identifier semantics, as they are taken from the corresponding RelationType.
+            // because of that, we match the excluded columns names case-insensitive
+            // TODO apply proper identifier semantics
+            Set<String> excludedNames = excludedColumnsDescriptor.getFields().stream()
+                    .map(Descriptor.Field::getName)
+                    .map(name -> name.orElseThrow().toLowerCase(ENGLISH))
+                    .collect(toImmutableSet());
+
+            List<RowType.Field> inputSchema = ((TableArgument) arguments.get(TABLE_ARGUMENT_NAME)).getRowType().getFields();
+            Set<String> inputNames = inputSchema.stream()
+                    .map(RowType.Field::getName)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .map(name -> name.toLowerCase(ENGLISH))
+                    .collect(toImmutableSet());
+
+            if (!inputNames.containsAll(excludedNames)) {
+                String missingColumns = Sets.difference(excludedNames, inputNames).stream()
+                        .collect(joining(", ", "[", "]"));
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, format("Excluded columns: %s not present in the table", missingColumns));
+            }
+
+            ImmutableList.Builder<Integer> requiredColumns = ImmutableList.builder();
+            ImmutableList.Builder<Descriptor.Field> returnedColumns = ImmutableList.builder();
+
+            for (int i = 0; i < inputSchema.size(); i++) {
+                Optional<String> name = inputSchema.get(i).getName();
+                if (name.isEmpty() || !excludedNames.contains(name.orElseThrow().toLowerCase(ENGLISH))) {
+                    requiredColumns.add(i);
+                    // per SQL standard, all columns produced by a table function must be named. We allow anonymous columns.
+                    returnedColumns.add(new Descriptor.Field(name, Optional.of(inputSchema.get(i).getType())));
+                }
+            }
+
+            List<Descriptor.Field> returnedType = returnedColumns.build();
+            if (returnedType.isEmpty()) {
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "All columns are excluded");
+            }
+
+            return TableFunctionAnalysis.builder()
+                    .requiredColumns(TABLE_ARGUMENT_NAME, requiredColumns.build())
+                    .returnedType(new Descriptor(returnedType))
+                    // there's no information to remember. All logic is effectively delegated to the engine via `requiredColumns`. We do not pass a ConnectorTableHandle. EMPTY_HANDLE will be used.
+                    .build();
+        }
+    }
+
+    public static TableFunctionProcessorProvider getExcludeColumnsFunctionProcessorProvider()
+    {
+        return new TableFunctionProcessorProvider()
+        {
+            @Override
+            public TableFunctionDataProcessor getDataProcessor(ConnectorTableFunctionHandle handle)
+            {
+                return input -> {
+                    if (input == null) {
+                        return FINISHED;
+                    }
+                    return usedInputAndProduced(getOnlyElement(input).orElseThrow());
+                };
+            }
+        };
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1661,7 +1661,7 @@ class StatementAnalyzer
             // proper columns first
             if (properColumnsDescriptor != null) {
                 properColumnsDescriptor.getFields().stream()
-                        // per spec, field names are mandatory
+                        // per spec, field names are mandatory. We support anonymous fields.
                         .map(field -> Field.newUnqualified(field.getName(), field.getType().orElseThrow(() -> new IllegalStateException("missing returned type for proper field"))))
                         .forEach(fields::add);
             }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -1862,7 +1862,7 @@ public class PlanPrinter
             }
             else {
                 descriptor = argument.getDescriptor().orElseThrow().getFields().stream()
-                        .map(field -> anonymizer.anonymizeColumn(field.getName()) + field.getType().map(type -> " " + type.getDisplayName()).orElse(""))
+                        .map(field -> anonymizer.anonymizeColumn(field.getName().orElseThrow()) + field.getType().map(type -> " " + type.getDisplayName()).orElse(""))
                         .collect(joining(", ", "(", ")"));
             }
             return format("%s => DescriptorArgument{%s}", argumentName, descriptor);

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -122,6 +122,7 @@ import io.trino.operator.index.IndexJoinLookupStats;
 import io.trino.operator.scalar.json.JsonExistsFunction;
 import io.trino.operator.scalar.json.JsonQueryFunction;
 import io.trino.operator.scalar.json.JsonValueFunction;
+import io.trino.operator.table.ExcludeColumns.ExcludeColumnsFunction;
 import io.trino.plugin.base.security.AllowAllSystemAccessControl;
 import io.trino.security.GroupProviderManager;
 import io.trino.server.PluginManager;
@@ -467,7 +468,8 @@ public class LocalQueryRunner
                 new ColumnPropertiesSystemTable(metadata, accessControl, columnPropertyManager),
                 new AnalyzePropertiesSystemTable(metadata, accessControl, analyzePropertyManager),
                 new TransactionsSystemTable(typeManager, transactionManager)),
-                ImmutableSet.of());
+                ImmutableSet.of(),
+                ImmutableSet.of(new ExcludeColumnsFunction()));
 
         exchangeManagerRegistry = new ExchangeManagerRegistry();
         this.pluginManager = new PluginManager(

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/Descriptor.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/Descriptor.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static io.trino.spi.ptf.Preconditions.checkArgument;
-import static io.trino.spi.ptf.Preconditions.checkNotNullOrEmpty;
 import static java.util.Objects.requireNonNull;
 
 @Experimental(eta = "2022-10-31")
@@ -94,18 +93,24 @@ public class Descriptor
 
     public static class Field
     {
-        private final String name;
+        private final Optional<String> name;
         private final Optional<Type> type;
 
-        @JsonCreator
-        public Field(@JsonProperty("name") String name, @JsonProperty("type") Optional<Type> type)
+        public Field(String name, Optional<Type> type)
         {
-            this.name = checkNotNullOrEmpty(name, "name");
+            this(Optional.of(name), type);
+        }
+
+        @JsonCreator
+        public Field(@JsonProperty("name") Optional<String> name, @JsonProperty("type") Optional<Type> type)
+        {
+            this.name = requireNonNull(name, "name is null");
+            name.ifPresent(nameValue -> checkArgument(!nameValue.isEmpty(), "name is empty"));
             this.type = requireNonNull(type, "type is null");
         }
 
         @JsonProperty
-        public String getName()
+        public Optional<String> getName()
         {
             return name;
         }

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/DescriptorArgument.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/DescriptorArgument.java
@@ -21,6 +21,7 @@ import io.trino.spi.expression.ConnectorExpression;
 import java.util.Objects;
 import java.util.Optional;
 
+import static io.trino.spi.ptf.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -40,6 +41,9 @@ public class DescriptorArgument
     public DescriptorArgument(@JsonProperty("descriptor") Optional<Descriptor> descriptor)
     {
         this.descriptor = requireNonNull(descriptor, "descriptor is null");
+        descriptor.ifPresent(descriptorValue -> checkArgument(
+                descriptorValue.getFields().stream().allMatch(field -> field.getName().isPresent()),
+                "All fields of a descriptor argument must have names"));
     }
 
     @JsonProperty

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/DescriptorArgumentSpecification.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/DescriptorArgumentSpecification.java
@@ -15,6 +15,8 @@ package io.trino.spi.ptf;
 
 import io.trino.spi.Experimental;
 
+import static io.trino.spi.ptf.Preconditions.checkArgument;
+
 @Experimental(eta = "2022-10-31")
 public class DescriptorArgumentSpecification
         extends ArgumentSpecification
@@ -22,6 +24,9 @@ public class DescriptorArgumentSpecification
     private DescriptorArgumentSpecification(String name, boolean required, Descriptor defaultValue)
     {
         super(name, required, defaultValue);
+        checkArgument(
+                defaultValue == null || defaultValue.getFields().stream().allMatch(field -> field.getName().isPresent()),
+                "All fields of a descriptor argument must have names");
     }
 
     public static Builder builder()

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/EmptyTableFunctionHandle.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/EmptyTableFunctionHandle.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.ptf;
+
+public enum EmptyTableFunctionHandle
+        implements ConnectorTableFunctionHandle
+{
+    EMPTY_HANDLE
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionAnalysis.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionAnalysis.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static io.trino.spi.ptf.EmptyTableFunctionHandle.EMPTY_HANDLE;
 import static io.trino.spi.ptf.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toMap;
@@ -81,7 +82,7 @@ public final class TableFunctionAnalysis
     {
         private Descriptor returnedType;
         private final Map<String, List<Integer>> requiredColumns = new HashMap<>();
-        private ConnectorTableFunctionHandle handle = new ConnectorTableFunctionHandle() {};
+        private ConnectorTableFunctionHandle handle = EMPTY_HANDLE;
 
         private Builder() {}
 

--- a/docs/src/main/sphinx/functions/table.rst
+++ b/docs/src/main/sphinx/functions/table.rst
@@ -15,6 +15,9 @@ Polymorphic table functions allow you to dynamically invoke custom logic from
 within the SQL query. They can be used for working with external systems as
 well as for enhancing Trino with capabilities going beyond the SQL standard.
 
+For the list of built-in table functions available in Trino, see :ref:`built in
+table functions<built_in_table_functions>`.
+
 Trino supports adding custom table functions. They are declared by connectors
 through implementing dedicated interfaces. For guidance on adding new table
 functions, see the :doc:`developer guide</develop/table-functions>`.
@@ -22,6 +25,23 @@ functions, see the :doc:`developer guide</develop/table-functions>`.
 Connectors offer support for different functions on a per-connector basis. For
 more information about supported table functions, refer to the :doc:`connector
 documentation <../../connector>`.
+
+.. _built_in_table_functions:
+
+Built-in table functions
+------------------------
+
+.. function:: exclude_columns(input => table, columns => descriptor) -> table
+
+    Excludes from ``table`` all columns listed in ``descriptor``::
+
+        SELECT *
+        FROM TABLE(exclude_columns(
+                                input => TABLE(orders),
+                                columns => DESCRIPTOR(clerk, comment)))
+
+    The argument ``input`` is a table or a query.
+    The argument ``columns`` is a descriptor without types.
 
 Table function invocation
 -------------------------

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestExcludeColumnsFunction.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestExcludeColumnsFunction.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests;
+
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.Test;
+
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestExcludeColumnsFunction
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(testSessionBuilder().build()).build();
+        queryRunner.installPlugin(new TpchPlugin());
+        queryRunner.createCatalog("tpch", "tpch");
+        return queryRunner;
+    }
+
+    @Test
+    public void testExcludeColumnsFunction()
+    {
+        assertThat(query("SELECT * FROM tpch.tiny.nation")).matches("SELECT nationkey, name, regionkey, comment FROM tpch.tiny.nation");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(exclude_columns(
+                                    input => TABLE(tpch.tiny.nation),
+                                    columns => DESCRIPTOR(comment)))
+                """))
+                .matches("SELECT nationkey, name, regionkey FROM tpch.tiny.nation");
+
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(exclude_columns(
+                                    input => TABLE(tpch.tiny.nation),
+                                    columns => DESCRIPTOR(regionkey, nationkey)))
+                """))
+                .matches("SELECT name, comment FROM tpch.tiny.nation");
+    }
+
+    @Test
+    public void testInvalidArgument()
+    {
+        assertThatThrownBy(() -> query("""
+                SELECT *
+                FROM TABLE(exclude_columns(
+                                    input => TABLE(tpch.tiny.nation),
+                                    columns => CAST(null AS DESCRIPTOR)))
+                """))
+                .hasMessage("COLUMNS descriptor is null");
+
+        assertThatThrownBy(() -> query("""
+                SELECT *
+                FROM TABLE(exclude_columns(
+                                    input => TABLE(tpch.tiny.nation),
+                                    columns => DESCRIPTOR()))
+                """))
+                .hasMessage("line 4:21: Invalid descriptor argument COLUMNS. Descriptors should be formatted as 'DESCRIPTOR(name [type], ...)'");
+
+        assertThatThrownBy(() -> query("""
+                SELECT *
+                FROM TABLE(exclude_columns(
+                                    input => TABLE(tpch.tiny.nation),
+                                    columns => DESCRIPTOR(foo, comment, bar)))
+                """))
+                .hasMessage("Excluded columns: [foo, bar] not present in the table");
+
+        assertThatThrownBy(() -> query("""
+                SELECT *
+                FROM TABLE(exclude_columns(
+                                    input => TABLE(tpch.tiny.nation),
+                                    columns => DESCRIPTOR(nationkey bigint, comment)))
+                """))
+                .hasMessage("COLUMNS descriptor contains types");
+
+        assertThatThrownBy(() -> query("""
+                SELECT *
+                FROM TABLE(exclude_columns(
+                                    input => TABLE(tpch.tiny.nation),
+                                    columns => DESCRIPTOR(nationkey, name, regionkey, comment)))
+                """))
+                .hasMessage("All columns are excluded");
+    }
+
+    @Test
+    public void testColumnResolution()
+    {
+        // excluded column names are matched case-insensitive
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(exclude_columns(
+                                    input => TABLE(SELECT 1, 2, 3, 4, 5) t(a, B, "c", "D", e),
+                                    columns => DESCRIPTOR("A", "b", C, d)))
+                """))
+                .matches("SELECT 5");
+    }
+
+    @Test
+    public void testReturnedColumnNames()
+    {
+        // the function preserves the incoming column names. (However, due to how the analyzer handles identifiers, these are not the canonical names according to the SQL identifier semantics.)
+        assertThat(query("""
+                SELECT a, b, c, d
+                FROM TABLE(exclude_columns(
+                                    input => TABLE(SELECT 1, 2, 3, 4, 5) t(a, B, "c", "D", e),
+                                    columns => DESCRIPTOR(e)))
+                """))
+                .matches("SELECT 1, 2, 3, 4");
+    }
+
+    @Test
+    public void testHiddenColumn()
+    {
+        assertThat(query("SELECT row_number FROM tpch.tiny.region")).matches("SELECT * FROM UNNEST(sequence(0, 4))");
+
+        // the hidden column is not provided to the function
+        assertThatThrownBy(() -> query("""
+                SELECT row_number
+                FROM TABLE(exclude_columns(
+                                    input => TABLE(tpch.tiny.nation),
+                                    columns => DESCRIPTOR(comment)))
+                """))
+                .hasMessage("line 1:8: Column 'row_number' cannot be resolved");
+
+        assertThatThrownBy(() -> query("""
+                SELECT *
+                FROM TABLE(exclude_columns(
+                                    input => TABLE(tpch.tiny.nation),
+                                    columns => DESCRIPTOR(row_number)))
+                """))
+                .hasMessage("Excluded columns: [row_number] not present in the table");
+    }
+
+    @Test
+    public void testAnonymousColumn()
+    {
+        // cannot exclude an unnamed columns. the unnamed columns are passed on unnamed.
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(exclude_columns(
+                                    input => TABLE(SELECT 1 a, 2, 3 c, 4),
+                                    columns => DESCRIPTOR(a, c)))
+                """))
+                .matches("SELECT 2, 4");
+    }
+
+    @Test
+    public void testDuplicateExcludedColumn()
+    {
+        // duplicates in excluded column names are allowed
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(exclude_columns(
+                                    input => TABLE(tpch.tiny.nation),
+                                    columns => DESCRIPTOR(comment, name, comment)))
+                """))
+                .matches("SELECT nationkey, regionkey FROM tpch.tiny.nation");
+    }
+
+    @Test
+    public void testDuplicateInputColumn()
+    {
+        // all input columns with given name are excluded
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(exclude_columns(
+                                    input => TABLE(SELECT 1, 2, 3, 4, 5) t(a, b, c, a, b),
+                                    columns => DESCRIPTOR(a, b)))
+                """))
+                .matches("SELECT 3");
+    }
+
+    @Test
+    public void testFunctionResolution()
+    {
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(system.builtin.exclude_columns(
+                                    input => TABLE(tpch.tiny.nation),
+                                    columns => DESCRIPTOR(comment)))
+                """))
+                .matches("""
+                        SELECT *
+                        FROM TABLE(exclude_columns(
+                                            input => TABLE(tpch.tiny.nation),
+                                            columns => DESCRIPTOR(comment)))
+                        """);
+    }
+
+    @Test
+    public void testBigInput()
+    {
+        assertThat(query("""
+                SELECT *
+                FROM TABLE(exclude_columns(
+                                    input => TABLE(tpch.tiny.orders),
+                                    columns => DESCRIPTOR(orderstatus, orderdate, orderpriority, clerk, shippriority, comment)))
+                """))
+                .matches("SELECT orderkey, custkey, totalprice FROM tpch.tiny.orders");
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Adds a new table function `exclude_columns` as a built-in table function.

```
SELECT *
FROM TABLE(exclude_columns(
                        input => TABLE(orders),
                        columns => DESCRIPTOR(clerk, comment)))
```

This function is a replacement for syntax `SELECT * EXCEPT(...)`. Such syntax, in a few variants, is supported by different databases (as discussed here https://stackoverflow.com/questions/413819/select-except). However, it is not part of the SQL standard, and so Trino does not support it.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

There is a related optimization PR submitted for review: https://github.com/trinodb/trino/pull/16012. Technically, the optimization is not a prerequisite, but it could affect the performance a lot by enabling column pruning.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# General
* Add a built-in table function `exclude_columns()`.
```

```markdown
# General
* Allow table functions to return anonymous columns.
```

Docs included.