### PR TITLE
Use a more specific name for all connectors smoke test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -925,7 +925,7 @@ jobs:
               suite: suite-hms-only
             # this suite is not meant to be run with different configs
             - config: default
-              suite: suite-all
+              suite: suite-all-connectors-smoke
             # this suite is not meant to be run with different configs
             - config: default
               suite: suite-delta-lake-oss

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteAllConnectorsSmoke.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteAllConnectorsSmoke.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 import static io.trino.tests.product.launcher.suite.SuiteTestRun.testOnEnvironment;
 
-public class SuiteAll
+public class SuiteAllConnectorsSmoke
         extends Suite
 {
     @Override

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteAllConnectorsSmoke.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteAllConnectorsSmoke.java
@@ -23,6 +23,11 @@ import java.util.List;
 
 import static io.trino.tests.product.launcher.suite.SuiteTestRun.testOnEnvironment;
 
+/**
+ * Suite that verifies that the cluster starts with as many connectors
+ * enabled as possible. The catalogs do not have to have valid configuration,
+ * so it might not be possible to execute queries using them.
+ */
 public class SuiteAllConnectorsSmoke
         extends Suite
 {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

`SuiteAll` is too generic and does not reflect it only tests if the cluster starts at all, with all connectors being enabled.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
