### PR TITLE
Update `first_tested_version` to 18 month ago in JDBC driver test

### DIFF
--- a/testing/trino-test-jdbc-compatibility-old-driver/bin/run_tests.sh
+++ b/testing/trino-test-jdbc-compatibility-old-driver/bin/run_tests.sh
@@ -10,7 +10,7 @@ maven_run_tests="${maven} clean test ${MAVEN_TEST:--B} -pl :trino-test-jdbc-comp
 
 current_version=$(${maven} help:evaluate -Dexpression=project.version -q -DforceStdout)
 previous_released_version=$((${current_version%-SNAPSHOT}-1))
-first_tested_version=352
+first_tested_version=$(git tag --contain $(git rev-list HEAD --since-as-filter='18 month ago' | tail -1) | sort | head -1)
 # test n-th version only
 version_step=7
 


### PR DESCRIPTION
## Description

Update `first_tested_version` to 368 in JDBC driver test to avoid CI timeout. 

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
