### PR TITLE
Refactor partition values handling in DeltaLakePageSource

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSource.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSource.java
@@ -66,7 +66,7 @@ public class DeltaLakePageSource
             List<DeltaLakeColumnHandle> columns,
             Set<String> missingColumnNames,
             Map<String, Optional<String>> partitionKeys,
-            List<String> partitionValues,
+            Optional<List<String>> partitionValues,
             ConnectorPageSource delegate,
             String path,
             long fileSize,
@@ -109,7 +109,7 @@ public class DeltaLakePageSource
             else if (column.getName().equals(ROW_ID_COLUMN_NAME)) {
                 rowIdIndex = outputIndex;
                 pathBlock = Utils.nativeValueToBlock(VARCHAR, utf8Slice(path));
-                partitionsBlock = Utils.nativeValueToBlock(VARCHAR, wrappedBuffer(PARTITIONS_CODEC.toJsonBytes(partitionValues)));
+                partitionsBlock = Utils.nativeValueToBlock(VARCHAR, wrappedBuffer(PARTITIONS_CODEC.toJsonBytes(partitionValues.orElseThrow(() -> new IllegalStateException("partitionValues not provided")))));
                 delegateIndexes[outputIndex] = delegateIndex;
                 delegateIndex++;
             }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
@@ -130,12 +130,13 @@ public class DeltaLakePageSourceProvider
 
         Map<String, Optional<String>> partitionKeys = split.getPartitionKeys();
 
-        List<String> partitionValues = new ArrayList<>();
+        Optional<List<String>> partitionValues = Optional.empty();
         if (deltaLakeColumns.stream().anyMatch(column -> column.getName().equals(ROW_ID_COLUMN_NAME))) {
+            partitionValues = Optional.of(new ArrayList<>());
             for (DeltaLakeColumnMetadata column : extractSchema(table.getMetadataEntry(), typeManager)) {
                 Optional<String> value = partitionKeys.get(column.getName());
                 if (value != null) {
-                    partitionValues.add(value.orElse(null));
+                    partitionValues.get().add(value.orElse(null));
                 }
             }
         }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
@@ -135,9 +135,7 @@ public class DeltaLakePageSourceProvider
             partitionValues = Optional.of(new ArrayList<>());
             for (DeltaLakeColumnMetadata column : extractSchema(table.getMetadataEntry(), typeManager)) {
                 Optional<String> value = partitionKeys.get(column.getName());
-                if (value != null) {
-                    partitionValues.get().add(value.orElse(null));
-                }
+                partitionValues.get().add(value.orElse(null));
             }
         }
 


### PR DESCRIPTION
The partition values list is filled only when row ID column is projected, so it's a conditional information. When row ID is not present, pass it as the empty optional, rather then list that happens to be empty.
