### PR TITLE
Allow forcing delta lake to recalculate all statistics

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.rst
+++ b/docs/src/main/sphinx/connector/delta-lake.rst
@@ -918,6 +918,13 @@ To collect statistics for a table, execute the following statement::
 
   ANALYZE table_schema.table_name;
 
+To recalculate from scratch the statistics for the table use additional parameter ``mode``:
+
+  ANALYZE table_schema.table_name WITH(mode = 'full_refresh');
+
+There are two modes available ``full_refresh`` and ``incremental``.
+The procedure use ``incremental`` by default.
+
 To gain the most benefit from cost-based optimizations, run periodic ``ANALYZE``
 statements on every large table that is frequently queried.
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AnalyzeHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AnalyzeHandle.java
@@ -16,6 +16,7 @@ package io.trino.plugin.deltalake;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSet;
+import io.trino.plugin.deltalake.DeltaLakeAnalyzeProperties.AnalyzeMode;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -25,26 +26,26 @@ import static java.util.Objects.requireNonNull;
 
 public class AnalyzeHandle
 {
-    private final boolean initialAnalyze;
+    private final AnalyzeMode analyzeMode;
     private final Optional<Instant> filesModifiedAfter;
     private final Optional<Set<String>> columns;
 
     @JsonCreator
     public AnalyzeHandle(
-            @JsonProperty("initialAnalyze") boolean initialAnalyze,
+            @JsonProperty("analyzeMode") AnalyzeMode analyzeMode,
             @JsonProperty("startTime") Optional<Instant> filesModifiedAfter,
             @JsonProperty("columns") Optional<Set<String>> columns)
     {
-        this.initialAnalyze = initialAnalyze;
+        this.analyzeMode = requireNonNull(analyzeMode, "analyzeMode is null");
         this.filesModifiedAfter = requireNonNull(filesModifiedAfter, "filesModifiedAfter is null");
         requireNonNull(columns, "columns is null");
         this.columns = columns.map(ImmutableSet::copyOf);
     }
 
     @JsonProperty
-    public boolean isInitialAnalyze()
+    public AnalyzeMode getAnalyzeMode()
     {
-        return initialAnalyze;
+        return analyzeMode;
     }
 
     @JsonProperty

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeAnalyzeProperties.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeAnalyzeProperties.java
@@ -29,15 +29,24 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.plugin.deltalake.DeltaLakeAnalyzeProperties.AnalyzeMode.INCREMENTAL;
 import static io.trino.spi.StandardErrorCode.INVALID_ANALYZE_PROPERTY;
+import static io.trino.spi.session.PropertyMetadata.enumProperty;
 import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.String.format;
 
 public class DeltaLakeAnalyzeProperties
 {
+    enum AnalyzeMode
+    {
+        INCREMENTAL,
+        FULL_REFRESH,
+    }
+
     public static final String FILES_MODIFIED_AFTER = "files_modified_after";
     public static final String COLUMNS_PROPERTY = "columns";
+    public static final String MODE_PROPERTY = "mode";
 
     private final List<PropertyMetadata<?>> analyzeProperties;
 
@@ -62,7 +71,13 @@ public class DeltaLakeAnalyzeProperties
                         null,
                         false,
                         DeltaLakeAnalyzeProperties::decodeColumnNames,
-                        value -> value));
+                        value -> value),
+                enumProperty(
+                        MODE_PROPERTY,
+                        "Analyze mode",
+                        AnalyzeMode.class,
+                        INCREMENTAL,
+                        false));
     }
 
     public List<PropertyMetadata<?>> getAnalyzeProperties()
@@ -73,6 +88,11 @@ public class DeltaLakeAnalyzeProperties
     public static Optional<Instant> getFilesModifiedAfterProperty(Map<String, Object> properties)
     {
         return Optional.ofNullable((Instant) properties.get(FILES_MODIFIED_AFTER));
+    }
+
+    public static AnalyzeMode getRefreshMode(Map<String, Object> properties)
+    {
+        return (AnalyzeMode) properties.get(MODE_PROPERTY);
     }
 
     public static Optional<Set<String>> getColumnNames(Map<String, Object> properties)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
@@ -57,6 +57,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.deltalake.DeltaLakeAnalyzeProperties.AnalyzeMode.FULL_REFRESH;
 import static io.trino.plugin.deltalake.DeltaLakeColumnHandle.pathColumnHandle;
 import static io.trino.plugin.deltalake.DeltaLakeMetadata.createStatisticsPredicate;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getDynamicFilteringWaitTimeout;
@@ -177,11 +178,11 @@ public class DeltaLakeSplitManager
         List<DeltaLakeColumnMetadata> predicatedColumns = schema.stream()
                 .filter(column -> predicatedColumnNames.contains(column.getName())) // DeltaLakeColumnMetadata.name is lowercase
                 .collect(toImmutableList());
-
         return validDataFiles.stream()
                 .flatMap(addAction -> {
-                    if (tableHandle.getAnalyzeHandle().isPresent() && !tableHandle.getAnalyzeHandle().get().isInitialAnalyze() && !addAction.isDataChange()) {
-                        // skip files which do not introduce data change on non-initial ANALYZE
+                    if (tableHandle.getAnalyzeHandle().isPresent() &&
+                            !(tableHandle.getAnalyzeHandle().get().getAnalyzeMode() == FULL_REFRESH) && !addAction.isDataChange()) {
+                        // skip files which do not introduce data change on non FULL REFRESH
                         return Stream.empty();
                     }
 


### PR DESCRIPTION
## Description
fixes: https://github.com/trinodb/trino/issues/15968 

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Delat Lake
* Add support for recalculating all statistics in `ANALYZE` statement. ({issue}`15968`)
```
