### PR TITLE
Fix TestIcebergInsert.testIcebergConcurrentInsert timeout on CI

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergInsert.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergInsert.java
@@ -50,7 +50,7 @@ public class TestIcebergInsert
             throws Exception
     {
         int threads = 3;
-        int insertsPerThread = 7;
+        int insertsPerThread = 4;
 
         String tableName = "iceberg.default.test_insert_concurrent_" + randomNameSuffix();
         onTrino().executeQuery("CREATE TABLE " + tableName + "(a bigint)");


### PR DESCRIPTION
The test seems dominated by `finishInsert` time. since bf04a72875f27d43301d7896b6e04f0bc1199a6d `finishInsert` is slower as we commit twice (first committing data then statistics).

Fixes https://github.com/trinodb/trino/issues/16652 