### PR TITLE
Fix hashing in BlackHoleNodePartitioningProvider

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/output/PagePartitioner.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PagePartitioner.java
@@ -259,6 +259,7 @@ public class PagePartitioner
         return partitionPositions;
     }
 
+    @SuppressWarnings("NumericCastThatLosesPrecision")
     private static int initialPartitionSize(int averagePositionsPerPartition)
     {
         // 1.1 coefficient compensates for the not perfect hash distribution.
@@ -354,7 +355,7 @@ public class PagePartitioner
         }
     }
 
-    private IntArrayList[] partitionNullablePositions(Page page, int position, IntArrayList[] partitionPositions, IntUnaryOperator partitionFunction)
+    private void partitionNullablePositions(Page page, int position, IntArrayList[] partitionPositions, IntUnaryOperator partitionFunction)
     {
         Block nullsBlock = page.getBlock(nullChannel);
         int[] nullPositions = new int[page.getPositionCount()];
@@ -376,10 +377,9 @@ public class PagePartitioner
             int partition = partitionFunction.applyAsInt(nonNullPosition);
             partitionPositions[partition].add(nonNullPosition);
         }
-        return partitionPositions;
     }
 
-    private IntArrayList[] partitionNotNullPositions(Page page, int startingPosition, IntArrayList[] partitionPositions, IntUnaryOperator partitionFunction)
+    private void partitionNotNullPositions(Page page, int startingPosition, IntArrayList[] partitionPositions, IntUnaryOperator partitionFunction)
     {
         int positionCount = page.getPositionCount();
         int[] partitionPerPosition = new int[positionCount];
@@ -391,8 +391,6 @@ public class PagePartitioner
         for (int position = startingPosition; position < positionCount; position++) {
             partitionPositions[partitionPerPosition[position]].add(position);
         }
-
-        return partitionPositions;
     }
 
     private Page getPartitionFunctionArguments(Page page)

--- a/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleNodePartitioningProvider.java
+++ b/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleNodePartitioningProvider.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.blackhole;
 
+import io.trino.spi.block.Block;
 import io.trino.spi.connector.BucketFunction;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
 import io.trino.spi.connector.ConnectorPartitioningHandle;
@@ -29,6 +30,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
+import static io.trino.spi.type.TypeUtils.NULL_HASH_CODE;
 
 public class BlackHoleNodePartitioningProvider
         implements ConnectorNodePartitioningProvider
@@ -55,8 +57,16 @@ public class BlackHoleNodePartitioningProvider
         return (page, position) -> {
             long hash = 13;
             for (int i = 0; i < partitionChannelTypes.size(); i++) {
+                Block block = page.getBlock(i);
                 try {
-                    hash = 31 * hash + (long) hashCodeInvokers.get(i).invokeExact(page.getBlock(i), 0);
+                    long valueHash;
+                    if (block.isNull(position)) {
+                        valueHash = NULL_HASH_CODE;
+                    }
+                    else {
+                        valueHash = (long) hashCodeInvokers.get(i).invokeExact(block, position);
+                    }
+                    hash = 31 * hash + valueHash;
                 }
                 catch (Throwable throwable) {
                     throwIfUnchecked(throwable);


### PR DESCRIPTION
It ignored `position` and didn't check for null, so could fail.

Even if this doesn't matter for blackhole connector, the code could be used as inspiration for other bucketing function implementations.
