### PR TITLE
Add NullablePosition to SumDataSizeForStats

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/SumDataSizeForStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/SumDataSizeForStats.java
@@ -37,7 +37,7 @@ public final class SumDataSizeForStats
 
     @InputFunction
     @TypeParameter("T")
-    public static void input(@AggregationState LongState state, @BlockPosition @SqlType("T") Block block, @BlockIndex int index)
+    public static void input(@AggregationState LongState state, @NullablePosition @BlockPosition @SqlType("T") Block block, @BlockIndex int index)
     {
         update(state, block.getEstimatedDataSizeForStats(index));
     }


### PR DESCRIPTION
## Description
Avoids an extra null check as block.getEstimatedDataSizeForStats will also check for null

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Missed making this change in https://github.com/trinodb/trino/pull/16675 , but it doesn't affect correctness.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
