### PR TITLE
Add use_cost_based_partitioning

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -182,6 +182,7 @@ public final class SystemSessionProperties
     public static final String MIN_INPUT_SIZE_PER_TASK = "min_input_size_per_task";
     public static final String MIN_INPUT_ROWS_PER_TASK = "min_input_rows_per_task";
     public static final String USE_EXACT_PARTITIONING = "use_exact_partitioning";
+    public static final String USE_COST_BASED_PARTITIONING = "use_cost_based_partitioning";
     public static final String FORCE_SPILLING_JOIN = "force_spilling_join";
     public static final String FAULT_TOLERANT_EXECUTION_FORCE_PREFERRED_WRITE_PARTITIONING_ENABLED = "fault_tolerant_execution_force_preferred_write_partitioning_enabled";
     public static final String PAGE_PARTITIONING_BUFFER_POOL_SIZE = "page_partitioning_buffer_pool_size";
@@ -914,6 +915,11 @@ public final class SystemSessionProperties
                         optimizerConfig.isUseExactPartitioning(),
                         false),
                 booleanProperty(
+                        USE_COST_BASED_PARTITIONING,
+                        "When enabled the cost based optimizer is used to determine if repartitioning the output of an already partitioned stage is necessary",
+                        optimizerConfig.isUseCostBasedPartitioning(),
+                        false),
+                booleanProperty(
                         FORCE_SPILLING_JOIN,
                         "Force the usage of spliing join operator in favor of the non-spilling one, even if spill is not enabled",
                         featuresConfig.isForceSpillingJoin(),
@@ -1641,6 +1647,11 @@ public final class SystemSessionProperties
     public static boolean isUseExactPartitioning(Session session)
     {
         return session.getSystemProperty(USE_EXACT_PARTITIONING, Boolean.class);
+    }
+
+    public static boolean isUseCostBasedPartitioning(Session session)
+    {
+        return session.getSystemProperty(USE_COST_BASED_PARTITIONING, Boolean.class);
     }
 
     public static boolean isForceSpillingOperator(Session session)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
@@ -87,6 +87,7 @@ public class OptimizerConfig
     private boolean mergeProjectWithValues = true;
     private boolean forceSingleNodeOutput;
     private boolean useExactPartitioning;
+    private boolean useCostBasedPartitioning = true;
     // adaptive partial aggregation
     private boolean adaptivePartialAggregationEnabled = true;
     private long adaptivePartialAggregationMinRows = 100_000;
@@ -800,6 +801,19 @@ public class OptimizerConfig
     public OptimizerConfig setUseExactPartitioning(boolean useExactPartitioning)
     {
         this.useExactPartitioning = useExactPartitioning;
+        return this;
+    }
+
+    public boolean isUseCostBasedPartitioning()
+    {
+        return useCostBasedPartitioning;
+    }
+
+    @Config("optimizer.use-cost-based-partitioning")
+    @ConfigDescription("When enabled the cost based optimizer is used to determine if repartitioning the output of an already partitioned stage is necessary")
+    public OptimizerConfig setUseCostBasedPartitioning(boolean useCostBasedPartitioning)
+    {
+        this.useCostBasedPartitioning = useCostBasedPartitioning;
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
@@ -109,6 +109,7 @@ import static io.trino.SystemSessionProperties.ignoreDownStreamPreferences;
 import static io.trino.SystemSessionProperties.isColocatedJoinEnabled;
 import static io.trino.SystemSessionProperties.isDistributedSortEnabled;
 import static io.trino.SystemSessionProperties.isForceSingleNodeOutput;
+import static io.trino.SystemSessionProperties.isUseCostBasedPartitioning;
 import static io.trino.SystemSessionProperties.isUseExactPartitioning;
 import static io.trino.SystemSessionProperties.isUsePartialDistinctLimit;
 import static io.trino.sql.planner.FragmentTableScanCounter.countSources;
@@ -276,7 +277,7 @@ public class AddExchanges
          */
         private Optional<List<Symbol>> useParentPreferredPartitioning(AggregationNode node, Set<Symbol> parentPreferredPartitioningColumns)
         {
-            if (isUseExactPartitioning(session)) {
+            if (isUseExactPartitioning(session) || !isUseCostBasedPartitioning(session)) {
                 return Optional.empty();
             }
             if (parentPreferredPartitioningColumns.isEmpty()) {

--- a/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
@@ -91,7 +91,8 @@ public class TestOptimizerConfig
                 .setJoinPartitionedBuildMinRowCount(1_000_000)
                 .setMinInputSizePerTask(DataSize.of(5, GIGABYTE))
                 .setMinInputRowsPerTask(10_000_000L)
-                .setUseExactPartitioning(false));
+                .setUseExactPartitioning(false)
+                .setUseCostBasedPartitioning(true));
     }
 
     @Test
@@ -150,6 +151,7 @@ public class TestOptimizerConfig
                 .put("optimizer.min-input-size-per-task", "1MB")
                 .put("optimizer.min-input-rows-per-task", "1000000")
                 .put("optimizer.use-exact-partitioning", "true")
+                .put("optimizer.use-cost-based-partitioning", "false")
                 .buildOrThrow();
 
         OptimizerConfig expected = new OptimizerConfig()
@@ -204,7 +206,8 @@ public class TestOptimizerConfig
                 .setJoinPartitionedBuildMinRowCount(1)
                 .setMinInputSizePerTask(DataSize.of(1, MEGABYTE))
                 .setMinInputRowsPerTask(1_000_000L)
-                .setUseExactPartitioning(true);
+                .setUseExactPartitioning(true)
+                .setUseCostBasedPartitioning(false);
         assertFullMapping(properties, expected);
     }
 }

--- a/docs/src/main/sphinx/admin/properties-optimizer.rst
+++ b/docs/src/main/sphinx/admin/properties-optimizer.rst
@@ -272,3 +272,13 @@ increases concurrency on large clusters where multiple small queries are running
 The estimated value will always be between ``min_hash_partition_count`` and
 ``max_hash_partition_count`` session property.
 A value of ``0`` disables this optimization.
+
+``optimizer.use-cost-based-partitioning``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** :ref:`prop-type-boolean`
+* **Default value:** ``true``
+* **Session property:** ``use_cost_based_partitioning``
+
+When enabled the cost based optimizer is used to determine if repartitioning the output of an
+already partitioned stage is necessary.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Use use_cost_based_partitioning instead of use_exact_partitioning to control the cost-based optimization to prefer parent partitioning. The motivation is to be able to disable the optimization if the NDV statistics are overestimated and the optimization would hurt parallelism.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Add `optimizer.use-cost-based-partitioning` configuration property and `use_cost_based_partitioning` session property to allow disabling usage of cost based optimizer for determining partitioning of a stage. ({issue}`16781`)
```
