### PR TITLE
Improve performance of `drop_stats` procedure in Hive thrift metastore

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
@@ -147,6 +147,12 @@ public class HiveMetastoreClosure
         delegate.updatePartitionStatistics(table, updates);
     }
 
+    public void dropPartitionStatistics(String databaseName, String tableName, String partitionName)
+    {
+        Table table = getExistingTable(databaseName, tableName);
+        delegate.dropPartitionStatistics(table, partitionName);
+    }
+
     public List<String> getAllTables(String databaseName)
     {
         return delegate.getAllTables(databaseName);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/ForwardingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/ForwardingHiveMetastore.java
@@ -109,6 +109,12 @@ public abstract class ForwardingHiveMetastore
     }
 
     @Override
+    public void dropPartitionStatistics(Table table, String partitionName)
+    {
+        delegate.dropPartitionStatistics(table, partitionName);
+    }
+
+    @Override
     public List<String> getAllTables(String databaseName)
     {
         return delegate.getAllTables(databaseName);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
@@ -60,6 +60,8 @@ public interface HiveMetastore
 
     void updatePartitionStatistics(Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates);
 
+    void dropPartitionStatistics(Table table, String partitionName);
+
     List<String> getAllTables(String databaseName);
 
     List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/alluxio/AlluxioHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/alluxio/AlluxioHiveMetastore.java
@@ -199,6 +199,12 @@ public class AlluxioHiveMetastore
     }
 
     @Override
+    public void dropPartitionStatistics(Table table, String partitionName)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "dropPartitionStatistics");
+    }
+
+    @Override
     public List<String> getAllTables(String databaseName)
     {
         try {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -646,6 +646,20 @@ public class CachingHiveMetastore
     }
 
     @Override
+    public void dropPartitionStatistics(Table table, String partitionName)
+    {
+        try {
+            delegate.dropPartitionStatistics(table, partitionName);
+        }
+        finally {
+            HivePartitionName hivePartitionName = hivePartitionName(hiveTableName(table.getDatabaseName(), table.getTableName()), partitionName);
+            partitionStatisticsCache.invalidate(hivePartitionName);
+            // basic stats are stored as partition properties
+            partitionCache.invalidate(hivePartitionName);
+        }
+    }
+
+    @Override
     public List<String> getAllTables(String databaseName)
     {
         return get(tableNamesCache, databaseName);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -508,6 +508,12 @@ public class FileHiveMetastore
     }
 
     @Override
+    public void dropPartitionStatistics(Table table, String partitionName)
+    {
+        updatePartitionStatistics(table, ImmutableMap.of(partitionName, stats -> PartitionStatistics.empty()));
+    }
+
+    @Override
     public synchronized List<String> getAllTables(String databaseName)
     {
         return listAllTables(databaseName).stream()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -413,6 +413,12 @@ public class GlueHiveMetastore
     }
 
     @Override
+    public void dropPartitionStatistics(Table table, String partitionName)
+    {
+        updatePartitionStatistics(table, ImmutableMap.of(partitionName, stats -> PartitionStatistics.empty()));
+    }
+
+    @Override
     public List<String> getAllTables(String databaseName)
     {
         try {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/recording/RecordingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/recording/RecordingHiveMetastore.java
@@ -125,6 +125,13 @@ public class RecordingHiveMetastore
     }
 
     @Override
+    public void dropPartitionStatistics(Table table, String partitionName)
+    {
+        verifyRecordingMode();
+        delegate.dropPartitionStatistics(table, partitionName);
+    }
+
+    @Override
     public List<String> getAllTables(String databaseName)
     {
         return recording.getAllTables(databaseName, () -> delegate.getAllTables(databaseName));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -137,6 +137,13 @@ public class BridgingHiveMetastore
     }
 
     @Override
+    public void dropPartitionStatistics(Table table, String partitionName)
+    {
+        io.trino.hive.thrift.metastore.Table metastoreTable = toMetastoreApiTable(table);
+        delegate.dropPartitionStatistics(metastoreTable, partitionName);
+    }
+
+    @Override
     public List<String> getAllTables(String databaseName)
     {
         return delegate.getAllTables(databaseName);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastore.java
@@ -95,6 +95,8 @@ public interface ThriftMetastore
 
     void updatePartitionStatistics(Table table, String partitionName, Function<PartitionStatistics, PartitionStatistics> update);
 
+    void dropPartitionStatistics(Table table, String partitionName);
+
     void createRole(String role, String grantor);
 
     void dropRole(String role);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/DropStatsProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/DropStatsProcedure.java
@@ -123,11 +123,10 @@ public class DropStatsProcedure
                     .collect(toImmutableList());
             validatePartitions(partitionStringValues, partitionColumns);
 
-            partitionStringValues.forEach(values -> metastore.updatePartitionStatistics(
+            partitionStringValues.forEach(values -> metastore.dropPartitionStatistics(
                     schema,
                     table,
-                    makePartName(partitionColumns, values),
-                    stats -> PartitionStatistics.empty()));
+                    makePartName(partitionColumns, values)));
         }
         else {
             // no partition specified, so drop stats for the entire table
@@ -142,11 +141,10 @@ public class DropStatsProcedure
             else {
                 // the table is partitioned; remove stats for every partition
                 metastore.getPartitionNamesByFilter(handle.getSchemaName(), handle.getTableName(), partitionColumns, TupleDomain.all())
-                        .ifPresent(partitions -> partitions.forEach(partitionName -> metastore.updatePartitionStatistics(
+                        .ifPresent(partitions -> partitions.forEach(partitionName -> metastore.dropPartitionStatistics(
                                 schema,
                                 table,
-                                partitionName,
-                                stats -> PartitionStatistics.empty())));
+                                partitionName)));
             }
         }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/CountingAccessHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/CountingAccessHiveMetastore.java
@@ -324,6 +324,12 @@ public class CountingAccessHiveMetastore
     }
 
     @Override
+    public void dropPartitionStatistics(Table table, String partitionName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public List<String> getAllTables(String databaseName)
     {
         throw new UnsupportedOperationException();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/UnimplementedHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/UnimplementedHiveMetastore.java
@@ -83,6 +83,12 @@ public class UnimplementedHiveMetastore
     }
 
     @Override
+    public void dropPartitionStatistics(Table table, String partitionName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public List<String> getAllTables(String databaseName)
     {
         throw new UnsupportedOperationException();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
@@ -493,6 +493,13 @@ public class InMemoryThriftMetastore
     }
 
     @Override
+    public void dropPartitionStatistics(Table table, String partitionName)
+    {
+        PartitionName partitionKey = PartitionName.partition(table.getDbName(), table.getTableName(), partitionName);
+        partitionColumnStatistics.remove(partitionKey);
+    }
+
+    @Override
     public void createRole(String role, String grantor)
     {
         throw new UnsupportedOperationException();


### PR DESCRIPTION
## Description

Improve performance of `drop_stats` procedure in Hive thrift metastore

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Improve performance of `drop_stats` procedure in Hive thrift metastore. ({issue}`16739`)
```
