### PR TITLE
Fix BigQuery tests for column names with special characters

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -234,7 +234,7 @@ public abstract class BaseBigQueryConnectorTest
     @Override
     protected boolean isColumnNameRejected(Exception exception, String columnName, boolean delimited)
     {
-        return nullToEmpty(exception.getMessage()).matches(".*(Fields must contain only letters, numbers, and underscores, start with a letter or underscore, and be at most 300 characters long).*");
+        return nullToEmpty(exception.getMessage()).matches(".*Invalid field name \"%s\". Fields must contain the allowed characters, and be at most 300 characters long..*".formatted(columnName.replace("\\", "\\\\")));
     }
 
     @Test

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryAvroConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryAvroConnectorTest.java
@@ -14,11 +14,32 @@
 package io.trino.plugin.bigquery;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.trino.testing.QueryRunner;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static io.trino.testing.DataProviders.toDataProvider;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestBigQueryAvroConnectorTest
         extends BaseBigQueryConnectorTest
 {
+    private static final Set<String> UNSUPPORTED_COLUMN_NAMES = ImmutableSet.<String>builder()
+            .add("a-hyphen-minus")
+            .add("a space")
+            .add("atrailingspace ")
+            .add(" aleadingspace")
+            .add("a:colon")
+            .add("an'apostrophe")
+            .add("0startwithdigit")
+            .build();
+
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
@@ -27,5 +48,42 @@ public class TestBigQueryAvroConnectorTest
                 ImmutableMap.of(),
                 ImmutableMap.of(),
                 REQUIRED_TPCH_TABLES);
+    }
+
+    @Override
+    protected Optional<String> filterColumnNameTestData(String columnName)
+    {
+        if (UNSUPPORTED_COLUMN_NAMES.contains(columnName)) {
+            return Optional.empty();
+        }
+        return Optional.of(columnName);
+    }
+
+    // TODO: Disable all operations for unsupported column names
+    @Test(dataProvider = "unsupportedColumnNameDataProvider")
+    public void testSelectFailsForColumnName(String columnName)
+    {
+        String tableName = "test.test_unsupported_column_name" + randomNameSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName + "(\"" + columnName + "\" varchar(50))");
+        try {
+            assertUpdate("INSERT INTO " + tableName + " VALUES ('test value')", 1);
+            // The storage API can't read the table, but query based API can read it
+            assertThatThrownBy(() -> query("SELECT * FROM " + tableName))
+                    .cause()
+                    .hasMessageMatching(".*(Illegal initial character|Invalid name).*");
+            assertThat(bigQuerySqlExecutor.executeQuery("SELECT * FROM " + tableName).getValues())
+                    .extracting(field -> field.get(0).getStringValue())
+                    .containsExactly("test value");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @DataProvider
+    public Object[][] unsupportedColumnNameDataProvider()
+    {
+        return UNSUPPORTED_COLUMN_NAMES.stream().collect(toDataProvider());
     }
 }


### PR DESCRIPTION
Some column names started to fail because of BigQuery internal change
~ between
18:00 16 of March 2023 GMT and
00:00 17 of March 2023 GMT,
first noticed when 90d6f0737a1f8dd4fbb8b85c2d95b20093d1b4ba merged to
master.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fixes #16603

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
