### PR TITLE
Expect at least one success when inserting concurrently

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -4357,7 +4357,9 @@ public abstract class BaseConnectorTest
                     .collect(toImmutableList());
 
             if (values.isEmpty()) {
+                // We expect that at least one INSERT succeed. More importantly though, we expect that the table state matches succeeding queries.
                 assertQueryReturnsEmptyResult("TABLE " + tableName);
+                fail("Expected at least one INSERT to succeed");
             }
             else {
                 // Cast to integer because some connectors (e.g. Oracle) map integer to different types that skippingTypesCheck can't resolve the mismatch.


### PR DESCRIPTION
Increased test coverage related to to https://github.com/trinodb/trino/issues/16652#issuecomment-1480743830

This matches expectation in a related product test
https://github.com/trinodb/trino/blob/4e41df9b4f9a4f1308e673053c6e82c42eef1385/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergInsert.java#L85
