### PR TITLE
Set thread name for DDL queries

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlQueryManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlQueryManager.java
@@ -15,6 +15,7 @@ package io.trino.execution;
 
 import com.google.common.collect.Ordering;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.concurrent.SetThreadName;
 import io.airlift.concurrent.ThreadPoolExecutorMBean;
 import io.airlift.log.Logger;
 import io.airlift.units.DataSize;
@@ -246,7 +247,9 @@ public class SqlQueryManager
             queryTracker.expireQuery(queryExecution.getQueryId());
         });
 
-        queryExecution.start();
+        try (SetThreadName ignored = new SetThreadName("Query-%s", queryExecution.getQueryId())) {
+            queryExecution.start();
+        }
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestEventDrivenTaskSource.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestEventDrivenTaskSource.java
@@ -103,7 +103,7 @@ public class TestEventDrivenTaskSource
     @BeforeClass
     public void setUp()
     {
-        executor = listeningDecorator(newScheduledThreadPool(10, daemonThreadsNamed("dispatcher-query-%s")));
+        executor = listeningDecorator(newScheduledThreadPool(10, daemonThreadsNamed(getClass().getName())));
     }
 
     @AfterClass(alwaysRun = true)

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinode.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinode.java
@@ -30,7 +30,6 @@ import static io.trino.tests.product.launcher.env.common.Hadoop.CONTAINER_TRINO_
 import static io.trino.tests.product.launcher.env.common.Hadoop.CONTAINER_TRINO_HIVE_TIMESTAMP_NANOS;
 import static io.trino.tests.product.launcher.env.common.Hadoop.CONTAINER_TRINO_HIVE_WITH_EXTERNAL_WRITES_PROPERTIES;
 import static io.trino.tests.product.launcher.env.common.Hadoop.CONTAINER_TRINO_ICEBERG_PROPERTIES;
-import static io.trino.tests.product.launcher.env.common.Standard.CONTAINER_TRINO_ETC;
 import static io.trino.tests.product.launcher.env.common.Standard.CONTAINER_TRINO_JVM_CONFIG;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
@@ -39,8 +38,6 @@ import static org.testcontainers.utility.MountableFile.forHostPath;
 public final class EnvMultinode
         extends EnvironmentProvider
 {
-    public static final String CONTAINER_TRINO_HIVE_ACCESS_CONTROL = CONTAINER_TRINO_ETC + "/catalog/hive.properties";
-
     private final DockerFiles dockerFiles;
     private final DockerFiles.ResourceProvider configDir;
 


### PR DESCRIPTION
Before the change, the DDL tasks where being executed with a thread name of `dispatch-query-%d`.
