### PR TITLE
Add missing AWS dependencies to the Iceberg connector

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -16,6 +16,8 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
 
+        <awsjavasdk.version>2.17.151</awsjavasdk.version>
+
         <!--
           Project's default for air.test.parallel is 'methods'. By design, 'instances' runs all the methods in the same instance in the same thread,
           but two methods on two different instances will be running in different threads.
@@ -209,6 +211,11 @@
 
         <dependency>
             <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-aws</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-core</artifactId>
         </dependency>
 
@@ -305,6 +312,27 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <version>${awsjavasdk.version}</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
@@ -17,12 +17,14 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.hdfs.ConfigurationUtils;
 import io.trino.plugin.base.CatalogName;
 import io.trino.plugin.hive.NodeVersion;
+import io.trino.plugin.hive.s3.HiveS3Config;
 import io.trino.plugin.iceberg.IcebergConfig;
 import io.trino.plugin.iceberg.catalog.TrinoCatalog;
 import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
 import io.trino.plugin.iceberg.catalog.rest.IcebergRestCatalogConfig.SessionType;
 import io.trino.spi.security.ConnectorIdentity;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.rest.RESTSessionCatalog;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -40,6 +42,10 @@ public class TrinoIcebergRestCatalogFactory
     private final String trinoVersion;
     private final URI serverUri;
     private final Optional<String> warehouse;
+    private final Optional<String> s3AccessKey;
+    private final Optional<String> s3SecretKey;
+    private final Optional<String> s3Endpoint;
+    private final boolean s3PathStyleAccess;
     private final SessionType sessionType;
     private final SecurityProperties securityProperties;
     private final boolean uniqueTableLocation;
@@ -53,6 +59,7 @@ public class TrinoIcebergRestCatalogFactory
             IcebergRestCatalogConfig restConfig,
             SecurityProperties securityProperties,
             IcebergConfig icebergConfig,
+            HiveS3Config hiveS3Config,
             NodeVersion nodeVersion)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
@@ -60,6 +67,10 @@ public class TrinoIcebergRestCatalogFactory
         requireNonNull(restConfig, "restConfig is null");
         this.serverUri = restConfig.getBaseUri();
         this.warehouse = restConfig.getWarehouse();
+        this.s3Endpoint = Optional.ofNullable(hiveS3Config.getS3Endpoint());
+        this.s3PathStyleAccess = hiveS3Config.isS3PathStyleAccess();
+        this.s3AccessKey = Optional.ofNullable(hiveS3Config.getS3AwsAccessKey());
+        this.s3SecretKey = Optional.ofNullable(hiveS3Config.getS3AwsSecretKey());
         this.sessionType = restConfig.getSessionType();
         this.securityProperties = requireNonNull(securityProperties, "securityProperties is null");
         requireNonNull(icebergConfig, "icebergConfig is null");
@@ -75,6 +86,11 @@ public class TrinoIcebergRestCatalogFactory
             ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
             properties.put(CatalogProperties.URI, serverUri.toString());
             warehouse.ifPresent(location -> properties.put(CatalogProperties.WAREHOUSE_LOCATION, location));
+            s3Endpoint.ifPresent(endpoint -> properties.put(AwsProperties.S3FILEIO_ENDPOINT, endpoint));
+            s3AccessKey.ifPresent(accessKey -> properties.put(AwsProperties.S3FILEIO_ACCESS_KEY_ID, accessKey));
+            s3SecretKey.ifPresent(secretKey -> properties.put(AwsProperties.S3FILEIO_SECRET_ACCESS_KEY, secretKey));
+            properties.put(AwsProperties.S3FILEIO_PATH_STYLE_ACCESS, String.valueOf(s3PathStyleAccess));
+            properties.put(AwsProperties.HTTP_CLIENT_TYPE, AwsProperties.HTTP_CLIENT_TYPE_APACHE);
             properties.put("trino-version", trinoVersion);
             properties.putAll(securityProperties.get());
             RESTSessionCatalog icebergCatalogInstance = new RESTSessionCatalog();

--- a/pom.xml
+++ b/pom.xml
@@ -1687,6 +1687,18 @@
 
             <dependency>
                 <groupId>org.apache.iceberg</groupId>
+                <artifactId>iceberg-aws</artifactId>
+                <version>${dep.iceberg.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.iceberg</groupId>
                 <artifactId>iceberg-core</artifactId>
                 <version>${dep.iceberg.version}</version>
                 <exclusions>


### PR DESCRIPTION
## Description

The Iceberg connector threw an error when using the REST catalog, as described in #16213.

    Cannot initialize FileIO, missing no-arg constructor: org.apache.iceberg.aws.s3.S3FileIO

This change adds the missing AWS SDK v2 dependencies and sets the Apache HTTP client option to make the S3FileIO backend work with the REST catalog.

The REST catalog is now configured with the following "hive.s3" settings to allow the usage of a custom endpoint.

- `hive.s3.endpoint`
- `hive.s3.aws-access-key`
- `hive.s3.aws-secret-key`
- `hive.s3.path-style-access`

Fixes #16213

## Additional context and related issues

Issue #16213 got closed by the reporting user, but I ran into the same problem when using Iceberg's REST catalog.

With the changes in this PR, I can use Trino with the `tabulario/iceberg-rest` Docker image and a MinIO server.

The Iceberg connector uses the `hive.s3.*` settings mentioned above to access the data files in S3. I re-used them to configure the REST catalog instead of introducing new Iceberg-specific configuration options.

## Questions

I have a question about the AWS SDK v2 version:

The `trino-exchange-filesystem` plugin uses a `awsjavasdk.version` property for the AWS SDK v2 version. I had to use the same version for the `trino-iceberg` plugin to avoid an error from the enforcer plugin.

What is the correct way to share the version property? Adding it to the root `pom.xml` file?

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# Iceberg connector
* Fix missing dependencies and configure S3 endpoint settings for REST catalog. ({issue}`16213`)
```
