### PR TITLE
Remove kill-switch to disable automatic fetch-size selection

### DIFF
--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
@@ -196,7 +196,6 @@ public class OracleClient
             .put(TIMESTAMP_TZ_MILLIS, WriteMapping.longMapping("timestamp(3) with time zone", oracleTimestampWithTimeZoneWriteFunction()))
             .buildOrThrow();
 
-    private final boolean disableAutomaticFetchSize;
     private final boolean synonymsEnabled;
     private final ConnectorExpressionRewriter<ParameterizedExpression> connectorExpressionRewriter;
     private final AggregateFunctionRewriter<JdbcExpression, ?> aggregateFunctionRewriter;
@@ -212,7 +211,6 @@ public class OracleClient
     {
         super("\"", connectionFactory, queryBuilder, config.getJdbcTypesMappedToVarchar(), identifierMapping, queryModifier, false);
 
-        this.disableAutomaticFetchSize = oracleConfig.isDisableAutomaticFetchSize();
         this.synonymsEnabled = oracleConfig.isSynonymsEnabled();
 
         this.connectorExpressionRewriter = JdbcConnectorExpressionRewriterBuilder.newBuilder()
@@ -262,12 +260,9 @@ public class OracleClient
             throws SQLException
     {
         PreparedStatement statement = connection.prepareStatement(sql);
-        if (disableAutomaticFetchSize) {
-            statement.setFetchSize(1000);
-        }
         // This is a heuristic, not exact science. A better formula can perhaps be found with measurements.
         // Column count is not known for non-SELECT queries. Not setting fetch size for these.
-        else if (columnCount.isPresent()) {
+        if (columnCount.isPresent()) {
             statement.setFetchSize(max(100_000 / columnCount.get(), 1_000));
         }
         return statement;

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleConfig.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleConfig.java
@@ -15,6 +15,7 @@ package io.trino.plugin.oracle;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.DefunctConfig;
 import io.airlift.units.Duration;
 
 import javax.validation.constraints.AssertTrue;
@@ -27,9 +28,9 @@ import java.util.Optional;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 
+@DefunctConfig("oracle.disable-automatic-fetch-size")
 public class OracleConfig
 {
-    private boolean disableAutomaticFetchSize;
     private boolean synonymsEnabled;
     private boolean remarksReportingEnabled;
     private Integer defaultNumberScale;
@@ -38,20 +39,6 @@ public class OracleConfig
     private int connectionPoolMinSize = 1;
     private int connectionPoolMaxSize = 30;
     private Duration inactiveConnectionTimeout = new Duration(20, MINUTES);
-
-    @Deprecated
-    public boolean isDisableAutomaticFetchSize()
-    {
-        return disableAutomaticFetchSize;
-    }
-
-    @Deprecated // TODO temporary kill-switch, to be removed
-    @Config("oracle.disable-automatic-fetch-size")
-    public OracleConfig setDisableAutomaticFetchSize(boolean disableAutomaticFetchSize)
-    {
-        this.disableAutomaticFetchSize = disableAutomaticFetchSize;
-        return this;
-    }
 
     @NotNull
     public boolean isSynonymsEnabled()

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConfig.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConfig.java
@@ -36,7 +36,6 @@ public class TestOracleConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(OracleConfig.class)
-                .setDisableAutomaticFetchSize(false)
                 .setSynonymsEnabled(false)
                 .setRemarksReportingEnabled(false)
                 .setDefaultNumberScale(null)
@@ -51,7 +50,6 @@ public class TestOracleConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("oracle.disable-automatic-fetch-size", "true")
                 .put("oracle.synonyms.enabled", "true")
                 .put("oracle.remarks-reporting.enabled", "true")
                 .put("oracle.number.default-scale", "2")
@@ -63,7 +61,6 @@ public class TestOracleConfig
                 .buildOrThrow();
 
         OracleConfig expected = new OracleConfig()
-                .setDisableAutomaticFetchSize(true)
                 .setSynonymsEnabled(true)
                 .setRemarksReportingEnabled(true)
                 .setDefaultNumberScale(2)

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -269,7 +269,6 @@ public class PostgreSqlClient
         return FULL_PUSHDOWN.apply(session, simplifiedDomain);
     };
 
-    private final boolean disableAutomaticFetchSize;
     private final Type jsonType;
     private final Type uuidType;
     private final MapType varcharMapType;
@@ -290,7 +289,6 @@ public class PostgreSqlClient
             RemoteQueryModifier queryModifier)
     {
         super("\"", connectionFactory, queryBuilder, config.getJdbcTypesMappedToVarchar(), identifierMapping, queryModifier, true);
-        this.disableAutomaticFetchSize = postgreSqlConfig.isDisableAutomaticFetchSize();
         this.jsonType = typeManager.getType(new TypeSignature(JSON));
         this.uuidType = typeManager.getType(new TypeSignature(StandardTypes.UUID));
         this.varcharMapType = (MapType) typeManager.getType(mapType(VARCHAR.getTypeSignature(), VARCHAR.getTypeSignature()));
@@ -408,12 +406,9 @@ public class PostgreSqlClient
         // fetch-size is ignored when connection is in auto-commit
         connection.setAutoCommit(false);
         PreparedStatement statement = connection.prepareStatement(sql);
-        if (disableAutomaticFetchSize) {
-            statement.setFetchSize(1000);
-        }
         // This is a heuristic, not exact science. A better formula can perhaps be found with measurements.
         // Column count is not known for non-SELECT queries. Not setting fetch size for these.
-        else if (columnCount.isPresent()) {
+        if (columnCount.isPresent()) {
             statement.setFetchSize(max(100_000 / columnCount.get(), 1_000));
         }
         return statement;

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlConfig.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlConfig.java
@@ -14,30 +14,17 @@
 package io.trino.plugin.postgresql;
 
 import io.airlift.configuration.Config;
+import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.LegacyConfig;
 
 import javax.validation.constraints.NotNull;
 
+@DefunctConfig("postgresql.disable-automatic-fetch-size")
 public class PostgreSqlConfig
 {
-    private boolean disableAutomaticFetchSize;
     private ArrayMapping arrayMapping = ArrayMapping.DISABLED;
     private boolean includeSystemTables;
     private boolean enableStringPushdownWithCollate;
-
-    @Deprecated
-    public boolean isDisableAutomaticFetchSize()
-    {
-        return disableAutomaticFetchSize;
-    }
-
-    @Deprecated // TODO temporary kill-switch, to be removed
-    @Config("postgresql.disable-automatic-fetch-size")
-    public PostgreSqlConfig setDisableAutomaticFetchSize(boolean disableAutomaticFetchSize)
-    {
-        this.disableAutomaticFetchSize = disableAutomaticFetchSize;
-        return this;
-    }
 
     public enum ArrayMapping
     {

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConfig.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConfig.java
@@ -28,7 +28,6 @@ public class TestPostgreSqlConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(PostgreSqlConfig.class)
-                .setDisableAutomaticFetchSize(false)
                 .setArrayMapping(PostgreSqlConfig.ArrayMapping.DISABLED)
                 .setIncludeSystemTables(false)
                 .setEnableStringPushdownWithCollate(false));
@@ -38,14 +37,12 @@ public class TestPostgreSqlConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("postgresql.disable-automatic-fetch-size", "true")
                 .put("postgresql.array-mapping", "AS_ARRAY")
                 .put("postgresql.include-system-tables", "true")
                 .put("postgresql.experimental.enable-string-pushdown-with-collate", "true")
                 .buildOrThrow();
 
         PostgreSqlConfig expected = new PostgreSqlConfig()
-                .setDisableAutomaticFetchSize(true)
                 .setArrayMapping(PostgreSqlConfig.ArrayMapping.AS_ARRAY)
                 .setIncludeSystemTables(true)
                 .setEnableStringPushdownWithCollate(true);

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftConfig.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftConfig.java
@@ -14,25 +14,12 @@
 package io.trino.plugin.redshift;
 
 import io.airlift.configuration.Config;
+import io.airlift.configuration.DefunctConfig;
 
+@DefunctConfig("redshift.disable-automatic-fetch-size")
 public class RedshiftConfig
 {
-    private boolean disableAutomaticFetchSize;
     private boolean legacyTypeMapping;
-
-    @Deprecated
-    public boolean isDisableAutomaticFetchSize()
-    {
-        return disableAutomaticFetchSize;
-    }
-
-    @Deprecated // TODO temporary kill-switch, to be removed
-    @Config("redshift.disable-automatic-fetch-size")
-    public RedshiftConfig setDisableAutomaticFetchSize(boolean disableAutomaticFetchSize)
-    {
-        this.disableAutomaticFetchSize = disableAutomaticFetchSize;
-        return this;
-    }
 
     public boolean isLegacyTypeMapping()
     {

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConfig.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConfig.java
@@ -28,7 +28,6 @@ public class TestRedshiftConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(RedshiftConfig.class)
-                .setDisableAutomaticFetchSize(false)
                 .setLegacyTypeMapping(false));
     }
 
@@ -36,12 +35,10 @@ public class TestRedshiftConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("redshift.disable-automatic-fetch-size", "true")
                 .put("redshift.use-legacy-type-mapping", "true")
                 .buildOrThrow();
 
         RedshiftConfig expected = new RedshiftConfig()
-                .setDisableAutomaticFetchSize(true)
                 .setLegacyTypeMapping(true);
 
         assertFullMapping(properties, expected);


### PR DESCRIPTION
The configuration toggles `xxx.disable-automatic-fetch-size` were
introduced only temporarily, as a kill-switch.

To be merged after some time since https://github.com/trinodb/trino/pull/16644 is merged and released (in 411).