### PR TITLE
Adjust retry policy for dropping delta tables backed by AWS Glue on Databricks

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/DeltaLakeTestUtils.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/DeltaLakeTestUtils.java
@@ -23,7 +23,6 @@ import dev.failsafe.Failsafe;
 import dev.failsafe.RetryPolicy;
 import io.airlift.log.Logger;
 import io.trino.tempto.query.QueryResult;
-import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.intellij.lang.annotations.Language;
 
 import java.time.temporal.ChronoUnit;
@@ -46,7 +45,7 @@ public final class DeltaLakeTestUtils
             "\\Q[Databricks][DatabricksJDBCDriver](500593) Communication link failure. Failed to connect to server. Reason: HTTP retry after response received with no Retry-After header, error: HTTP Response code: 503, Error message: Unknown.";
     private static final RetryPolicy<QueryResult> CONCURRENT_MODIFICATION_EXCEPTION_RETRY_POLICY = RetryPolicy.<QueryResult>builder()
             .handleIf(throwable -> Throwables.getRootCause(throwable) instanceof ConcurrentModificationException)
-            .handleIf(throwable -> Throwables.getRootCause(throwable) instanceof MetaException metaException && metaException.getMessage() != null && metaException.getMessage().contains("Table being modified concurrently"))
+            .handleIf(throwable -> throwable.getMessage() != null && throwable.getMessage().contains("Table being modified concurrently"))
             .withBackoff(1, 10, ChronoUnit.SECONDS)
             .withMaxRetries(3)
             .onRetry(event -> log.warn(event.getLastException(), "Query failed on attempt %d, will retry.", event.getAttemptCount()))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Given the fact that the previous iteration of extending the retry policy f6ad5425 was not effective, search only for `"Table being modified concurrently"` in the exception message to catch the situations where the AWS Glue table gets modified by Databricks while being deleted by Trino.


Context: https://github.com/trinodb/trino/issues/13199#issuecomment-1476951843

```
 2023-03-20 17:08:18 SEVERE: Failure cause:
tests               | io.trino.tempto.query.QueryExecutionException: java.sql.SQLException: [Databricks][DatabricksJDBCDriver](500051) ERROR processing query/statement. Error Code: 0, SQL state: org.apache.hive.service.cli.HiveSQLException: Error running query: org.apache.spark.sql.AnalysisException: org.apache.hadoop.hive.ql.metadata.HiveException: MetaException(message:Table being modified concurrently. (Service: AWSGlue; Status Code: 400; Error Code: ConcurrentModificationException; Request ID: 92289870-549a-4b0b-80bf-a9ce0d301d1a; Proxy: null))
```

Fixes https://github.com/trinodb/trino/issues/13199

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
