### PR TITLE
Reduce per-transaction-file-status-cache-maximum-size to prevent OOMs

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
@@ -143,7 +143,7 @@ public class HiveConfig
     private Duration fileStatusCacheExpireAfterWrite = new Duration(1, MINUTES);
     private long fileStatusCacheMaxSize = 1000 * 1000;
     private List<String> fileStatusCacheTables = ImmutableList.of();
-    private long perTransactionFileStatusCacheMaximumSize = 1000 * 1000;
+    private long perTransactionFileStatusCacheMaximumSize = 10_000;
 
     private boolean translateHiveViews;
     private boolean legacyHiveViewTranslation;

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
@@ -97,7 +97,7 @@ public class TestHiveConfig
                 .setFileStatusCacheExpireAfterWrite(new Duration(1, TimeUnit.MINUTES))
                 .setFileStatusCacheMaxSize(1000 * 1000)
                 .setFileStatusCacheTables("")
-                .setPerTransactionFileStatusCacheMaximumSize(1000 * 1000)
+                .setPerTransactionFileStatusCacheMaximumSize(10_000)
                 .setTranslateHiveViews(false)
                 .setLegacyHiveViewTranslation(false)
                 .setHiveViewsRunAsInvoker(false)


### PR DESCRIPTION
    In some high concurrency scenarios and with smaller coordinator
    having 1M as cache size limit can cause coordinator to OOM.