### PR TITLE
Fix race condition in the hive table stats cache

### DIFF
--- a/lib/trino-collect/src/main/java/io/trino/collect/cache/EvictableCache.java
+++ b/lib/trino-collect/src/main/java/io/trino/collect/cache/EvictableCache.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Verify.verify;
@@ -292,6 +293,13 @@ class EvictableCache<K, V>
             @Override
             public V putIfAbsent(K key, V value)
             {
+                throw new UnsupportedOperationException("The operation is not supported, as in inherently races with cache invalidation");
+            }
+
+            @Override
+            public V compute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction)
+            {
+                // default implementation of ConcurrentMap#compute uses not supported putIfAbsent in some cases
                 throw new UnsupportedOperationException("The operation is not supported, as in inherently races with cache invalidation");
             }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/Table.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/Table.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import io.trino.spi.connector.SchemaTableName;
 
 import javax.annotation.concurrent.Immutable;
@@ -29,10 +30,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -154,6 +157,16 @@ public class Table
     public OptionalLong getWriteId()
     {
         return writeId;
+    }
+
+    public Table withSelectedDataColumnsOnly(Set<String> columns)
+    {
+        Map<String, Column> columnNameToColumn = Maps.uniqueIndex(getDataColumns(), Column::getName);
+        return Table.builder(this)
+                .setDataColumns(columns.stream()
+                        .map(column -> requireNonNull(columnNameToColumn.get(column), "column " + column + " not found in table: " + this))
+                        .collect(toImmutableList()))
+                .build();
     }
 
     public static Builder builder()


### PR DESCRIPTION
putIfAbsent method is not implemented in the EvictableCache because of race condition with invalidation so to avoid the race condition we use AtomicReference that at some cases can be thrown away, but it makes cached value fresh even if invalidation happens during value load

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

fixes https://github.com/trinodb/trino/issues/16653

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
