### PR TITLE
Support DML operations on Delta Lake tables with `id` column mapping

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeCdfPageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeCdfPageSink.java
@@ -42,7 +42,8 @@ public class DeltaLakeCdfPageSink
             Location outputPath,
             ConnectorSession session,
             DeltaLakeWriterStats stats,
-            String trinoVersion)
+            String trinoVersion,
+            DeltaLakeParquetSchemaMapping parquetSchemaMapping)
     {
         super(
                 typeOperators,
@@ -56,7 +57,8 @@ public class DeltaLakeCdfPageSink
                 outputPath,
                 session,
                 stats,
-                trinoVersion);
+                trinoVersion,
+                parquetSchemaMapping);
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -1434,9 +1434,11 @@ public class DeltaLakeMetadata
             // it is not obvious why we need to persist this readVersion
             transactionLogWriter.appendCommitInfoEntry(getCommitInfoEntry(session, commitVersion, createdTime, INSERT_OPERATION, handle.getReadVersion()));
 
-            List<String> partitionColumns = getColumnMappingMode(handle.getMetadataEntry()) == ColumnMappingMode.NAME
-                    ? getPartitionColumnsForNameMapping(handle.getMetadataEntry().getOriginalPartitionColumns(), handle.getInputColumns())
-                    : handle.getMetadataEntry().getOriginalPartitionColumns();
+            ColumnMappingMode columnMappingMode = getColumnMappingMode(handle.getMetadataEntry());
+            List<String> partitionColumns = getPartitionColumns(
+                    handle.getMetadataEntry().getOriginalPartitionColumns(),
+                    handle.getInputColumns(),
+                    columnMappingMode);
             appendAddFileEntries(transactionLogWriter, dataFileInfos, partitionColumns, true);
 
             transactionLogWriter.flush();
@@ -1470,7 +1472,16 @@ public class DeltaLakeMetadata
         return Optional.empty();
     }
 
-    private static List<String> getPartitionColumnsForNameMapping(List<String> originalPartitionColumns, List<DeltaLakeColumnHandle> dataColumns)
+    private static List<String> getPartitionColumns(List<String> originalPartitionColumns, List<DeltaLakeColumnHandle> dataColumns, ColumnMappingMode columnMappingMode)
+    {
+        return switch (columnMappingMode) {
+            case NAME, ID -> getPartitionColumnsForNameOrIdMapping(originalPartitionColumns, dataColumns);
+            case NONE -> originalPartitionColumns;
+            case UNKNOWN -> throw new TrinoException(NOT_SUPPORTED, "Unsupported column mapping mode");
+        };
+    }
+
+    private static List<String> getPartitionColumnsForNameOrIdMapping(List<String> originalPartitionColumns, List<DeltaLakeColumnHandle> dataColumns)
     {
         Map<String, DeltaLakeColumnHandle> nameToDataColumns = dataColumns.stream()
                 .collect(toImmutableMap(DeltaLakeColumnHandle::getColumnName, Function.identity()));
@@ -1600,9 +1611,11 @@ public class DeltaLakeMetadata
                 transactionLogWriter.appendRemoveFileEntry(new RemoveFileEntry(file, writeTimestamp, true));
             }
 
-            List<String> partitionColumns = getColumnMappingMode(handle.getMetadataEntry()) == ColumnMappingMode.NAME
-                    ? getPartitionColumnsForNameMapping(handle.getMetadataEntry().getOriginalPartitionColumns(), mergeHandle.getInsertTableHandle().getInputColumns())
-                    : handle.getMetadataEntry().getOriginalPartitionColumns();
+            ColumnMappingMode columnMappingMode = getColumnMappingMode(handle.getMetadataEntry());
+            List<String> partitionColumns = getPartitionColumns(
+                    handle.getMetadataEntry().getOriginalPartitionColumns(),
+                    mergeHandle.getInsertTableHandle().getInputColumns(),
+                    columnMappingMode);
             appendAddFileEntries(transactionLogWriter, newFiles, partitionColumns, true);
 
             transactionLogWriter.flush();
@@ -1841,7 +1854,7 @@ public class DeltaLakeMetadata
         checkSupportedWriterVersion(session, handle);
         checkUnsupportedGeneratedColumns(handle.getMetadataEntry());
         ColumnMappingMode columnMappingMode = getColumnMappingMode(handle.getMetadataEntry());
-        if (!(columnMappingMode == NONE || columnMappingMode == ColumnMappingMode.NAME)) {
+        if (!(columnMappingMode == NONE || columnMappingMode == ColumnMappingMode.NAME || columnMappingMode == ColumnMappingMode.ID)) {
             throw new TrinoException(NOT_SUPPORTED, "Writing with column mapping %s is not supported".formatted(columnMappingMode.name().toLowerCase(ENGLISH)));
         }
         // TODO: Check writer-features

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
@@ -38,7 +38,8 @@ public class DeltaLakePageSink
             Location tableLocation,
             ConnectorSession session,
             DeltaLakeWriterStats stats,
-            String trinoVersion)
+            String trinoVersion,
+            DeltaLakeParquetSchemaMapping parquetSchemaMapping)
     {
         super(
                 typeOperators,
@@ -52,7 +53,8 @@ public class DeltaLakePageSink
                 tableLocation,
                 session,
                 stats,
-                trinoVersion);
+                trinoVersion,
+                parquetSchemaMapping);
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeParquetSchemaMapping.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeParquetSchemaMapping.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.type.Type;
+import org.apache.parquet.schema.MessageType;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public record DeltaLakeParquetSchemaMapping(MessageType messageType, Map<List<String>, Type> primitiveTypes)
+{
+    public DeltaLakeParquetSchemaMapping
+    {
+        requireNonNull(messageType, "messageType is null");
+        primitiveTypes = ImmutableMap.copyOf(requireNonNull(primitiveTypes, "primitiveTypes is null"));
+    }
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeParquetSchemas.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeParquetSchemas.java
@@ -1,0 +1,401 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.json.ObjectMapperProvider;
+import io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport;
+import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
+import io.trino.spi.Location;
+import io.trino.spi.TrinoException;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.StandardTypes;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.TypeNotFoundException;
+import io.trino.spi.type.TypeSignature;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.Streams.stream;
+import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_INVALID_SCHEMA;
+import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.getColumnMappingMode;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.Decimals.MAX_PRECISION;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.decimalType;
+import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
+import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+
+/**
+ * Delta Lake specific utility which converts the Delta table schema to
+ * a Parquet schema.
+ * This utility is used instead of Hive's
+ * {@link io.trino.parquet.writer.ParquetSchemaConverter}
+ * in order to be able to include the field IDs in the Parquet schema.
+ */
+public final class DeltaLakeParquetSchemas
+{
+    // Map precision to the number bytes needed for binary conversion.
+    // Based on org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe
+    private static final int[] PRECISION_TO_BYTE_COUNT = new int[MAX_PRECISION + 1];
+
+    static {
+        for (int precision = 1; precision <= MAX_PRECISION; precision++) {
+            // Estimated number of bytes needed.
+            PRECISION_TO_BYTE_COUNT[precision] = (int) Math.ceil((Math.log(Math.pow(10, precision) - 1) / Math.log(2) + 1) / 8);
+        }
+    }
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapperProvider().get();
+
+    private DeltaLakeParquetSchemas() {}
+
+    public static DeltaLakeParquetSchemaMapping createParquetSchemaMapping(MetadataEntry metadataEntry, TypeManager typeManager)
+    {
+        return createParquetSchemaMapping(metadataEntry, typeManager, false);
+    }
+
+    public static DeltaLakeParquetSchemaMapping createParquetSchemaMapping(MetadataEntry metadataEntry, TypeManager typeManager, boolean addChangeDataFeedFields)
+    {
+        DeltaLakeSchemaSupport.ColumnMappingMode columnMappingMode = getColumnMappingMode(metadataEntry);
+        return createParquetSchemaMapping(
+                metadataEntry.getSchemaString(),
+                typeManager,
+                columnMappingMode,
+                metadataEntry.getOriginalPartitionColumns(),
+                addChangeDataFeedFields);
+    }
+
+    public static DeltaLakeParquetSchemaMapping createParquetSchemaMapping(
+            String jsonSchema,
+            TypeManager typeManager,
+            DeltaLakeSchemaSupport.ColumnMappingMode columnMappingMode,
+            List<String> partitionColumnNames)
+    {
+        return createParquetSchemaMapping(jsonSchema, typeManager, columnMappingMode, partitionColumnNames, false);
+    }
+
+    private static DeltaLakeParquetSchemaMapping createParquetSchemaMapping(
+            String jsonSchema,
+            TypeManager typeManager,
+            DeltaLakeSchemaSupport.ColumnMappingMode columnMappingMode,
+            List<String> partitionColumnNames,
+            boolean addChangeDataFeedFields)
+    {
+        requireNonNull(typeManager, "typeManager is null");
+        requireNonNull(columnMappingMode, "columnMappingMode is null");
+        requireNonNull(partitionColumnNames, "partitionColumnNames is null");
+        Types.MessageTypeBuilder builder = Types.buildMessage();
+        ImmutableMap.Builder<List<String>, Type> primitiveTypesBuilder = ImmutableMap.builder();
+        try {
+            stream(OBJECT_MAPPER.readTree(jsonSchema).get("fields").elements())
+                    .filter(fieldNode -> !partitionColumnNames.contains(fieldNode.get("name").asText()))
+                    .map(fieldNode -> buildType(fieldNode, typeManager, columnMappingMode, ImmutableList.of(), primitiveTypesBuilder))
+                    .forEach(builder::addField);
+        }
+        catch (JsonProcessingException e) {
+            throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, getLocation(e), "Failed to parse serialized schema: " + jsonSchema, e);
+        }
+        if (addChangeDataFeedFields) {
+            builder.addField(buildPrimitiveType("string", typeManager, OPTIONAL, DeltaLakeCdfPageSink.CHANGE_TYPE_COLUMN_NAME, OptionalInt.empty(), ImmutableList.of(), primitiveTypesBuilder));
+        }
+
+        return new DeltaLakeParquetSchemaMapping(builder.named("trino_schema"), primitiveTypesBuilder.buildOrThrow());
+    }
+
+    private static org.apache.parquet.schema.Type buildType(
+            JsonNode fieldNode,
+            TypeManager typeManager,
+            DeltaLakeSchemaSupport.ColumnMappingMode columnMappingMode,
+            List<String> parent,
+            ImmutableMap.Builder<List<String>, Type> primitiveTypesBuilder)
+    {
+        JsonNode typeNode = fieldNode.get("type");
+        OptionalInt fieldId = OptionalInt.empty();
+        String physicalName;
+
+        switch (columnMappingMode) {
+            case ID -> {
+                String columnMappingId = fieldNode.get("metadata").get("delta.columnMapping.id").asText();
+                verify(!isNullOrEmpty(columnMappingId), "id is null or empty");
+                fieldId = OptionalInt.of(Integer.parseInt(columnMappingId));
+                // Databricks stores column statistics with physical name
+                physicalName = fieldNode.get("metadata").get("delta.columnMapping.physicalName").asText();
+                verify(!isNullOrEmpty(physicalName), "physicalName is null or empty");
+            }
+            case NAME -> {
+                physicalName = fieldNode.get("metadata").get("delta.columnMapping.physicalName").asText();
+                verify(!isNullOrEmpty(physicalName), "physicalName is null or empty");
+            }
+            case NONE -> {
+                physicalName = fieldNode.get("name").asText();
+                verify(!isNullOrEmpty(physicalName), "name is null or empty");
+            }
+            default -> throw new UnsupportedOperationException("Unsupported parameter columnMappingMode");
+        }
+
+        return buildType(typeNode, typeManager, OPTIONAL, physicalName, fieldId, columnMappingMode, parent, primitiveTypesBuilder);
+    }
+
+    private static org.apache.parquet.schema.Type buildType(
+            JsonNode typeNode,
+            TypeManager typeManager,
+            org.apache.parquet.schema.Type.Repetition repetition,
+            String name,
+            OptionalInt id,
+            DeltaLakeSchemaSupport.ColumnMappingMode columnMappingMode,
+            List<String> parent,
+            ImmutableMap.Builder<List<String>, Type> primitiveTypesBuilder)
+    {
+        if (typeNode.isContainerNode()) {
+            return buildContainerType(typeNode, typeManager, repetition, name, id, columnMappingMode, parent, primitiveTypesBuilder);
+        }
+
+        String primitiveType = typeNode.asText();
+        return buildPrimitiveType(primitiveType, typeManager, repetition, name, id, parent, primitiveTypesBuilder);
+    }
+
+    private static org.apache.parquet.schema.Type buildPrimitiveType(
+            String primitiveType,
+            TypeManager typeManager,
+            org.apache.parquet.schema.Type.Repetition repetition,
+            String name,
+            OptionalInt id,
+            List<String> parent,
+            ImmutableMap.Builder<List<String>, Type> primitiveTypesBuilder)
+    {
+        Types.PrimitiveBuilder<PrimitiveType> typeBuilder;
+        Type trinoType;
+        if (primitiveType.startsWith(StandardTypes.DECIMAL)) {
+            trinoType = typeManager.fromSqlType(primitiveType);
+            verify(trinoType instanceof DecimalType, "type %s does not map to Trino decimal".formatted(primitiveType));
+            DecimalType trinoDecimalType = (DecimalType) trinoType;
+            if (trinoDecimalType.getPrecision() <= 9) {
+                typeBuilder = Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, repetition);
+            }
+            else if (trinoDecimalType.isShort()) {
+                typeBuilder = Types.primitive(PrimitiveType.PrimitiveTypeName.INT64, repetition);
+            }
+            else {
+                typeBuilder = Types.primitive(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, repetition)
+                        .length(PRECISION_TO_BYTE_COUNT[trinoDecimalType.getPrecision()]);
+            }
+            typeBuilder = typeBuilder.as(decimalType(trinoDecimalType.getScale(), trinoDecimalType.getPrecision()));
+            return buildType(name, id, parent, typeBuilder, trinoType, primitiveTypesBuilder);
+        }
+        switch (primitiveType) {
+            case "string" -> {
+                typeBuilder = Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, repetition).as(LogicalTypeAnnotation.stringType());
+                trinoType = VARCHAR;
+            }
+            case "byte" -> {
+                typeBuilder = Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, repetition);
+                trinoType = TINYINT;
+            }
+            case "short" -> {
+                typeBuilder = Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, repetition);
+                trinoType = SMALLINT;
+            }
+            case "integer" -> {
+                typeBuilder = Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, repetition);
+                trinoType = INTEGER;
+            }
+            case "long" -> {
+                typeBuilder = Types.primitive(PrimitiveType.PrimitiveTypeName.INT64, repetition);
+                trinoType = BIGINT;
+            }
+            case "float" -> {
+                typeBuilder = Types.primitive(PrimitiveType.PrimitiveTypeName.FLOAT, repetition);
+                trinoType = REAL;
+            }
+            case "double" -> {
+                typeBuilder = Types.primitive(PrimitiveType.PrimitiveTypeName.DOUBLE, repetition);
+                trinoType = DOUBLE;
+            }
+            case "boolean" -> {
+                typeBuilder = Types.primitive(PrimitiveType.PrimitiveTypeName.BOOLEAN, repetition);
+                trinoType = BOOLEAN;
+            }
+            case "binary" -> {
+                typeBuilder = Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, repetition);
+                trinoType = VARBINARY;
+            }
+            case "date" -> {
+                typeBuilder = Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, repetition).as(LogicalTypeAnnotation.dateType());
+                trinoType = DATE;
+            }
+            case "timestamp" -> {
+                // Spark / Delta Lake stores timestamps in UTC, but renders them in session time zone.
+                typeBuilder = Types.primitive(PrimitiveType.PrimitiveTypeName.INT64, repetition).as(LogicalTypeAnnotation.timestampType(false, LogicalTypeAnnotation.TimeUnit.MILLIS));
+                trinoType = TIMESTAMP_MILLIS;
+            }
+            default -> throw new TrinoException(NOT_SUPPORTED, format("Unsupported primitive type: %s", primitiveType));
+        }
+
+        return buildType(name, id, parent, typeBuilder, trinoType, primitiveTypesBuilder);
+    }
+
+    private static PrimitiveType buildType(String name, OptionalInt id, List<String> parent, Types.PrimitiveBuilder<PrimitiveType> typeBuilder, Type trinoType, ImmutableMap.Builder<List<String>, Type> primitiveTypesBuilder)
+    {
+        if (id.isPresent()) {
+            typeBuilder.id(id.getAsInt());
+        }
+
+        List<String> fullName = ImmutableList.<String>builder().addAll(parent).add(name).build();
+        primitiveTypesBuilder.put(fullName, trinoType);
+
+        return typeBuilder.named(name);
+    }
+
+    private static org.apache.parquet.schema.Type buildContainerType(
+            JsonNode typeNode,
+            TypeManager typeManager,
+            org.apache.parquet.schema.Type.Repetition repetition,
+            String name,
+            OptionalInt id,
+            DeltaLakeSchemaSupport.ColumnMappingMode columnMappingMode,
+            List<String> parent,
+            ImmutableMap.Builder<List<String>, Type> primitiveTypesBuilder)
+    {
+        String containerType = typeNode.get("type").asText();
+        return switch (containerType) {
+            case "array" -> buildArrayType(typeNode, typeManager, repetition, name, id, columnMappingMode, parent, primitiveTypesBuilder);
+            case "map" -> buildMapType(typeNode, typeManager, repetition, name, id, columnMappingMode, parent, primitiveTypesBuilder);
+            case "struct" -> buildRowType(typeNode, typeManager, repetition, name, id, columnMappingMode, parent, primitiveTypesBuilder);
+            default -> throw new TypeNotFoundException(new TypeSignature(containerType));
+        };
+    }
+
+    private static org.apache.parquet.schema.Type buildArrayType(
+            JsonNode typeNode,
+            TypeManager typeManager,
+            org.apache.parquet.schema.Type.Repetition repetition,
+            String name,
+            OptionalInt id,
+            DeltaLakeSchemaSupport.ColumnMappingMode columnMappingMode,
+            List<String> parent,
+            ImmutableMap.Builder<List<String>, Type> primitiveTypesBuilder)
+    {
+        parent = ImmutableList.<String>builder().addAll(parent).add(name).add("list").build();
+
+        JsonNode elementTypeNode = typeNode.get("elementType");
+        org.apache.parquet.schema.Type elementType;
+
+        if (elementTypeNode.isContainerNode()) {
+            elementType = buildContainerType(elementTypeNode, typeManager, OPTIONAL, "element", OptionalInt.empty(), columnMappingMode, parent, primitiveTypesBuilder);
+        }
+        else {
+            elementType = buildType(elementTypeNode, typeManager, OPTIONAL, "element", OptionalInt.empty(), columnMappingMode, parent, primitiveTypesBuilder);
+        }
+
+        GroupType arrayType = Types.list(repetition)
+                .element(elementType)
+                .named(name);
+        if (id.isPresent()) {
+            arrayType = arrayType.withId(id.getAsInt());
+        }
+        return arrayType;
+    }
+
+    private static org.apache.parquet.schema.Type buildMapType(
+            JsonNode typeNode,
+            TypeManager typeManager,
+            org.apache.parquet.schema.Type.Repetition repetition,
+            String name,
+            OptionalInt id,
+            DeltaLakeSchemaSupport.ColumnMappingMode columnMappingMode,
+            List<String> parent,
+            ImmutableMap.Builder<List<String>, Type> primitiveTypesBuilder)
+    {
+        Types.MapBuilder<GroupType> builder = Types.map(repetition);
+        if (id.isPresent()) {
+            builder.id(id.getAsInt());
+        }
+
+        parent = ImmutableList.<String>builder().addAll(parent).add(name).add("key_value").build();
+
+        JsonNode keyTypeNode = typeNode.get("keyType");
+        org.apache.parquet.schema.Type keyType;
+        if (keyTypeNode.isContainerNode()) {
+            keyType = buildContainerType(keyTypeNode, typeManager, REQUIRED, "key", OptionalInt.empty(), columnMappingMode, parent, primitiveTypesBuilder);
+        }
+        else {
+            keyType = buildType(keyTypeNode, typeManager, REQUIRED, "key", OptionalInt.empty(), columnMappingMode, parent, primitiveTypesBuilder);
+        }
+        JsonNode valueTypeNode = typeNode.get("valueType");
+        org.apache.parquet.schema.Type valueType;
+        if (valueTypeNode.isContainerNode()) {
+            valueType = buildContainerType(valueTypeNode, typeManager, OPTIONAL, "value", OptionalInt.empty(), columnMappingMode, parent, primitiveTypesBuilder);
+        }
+        else {
+            valueType = buildType(valueTypeNode, typeManager, OPTIONAL, "value", OptionalInt.empty(), columnMappingMode, parent, primitiveTypesBuilder);
+        }
+
+        return builder
+                .key(keyType)
+                .value(valueType)
+                .named(name);
+    }
+
+    private static org.apache.parquet.schema.Type buildRowType(
+            JsonNode typeNode,
+            TypeManager typeManager,
+            org.apache.parquet.schema.Type.Repetition repetition,
+            String name,
+            OptionalInt id,
+            DeltaLakeSchemaSupport.ColumnMappingMode columnMappingMode,
+            List<String> parent,
+            ImmutableMap.Builder<List<String>, Type> primitiveTypesBuilder)
+    {
+        Types.GroupBuilder<GroupType> builder = Types.buildGroup(repetition);
+        if (id.isPresent()) {
+            builder.id(id.getAsInt());
+        }
+        List<String> currentParent = ImmutableList.<String>builder().addAll(parent).add(name).build();
+        stream(typeNode.get("fields").elements())
+                .map(node -> buildType(node, typeManager, columnMappingMode, currentParent, primitiveTypesBuilder))
+                .forEach(builder::addField);
+        return builder.named(name);
+    }
+
+    private static Optional<Location> getLocation(JsonProcessingException e)
+    {
+        return Optional.ofNullable(e.getLocation()).map(location -> new Location(location.getLineNr(), location.getColumnNr()));
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeParquetSchemas.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeParquetSchemas.java
@@ -1,0 +1,356 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport;
+import io.trino.spi.type.TestingTypeManager;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.trino.plugin.deltalake.DeltaLakeParquetSchemas.createParquetSchemaMapping;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
+import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+import static org.testng.Assert.assertEquals;
+
+public class TestDeltaLakeParquetSchemas
+{
+    private final TypeManager typeManager = new TestingTypeManager();
+
+    @Test
+    public void testStringFieldColumnMappingNoneUnpartitioned()
+    {
+        @Language("JSON")
+        String jsonSchema = """
+                {
+                    "type": "struct",
+                    "fields": [
+                        {
+                            "name": "a_string",
+                            "type": "string",
+                            "nullable": true,
+                            "metadata": {}
+                        }
+                    ]
+                }
+                """;
+        DeltaLakeSchemaSupport.ColumnMappingMode columnMappingMode = DeltaLakeSchemaSupport.ColumnMappingMode.NONE;
+        List<String> partitionColumnNames = ImmutableList.of();
+        org.apache.parquet.schema.Type expectedMessageType = Types.buildMessage()
+                .addField(Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, OPTIONAL)
+                        .as(LogicalTypeAnnotation.stringType())
+                        .named("a_string"))
+                .named("trino_schema");
+        Map<List<String>, Type> expectedPrimitiveTypes = ImmutableMap.<List<String>, Type>builder()
+                .put(List.of("a_string"), VARCHAR)
+                .buildOrThrow();
+
+        assertParquetSchemaMappingCreationAccuracy(jsonSchema, columnMappingMode, partitionColumnNames, expectedMessageType, expectedPrimitiveTypes);
+    }
+
+    @Test
+    public void testStringFieldColumnMappingNonePartitioned()
+    {
+        @Language("JSON")
+        String jsonSchema = """
+                {
+                     "type": "struct",
+                     "fields": [
+                         {
+                             "name": "a_string",
+                             "type": "string",
+                             "nullable": true,
+                             "metadata": {}
+                         },
+                         {
+                             "name": "part",
+                             "type": "string",
+                             "nullable": true,
+                             "metadata": {}
+                         }
+                     ]
+                 }
+                """;
+        DeltaLakeSchemaSupport.ColumnMappingMode columnMappingMode = DeltaLakeSchemaSupport.ColumnMappingMode.NONE;
+        List<String> partitionColumnNames = ImmutableList.of("part");
+        org.apache.parquet.schema.Type expectedMessageType = Types.buildMessage()
+                .addField(Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, OPTIONAL)
+                        .as(LogicalTypeAnnotation.stringType())
+                        .named("a_string"))
+                .named("trino_schema");
+        Map<List<String>, Type> expectedPrimitiveTypes = ImmutableMap.<List<String>, Type>builder()
+                .put(List.of("a_string"), VARCHAR)
+                .buildOrThrow();
+
+        assertParquetSchemaMappingCreationAccuracy(jsonSchema, columnMappingMode, partitionColumnNames, expectedMessageType, expectedPrimitiveTypes);
+    }
+
+    @Test
+    public void testStringFieldColumnMappingIdUnpartitioned()
+    {
+        @Language("JSON")
+        String jsonSchema = """
+                {
+                    "type": "struct",
+                    "fields": [
+                        {
+                            "name": "a_string",
+                            "type": "string",
+                            "nullable": true,
+                            "metadata": {
+                                "delta.columnMapping.id": 1,
+                                "delta.columnMapping.physicalName": "col-eafe32e6-bd93-47f7-8921-34b7a4e66a06"
+                            }
+                        }
+                    ]
+                }
+                """;
+        org.apache.parquet.schema.Type expectedMessageType = Types.buildMessage()
+                .addField(Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, OPTIONAL)
+                        .as(LogicalTypeAnnotation.stringType())
+                        .id(1)
+                        .named("col-eafe32e6-bd93-47f7-8921-34b7a4e66a06"))
+                .named("trino_schema");
+        Map<List<String>, Type> expectedPrimitiveTypes = ImmutableMap.<List<String>, Type>builder()
+                .put(List.of("col-eafe32e6-bd93-47f7-8921-34b7a4e66a06"), VARCHAR)
+                .buildOrThrow();
+
+        assertParquetSchemaMappingCreationAccuracy(jsonSchema, DeltaLakeSchemaSupport.ColumnMappingMode.ID, ImmutableList.of(), expectedMessageType, expectedPrimitiveTypes);
+    }
+
+    @Test
+    public void testStringFieldColumnMappingIdPartitioned()
+    {
+        @Language("JSON")
+        String jsonSchema = """
+                {
+                    "type": "struct",
+                    "fields": [
+                        {
+                            "name": "a_string",
+                            "type": "string",
+                            "nullable": true,
+                            "metadata": {
+                                "delta.columnMapping.id": 1,
+                                "delta.columnMapping.physicalName": "col-40feefa6-d999-4c90-a923-190ecea9191c"
+                            }
+                        },
+                        {
+                            "name": "part",
+                            "type": "string",
+                            "nullable": true,
+                            "metadata": {
+                                "delta.columnMapping.id": 2,
+                                "delta.columnMapping.physicalName": "col-77789070-4b77-44b4-adf2-32d5df94f9e7"
+                            }
+                        }
+                    ]
+                }
+                """;
+        org.apache.parquet.schema.Type expectedMessageType = Types.buildMessage()
+                .addField(Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, OPTIONAL)
+                        .as(LogicalTypeAnnotation.stringType())
+                        .id(1)
+                        .named("col-40feefa6-d999-4c90-a923-190ecea9191c"))
+                .named("trino_schema");
+        Map<List<String>, Type> expectedPrimitiveTypes = ImmutableMap.<List<String>, Type>builder()
+                .put(List.of("col-40feefa6-d999-4c90-a923-190ecea9191c"), VARCHAR)
+                .buildOrThrow();
+
+        assertParquetSchemaMappingCreationAccuracy(jsonSchema, DeltaLakeSchemaSupport.ColumnMappingMode.ID, ImmutableList.of("part"), expectedMessageType, expectedPrimitiveTypes);
+    }
+
+    @Test
+    public void testStringFieldColumnMappingNameUnpartitioned()
+    {
+        @Language("JSON")
+        String jsonSchema = """
+                {
+                    "type": "struct",
+                    "fields": [
+                        {
+                            "name": "a_string",
+                            "type": "string",
+                            "nullable": true,
+                            "metadata": {
+                                "delta.columnMapping.id": 1,
+                                "delta.columnMapping.physicalName": "col-0200c2be-bb8d-4be8-b724-674d71074143"
+                            }
+                        }
+                    ]
+                }
+                """;
+        org.apache.parquet.schema.Type expectedMessageType = Types.buildMessage()
+                .addField(Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, OPTIONAL)
+                        .as(LogicalTypeAnnotation.stringType())
+                        .id(1)
+                        .named("col-0200c2be-bb8d-4be8-b724-674d71074143"))
+                .named("trino_schema");
+        Map<List<String>, Type> expectedPrimitiveTypes = ImmutableMap.<List<String>, Type>builder()
+                .put(List.of("col-0200c2be-bb8d-4be8-b724-674d71074143"), VARCHAR)
+                .buildOrThrow();
+
+        assertParquetSchemaMappingCreationAccuracy(jsonSchema, DeltaLakeSchemaSupport.ColumnMappingMode.ID, ImmutableList.of(), expectedMessageType, expectedPrimitiveTypes);
+    }
+
+    @Test
+    public void testRowFieldColumnMappingNameUnpartitioned()
+    {
+        // Corresponds to Databricks Delta type `a_complex_struct STRUCT<nested_struct: STRUCT<a_string: STRING>, a_string_array ARRAY<STRING>, a_complex_map MAP<STRING, STRUCT<a_string: STRING>>>`
+        @Language("JSON")
+        String jsonSchema = """
+                {
+                    "type": "struct",
+                    "fields": [
+                        {
+                            "name": "a_complex_struct",
+                            "type": {
+                                "type": "struct",
+                                "fields": [
+                                    {
+                                        "name": "nested_struct",
+                                        "type": {
+                                            "type": "struct",
+                                            "fields": [
+                                                {
+                                                    "name": "a_string",
+                                                    "type": "string",
+                                                    "nullable": true,
+                                                    "metadata": {
+                                                        "delta.columnMapping.id": 3,
+                                                        "delta.columnMapping.physicalName": "col-1830cfed-bdd2-43c4-98c8-f2685cff6faf"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "nullable": true,
+                                        "metadata": {
+                                            "delta.columnMapping.id": 2,
+                                            "delta.columnMapping.physicalName": "col-5e0e4060-8e54-427b-8a8d-72a4fd6b67bd"
+                                        }
+                                    },
+                                    {
+                                        "name": "a_string_array",
+                                        "type": {
+                                            "type": "array",
+                                            "elementType": "string",
+                                            "containsNull": true
+                                        },
+                                        "nullable": true,
+                                        "metadata": {
+                                            "delta.columnMapping.id": 4,
+                                            "delta.columnMapping.physicalName": "col-ff99c229-b1ce-4971-bfbc-3a68fec3dfea"
+                                        }
+                                    },
+                                    {
+                                        "name": "a_complex_map",
+                                        "type": {
+                                            "type": "map",
+                                            "keyType": "string",
+                                            "valueType": {
+                                                "type": "struct",
+                                                "fields": [
+                                                    {
+                                                        "name": "a_string",
+                                                        "type": "string",
+                                                        "nullable": true,
+                                                        "metadata": {
+                                                            "delta.columnMapping.id": 6,
+                                                            "delta.columnMapping.physicalName": "col-5cb932a5-69aa-47e6-9d75-40f87bd8a239"
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "valueContainsNull": true
+                                        },
+                                        "nullable": true,
+                                        "metadata": {
+                                            "delta.columnMapping.id": 5,
+                                            "delta.columnMapping.physicalName": "col-85dededd-8dd2-4a81-ab3c-1439c1fd895a"
+                                        }
+                                    }
+                                ]
+                            },
+                            "nullable": true,
+                            "metadata": {
+                                "delta.columnMapping.id": 1,
+                                "delta.columnMapping.physicalName": "col-306694c6-846e-4c72-a3ea-976e4b19160a"
+                            }
+                        }
+                    ]
+                }
+                """;
+        org.apache.parquet.schema.Type expectedMessageType = Types.buildMessage()
+                .addField(Types.buildGroup(OPTIONAL)
+                        .addField(Types.buildGroup(OPTIONAL)
+                                .addField(Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, OPTIONAL)
+                                        .as(LogicalTypeAnnotation.stringType())
+                                        .id(3)
+                                        .named("col-1830cfed-bdd2-43c4-98c8-f2685cff6faf"))
+                                .id(2)
+                                .named("col-5e0e4060-8e54-427b-8a8d-72a4fd6b67bd"))
+                        .addField(Types.optionalList()
+                                .element(Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, OPTIONAL)
+                                        .as(LogicalTypeAnnotation.stringType())
+                                        .named("element"))
+                                .id(4)
+                                .named("col-ff99c229-b1ce-4971-bfbc-3a68fec3dfea"))
+                        .addField(Types.map(OPTIONAL)
+                                .key(Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, REQUIRED)
+                                        .as(LogicalTypeAnnotation.stringType())
+                                        .named("key"))
+                                .value(Types.buildGroup(OPTIONAL)
+                                        .addField(Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, OPTIONAL)
+                                                .as(LogicalTypeAnnotation.stringType())
+                                                .id(6)
+                                                .named("col-5cb932a5-69aa-47e6-9d75-40f87bd8a239"))
+                                        .named("value"))
+                                .id(5)
+                                .named("col-85dededd-8dd2-4a81-ab3c-1439c1fd895a"))
+                        .id(1)
+                        .named("col-306694c6-846e-4c72-a3ea-976e4b19160a"))
+                .named("trino_schema");
+        Map<List<String>, Type> expectedPrimitiveTypes = ImmutableMap.<List<String>, Type>builder()
+                .put(List.of("col-306694c6-846e-4c72-a3ea-976e4b19160a", "col-5e0e4060-8e54-427b-8a8d-72a4fd6b67bd", "col-1830cfed-bdd2-43c4-98c8-f2685cff6faf"), VARCHAR)
+                .put(List.of("col-306694c6-846e-4c72-a3ea-976e4b19160a", "col-ff99c229-b1ce-4971-bfbc-3a68fec3dfea", "list", "element"), VARCHAR)
+                .put(List.of("col-306694c6-846e-4c72-a3ea-976e4b19160a", "col-85dededd-8dd2-4a81-ab3c-1439c1fd895a", "key_value", "key"), VARCHAR)
+                .put(List.of("col-306694c6-846e-4c72-a3ea-976e4b19160a", "col-85dededd-8dd2-4a81-ab3c-1439c1fd895a", "key_value", "value", "col-5cb932a5-69aa-47e6-9d75-40f87bd8a239"), VARCHAR)
+                .buildOrThrow();
+
+        assertParquetSchemaMappingCreationAccuracy(
+                jsonSchema, DeltaLakeSchemaSupport.ColumnMappingMode.ID, ImmutableList.of(), expectedMessageType, expectedPrimitiveTypes);
+    }
+
+    private void assertParquetSchemaMappingCreationAccuracy(
+            @Language("JSON") String jsonSchema,
+            DeltaLakeSchemaSupport.ColumnMappingMode columnMappingMode,
+            List<String> partitionColumnNames,
+            org.apache.parquet.schema.Type expectedMessageType,
+            Map<List<String>, Type> expectedPrimitiveTypes)
+    {
+        DeltaLakeParquetSchemaMapping parquetSchemaMapping = createParquetSchemaMapping(jsonSchema, typeManager, columnMappingMode, partitionColumnNames);
+        assertEquals(parquetSchemaMapping.messageType(), expectedMessageType);
+        assertEquals(parquetSchemaMapping.primitiveTypes(), expectedPrimitiveTypes);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This PR is a follow-up of https://github.com/trinodb/trino/pull/16183 and relates to https://github.com/trinodb/trino/issues/12638

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



https://books.japila.pl/delta-lake-internals/DeltaConfigs/#COLUMN_MAPPING_MODE

id | A column ID is the identifier of a column. This mode is used for tables converted from Iceberg and parquet files in this mode will also have corresponding field Ids for each column in their file schema.
-- | --

I intended to test this column mapping mode for tables migrated from Iceberg and used

https://docs.databricks.com/sql/language-manual/delta-convert-to-delta.html


Apply `CLONE` on an Iceberg table created by Trino was causing internal error issues on Databricks, so I used Spark with Iceberg to create the table on AWS and then applied `CLONE` via Databricks.

```
CREATE OR REPLACE TABLE default.findinpath_table_migrated CLONE iceberg.`s3://trino-bucket/iceberg-warehouse/findinpath.db/findinpath_table/metadata/00001-0b3c1ecd-e5b9-479f-9ddd-e286b9efd472.metadata.json`
``` 

Outcome was a table with table writer version 7 , which can't be written by Trino. :( 

Nevertheless, relevant info - the Parquet files written via Iceberg look like:

```
➜  ~ parquet-tools schema  /Users/marius/Downloads/00001-3-c0e1f76e-1234-4de8-9348-b18789e0720f-00001.parquet 
message table {
  required binary c (STRING) = 1;
}
```

The new Parquet schema for the files written by Databricks (on `INSERT` statements after the `CLONE` statement) look like 

```
➜  ~ parquet-tools schema /Users/marius/Downloads/part-00000-cdd011ba-6032-4012-9cb7-364ca60a5b1f-c000.snappy\ \(1\).parquet
message spark_schema {
  optional binary col-34630ee4-4dbf-4916-a464-5f13f9d3ff46 (STRING) = 1;
}
```

The parquet files produced by Trino with the column mapping mode set to `id` are also consistent with this schema.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Support DML operations on Delta Lake tables with `id` column mapping ({issue}`issuenumber`)
```
