### PR TITLE
Fix BaseFailureRecoveryTest temp table checking message pattern

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
@@ -437,7 +437,7 @@ public abstract class BaseFailureRecoveryTest
                 String temporaryTableName = (String) temporaryTableRow.getField(0);
                 try {
                     assertThatThrownBy(() -> getQueryRunner().execute("SELECT 1 FROM %s WHERE 1 = 0".formatted(temporaryTableName)))
-                            .hasMessageContaining("%s does not exist", temporaryTableName);
+                            .hasMessageContaining("Table '%s' does not exist", temporaryTableName);
                 }
                 catch (AssertionError e) {
                     remainingTemporaryTables.computeIfAbsent(queryId, ignored -> new HashSet<>()).add(temporaryTableName);


### PR DESCRIPTION
The expected exception message pattern needs to match the one used in `StatementAnalyzer.Visitor#visitTable`, e.g. the table name should be expected in apostrophes.

This should fix errors on CI like the one below (https://github.com/trinodb/trino/actions/runs/4467931974/jobs/7848093602)

```
Error:  io.trino.plugin.bigquery.TestBigQueryTaskFailureRecoveryTest.testParallel[testExplainAnalyze](9)  Time elapsed: 107.3 s  <<< FAILURE!
java.lang.AssertionError:
[There should be no remaining tmp_trino tables that are queryable. They are:
	For queryId [20230320_124434_00162_6w4f2] (prefix [tmp_trino_3a3f1a6f_]) remaining tables: [tmp_trino_3a3f1a6f_e3d45e3f]
		With errors: [
			Expecting throwable message:
			  "line 1:15: Table 'bigquery.tpch.tmp_trino_3a3f1a6f_e3d45e3f' does not exist"
			to contain:
			  "tmp_trino_3a3f1a6f_e3d45e3f does not exist"
			but did not.

			Throwable that failed the check:

			io.trino.testing.QueryFailedException: line 1:15: Table 'bigquery.tpch.tmp_trino_3a3f1a6f_e3d45e3f' does not exist
				at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:122)
				at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:85)
				at io.trino.testing.DistributedQueryRunner.execute(DistributedQueryRunner.java:477)
				at io.trino.testing.BaseFailureRecoveryTest.lambda$checkTemporaryTables$15(BaseFailureRecoveryTest.java:439)
				at org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:63)
				at org.assertj.core.api.AssertionsForClassTypes.catchThrowable(AssertionsForClassTypes.java:892)
				at org.assertj.core.api.Assertions.catchThrowable(Assertions.java:1366)
				at org.assertj.core.api.Assertions.assertThatThrownBy(Assertions.java:1210)
				at io.trino.testing.BaseFailureRecoveryTest.checkTemporaryTables(BaseFailureRecoveryTest.java:439)
				at io.trino.testing.BaseFailureRecoveryTest$FailureRecoveryAssert.cleansUpTemporaryTables(BaseFailureRecoveryTest.java:619)
				at io.trino.testing.BaseFailureRecoveryTest.testNonSelect(BaseFailureRecoveryTest.java:365)
				at io.trino.testing.BaseFailureRecoveryTest.testTableModification(BaseFailureRecoveryTest.java:342)
				at io.trino.testing.BaseFailureRecoveryTest.testTableModification(BaseFailureRecoveryTest.java:337)
				at io.trino.testing.BaseFailureRecoveryTest.testExplainAnalyze(BaseFailureRecoveryTest.java:315)
				at io.trino.testing.BaseFailureRecoveryTest$ParallelTestRunnable.run(BaseFailureRecoveryTest.java:899)
				at io.trino.testing.BaseFailureRecoveryTest.testParallel(BaseFailureRecoveryTest.java:222)
				at jdk.internal.reflect.GeneratedMethodAccessor1309.invoke(Unknown Source)
				at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
				at java.base/java.lang.reflect.Method.invoke(Method.java:568)
				at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:104)
				at org.testng.internal.Invoker.invokeMethod(Invoker.java:645)
				at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:851)
				at org.testng.internal.TestMethodWithDataProviderMethodWorker.call(TestMethodWithDataProviderMethodWorker.java:75)
				at org.testng.internal.TestMethodWithDataProviderMethodWorker.call(TestMethodWithDataProviderMethodWorker.java:14)
				at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
				at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
				at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
				at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
				at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
				at java.base/java.lang.Thread.run(Thread.java:833)
			Caused by: io.trino.spi.TrinoException: line 1:15: Table 'bigquery.tpch.tmp_trino_3a3f1a6f_e3d45e3f' does not exist
				at io.trino.sql.analyzer.SemanticExceptions.semanticException(SemanticExceptions.java:48)
				at io.trino.sql.analyzer.SemanticExceptions.semanticException(SemanticExceptions.java:43)
				at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitTable(StatementAnalyzer.java:2179)
				at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitTable(StatementAnalyzer.java:484)
				at io.trino.sql.tree.Table.accept(Table.java:60)
				at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
				at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:501)
				at io.trino.sql.analyzer.StatementAnalyzer$Visitor.analyzeFrom(StatementAnalyzer.java:4466)
				at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:2933)
				at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:484)
				at io.trino.sql.tree.QuerySpecification.accept(QuerySpecification.java:155)
				at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
				at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:501)
				at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:509)
				at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:1460)
				at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:484)
				at io.trino.sql.tree.Query.accept(Query.java:107)
				at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
				at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:501)
				at io.trino.sql.analyzer.StatementAnalyzer.analyze(StatementAnalyzer.java:463)
				at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:79)
				at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:71)
				at io.trino.execution.SqlQueryExecution.analyze(SqlQueryExecution.java:258)
				at io.trino.execution.SqlQueryExecution.<init>(SqlQueryExecution.java:196)
				at io.trino.execution.SqlQueryExecution$SqlQueryExecutionFactory.createQueryExecution(SqlQueryExecution.java:818)
				at io.trino.dispatcher.LocalDispatchQueryFactory.lambda$createDispatchQuery$0(LocalDispatchQueryFactory.java:149)
				at io.trino.$gen.Trino_testversion____20230320_122419_784.call(Unknown Source)
				at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131)
				at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)
				at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:82)
				at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
				at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
				at java.base/java.lang.Thread.run(Thread.java:833)
			]]
Expecting value to be true but was false
	at io.trino.testing.BaseFailureRecoveryTest.checkTemporaryTables(BaseFailureRecoveryTest.java:458)
	at io.trino.testing.BaseFailureRecoveryTest$FailureRecoveryAssert.cleansUpTemporaryTables(BaseFailureRecoveryTest.java:619)
	at io.trino.testing.BaseFailureRecoveryTest.testNonSelect(BaseFailureRecoveryTest.java:365)
	at io.trino.testing.BaseFailureRecoveryTest.testTableModification(BaseFailureRecoveryTest.java:342)
	at io.trino.testing.BaseFailureRecoveryTest.testTableModification(BaseFailureRecoveryTest.java:337)
	at io.trino.testing.BaseFailureRecoveryTest.testExplainAnalyze(BaseFailureRecoveryTest.java:315)
	at io.trino.testing.BaseFailureRecoveryTest$ParallelTestRunnable.run(BaseFailureRecoveryTest.java:899)
	at io.trino.testing.BaseFailureRecoveryTest.testParallel(BaseFailureRecoveryTest.java:222)
	at jdk.internal.reflect.GeneratedMethodAccessor1309.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:104)
	at org.testng.internal.Invoker.invokeMethod(Invoker.java:645)
	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:851)
	at org.testng.internal.TestMethodWithDataProviderMethodWorker.call(TestMethodWithDataProviderMethodWorker.java:75)
	at org.testng.internal.TestMethodWithDataProviderMethodWorker.call(TestMethodWithDataProviderMethodWorker.java:14)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```


Follows https://github.com/trinodb/trino/pull/16499