### PR TITLE
Make setup of bucketed tables in HiveQueryRunner optional

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -217,6 +217,7 @@ public abstract class BaseHiveConnectorTest
                         "hive.minimum-assigned-split-weight", "0.5"))
                 .addExtraProperty("legacy.allow-set-view-authorization", "true")
                 .setInitialTables(REQUIRED_TPCH_TABLES)
+                .setTpchBucketedCatalogEnabled(true)
                 .build();
 
         // extra catalog with NANOSECOND timestamp precision

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
@@ -107,6 +107,7 @@ public final class HiveQueryRunner
         private Module module = EMPTY_MODULE;
         private Optional<DirectoryLister> directoryLister = Optional.empty();
         private boolean tpcdsCatalogEnabled;
+        private boolean tpchBucketedCatalogEnabled;
         private String security = SQL_STANDARD;
         private boolean createTpchSchemas = true;
         private ColumnNaming tpchColumnNaming = SIMPLIFIED;
@@ -183,6 +184,12 @@ public final class HiveQueryRunner
             return self();
         }
 
+        public SELF setTpchBucketedCatalogEnabled(boolean tpchBucketedCatalogEnabled)
+        {
+            this.tpchBucketedCatalogEnabled = tpchBucketedCatalogEnabled;
+            return self();
+        }
+
         public SELF setSecurity(String security)
         {
             this.security = requireNonNull(security, "security is null");
@@ -242,17 +249,19 @@ public final class HiveQueryRunner
                 hiveProperties.put("hive.security", security);
                 hiveProperties.putAll(this.hiveProperties.buildOrThrow());
 
-                Map<String, String> hiveBucketedProperties = ImmutableMap.<String, String>builder()
-                        .putAll(hiveProperties)
-                        .put("hive.max-initial-split-size", "10kB") // so that each bucket has multiple splits
-                        .put("hive.max-split-size", "10kB") // so that each bucket has multiple splits
-                        .put("hive.storage-format", "TEXTFILE") // so that there's no minimum split size for the file
-                        .buildOrThrow();
-                hiveBucketedProperties = new HashMap<>(hiveBucketedProperties);
-                hiveBucketedProperties.put("hive.compression-codec", "NONE"); // so that the file is splittable
+                if (tpchBucketedCatalogEnabled) {
+                    Map<String, String> hiveBucketedProperties = ImmutableMap.<String, String>builder()
+                            .putAll(hiveProperties)
+                            .put("hive.max-initial-split-size", "10kB") // so that each bucket has multiple splits
+                            .put("hive.max-split-size", "10kB") // so that each bucket has multiple splits
+                            .put("hive.storage-format", "TEXTFILE") // so that there's no minimum split size for the file
+                            .buildOrThrow();
+                    hiveBucketedProperties = new HashMap<>(hiveBucketedProperties);
+                    hiveBucketedProperties.put("hive.compression-codec", "NONE"); // so that the file is splittable
+                    queryRunner.createCatalog(HIVE_BUCKETED_CATALOG, "hive", hiveBucketedProperties);
+                }
 
                 queryRunner.createCatalog(HIVE_CATALOG, "hive", hiveProperties);
-                queryRunner.createCatalog(HIVE_BUCKETED_CATALOG, "hive", hiveBucketedProperties);
 
                 if (createTpchSchemas) {
                     populateData(queryRunner, metastore);
@@ -274,7 +283,7 @@ public final class HiveQueryRunner
                 copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, session, initialTables);
             }
 
-            if (metastore.getDatabase(TPCH_BUCKETED_SCHEMA).isEmpty()) {
+            if (tpchBucketedCatalogEnabled && metastore.getDatabase(TPCH_BUCKETED_SCHEMA).isEmpty()) {
                 metastore.createDatabase(createDatabaseMetastoreObject(TPCH_BUCKETED_SCHEMA, initialSchemasLocationBase));
                 Session session = initialTablesSessionMutator.apply(createBucketedSession(Optional.empty()));
                 copyTpchTablesBucketed(queryRunner, "tpch", TINY_SCHEMA_NAME, session, initialTables, tpchColumnNaming);
@@ -302,9 +311,7 @@ public final class HiveQueryRunner
     {
         return testSessionBuilder()
                 .setIdentity(Identity.forUser("hive")
-                        .withConnectorRoles(role.map(selectedRole -> ImmutableMap.of(
-                                        HIVE_CATALOG, selectedRole,
-                                        HIVE_BUCKETED_CATALOG, selectedRole))
+                        .withConnectorRoles(role.map(selectedRole -> ImmutableMap.of(HIVE_CATALOG, selectedRole))
                                 .orElse(ImmutableMap.of()))
                         .build())
                 .setCatalog(HIVE_CATALOG)

--- a/plugin/trino-session-property-managers/src/test/java/io/trino/plugin/session/TestSessionPropertyManagerInTransaction.java
+++ b/plugin/trino-session-property-managers/src/test/java/io/trino/plugin/session/TestSessionPropertyManagerInTransaction.java
@@ -55,6 +55,6 @@ public class TestSessionPropertyManagerInTransaction
         // Ensure that the previous statement was successful
         assertQuery(
                 "SHOW SCHEMAS FROM hive",
-                "VALUES('information_schema'),('test'),('tpch'),('tpch_bucketed')");
+                "VALUES('information_schema'),('test'),('tpch')");
     }
 }


### PR DESCRIPTION
## Description
Make setup of bucketed tables in HiveQueryRunner optional

Bucketed tables are unnecessary in many tests

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
