### PR TITLE
Add extra_properties to hive table properties

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -64,6 +64,7 @@ import io.trino.sql.tree.DoubleLiteral;
 import io.trino.sql.tree.Explain;
 import io.trino.sql.tree.ExplainAnalyze;
 import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.FunctionCall;
 import io.trino.sql.tree.Identifier;
 import io.trino.sql.tree.LikePredicate;
 import io.trino.sql.tree.LongLiteral;
@@ -75,6 +76,7 @@ import io.trino.sql.tree.Property;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.Query;
 import io.trino.sql.tree.Relation;
+import io.trino.sql.tree.Row;
 import io.trino.sql.tree.ShowCatalogs;
 import io.trino.sql.tree.ShowColumns;
 import io.trino.sql.tree.ShowCreate;
@@ -154,6 +156,7 @@ import static io.trino.sql.tree.ShowCreate.Type.SCHEMA;
 import static io.trino.sql.tree.ShowCreate.Type.TABLE;
 import static io.trino.sql.tree.ShowCreate.Type.VIEW;
 import static java.lang.String.format;
+import static java.util.Arrays.asList;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -561,6 +564,13 @@ public final class ShowQueriesRewrite
                 return new Array(list.stream()
                         .map(Visitor::toExpression)
                         .collect(toList()));
+            }
+
+            if (value instanceof Map) {
+                Map<?, ?> map = (Map<?, ?>) value;
+                return new FunctionCall(QualifiedName.of("map_from_entries"), ImmutableList.of(new Array(map.entrySet().stream()
+                        .map(entry -> new Row(asList(toExpression(entry.getKey()), toExpression(entry.getValue()))))
+                        .collect(toImmutableList()))));
             }
 
             throw new TrinoException(INVALID_TABLE_PROPERTY, format("Failed to convert object of type %s to expression: %s", value.getClass().getName(), value));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -222,6 +222,7 @@ import static io.trino.plugin.hive.HiveTableProperties.CSV_ESCAPE;
 import static io.trino.plugin.hive.HiveTableProperties.CSV_QUOTE;
 import static io.trino.plugin.hive.HiveTableProperties.CSV_SEPARATOR;
 import static io.trino.plugin.hive.HiveTableProperties.EXTERNAL_LOCATION_PROPERTY;
+import static io.trino.plugin.hive.HiveTableProperties.EXTRA_PROPERTIES;
 import static io.trino.plugin.hive.HiveTableProperties.NULL_FORMAT_PROPERTY;
 import static io.trino.plugin.hive.HiveTableProperties.ORC_BLOOM_FILTER_COLUMNS;
 import static io.trino.plugin.hive.HiveTableProperties.ORC_BLOOM_FILTER_FPP;
@@ -238,6 +239,7 @@ import static io.trino.plugin.hive.HiveTableProperties.getAvroSchemaLiteral;
 import static io.trino.plugin.hive.HiveTableProperties.getAvroSchemaUrl;
 import static io.trino.plugin.hive.HiveTableProperties.getBucketProperty;
 import static io.trino.plugin.hive.HiveTableProperties.getExternalLocation;
+import static io.trino.plugin.hive.HiveTableProperties.getExtraProperties;
 import static io.trino.plugin.hive.HiveTableProperties.getFooterSkipCount;
 import static io.trino.plugin.hive.HiveTableProperties.getHeaderSkipCount;
 import static io.trino.plugin.hive.HiveTableProperties.getHiveStorageFormat;
@@ -374,6 +376,17 @@ public class HiveMetadata
     private static final String AUTO_PURGE_KEY = "auto.purge";
 
     public static final String MODIFYING_NON_TRANSACTIONAL_TABLE_MESSAGE = "Modifying Hive table rows is only supported for transactional tables";
+
+    private static final Set<String> TABLE_PROPERTIES_TO_SKIP = ImmutableSet.of(
+            PRESTO_VERSION_NAME,
+            PRESTO_QUERY_ID_NAME,
+            BUCKETING_VERSION,
+            "EXTERNAL",
+            "numFiles",
+            "totalSize",
+            "last_modified_time",
+            "transient_lastDdlTime",
+            "last_modified_by");
 
     private final CatalogName catalogName;
     private final SemiTransactionalHiveMetastore metastore;
@@ -655,84 +668,91 @@ public class HiveMetadata
             properties.put(SORTED_BY_PROPERTY, property.getSortedBy());
         });
 
+        TableParameterProvider tableParameterProvider = new TableParameterProvider(table);
+
         // Transactional properties
-        String transactionalProperty = table.getParameters().get(HiveMetadata.TRANSACTIONAL);
+        String transactionalProperty = tableParameterProvider.getParameter(HiveMetadata.TRANSACTIONAL);
         if (parseBoolean(transactionalProperty)) {
             properties.put(HiveTableProperties.TRANSACTIONAL, true);
         }
 
         // ORC format specific properties
-        String orcBloomFilterColumns = table.getParameters().get(ORC_BLOOM_FILTER_COLUMNS_KEY);
+        String orcBloomFilterColumns = tableParameterProvider.getParameter(ORC_BLOOM_FILTER_COLUMNS_KEY);
         if (orcBloomFilterColumns != null) {
             properties.put(ORC_BLOOM_FILTER_COLUMNS, Splitter.on(',').trimResults().omitEmptyStrings().splitToList(orcBloomFilterColumns));
         }
-        String orcBloomFilterFfp = table.getParameters().get(ORC_BLOOM_FILTER_FPP_KEY);
+        String orcBloomFilterFfp = tableParameterProvider.getParameter(ORC_BLOOM_FILTER_FPP_KEY);
         if (orcBloomFilterFfp != null) {
             properties.put(ORC_BLOOM_FILTER_FPP, Double.parseDouble(orcBloomFilterFfp));
         }
 
         // Avro specific property
-        String avroSchemaUrl = table.getParameters().get(AVRO_SCHEMA_URL_KEY);
+        String avroSchemaUrl = tableParameterProvider.getParameter(AVRO_SCHEMA_URL_KEY);
         if (avroSchemaUrl != null) {
             properties.put(AVRO_SCHEMA_URL, avroSchemaUrl);
         }
-        String avroSchemaLiteral = table.getParameters().get(AVRO_SCHEMA_LITERAL_KEY);
+        String avroSchemaLiteral = tableParameterProvider.getParameter(AVRO_SCHEMA_LITERAL_KEY);
         if (avroSchemaLiteral != null) {
             properties.put(AVRO_SCHEMA_LITERAL, avroSchemaLiteral);
         }
 
         // Textfile and CSV specific properties
-        getSerdeProperty(table, SKIP_HEADER_COUNT_KEY)
+        getSerdeProperty(tableParameterProvider, SKIP_HEADER_COUNT_KEY)
                 .ifPresent(skipHeaderCount -> properties.put(SKIP_HEADER_LINE_COUNT, Integer.valueOf(skipHeaderCount)));
-        getSerdeProperty(table, SKIP_FOOTER_COUNT_KEY)
+        getSerdeProperty(tableParameterProvider, SKIP_FOOTER_COUNT_KEY)
                 .ifPresent(skipFooterCount -> properties.put(SKIP_FOOTER_LINE_COUNT, Integer.valueOf(skipFooterCount)));
 
         // Multi-format property
-        getSerdeProperty(table, NULL_FORMAT_KEY)
+        getSerdeProperty(tableParameterProvider, NULL_FORMAT_KEY)
                 .ifPresent(nullFormat -> properties.put(NULL_FORMAT_PROPERTY, nullFormat));
 
         // Textfile specific properties
-        getSerdeProperty(table, TEXT_FIELD_SEPARATOR_KEY)
+        getSerdeProperty(tableParameterProvider, TEXT_FIELD_SEPARATOR_KEY)
                 .ifPresent(fieldSeparator -> properties.put(TEXTFILE_FIELD_SEPARATOR, fieldSeparator));
-        getSerdeProperty(table, TEXT_FIELD_SEPARATOR_ESCAPE_KEY)
+        getSerdeProperty(tableParameterProvider, TEXT_FIELD_SEPARATOR_ESCAPE_KEY)
                 .ifPresent(fieldEscape -> properties.put(TEXTFILE_FIELD_SEPARATOR_ESCAPE, fieldEscape));
 
         // CSV specific properties
-        getCsvSerdeProperty(table, CSV_SEPARATOR_KEY)
+        getCsvSerdeProperty(tableParameterProvider, CSV_SEPARATOR_KEY)
                 .ifPresent(csvSeparator -> properties.put(CSV_SEPARATOR, csvSeparator));
-        getCsvSerdeProperty(table, CSV_QUOTE_KEY)
+        getCsvSerdeProperty(tableParameterProvider, CSV_QUOTE_KEY)
                 .ifPresent(csvQuote -> properties.put(CSV_QUOTE, csvQuote));
-        getCsvSerdeProperty(table, CSV_ESCAPE_KEY)
+        getCsvSerdeProperty(tableParameterProvider, CSV_ESCAPE_KEY)
                 .ifPresent(csvEscape -> properties.put(CSV_ESCAPE, csvEscape));
 
         // REGEX specific properties
-        getSerdeProperty(table, REGEX_KEY)
+        getSerdeProperty(tableParameterProvider, REGEX_KEY)
                 .ifPresent(regex -> properties.put(REGEX_PATTERN, regex));
-        getSerdeProperty(table, REGEX_CASE_SENSITIVE_KEY)
+        getSerdeProperty(tableParameterProvider, REGEX_CASE_SENSITIVE_KEY)
                 .ifPresent(regexCaseInsensitive -> properties.put(REGEX_CASE_INSENSITIVE, parseBoolean(regexCaseInsensitive)));
 
-        Optional<String> comment = Optional.ofNullable(table.getParameters().get(TABLE_COMMENT));
+        Optional<String> comment = Optional.ofNullable(tableParameterProvider.getParameter(TABLE_COMMENT));
 
-        String autoPurgeProperty = table.getParameters().get(AUTO_PURGE_KEY);
+        String autoPurgeProperty = tableParameterProvider.getParameter(AUTO_PURGE_KEY);
         if (parseBoolean(autoPurgeProperty)) {
             properties.put(AUTO_PURGE, true);
         }
 
         // Partition Projection specific properties
-        properties.putAll(partitionProjectionService.getPartitionProjectionTrinoTableProperties(table));
+        properties.putAll(partitionProjectionService.getPartitionProjectionTrinoTableProperties(tableParameterProvider));
+
+        Map<String, String> remainingProperties = tableParameterProvider.getUnconsumedProperty();
+        if (!remainingProperties.isEmpty()) {
+            properties.put(EXTRA_PROPERTIES, remainingProperties);
+        }
 
         return new ConnectorTableMetadata(tableName, columns.build(), properties.buildOrThrow(), comment);
     }
 
-    private static Optional<String> getCsvSerdeProperty(Table table, String key)
+    private static Optional<String> getCsvSerdeProperty(TableParameterProvider tableParameterProvider, String key)
     {
-        return getSerdeProperty(table, key).map(csvSerdeProperty -> csvSerdeProperty.substring(0, 1));
+        return getSerdeProperty(tableParameterProvider, key).map(csvSerdeProperty -> csvSerdeProperty.substring(0, 1));
     }
 
-    private static Optional<String> getSerdeProperty(Table table, String key)
+    private static Optional<String> getSerdeProperty(TableParameterProvider tableParameterProvider, String key)
     {
-        String serdePropertyValue = table.getStorage().getSerdeParameters().get(key);
-        String tablePropertyValue = table.getParameters().get(key);
+        String serdePropertyValue = tableParameterProvider.getTable().getStorage().getSerdeParameters().get(key);
+        String tablePropertyValue = tableParameterProvider.getParameter(key);
         if (serdePropertyValue != null && tablePropertyValue != null && !tablePropertyValue.equals(serdePropertyValue)) {
             // in Hive one can set conflicting values for the same property, in such case it looks like table properties are used
             throw new TrinoException(
@@ -1156,6 +1176,14 @@ public class HiveMetadata
         // external table over large data set.
         tableProperties.put("numFiles", "-1");
         tableProperties.put("totalSize", "-1");
+
+        // Extra properties
+        Map<String, String> extraProperties = getExtraProperties(tableMetadata.getProperties());
+        if (extraProperties != null) {
+            for (Map.Entry<String, String> extraProperty : extraProperties.entrySet()) {
+                tableProperties.put(extraProperty.getKey(), extraProperty.getValue());
+            }
+        }
 
         // Table comment property
         tableMetadata.getComment().ifPresent(value -> tableProperties.put(TABLE_COMMENT, value));
@@ -3845,5 +3873,34 @@ public class HiveMetadata
     public boolean supportsReportingWrittenBytes(ConnectorSession session, SchemaTableName schemaTableName, Map<String, Object> tableProperties)
     {
         return true;
+    }
+
+    public static class TableParameterProvider
+    {
+        private final Table table;
+        private final Set<String> consumedParameters = new HashSet<>(TABLE_PROPERTIES_TO_SKIP);
+
+        public TableParameterProvider(Table table)
+        {
+            this.table = requireNonNull(table, "table is null");
+        }
+
+        public String getParameter(String key)
+        {
+            consumedParameters.add(key);
+            return table.getParameters().get(key);
+        }
+
+        public Table getTable()
+        {
+            return table;
+        }
+
+        public Map<String, String> getUnconsumedProperty()
+        {
+            return table.getParameters().entrySet().stream()
+                    .filter(entry -> !consumedParameters.contains(entry.getKey()))
+                    .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -3746,7 +3746,7 @@ public class HiveMetadata
         }
         // we need to chop off any "$partitions" and similar suffixes from table name while querying the metastore for the Table object
         TableNameSplitResult tableNameSplit = splitTableName(tableName.getTableName());
-        Optional<Table> table = metastore.getTable(tableName.getSchemaName(), tableNameSplit.getBaseTableName());
+        Optional<Table> table = metastore.getTable(tableName.getSchemaName(), tableNameSplit.baseTableName());
         if (table.isEmpty() || VIRTUAL_VIEW.name().equals(table.get().getTableType())) {
             return Optional.empty();
         }
@@ -3760,7 +3760,7 @@ public class HiveMetadata
                 name.getCatalogName(),
                 new SchemaTableName(
                         name.getSchemaTableName().getSchemaName(),
-                        name.getSchemaTableName().getTableName() + tableNameSplit.getSuffix().orElse(""))));
+                        name.getSchemaTableName().getTableName() + tableNameSplit.suffix().orElse(""))));
     }
 
     private Optional<CatalogSchemaTableName> redirectTableToIceberg(ConnectorSession session, Table table)
@@ -3807,25 +3807,12 @@ public class HiveMetadata
                 new TableNameSplitResult(tableName.substring(0, metadataMarkerIndex), Optional.of(tableName.substring(metadataMarkerIndex)));
     }
 
-    private static class TableNameSplitResult
+    private record TableNameSplitResult(String baseTableName, Optional<String> suffix)
     {
-        private final String baseTableName;
-        private final Optional<String> suffix;
-
-        public TableNameSplitResult(String baseTableName, Optional<String> suffix)
+        private TableNameSplitResult
         {
-            this.baseTableName = requireNonNull(baseTableName, "baseTableName is null");
-            this.suffix = requireNonNull(suffix, "suffix is null");
-        }
-
-        public String getBaseTableName()
-        {
-            return baseTableName;
-        }
-
-        public Optional<String> getSuffix()
-        {
-            return suffix;
+            requireNonNull(baseTableName, "baseTableName is null");
+            requireNonNull(suffix, "suffix is null");
         }
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableProperties.java
@@ -21,6 +21,8 @@ import io.trino.plugin.hive.util.HiveUtil;
 import io.trino.spi.TrinoException;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.TypeManager;
 
 import javax.inject.Inject;
 
@@ -69,13 +71,15 @@ public class HiveTableProperties
     public static final String REGEX_CASE_INSENSITIVE = "regex_case_insensitive";
     public static final String TRANSACTIONAL = "transactional";
     public static final String AUTO_PURGE = "auto_purge";
+    public static final String EXTRA_PROPERTIES = "extra_properties";
 
     private final List<PropertyMetadata<?>> tableProperties;
 
     @Inject
     public HiveTableProperties(
             HiveConfig config,
-            OrcWriterConfig orcWriterConfig)
+            OrcWriterConfig orcWriterConfig,
+            TypeManager typeManager)
     {
         tableProperties = ImmutableList.of(
                 stringProperty(
@@ -173,7 +177,16 @@ public class HiveTableProperties
                         PARTITION_PROJECTION_LOCATION_TEMPLATE,
                         "Partition projection location template",
                         null,
-                        false));
+                        false),
+                new PropertyMetadata<>(
+                        EXTRA_PROPERTIES,
+                        "Extra table properties",
+                        new MapType(VARCHAR, VARCHAR, typeManager.getTypeOperators()),
+                        Map.class,
+                        null,
+                        false,
+                        value -> ((Map<String, String>) value),
+                        value -> value));
     }
 
     public List<PropertyMetadata<?>> getTableProperties()
@@ -310,5 +323,14 @@ public class HiveTableProperties
     public static Optional<Boolean> isAutoPurge(Map<String, Object> tableProperties)
     {
         return Optional.ofNullable((Boolean) tableProperties.get(AUTO_PURGE));
+    }
+
+    public static Map<String, String> getExtraProperties(Map<String, Object> tableProperties)
+    {
+        Map<String, String> extraProperties = (Map<String, String>) tableProperties.get(EXTRA_PROPERTIES);
+        if (extraProperties != null && extraProperties.containsValue(null)) {
+            throw new TrinoException(INVALID_TABLE_PROPERTY, format("Extra table property value cannot be null '%s'", extraProperties));
+        }
+        return extraProperties;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/aws/athena/PartitionProjectionService.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/aws/athena/PartitionProjectionService.java
@@ -18,6 +18,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.plugin.hive.HiveConfig;
+import io.trino.plugin.hive.HiveMetadata;
 import io.trino.plugin.hive.aws.athena.projection.Projection;
 import io.trino.plugin.hive.aws.athena.projection.ProjectionFactory;
 import io.trino.plugin.hive.aws.athena.projection.ProjectionType;
@@ -90,13 +91,12 @@ public final class PartitionProjectionService
         this.projectionFactories = ImmutableMap.copyOf(requireNonNull(projectionFactories, "projectionFactories is null"));
     }
 
-    public Map<String, Object> getPartitionProjectionTrinoTableProperties(Table table)
+    public Map<String, Object> getPartitionProjectionTrinoTableProperties(HiveMetadata.TableParameterProvider tableParameterProvider)
     {
-        Map<String, String> metastoreTableProperties = table.getParameters();
         ImmutableMap.Builder<String, Object> trinoTablePropertiesBuilder = ImmutableMap.builder();
-        rewriteProperty(metastoreTableProperties, trinoTablePropertiesBuilder, METASTORE_PROPERTY_PROJECTION_IGNORE, PARTITION_PROJECTION_IGNORE, Boolean::valueOf);
-        rewriteProperty(metastoreTableProperties, trinoTablePropertiesBuilder, METASTORE_PROPERTY_PROJECTION_ENABLED, PARTITION_PROJECTION_ENABLED, Boolean::valueOf);
-        rewriteProperty(metastoreTableProperties, trinoTablePropertiesBuilder, METASTORE_PROPERTY_PROJECTION_LOCATION_TEMPLATE, PARTITION_PROJECTION_LOCATION_TEMPLATE, String::valueOf);
+        rewriteProperty(tableParameterProvider::getParameter, trinoTablePropertiesBuilder, METASTORE_PROPERTY_PROJECTION_IGNORE, PARTITION_PROJECTION_IGNORE, Boolean::valueOf);
+        rewriteProperty(tableParameterProvider::getParameter, trinoTablePropertiesBuilder, METASTORE_PROPERTY_PROJECTION_ENABLED, PARTITION_PROJECTION_ENABLED, Boolean::valueOf);
+        rewriteProperty(tableParameterProvider::getParameter, trinoTablePropertiesBuilder, METASTORE_PROPERTY_PROJECTION_LOCATION_TEMPLATE, PARTITION_PROJECTION_LOCATION_TEMPLATE, String::valueOf);
         return trinoTablePropertiesBuilder.buildOrThrow();
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/aws/athena/PartitionProjectionService.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/aws/athena/PartitionProjectionService.java
@@ -100,12 +100,6 @@ public final class PartitionProjectionService
         return trinoTablePropertiesBuilder.buildOrThrow();
     }
 
-    public Map<String, Object> getPartitionProjectionTrinoColumnProperties(Table table, String columnName)
-    {
-        Map<String, String> metastoreTableProperties = table.getParameters();
-        return rewriteColumnProjectionProperties(metastoreTableProperties, columnName);
-    }
-
     public Map<String, String> getPartitionProjectionHiveTableProperties(ConnectorTableMetadata tableMetadata)
     {
         // If partition projection is globally disabled we don't allow defining its properties
@@ -363,7 +357,17 @@ public final class PartitionProjectionService
             String targetPropertyKey,
             Function<I, V> valueMapper)
     {
-        Optional.ofNullable(sourceProperties.get(sourcePropertyKey))
+        rewriteProperty(sourceProperties::get, targetPropertiesBuilder, sourcePropertyKey, targetPropertyKey, valueMapper);
+    }
+
+    private <I, V> void rewriteProperty(
+            Function<String, I> sourcePropertyProvider,
+            ImmutableMap.Builder<String, V> targetPropertiesBuilder,
+            String sourcePropertyKey,
+            String targetPropertyKey,
+            Function<I, V> valueMapper)
+    {
+        Optional.ofNullable(sourcePropertyProvider.apply(sourcePropertyKey))
                 .ifPresent(value -> targetPropertiesBuilder.put(targetPropertyKey, valueMapper.apply(value)));
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorSmokeTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorSmokeTest.java
@@ -86,14 +86,15 @@ public class TestHiveConnectorSmokeTest
     public void testShowCreateTable()
     {
         assertThat((String) computeScalar("SHOW CREATE TABLE region"))
-                .isEqualTo("" +
-                        "CREATE TABLE hive.tpch.region (\n" +
-                        "   regionkey bigint,\n" +
-                        "   name varchar(25),\n" +
-                        "   comment varchar(152)\n" +
-                        ")\n" +
-                        "WITH (\n" +
-                        "   format = 'ORC'\n" +
-                        ")");
+                .matches("""
+                                CREATE TABLE hive\\.tpch\\.region \\(
+                                   regionkey bigint,
+                                   name varchar\\(25\\),
+                                   comment varchar\\(152\\)
+                                \\)
+                                WITH \\(
+                                   extra_properties = map_from_entries\\(ARRAY.*\\),
+                                   format = 'ORC'
+                                \\)""");
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveSparkCompatibility.java
@@ -15,6 +15,7 @@ package io.trino.tests.product.hive;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.tempto.ProductTest;
+import org.assertj.core.api.Assertions;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -161,31 +162,30 @@ public class TestHiveSparkCompatibility
         onTrino().executeQuery("SET SESSION hive.timestamp_precision = 'NANOSECONDS'");
         assertThat(onTrino().executeQuery("SELECT * FROM " + trinoTableName)).containsOnly(expected);
 
-        assertThat(onTrino().executeQuery("SHOW CREATE TABLE " + trinoTableName))
-                .containsOnly(row(format(
-                        "CREATE TABLE %s (\n" +
-                                "   a_boolean boolean,\n" +
-                                "   a_tinyint tinyint,\n" +
-                                "   a_smallint smallint,\n" +
-                                "   an_integer integer,\n" +
-                                "   a_bigint bigint,\n" +
-                                "   a_real real,\n" +
-                                "   a_double double,\n" +
-                                "   a_short_decimal decimal(11, 4),\n" +
-                                "   a_long_decimal decimal(26, 7),\n" +
-                                "   a_string varchar,\n" +
-                                "   a_date date,\n" +
-                                "   a_timestamp_seconds timestamp(9),\n" +
-                                "   a_timestamp_millis timestamp(9),\n" +
-                                "   a_timestamp_micros timestamp(9),\n" +
-                                "   a_timestamp_nanos timestamp(9),\n" +
-                                "   a_dummy varchar\n" +
-                                ")\n" +
-                                "WITH (\n" +
-                                "   format = '%s'\n" +
-                                ")",
-                        trinoTableName,
-                        expectedTrinoTableFormat)));
+        Assertions.assertThat((String) onTrino().executeQuery("SHOW CREATE TABLE " + trinoTableName).getOnlyValue())
+                .matches("""
+                                   CREATE TABLE %s\\.default\\.%s \\(
+                                      a_boolean boolean,
+                                      a_tinyint tinyint,
+                                      a_smallint smallint,
+                                      an_integer integer,
+                                      a_bigint bigint,
+                                      a_real real,
+                                      a_double double,
+                                      a_short_decimal decimal\\(11, 4\\),
+                                      a_long_decimal decimal\\(26, 7\\),
+                                      a_string varchar,
+                                      a_date date,
+                                      a_timestamp_seconds timestamp\\(9\\),
+                                      a_timestamp_millis timestamp\\(9\\),
+                                      a_timestamp_micros timestamp\\(9\\),
+                                      a_timestamp_nanos timestamp\\(9\\),
+                                      a_dummy varchar
+                                   \\)
+                                   WITH \\(
+                                      extra_properties = map_from_entries\\(ARRAY.*\\),
+                                      format = 'ORC'
+                                   \\)""".formatted(TRINO_CATALOG, sparkTableName));
 
         onSpark().executeQuery("DROP TABLE " + sparkTableName);
     }
@@ -627,20 +627,19 @@ public class TestHiveSparkCompatibility
         assertThat(onTrino().executeQuery("SELECT a_string, a_bigint, an_integer, a_real, a_double, a_boolean FROM " + trinoTableName))
                 .containsOnly(expected);
 
-        assertThat(onTrino().executeQuery("SHOW CREATE TABLE " + trinoTableName))
-                .containsOnly(row(format(
-                        "CREATE TABLE %s (\n" +
-                                "   a_string varchar,\n" +
-                                "   a_bigint bigint,\n" +
-                                "   an_integer integer,\n" +
-                                "   a_real real,\n" +
-                                "   a_double double,\n" +
-                                "   a_boolean boolean\n" +
-                                ")\n" +
-                                "WITH (\n" +
-                                "   format = 'ORC'\n" +
-                                ")",
-                        trinoTableName)));
+        Assertions.assertThat((String) onTrino().executeQuery("SHOW CREATE TABLE " + trinoTableName).getOnlyValue())
+                .matches("""
+                                   CREATE TABLE %s\\.default\\.%s \\(
+                                      a_string varchar,
+                                      a_bigint bigint,
+                                      an_integer integer,
+                                      a_double double,
+                                      a_boolean boolean
+                                   \\)
+                                   WITH \\(
+                                      extra_properties = map_from_entries\\(ARRAY.*\\),
+                                      format = 'ORC'
+                                   \\)""".formatted(TRINO_CATALOG, sparkTableName));
 
         assertQueryFailure(() -> onTrino().executeQuery("SELECT a_string, a_bigint, an_integer, a_real, a_double, a_boolean, \"$bucket\" FROM " + trinoTableName))
                 .hasMessageContaining("Column '$bucket' cannot be resolved");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR allows us to pass through additional properties to Hive when creating table in Trino. 
The additional properties can provided in the following format 
```
extra_properties = map_from_entries(ARRAY[ROW('extra.property.one', 'one'),ROW('extra.property.two', 'two')]
```


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/954
Extension of https://github.com/trinodb/trino/pull/9475


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Introduce `extra_properties` for adding arbitrary properties to hive table. ({issue}`954`)
```

Will be doing a self review before making it ready for review. 