### PR TITLE
Add support of JDBC store for the dynamic catalog feature

### DIFF
--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -92,6 +92,12 @@
             <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -343,6 +343,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.locationtech.jts</groupId>
             <artifactId>jts-core</artifactId>
         </dependency>
@@ -369,9 +374,28 @@
 
         <!-- used by tests but also needed transitively -->
         <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+            <version>${dep.oracle.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna-platform</artifactId>
             <version>5.12.1</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/core/trino-main/src/main/java/io/trino/connector/CatalogStoreConfig.java
+++ b/core/trino-main/src/main/java/io/trino/connector/CatalogStoreConfig.java
@@ -21,7 +21,7 @@ public class CatalogStoreConfig
 {
     public enum CatalogStoreKind
     {
-        MEMORY, FILE
+        MEMORY, FILE, JDBC
     }
 
     private CatalogStoreKind catalogStoreKind = CatalogStoreKind.FILE;

--- a/core/trino-main/src/main/java/io/trino/connector/DynamicCatalogManagerModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/DynamicCatalogManagerModule.java
@@ -39,6 +39,10 @@ public class DynamicCatalogManagerModule
                     configBinder(binder).bindConfig(FileCatalogStoreConfig.class);
                     binder.bind(CatalogStore.class).to(FileCatalogStore.class).in(Scopes.SINGLETON);
                 }
+                case JDBC -> {
+                    configBinder(binder).bindConfig(JdbcCatalogStoreConfig.class);
+                    binder.bind(CatalogStore.class).to(JdbcCatalogStore.class).in(Scopes.SINGLETON);
+                }
             }
             binder.bind(ConnectorServicesProvider.class).to(CoordinatorDynamicCatalogManager.class).in(Scopes.SINGLETON);
             binder.bind(CatalogManager.class).to(CoordinatorDynamicCatalogManager.class).in(Scopes.SINGLETON);

--- a/core/trino-main/src/main/java/io/trino/connector/JdbcCatalogStore.java
+++ b/core/trino-main/src/main/java/io/trino/connector/JdbcCatalogStore.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+import io.airlift.log.Logger;
+import io.trino.connector.system.GlobalSystemConnector;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.CatalogHandle;
+import io.trino.spi.connector.CatalogHandle.CatalogVersion;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.mapper.reflect.ColumnName;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.Maps.fromProperties;
+import static io.trino.spi.StandardErrorCode.CATALOG_STORE_ERROR;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.connector.CatalogHandle.createRootCatalogHandle;
+import static java.util.Objects.requireNonNull;
+
+public final class JdbcCatalogStore
+        implements CatalogStore
+{
+    private static final Logger log = Logger.get(JdbcCatalogStore.class);
+
+    private final boolean readOnly;
+    private final Jdbi catalogsJdbi;
+
+    private final ConcurrentMap<String, StoredCatalog> catalogs = new ConcurrentHashMap<>();
+
+    @Inject
+    public JdbcCatalogStore(JdbcCatalogStoreConfig config)
+    {
+        requireNonNull(config, "config is null");
+        readOnly = config.isReadOnly();
+        String catalogsUrl = config.getCatalogConfigDbUrl();
+        String catalogsUser = config.getCatalogConfigDbUser();
+        String catalogsPassword = config.getCatalogConfigDbPassword();
+
+        catalogsJdbi = Jdbi.create(catalogsUrl, catalogsUser, catalogsPassword);
+
+        List<String> disabledCatalogs = firstNonNull(config.getDisabledCatalogs(), ImmutableList.of());
+
+        List<JdbcStoredCatalog> dbCatalogs = catalogsJdbi.withHandle(handle -> {
+            handle.execute("CREATE TABLE IF NOT EXISTS catalogs (name VARCHAR(255), properties TEXT, PRIMARY KEY (name))");
+
+            return handle.createQuery("SELECT name, properties FROM catalogs")
+                    .mapToBean(JdbcStoredCatalog.class)
+                    .list();
+        });
+
+        for (JdbcStoredCatalog catalog : dbCatalogs) {
+            String catalogName = catalog.getName();
+            checkArgument(!catalogName.equals(GlobalSystemConnector.NAME), "Catalog name SYSTEM is reserved for internal usage");
+
+            if (disabledCatalogs.contains(catalogName)) {
+                log.info("Skipping disabled catalog %s", catalogName);
+                continue;
+            }
+            catalogs.put(catalog.getName(), catalog);
+        }
+    }
+
+    @Override
+    public Collection<StoredCatalog> getCatalogs()
+    {
+        return ImmutableList.copyOf(catalogs.values());
+    }
+
+    @Override
+    public CatalogProperties createCatalogProperties(String catalogName, ConnectorName connectorName, Map<String, String> properties)
+    {
+        checkModifiable();
+        return new CatalogProperties(
+                createRootCatalogHandle(catalogName, computeCatalogVersion(catalogName, connectorName, properties)),
+                connectorName,
+                ImmutableMap.copyOf(properties));
+    }
+
+    @Override
+    public void addOrReplaceCatalog(CatalogProperties catalogProperties)
+    {
+        checkModifiable();
+        String catalogName = catalogProperties.getCatalogHandle().getCatalogName();
+
+        Properties properties = new Properties();
+        properties.setProperty("connector.name", catalogProperties.getConnectorName().toString());
+        properties.putAll(catalogProperties.getProperties());
+
+        StringWriter writer = new StringWriter();
+        try {
+            properties.store(writer, null);
+        }
+        catch (IOException e) {
+            log.error(e, "Could not store catalog properties for %s", catalogName);
+            // don't expose exception to end user
+            throw new TrinoException(CATALOG_STORE_ERROR, "Could not store catalog properties");
+        }
+
+        String stringProperties = writer.getBuffer().toString();
+
+        JdbcStoredCatalog jdbcCatalog = new JdbcStoredCatalog(catalogName, stringProperties);
+
+        catalogsJdbi.withHandle(handle -> {
+            handle.createUpdate("INSERT INTO catalogs (name,properties) VALUES (:name, :properties)")
+                    .bind("name", catalogName)
+                    .bind("properties", stringProperties)
+                    .execute();
+            return null;
+        });
+
+        catalogs.put(catalogName, jdbcCatalog);
+    }
+
+    @Override
+    public void removeCatalog(String catalogName)
+    {
+        checkModifiable();
+
+        catalogsJdbi.withHandle(handle -> {
+            handle.createUpdate("DELETE FROM catalogs WHERE name = :name")
+                    .bind("name", catalogName)
+                    .execute();
+            return null;
+        });
+
+        catalogs.remove(catalogName);
+    }
+
+    private void checkModifiable()
+    {
+        if (readOnly) {
+            throw new TrinoException(NOT_SUPPORTED, "Catalog store is read only");
+        }
+    }
+
+    /**
+     * This is not a generic, universal, or stable version computation, and can and will change from version to version without warning.
+     * For places that need a long term stable version, do not use this code.
+     */
+    static CatalogVersion computeCatalogVersion(String catalogName, ConnectorName connectorName, Map<String, String> properties)
+    {
+        Hasher hasher = Hashing.sha256().newHasher();
+        hasher.putUnencodedChars("catalog-hash");
+        hashLengthPrefixedString(hasher, catalogName);
+        hashLengthPrefixedString(hasher, connectorName.toString());
+        hasher.putInt(properties.size());
+        ImmutableSortedMap.copyOf(properties).forEach((key, value) -> {
+            hashLengthPrefixedString(hasher, key);
+            hashLengthPrefixedString(hasher, value);
+        });
+        return new CatalogVersion(hasher.hash().toString());
+    }
+
+    private static void hashLengthPrefixedString(Hasher hasher, String value)
+    {
+        hasher.putInt(value.length());
+        hasher.putUnencodedChars(value);
+    }
+
+    public static class JdbcStoredCatalog
+            implements StoredCatalog
+    {
+        private String name;
+        private String properties;
+
+        public JdbcStoredCatalog() {}
+
+        public JdbcStoredCatalog(String name, String properties)
+        {
+            this.name = name;
+            this.properties = properties;
+        }
+
+        @ColumnName("properties")
+        public String getProperties()
+        {
+            return properties;
+        }
+
+        public void setProperties(String properties)
+        {
+            this.properties = properties;
+        }
+
+        @ColumnName("name")
+        @Override
+        public String getName()
+        {
+            return name;
+        }
+
+        public void setName(String name)
+        {
+            this.name = name;
+        }
+
+        @Override
+        public CatalogProperties loadProperties()
+        {
+            final Properties properties = new Properties();
+
+            try {
+                properties.load(new StringReader(this.properties));
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException("Error reading catalog properties " + this.name, e);
+            }
+
+            Map<String, String> props = new HashMap<>(
+                    fromProperties(properties)
+                            .entrySet().stream()
+                            .collect(toImmutableMap(Entry::getKey, entry -> entry.getValue().trim())));
+
+            String connectorNameValue = props.remove("connector.name");
+            checkState(connectorNameValue != null, "Catalog configuration %s does not contain 'connector.name'", this.name);
+
+            if (connectorNameValue.indexOf('-') >= 0) {
+                String deprecatedConnectorName = connectorNameValue;
+                connectorNameValue = connectorNameValue.replace('-', '_');
+                log.warn("Catalog '%s' is using the deprecated connector name '%s'. The correct connector name is '%s'", name, deprecatedConnectorName, connectorNameValue);
+            }
+
+            ConnectorName connectorName = new ConnectorName(connectorNameValue);
+            CatalogHandle catalogHandle = createRootCatalogHandle(name, computeCatalogVersion(name, connectorName, props));
+
+            return new CatalogProperties(catalogHandle, connectorName, ImmutableMap.copyOf(props));
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/connector/JdbcCatalogStoreConfig.java
+++ b/core/trino-main/src/main/java/io/trino/connector/JdbcCatalogStoreConfig.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import io.airlift.configuration.Config;
+import io.airlift.configuration.LegacyConfig;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.List;
+
+public class JdbcCatalogStoreConfig
+{
+    private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
+
+    private String configUrl;
+    private String configUser;
+    private String configPassword;
+    private List<String> disabledCatalogs;
+    private boolean readOnly;
+
+    @NotNull
+    public String getCatalogConfigDbUrl()
+    {
+        return configUrl;
+    }
+
+    public String getCatalogConfigDbUser()
+    {
+        return configUser;
+    }
+
+    public String getCatalogConfigDbPassword()
+    {
+        return configPassword;
+    }
+
+    @LegacyConfig("plugin.config-dir")
+    @Config("catalog.config-db-url")
+    public JdbcCatalogStoreConfig setCatalogConfigDbUrl(String configUrl)
+    {
+        this.configUrl = configUrl;
+        return this;
+    }
+
+    @Config("catalog.config-db-user")
+    public JdbcCatalogStoreConfig setCatalogConfigDbUser(String configUser)
+    {
+        this.configUser = configUser;
+        return this;
+    }
+
+    @Config("catalog.config-db-password")
+    public JdbcCatalogStoreConfig setCatalogConfigDbPassword(String configPassword)
+    {
+        this.configPassword = configPassword;
+        return this;
+    }
+
+    public List<String> getDisabledCatalogs()
+    {
+        return disabledCatalogs;
+    }
+
+    @Config("catalog.disabled-catalogs")
+    public JdbcCatalogStoreConfig setDisabledCatalogs(String catalogs)
+    {
+        this.disabledCatalogs = (catalogs == null) ? null : SPLITTER.splitToList(catalogs);
+        return this;
+    }
+
+    public JdbcCatalogStoreConfig setDisabledCatalogs(List<String> catalogs)
+    {
+        this.disabledCatalogs = (catalogs == null) ? null : ImmutableList.copyOf(catalogs);
+        return this;
+    }
+
+    public boolean isReadOnly()
+    {
+        return readOnly;
+    }
+
+    @Config("catalog.read-only")
+    public JdbcCatalogStoreConfig setReadOnly(boolean readOnly)
+    {
+        this.readOnly = readOnly;
+        return this;
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/connector/TestJdbcCatalogStoreConfig.java
+++ b/core/trino-main/src/test/java/io/trino/connector/TestJdbcCatalogStoreConfig.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestJdbcCatalogStoreConfig
+{
+    protected PostgreSQLContainer<?> container;
+
+    @BeforeClass
+    public void setup()
+    {
+        container = new PostgreSQLContainer<>("postgres");
+        container.start();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        if (container != null) {
+            container.close();
+            container = null;
+        }
+    }
+
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(JdbcCatalogStoreConfig.class)
+                .setDisabledCatalogs((String) null)
+                .setCatalogConfigDbUrl((String) null)
+                .setCatalogConfigDbUser((String) null)
+                .setCatalogConfigDbPassword((String) null)
+                .setReadOnly(false));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("catalog.config-db-url", container.getJdbcUrl())
+                .put("catalog.config-db-user", container.getUsername())
+                .put("catalog.config-db-password", container.getPassword())
+                .put("catalog.disabled-catalogs", "abc,xyz")
+                .put("catalog.read-only", "true")
+                .buildOrThrow();
+
+        JdbcCatalogStoreConfig expected = new JdbcCatalogStoreConfig()
+                .setCatalogConfigDbUrl(container.getJdbcUrl())
+                .setCatalogConfigDbUser(container.getUsername())
+                .setCatalogConfigDbPassword(container.getPassword())
+                .setDisabledCatalogs(ImmutableList.of("abc", "xyz"))
+                .setReadOnly(true);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -276,6 +276,10 @@
                     <groupId>com.github.stephenc.jcip</groupId>
                     <artifactId>jcip-annotations</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -284,6 +288,12 @@
             <artifactId>trino-main</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/plugin/trino-geospatial/pom.xml
+++ b/plugin/trino-geospatial/pom.xml
@@ -98,6 +98,12 @@
             <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -105,6 +111,12 @@
             <artifactId>trino-main</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/plugin/trino-hive-hadoop2/pom.xml
+++ b/plugin/trino-hive-hadoop2/pom.xml
@@ -144,6 +144,12 @@
             <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -363,12 +363,24 @@
             <artifactId>trino-main</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/plugin/trino-hudi/pom.xml
+++ b/plugin/trino-hudi/pom.xml
@@ -279,6 +279,12 @@
             <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -286,6 +292,12 @@
             <artifactId>trino-main</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/plugin/trino-kudu/pom.xml
+++ b/plugin/trino-kudu/pom.xml
@@ -137,6 +137,12 @@
             <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -144,6 +150,12 @@
             <artifactId>trino-main</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Description
Based on the new dynamic catalog, compatible with file and memory. I've try to add a compatibility with a jdbc database for store them.
The main feature of dynamic catalog come from this Issue : https://github.com/trinodb/trino/issues/12709#issuecomment-1290290147

## Additional context and related issues
Goal is to avoid the need of a persistant volume with a persistent dynamic catalog.

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```
# DynamicCatalog
* Add support for storing the dynamic catalog through a jdbc connector
```
