### PR TITLE
Change ViewExpression.identity to be Optional<Identity>

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -4664,8 +4664,8 @@ class StatementAnalyzer
             ExpressionAnalysis expressionAnalysis;
             try {
                 Identity filterIdentity = filter.getSecurityIdentity()
-                        .map(filterUser -> Identity.forUser(filterUser)
-                                .withGroups(groupProvider.getGroups(filterUser))
+                        .map(identity -> Identity.from(identity)
+                                .withGroups(groupProvider.getGroups(identity.getUser()))
                                 .build())
                         .orElseGet(session::getIdentity);
                 expressionAnalysis = ExpressionAnalyzer.analyzeExpression(
@@ -4717,9 +4717,9 @@ class StatementAnalyzer
             ExpressionAnalysis expressionAnalysis;
             try {
                 Identity constraintIdentity = constraint.getSecurityIdentity()
-                        .map(user -> Identity.forUser(user)
-                            .withGroups(groupProvider.getGroups(user))
-                            .build())
+                        .map(identity -> Identity.from(identity)
+                                .withGroups(groupProvider.getGroups(identity.getUser()))
+                                .build())
                         .orElseGet(session::getIdentity);
                 expressionAnalysis = ExpressionAnalyzer.analyzeExpression(
                         createViewSession(constraint.getCatalog(), constraint.getSchema(), constraintIdentity, session.getPath()),
@@ -4782,8 +4782,8 @@ class StatementAnalyzer
 
             try {
                 Identity maskIdentity = mask.getSecurityIdentity()
-                        .map(maskUser -> Identity.forUser(maskUser)
-                                .withGroups(groupProvider.getGroups(maskUser))
+                        .map(identity -> Identity.from(identity)
+                                .withGroups(groupProvider.getGroups(identity.getUser()))
                                 .build())
                         .orElseGet(session::getIdentity);
                 expressionAnalysis = ExpressionAnalyzer.analyzeExpression(

--- a/core/trino-main/src/test/java/io/trino/security/TestAccessControlManager.java
+++ b/core/trino-main/src/test/java/io/trino/security/TestAccessControlManager.java
@@ -231,7 +231,7 @@ public class TestAccessControlManager
                         @Override
                         public List<ViewExpression> getColumnMasks(SystemSecurityContext context, CatalogSchemaTableName tableName, String column, Type type)
                         {
-                            return ImmutableList.of(new ViewExpression(Optional.of("user"), Optional.empty(), Optional.empty(), "system mask"));
+                            return ImmutableList.of(new ViewExpression(Optional.of(Identity.ofUser("user")), Optional.empty(), Optional.empty(), "system mask"));
                         }
 
                         @Override
@@ -249,7 +249,7 @@ public class TestAccessControlManager
                 @Override
                 public List<ViewExpression> getColumnMasks(ConnectorSecurityContext context, SchemaTableName tableName, String column, Type type)
                 {
-                    return ImmutableList.of(new ViewExpression(Optional.of("user"), Optional.empty(), Optional.empty(), "connector mask"));
+                    return ImmutableList.of(new ViewExpression(Optional.of(Identity.ofUser("user")), Optional.empty(), Optional.empty(), "connector mask"));
                 }
 
                 @Override

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestFilterInaccessibleColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestFilterInaccessibleColumns.java
@@ -153,7 +153,7 @@ public class TestFilterInaccessibleColumns
     {
         accessControl.rowFilter(new QualifiedObjectName(TEST_CATALOG_NAME, TINY_SCHEMA_NAME, "nation"),
                 USER,
-                new ViewExpression(Optional.of(ADMIN), Optional.of(TEST_CATALOG_NAME), Optional.of(TINY_SCHEMA_NAME), "comment IS NOT null"));
+                new ViewExpression(Optional.of(Identity.ofUser(ADMIN)), Optional.of(TEST_CATALOG_NAME), Optional.of(TINY_SCHEMA_NAME), "comment IS NOT null"));
         accessControl.deny(privilege(USER, "nation.comment", SELECT_COLUMN));
         assertThat(assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
                 .matches("VALUES (BIGINT '6', CAST('FRANCE' AS VARCHAR(25)), BIGINT '3')");
@@ -164,7 +164,7 @@ public class TestFilterInaccessibleColumns
     {
         accessControl.rowFilter(new QualifiedObjectName(TEST_CATALOG_NAME, TINY_SCHEMA_NAME, "nation"),
                 USER,
-                new ViewExpression(Optional.of(USER), Optional.of(TEST_CATALOG_NAME), Optional.of(TINY_SCHEMA_NAME), "comment IS NOT null"));
+                new ViewExpression(Optional.of(Identity.ofUser(USER)), Optional.of(TEST_CATALOG_NAME), Optional.of(TINY_SCHEMA_NAME), "comment IS NOT null"));
         accessControl.deny(privilege(USER, "nation.comment", SELECT_COLUMN));
         assertThatThrownBy(() -> assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
                 .hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view test-catalog.tiny.nation");
@@ -191,7 +191,7 @@ public class TestFilterInaccessibleColumns
         accessControl.columnMask(new QualifiedObjectName(TEST_CATALOG_NAME, TINY_SCHEMA_NAME, "nation"),
                 "nationkey",
                 USER,
-                new ViewExpression(Optional.of(ADMIN), Optional.of(TEST_CATALOG_NAME), Optional.of(TINY_SCHEMA_NAME), "-nationkey"));
+                new ViewExpression(Optional.of(Identity.ofUser(ADMIN)), Optional.of(TEST_CATALOG_NAME), Optional.of(TINY_SCHEMA_NAME), "-nationkey"));
         assertThat(assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
                 .matches("VALUES (BIGINT '-6',CAST('FRANCE' AS VARCHAR(25)), BIGINT '3', CAST('refully final requests. regular, ironi' AS VARCHAR(152)))");
     }
@@ -203,7 +203,7 @@ public class TestFilterInaccessibleColumns
         accessControl.columnMask(new QualifiedObjectName(TEST_CATALOG_NAME, TINY_SCHEMA_NAME, "nation"),
                 "comment",
                 USER,
-                new ViewExpression(Optional.of(USER), Optional.of(TEST_CATALOG_NAME), Optional.of(TINY_SCHEMA_NAME), "CASE nationkey WHEN 6 THEN 'masked-comment' ELSE comment END"));
+                new ViewExpression(Optional.of(Identity.ofUser(USER)), Optional.of(TEST_CATALOG_NAME), Optional.of(TINY_SCHEMA_NAME), "CASE nationkey WHEN 6 THEN 'masked-comment' ELSE comment END"));
 
         assertThatThrownBy(() -> assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
                 .hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view test-catalog.tiny.nation");
@@ -216,7 +216,7 @@ public class TestFilterInaccessibleColumns
         accessControl.columnMask(new QualifiedObjectName(TEST_CATALOG_NAME, TINY_SCHEMA_NAME, "nation"),
                 "comment",
                 USER,
-                new ViewExpression(Optional.of(ADMIN), Optional.of(TEST_CATALOG_NAME), Optional.of(TINY_SCHEMA_NAME), "CASE nationkey WHEN 6 THEN 'masked-comment' ELSE comment END"));
+                new ViewExpression(Optional.of(Identity.ofUser(ADMIN)), Optional.of(TEST_CATALOG_NAME), Optional.of(TINY_SCHEMA_NAME), "CASE nationkey WHEN 6 THEN 'masked-comment' ELSE comment END"));
 
         assertThat(assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
                 .matches("VALUES (CAST('FRANCE' AS VARCHAR(25)), BIGINT '3', CAST('masked-comment' AS VARCHAR(152)))");

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestRowFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestRowFilter.java
@@ -58,6 +58,7 @@ public class TestRowFilter
     private static final String USER = "user";
     private static final String VIEW_OWNER = "view-owner";
     private static final String RUN_AS_USER = "run-as-user";
+    private static final Optional<Identity> RUN_AS_USER_IDENTITY = Optional.of(Identity.ofUser(RUN_AS_USER));
 
     private static final Session SESSION = testSessionBuilder()
             .setCatalog(LOCAL_CATALOG)
@@ -277,12 +278,12 @@ public class TestRowFilter
         accessControl.rowFilter(
                 new QualifiedObjectName(LOCAL_CATALOG, "tiny", "orders"),
                 RUN_AS_USER,
-                new ViewExpression(Optional.of(RUN_AS_USER), Optional.of(LOCAL_CATALOG), Optional.of("tiny"), "orderkey = 1"));
+                new ViewExpression(RUN_AS_USER_IDENTITY, Optional.of(LOCAL_CATALOG), Optional.of("tiny"), "orderkey = 1"));
 
         accessControl.rowFilter(
                 new QualifiedObjectName(LOCAL_CATALOG, "tiny", "orders"),
                 USER,
-                new ViewExpression(Optional.of(RUN_AS_USER), Optional.of(LOCAL_CATALOG), Optional.of("tiny"), "orderkey IN (SELECT orderkey FROM orders)"));
+                new ViewExpression(RUN_AS_USER_IDENTITY, Optional.of(LOCAL_CATALOG), Optional.of("tiny"), "orderkey IN (SELECT orderkey FROM orders)"));
 
         assertThat(assertions.query("SELECT count(*) FROM orders")).matches("VALUES BIGINT '1'");
     }
@@ -422,7 +423,7 @@ public class TestRowFilter
         accessControl.rowFilter(
                 new QualifiedObjectName(LOCAL_CATALOG, "tiny", "orders"),
                 USER,
-                new ViewExpression(Optional.of(RUN_AS_USER), Optional.of(LOCAL_CATALOG), Optional.of("tiny"), "orderkey = 0"));
+                new ViewExpression(RUN_AS_USER_IDENTITY, Optional.of(LOCAL_CATALOG), Optional.of("tiny"), "orderkey = 0"));
 
         assertThat(assertions.query("SHOW STATS FOR (SELECT * FROM tiny.orders)"))
                 .containsAll(

--- a/core/trino-spi/src/main/java/io/trino/spi/security/ViewExpression.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/ViewExpression.java
@@ -19,7 +19,7 @@ import static java.util.Objects.requireNonNull;
 
 public class ViewExpression
 {
-    private final Optional<String> identity;
+    private final Optional<Identity> identity;
     private final Optional<String> catalog;
     private final Optional<String> schema;
     private final String expression;
@@ -27,10 +27,10 @@ public class ViewExpression
     @Deprecated
     public ViewExpression(String identity, Optional<String> catalog, Optional<String> schema, String expression)
     {
-        this(Optional.of(identity), catalog, schema, expression);
+        this(Optional.of(Identity.ofUser(identity)), catalog, schema, expression);
     }
 
-    public ViewExpression(Optional<String> identity, Optional<String> catalog, Optional<String> schema, String expression)
+    public ViewExpression(Optional<Identity> identity, Optional<String> catalog, Optional<String> schema, String expression)
     {
         this.identity = requireNonNull(identity, "identity is null");
         this.catalog = requireNonNull(catalog, "catalog is null");
@@ -45,14 +45,14 @@ public class ViewExpression
     @Deprecated
     public String getIdentity()
     {
-        return identity.orElseThrow();
+        return identity.orElseThrow().getUser();
     }
 
     /**
-     * @return user as whom the view expression will be evaluated. If empty identity is returned
-     * then session user is used.
+     * @return Identity as whom the view expression will be evaluated. If empty identity is returned
+     * then session identity is used.
      */
-    public Optional<String> getSecurityIdentity()
+    public Optional<Identity> getSecurityIdentity()
     {
         return identity;
     }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/TableAccessControlRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/TableAccessControlRule.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.security.Identity;
 import io.trino.spi.security.ViewExpression;
 
 import java.util.List;
@@ -106,7 +107,7 @@ public class TableAccessControlRule
     {
         return Optional.ofNullable(columnConstraints.get(column)).flatMap(constraint ->
                 constraint.getMask().map(mask -> new ViewExpression(
-                        constraint.getMaskEnvironment().flatMap(ExpressionEnvironment::getUser),
+                        constraint.getMaskEnvironment().flatMap(ExpressionEnvironment::getUser).map(Identity::ofUser),
                         Optional.of(catalog),
                         Optional.of(schema),
                         mask)));
@@ -115,7 +116,7 @@ public class TableAccessControlRule
     public Optional<ViewExpression> getFilter(String catalog, String schema)
     {
         return filter.map(filter -> new ViewExpression(
-                filterEnvironment.flatMap(ExpressionEnvironment::getUser),
+                filterEnvironment.flatMap(ExpressionEnvironment::getUser).map(Identity::ofUser),
                 Optional.of(catalog),
                 Optional.of(schema),
                 filter));

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedSystemAccessControlTest.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedSystemAccessControlTest.java
@@ -1433,7 +1433,7 @@ public abstract class BaseFileBasedSystemAccessControlTest
                         new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"),
                         "masked_with_user",
                         VARCHAR).orElseThrow(),
-                new ViewExpression(Optional.of("mask-user"), Optional.of("some-catalog"), Optional.of("bobschema"), "'mask-with-user'"));
+                new ViewExpression(Optional.of(Identity.ofUser("mask-user")), Optional.of("some-catalog"), Optional.of("bobschema"), "'mask-with-user'"));
     }
 
     @Test
@@ -1455,7 +1455,7 @@ public abstract class BaseFileBasedSystemAccessControlTest
         assertEquals(rowFilters.size(), 1);
         assertViewExpressionEquals(
                 rowFilters.get(0),
-                new ViewExpression(Optional.of("filter-user"), Optional.of("some-catalog"), Optional.of("bobschema"), "starts_with(value, 'filter-with-user')"));
+                new ViewExpression(Optional.of(Identity.ofUser("filter-user")), Optional.of("some-catalog"), Optional.of("bobschema"), "starts_with(value, 'filter-with-user')"));
     }
 
     private static void assertViewExpressionEquals(ViewExpression actual, ViewExpression expected)


### PR DESCRIPTION
Before this commit, it was Optional\<String\>, containing the user string, but that drops information, especially for row filters and views.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
