### PR TITLE
Add a check to enforce alwaysRun = true on test after-methods

### DIFF
--- a/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
@@ -134,7 +134,7 @@ public abstract class BaseDataDefinitionTaskTest
         queryStateMachine = stateMachine(transactionManager, createTestMetadataManager(), new AllowAllAccessControl(), testSession);
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         if (queryRunner != null) {

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateCatalogTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateCatalogTask.java
@@ -76,7 +76,7 @@ public class TestCreateCatalogTask
                 new NodeVersion("test"));
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         if (queryRunner != null) {

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropCatalogTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropCatalogTask.java
@@ -52,7 +52,7 @@ public class TestDropCatalogTask
         queryRunner.registerCatalogFactory(new TpchConnectorFactory());
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         if (queryRunner != null) {

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHivePlugin.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHivePlugin.java
@@ -61,7 +61,7 @@ public class TestHivePlugin
         deleteRecursively(tempDirectory, ALLOW_INSECURE);
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     @BeforeMethod
     public void deinitializeRubix()
     {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/rubix/TestRubixCaching.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/rubix/TestRubixCaching.java
@@ -131,7 +131,7 @@ public class TestRubixCaching
         nonCachingFileSystem = getNonCachingFileSystem();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     @BeforeMethod
     public void deinitializeRubix()
     {

--- a/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/TestMinimalFunctionality.java
+++ b/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/TestMinimalFunctionality.java
@@ -163,7 +163,7 @@ public class TestMinimalFunctionality
                 .matches("VALUES %s".formatted(count));
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         embeddedKinesisStream.deleteStream(streamName);

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/ReportAfterMethodNotAlwaysRun.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/ReportAfterMethodNotAlwaysRun.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testng.services;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import org.testng.IClassListener;
+import org.testng.ITestClass;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.AfterTest;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import static com.google.common.base.Throwables.getStackTraceAsString;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.testng.services.Listeners.reportListenerFailure;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Predicate.not;
+import static java.util.stream.Collectors.joining;
+
+public class ReportAfterMethodNotAlwaysRun
+        implements IClassListener
+{
+    private static final Set<AnnotationPredicate<?>> VIOLATIONS = ImmutableSet.of(
+            new AnnotationPredicate<>(AfterTest.class, not(AfterTest::alwaysRun)),
+            new AnnotationPredicate<>(AfterMethod.class, not(AfterMethod::alwaysRun)),
+            new AnnotationPredicate<>(AfterClass.class, not(AfterClass::alwaysRun)),
+            new AnnotationPredicate<>(AfterSuite.class, not(AfterSuite::alwaysRun)),
+            new AnnotationPredicate<>(AfterGroups.class, not(AfterGroups::alwaysRun)));
+
+    @Override
+    public void onBeforeClass(ITestClass testClass)
+    {
+        try {
+            checkHasAfterMethodsNotAlwaysRun(testClass.getRealClass());
+        }
+        catch (RuntimeException | Error e) {
+            reportListenerFailure(
+                    ReportAfterMethodNotAlwaysRun.class,
+                    "Failed to process %s:%n%s",
+                    testClass.getName(),
+                    getStackTraceAsString(e));
+        }
+    }
+
+    @VisibleForTesting
+    static void checkHasAfterMethodsNotAlwaysRun(Class<?> testClass)
+    {
+        List<Method> notAlwaysRunMethods = Arrays.stream(testClass.getMethods())
+                .filter(ReportAfterMethodNotAlwaysRun::isAfterMethodNotAlwaysRun)
+                .collect(toImmutableList());
+
+        if (!notAlwaysRunMethods.isEmpty()) {
+            throw new RuntimeException(notAlwaysRunMethods.stream()
+                    .map(Method::toString)
+                    .sorted()
+                    .collect(joining("\n", "The @AfterX methods should have the alwaysRun = true attribute to make sure that they'll run even if tests were skipped:\n", "")));
+        }
+    }
+
+    private static boolean isAfterMethodNotAlwaysRun(Method method)
+    {
+        return VIOLATIONS.stream().anyMatch(p -> p.test(method));
+    }
+
+    @Override
+    public void onAfterClass(ITestClass testClass) {}
+
+    private record AnnotationPredicate<T extends Annotation>(Class<T> annotationType, Predicate<T> predicate)
+            implements Predicate<Method>
+    {
+        AnnotationPredicate
+        {
+            requireNonNull(annotationType);
+            requireNonNull(predicate);
+        }
+
+        @Override
+        public boolean test(Method method)
+        {
+            return Optional.ofNullable(method.getAnnotation(annotationType)).filter(predicate).isPresent();
+        }
+    }
+}

--- a/testing/trino-testing-services/src/main/resources/META-INF/services/org.testng.ITestNGListener
+++ b/testing/trino-testing-services/src/main/resources/META-INF/services/org.testng.ITestNGListener
@@ -1,4 +1,5 @@
 io.trino.testng.services.ManageTestResources
+io.trino.testng.services.ReportAfterMethodNotAlwaysRun
 io.trino.testng.services.ReportOrphanedExecutors
 io.trino.testng.services.ReportPrivateMethods
 io.trino.testng.services.ReportUnannotatedMethods

--- a/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestReportAfterMethodNotAlwaysRun.java
+++ b/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestReportAfterMethodNotAlwaysRun.java
@@ -1,0 +1,351 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testng.services;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestReportAfterMethodNotAlwaysRun
+{
+    @Test(dataProvider = "correctCases")
+    public void testCorrectCases(Class<?> testClass)
+    {
+        assertThatNoException().isThrownBy(() -> ReportAfterMethodNotAlwaysRun.checkHasAfterMethodsNotAlwaysRun(testClass));
+    }
+
+    @DataProvider
+    public static Object[][] correctCases()
+    {
+        return new Object[][] {
+                {NoAfterMethods.class},
+                {AllAlwaysRun.class},
+                {SubClassWithBaseAlwaysRunNoOverride.class},
+                {SubClassAlwaysRunWithBaseAlwaysRun.class},
+                {SubClassAlwaysRunWithBaseNotAlwaysRun.class},
+                {SubClassAddsAlwaysRunWithBaseAlwaysRun.class},
+        };
+    }
+
+    @Test(dataProvider = "incorrectCases")
+    public void testIncorrectCases(Class<?> testClass, String... failMethods)
+    {
+        assertThatThrownBy(() -> ReportAfterMethodNotAlwaysRun.checkHasAfterMethodsNotAlwaysRun(testClass))
+                .hasMessage(
+                        "The @AfterX methods should have the alwaysRun = true attribute to make sure that they'll run even if tests were skipped:%n%s",
+                        String.join("\n", failMethods));
+    }
+
+    @DataProvider
+    public static Object[][] incorrectCases()
+            throws NoSuchMethodException
+    {
+        return new Object[][] {
+                {
+                        ClassNotAlwaysRun.class,
+                        ClassNotAlwaysRun.class.getMethod("afterClass").toString(),
+                },
+                {
+                        GroupNotAlwaysRun.class,
+                        GroupNotAlwaysRun.class.getMethod("afterGroup").toString(),
+                },
+                {
+                        MethodNotAlwaysRun.class,
+                        MethodNotAlwaysRun.class.getMethod("afterMethod").toString(),
+                },
+                {
+                        SuiteNotAlwaysRun.class,
+                        SuiteNotAlwaysRun.class.getMethod("afterSuite").toString(),
+                },
+                {
+                        TestNotAlwaysRun.class,
+                        TestNotAlwaysRun.class.getMethod("afterTest").toString(),
+                },
+                {
+                        AllNotAlwaysRunTwice.class,
+                        AllNotAlwaysRunTwice.class.getMethod("afterClass1").toString(),
+                        AllNotAlwaysRunTwice.class.getMethod("afterClass2").toString(),
+                        AllNotAlwaysRunTwice.class.getMethod("afterGroup1").toString(),
+                        AllNotAlwaysRunTwice.class.getMethod("afterGroup2").toString(),
+                        AllNotAlwaysRunTwice.class.getMethod("afterMethod1").toString(),
+                        AllNotAlwaysRunTwice.class.getMethod("afterMethod2").toString(),
+                        AllNotAlwaysRunTwice.class.getMethod("afterSuite1").toString(),
+                        AllNotAlwaysRunTwice.class.getMethod("afterSuite2").toString(),
+                        AllNotAlwaysRunTwice.class.getMethod("afterTest1").toString(),
+                        AllNotAlwaysRunTwice.class.getMethod("afterTest2").toString(),
+                },
+                {
+                        SubClassWithBaseNotAlwaysRunNoOverride.class,
+                        SubClassWithBaseNotAlwaysRunNoOverride.class.getMethod("afterMethod").toString(),
+                },
+                {
+                        SubClassNotAlwaysRunWithBaseAlwaysRun.class,
+                        SubClassNotAlwaysRunWithBaseAlwaysRun.class.getMethod("afterMethod").toString(),
+                },
+                {
+                        SubClassNotAlwaysRunWithBaseNotAlwaysRun.class,
+                        SubClassNotAlwaysRunWithBaseNotAlwaysRun.class.getMethod("afterMethod").toString(),
+                },
+                {
+                        SubClassAddsNotAlwaysRunWithBaseAlwaysRun.class,
+                        SubClassAddsNotAlwaysRunWithBaseAlwaysRun.class.getMethod("afterMethodSub").toString(),
+                },
+                {
+                        SubClassAddsAlwaysRunWithBaseNotAlwaysRun.class,
+                        SubClassAddsAlwaysRunWithBaseNotAlwaysRun.class.getMethod("afterMethod").toString(),
+                },
+                {
+                        SubClassAddsNotAlwaysRunWithBaseNotAlwaysRun.class,
+                        SubClassAddsNotAlwaysRunWithBaseNotAlwaysRun.class.getMethod("afterMethod").toString(),
+                        SubClassAddsNotAlwaysRunWithBaseNotAlwaysRun.class.getMethod("afterMethodSub").toString(),
+                },
+        };
+    }
+
+    private static class NoAfterMethods
+    {
+    }
+
+    private static class AllAlwaysRun
+    {
+        @AfterClass(alwaysRun = true)
+        public void afterClass() {}
+
+        @AfterGroups(alwaysRun = true)
+        public void afterGroup() {}
+
+        @AfterMethod(alwaysRun = true)
+        public void afterMethod() {}
+
+        @AfterSuite(alwaysRun = true)
+        public void afterSuite() {}
+
+        @AfterTest(alwaysRun = true)
+        public void afterTest() {}
+    }
+
+    private static class ClassNotAlwaysRun
+    {
+        @AfterClass
+        public void afterClass() {}
+
+        @AfterGroups(alwaysRun = true)
+        public void afterGroup() {}
+
+        @AfterMethod(alwaysRun = true)
+        public void afterMethod() {}
+
+        @AfterSuite(alwaysRun = true)
+        public void afterSuite() {}
+
+        @AfterTest(alwaysRun = true)
+        public void afterTest() {}
+    }
+
+    private static class GroupNotAlwaysRun
+    {
+        @AfterClass(alwaysRun = true)
+        public void afterClass() {}
+
+        @AfterGroups
+        public void afterGroup() {}
+
+        @AfterMethod(alwaysRun = true)
+        public void afterMethod() {}
+
+        @AfterSuite(alwaysRun = true)
+        public void afterSuite() {}
+
+        @AfterTest(alwaysRun = true)
+        public void afterTest() {}
+    }
+
+    private static class MethodNotAlwaysRun
+    {
+        @AfterClass(alwaysRun = true)
+        public void afterClass() {}
+
+        @AfterGroups(alwaysRun = true)
+        public void afterGroup() {}
+
+        @AfterMethod
+        public void afterMethod() {}
+
+        @AfterSuite(alwaysRun = true)
+        public void afterSuite() {}
+
+        @AfterTest(alwaysRun = true)
+        public void afterTest() {}
+    }
+
+    private static class SuiteNotAlwaysRun
+    {
+        @AfterClass(alwaysRun = true)
+        public void afterClass() {}
+
+        @AfterGroups(alwaysRun = true)
+        public void afterGroup() {}
+
+        @AfterMethod(alwaysRun = true)
+        public void afterMethod() {}
+
+        @AfterSuite
+        public void afterSuite() {}
+
+        @AfterTest(alwaysRun = true)
+        public void afterTest() {}
+    }
+
+    private static class TestNotAlwaysRun
+    {
+        @AfterClass(alwaysRun = true)
+        public void afterClass() {}
+
+        @AfterGroups(alwaysRun = true)
+        public void afterGroup() {}
+
+        @AfterMethod(alwaysRun = true)
+        public void afterMethod() {}
+
+        @AfterSuite(alwaysRun = true)
+        public void afterSuite() {}
+
+        @AfterTest
+        public void afterTest() {}
+    }
+
+    private static class AllNotAlwaysRunTwice
+    {
+        @AfterClass
+        public void afterClass1() {}
+
+        @AfterClass
+        public void afterClass2() {}
+
+        @AfterGroups
+        public void afterGroup1() {}
+
+        @AfterGroups
+        public void afterGroup2() {}
+
+        @AfterMethod
+        public void afterMethod1() {}
+
+        @AfterMethod
+        public void afterMethod2() {}
+
+        @AfterSuite
+        public void afterSuite1() {}
+
+        @AfterSuite
+        public void afterSuite2() {}
+
+        @AfterTest
+        public void afterTest1() {}
+
+        @AfterTest
+        public void afterTest2() {}
+    }
+
+    private abstract static class BaseClassAlwaysRun
+    {
+        @AfterMethod(alwaysRun = true)
+        public void afterMethod() {}
+    }
+
+    private abstract static class BaseClassNotAlwaysRun
+    {
+        @AfterMethod
+        public void afterMethod() {}
+    }
+
+    private static class SubClassWithBaseAlwaysRunNoOverride
+            extends BaseClassAlwaysRun
+    {
+    }
+
+    private static class SubClassWithBaseNotAlwaysRunNoOverride
+            extends BaseClassNotAlwaysRun
+    {
+    }
+
+    private static class SubClassAlwaysRunWithBaseAlwaysRun
+            extends BaseClassAlwaysRun
+    {
+        @SuppressWarnings("RedundantMethodOverride")
+        @Override
+        @AfterMethod(alwaysRun = true)
+        public void afterMethod() {}
+    }
+
+    private static class SubClassNotAlwaysRunWithBaseAlwaysRun
+            extends BaseClassAlwaysRun
+    {
+        @Override
+        @AfterMethod
+        public void afterMethod() {}
+    }
+
+    private static class SubClassAlwaysRunWithBaseNotAlwaysRun
+            extends BaseClassNotAlwaysRun
+    {
+        @Override
+        @AfterMethod(alwaysRun = true)
+        public void afterMethod() {}
+    }
+
+    private static class SubClassNotAlwaysRunWithBaseNotAlwaysRun
+            extends BaseClassNotAlwaysRun
+    {
+        @SuppressWarnings("RedundantMethodOverride")
+        @Override
+        @AfterMethod
+        public void afterMethod() {}
+    }
+
+    private static class SubClassAddsAlwaysRunWithBaseAlwaysRun
+            extends BaseClassAlwaysRun
+    {
+        @AfterMethod(alwaysRun = true)
+        public void afterMethodSub() {}
+    }
+
+    private static class SubClassAddsNotAlwaysRunWithBaseAlwaysRun
+            extends BaseClassAlwaysRun
+    {
+        @AfterMethod
+        public void afterMethodSub() {}
+    }
+
+    private static class SubClassAddsAlwaysRunWithBaseNotAlwaysRun
+            extends BaseClassNotAlwaysRun
+    {
+        @AfterMethod(alwaysRun = true)
+        public void afterMethodSub() {}
+    }
+
+    private static class SubClassAddsNotAlwaysRunWithBaseNotAlwaysRun
+            extends BaseClassNotAlwaysRun
+    {
+        @AfterMethod
+        public void afterMethodSub() {}
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Turns out that the `@AfterX` methods do not get executed by default if any of the previous methods failed or were skipped - and that includes the test methods as well. So if any of the tests is skipped, cleanup for the test may also be skipped. The `alwaysRun = true` annotation enforces that the cleanup method always gets executed.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

The failure to run the cleanup method may cause the resource leak detector to trigger and mask the actual cause the test was skipped.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
