### PR TITLE
Improve LongSumAggregation and DoubleSumAggregation serde

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/LongDoubleState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/LongDoubleState.java
@@ -13,7 +13,6 @@
  */
 package io.trino.operator.aggregation;
 
-import io.trino.operator.aggregation.state.InitialBooleanValue;
 import io.trino.spi.function.AccumulatorState;
 
 public interface LongDoubleState
@@ -23,17 +22,7 @@ public interface LongDoubleState
 
     void setFirst(long first);
 
-    @InitialBooleanValue(true)
-    boolean isFirstNull();
-
-    void setFirstNull(boolean firstNull);
-
     double getSecond();
 
     void setSecond(double second);
-
-    @InitialBooleanValue(true)
-    boolean isSecondNull();
-
-    void setSecondNull(boolean secondNull);
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/LongLongState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/LongLongState.java
@@ -13,7 +13,6 @@
  */
 package io.trino.operator.aggregation;
 
-import io.trino.operator.aggregation.state.InitialBooleanValue;
 import io.trino.spi.function.AccumulatorState;
 
 public interface LongLongState
@@ -23,17 +22,7 @@ public interface LongLongState
 
     void setFirst(long first);
 
-    @InitialBooleanValue(true)
-    boolean isFirstNull();
-
-    void setFirstNull(boolean firstNull);
-
     long getSecond();
 
     void setSecond(long second);
-
-    @InitialBooleanValue(true)
-    boolean isSecondNull();
-
-    void setSecondNull(boolean secondNull);
 }

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerWithSplits.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerWithSplits.java
@@ -164,7 +164,7 @@ public class TestEventListenerWithSplits
         assertEquals(statistics.getPhysicalInputRows(), expectedCompletedPositions);
         assertEquals(statistics.getProcessedInputBytes(), 0);
         assertEquals(statistics.getProcessedInputRows(), expectedCompletedPositions);
-        assertEquals(statistics.getInternalNetworkBytes(), 381);
+        assertEquals(statistics.getInternalNetworkBytes(), 261);
         assertEquals(statistics.getInternalNetworkRows(), 3);
         assertEquals(statistics.getTotalBytes(), 0);
         assertEquals(statistics.getOutputBytes(), 9);


### PR DESCRIPTION
Previously row(bigint, boolean, bigint, boolean)] was used for long sum serde (and similar for doubles).

Now it's row(bigint, bigint)

The extra bigint (row count) is still only required for WINDOW function but this PR slighly improves serde.

We can remove extra booleans because Long and Decimal aggregations use row count to determine if null should be outputted.

RN
```
General
* Improve `sum` aggregtion query performance. ({issue})
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
