### PR TITLE
Reduce synchronization on PipelinedStageExecution

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedStageExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedStageExecution.java
@@ -207,13 +207,13 @@ public class PipelinedStageExecution
     }
 
     @Override
-    public synchronized void beginScheduling()
+    public void beginScheduling()
     {
         stateMachine.transitionToScheduling();
     }
 
     @Override
-    public synchronized void transitionToSchedulingSplits()
+    public void transitionToSchedulingSplits()
     {
         stateMachine.transitionToSchedulingSplits();
     }


### PR DESCRIPTION
## Description
Removes synchronization from `beginScheduling()` and `transitionToSchedulingSplits()` both of which only perform state machine updates (if necessary) and do not require accessing synchronized state.

Follows up from https://github.com/trinodb/trino/pull/16585

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
