### PR TITLE
Add table function to execute stored procedure in SQLServer

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/system/SystemPageSourceProvider.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SystemPageSourceProvider.java
@@ -14,6 +14,8 @@
 package io.trino.connector.system;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.plugin.base.MappedPageSource;
+import io.trino.plugin.base.MappedRecordSet;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
@@ -32,8 +34,6 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.Type;
-import io.trino.split.MappedPageSource;
-import io.trino.split.MappedRecordSet;
 
 import java.util.HashMap;
 import java.util.List;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -149,6 +149,7 @@ import io.trino.operator.window.pattern.MeasureComputation.MeasureComputationSup
 import io.trino.operator.window.pattern.PhysicalValueAccessor;
 import io.trino.operator.window.pattern.PhysicalValuePointer;
 import io.trino.operator.window.pattern.SetEvaluator.SetEvaluatorSupplier;
+import io.trino.plugin.base.MappedRecordSet;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.TrinoException;
@@ -172,7 +173,6 @@ import io.trino.spi.type.Type;
 import io.trino.spiller.PartitioningSpillerFactory;
 import io.trino.spiller.SingleStreamSpillerFactory;
 import io.trino.spiller.SpillerFactory;
-import io.trino.split.MappedRecordSet;
 import io.trino.split.PageSinkManager;
 import io.trino.split.PageSourceProvider;
 import io.trino.sql.DynamicFilters;

--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -367,6 +367,50 @@ nations by population::
         )
       );
 
+.. _sqlserver-procedure-function:
+
+``procedure(varchar) -> table``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``procedure`` function allows you to run stored procedures on the underlying
+database directly. It requires syntax native to SQL Server, because the full query
+is pushed down and processed in SQL Server. In order to use this table function set
+``sqlserver.experimental.stored-procedure-table-function-enabled`` to ``true``.
+
+.. note::
+
+    The ``procedure`` function does not support running StoredProcedures that return multiple statements,
+    use a non-select statement, use output parameters, or use conditional statements.
+
+.. warning::
+
+    This feature is experimental only. The function has security implication and syntax might change and
+    be backward incompatible.
+
+
+The follow example runs the stored procedure ``employee_sp`` in the ``example`` catalog and the
+``example_schema`` schema in the underlying SQL Server database::
+
+    SELECT
+      *
+    FROM
+      TABLE(
+        example.system.procedure(
+          query => 'EXECUTE example_schema.employee_sp'
+        )
+      );
+
+If the stored procedure ``employee_sp`` requires any input
+append the parameter value to the procedure statement::
+
+    SELECT
+      *
+    FROM
+      TABLE(
+        example.system.procedure(
+          query => 'EXECUTE example_schema.employee_sp 0'
+        )
+      );
 
 Performance
 -----------

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/MappedPageSource.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/MappedPageSource.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.split;
+package io.trino.plugin.base;
 
 import com.google.common.primitives.Ints;
 import io.trino.spi.Page;

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/MappedRecordSet.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/MappedRecordSet.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.split;
+package io.trino.plugin.base;
 
 import com.google.common.primitives.Ints;
 import io.airlift.slice.Slice;

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.io.Closer;
 import io.airlift.log.Logger;
+import io.trino.plugin.jdbc.JdbcProcedureHandle.ProcedureQuery;
 import io.trino.plugin.jdbc.expression.ParameterizedExpression;
 import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
@@ -46,6 +47,7 @@ import io.trino.spi.type.VarcharType;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
@@ -250,6 +252,12 @@ public abstract class BaseJdbcClient
         }
     }
 
+    @Override
+    public JdbcProcedureHandle getProcedureHandle(ConnectorSession session, ProcedureQuery procedureQuery)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "Procedure is not supported");
+    }
+
     protected List<JdbcColumnHandle> getColumns(ConnectorSession session, Connection connection, ResultSetMetaData metadata)
             throws SQLException
     {
@@ -406,10 +414,23 @@ public abstract class BaseJdbcClient
     }
 
     @Override
+    public ConnectorSplitSource getSplits(ConnectorSession session, JdbcProcedureHandle procedureHandle)
+    {
+        return new FixedSplitSource(new JdbcSplit(Optional.empty()));
+    }
+
+    @Override
     public Connection getConnection(ConnectorSession session, JdbcSplit split, JdbcTableHandle tableHandle)
             throws SQLException
     {
         verify(tableHandle.getAuthorization().isEmpty(), "Unexpected authorization is required for table: %s".formatted(tableHandle));
+        return getConnection(session);
+    }
+
+    @Override
+    public Connection getConnection(ConnectorSession session, JdbcSplit split, JdbcProcedureHandle procedureHandle)
+            throws SQLException
+    {
         return getConnection(session);
     }
 
@@ -450,6 +471,13 @@ public abstract class BaseJdbcClient
     {
         PreparedQuery preparedQuery = prepareQuery(session, connection, table, Optional.empty(), columns, ImmutableMap.of(), Optional.of(split));
         return queryBuilder.prepareStatement(this, session, connection, preparedQuery, Optional.of(columns.size()));
+    }
+
+    @Override
+    public CallableStatement buildProcedure(ConnectorSession session, Connection connection, JdbcSplit split, JdbcProcedureHandle procedureHandle)
+            throws SQLException
+    {
+        return queryBuilder.callProcedure(this, session, connection, procedureHandle.getProcedureQuery());
     }
 
     protected PreparedQuery prepareQuery(

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcConnectorTableHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcConnectorTableHandle.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import io.trino.spi.connector.ConnectorTableHandle;
+
+import java.util.List;
+import java.util.Optional;
+
+public abstract class BaseJdbcConnectorTableHandle
+        implements ConnectorTableHandle
+{
+    public abstract Optional<List<JdbcColumnHandle>> getColumns();
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
+import io.trino.plugin.jdbc.JdbcProcedureHandle.ProcedureQuery;
 import io.trino.plugin.jdbc.expression.ParameterizedExpression;
 import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.spi.connector.ColumnHandle;
@@ -30,6 +31,7 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
 import io.trino.spi.type.Type;
 
+import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -218,6 +220,13 @@ public class DefaultQueryBuilder
         }
 
         return statement;
+    }
+
+    @Override
+    public CallableStatement callProcedure(JdbcClient client, ConnectorSession session, Connection connection, ProcedureQuery procedureQuery)
+            throws SQLException
+    {
+        return connection.prepareCall(procedureQuery.query());
     }
 
     protected String formatJoinCondition(JdbcClient client, String leftRelationAlias, String rightRelationAlias, JdbcJoinCondition condition)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.jdbc;
 
+import io.trino.plugin.jdbc.JdbcProcedureHandle.ProcedureQuery;
 import io.trino.plugin.jdbc.expression.ParameterizedExpression;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.ColumnHandle;
@@ -30,6 +31,7 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.spi.type.Type;
 
+import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -92,6 +94,12 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
+    public JdbcProcedureHandle getProcedureHandle(ConnectorSession session, ProcedureQuery procedureQuery)
+    {
+        return delegate().getProcedureHandle(session, procedureQuery);
+    }
+
+    @Override
     public List<JdbcColumnHandle> getColumns(ConnectorSession session, JdbcTableHandle tableHandle)
     {
         return delegate().getColumns(session, tableHandle);
@@ -140,10 +148,23 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
+    public ConnectorSplitSource getSplits(ConnectorSession session, JdbcProcedureHandle procedureHandle)
+    {
+        return delegate().getSplits(session, procedureHandle);
+    }
+
+    @Override
     public Connection getConnection(ConnectorSession session, JdbcSplit split, JdbcTableHandle tableHandle)
             throws SQLException
     {
         return delegate().getConnection(session, split, tableHandle);
+    }
+
+    @Override
+    public Connection getConnection(ConnectorSession session, JdbcSplit split, JdbcProcedureHandle procedureHandle)
+            throws SQLException
+    {
+        return delegate().getConnection(session, split, procedureHandle);
     }
 
     @Override
@@ -169,6 +190,13 @@ public abstract class ForwardingJdbcClient
             throws SQLException
     {
         return delegate().buildSql(session, connection, split, tableHandle, columnHandles);
+    }
+
+    @Override
+    public CallableStatement buildProcedure(ConnectorSession session, Connection connection, JdbcSplit split, JdbcProcedureHandle procedureHandle)
+            throws SQLException
+    {
+        return delegate().buildProcedure(session, connection, split, procedureHandle);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.jdbc;
 
+import io.trino.plugin.jdbc.JdbcProcedureHandle.ProcedureQuery;
 import io.trino.plugin.jdbc.expression.ParameterizedExpression;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.AggregateFunction;
@@ -31,6 +32,7 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.spi.type.Type;
 
+import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -57,6 +59,8 @@ public interface JdbcClient
     Optional<JdbcTableHandle> getTableHandle(ConnectorSession session, SchemaTableName schemaTableName);
 
     JdbcTableHandle getTableHandle(ConnectorSession session, PreparedQuery preparedQuery);
+
+    JdbcProcedureHandle getProcedureHandle(ConnectorSession session, ProcedureQuery procedureQuery);
 
     List<JdbcColumnHandle> getColumns(ConnectorSession session, JdbcTableHandle tableHandle);
 
@@ -86,7 +90,12 @@ public interface JdbcClient
 
     ConnectorSplitSource getSplits(ConnectorSession session, JdbcTableHandle tableHandle);
 
+    ConnectorSplitSource getSplits(ConnectorSession session, JdbcProcedureHandle procedureHandle);
+
     Connection getConnection(ConnectorSession session, JdbcSplit split, JdbcTableHandle tableHandle)
+            throws SQLException;
+
+    Connection getConnection(ConnectorSession session, JdbcSplit split, JdbcProcedureHandle procedureHandle)
             throws SQLException;
 
     default void abortReadConnection(Connection connection, ResultSet resultSet)
@@ -103,6 +112,9 @@ public interface JdbcClient
             Map<String, ParameterizedExpression> columnExpressions);
 
     PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columns)
+            throws SQLException;
+
+    CallableStatement buildProcedure(ConnectorSession session, Connection connection, JdbcSplit split, JdbcProcedureHandle procedureHandle)
             throws SQLException;
 
     Optional<PreparedQuery> implementJoin(

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcDynamicFilteringSplitManager.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcDynamicFilteringSplitManager.java
@@ -69,6 +69,11 @@ public class JdbcDynamicFilteringSplitManager
             DynamicFilter dynamicFilter,
             Constraint constraint)
     {
+        // JdbcProcedureHandle doesn't support any pushdown operation, so we rely on delegateSplitManager
+        if (table instanceof JdbcProcedureHandle) {
+            return delegateSplitManager.getSplits(transaction, session, table, dynamicFilter, constraint);
+        }
+
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
         // pushing DF through limit could reduce query performance
         boolean hasLimit = tableHandle.getLimit().isPresent();

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadata.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.jdbc;
 
+import io.trino.plugin.jdbc.JdbcProcedureHandle.ProcedureQuery;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorSession;
 
@@ -20,6 +21,8 @@ public interface JdbcMetadata
         extends ConnectorMetadata
 {
     JdbcTableHandle getTableHandle(ConnectorSession session, PreparedQuery preparedQuery);
+
+    JdbcProcedureHandle getProcedureHandle(ConnectorSession session, ProcedureQuery procedureQuery);
 
     void rollback();
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcProcedureHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcProcedureHandle.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class JdbcProcedureHandle
+        extends BaseJdbcConnectorTableHandle
+{
+    private final ProcedureQuery procedure;
+    private final List<JdbcColumnHandle> columns;
+
+    @JsonCreator
+    public JdbcProcedureHandle(@JsonProperty ProcedureQuery procedureQuery, @JsonProperty List<JdbcColumnHandle> columns)
+    {
+        this.procedure = requireNonNull(procedureQuery, "procedureQuery is null");
+        this.columns = requireNonNull(columns, "columns is null");
+    }
+
+    @JsonProperty
+    public ProcedureQuery getProcedureQuery()
+    {
+        return procedure;
+    }
+
+    @Override
+    @JsonProperty
+    public Optional<List<JdbcColumnHandle>> getColumns()
+    {
+        return Optional.of(columns);
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("Procedure[%s], Columns=%s", procedure, columns);
+    }
+
+    public record ProcedureQuery(@JsonProperty String query)
+    {
+        @JsonCreator
+        public ProcedureQuery
+        {
+            requireNonNull(query, "query is null");
+        }
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordCursor.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordCursor.java
@@ -63,7 +63,7 @@ public class JdbcRecordCursor
     private ResultSet resultSet;
     private boolean closed;
 
-    public JdbcRecordCursor(JdbcClient jdbcClient, ExecutorService executor, ConnectorSession session, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columnHandles)
+    public JdbcRecordCursor(JdbcClient jdbcClient, ExecutorService executor, ConnectorSession session, JdbcSplit split, BaseJdbcConnectorTableHandle table, List<JdbcColumnHandle> columnHandles)
     {
         this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
         this.executor = requireNonNull(executor, "executor is null");
@@ -78,7 +78,7 @@ public class JdbcRecordCursor
         objectReadFunctions = new ObjectReadFunction[columnHandles.size()];
 
         try {
-            connection = jdbcClient.getConnection(session, split, table);
+            connection = jdbcClient.getConnection(session, split, (JdbcTableHandle) table);
 
             for (int i = 0; i < this.columnHandles.length; i++) {
                 JdbcColumnHandle columnHandle = columnHandles.get(i);
@@ -109,7 +109,7 @@ public class JdbcRecordCursor
                 }
             }
 
-            statement = jdbcClient.buildSql(session, connection, split, table, columnHandles);
+            statement = jdbcClient.buildSql(session, connection, split, (JdbcTableHandle) table, columnHandles);
         }
         catch (SQLException | RuntimeException e) {
             throw handleSqlException(e);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordCursor.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordCursor.java
@@ -78,7 +78,12 @@ public class JdbcRecordCursor
         objectReadFunctions = new ObjectReadFunction[columnHandles.size()];
 
         try {
-            connection = jdbcClient.getConnection(session, split, (JdbcTableHandle) table);
+            if (table instanceof JdbcProcedureHandle procedureHandle) {
+                connection = jdbcClient.getConnection(session, split, procedureHandle);
+            }
+            else {
+                connection = jdbcClient.getConnection(session, split, (JdbcTableHandle) table);
+            }
 
             for (int i = 0; i < this.columnHandles.length; i++) {
                 JdbcColumnHandle columnHandle = columnHandles.get(i);
@@ -109,7 +114,12 @@ public class JdbcRecordCursor
                 }
             }
 
-            statement = jdbcClient.buildSql(session, connection, split, (JdbcTableHandle) table, columnHandles);
+            if (table instanceof JdbcProcedureHandle procedureHandle) {
+                statement = jdbcClient.buildProcedure(session, connection, split, procedureHandle);
+            }
+            else {
+                statement = jdbcClient.buildSql(session, connection, split, (JdbcTableHandle) table, columnHandles);
+            }
         }
         catch (SQLException | RuntimeException e) {
             throw handleSqlException(e);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordSet.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordSet.java
@@ -29,13 +29,13 @@ public class JdbcRecordSet
 {
     private final JdbcClient jdbcClient;
     private final ExecutorService executor;
-    private final JdbcTableHandle table;
+    private final BaseJdbcConnectorTableHandle table;
     private final List<JdbcColumnHandle> columnHandles;
     private final List<Type> columnTypes;
     private final JdbcSplit split;
     private final ConnectorSession session;
 
-    public JdbcRecordSet(JdbcClient jdbcClient, ExecutorService executor, ConnectorSession session, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columnHandles)
+    public JdbcRecordSet(JdbcClient jdbcClient, ExecutorService executor, ConnectorSession session, JdbcSplit split, BaseJdbcConnectorTableHandle table, List<JdbcColumnHandle> columnHandles)
     {
         this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
         this.executor = requireNonNull(executor, "executor is null");

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcSplitManager.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcSplitManager.java
@@ -45,6 +45,10 @@ public class JdbcSplitManager
             DynamicFilter dynamicFilter,
             Constraint constraint)
     {
+        if (table instanceof JdbcProcedureHandle procedureHandle) {
+            return jdbcClient.getSplits(session, procedureHandle);
+        }
+
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
         ConnectorSplitSource jdbcSplitSource = jdbcClient.getSplits(session, tableHandle);
         if (dynamicFilteringEnabled(session)) {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcTableHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcTableHandle.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.trino.plugin.jdbc.expression.ParameterizedExpression;
 import io.trino.spi.connector.ColumnHandle;
-import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 
@@ -35,7 +34,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 public final class JdbcTableHandle
-        implements ConnectorTableHandle
+        extends BaseJdbcConnectorTableHandle
 {
     private final JdbcRelationHandle relationHandle;
 
@@ -150,6 +149,7 @@ public final class JdbcTableHandle
         return limit;
     }
 
+    @Override
     @JsonProperty
     public Optional<List<JdbcColumnHandle>> getColumns()
     {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
@@ -13,12 +13,14 @@
  */
 package io.trino.plugin.jdbc;
 
+import io.trino.plugin.jdbc.JdbcProcedureHandle.ProcedureQuery;
 import io.trino.plugin.jdbc.expression.ParameterizedExpression;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.JoinType;
 import io.trino.spi.predicate.TupleDomain;
 
+import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -64,5 +66,12 @@ public interface QueryBuilder
             Connection connection,
             PreparedQuery preparedQuery,
             Optional<Integer> columnCount)
+            throws SQLException;
+
+    CallableStatement callProcedure(
+            JdbcClient client,
+            ConnectorSession session,
+            Connection connection,
+            ProcedureQuery procedureQuery)
             throws SQLException;
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/JdbcClientStats.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/JdbcClientStats.java
@@ -25,6 +25,7 @@ public final class JdbcClientStats
     private final JdbcApiStats buildInsertSql = new JdbcApiStats();
     private final JdbcApiStats prepareQuery = new JdbcApiStats();
     private final JdbcApiStats buildSql = new JdbcApiStats();
+    private final JdbcApiStats buildProcedure = new JdbcApiStats();
     private final JdbcApiStats implementJoin = new JdbcApiStats();
     private final JdbcApiStats commitCreateTable = new JdbcApiStats();
     private final JdbcApiStats createSchema = new JdbcApiStats();
@@ -40,11 +41,14 @@ public final class JdbcClientStats
     private final JdbcApiStats getColumns = new JdbcApiStats();
     private final JdbcApiStats getConnectionWithHandle = new JdbcApiStats();
     private final JdbcApiStats getConnectionWithSplit = new JdbcApiStats();
+    private final JdbcApiStats getConnectionWithProcedure = new JdbcApiStats();
     private final JdbcApiStats getPreparedStatement = new JdbcApiStats();
     private final JdbcApiStats getSchemaNames = new JdbcApiStats();
     private final JdbcApiStats getSplits = new JdbcApiStats();
+    private final JdbcApiStats getSplitsForProcedure = new JdbcApiStats();
     private final JdbcApiStats getTableHandle = new JdbcApiStats();
     private final JdbcApiStats getTableHandleForQuery = new JdbcApiStats();
+    private final JdbcApiStats getProcedureHandle = new JdbcApiStats();
     private final JdbcApiStats getTableNames = new JdbcApiStats();
     private final JdbcApiStats getTableStatistics = new JdbcApiStats();
     private final JdbcApiStats renameColumn = new JdbcApiStats();
@@ -109,6 +113,13 @@ public final class JdbcClientStats
     public JdbcApiStats getBuildSql()
     {
         return buildSql;
+    }
+
+    @Managed
+    @Nested
+    public JdbcApiStats getBuildProcedure()
+    {
+        return buildProcedure;
     }
 
     @Managed
@@ -218,6 +229,13 @@ public final class JdbcClientStats
 
     @Managed
     @Nested
+    public JdbcApiStats getGetConnectionWithProcedure()
+    {
+        return getConnectionWithProcedure;
+    }
+
+    @Managed
+    @Nested
     public JdbcApiStats getGetPreparedStatement()
     {
         return getPreparedStatement;
@@ -239,6 +257,13 @@ public final class JdbcClientStats
 
     @Managed
     @Nested
+    public JdbcApiStats getGetSplitsForProcedure()
+    {
+        return getSplitsForProcedure;
+    }
+
+    @Managed
+    @Nested
     public JdbcApiStats getGetTableHandle()
     {
         return getTableHandle;
@@ -249,6 +274,13 @@ public final class JdbcClientStats
     public JdbcApiStats getGetTableHandleForQuery()
     {
         return getTableHandleForQuery;
+    }
+
+    @Managed
+    @Nested
+    public JdbcApiStats getGetProcedureHandle()
+    {
+        return getProcedureHandle;
     }
 
     @Managed

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ptf/Procedure.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ptf/Procedure.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.ptf;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airlift.slice.Slice;
+import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorTableFunction;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcMetadata;
+import io.trino.plugin.jdbc.JdbcProcedureHandle;
+import io.trino.plugin.jdbc.JdbcProcedureHandle.ProcedureQuery;
+import io.trino.plugin.jdbc.JdbcTransactionManager;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.ptf.AbstractConnectorTableFunction;
+import io.trino.spi.ptf.Argument;
+import io.trino.spi.ptf.ConnectorTableFunction;
+import io.trino.spi.ptf.ConnectorTableFunctionHandle;
+import io.trino.spi.ptf.Descriptor;
+import io.trino.spi.ptf.Descriptor.Field;
+import io.trino.spi.ptf.ScalarArgument;
+import io.trino.spi.ptf.ScalarArgumentSpecification;
+import io.trino.spi.ptf.TableFunctionAnalysis;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.spi.ptf.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public class Procedure
+        implements Provider<ConnectorTableFunction>
+{
+    public static final String SCHEMA_NAME = "system";
+    public static final String NAME = "procedure";
+
+    private final JdbcTransactionManager transactionManager;
+
+    @Inject
+    public Procedure(JdbcTransactionManager transactionManager)
+    {
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+    }
+
+    @Override
+    public ConnectorTableFunction get()
+    {
+        return new ClassLoaderSafeConnectorTableFunction(new ProcedureFunction(transactionManager), getClass().getClassLoader());
+    }
+
+    public static class ProcedureFunction
+            extends AbstractConnectorTableFunction
+    {
+        private final JdbcTransactionManager transactionManager;
+
+        public ProcedureFunction(JdbcTransactionManager transactionManager)
+        {
+            super(
+                    SCHEMA_NAME,
+                    NAME,
+                    List.of(
+                            ScalarArgumentSpecification.builder()
+                                    .name("QUERY")
+                                    .type(VARCHAR)
+                                    .build()),
+                    GENERIC_TABLE);
+            this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        }
+
+        @Override
+        public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
+        {
+            ScalarArgument argument = (ScalarArgument) getOnlyElement(arguments.values());
+            String procedureQuery = ((Slice) argument.getValue()).toStringUtf8();
+
+            JdbcMetadata metadata = transactionManager.getMetadata(transaction);
+            JdbcProcedureHandle tableHandle = metadata.getProcedureHandle(session, new ProcedureQuery(procedureQuery));
+            List<JdbcColumnHandle> columns = tableHandle.getColumns().orElseThrow(() -> new IllegalStateException("Handle doesn't have columns info"));
+            Descriptor returnedType = new Descriptor(columns.stream()
+                    .map(column -> new Field(column.getColumnName(), Optional.of(column.getColumnType())))
+                    .collect(toImmutableList()));
+
+            ProcedureFunctionHandle handle = new ProcedureFunctionHandle(tableHandle);
+
+            return TableFunctionAnalysis.builder()
+                    .returnedType(returnedType)
+                    .handle(handle)
+                    .build();
+        }
+    }
+
+    public static class ProcedureFunctionHandle
+            implements ConnectorTableFunctionHandle
+    {
+        private final JdbcProcedureHandle tableHandle;
+
+        @JsonCreator
+        public ProcedureFunctionHandle(@JsonProperty("tableHandle") JdbcProcedureHandle tableHandle)
+        {
+            this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
+        }
+
+        @JsonProperty
+        public ConnectorTableHandle getTableHandle()
+        {
+            return tableHandle;
+        }
+    }
+}

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestProcedure.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestProcedure.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import io.trino.testing.sql.SqlExecutor;
+import io.trino.testing.sql.TemporaryRelation;
+
+import static java.util.Objects.requireNonNull;
+
+public class TestProcedure
+        implements TemporaryRelation
+{
+    protected final SqlExecutor sqlExecutor;
+    protected final String name;
+
+    public TestProcedure(SqlExecutor sqlExecutor, String name, String createProcedureTemplate)
+    {
+        this.sqlExecutor = requireNonNull(sqlExecutor, "sqlExecutor is null");
+        this.name = requireNonNull(name, "name is null");
+        sqlExecutor.execute(createProcedureTemplate.formatted(name));
+    }
+
+    @Override
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public void close()
+    {
+        sqlExecutor.execute("DROP PROCEDURE " + name);
+    }
+}

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClientModule.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClientModule.java
@@ -29,11 +29,13 @@ import io.trino.plugin.jdbc.JdbcJoinPushdownSupportModule;
 import io.trino.plugin.jdbc.JdbcStatisticsConfig;
 import io.trino.plugin.jdbc.MaxDomainCompactionThreshold;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
+import io.trino.plugin.jdbc.ptf.Procedure;
 import io.trino.plugin.jdbc.ptf.Query;
 import io.trino.spi.ptf.ConnectorTableFunction;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.trino.plugin.jdbc.JdbcModule.bindSessionPropertiesProvider;
 import static io.trino.plugin.jdbc.JdbcModule.bindTablePropertiesProvider;
@@ -53,6 +55,11 @@ public class SqlServerClientModule
         newOptionalBinder(binder, Key.get(int.class, MaxDomainCompactionThreshold.class)).setBinding().toInstance(SQL_SERVER_MAX_LIST_EXPRESSIONS);
         newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Query.class).in(Scopes.SINGLETON);
         install(new JdbcJoinPushdownSupportModule());
+
+        install(conditionalModule(
+                SqlServerConfig.class,
+                SqlServerConfig::isStoredProcedureTableFunctionEnabled,
+                internalBinder -> newSetBinder(internalBinder, ConnectorTableFunction.class).addBinding().toProvider(Procedure.class).in(Scopes.SINGLETON)));
     }
 
     @Provides

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerConfig.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerConfig.java
@@ -21,6 +21,7 @@ public class SqlServerConfig
     private boolean snapshotIsolationDisabled;
     private boolean bulkCopyForWrite;
     private boolean bulkCopyForWriteLockDestinationTable;
+    private boolean storedProcedureTableFunctionEnabled;
 
     public boolean isBulkCopyForWrite()
     {
@@ -58,6 +59,19 @@ public class SqlServerConfig
     public SqlServerConfig setSnapshotIsolationDisabled(boolean snapshotIsolationDisabled)
     {
         this.snapshotIsolationDisabled = snapshotIsolationDisabled;
+        return this;
+    }
+
+    public boolean isStoredProcedureTableFunctionEnabled()
+    {
+        return storedProcedureTableFunctionEnabled;
+    }
+
+    @Config("sqlserver.experimental.stored-procedure-table-function-enabled")
+    @ConfigDescription("Allows accessing Stored procedure as a table function")
+    public SqlServerConfig setStoredProcedureTableFunctionEnabled(boolean storedProcedureTableFunctionEnabled)
+    {
+        this.storedProcedureTableFunctionEnabled = storedProcedureTableFunctionEnabled;
         return this;
     }
 }

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConfig.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConfig.java
@@ -30,7 +30,8 @@ public class TestSqlServerConfig
         assertRecordedDefaults(recordDefaults(SqlServerConfig.class)
                 .setBulkCopyForWrite(false)
                 .setBulkCopyForWriteLockDestinationTable(false)
-                .setSnapshotIsolationDisabled(false));
+                .setSnapshotIsolationDisabled(false)
+                .setStoredProcedureTableFunctionEnabled(false));
     }
 
     @Test
@@ -40,11 +41,13 @@ public class TestSqlServerConfig
                 .put("sqlserver.bulk-copy-for-write.enabled", "true")
                 .put("sqlserver.bulk-copy-for-write.lock-destination-table", "true")
                 .put("sqlserver.snapshot-isolation.disabled", "true")
+                .put("sqlserver.experimental.stored-procedure-table-function-enabled", "true")
                 .buildOrThrow();
 
         SqlServerConfig expected = new SqlServerConfig()
                 .setBulkCopyForWrite(true)
                 .setBulkCopyForWriteLockDestinationTable(true)
+                .setStoredProcedureTableFunctionEnabled(true)
                 .setSnapshotIsolationDisabled(true);
 
         assertFullMapping(properties, expected);

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorTest.java
@@ -55,7 +55,11 @@ public class TestSqlServerConnectorTest
             throws Exception
     {
         sqlServer = closeAfterClass(new TestingSqlServer());
-        return createSqlServerQueryRunner(sqlServer, ImmutableMap.of(), ImmutableMap.of(), REQUIRED_TPCH_TABLES);
+        return createSqlServerQueryRunner(
+                sqlServer,
+                ImmutableMap.of(),
+                ImmutableMap.of("sqlserver.experimental.stored-procedure-table-function-enabled", "true"),
+                REQUIRED_TPCH_TABLES);
     }
 
     @Override

--- a/plugin/trino-thrift-testing-server/pom.xml
+++ b/plugin/trino-thrift-testing-server/pom.xml
@@ -21,7 +21,7 @@
     <dependencies>
         <dependency>
             <groupId>io.trino</groupId>
-            <artifactId>trino-main</artifactId>
+            <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 
         <dependency>

--- a/plugin/trino-thrift-testing-server/src/main/java/io/trino/plugin/thrift/server/ThriftIndexedTpchService.java
+++ b/plugin/trino-thrift-testing-server/src/main/java/io/trino/plugin/thrift/server/ThriftIndexedTpchService.java
@@ -15,6 +15,7 @@ package io.trino.plugin.thrift.server;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import io.trino.plugin.base.MappedRecordSet;
 import io.trino.plugin.thrift.api.TrinoThriftBlock;
 import io.trino.plugin.thrift.api.TrinoThriftId;
 import io.trino.plugin.thrift.api.TrinoThriftNullableToken;
@@ -27,7 +28,6 @@ import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.RecordPageSource;
 import io.trino.spi.connector.RecordSet;
 import io.trino.spi.type.Type;
-import io.trino.split.MappedRecordSet;
 import io.trino.testing.tpch.TpchIndexedData;
 import io.trino.testing.tpch.TpchIndexedData.IndexedTable;
 import io.trino.testing.tpch.TpchScaledTable;

--- a/testing/trino-testing/src/main/java/io/trino/testing/tpch/TpchIndexProvider.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/tpch/TpchIndexProvider.java
@@ -14,6 +14,7 @@
 package io.trino.testing.tpch;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.plugin.base.MappedRecordSet;
 import io.trino.plugin.tpch.TpchColumnHandle;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorIndex;
@@ -25,7 +26,6 @@ import io.trino.spi.connector.RecordSet;
 import io.trino.spi.predicate.NullableValue;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.Type;
-import io.trino.split.MappedRecordSet;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

A dedicated table function which allows us to run stored procedures in SQLServer. We can't use existing query table function - as it wraps with inside a query like `SELECT * FROM (EXECUTE my_procedure) o` -  so we are handing them via a different function.  All the pushdown are disabled for `JdbcProcedureHandle` resolved by this `Procedure`. 

Slightly different implementation from https://github.com/trinodb/trino/pull/15982

#### Limitation

- Stored procedures with multiple ResultSet are not supported. 
- Stored procedures with output variables are not supported.
- Non Select statements are not supported. 

#### Example 

```
SELECT * FROM TABLE(system.procedure(query => 'EXECUTE my_schema.my_new_procedure')
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# SQLServer 
* Add support for executing stored procedures using `procedure` table function. 
```
