### PR TITLE
Simplify MaxDataSizeForStats and SumDataSizeForStats

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/SumDataSizeForStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/SumDataSizeForStats.java
@@ -13,7 +13,7 @@
  */
 package io.trino.operator.aggregation;
 
-import io.trino.operator.aggregation.state.NullableLongState;
+import io.trino.operator.aggregation.state.LongState;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.function.AggregationFunction;
@@ -37,31 +37,25 @@ public final class SumDataSizeForStats
 
     @InputFunction
     @TypeParameter("T")
-    public static void input(@AggregationState NullableLongState state, @BlockPosition @SqlType("T") Block block, @BlockIndex int index)
+    public static void input(@AggregationState LongState state, @BlockPosition @SqlType("T") Block block, @BlockIndex int index)
     {
         update(state, block.getEstimatedDataSizeForStats(index));
     }
 
     @CombineFunction
-    public static void combine(@AggregationState NullableLongState state, @AggregationState NullableLongState otherState)
+    public static void combine(@AggregationState LongState state, @AggregationState LongState otherState)
     {
         update(state, otherState.getValue());
     }
 
-    private static void update(NullableLongState state, long size)
+    private static void update(LongState state, long size)
     {
-        if (state.isNull()) {
-            state.setNull(false);
-            state.setValue(size);
-        }
-        else {
-            state.setValue(state.getValue() + size);
-        }
+        state.setValue(state.getValue() + size);
     }
 
     @OutputFunction(StandardTypes.BIGINT)
-    public static void output(@AggregationState NullableLongState state, BlockBuilder out)
+    public static void output(@AggregationState LongState state, BlockBuilder out)
     {
-        NullableLongState.write(BigintType.BIGINT, state, out);
+        BigintType.BIGINT.writeLong(out, state.getValue());
     }
 }


### PR DESCRIPTION
## Description
Block#getEstimatedDataSizeForStats is well defined for null positions. 
We can use this to replace NullableLongState with LongState.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
