### PR TITLE
Fix Kerberos ticket refresh

### DIFF
--- a/lib/trino-hdfs/src/main/java/io/trino/hdfs/authentication/CachingKerberosHadoopAuthentication.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/hdfs/authentication/CachingKerberosHadoopAuthentication.java
@@ -19,6 +19,8 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.security.auth.Subject;
 import javax.security.auth.kerberos.KerberosTicket;
 
+import java.util.Set;
+
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.plugin.base.authentication.KerberosTicketUtils.getRefreshTime;
 import static io.trino.plugin.base.authentication.KerberosTicketUtils.getTicketGrantingTicket;
@@ -30,22 +32,40 @@ public class CachingKerberosHadoopAuthentication
 {
     private final KerberosHadoopAuthentication delegate;
 
-    @GuardedBy("this")
-    private UserGroupInformation userGroupInformation;
+    private final UserGroupInformation userGroupInformation;
     @GuardedBy("this")
     private long nextRefreshTime;
 
     public CachingKerberosHadoopAuthentication(KerberosHadoopAuthentication delegate)
     {
         this.delegate = requireNonNull(delegate, "delegate is null");
+        this.userGroupInformation = requireNonNull(delegate.getUserGroupInformation(), "delegate.getUserGroupInformation() is null");
+        nextRefreshTime = calculateNextRefreshTime(userGroupInformation);
     }
 
     @Override
     public synchronized UserGroupInformation getUserGroupInformation()
     {
-        if (nextRefreshTime < System.currentTimeMillis() || userGroupInformation == null) {
-            userGroupInformation = requireNonNull(delegate.getUserGroupInformation(), "delegate.getUserGroupInformation() is null");
-            nextRefreshTime = calculateNextRefreshTime(userGroupInformation);
+        if (nextRefreshTime < System.currentTimeMillis()) {
+            Subject existingSubject = getSubject(userGroupInformation);
+            UserGroupInformation newUserGroupInformation = requireNonNull(delegate.getUserGroupInformation(), "delegate.getUserGroupInformation() is null");
+            Subject newSubject = getSubject(newUserGroupInformation);
+
+            // We modify the existing UGI's credentials in-place instead of returning new UGI because some parts of Hadoop code reuse UGI (e.g. DFSClient)
+            // We also need to clear the old credentials because JDK assumes that the first credential is the TGT which is not always true
+            existingSubject.getPrincipals().addAll(newSubject.getPrincipals());
+            Set<Object> privateCredentials = existingSubject.getPrivateCredentials();
+            synchronized (privateCredentials) {
+                privateCredentials.clear();
+                privateCredentials.addAll(newSubject.getPrivateCredentials());
+            }
+
+            Set<Object> publicCredentials = existingSubject.getPublicCredentials();
+            synchronized (publicCredentials) {
+                publicCredentials.clear();
+                publicCredentials.addAll(newSubject.getPublicCredentials());
+            }
+            nextRefreshTime = calculateNextRefreshTime(newUserGroupInformation);
         }
         return userGroupInformation;
     }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/HadoopKerberos.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/HadoopKerberos.java
@@ -70,6 +70,7 @@ public class HadoopKerberos
             container
                     .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withDomainName("docker.cluster"))
                     .withCopyFileToContainer(forHostPath(configDir.getPath("config.properties")), CONTAINER_TRINO_CONFIG_PROPERTIES)
+                    .withCopyFileToContainer(forHostPath(configDir.getPath("krb5.conf")), "/etc/krb5.conf")
                     .withCopyFileToContainer(
                             forHostPath(configDir.getPath("create_kerberos_credential_cache_files.sh")),
                             "/docker/presto-init.d/create_kerberos_credentials.sh");

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite2.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite2.java
@@ -38,7 +38,7 @@ public class Suite2
                         .withGroups("configured_features", "hdfs_no_impersonation")
                         .build(),
                 testOnEnvironment(EnvSinglenodeKerberosHdfsNoImpersonation.class)
-                        .withGroups("configured_features", "storage_formats", "hdfs_no_impersonation")
+                        .withGroups("configured_features", "storage_formats", "hdfs_no_impersonation", "hive_kerberos")
                         .build(),
                 testOnEnvironment(EnvSinglenodeKerberosHiveNoImpersonationWithCredentialCache.class)
                         .withGroups("configured_features", "storage_formats", "hdfs_no_impersonation")
@@ -47,7 +47,7 @@ public class Suite2
                         .withGroups("configured_features", "storage_formats", "cli", "hdfs_impersonation")
                         .build(),
                 testOnEnvironment(EnvSinglenodeKerberosHdfsImpersonation.class)
-                        .withGroups("configured_features", "storage_formats", "cli", "hdfs_impersonation", "authorization", "hive_file_header")
+                        .withGroups("configured_features", "storage_formats", "cli", "hdfs_impersonation", "authorization", "hive_file_header", "hive_kerberos")
                         .build());
     }
 }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite5.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite5.java
@@ -37,7 +37,7 @@ public class Suite5
                         .withGroups("configured_features", "storage_formats", "hdfs_impersonation")
                         .build(),
                 testOnEnvironment(EnvSinglenodeKerberosHiveImpersonation.class)
-                        .withGroups("configured_features", "storage_formats", "hdfs_impersonation", "authorization")
+                        .withGroups("configured_features", "storage_formats", "hdfs_impersonation", "authorization", "hive_kerberos")
                         .build(),
                 testOnEnvironment(EnvSinglenodeKerberosHiveImpersonationWithCredentialCache.class)
                         .withGroups("configured_features", "storage_formats", "hdfs_impersonation", "authorization")

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite7NonGeneric.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite7NonGeneric.java
@@ -54,7 +54,7 @@ public class Suite7NonGeneric
                         .withGroups("configured_features", "hive_spark_no_stats_fallback")
                         .build(),
                 testOnEnvironment(EnvSinglenodeKerberosHdfsImpersonationCrossRealm.class)
-                        .withGroups("configured_features", "storage_formats", "cli", "hdfs_impersonation")
+                        .withGroups("configured_features", "storage_formats", "cli", "hdfs_impersonation", "hive_kerberos")
                         .build(),
                 testOnEnvironment(EnvMultinodeKerberosKudu.class)
                         .withGroups("configured_features", "kudu")

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop-kerberos/create_kerberos_credential_cache_files.sh
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop-kerberos/create_kerberos_credential_cache_files.sh
@@ -2,15 +2,18 @@
 
 set -exuo pipefail
 
-kinit -f -c /etc/trino/conf/presto-server-krbcc \
+# kinit with enough lifetime to make sure that ticket in cache is valid when the first refresh is triggered on Trino
+TICKET_LIFETIME='30m'
+
+kinit -l "$TICKET_LIFETIME" -f -c /etc/trino/conf/presto-server-krbcc \
       -kt /etc/trino/conf/presto-server.keytab presto-server/$(hostname -f)@LABS.TERADATA.COM
 
-kinit -f -c /etc/trino/conf/hive-presto-master-krbcc \
+kinit -l "$TICKET_LIFETIME" -f -c /etc/trino/conf/hive-presto-master-krbcc \
       -kt /etc/trino/conf/hive-presto-master.keytab hive/$(hostname -f)@LABS.TERADATA.COM
 
 
-kinit -f -c /etc/trino/conf/hdfs-krbcc \
+kinit -l "$TICKET_LIFETIME" -f -c /etc/trino/conf/hdfs-krbcc \
       -kt /etc/hadoop/conf/hdfs.keytab hdfs/hadoop-master@LABS.TERADATA.COM
 
-kinit -f -c /etc/trino/conf/hive-krbcc \
+kinit -l "$TICKET_LIFETIME" -f -c /etc/trino/conf/hive-krbcc \
       -kt /etc/hive/conf/hive.keytab hive/hadoop-master@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop-kerberos/krb5.conf
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop-kerberos/krb5.conf
@@ -1,0 +1,25 @@
+# Copy of hdp2.6-hive-kerberized/etc/krb5.conf with lower ticket_lifetime
+[logging]
+ default = FILE:/var/log/krb5libs.log
+ kdc = FILE:/var/log/krb5kdc.log
+ admin_server = FILE:/var/log/kadmind.log
+
+[libdefaults]
+ default_realm = LABS.TERADATA.COM
+ dns_lookup_realm = false
+ dns_lookup_kdc = false
+ forwardable = true
+ allow_weak_crypto = true
+ # low ticket_lifetime to make sure refresh code in Trino is tested
+ ticket_lifetime = 30s
+
+[realms]
+ LABS.TERADATA.COM = {
+  kdc = hadoop-master:88
+  admin_server = hadoop-master
+ }
+ OTHERLABS.TERADATA.COM = {
+  kdc = hadoop-master:89
+  admin_server = hadoop-master
+ }
+

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestGroups.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestGroups.java
@@ -52,6 +52,7 @@ public final class TestGroups
     public static final String HIVE_CACHING = "hive_caching";
     public static final String HIVE_ICEBERG_REDIRECTIONS = "hive_iceberg_redirections";
     public static final String HIVE_HUDI_REDIRECTIONS = "hive_hudi_redirections";
+    public static final String HIVE_KERBEROS = "hive_kerberos";
     public static final String AUTHORIZATION = "authorization";
     public static final String HIVE_COERCION = "hive_coercion";
     public static final String AZURE = "azure";

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveConnectorKerberosSmokeTest.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveConnectorKerberosSmokeTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.hive;
+
+import com.google.common.io.Closer;
+import io.trino.tempto.AfterTestWithContext;
+import io.trino.tempto.BeforeTestWithContext;
+import io.trino.tempto.query.QueryResult;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.trino.tests.product.TestGroups.HIVE_KERBEROS;
+import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.fail;
+
+public class TestHiveConnectorKerberosSmokeTest
+{
+    private Closer closer;
+    private ExecutorService executor;
+
+    @BeforeTestWithContext
+    public void setUp()
+    {
+        closer = Closer.create();
+        executor = newSingleThreadExecutor(); // single thread is enough, it schedules the query to cancel
+        closer.register(executor::shutdownNow);
+    }
+
+    @AfterTestWithContext
+    public void cleanUp()
+            throws IOException
+    {
+        executor = null;
+        closer.close();
+        closer = null;
+    }
+
+    @Test(groups = {HIVE_KERBEROS, PROFILE_SPECIFIC_TESTS}, timeOut = 120_000L)
+    public void kerberosTicketExpiryTest()
+            throws Exception
+    {
+        // Session properties to reduce memory usage and also make the query run longer
+        onTrino().executeQuery("SET SESSION scale_writers = false");
+        onTrino().executeQuery("SET SESSION task_scale_writers_enabled = false");
+
+        String sql = "CREATE TABLE orders AS SELECT * FROM tpch.sf1000.orders";
+        Future<?> queryExecution = executor.submit(() -> onTrino().executeQuery(sql));
+
+        // 2x of ticket_lifetime as configured in hadoop-kerberos krb5.conf, sufficient to cause at-least 1 ticket expiry
+        SECONDS.sleep(60L);
+        cancelQueryIfRunning(sql);
+
+        try {
+            queryExecution.get(30, SECONDS);
+            fail("Expected query to have failed");
+        }
+        catch (TimeoutException e) {
+            queryExecution.cancel(true);
+            throw e;
+        }
+        catch (ExecutionException expected) {
+            assertThat(expected.getCause())
+                    .hasMessageEndingWith("Message: explicitly cancelled for test without failure");
+        }
+    }
+
+    private void cancelQueryIfRunning(String sql)
+    {
+        QueryResult queryResult = onTrino().executeQuery("SELECT query_id FROM system.runtime.queries WHERE query = '%s' AND state = 'RUNNING' LIMIT 2".formatted(sql));
+        checkState(queryResult.getRowsCount() < 2, "Found multiple queries");
+        if (queryResult.getRowsCount() == 1) {
+            String queryId = (String) queryResult.getOnlyValue();
+            onTrino().executeQuery("CALL system.runtime.kill_query(query_id => '%s', message => 'explicitly cancelled for test without failure')".formatted(queryId));
+        }
+    }
+}


### PR DESCRIPTION
The Hadoop UGI class handles ticket refresh only if the Subject is not provided externally. For external Subject UGI expects the refresh will be handled by the creator of the Subject which in our case we did not do.

Because of this before this change any Trino query which ran longer than the ticket_lifetime failed with errors like

    GSS initiate failed [Caused by GSSException: No valid credentials
    provided (Mechanism level: Failed to find any Kerberos tgt)].

In Hadoop code the UGI instance also gets re-used in some places (e.g. DFSClient) which means we cannot just create a new UGI with refreshed credentials and return that since other parts of code will keep using the old UGI with expired credentials. So the fix is to create a new UGI, extract the credentials from it and update the existing UGI's credentials with them so that all users of the existing UGI also observe the new valid credentials.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Fix possible query failure with a Kerberized Hive connector when the query executes longer than the Kerberos ticket lifetime. ({issue}`16680`)
```
