### PR TITLE
Add support for Hive OpenCSV no-quoting and no-escaping behavior

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/csv/CsvSerializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/csv/CsvSerializer.java
@@ -81,7 +81,8 @@ public class CsvSerializer
                 }
 
                 Slice value = VARCHAR.getSlice(block, position);
-                if (value.indexOfByte(quoteChar) < 0 && (escapeChar == quoteChar || value.indexOfByte(escapeChar) < 0)) {
+                // if escape is zero, escaping is disabled; otherwise, check if value contains quote or escape character
+                if (escapeChar == '\0' || (value.indexOfByte(quoteChar) < 0 && (escapeChar == quoteChar || value.indexOfByte(escapeChar) < 0))) {
                     sliceOutput.appendBytes(value);
                 }
                 else {

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/csv/CsvSerializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/csv/CsvSerializer.java
@@ -75,7 +75,10 @@ public class CsvSerializer
             }
             Block block = page.getBlock(channel);
             if (!block.isNull(position)) {
-                sliceOutput.write(quoteChar);
+                // if quote is zero, quoting is disabled
+                if (quoteChar != '\0') {
+                    sliceOutput.write(quoteChar);
+                }
 
                 Slice value = VARCHAR.getSlice(block, position);
                 if (value.indexOfByte(quoteChar) < 0 && (escapeChar == quoteChar || value.indexOfByte(escapeChar) < 0)) {
@@ -91,7 +94,9 @@ public class CsvSerializer
                     }
                 }
 
-                sliceOutput.write(quoteChar);
+                if (quoteChar != '\0') {
+                    sliceOutput.write(quoteChar);
+                }
             }
         }
     }

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/csv/TestCsvFormat.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/csv/TestCsvFormat.java
@@ -121,6 +121,10 @@ public class TestCsvFormat
         assertTrinoHiveByteForByte(true, Arrays.asList("foo", "bar", "baz"), Optional.of('\t'), Optional.of('\0'), Optional.of('\\'));
         assertTrinoHiveByteForByte(false, Arrays.asList("f\0\0", "\0bar\0", "baz"), Optional.of('\t'), Optional.of('\0'), Optional.of('\\'));
 
+        // If escape character is `\0` then escaping is simply disabled, even if this would cause output that does not round trip
+        assertTrinoHiveByteForByte(true, Arrays.asList("f**", "b*r", "b*z"), Optional.of('\t'), Optional.of('*'), Optional.of('#'));
+        assertTrinoHiveByteForByte(false, Arrays.asList("f**", "b*r", "b*z"), Optional.of('\t'), Optional.of('*'), Optional.of('\0'));
+
         // These cases don't round trip, because Hive uses different default escape characters for serialization and deserialization.
         // For serialization the pipe character is escaped with a quote char, but for deserialization escape character is the backslash character
         assertTrinoHiveByteForByte(false, Arrays.asList("|", "a", "b"), Optional.empty(), Optional.of('|'), Optional.empty());

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/csv/TestCsvFormat.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/csv/TestCsvFormat.java
@@ -64,8 +64,6 @@ public class TestCsvFormat
     public void testCsv()
             throws Exception
     {
-        assertTrinoHiveByteForByte(false, Arrays.asList("|", "a", "|"), Optional.empty(), Optional.of('|'), Optional.empty());
-
         assertLine(true, "", Arrays.asList(null, null, null));
         assertLine(true, " ", Arrays.asList(" ", null, null));
 

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/csv/TestCsvFormat.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/csv/TestCsvFormat.java
@@ -117,6 +117,10 @@ public class TestCsvFormat
         // Note: the quote is ignored in the first value due to strange special handling at beginning of line
         assertLine(true, "\"a\"  ,  \"b\"  ,  \"c\"  ", Arrays.asList("a  ", "b\"  ", "c\"  "));
 
+        // If quote character is `\0` then quoting is simply disabled, even if this would cause output that does not round trip
+        assertTrinoHiveByteForByte(true, Arrays.asList("foo", "bar", "baz"), Optional.of('\t'), Optional.of('\0'), Optional.of('\\'));
+        assertTrinoHiveByteForByte(false, Arrays.asList("f\0\0", "\0bar\0", "baz"), Optional.of('\t'), Optional.of('\0'), Optional.of('\\'));
+
         // These cases don't round trip, because Hive uses different default escape characters for serialization and deserialization.
         // For serialization the pipe character is escaped with a quote char, but for deserialization escape character is the backslash character
         assertTrinoHiveByteForByte(false, Arrays.asList("|", "a", "b"), Optional.empty(), Optional.of('|'), Optional.empty());


### PR DESCRIPTION
## Description

Hive OpenCSV writer will disable quoting and escaping behavior if the quote or escape character is zero.  This can result in data that does not round trip, but is an expected feature (bug?) of the writer.

## Additional context and related issues

Fixes #16710

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
*  In the native CSV writer, Disable quoting when quote character is zero, and disable escaping when escape character is zero. ({issue}`16710`)
```
