### PR TITLE
Remove unused method from QueryManagerStats

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/QueryManagerStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryManagerStats.java
@@ -59,13 +59,6 @@ public class QueryManagerStats
         managedQueryExecution.addStateChangeListener(new StatisticsListener(managedQueryExecution));
     }
 
-    public void trackQueryStats(QueryExecution managedQueryExecution)
-    {
-        submittedQueries.update(1);
-        managedQueryExecution.addStateChangeListener(new StatisticsListener());
-        managedQueryExecution.addFinalQueryInfoListener(finalQueryInfo -> queryFinished(new BasicQueryInfo(finalQueryInfo)));
-    }
-
     private void queryStarted()
     {
         startedQueries.update(1);


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
