### PR TITLE
Make LeafTableFunctionOperator handle EmptySplit correctly

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/LeafTableFunctionOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/LeafTableFunctionOperator.java
@@ -25,6 +25,7 @@ import io.trino.spi.ptf.TableFunctionProcessorState;
 import io.trino.spi.ptf.TableFunctionProcessorState.Blocked;
 import io.trino.spi.ptf.TableFunctionProcessorState.Processed;
 import io.trino.spi.ptf.TableFunctionSplitProcessor;
+import io.trino.split.EmptySplit;
 import io.trino.sql.planner.plan.PlanNodeId;
 
 import java.util.ArrayList;
@@ -167,6 +168,12 @@ public class LeafTableFunctionOperator
                 return null;
             }
             currentSplit = pendingSplits.remove(0);
+            while (currentSplit instanceof EmptySplit) {
+                if (pendingSplits.isEmpty()) {
+                    return null;
+                }
+                currentSplit = pendingSplits.remove(0);
+            }
             resetProcessor();
         }
         else {

--- a/core/trino-main/src/test/java/io/trino/connector/TestingTableFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/connector/TestingTableFunctions.java
@@ -1102,7 +1102,7 @@ public class TestingTableFunctions
         {
             ScalarArgument count = (ScalarArgument) arguments.get("N");
             requireNonNull(count.getValue(), "count value for function repeat() is null");
-            checkArgument((long) count.getValue() > 0, "count value for function repeat() must be positive");
+            checkArgument((long) count.getValue() >= 0, "count value for function repeat() must not be negative");
 
             return TableFunctionAnalysis.builder()
                     .handle(new ConstantFunctionHandle((Long) ((ScalarArgument) arguments.get("VALUE")).getValue(), (long) count.getValue()))

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestTableFunctionInvocation.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestTableFunctionInvocation.java
@@ -731,5 +731,10 @@ public class TestTableFunctionInvocation
                 FROM TABLE(system.constant(2, 1000000))
                 """))
                 .matches("VALUES (BIGINT '1000000', BIGINT '1', 2)");
+
+        assertQueryReturnsEmptyResult("""
+                SELECT *
+                FROM TABLE(system.constant(5, 0))
+                """);
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
While trying to apply this comment https://github.com/trinodb/trino/pull/16205#issuecomment-1487373782 I figured out that there is a problem with a case when there is no data for the current function invocation and EmptySplit is provided to the `TableFunctionSplitProcessor` which should not happen 


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
