### PR TITLE
Optimize partition end search for small partitions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/PositionSearcher.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PositionSearcher.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
+
+public class PositionSearcher
+{
+    private PositionSearcher()
+    {
+    }
+
+    /**
+     * @param startPosition - inclusive
+     * @param endPosition - exclusive
+     * @param comparator - returns true if positions given as parameters are equal
+     * @return the end of the group position exclusive
+     */
+    public static int findEndPosition(int startPosition, int endPosition, PositionComparator comparator)
+    {
+        checkArgument(startPosition >= 0, "startPosition must be greater or equal than zero: %s", startPosition);
+        checkArgument(startPosition < endPosition, "startPosition (%s) must be less than endPosition (%s)", startPosition, endPosition);
+
+        // exponential search to find the range enclosing the searched position, optimized for small partitions
+        // use long to avoid int overflow
+        long left;
+        long right = startPosition;
+        long distance = 1;
+        do {
+            left = right;
+            right += distance;
+            distance *= 2;
+        }
+        while (right < endPosition && comparator.test(toIntExact(left), toIntExact(right)));
+
+        // binary search to find the searched position within the range
+        // intLeft is always a position within the group
+        int intLeft = toIntExact(left);
+        // intRight is always a position out of the group
+        int intRight = toIntExact(min(right, endPosition));
+
+        while (intRight - intLeft > 1) {
+            int middle = (intLeft + intRight) >>> 1;
+
+            if (comparator.test(startPosition, middle)) {
+                intLeft = middle;
+            }
+            else {
+                intRight = middle;
+            }
+        }
+        // the returned value is the first position out of the group
+        return intRight;
+    }
+
+    public interface PositionComparator
+    {
+        boolean test(int first, int second);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/TableFunctionOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableFunctionOperator.java
@@ -13,7 +13,6 @@
  */
 package io.trino.operator;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -39,6 +38,7 @@ import static com.google.common.base.Preconditions.checkPositionIndex;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.concat;
+import static io.trino.operator.PositionSearcher.findEndPosition;
 import static io.trino.spi.connector.SortOrder.ASC_NULLS_LAST;
 import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
@@ -511,40 +511,6 @@ public class TableFunctionOperator
         checkPositionIndex(startPosition, pagesIndex.getPositionCount(), "startPosition out of bounds");
 
         return findEndPosition(startPosition, pagesIndex.getPositionCount(), (firstPosition, secondPosition) -> pagesIndex.positionNotDistinctFromPosition(pagesHashStrategy, firstPosition, secondPosition));
-    }
-
-    /**
-     * @param startPosition - inclusive
-     * @param endPosition - exclusive
-     * @param comparator - returns true if positions given as parameters are equal
-     * @return the end of the group position exclusive (the position the very next group starts)
-     */
-    @VisibleForTesting
-    static int findEndPosition(int startPosition, int endPosition, PositionComparator comparator)
-    {
-        checkArgument(startPosition >= 0, "startPosition must be greater or equal than zero: %s", startPosition);
-        checkArgument(startPosition < endPosition, "startPosition (%s) must be less than endPosition (%s)", startPosition, endPosition);
-
-        int left = startPosition;
-        int right = endPosition;
-
-        while (right - left > 1) {
-            int middle = (left + right) >>> 1;
-
-            if (comparator.test(startPosition, middle)) {
-                left = middle;
-            }
-            else {
-                right = middle;
-            }
-        }
-
-        return right;
-    }
-
-    private interface PositionComparator
-    {
-        boolean test(int first, int second);
     }
 
     private WorkProcessor<TableFunctionPartition> pagesIndexToTableFunctionPartitions(

--- a/core/trino-main/src/test/java/io/trino/operator/TestWindowOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestWindowOperator.java
@@ -56,6 +56,7 @@ import static io.trino.operator.OperatorAssertion.assertOperatorEquals;
 import static io.trino.operator.OperatorAssertion.assertOperatorEqualsIgnoreOrder;
 import static io.trino.operator.OperatorAssertion.toMaterializedResult;
 import static io.trino.operator.OperatorAssertion.toPages;
+import static io.trino.operator.PositionSearcher.findEndPosition;
 import static io.trino.operator.WindowFunctionDefinition.window;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -796,7 +797,7 @@ public class TestWindowOperator
     private static void assertFindEndPosition(String values, int expected)
     {
         char[] array = values.toCharArray();
-        assertEquals(WindowOperator.findEndPosition(0, array.length, (first, second) -> array[first] == array[second]), expected);
+        assertEquals(findEndPosition(0, array.length, (first, second) -> array[first] == array[second]), expected);
     }
 
     private WindowOperatorFactory createFactoryUnbounded(


### PR DESCRIPTION
This change applies to `WindowOperator` and `TableFunctionOperator`, and affects the way that input is split into partitions.

Binary search is replaced with exponential search.
First, the search range is limited with exponential search, and then binary search is applied within the limited range. It should improve performance in case of many small partitions.

Benchmarks needed.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
