### PR TITLE
Fix incorrect result when table location contains a hidden directory in Iceberg `migrate` procedure

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrateProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrateProcedure.java
@@ -317,7 +317,8 @@ public class MigrateProcedure
         ImmutableList.Builder<DataFile> dataFilesBuilder = ImmutableList.builder();
         while (files.hasNext()) {
             FileEntry file = files.next();
-            if (file.location().contains("/_") || file.location().contains("/.")) {
+            String relativePath = file.location().substring(location.length());
+            if (relativePath.contains("/_") || relativePath.contains("/.")) {
                 continue;
             }
             if (recursive == RecursiveDirectory.FALSE && isRecursive(location, file.location())) {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMigrateProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMigrateProcedure.java
@@ -41,8 +41,8 @@ public class TestIcebergMigrateProcedure
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        DistributedQueryRunner queryRunner = IcebergQueryRunner.builder().build();
-        dataDirectory = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data");
+        dataDirectory = Files.createTempDirectory("_test_hidden");
+        DistributedQueryRunner queryRunner = IcebergQueryRunner.builder().setMetastoreDirectory(dataDirectory.toFile()).build();
         queryRunner.installPlugin(new TestingHivePlugin());
         queryRunner.createCatalog("hive", "hive", ImmutableMap.<String, String>builder()
                         .put("hive.metastore", "file")


### PR DESCRIPTION
## Description

Fix incorrect result when table location contains a hidden directory in Iceberg `migrate` procedure
Thank @krvikash for finding the issue. 

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Fix incorrect result when table location contains a hidden directory in `migrate` procedure. ({issue}`16779`)
```
