### PR TITLE
Allow configuring a custom DNS resolver for the JDBC driver

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
@@ -88,6 +88,8 @@ final class ConnectionProperties
     public static final ConnectionProperty<String> TRACE_TOKEN = new TraceToken();
     public static final ConnectionProperty<Map<String, String>> SESSION_PROPERTIES = new SessionProperties();
     public static final ConnectionProperty<String> SOURCE = new Source();
+    public static final ConnectionProperty<Class<? extends DnsResolver>> DNS_RESOLVER = new Resolver();
+    public static final ConnectionProperty<String> DNS_RESOLVER_CONTEXT = new ResolverContext();
 
     private static final Set<ConnectionProperty<?>> ALL_PROPERTIES = ImmutableSet.<ConnectionProperty<?>>builder()
             .add(USER)
@@ -128,6 +130,8 @@ final class ConnectionProperties
             .add(EXTERNAL_AUTHENTICATION_TIMEOUT)
             .add(EXTERNAL_AUTHENTICATION_TOKEN_CACHE)
             .add(EXTERNAL_AUTHENTICATION_REDIRECT_HANDLERS)
+            .add(DNS_RESOLVER)
+            .add(DNS_RESOLVER_CONTEXT)
             .build();
 
     private static final Map<String, ConnectionProperty<?>> KEY_LOOKUP = unmodifiableMap(ALL_PROPERTIES.stream()
@@ -610,6 +614,34 @@ final class ConnectionProperties
         public Source()
         {
             super("source", NOT_REQUIRED, ALLOWED, STRING_CONVERTER);
+        }
+    }
+
+    private static class Resolver
+            extends AbstractConnectionProperty<Class<? extends DnsResolver>>
+    {
+        public Resolver()
+        {
+            super("dnsResolver", NOT_REQUIRED, ALLOWED, Resolver::findByName);
+        }
+
+        public static Class<? extends DnsResolver> findByName(String name)
+        {
+            try {
+                return Class.forName(name).asSubclass(DnsResolver.class);
+            }
+            catch (ClassNotFoundException e) {
+                throw new RuntimeException("DNS resolver class not found: " + name, e);
+            }
+        }
+    }
+
+    private static class ResolverContext
+            extends AbstractConnectionProperty<String>
+    {
+        public ResolverContext()
+        {
+            super("dnsResolverContext", NOT_REQUIRED, ALLOWED, STRING_CONVERTER);
         }
     }
 

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/DnsResolver.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/DnsResolver.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.jdbc;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+
+public interface DnsResolver
+{
+    List<InetAddress> lookup(String hostname)
+            throws UnknownHostException;
+}

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
@@ -58,6 +58,8 @@ import static io.trino.jdbc.ConnectionProperties.ASSUME_LITERAL_UNDERSCORE_IN_ME
 import static io.trino.jdbc.ConnectionProperties.CLIENT_INFO;
 import static io.trino.jdbc.ConnectionProperties.CLIENT_TAGS;
 import static io.trino.jdbc.ConnectionProperties.DISABLE_COMPRESSION;
+import static io.trino.jdbc.ConnectionProperties.DNS_RESOLVER;
+import static io.trino.jdbc.ConnectionProperties.DNS_RESOLVER_CONTEXT;
 import static io.trino.jdbc.ConnectionProperties.EXTERNAL_AUTHENTICATION;
 import static io.trino.jdbc.ConnectionProperties.EXTERNAL_AUTHENTICATION_REDIRECT_HANDLERS;
 import static io.trino.jdbc.ConnectionProperties.EXTERNAL_AUTHENTICATION_TIMEOUT;
@@ -348,12 +350,25 @@ public final class TrinoDriverUri
                 builder.authenticator(authenticator);
                 builder.addInterceptor(authenticator);
             }
+
+            Optional<String> resolverContext = DNS_RESOLVER_CONTEXT.getValue(properties);
+            DNS_RESOLVER.getValue(properties).ifPresent(resolverClass -> builder.dns(instantiateDnsResolver(resolverClass, resolverContext)::lookup));
         }
         catch (ClientException e) {
             throw new SQLException(e.getMessage(), e);
         }
         catch (RuntimeException e) {
             throw new SQLException("Error setting up connection", e);
+        }
+    }
+
+    private static DnsResolver instantiateDnsResolver(Class<? extends DnsResolver> resolverClass, Optional<String> context)
+    {
+        try {
+            return resolverClass.getConstructor(String.class).newInstance(context.orElse(null));
+        }
+        catch (ReflectiveOperationException e) {
+            throw new ClientException("Unable to instantiate custom DNS resolver " + resolverClass.getName(), e);
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Provide a way to configure a custom DNS resolver for the JDBC driver.

Adds 2 new new JDBC URL parameters:

- `dnsResolver` - the name of the class implementing interface `io.trino.jdbc.DnsResolver`
- `dnsResolverContext` - a string argument to be passed to the constructor of the above class (if this parameter is not provided, `null` will be used)

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(X) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown

```
