### PR TITLE
Introduce LoadableComponent and simplify OAuth2Client binding

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/LoadableComponent.java
+++ b/core/trino-main/src/main/java/io/trino/server/LoadableComponent.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server;
+
+public interface LoadableComponent
+{
+    void load();
+}

--- a/core/trino-main/src/main/java/io/trino/server/Server.java
+++ b/core/trino-main/src/main/java/io/trino/server/Server.java
@@ -59,7 +59,6 @@ import io.trino.server.security.CertificateAuthenticatorManager;
 import io.trino.server.security.HeaderAuthenticatorManager;
 import io.trino.server.security.PasswordAuthenticatorManager;
 import io.trino.server.security.ServerSecurityModule;
-import io.trino.server.security.oauth2.OAuth2Client;
 import io.trino.spi.connector.CatalogHandle;
 import io.trino.transaction.TransactionManagerModule;
 import io.trino.version.EmbedVersion;
@@ -167,7 +166,8 @@ public class Server
             injector.getInstance(optionalKey(HeaderAuthenticatorManager.class))
                     .ifPresent(HeaderAuthenticatorManager::loadHeaderAuthenticator);
 
-            injector.getInstance(optionalKey(OAuth2Client.class)).ifPresent(OAuth2Client::load);
+            Set<LoadableComponent> loadableComponents = injector.getInstance(Key.get(new TypeLiteral<>() {}));
+            loadableComponents.forEach(LoadableComponent::load);
 
             injector.getInstance(Announcer.class).start();
 

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -481,6 +481,8 @@ public class ServerMainModule
         // TODO: remove this when system tables are bound separately for coordinator and worker
         newOptionalBinder(binder, RuleStatsRecorder.class);
 
+        newSetBinder(binder, LoadableComponent.class);
+
         // cleanup
         binder.bind(ExecutorCleanup.class).in(Scopes.SINGLETON);
     }

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/NimbusOAuth2Client.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/NimbusOAuth2Client.java
@@ -57,6 +57,7 @@ import com.nimbusds.openid.connect.sdk.validators.IDTokenValidator;
 import com.nimbusds.openid.connect.sdk.validators.InvalidHashException;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
+import io.trino.server.LoadableComponent;
 import io.trino.server.security.oauth2.OAuth2ServerConfigProvider.OAuth2ServerConfig;
 
 import javax.inject.Inject;
@@ -82,7 +83,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class NimbusOAuth2Client
-        implements OAuth2Client
+        implements OAuth2Client, LoadableComponent
 {
     private static final Logger LOG = Logger.get(NimbusAirliftHttpClient.class);
 

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Client.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Client.java
@@ -22,8 +22,6 @@ import static java.util.Objects.requireNonNull;
 
 public interface OAuth2Client
 {
-    void load();
-
     Request createAuthorizationRequest(String state, URI callbackUri);
 
     Response getOAuth2Response(String code, URI callbackUri, Optional<String> nonce)

--- a/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
@@ -1012,11 +1012,6 @@ public class TestResourceSecurity
             return new OAuth2Client()
             {
                 @Override
-                public void load()
-                {
-                }
-
-                @Override
                 public Request createAuthorizationRequest(String state, URI callbackUri)
                 {
                     return new Request(URI.create("http://example.com/authorize?" + state), Optional.of(UUID.randomUUID().toString()));

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/BaseOAuth2WebUiAuthenticationFilterTest.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/BaseOAuth2WebUiAuthenticationFilterTest.java
@@ -106,7 +106,7 @@ public abstract class BaseOAuth2WebUiAuthenticationFilterTest
                 .setAdditionalModule(new WebUiModule())
                 .setProperties(getOAuth2Config(idpUrl))
                 .build();
-        server.getInstance(Key.get(OAuth2Client.class)).load();
+        server.getInstance(Key.get(NimbusOAuth2Client.class)).load();
         server.waitForNodeRefresh(Duration.ofSeconds(10));
         serverUri = server.getHttpsBaseUrl();
         uiUri = serverUri.resolve("/ui/");

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestJweTokenSerializer.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestJweTokenSerializer.java
@@ -124,11 +124,6 @@ public class TestJweTokenSerializer
                 .setSubject("user");
 
         @Override
-        public void load()
-        {
-        }
-
-        @Override
         public Request createAuthorizationRequest(String state, URI callbackUri)
         {
             throw new UnsupportedOperationException("operation is not yet supported");

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOidcDiscovery.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOidcDiscovery.java
@@ -263,7 +263,7 @@ public class TestOidcDiscovery
         assertThat(authenticators.get(0)).isInstanceOf(OAuth2Authenticator.class);
         assertThat(server.getInstance(Key.get(WebUiAuthenticationFilter.class))).isInstanceOf(OAuth2WebUiAuthenticationFilter.class);
         // does not throw an exception
-        server.getInstance(Key.get(OAuth2Client.class)).load();
+        server.getInstance(Key.get(NimbusOAuth2Client.class)).load();
     }
 
     private static TestingTrinoServer createServer(Map<String, String> configuration)

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestingHydraIdentityProvider.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestingHydraIdentityProvider.java
@@ -363,7 +363,7 @@ public class TestingHydraIdentityProvider
                     .setAdditionalModule(new WebUiModule())
                     .setProperties(config.buildOrThrow())
                     .build()) {
-                server.getInstance(Key.get(OAuth2Client.class)).load();
+                server.getInstance(Key.get(NimbusOAuth2Client.class)).load();
                 Thread.sleep(Long.MAX_VALUE);
             }
         }

--- a/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
+++ b/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
@@ -1245,11 +1245,6 @@ public class TestWebUi
         }
 
         @Override
-        public void load()
-        {
-        }
-
-        @Override
         public Request createAuthorizationRequest(String state, URI callbackUri)
         {
             return new Request(URI.create("http://example.com/authorize"), nonce);


### PR DESCRIPTION
Introduce LoadableComponent and simplify OAuth2Client binding

There are many guice components that we load after the creation
of guice injector.

This commit only replaces optional OAuth2Client with usage of
LoadableComponent. In next steps other could be also replaced with it.
The only caveat is that only components that can be loaded in any order
can use LoadableComponent.
