### PR TITLE
Add missing groups to `TestIcebergProcedureCalls.testMigrateHiveBucketedOnMultipleColumns`

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergProcedureCalls.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergProcedureCalls.java
@@ -99,7 +99,7 @@ public class TestIcebergProcedureCalls
         onTrino().executeQuery("DROP TABLE IF EXISTS " + hiveTableName);
     }
 
-    @Test
+    @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS})
     public void testMigrateHiveBucketedOnMultipleColumns()
     {
         String tableName = "test_migrate_bucketed_" + randomNameSuffix();


### PR DESCRIPTION
## Description

Add missing groups to `TestIcebergProcedureCalls.testMigrateHiveBucketedOnMultipleColumns`

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
