### PR TITLE
Verify authorization access for SET AUTHORIZATION statements

### DIFF
--- a/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
+++ b/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
@@ -63,6 +63,7 @@ import static io.trino.sql.analyzer.RegexLibrary.JONI;
         "experimental.spill-order-by",
         "spill-window-operator",
         "experimental.spill-window-operator",
+        "legacy.allow-set-view-authorization",
 })
 public class FeaturesConfig
 {
@@ -100,7 +101,6 @@ public class FeaturesConfig
 
     private boolean legacyCatalogRoles;
     private boolean incrementalHashArrayLoadFactorEnabled = true;
-    private boolean allowSetViewAuthorization;
 
     private boolean legacyMaterializedViewGracePeriod;
     private boolean hideInaccessibleColumns;
@@ -471,20 +471,6 @@ public class FeaturesConfig
     public FeaturesConfig setHideInaccessibleColumns(boolean hideInaccessibleColumns)
     {
         this.hideInaccessibleColumns = hideInaccessibleColumns;
-        return this;
-    }
-
-    public boolean isAllowSetViewAuthorization()
-    {
-        return allowSetViewAuthorization;
-    }
-
-    @Config("legacy.allow-set-view-authorization")
-    @ConfigDescription("For security reasons ALTER VIEW SET AUTHORIZATION is disabled for SECURITY DEFINER; " +
-            "setting this option to true will re-enable this functionality")
-    public FeaturesConfig setAllowSetViewAuthorization(boolean allowSetViewAuthorization)
-    {
-        this.allowSetViewAuthorization = allowSetViewAuthorization;
         return this;
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/SetViewAuthorizationTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetViewAuthorizationTask.java
@@ -15,14 +15,11 @@ package io.trino.execution;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Inject;
-import io.trino.FeaturesConfig;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
-import io.trino.metadata.ViewDefinition;
 import io.trino.security.AccessControl;
-import io.trino.spi.TrinoException;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.SetViewAuthorization;
@@ -35,10 +32,8 @@ import static io.trino.metadata.MetadataUtil.checkRoleExists;
 import static io.trino.metadata.MetadataUtil.createPrincipal;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.metadata.MetadataUtil.getRequiredCatalogHandle;
-import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class SetViewAuthorizationTask
@@ -46,14 +41,12 @@ public class SetViewAuthorizationTask
 {
     private final Metadata metadata;
     private final AccessControl accessControl;
-    private final boolean isAllowSetViewAuthorization;
 
     @Inject
-    public SetViewAuthorizationTask(Metadata metadata, AccessControl accessControl, FeaturesConfig featuresConfig)
+    public SetViewAuthorizationTask(Metadata metadata, AccessControl accessControl)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
-        this.isAllowSetViewAuthorization = featuresConfig.isAllowSetViewAuthorization();
     }
 
     @Override
@@ -72,19 +65,13 @@ public class SetViewAuthorizationTask
         Session session = stateMachine.getSession();
         QualifiedObjectName viewName = createQualifiedObjectName(session, statement, statement.getSource());
         getRequiredCatalogHandle(metadata, session, statement, viewName.getCatalogName());
-        ViewDefinition view = metadata.getView(session, viewName)
-                .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, statement, "View '%s' does not exist", viewName));
+        if (metadata.getView(session, viewName).isEmpty()) {
+            throw semanticException(TABLE_NOT_FOUND, statement, "View '%s' does not exist", viewName);
+        }
 
         TrinoPrincipal principal = createPrincipal(statement.getPrincipal());
         checkRoleExists(session, statement, metadata, principal, Optional.of(viewName.getCatalogName()).filter(catalog -> metadata.isCatalogManagedSecurity(session, catalog)));
 
-        if (!view.isRunAsInvoker() && !isAllowSetViewAuthorization) {
-            throw new TrinoException(
-                    NOT_SUPPORTED,
-                    format(
-                            "Cannot set authorization for view %s to %s: this feature is disabled",
-                            viewName.getCatalogName() + '.' + viewName.getSchemaName() + '.' + viewName.getObjectName(), principal));
-        }
         accessControl.checkCanSetViewAuthorization(session.toSecurityContext(), viewName, principal);
 
         metadata.setViewAuthorization(session, viewName.asCatalogSchemaTableName(), principal);

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
@@ -64,7 +64,6 @@ public class TestFeaturesConfig
                 .setIncrementalHashArrayLoadFactorEnabled(true)
                 .setLegacyMaterializedViewGracePeriod(false)
                 .setHideInaccessibleColumns(false)
-                .setAllowSetViewAuthorization(false)
                 .setForceSpillingJoin(false)
                 .setFaultTolerantExecutionExchangeEncryptionEnabled(true));
     }
@@ -100,7 +99,6 @@ public class TestFeaturesConfig
                 .put("incremental-hash-array-load-factor.enabled", "false")
                 .put("legacy.materialized-view-grace-period", "true")
                 .put("hide-inaccessible-columns", "true")
-                .put("legacy.allow-set-view-authorization", "true")
                 .put("force-spilling-join-operator", "true")
                 .put("fault-tolerant-execution.exchange-encryption-enabled", "false")
                 .buildOrThrow();
@@ -133,7 +131,6 @@ public class TestFeaturesConfig
                 .setIncrementalHashArrayLoadFactorEnabled(false)
                 .setLegacyMaterializedViewGracePeriod(true)
                 .setHideInaccessibleColumns(true)
-                .setAllowSetViewAuthorization(true)
                 .setForceSpillingJoin(true)
                 .setFaultTolerantExecutionExchangeEncryptionEnabled(false);
         assertFullMapping(properties, expected);

--- a/docs/src/main/sphinx/security/authorization.json
+++ b/docs/src/main/sphinx/security/authorization.json
@@ -1,0 +1,26 @@
+{
+  "authorization": [
+    {
+      "original_role": "admin",
+      "new_user": "bob",
+      "allow": false
+    },
+    {
+      "original_role": "admin",
+      "new_user": ".*",
+      "new_role": ".*"
+    }
+  ],
+  "schemas": [
+    {
+      "role": "admin",
+      "owner": true
+    }
+  ],
+  "tables": [
+    {
+      "role": "admin",
+      "privileges": ["OWNERSHIP"]
+    }
+  ]
+}

--- a/docs/src/main/sphinx/security/file-system-access-control.rst
+++ b/docs/src/main/sphinx/security/file-system-access-control.rst
@@ -722,6 +722,50 @@ The fixed management user only applies to HTTP by default. To enable the fixed
 user over HTTPS, set the ``management.user.https-enabled`` configuration
 property.
 
+.. _system-file-auth-authorization:
+
+Authorization rules
+-------------------
+
+These rules control the ability of how owner of schema, table or view can
+be altered. These rules are applicable to commands like:
+
+    ALTER SCHEMA name SET AUTHORIZATION ( user | USER user | ROLE role )
+    ALTER TABLE name SET AUTHORIZATION ( user | USER user | ROLE role )
+    ALTER VIEW name SET AUTHORIZATION ( user | USER user | ROLE role )
+
+When these rules are present, the authorization is based on the first matching
+rule, processed from top to bottom. If no rules match, the authorization is
+denied.
+
+Notice that in order to execute ``ALTER`` command on schema, table or view user requires ``OWNERSHIP``
+privilege.
+
+Each authorization rule is composed of the following fields:
+
+* ``original_user`` (optional): regex to match against the user requesting the
+  authorization. Defaults to ``.*``.
+* ``original_group`` (optional): regex to match against group names of the
+  requesting authorization. Defaults to ``.*``.
+* ``original_role`` (optional): regex to match against role names of the
+  requesting authorization. Defaults to ``.*``.
+* ``new_user`` (optional): regex to match against the new owner user of the schema, table or view.
+  By default it does not match.
+* ``new_role`` (optional): regex to match against the new owner role of the schema, table or view.
+  By default it does not match.
+* ``allow`` (optional): boolean indicating if the authentication should be
+  allowed. Defaults to ``true``.
+
+Notice that ``new_user`` and ``new_role`` are optional, however it is required to provide at least one of them.
+
+The following example allows the ``admin`` role, to change owner of any schema, table or view
+to any user, except to``bob``.
+
+.. literalinclude:: authorization.json
+    :language: json
+
+.. _system-file-auth-system_information:
+
 .. _catalog-file-based-access-control:
 
 Catalog-level access control files

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AccessControlRules.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AccessControlRules.java
@@ -27,18 +27,21 @@ public class AccessControlRules
     private final List<TableAccessControlRule> tableRules;
     private final List<SessionPropertyAccessControlRule> sessionPropertyRules;
     private final List<FunctionAccessControlRule> functionRules;
+    private final List<AuthorizationRule> authorizationRules;
 
     @JsonCreator
     public AccessControlRules(
             @JsonProperty("schemas") Optional<List<SchemaAccessControlRule>> schemaRules,
             @JsonProperty("tables") Optional<List<TableAccessControlRule>> tableRules,
             @JsonProperty("session_properties") @JsonAlias("sessionProperties") Optional<List<SessionPropertyAccessControlRule>> sessionPropertyRules,
-            @JsonProperty("functions") Optional<List<FunctionAccessControlRule>> functionRules)
+            @JsonProperty("functions") Optional<List<FunctionAccessControlRule>> functionRules,
+            @JsonProperty("authorization") Optional<List<AuthorizationRule>> authorizationRules)
     {
         this.schemaRules = schemaRules.orElse(ImmutableList.of(SchemaAccessControlRule.ALLOW_ALL));
         this.tableRules = tableRules.orElse(ImmutableList.of(TableAccessControlRule.ALLOW_ALL));
         this.sessionPropertyRules = sessionPropertyRules.orElse(ImmutableList.of(SessionPropertyAccessControlRule.ALLOW_ALL));
         this.functionRules = functionRules.orElse(ImmutableList.of(FunctionAccessControlRule.ALLOW_ALL));
+        this.authorizationRules = authorizationRules.orElse(ImmutableList.of());
     }
 
     public List<SchemaAccessControlRule> getSchemaRules()
@@ -61,11 +64,18 @@ public class AccessControlRules
         return functionRules;
     }
 
+    public List<AuthorizationRule> getAuthorizationRules()
+    {
+        return authorizationRules;
+    }
+
     public boolean hasRoleRules()
     {
         return schemaRules.stream().anyMatch(rule -> rule.getRoleRegex().isPresent()) ||
                 tableRules.stream().anyMatch(rule -> rule.getRoleRegex().isPresent()) ||
                 sessionPropertyRules.stream().anyMatch(rule -> rule.getRoleRegex().isPresent()) ||
-                functionRules.stream().anyMatch(rule -> rule.getRoleRegex().isPresent());
+                functionRules.stream().anyMatch(rule -> rule.getRoleRegex().isPresent()) ||
+                authorizationRules.stream().anyMatch(rule -> rule.getOriginalRolePattern().isPresent()) ||
+                authorizationRules.stream().anyMatch(rule -> rule.getNewRolePattern().isPresent());
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AuthorizationRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AuthorizationRule.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.security.TrinoPrincipal;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Boolean.TRUE;
+import static java.util.Objects.requireNonNull;
+
+public class AuthorizationRule
+{
+    private final Optional<Pattern> originalUserPattern;
+    private final Optional<Pattern> originalGroupPattern;
+    private final Optional<Pattern> originalRolePattern;
+    private final Optional<Pattern> newUserPattern;
+    private final Optional<Pattern> newRolePattern;
+    private final boolean allow;
+
+    @JsonCreator
+    public AuthorizationRule(
+            @JsonProperty("original_user") @JsonAlias("originalUser") Optional<Pattern> originalUserPattern,
+            @JsonProperty("original_group") @JsonAlias("originalGroup") Optional<Pattern> originalGroupPattern,
+            @JsonProperty("original_role") @JsonAlias("originalRole") Optional<Pattern> originalRolePattern,
+            @JsonProperty("new_user") @JsonAlias("newUser") Optional<Pattern> newUserPattern,
+            @JsonProperty("new_role") @JsonAlias("newRole") Optional<Pattern> newRolePattern,
+            @JsonProperty("allow") Boolean allow)
+    {
+        checkArgument(newUserPattern.isPresent() || newRolePattern.isPresent(), "At least one of new_use or new_role is required, none were provided");
+        this.originalUserPattern = requireNonNull(originalUserPattern, "originalUserPattern is null");
+        this.originalGroupPattern = requireNonNull(originalGroupPattern, "originalGroupPattern is null");
+        this.originalRolePattern = requireNonNull(originalRolePattern, "originalRolePattern is null");
+        this.newUserPattern = requireNonNull(newUserPattern, "newUserPattern is null");
+        this.newRolePattern = requireNonNull(newRolePattern, "newRolePattern is null");
+        this.allow = firstNonNull(allow, TRUE);
+    }
+
+    public Optional<Boolean> match(String user, Set<String> groups, Set<String> roles, TrinoPrincipal newPrincipal)
+    {
+        if (originalUserPattern.map(regex -> regex.matcher(user).matches()).orElse(true) &&
+                (originalGroupPattern.isEmpty() || groups.stream().anyMatch(group -> originalGroupPattern.get().matcher(group).matches())) &&
+                (originalRolePattern.isEmpty() || roles.stream().anyMatch(role -> originalRolePattern.get().matcher(role).matches())) &&
+                matches(newPrincipal)) {
+            return Optional.of(allow);
+        }
+        return Optional.empty();
+    }
+
+    private boolean matches(TrinoPrincipal newPrincipal)
+    {
+        return switch (newPrincipal.getType()) {
+            case USER -> newUserPattern.map(regex -> regex.matcher(newPrincipal.getName()).matches()).orElse(false);
+            case ROLE -> newRolePattern.map(regex -> regex.matcher(newPrincipal.getName()).matches()).orElse(false);
+        };
+    }
+
+    public Optional<Pattern> getOriginalRolePattern()
+    {
+        return originalRolePattern;
+    }
+
+    public Optional<Pattern> getNewRolePattern()
+    {
+        return newRolePattern;
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
@@ -108,6 +108,7 @@ public class FileBasedAccessControl
     private final List<TableAccessControlRule> tableRules;
     private final List<SessionPropertyAccessControlRule> sessionPropertyRules;
     private final List<FunctionAccessControlRule> functionRules;
+    private final List<AuthorizationRule> authorizationRules;
     private final Set<AnySchemaPermissionsRule> anySchemaPermissionsRules;
 
     public FileBasedAccessControl(CatalogName catalogName, AccessControlRules rules)
@@ -120,6 +121,7 @@ public class FileBasedAccessControl
         this.tableRules = rules.getTableRules();
         this.sessionPropertyRules = rules.getSessionPropertyRules();
         this.functionRules = rules.getFunctionRules();
+        this.authorizationRules = rules.getAuthorizationRules();
         ImmutableSet.Builder<AnySchemaPermissionsRule> anySchemaPermissionsRules = ImmutableSet.builder();
         schemaRules.stream()
                 .map(SchemaAccessControlRule::toAnySchemaPermissionsRule)
@@ -167,6 +169,9 @@ public class FileBasedAccessControl
     public void checkCanSetSchemaAuthorization(ConnectorSecurityContext context, String schemaName, TrinoPrincipal principal)
     {
         if (!isSchemaOwner(context, schemaName)) {
+            denySetSchemaAuthorization(schemaName, principal);
+        }
+        if (!checkCanSetAuthorization(context, principal)) {
             denySetSchemaAuthorization(schemaName, principal);
         }
     }
@@ -347,6 +352,9 @@ public class FileBasedAccessControl
         if (!checkTablePermission(context, tableName, OWNERSHIP)) {
             denySetTableAuthorization(tableName.toString(), principal);
         }
+        if (!checkCanSetAuthorization(context, principal)) {
+            denySetTableAuthorization(tableName.toString(), principal);
+        }
     }
 
     @Override
@@ -421,6 +429,9 @@ public class FileBasedAccessControl
     public void checkCanSetViewAuthorization(ConnectorSecurityContext context, SchemaTableName viewName, TrinoPrincipal principal)
     {
         if (!checkTablePermission(context, viewName, OWNERSHIP)) {
+            denySetViewAuthorization(viewName.toString(), principal);
+        }
+        if (!checkCanSetAuthorization(context, principal)) {
             denySetViewAuthorization(viewName.toString(), principal);
         }
     }
@@ -748,5 +759,17 @@ public class FileBasedAccessControl
                 .findFirst()
                 .filter(executePredicate)
                 .isPresent();
+    }
+
+    private boolean checkCanSetAuthorization(ConnectorSecurityContext context, TrinoPrincipal principal)
+    {
+        ConnectorIdentity identity = context.getIdentity();
+        Set<String> roles = identity.getConnectorRole().stream()
+                .flatMap(role -> role.getRole().stream())
+                .collect(toImmutableSet());
+        return authorizationRules.stream()
+                .flatMap(rule -> rule.match(identity.getUser(), identity.getGroups(), roles, principal).stream())
+                .findFirst()
+                .orElse(false);
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControlModule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControlModule.java
@@ -103,6 +103,7 @@ public class FileBasedSystemAccessControlModule
                 .setImpersonationRules(rules.getImpersonationRules())
                 .setPrincipalUserMatchRules(rules.getPrincipalUserMatchRules())
                 .setSystemInformationRules(rules.getSystemInformationRules())
+                .setAuthorizationRules(rules.getAuthorizationRules())
                 .setSchemaRules(rules.getSchemaRules().orElse(ImmutableList.of(CatalogSchemaAccessControlRule.ALLOW_ALL)))
                 .setTableRules(rules.getTableRules().orElse(ImmutableList.of(CatalogTableAccessControlRule.ALLOW_ALL)))
                 .setSessionPropertyRules(rules.getSessionPropertyRules().orElse(ImmutableList.of(SessionPropertyAccessControlRule.ALLOW_ALL)))

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControlRules.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControlRules.java
@@ -27,6 +27,7 @@ public class FileBasedSystemAccessControlRules
     private final Optional<List<ImpersonationRule>> impersonationRules;
     private final Optional<List<PrincipalUserMatchRule>> principalUserMatchRules;
     private final Optional<List<SystemInformationRule>> systemInformationRules;
+    private final Optional<List<AuthorizationRule>> authorizationRules;
     private final Optional<List<CatalogSchemaAccessControlRule>> schemaRules;
     private final Optional<List<CatalogTableAccessControlRule>> tableRules;
     private final Optional<List<SessionPropertyAccessControlRule>> sessionPropertyRules;
@@ -40,6 +41,7 @@ public class FileBasedSystemAccessControlRules
             @JsonProperty("impersonation") Optional<List<ImpersonationRule>> impersonationRules,
             @JsonProperty("principals") Optional<List<PrincipalUserMatchRule>> principalUserMatchRules,
             @JsonProperty("system_information") Optional<List<SystemInformationRule>> systemInformationRules,
+            @JsonProperty("authorization") Optional<List<AuthorizationRule>> authorizationRules,
             @JsonProperty("schemas") Optional<List<CatalogSchemaAccessControlRule>> schemaAccessControlRules,
             @JsonProperty("tables") Optional<List<CatalogTableAccessControlRule>> tableAccessControlRules,
             @JsonProperty("system_session_properties") Optional<List<SessionPropertyAccessControlRule>> sessionPropertyRules,
@@ -51,6 +53,7 @@ public class FileBasedSystemAccessControlRules
         this.principalUserMatchRules = principalUserMatchRules.map(ImmutableList::copyOf);
         this.impersonationRules = impersonationRules.map(ImmutableList::copyOf);
         this.systemInformationRules = systemInformationRules.map(ImmutableList::copyOf);
+        this.authorizationRules = authorizationRules.map(ImmutableList::copyOf);
         this.schemaRules = schemaAccessControlRules.map(ImmutableList::copyOf);
         this.tableRules = tableAccessControlRules.map(ImmutableList::copyOf);
         this.sessionPropertyRules = sessionPropertyRules.map(ImmutableList::copyOf);
@@ -81,6 +84,11 @@ public class FileBasedSystemAccessControlRules
     public Optional<List<SystemInformationRule>> getSystemInformationRules()
     {
         return systemInformationRules;
+    }
+
+    public List<AuthorizationRule> getAuthorizationRules()
+    {
+        return authorizationRules.orElseGet(ImmutableList::of);
     }
 
     public Optional<List<CatalogSchemaAccessControlRule>> getSchemaRules()

--- a/lib/trino-plugin-toolkit/src/test/resources/authorization-no-roles.json
+++ b/lib/trino-plugin-toolkit/src/test/resources/authorization-no-roles.json
@@ -1,0 +1,37 @@
+{
+    "authorization": [
+        {
+            "original_user": ".*DENY.*",
+            "new_user": ".*",
+            "allow": false
+        },
+        {
+            "original_user": ".*authorized",
+            "new_user": ".*"
+        }
+    ],
+    "schemas": [
+        {
+            "user": "owner.*",
+            "schema": "owned_by_user",
+            "owner": true
+        },
+        {
+            "group": "owner.*",
+            "schema": "owned_by_group",
+            "owner": true
+        }
+    ],
+    "tables": [
+        {
+            "user": "owner.*",
+            "table": "owned_by_user",
+            "privileges": ["OWNERSHIP"]
+        },
+        {
+            "group": "owner*",
+            "table": "owned_by_group",
+            "privileges": ["OWNERSHIP"]
+        }
+    ]
+}

--- a/lib/trino-plugin-toolkit/src/test/resources/authorization.json
+++ b/lib/trino-plugin-toolkit/src/test/resources/authorization.json
@@ -1,0 +1,69 @@
+{
+    "authorization": [
+        {
+            "original_user": ".*DENY.*",
+            "new_user": ".*",
+            "new_role": ".*",
+            "allow": false
+        },
+        {
+            "original_group": ".*DENY.*",
+            "new_user": ".*",
+            "new_role": ".*",
+            "allow": false
+        },
+        {
+            "original_role": ".*DENY.*",
+            "new_user": ".*",
+            "new_role": ".*",
+            "allow": false
+        },
+        {
+            "original_user": ".*authorized",
+            "new_user": ".*"
+        },
+        {
+            "original_group": ".*authorized",
+            "new_user": ".*",
+            "new_role": ".*"
+        },
+        {
+            "original_role": ".*authorized",
+            "new_role": ".*"
+        }
+    ],
+    "schemas": [
+        {
+            "user": "owner.*",
+            "schema": "owned_by_user",
+            "owner": true
+        },
+        {
+            "group": "owner.*",
+            "schema": "owned_by_group",
+            "owner": true
+        },
+        {
+            "role": "owner.*",
+            "schema": "owned_by_role",
+            "owner": true
+        }
+    ],
+    "tables": [
+        {
+            "user": "owner.*",
+            "table": "owned_by_user",
+            "privileges": ["OWNERSHIP"]
+        },
+        {
+            "group": "owner*",
+            "table": "owned_by_group",
+            "privileges": ["OWNERSHIP"]
+        },
+        {
+            "role": "owner.*",
+            "table": "owned_by_role",
+            "privileges": ["OWNERSHIP"]
+        }
+    ]
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
@@ -155,7 +155,7 @@ public class SqlStandardAccessControl
     @Override
     public void checkCanSetSchemaAuthorization(ConnectorSecurityContext context, String schemaName, TrinoPrincipal principal)
     {
-        if (!isDatabaseOwner(context, schemaName)) {
+        if (!isAdmin(context)) {
             denySetSchemaAuthorization(schemaName, principal);
         }
     }
@@ -307,7 +307,7 @@ public class SqlStandardAccessControl
     @Override
     public void checkCanSetTableAuthorization(ConnectorSecurityContext context, SchemaTableName tableName, TrinoPrincipal principal)
     {
-        if (!isTableOwner(context, tableName)) {
+        if (!isAdmin(context)) {
             denySetTableAuthorization(tableName.toString(), principal);
         }
     }
@@ -372,7 +372,7 @@ public class SqlStandardAccessControl
     @Override
     public void checkCanSetViewAuthorization(ConnectorSecurityContext context, SchemaTableName viewName, TrinoPrincipal principal)
     {
-        if (!isTableOwner(context, viewName)) {
+        if (!isAdmin(context)) {
             denySetViewAuthorization(viewName.toString(), principal);
         }
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -220,7 +220,6 @@ public abstract class BaseHiveConnectorTest
                         "hive.writer-sort-buffer-size", "1MB",
                         // Make weighted split scheduling more conservative to avoid OOMs in test
                         "hive.minimum-assigned-split-weight", "0.5"))
-                .addExtraProperty("legacy.allow-set-view-authorization", "true")
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .setTpchBucketedCatalogEnabled(true)
                 .build();

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop-kerberos/config.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop-kerberos/config.properties
@@ -22,4 +22,3 @@ internal-communication.https.required=true
 internal-communication.shared-secret=internal-shared-secret
 internal-communication.https.keystore.path=/docker/presto-product-tests/conf/presto/etc/docker.cluster.jks
 internal-communication.https.keystore.key=123456
-legacy.allow-set-view-authorization=true

--- a/testing/trino-tests/src/test/java/io/trino/security/TestAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestAccessControl.java
@@ -797,9 +797,7 @@ public class TestAccessControl
     @Test
     public void testSetViewAuthorizationWithSecurityDefiner()
     {
-        assertQueryFails(
-                "ALTER VIEW mock.default.test_view_definer SET AUTHORIZATION some_other_user",
-                "Cannot set authorization for view mock.default.test_view_definer to USER some_other_user: this feature is disabled");
+        assertQuerySucceeds("ALTER VIEW mock.default.test_view_definer SET AUTHORIZATION some_other_user");
     }
 
     @Test


### PR DESCRIPTION
With this pull request we are going to assume from all pluggable access control to make sure that SET AUTHORIZATION statements are secure to be performed. Previously it was not clear if it is engine or access control responsibility. Hence we had `legacy.allow-set-view-authorization ` config property.

To accomplish that now:
 - `hive.security=sql-standard` requires admin role privilege to perform `ALTER ... SET AUTHORIZATION...` statements
 - File based access control have now new authorization rules that verify to whom AUTHORIZATION can be set.

Thanks to the above `legacy.allow-set-view-authorization` can be removed.

**Release notes:**
Hive
 -  The hive.security=sql-standard` securty requires admin role privilege to perform `ALTER ... SET AUTHORIZATION...` statements
 
 Security:
 - Introduce authorization rules to file based access controls to control `ALTER ... SET AUTHORIZATION...` to whom authorization can be set.
 - Remove `legacy.allow-set-view-authorization` configuration property
 
