### PR TITLE
Workaround error-prone record problem without warning suppression

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/RecordParameter.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/RecordParameter.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base;
+
+import com.google.errorprone.annotations.Keep;
+
+/**
+ * An annotation to put on record parameters as a workaround to
+ * <a href="https://github.com/google/error-prone/issues/2713">error-prone's 2713 issue</a>.
+ */
+@Keep
+public @interface RecordParameter {}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.jmx.CacheStatsMBean;
 import io.airlift.units.Duration;
 import io.trino.collect.cache.EvictableCacheBuilder;
+import io.trino.plugin.base.RecordParameter;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.plugin.jdbc.IdentityCacheMapping.IdentityCacheKey;
 import io.trino.spi.TrinoException;
@@ -658,9 +659,8 @@ public class CachingJdbcClient
         cache.invalidateAll(cacheKeys);
     }
 
-    private record ColumnsCacheKey(IdentityCacheKey identity, Map<String, Object> sessionProperties, SchemaTableName table)
+    private record ColumnsCacheKey(@RecordParameter IdentityCacheKey identity, @RecordParameter Map<String, Object> sessionProperties, @RecordParameter SchemaTableName table)
     {
-        @SuppressWarnings("UnusedVariable") // TODO: Remove once https://github.com/google/error-prone/issues/2713 is fixed
         private ColumnsCacheKey
         {
             requireNonNull(identity, "identity is null");


### PR DESCRIPTION
Warning suppression is not ideal as it may lead to suppression of more then originally desired. Work around
https://github.com/google/error-prone/issues/2713 using error-prone's annotation-based suppression mechanism.

Note: using `@Keep` directly is not effective. Only `@Keep`-annotated annotation seems to work.

Note 2: using this annotation isn't usually required, as parameter validation in compact constructor usually makes error-prone happy and avoids aforementioned issue. Use it only when needed.