### PR TITLE
Remove unnecessary and brittle tests

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
@@ -471,16 +471,6 @@ public class QueryAssertions
         }
 
         @CanIgnoreReturnValue
-        public QueryAssert hasColumnNames(String... expectedColumnNames)
-        {
-            return satisfies(actual -> {
-                assertThat(actual.getColumnNames())
-                        .as("Column names for query [%s]", query)
-                        .containsExactly(expectedColumnNames);
-            });
-        }
-
-        @CanIgnoreReturnValue
         public QueryAssert hasOutputTypes(List<Type> expectedTypes)
         {
             return satisfies(actual -> {

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -1680,14 +1680,8 @@ public abstract class BaseJdbcConnectorTest
     public void testNativeQueryColumnAlias()
     {
         // The output column type may differ per connector. Skipping the check because it's unrelated to the test purpose.
-        assertThat(query(format("SELECT * FROM TABLE(system.query(query => 'SELECT name AS region_name FROM %s.region WHERE regionkey = 0'))", getSession().getSchema().orElseThrow())))
-                .skippingTypesCheck()
-                .hasColumnNames("region_name")
-                .matches("VALUES 'AFRICA'");
-
         assertThat(query(format("SELECT region_name FROM TABLE(system.query(query => 'SELECT name AS region_name FROM %s.region WHERE regionkey = 0'))", getSession().getSchema().orElseThrow())))
                 .skippingTypesCheck()
-                .hasColumnNames("region_name")
                 .matches("VALUES 'AFRICA'");
     }
 

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectorTest.java
@@ -267,13 +267,7 @@ public class TestJdbcConnectorTest
     @Override
     public void testNativeQueryColumnAlias()
     {
-        // override because H2 uppercase column names by default
-        assertThat(query(format("SELECT * FROM TABLE(system.query(query => 'SELECT name AS region_name FROM %s.region WHERE regionkey = 0'))", getSession().getSchema().orElseThrow())))
-                .hasColumnNames("REGION_NAME")
-                .matches("VALUES CAST('AFRICA' AS VARCHAR(25))");
-
         assertThat(query(format("SELECT region_name FROM TABLE(system.query(query => 'SELECT name AS region_name FROM %s.region WHERE regionkey = 0'))", getSession().getSchema().orElseThrow())))
-                .hasColumnNames("region_name")
                 .matches("VALUES CAST('AFRICA' AS VARCHAR(25))");
     }
 

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -750,12 +750,7 @@ public abstract class BaseBigQueryConnectorTest
     @Test
     public void testNativeQueryColumnAlias()
     {
-        assertThat(query("SELECT * FROM TABLE(system.query(query => 'SELECT name AS region_name FROM tpch.region WHERE regionkey = 0'))"))
-                .hasColumnNames("region_name")
-                .matches("VALUES CAST('AFRICA' AS VARCHAR)");
-
         assertThat(query("SELECT region_name FROM TABLE(system.query(query => 'SELECT name AS region_name FROM tpch.region WHERE regionkey = 0'))"))
-                .hasColumnNames("region_name")
                 .matches("VALUES CAST('AFRICA' AS VARCHAR)");
     }
 

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
@@ -1393,12 +1393,7 @@ public class TestCassandraConnectorTest
     @Test
     public void testNativeQueryColumnAlias()
     {
-        assertThat(query("SELECT * FROM TABLE(system.query(query => 'SELECT name AS region_name FROM tpch.region WHERE regionkey = 0 ALLOW FILTERING'))"))
-                .hasColumnNames("region_name")
-                .matches("VALUES CAST('AFRICA' AS VARCHAR)");
-
         assertThat(query("SELECT region_name FROM TABLE(system.query(query => 'SELECT name AS region_name FROM tpch.region WHERE regionkey = 0 ALLOW FILTERING'))"))
-                .hasColumnNames("region_name")
                 .matches("VALUES CAST('AFRICA' AS VARCHAR)");
     }
 

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
@@ -433,13 +433,7 @@ public abstract class BaseOracleConnectorTest
     @Override
     public void testNativeQueryColumnAlias()
     {
-        // override because Oracle uppercase column names by default
-        assertThat(query(format("SELECT * FROM TABLE(system.query(query => 'SELECT name AS region_name FROM %s.region WHERE regionkey = 0'))", getSession().getSchema().orElseThrow())))
-                .hasColumnNames("REGION_NAME")
-                .matches("VALUES CAST('AFRICA' AS VARCHAR(25))");
-
         assertThat(query(format("SELECT region_name FROM TABLE(system.query(query => 'SELECT name AS region_name FROM %s.region WHERE regionkey = 0'))", getSession().getSchema().orElseThrow())))
-                .hasColumnNames("region_name")
                 .matches("VALUES CAST('AFRICA' AS VARCHAR(25))");
     }
 


### PR DESCRIPTION
Column names coming out of the query are not necessarily related to the column names in the table function. These tests are testing behavior that is not necessarily expected or guaranteed, so they are brittle and can break at any time.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
