### PR TITLE
Add task killer policy prefering task from biggest query

### DIFF
--- a/core/trino-main/src/main/java/io/trino/memory/BiggestQueryOnBlockedNodesTaskLowMemoryKiller.java
+++ b/core/trino-main/src/main/java/io/trino/memory/BiggestQueryOnBlockedNodesTaskLowMemoryKiller.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.memory;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.execution.TaskId;
+import io.trino.operator.RetryPolicy;
+import io.trino.spi.QueryId;
+import io.trino.spi.memory.MemoryPoolInfo;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.stream.Collectors.summingLong;
+
+public class BiggestQueryOnBlockedNodesTaskLowMemoryKiller
+        implements LowMemoryKiller
+{
+    @Override
+    public Optional<KillTarget> chooseTargetToKill(List<RunningQueryInfo> runningQueries, List<MemoryInfo> nodes)
+    {
+        Set<QueryId> queriesWithTaskRetryPolicy = runningQueries.stream()
+                                                          .filter(query -> query.getRetryPolicy() == RetryPolicy.TASK)
+                                                          .map(RunningQueryInfo::getQueryId)
+                                                          .collect(toImmutableSet());
+
+        if (queriesWithTaskRetryPolicy.isEmpty()) {
+            return Optional.empty();
+        }
+
+        ImmutableSet.Builder<TaskId> tasksToKillBuilder = ImmutableSet.builder();
+        for (MemoryInfo node : nodes) {
+            MemoryPoolInfo memoryPool = node.getPool();
+            if (memoryPool == null) {
+                continue;
+            }
+            if (memoryPool.getFreeBytes() + memoryPool.getReservedRevocableBytes() > 0) {
+                continue;
+            }
+
+            // consider only tasks from queries with task retries enabled
+            Map<TaskId, Long> retriableTasks = memoryPool.getTaskMemoryReservations().entrySet().stream()
+                    .map(entry -> new SimpleEntry<>(TaskId.valueOf(entry.getKey()), entry.getValue()))
+                    .filter(entry -> queriesWithTaskRetryPolicy.contains(entry.getKey().getQueryId()))
+                    .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            if (retriableTasks.isEmpty()) {
+                continue;
+            }
+
+            // find query which uses most memory on the node
+            QueryId biggestQueryOnNode = retriableTasks.entrySet()
+                    .stream()
+                    .collect(Collectors.groupingBy(entry -> entry.getKey().getQueryId(), summingLong(Map.Entry::getValue)))
+                    .entrySet()
+                    .stream()
+                    .max(Map.Entry.comparingByValue())
+                    .map(Map.Entry::getKey)
+                    .orElseThrow();
+
+            // kill the biggest task from the biggest query
+            retriableTasks.entrySet().stream()
+                    .filter(entry -> entry.getKey().getQueryId().equals(biggestQueryOnNode))
+                    .max(Map.Entry.comparingByValue())
+                    .map(Map.Entry::getKey)
+                    .ifPresent(tasksToKillBuilder::add);
+        }
+        Set<TaskId> tasksToKill = tasksToKillBuilder.build();
+        if (tasksToKill.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(KillTarget.selectedTasks(tasksToKill));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
@@ -236,6 +236,7 @@ public class MemoryManagerConfig
     {
         NONE,
         TOTAL_RESERVATION_ON_BLOCKED_NODES,
+        BIGGEST_QUERY_ON_BLOCKED_NODES,
         LEAST_WASTE,
         /**/;
 
@@ -246,6 +247,8 @@ public class MemoryManagerConfig
                     return NONE;
                 case "total-reservation-on-blocked-nodes":
                     return TOTAL_RESERVATION_ON_BLOCKED_NODES;
+                case "biggest-query-on-blocked-nodes":
+                    return BIGGEST_QUERY_ON_BLOCKED_NODES;
                 case "least-waste":
                     return LEAST_WASTE;
             }

--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -75,6 +75,7 @@ import io.trino.execution.scheduler.policy.AllAtOnceExecutionPolicy;
 import io.trino.execution.scheduler.policy.ExecutionPolicy;
 import io.trino.execution.scheduler.policy.PhasedExecutionPolicy;
 import io.trino.failuredetector.FailureDetectorModule;
+import io.trino.memory.BiggestQueryOnBlockedNodesTaskLowMemoryKiller;
 import io.trino.memory.ClusterMemoryManager;
 import io.trino.memory.ForMemoryManager;
 import io.trino.memory.LeastWastedEffortTaskLowMemoryKiller;
@@ -215,6 +216,7 @@ public class CoordinatorModule
 
         bindLowMemoryTaskKiller(LowMemoryTaskKillerPolicy.NONE, NoneLowMemoryKiller.class);
         bindLowMemoryTaskKiller(LowMemoryTaskKillerPolicy.TOTAL_RESERVATION_ON_BLOCKED_NODES, TotalReservationOnBlockedNodesTaskLowMemoryKiller.class);
+        bindLowMemoryTaskKiller(LowMemoryTaskKillerPolicy.BIGGEST_QUERY_ON_BLOCKED_NODES, BiggestQueryOnBlockedNodesTaskLowMemoryKiller.class);
         bindLowMemoryTaskKiller(LowMemoryTaskKillerPolicy.LEAST_WASTE, LeastWastedEffortTaskLowMemoryKiller.class);
         bindLowMemoryQueryKiller(LowMemoryQueryKillerPolicy.NONE, NoneLowMemoryKiller.class);
         bindLowMemoryQueryKiller(LowMemoryQueryKillerPolicy.TOTAL_RESERVATION, TotalReservationLowMemoryKiller.class);

--- a/core/trino-main/src/test/java/io/trino/memory/AbstractTaskLowMemoryKillerTest.java
+++ b/core/trino-main/src/test/java/io/trino/memory/AbstractTaskLowMemoryKillerTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.memory;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.memory.LowMemoryKillerTestingUtils.toNodeMemoryInfoList;
+import static io.trino.memory.LowMemoryKillerTestingUtils.toRunningQueryInfoList;
+import static junit.framework.TestCase.assertEquals;
+
+abstract class AbstractTaskLowMemoryKillerTest
+{
+    private LowMemoryKiller lowMemoryKiller;
+
+    @BeforeClass
+    public void setup()
+    {
+        this.lowMemoryKiller = createLowMemoryKiller();
+    }
+
+    protected LowMemoryKiller getLowMemoryKiller()
+    {
+        return lowMemoryKiller;
+    }
+
+    protected abstract LowMemoryKiller createLowMemoryKiller();
+
+    @Test
+    public void testMemoryPoolHasNoReservation()
+    {
+        int memoryPool = 12;
+        Map<String, Map<String, Long>> queries = ImmutableMap.of("q_1", ImmutableMap.of("n1", 0L, "n2", 0L, "n3", 0L, "n4", 0L, "n5", 0L));
+        assertEquals(
+                lowMemoryKiller.chooseTargetToKill(
+                        toRunningQueryInfoList(queries),
+                        toNodeMemoryInfoList(memoryPool, queries)),
+                Optional.empty());
+    }
+
+    @Test
+    public void testMemoryPoolNotBlocked()
+    {
+        int memoryPool = 12;
+        Map<String, Map<String, Long>> queries = ImmutableMap.<String, Map<String, Long>>builder()
+                .put("q_1", ImmutableMap.of("n1", 0L, "n2", 6L, "n3", 0L, "n4", 0L, "n5", 0L))
+                .put("q_2", ImmutableMap.of("n1", 3L, "n2", 5L, "n3", 2L, "n4", 4L, "n5", 0L))
+                .buildOrThrow();
+        assertEquals(
+                lowMemoryKiller.chooseTargetToKill(
+                        toRunningQueryInfoList(queries),
+                        toNodeMemoryInfoList(memoryPool, queries)),
+                Optional.empty());
+    }
+
+    @Test
+    public void testWillNotKillTaskForQueryWithoutTaskRetriesEnabled()
+    {
+        int memoryPool = 5;
+        Map<String, Map<String, Long>> queries = ImmutableMap.<String, Map<String, Long>>builder()
+                .put("q_1", ImmutableMap.of("n1", 0L, "n2", 0L, "n3", 2L))
+                .put("q_2", ImmutableMap.of("n1", 3L, "n2", 5L, "n3", 2L))
+                .buildOrThrow();
+        Map<String, Map<String, Map<Integer, Long>>> tasks = ImmutableMap.<String, Map<String, Map<Integer, Long>>>builder()
+                .put("q_1", ImmutableMap.of(
+                        "n3", ImmutableMap.of(1, 5L)))
+                .put("q_2", ImmutableMap.of(
+                        "n1", ImmutableMap.of(
+                                1, 1L,
+                                2, 2L),
+                        "n2", ImmutableMap.of(
+                                3, 3L,
+                                4, 1L,
+                                5, 1L),
+                        "n3", ImmutableMap.of(6, 2L)))
+                .buildOrThrow();
+
+        assertEquals(
+                lowMemoryKiller.chooseTargetToKill(
+                        toRunningQueryInfoList(queries),
+                        toNodeMemoryInfoList(memoryPool, queries, tasks)),
+                Optional.empty());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/memory/TestBiggestQueryOnBlockedNodesTaskLowMemoryKiller.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestBiggestQueryOnBlockedNodesTaskLowMemoryKiller.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.memory;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.memory.LowMemoryKillerTestingUtils.taskId;
+import static io.trino.memory.LowMemoryKillerTestingUtils.toNodeMemoryInfoList;
+import static io.trino.memory.LowMemoryKillerTestingUtils.toRunningQueryInfoList;
+import static org.testng.Assert.assertEquals;
+
+public class TestBiggestQueryOnBlockedNodesTaskLowMemoryKiller
+        extends AbstractTaskLowMemoryKillerTest
+{
+    @Override
+    protected LowMemoryKiller createLowMemoryKiller()
+    {
+        return new BiggestQueryOnBlockedNodesTaskLowMemoryKiller();
+    }
+
+    @Test
+    public void testPreferKillingTasks()
+    {
+        int memoryPool = 12;
+        Map<String, Map<String, Long>> queries = ImmutableMap.<String, Map<String, Long>>builder()
+                .put("q_1", ImmutableMap.of("n1", 0L, "n2", 8L, "n3", 0L, "n4", 0L, "n5", 0L))
+                .put("q_2", ImmutableMap.of("n1", 3L, "n2", 5L, "n3", 2L, "n4", 4L, "n5", 0L))
+                .put("q_3", ImmutableMap.of("n1", 0L, "n2", 0L, "n3", 11L, "n4", 0L, "n5", 0L))
+                .buildOrThrow();
+
+        Map<String, Map<String, Map<Integer, Long>>> tasks = ImmutableMap.of(
+                "q_2",
+                ImmutableMap.of(
+                        "n1", ImmutableMap.of(
+                                1, 1L,
+                                2, 3L),
+                        "n2", ImmutableMap.of(
+                                3, 3L,
+                                4, 1L,
+                                5, 1L),
+                        "n3", ImmutableMap.of(6, 2L),
+                        "n4", ImmutableMap.of(
+                                7, 2L,
+                                8, 2L),
+                        "n5", ImmutableMap.of()));
+
+        assertEquals(
+                getLowMemoryKiller().chooseTargetToKill(
+                        toRunningQueryInfoList(queries, ImmutableSet.of("q_2")),
+                        toNodeMemoryInfoList(memoryPool, queries, tasks)),
+                Optional.of(KillTarget.selectedTasks(
+                        ImmutableSet.of(
+                                taskId("q_2", 3),
+                                taskId("q_2", 6)))));
+    }
+
+    @Test
+    public void testKillsBiggestTasksFromBiggestQueries()
+    {
+        int memoryPool = 12;
+        Map<String, Map<String, Long>> queries = ImmutableMap.<String, Map<String, Long>>builder()
+                .put("q_1", ImmutableMap.of("n1", 0L, "n2", 10L, "n3", 0L, "n4", 0L, "n5", 0L))
+                .put("q_2", ImmutableMap.of("n1", 3L, "n2", 8L, "n3", 2L, "n4", 4L, "n5", 0L))
+                .put("q_3", ImmutableMap.of("n1", 0L, "n2", 0L, "n3", 11L, "n4", 0L, "n5", 0L))
+                .buildOrThrow();
+
+        Map<String, Map<String, Map<Integer, Long>>> tasks = ImmutableMap.<String, Map<String, Map<Integer, Long>>>builder()
+                .put("q_1", ImmutableMap.of(
+                                "n2", ImmutableMap.of(
+                                        1, 5L,
+                                        2, 2L,
+                                        3, 3L)))
+                .put("q_2", ImmutableMap.of(
+                        "n1", ImmutableMap.of(
+                                1, 1L,
+                                2, 3L),
+                        "n2", ImmutableMap.of(3, 8L),
+                        "n3", ImmutableMap.of(4, 2L),
+                        "n4", ImmutableMap.of(
+                                5, 2L,
+                                6, 2L),
+                        "n5", ImmutableMap.of()))
+                .put("q_3", ImmutableMap.of(
+                        "n3", ImmutableMap.of(1, 11L))) // should not be picked as n3 does not have task retries enabled
+                .buildOrThrow();
+
+        assertEquals(
+                getLowMemoryKiller().chooseTargetToKill(
+                        toRunningQueryInfoList(queries, ImmutableSet.of("q_1", "q_2")),
+                        toNodeMemoryInfoList(memoryPool, queries, tasks)),
+                Optional.of(KillTarget.selectedTasks(
+                        ImmutableSet.of(
+                                taskId("q_1", 1),
+                                taskId("q_2", 4)))));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/memory/TestTotalReservationOnBlockedNodesTaskLowMemoryKiller.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestTotalReservationOnBlockedNodesTaskLowMemoryKiller.java
@@ -11,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.trino.memory;
 
 import com.google.common.collect.ImmutableMap;
@@ -27,63 +26,12 @@ import static io.trino.memory.LowMemoryKillerTestingUtils.toRunningQueryInfoList
 import static org.testng.Assert.assertEquals;
 
 public class TestTotalReservationOnBlockedNodesTaskLowMemoryKiller
+        extends AbstractTaskLowMemoryKillerTest
 {
-    private final LowMemoryKiller lowMemoryKiller = new TotalReservationOnBlockedNodesTaskLowMemoryKiller();
-
-    @Test
-    public void testMemoryPoolHasNoReservation()
+    @Override
+    protected LowMemoryKiller createLowMemoryKiller()
     {
-        int memoryPool = 12;
-        Map<String, Map<String, Long>> queries = ImmutableMap.of("q_1", ImmutableMap.of("n1", 0L, "n2", 0L, "n3", 0L, "n4", 0L, "n5", 0L));
-        assertEquals(
-                lowMemoryKiller.chooseTargetToKill(
-                        toRunningQueryInfoList(queries),
-                        toNodeMemoryInfoList(memoryPool, queries)),
-                Optional.empty());
-    }
-
-    @Test
-    public void testMemoryPoolNotBlocked()
-    {
-        int memoryPool = 12;
-        Map<String, Map<String, Long>> queries = ImmutableMap.<String, Map<String, Long>>builder()
-                .put("q_1", ImmutableMap.of("n1", 0L, "n2", 6L, "n3", 0L, "n4", 0L, "n5", 0L))
-                .put("q_2", ImmutableMap.of("n1", 3L, "n2", 5L, "n3", 2L, "n4", 4L, "n5", 0L))
-                .buildOrThrow();
-        assertEquals(
-                lowMemoryKiller.chooseTargetToKill(
-                        toRunningQueryInfoList(queries),
-                        toNodeMemoryInfoList(memoryPool, queries)),
-                Optional.empty());
-    }
-
-    @Test
-    public void testWillNotKillTaskForQueryWithoutTaskRetriesEnabled()
-    {
-        int memoryPool = 5;
-        Map<String, Map<String, Long>> queries = ImmutableMap.<String, Map<String, Long>>builder()
-                .put("q_1", ImmutableMap.of("n1", 0L, "n2", 0L, "n3", 2L))
-                .put("q_2", ImmutableMap.of("n1", 3L, "n2", 5L, "n3", 2L))
-                .buildOrThrow();
-        Map<String, Map<String, Map<Integer, Long>>> tasks = ImmutableMap.<String, Map<String, Map<Integer, Long>>>builder()
-                .put("q_1", ImmutableMap.of(
-                        "n3", ImmutableMap.of(1, 5L)))
-                .put("q_2", ImmutableMap.of(
-                        "n1", ImmutableMap.of(
-                                1, 1L,
-                                2, 2L),
-                        "n2", ImmutableMap.of(
-                                3, 3L,
-                                4, 1L,
-                                5, 1L),
-                        "n3", ImmutableMap.of(6, 2L)))
-                .buildOrThrow();
-
-        assertEquals(
-                lowMemoryKiller.chooseTargetToKill(
-                        toRunningQueryInfoList(queries),
-                        toNodeMemoryInfoList(memoryPool, queries, tasks)),
-                Optional.empty());
+        return new TotalReservationOnBlockedNodesTaskLowMemoryKiller();
     }
 
     @Test
@@ -113,7 +61,7 @@ public class TestTotalReservationOnBlockedNodesTaskLowMemoryKiller
                         "n5", ImmutableMap.of()));
 
         assertEquals(
-                lowMemoryKiller.chooseTargetToKill(
+                getLowMemoryKiller().chooseTargetToKill(
                         toRunningQueryInfoList(queries, ImmutableSet.of("q_2")),
                         toNodeMemoryInfoList(memoryPool, queries, tasks)),
                 Optional.of(KillTarget.selectedTasks(
@@ -153,7 +101,7 @@ public class TestTotalReservationOnBlockedNodesTaskLowMemoryKiller
                 .buildOrThrow();
 
         assertEquals(
-                lowMemoryKiller.chooseTargetToKill(
+                getLowMemoryKiller().chooseTargetToKill(
                         toRunningQueryInfoList(queries, ImmutableSet.of("q_1", "q_2")),
                         toNodeMemoryInfoList(memoryPool, queries, tasks)),
                 Optional.of(KillTarget.selectedTasks(

--- a/docs/src/main/sphinx/admin/properties-query-management.rst
+++ b/docs/src/main/sphinx/admin/properties-query-management.rst
@@ -91,6 +91,9 @@ memory availability. Supports the following values:
 * ``total-reservation-on-blocked-nodes`` - Kill the tasks which are part of the queries
   which has task retries enabled and are currently using the most memory specifically
   on nodes that are now out of memory.
+* ``biggest-query-on-blocked-nodes`` - For each node, which is currently out of
+  memory, the biggest task from the biggest query is picked and killed. Only considers
+  tasks from queries with has task retries enabled.
 * ``least-waste`` - Kill the tasks which are part of the queries
   which has task retries enabled and use significant amount of memory on nodes
   which are now out of memory. This policy avoids killing tasks which are already


### PR DESCRIPTION
Add biggest-query-on-blocked-nodes low memory task killer policy.
With new plicy we pick the biggest tasks from query which takes most
memory on the node.

With new logic there is lower chance that OOM killer will repeatedly
kill short lived tasks from recently scheduled short tactical queries,
while long running beefy query which hogs the cluster keeps running.

The new logic is supposed to perform better for clusters running
interactive workloads when task based retries are enabled.


## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:



