### PR TITLE
Add link to duration prop type in JDBC config fragment

### DIFF
--- a/docs/src/main/sphinx/connector/jdbc-common-configurations.fragment
+++ b/docs/src/main/sphinx/connector/jdbc-common-configurations.fragment
@@ -15,21 +15,21 @@ connector:
     - Support case insensitive schema and table names.
     - ``false``
   * - ``case-insensitive-name-matching.cache-ttl``
-    -
+    - This value should be a :ref:`prop-type-duration`.
     - ``1m``
   * - ``case-insensitive-name-matching.config-file``
     - Path to a name mapping configuration file in JSON format that allows
       Trino to disambiguate between schemas and tables with similar names in
       different cases.
     - ``null``
-  * - ``case-insensitive-name-matching.refresh-period``
+  * - ``case-insensitive-name-matching.config-file.refresh-period``
     - Frequency with which Trino checks the name matching configuration file
-      for changes.
-    - ``0`` (refresh disabled)
+      for changes. This value should be a :ref:`prop-type-duration`.
+    - (refresh disabled)
   * - ``metadata.cache-ttl``
-    - Duration for which metadata, including table and column statistics, is
-      cached.
-    - ``0`` (caching disabled)
+    - :ref:`The duration <prop-type-duration>` for which metadata, including
+      table and column statistics, is cached.
+    - ``0s`` (caching disabled)
   * - ``metadata.cache-missing``
     - Cache the fact that metadata, including table and column statistics, is
       not available
@@ -46,8 +46,8 @@ connector:
     - Push down dynamic filters into JDBC queries
     - ``true``
   * - ``dynamic-filtering.wait-timeout``
-    - Maximum duration for which Trino will wait for dynamic filters to be
-      collected from the build side of joins before starting a JDBC query.
-      Using a large timeout can potentially result in more detailed dynamic filters.
-      However, it can also increase latency for some queries.
+    - Maximum :ref:`prop-type-duration` for which Trino will wait for dynamic
+      filters to be collected from the build side of joins before starting a
+      JDBC query. Using a large timeout can potentially result in more detailed
+      dynamic filters. However, it can also increase latency for some queries.
     - ``20s``


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

We had a [Slack question](https://trinodb.slack.com/archives/C0305TQ05KL/p1679065255177109) about the unclear way to configure one of the properties in this fragment. I've linked to the docs on what a duration is to make things more clear.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
