### PR TITLE
Remove Iceberg, Delta $data system table

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableName.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableName.java
@@ -31,9 +31,9 @@ public class TestDeltaLakeTableName
     public void testFrom()
     {
         assertFrom("abc", "abc", DATA);
-        assertFrom("abc$data", "abc", DATA);
         assertFrom("abc$history", "abc", DeltaLakeTableType.HISTORY);
 
+        assertInvalid("abc$data", "Invalid Delta Lake table name (unknown type 'data'): abc$data");
         assertInvalid("abc@123", "Invalid Delta Lake table name: abc@123");
         assertInvalid("abc@xyz", "Invalid Delta Lake table name: abc@xyz");
         assertInvalid("abc$what", "Invalid Delta Lake table name (unknown type 'what'): abc$what");
@@ -45,8 +45,8 @@ public class TestDeltaLakeTableName
     public void testIsDataTable()
     {
         assertTrue(DeltaLakeTableName.isDataTable("abc"));
-        assertTrue(DeltaLakeTableName.isDataTable("abc$data"));
 
+        assertFalse(DeltaLakeTableName.isDataTable("abc$data")); // it's invalid
         assertFalse(DeltaLakeTableName.isDataTable("abc$history"));
         assertFalse(DeltaLakeTableName.isDataTable("abc$invalid"));
     }
@@ -64,7 +64,7 @@ public class TestDeltaLakeTableName
     public void testTableTypeFrom()
     {
         assertEquals(DeltaLakeTableName.tableTypeFrom("abc"), Optional.of(DATA));
-        assertEquals(DeltaLakeTableName.tableTypeFrom("abc$data"), Optional.of(DATA));
+        assertEquals(DeltaLakeTableName.tableTypeFrom("abc$data"), Optional.empty()); // it's invalid
         assertEquals(DeltaLakeTableName.tableTypeFrom("abc$history"), Optional.of(HISTORY));
 
         assertEquals(DeltaLakeTableName.tableTypeFrom("abc$invalid"), Optional.empty());

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableName.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableName.java
@@ -29,10 +29,10 @@ public class TestIcebergTableName
     public void testFrom()
     {
         assertFrom("abc", "abc", TableType.DATA);
-        assertFrom("abc$data", "abc", TableType.DATA);
         assertFrom("abc$history", "abc", TableType.HISTORY);
         assertFrom("abc$snapshots", "abc", TableType.SNAPSHOTS);
 
+        assertInvalid("abc$data", "Invalid Iceberg table name (unknown type 'data'): abc$data");
         assertInvalid("abc@123", "Invalid Iceberg table name: abc@123");
         assertInvalid("abc@xyz", "Invalid Iceberg table name: abc@xyz");
         assertInvalid("abc$what", "Invalid Iceberg table name (unknown type 'what'): abc$what");
@@ -48,8 +48,8 @@ public class TestIcebergTableName
     public void testIsDataTable()
     {
         assertTrue(IcebergTableName.isDataTable("abc"));
-        assertTrue(IcebergTableName.isDataTable("abc$data"));
 
+        assertFalse(IcebergTableName.isDataTable("abc$data")); // it's invalid
         assertFalse(IcebergTableName.isDataTable("abc$history"));
         assertFalse(IcebergTableName.isDataTable("abc$invalid"));
     }
@@ -67,7 +67,7 @@ public class TestIcebergTableName
     public void testTableTypeFrom()
     {
         assertEquals(IcebergTableName.tableTypeFrom("abc"), Optional.of(TableType.DATA));
-        assertEquals(IcebergTableName.tableTypeFrom("abc$data"), Optional.of(TableType.DATA));
+        assertEquals(IcebergTableName.tableTypeFrom("abc$data"), Optional.empty()); // it's invalid
         assertEquals(IcebergTableName.tableTypeFrom("abc$history"), Optional.of(TableType.HISTORY));
 
         assertEquals(IcebergTableName.tableTypeFrom("abc$invalid"), Optional.empty());

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -4675,6 +4675,17 @@ public abstract class BaseConnectorTest
         }
     }
 
+    /**
+     * Some connectors support system table denoted with $-suffix. Ensure no connector exposes table_name$data
+     * directly to users, as it would mean the same thing as table_name itself.
+     */
+    @Test
+    public void testNoDataSystemTable()
+    {
+        assertQuerySucceeds("TABLE nation");
+        assertQueryFails("TABLE \"nation$data\"", "line 1:1: Table '\\w+.\\w+.nation\\$data' does not exist");
+    }
+
     @Test(dataProvider = "testColumnNameDataProvider")
     public void testColumnName(String columnName)
     {


### PR DESCRIPTION
It was not intentional to expose a table's data as `a_table$data` "system" table. This commit removes support for these tables.
