### PR TITLE
Allow migrating external tables in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrateProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrateProcedure.java
@@ -192,8 +192,8 @@ public class MigrateProcedure
         if (parseBoolean(transactionalProperty)) {
             throw new TrinoException(NOT_SUPPORTED, "Migrating transactional tables is unsupported");
         }
-        if (!"MANAGED_TABLE".equalsIgnoreCase(hiveTable.getTableType())) {
-            throw new TrinoException(NOT_SUPPORTED, "The procedure supports migrating only managed tables: " + hiveTable.getTableType());
+        if (!"MANAGED_TABLE".equalsIgnoreCase(hiveTable.getTableType()) && !"EXTERNAL_TABLE".equalsIgnoreCase(hiveTable.getTableType())) {
+            throw new TrinoException(NOT_SUPPORTED, "The procedure doesn't support migrating %s table type".formatted(hiveTable.getTableType()));
         }
         if (isDeltaLakeTable(hiveTable)) {
             throw new TrinoException(NOT_SUPPORTED, "The procedure doesn't support migrating Delta Lake tables");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMigrateProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMigrateProcedure.java
@@ -282,7 +282,7 @@ public class TestIcebergMigrateProcedure
 
         assertQueryFails(
                 "CALL iceberg.system.migrate('tpch', '" + viewName + "')",
-                "The procedure supports migrating only managed tables: .*");
+                "The procedure doesn't support migrating VIRTUAL_VIEW table type");
 
         assertQuery("SELECT * FROM " + trinoViewInHive, "VALUES 1");
         assertQuery("SELECT * FROM " + trinoViewInIceberg, "VALUES 1");


### PR DESCRIPTION
## Description

Allow migrating external tables in Iceberg

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Add support for Hive external tables in `migrate` procedure. ({issue}`16704`)
```
