### PR TITLE
Improve the performance of filter functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayFilterFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayFilterFunction.java
@@ -14,7 +14,6 @@
 package io.trino.operator.scalar;
 
 import io.trino.spi.block.Block;
-import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.function.Description;
 import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlType;
@@ -39,7 +38,8 @@ public final class ArrayFilterFunction
             @SqlType("function(T, boolean)") LongToBooleanFunction function)
     {
         int positionCount = arrayBlock.getPositionCount();
-        BlockBuilder resultBuilder = elementType.createBlockBuilder(null, positionCount);
+        int[] positions = new int[positionCount];
+        int length = 0;
         for (int position = 0; position < positionCount; position++) {
             Long input = null;
             if (!arrayBlock.isNull(position)) {
@@ -47,11 +47,13 @@ public final class ArrayFilterFunction
             }
 
             Boolean keep = function.apply(input);
-            if (TRUE.equals(keep)) {
-                elementType.appendTo(arrayBlock, position, resultBuilder);
-            }
+            positions[length] = position;
+            length += TRUE.equals(keep) ? 1 : 0;
         }
-        return resultBuilder.build();
+        if (positions.length == length) {
+            return arrayBlock;
+        }
+        return arrayBlock.copyPositions(positions, 0, length);
     }
 
     @TypeParameter("T")
@@ -63,7 +65,8 @@ public final class ArrayFilterFunction
             @SqlType("function(T, boolean)") DoubleToBooleanFunction function)
     {
         int positionCount = arrayBlock.getPositionCount();
-        BlockBuilder resultBuilder = elementType.createBlockBuilder(null, positionCount);
+        int[] positions = new int[positionCount];
+        int length = 0;
         for (int position = 0; position < positionCount; position++) {
             Double input = null;
             if (!arrayBlock.isNull(position)) {
@@ -71,11 +74,13 @@ public final class ArrayFilterFunction
             }
 
             Boolean keep = function.apply(input);
-            if (TRUE.equals(keep)) {
-                elementType.appendTo(arrayBlock, position, resultBuilder);
-            }
+            positions[length] = position;
+            length += TRUE.equals(keep) ? 1 : 0;
         }
-        return resultBuilder.build();
+        if (positions.length == length) {
+            return arrayBlock;
+        }
+        return arrayBlock.copyPositions(positions, 0, length);
     }
 
     @TypeParameter("T")
@@ -87,7 +92,8 @@ public final class ArrayFilterFunction
             @SqlType("function(T, boolean)") BooleanToBooleanFunction function)
     {
         int positionCount = arrayBlock.getPositionCount();
-        BlockBuilder resultBuilder = elementType.createBlockBuilder(null, positionCount);
+        int[] positions = new int[positionCount];
+        int length = 0;
         for (int position = 0; position < positionCount; position++) {
             Boolean input = null;
             if (!arrayBlock.isNull(position)) {
@@ -95,11 +101,13 @@ public final class ArrayFilterFunction
             }
 
             Boolean keep = function.apply(input);
-            if (TRUE.equals(keep)) {
-                elementType.appendTo(arrayBlock, position, resultBuilder);
-            }
+            positions[length] = position;
+            length += TRUE.equals(keep) ? 1 : 0;
         }
-        return resultBuilder.build();
+        if (positions.length == length) {
+            return arrayBlock;
+        }
+        return arrayBlock.copyPositions(positions, 0, length);
     }
 
     @TypeParameter("T")
@@ -111,7 +119,8 @@ public final class ArrayFilterFunction
             @SqlType("function(T, boolean)") ObjectToBooleanFunction function)
     {
         int positionCount = arrayBlock.getPositionCount();
-        BlockBuilder resultBuilder = elementType.createBlockBuilder(null, positionCount);
+        int[] positions = new int[positionCount];
+        int length = 0;
         for (int position = 0; position < positionCount; position++) {
             Object input = null;
             if (!arrayBlock.isNull(position)) {
@@ -119,10 +128,12 @@ public final class ArrayFilterFunction
             }
 
             Boolean keep = function.apply(input);
-            if (TRUE.equals(keep)) {
-                elementType.appendTo(arrayBlock, position, resultBuilder);
-            }
+            positions[length] = position;
+            length += TRUE.equals(keep) ? 1 : 0;
         }
-        return resultBuilder.build();
+        if (positions.length == length) {
+            return arrayBlock;
+        }
+        return arrayBlock.copyPositions(positions, 0, length);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayFilter.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayFilter.java
@@ -28,12 +28,14 @@ import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeSignature;
 import io.trino.sql.gen.ExpressionCompiler;
 import io.trino.sql.relational.CallExpression;
 import io.trino.sql.relational.LambdaDefinitionExpression;
 import io.trino.sql.relational.RowExpression;
+import io.trino.sql.relational.SpecialForm;
 import io.trino.sql.relational.VariableReferenceExpression;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.type.FunctionType;
@@ -58,19 +60,24 @@ import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.base.Verify.verify;
+import static io.trino.block.BlockAssertions.createRandomBlockForType;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.operator.scalar.BenchmarkArrayFilter.ExactArrayFilterFunction.EXACT_ARRAY_FILTER_FUNCTION;
+import static io.trino.operator.scalar.BenchmarkArrayFilter.ExactArrayFilterObjectFunction.EXACT_ARRAY_FILTER_OBJECT_FUNCTION;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.TypeSignature.arrayType;
 import static io.trino.spi.type.TypeSignature.functionType;
 import static io.trino.spi.type.TypeUtils.readNativeValue;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.trino.sql.relational.Expressions.constant;
 import static io.trino.sql.relational.Expressions.field;
+import static io.trino.sql.relational.SpecialForm.Form.DEREFERENCE;
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.util.Reflection.methodHandle;
 import static java.lang.Boolean.TRUE;
@@ -88,14 +95,28 @@ public class BenchmarkArrayFilter
     private static final int ARRAY_SIZE = 4;
     private static final int NUM_TYPES = 1;
     private static final List<Type> TYPES = ImmutableList.of(BIGINT);
+    private static final List<Type> ROW_TYPES = ImmutableList.of(RowType.anonymous(ImmutableList.of(BIGINT, DOUBLE)));
 
     static {
         verify(NUM_TYPES == TYPES.size());
+        verify(NUM_TYPES == ROW_TYPES.size());
     }
 
     @Benchmark
     @OperationsPerInvocation(POSITIONS * ARRAY_SIZE * NUM_TYPES)
     public List<Optional<Page>> benchmark(BenchmarkData data)
+    {
+        return ImmutableList.copyOf(
+                data.getPageProcessor().process(
+                        SESSION,
+                        new DriverYieldSignal(),
+                        newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName()),
+                        data.getPage()));
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(POSITIONS * ARRAY_SIZE * NUM_TYPES)
+    public List<Optional<Page>> benchmarkObject(RowBenchmarkData data)
     {
         return ImmutableList.copyOf(
                 data.getPageProcessor().process(
@@ -172,15 +193,85 @@ public class BenchmarkArrayFilter
         }
     }
 
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class RowBenchmarkData
+    {
+        @Param({"filter", "exact_filter"})
+        private String name = "filter";
+
+        private Page page;
+        private PageProcessor pageProcessor;
+
+        @Setup
+        public void setup()
+        {
+            TestingFunctionResolution functionResolution = new TestingFunctionResolution(InternalFunctionBundle.builder().function(EXACT_ARRAY_FILTER_OBJECT_FUNCTION).build());
+            ExpressionCompiler compiler = functionResolution.getExpressionCompiler();
+            ImmutableList.Builder<RowExpression> projectionsBuilder = ImmutableList.builder();
+            Block[] blocks = new Block[ROW_TYPES.size()];
+            for (int i = 0; i < ROW_TYPES.size(); i++) {
+                Type elementType = ROW_TYPES.get(i);
+                ArrayType arrayType = new ArrayType(elementType);
+                ResolvedFunction resolvedFunction = functionResolution.resolveFunction(
+                        QualifiedName.of(name),
+                        fromTypes(arrayType, new FunctionType(ROW_TYPES, BOOLEAN)));
+                ResolvedFunction lessThan = functionResolution.resolveOperator(LESS_THAN, ImmutableList.of(BIGINT, BIGINT));
+
+                projectionsBuilder.add(new CallExpression(resolvedFunction, ImmutableList.of(
+                        field(0, arrayType),
+                        new LambdaDefinitionExpression(
+                                ImmutableList.of(elementType),
+                                ImmutableList.of("x"),
+                                new CallExpression(
+                                        lessThan,
+                                        ImmutableList.of(
+                                                constant(0L, BIGINT),
+                                                new SpecialForm(
+                                                        DEREFERENCE,
+                                                        BIGINT,
+                                                        new VariableReferenceExpression("x", elementType),
+                                                        constant(0, INTEGER))))))));
+                blocks[i] = createChannel(POSITIONS, arrayType);
+            }
+
+            ImmutableList<RowExpression> projections = projectionsBuilder.build();
+            pageProcessor = compiler.compilePageProcessor(Optional.empty(), projections).get();
+            page = new Page(blocks);
+        }
+
+        private static Block createChannel(int positionCount, ArrayType arrayType)
+        {
+            return createRandomBlockForType(arrayType, positionCount, 0.2F);
+        }
+
+        public PageProcessor getPageProcessor()
+        {
+            return pageProcessor;
+        }
+
+        public Page getPage()
+        {
+            return page;
+        }
+    }
+
     public static void main(String[] args)
             throws Exception
     {
         // assure the benchmarks are valid before running
         BenchmarkData data = new BenchmarkData();
         data.setup();
-        new BenchmarkArrayFilter().benchmark(data);
+        BenchmarkArrayFilter benchmarkArrayFilter = new BenchmarkArrayFilter();
+        benchmarkArrayFilter.benchmark(data);
 
-        Benchmarks.benchmark(BenchmarkArrayFilter.class).run();
+        RowBenchmarkData rowData = new RowBenchmarkData();
+        rowData.setup();
+        benchmarkArrayFilter.benchmarkObject(rowData);
+
+        Benchmarks.benchmark(BenchmarkArrayFilter.class)
+                .withOptions(optionsBuilder -> optionsBuilder.jvmArgs("-Xmx4g"))
+                .run();
     }
 
     public static final class ExactArrayFilterFunction
@@ -222,6 +313,61 @@ public class BenchmarkArrayFilter
             BlockBuilder resultBuilder = type.createBlockBuilder(null, positionCount);
             for (int position = 0; position < positionCount; position++) {
                 Long input = (Long) readNativeValue(type, block, position);
+                Boolean keep;
+                try {
+                    keep = (Boolean) function.invokeExact(input);
+                }
+                catch (Throwable t) {
+                    throwIfUnchecked(t);
+                    throw new RuntimeException(t);
+                }
+                if (TRUE.equals(keep)) {
+                    type.appendTo(block, position, resultBuilder);
+                }
+            }
+            return resultBuilder.build();
+        }
+    }
+
+    public static final class ExactArrayFilterObjectFunction
+            extends SqlScalarFunction
+    {
+        public static final ExactArrayFilterObjectFunction EXACT_ARRAY_FILTER_OBJECT_FUNCTION = new ExactArrayFilterObjectFunction();
+
+        private static final MethodHandle METHOD_HANDLE = methodHandle(ExactArrayFilterObjectFunction.class, "filterObject", Type.class, Block.class, MethodHandle.class);
+
+        private ExactArrayFilterObjectFunction()
+        {
+            super(FunctionMetadata.scalarBuilder()
+                    .signature(Signature.builder()
+                            .name("exact_filter")
+                            .typeVariable("T")
+                            .returnType(arrayType(new TypeSignature("T")))
+                            .argumentType(arrayType(new TypeSignature("T")))
+                            .argumentType(functionType(new TypeSignature("T"), BOOLEAN.getTypeSignature()))
+                            .build())
+                    .nondeterministic()
+                    .description("return array containing elements that match the given predicate")
+                    .build());
+        }
+
+        @Override
+        protected SpecializedSqlScalarFunction specialize(BoundSignature boundSignature)
+        {
+            Type type = ((ArrayType) boundSignature.getReturnType()).getElementType();
+            return new ChoicesSpecializedSqlScalarFunction(
+                    boundSignature,
+                    FAIL_ON_NULL,
+                    ImmutableList.of(NEVER_NULL, NEVER_NULL),
+                    METHOD_HANDLE.bindTo(type));
+        }
+
+        public static Block filterObject(Type type, Block block, MethodHandle function)
+        {
+            int positionCount = block.getPositionCount();
+            BlockBuilder resultBuilder = type.createBlockBuilder(null, positionCount);
+            for (int position = 0; position < positionCount; position++) {
+                Object input = type.getObject(block, position);
                 Boolean keep;
                 try {
                     keep = (Boolean) function.invokeExact(input);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
In the original implementation of `ArrayFilterFunction.filter*`, an additional copy of the filtered block is adopted. The speed, especially for some nested column types such as `RowType` is not perfect.  

So we improved the implementation to record the block index position, then directly call `Block.copyPositions()` after the filtering is completed, in order to reduce unnecessary block copies such as `Type.appendTo()` and `BlockBuilder.build()`.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
### Before the change  
```
Benchmark                             (name)  Mode  Cnt   Score   Error  Units  
BenchmarkArrayFilter.benchmark        filter  avgt   20  22.543 ± 0.979  ns/op  
BenchmarkArrayFilter.benchmarkObject  filter  avgt   20  42.045 ± 2.088  ns/op 
``` 

### After the change
```
Benchmark                             (name)  Mode  Cnt   Score   Error  Units  
BenchmarkArrayFilter.benchmark        filter  avgt   20  13.576 ± 0.849  ns/op  
BenchmarkArrayFilter.benchmarkObject  filter  avgt   20  32.051 ± 0.268  ns/op 
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# General
*  Improve performance of `filter` function on arrays. ({issue}`16681`)
```
