### PR TITLE
Decrease number of old JDBC drivers tested

### DIFF
--- a/testing/trino-test-jdbc-compatibility-old-driver/bin/run_tests.sh
+++ b/testing/trino-test-jdbc-compatibility-old-driver/bin/run_tests.sh
@@ -12,7 +12,7 @@ current_version=$(${maven} help:evaluate -Dexpression=project.version -q -Dforce
 previous_released_version=$((${current_version%-SNAPSHOT}-1))
 first_tested_version=352
 # test n-th version only
-version_step=5
+version_step=7
 
 echo "Current version: ${current_version}"
 


### PR DESCRIPTION
## Description

Reduce timeout possibility of `test-jdbc-compatibility` https://github.com/trinodb/trino/actions/runs/4497438041/jobs/7913032219?pr=16321
Same approach as #14819

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
