### PR TITLE
Fix failure when partition column contains uppercase in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -775,7 +775,7 @@ public class IcebergMetadata
                 .distinct()
                 .collect(toImmutableList());
         List<String> partitioningColumnNames = partitioningColumns.stream()
-                .map(IcebergColumnHandle::getName)
+                .map(column -> column.getName().toLowerCase(ENGLISH))
                 .collect(toImmutableList());
 
         if (!forceRepartitioning && partitionSpec.fields().stream().allMatch(field -> field.transform().isIdentity())) {


### PR DESCRIPTION
## Description

Fixes #16622

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Fix failure when partitioned column names contain uppercase characters. ({issue}`16622`)
```
