### PR TITLE
Remove CatalogHandle from TableFunctionProcessorNode

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -1677,7 +1677,7 @@ public class LocalExecutionPlanner
                 OperatorFactory operatorFactory = new LeafTableFunctionOperatorFactory(
                         context.getNextOperatorId(),
                         node.getId(),
-                        node.getFunctionCatalog(),
+                        node.getHandle().getCatalogHandle(),
                         processorProvider,
                         node.getHandle().getFunctionHandle());
                 return new PhysicalOperation(operatorFactory, makeLayout(node), context);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ImplementTableFunctionSource.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ImplementTableFunctionSource.java
@@ -161,7 +161,6 @@ public class ImplementTableFunctionSource
             return Result.ofPlanNode(new TableFunctionProcessorNode(
                     node.getId(),
                     node.getName(),
-                    node.getFunctionCatalog(),
                     node.getProperOutputs(),
                     Optional.empty(),
                     false,
@@ -184,7 +183,6 @@ public class ImplementTableFunctionSource
             return Result.ofPlanNode(new TableFunctionProcessorNode(
                     node.getId(),
                     node.getName(),
-                    node.getFunctionCatalog(),
                     node.getProperOutputs(),
                     Optional.of(getOnlyElement(node.getSources())),
                     sourceProperties.isPruneWhenEmpty(),
@@ -280,7 +278,6 @@ public class ImplementTableFunctionSource
         return Result.ofPlanNode(new TableFunctionProcessorNode(
                 node.getId(),
                 node.getName(),
-                node.getFunctionCatalog(),
                 node.getProperOutputs(),
                 Optional.of(marked.node()),
                 pruneWhenEmpty,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneTableFunctionProcessorColumns.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneTableFunctionProcessorColumns.java
@@ -72,7 +72,6 @@ public class PruneTableFunctionProcessorColumns
         return Optional.of(new TableFunctionProcessorNode(
                 node.getId(),
                 node.getName(),
-                node.getFunctionCatalog(),
                 node.getProperOutputs(),
                 node.getSource(),
                 node.isPruneWhenEmpty(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneTableFunctionProcessorSourceColumns.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneTableFunctionProcessorSourceColumns.java
@@ -88,7 +88,6 @@ public class PruneTableFunctionProcessorSourceColumns
                 .map(child -> Result.ofPlanNode(new TableFunctionProcessorNode(
                         node.getId(),
                         node.getName(),
-                        node.getFunctionCatalog(),
                         node.getProperOutputs(),
                         Optional.of(child),
                         node.isPruneWhenEmpty(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
@@ -548,7 +548,6 @@ public class AddLocalExchanges
             TableFunctionProcessorNode result = new TableFunctionProcessorNode(
                     node.getId(),
                     node.getName(),
-                    node.getFunctionCatalog(),
                     node.getProperOutputs(),
                     Optional.of(child.getNode()),
                     node.isPruneWhenEmpty(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
@@ -403,7 +403,6 @@ public class SymbolMapper
         return new TableFunctionProcessorNode(
                 node.getId(),
                 node.getName(),
-                node.getFunctionCatalog(),
                 map(node.getProperOutputs()),
                 Optional.of(source),
                 node.isPruneWhenEmpty(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -379,7 +379,6 @@ public class UnaliasSymbolReferences
                         new TableFunctionProcessorNode(
                                 node.getId(),
                                 node.getName(),
-                                node.getFunctionCatalog(),
                                 mapper.map(node.getProperOutputs()),
                                 Optional.empty(),
                                 node.isPruneWhenEmpty(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableFunctionProcessorNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableFunctionProcessorNode.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.metadata.TableFunctionHandle;
-import io.trino.spi.connector.CatalogHandle;
 import io.trino.sql.planner.OrderingScheme;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.plan.TableFunctionNode.PassThroughSpecification;
@@ -39,8 +38,6 @@ public class TableFunctionProcessorNode
         extends PlanNode
 {
     private final String name;
-
-    private final CatalogHandle functionCatalog;
 
     // symbols produced by the function
     private final List<Symbol> properOutputs;
@@ -77,7 +74,6 @@ public class TableFunctionProcessorNode
     public TableFunctionProcessorNode(
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("name") String name,
-            @JsonProperty("functionCatalog") CatalogHandle functionCatalog,
             @JsonProperty("properOutputs") List<Symbol> properOutputs,
             @JsonProperty("source") Optional<PlanNode> source,
             @JsonProperty("pruneWhenEmpty") boolean pruneWhenEmpty,
@@ -92,7 +88,6 @@ public class TableFunctionProcessorNode
     {
         super(id);
         this.name = requireNonNull(name, "name is null");
-        this.functionCatalog = requireNonNull(functionCatalog, "functionCatalog is null");
         this.properOutputs = ImmutableList.copyOf(properOutputs);
         this.source = requireNonNull(source, "source is null");
         this.pruneWhenEmpty = pruneWhenEmpty;
@@ -125,12 +120,6 @@ public class TableFunctionProcessorNode
     public String getName()
     {
         return name;
-    }
-
-    @JsonProperty
-    public CatalogHandle getFunctionCatalog()
-    {
-        return functionCatalog;
     }
 
     @JsonProperty
@@ -235,7 +224,6 @@ public class TableFunctionProcessorNode
         return new TableFunctionProcessorNode(
                 getId(),
                 name,
-                functionCatalog,
                 properOutputs,
                 newSource,
                 pruneWhenEmpty,

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/TableFunctionProcessorBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/TableFunctionProcessorBuilder.java
@@ -120,7 +120,6 @@ public class TableFunctionProcessorBuilder
         return new TableFunctionProcessorNode(
                 idAllocator.getNextId(),
                 name,
-                TEST_CATALOG_HANDLE,
                 properOutputs,
                 source,
                 pruneWhenEmpty,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
There is no need to store CatalogHandle directly in TableFunctionProcessorNode as it is present in TableFunctionHandle


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
