### PR TITLE
Remove redundant override from PhoenixClient and enable `RedundantOverride` error-prone check

### DIFF
--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -239,12 +239,6 @@ public class PhoenixClient
     }
 
     @Override
-    public void execute(ConnectorSession session, String statement)
-    {
-        super.execute(session, statement);
-    }
-
-    @Override
     public Collection<String> listSchemas(Connection connection)
     {
         try (ResultSet resultSet = connection.getMetaData().getSchemas()) {

--- a/pom.xml
+++ b/pom.xml
@@ -2335,6 +2335,7 @@
                                     -Xep:Overrides:ERROR \
                                     -Xep:PreferredInterfaceType:OFF <!-- flags List fields even if initialized with ImmutableList --> \
                                     -Xep:PrimitiveArrayPassedToVarargsMethod:ERROR \
+                                    -Xep:RedundantOverride:ERROR \
                                     -Xep:StreamResourceLeak:ERROR \
                                     -Xep:UnnecessaryLambda:OFF <!-- we deliberately use it in a couple of places --> \
                                     -Xep:UnnecessaryMethodReference:ERROR \


### PR DESCRIPTION
## Description

* Remove redundant override from PhoenixClient
  * Note: this overridden method isn't caught by error-prone's `RedundantOverride` because the access modifier differs. 
* Enable RedundantOverride error-prone check

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
