### PR TITLE
Disable testReadMetadataWithRelationsConcurrentModifications on H2 because of flakes

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectorTest.java
@@ -140,6 +140,14 @@ public class TestJdbcConnectorTest
                 .hasStackTraceContaining("TrinoException: " + MODIFYING_ROWS_MESSAGE);
     }
 
+    @Override
+    public void testReadMetadataWithRelationsConcurrentModifications()
+    {
+        // Under concurrently, H2 sometimes returns null table name in DatabaseMetaData.getTables's ResultSet
+        // See https://github.com/trinodb/trino/issues/16658 for more information
+        throw new SkipException("Skipped due to H2 problems");
+    }
+
     @Test
     public void testUnknownTypeAsIgnored()
     {


### PR DESCRIPTION

Under concurrently, H2 sometimes returns null table name in `DatabaseMetaData.getTables`'s `ResultSet`.

Fixes https://github.com/trinodb/trino/issues/16658