### PR TITLE
use default fpp for writing in Hive connector if not provided in table metadata

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
@@ -749,11 +749,11 @@ public final class HiveUtil
     public static OrcWriterOptions getOrcWriterOptions(Map<String, String> schema, OrcWriterOptions orcWriterOptions)
     {
         if (schema.containsKey(ORC_BLOOM_FILTER_COLUMNS_KEY)) {
-            if (!schema.containsKey(ORC_BLOOM_FILTER_FPP_KEY)) {
-                throw new TrinoException(HIVE_INVALID_METADATA, "FPP for bloom filter is missing");
-            }
             try {
-                double fpp = parseDouble(schema.get(ORC_BLOOM_FILTER_FPP_KEY));
+                // use default fpp DEFAULT_BLOOM_FILTER_FPP if fpp key does not exist in table metadata
+                double fpp = schema.containsKey(ORC_BLOOM_FILTER_FPP_KEY)
+                        ? parseDouble(schema.get(ORC_BLOOM_FILTER_FPP_KEY))
+                        : orcWriterOptions.getBloomFilterFpp();
                 return orcWriterOptions
                         .withBloomFilterColumns(ImmutableSet.copyOf(COLUMN_NAMES_SPLITTER.splitToList(schema.get(ORC_BLOOM_FILTER_COLUMNS_KEY))))
                         .withBloomFilterFpp(fpp);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcWriterOptions.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcWriterOptions.java
@@ -116,4 +116,14 @@ public class TestOrcWriterOptions
                 .put(ORC_BLOOM_FILTER_FPP_KEY, fpp)
                 .buildOrThrow();
     }
+
+    @Test
+    public void testOrcWriterOptionsWithMissingFPPValue()
+    {
+        Map<String, String> tableProperties = ImmutableMap.<String, String>builder()
+                .put(ORC_BLOOM_FILTER_COLUMNS_KEY, "column_with_bloom_filter")
+                .buildOrThrow();
+        OrcWriterOptions orcWriterOptions = getOrcWriterOptions(tableProperties, new OrcWriterOptions());
+        assertThat(orcWriterOptions.getBloomFilterFpp()).isEqualTo(0.05);
+    }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
@@ -266,11 +266,10 @@ public class IcebergFileWriterFactory
     public static OrcWriterOptions withBloomFilterOptions(OrcWriterOptions orcWriterOptions, Map<String, String> storageProperties)
     {
         if (storageProperties.containsKey(ORC_BLOOM_FILTER_COLUMNS_KEY)) {
-            if (!storageProperties.containsKey(ORC_BLOOM_FILTER_FPP_KEY)) {
-                throw new TrinoException(ICEBERG_INVALID_METADATA, "FPP for Bloom filter is missing");
-            }
             try {
-                double fpp = parseDouble(storageProperties.get(ORC_BLOOM_FILTER_FPP_KEY));
+                double fpp = storageProperties.containsKey(ORC_BLOOM_FILTER_FPP_KEY)
+                        ? parseDouble(storageProperties.get(ORC_BLOOM_FILTER_FPP_KEY))
+                        : orcWriterOptions.getBloomFilterFpp();
                 return OrcWriterOptions.builderFrom(orcWriterOptions)
                         .setBloomFilterColumns(ImmutableSet.copyOf(COLUMN_NAMES_SPLITTER.splitToList(storageProperties.get(ORC_BLOOM_FILTER_COLUMNS_KEY))))
                         .setBloomFilterFpp(fpp)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

I think that if table metadata does not have FPP value, default fpp value should be used for bloom filter for writing ORC files.
As of now, it returns error saying that `FPP for bloom filter is missing`, which is ironic as
1. Hive uses default bloom filter value (0.05%) if value is missing
2. Trino doc saids that default value of fpp is 0.05

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Hive has default bloom filter of 0.05 (5%) 
- https://github.com/apache/hive/blob/master/storage-api/src/java/org/apache/hive/common/util/BloomFilter.java#L44

Trino doc saids that default value of fpp is 0.05
- https://trino.io/docs/current/connector/hive.html#table-properties

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive Connector
* Use default FPP for bloom filters in ORC when not specified in table metadata.

# Iceberg Connector
* Use default FPP for bloom filters in ORC when not specified in table metadata
```
