### PR TITLE
Avoid deserialization when no columns are needed

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/GenericHiveRecordCursor.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/GenericHiveRecordCursor.java
@@ -217,11 +217,14 @@ public class GenericHiveRecordCursor<K, V extends Writable>
                 return false;
             }
 
-            // reset loaded flags
-            Arrays.fill(loaded, false);
+            // Only deserialize the value if atleast one column is required
+            if (types.length > 0) {
+                // reset loaded flags
+                Arrays.fill(loaded, false);
 
-            // decode value
-            rowData = deserializer.deserialize(value);
+                // decode value
+                rowData = deserializer.deserialize(value);
+            }
 
             return true;
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Even when no columns are accessed for a scan, GenericHiveRecordCursor pays the cost of deserializing the record - which is never used to get values out. This change avoids that deserialization and improves performance for count(const) or count(*) queries on formats that use GenericHiveRecordCursor. 

Practically observed ~3x-4x improvement in CPU consumption for some queries. 

We still need to fetch the data as long as we're dependent on RecordReader API since it doesn't provide a way to get counts.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Test exists in `BaseHiveConnectorTest#testReadNoColumns`


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Hive
* Improve scan performance for count(*) queries on row-oriented formats. ({issue}`16595`)
```
