### PR TITLE
Skip literal vs round tripped comparison for non-orderable types in UnwrapCastInComparison

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
@@ -79,6 +79,7 @@ import static io.trino.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static io.trino.sql.tree.ComparisonExpression.Operator.EQUAL;
 import static io.trino.sql.tree.ComparisonExpression.Operator.GREATER_THAN;
 import static io.trino.sql.tree.ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL;
+import static io.trino.sql.tree.ComparisonExpression.Operator.IS_DISTINCT_FROM;
 import static io.trino.sql.tree.ComparisonExpression.Operator.LESS_THAN;
 import static io.trino.sql.tree.ComparisonExpression.Operator.LESS_THAN_OR_EQUAL;
 import static io.trino.sql.tree.ComparisonExpression.Operator.NOT_EQUAL;
@@ -319,43 +320,45 @@ public class UnwrapCastInComparison
                 return expression;
             }
 
-            Object roundtripLiteral = coerce(literalInSourceType, sourceToTarget);
+            if (targetType.isOrderable()) {
+                Object roundtripLiteral = coerce(literalInSourceType, sourceToTarget);
 
-            int literalVsRoundtripped = compare(targetType, right, roundtripLiteral);
+                int literalVsRoundtripped = compare(targetType, right, roundtripLiteral);
 
-            if (literalVsRoundtripped > 0) {
-                // cast rounded down
-                return switch (operator) {
-                    case EQUAL -> falseIfNotNull(cast.getExpression());
-                    case NOT_EQUAL -> trueIfNotNull(cast.getExpression());
-                    case IS_DISTINCT_FROM -> TRUE_LITERAL;
-                    case LESS_THAN, LESS_THAN_OR_EQUAL -> {
-                        if (sourceRange.isPresent() && compare(sourceType, sourceRange.get().getMin(), literalInSourceType) == 0) {
-                            yield new ComparisonExpression(EQUAL, cast.getExpression(), literalEncoder.toExpression(session, literalInSourceType, sourceType));
+                if (literalVsRoundtripped > 0) {
+                    // cast rounded down
+                    return switch (operator) {
+                        case EQUAL -> falseIfNotNull(cast.getExpression());
+                        case NOT_EQUAL -> trueIfNotNull(cast.getExpression());
+                        case IS_DISTINCT_FROM -> TRUE_LITERAL;
+                        case LESS_THAN, LESS_THAN_OR_EQUAL -> {
+                            if (sourceRange.isPresent() && compare(sourceType, sourceRange.get().getMin(), literalInSourceType) == 0) {
+                                yield new ComparisonExpression(EQUAL, cast.getExpression(), literalEncoder.toExpression(session, literalInSourceType, sourceType));
+                            }
+                            yield new ComparisonExpression(LESS_THAN_OR_EQUAL, cast.getExpression(), literalEncoder.toExpression(session, literalInSourceType, sourceType));
                         }
-                        yield new ComparisonExpression(LESS_THAN_OR_EQUAL, cast.getExpression(), literalEncoder.toExpression(session, literalInSourceType, sourceType));
-                    }
-                    case GREATER_THAN, GREATER_THAN_OR_EQUAL ->
-                        // We expect implicit coercions to be order-preserving, so the result of converting back from target -> source cannot produce a value
-                        // larger than the next value in the source type
-                            new ComparisonExpression(GREATER_THAN, cast.getExpression(), literalEncoder.toExpression(session, literalInSourceType, sourceType));
-                };
-            }
+                        case GREATER_THAN, GREATER_THAN_OR_EQUAL ->
+                                // We expect implicit coercions to be order-preserving, so the result of converting back from target -> source cannot produce a value
+                                // larger than the next value in the source type
+                                new ComparisonExpression(GREATER_THAN, cast.getExpression(), literalEncoder.toExpression(session, literalInSourceType, sourceType));
+                    };
+                }
 
-            if (literalVsRoundtripped < 0) {
-                // cast rounded up
-                return switch (operator) {
-                    case EQUAL -> falseIfNotNull(cast.getExpression());
-                    case NOT_EQUAL -> trueIfNotNull(cast.getExpression());
-                    case IS_DISTINCT_FROM -> TRUE_LITERAL;
-                    case LESS_THAN, LESS_THAN_OR_EQUAL ->
-                        // We expect implicit coercions to be order-preserving, so the result of converting back from target -> source cannot produce a value
-                        // smaller than the next value in the source type
-                            new ComparisonExpression(LESS_THAN, cast.getExpression(), literalEncoder.toExpression(session, literalInSourceType, sourceType));
-                    case GREATER_THAN, GREATER_THAN_OR_EQUAL -> sourceRange.isPresent() && compare(sourceType, sourceRange.get().getMax(), literalInSourceType) == 0 ?
-                            new ComparisonExpression(EQUAL, cast.getExpression(), literalEncoder.toExpression(session, literalInSourceType, sourceType)) :
-                            new ComparisonExpression(GREATER_THAN_OR_EQUAL, cast.getExpression(), literalEncoder.toExpression(session, literalInSourceType, sourceType));
-                };
+                if (literalVsRoundtripped < 0) {
+                    // cast rounded up
+                    return switch (operator) {
+                        case EQUAL -> falseIfNotNull(cast.getExpression());
+                        case NOT_EQUAL -> trueIfNotNull(cast.getExpression());
+                        case IS_DISTINCT_FROM -> TRUE_LITERAL;
+                        case LESS_THAN, LESS_THAN_OR_EQUAL ->
+                                // We expect implicit coercions to be order-preserving, so the result of converting back from target -> source cannot produce a value
+                                // smaller than the next value in the source type
+                                new ComparisonExpression(LESS_THAN, cast.getExpression(), literalEncoder.toExpression(session, literalInSourceType, sourceType));
+                        case GREATER_THAN, GREATER_THAN_OR_EQUAL -> sourceRange.isPresent() && compare(sourceType, sourceRange.get().getMax(), literalInSourceType) == 0 ?
+                                new ComparisonExpression(EQUAL, cast.getExpression(), literalEncoder.toExpression(session, literalInSourceType, sourceType)) :
+                                new ComparisonExpression(GREATER_THAN_OR_EQUAL, cast.getExpression(), literalEncoder.toExpression(session, literalInSourceType, sourceType));
+                    };
+                }
             }
 
             return new ComparisonExpression(operator, cast.getExpression(), literalEncoder.toExpression(session, literalInSourceType, sourceType));

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestUnwrapCastInComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestUnwrapCastInComparison.java
@@ -418,6 +418,26 @@ public class TestUnwrapCastInComparison
         }
     }
 
+    @Test
+    public void testMap()
+    {
+        String from = "MAP(ARRAY['foo', 'bar'], ARRAY[1, 2])";
+        String to = "MAP(ARRAY['foo', 'bar'], ARRAY[bigint '1', bigint '3'])";
+        for (String operator : asList("=", "!=", "<>", "IS DISTINCT FROM", "IS NOT DISTINCT FROM")) {
+            validate(operator, "MAP(VARCHAR(3),INTEGER)", from, "MAP(VARCHAR(3),BIGINT)", to);
+        }
+    }
+
+    @Test
+    public void testRow()
+    {
+        String from = "ROW(MAP(ARRAY['foo', 'bar'], ARRAY[1, 2]))";
+        String to = "ROW(MAP(ARRAY['foo', 'bar'], ARRAY[bigint '1', bigint '3']))";
+        for (String operator : asList("=", "!=", "<>", "IS DISTINCT FROM", "IS NOT DISTINCT FROM")) {
+            validate(operator, "ROW(MAP(VARCHAR(3),INTEGER))", from, "ROW(MAP(VARCHAR(3),BIGINT))", to);
+        }
+    }
+
     private void validate(String operator, String fromType, Object fromValue, String toType, Object toValue)
     {
         validate(assertions.getDefaultSession(), operator, fromType, fromValue, toType, toValue);
@@ -429,7 +449,7 @@ public class TestUnwrapCastInComparison
                 "SELECT (CAST(v AS %s) %s CAST(%s AS %s)) " +
                         "IS NOT DISTINCT FROM " +
                         "(CAST(%s AS %s) %s CAST(%s AS %s)) " +
-                        "FROM (VALUES CAST(%s AS %s)) t(v)",
+                        "FROM (VALUES CAST(ROW(%s) AS ROW(%s))) t(v)",
                 toType, operator, toValue, toType,
                 fromValue, toType, operator, toValue, toType,
                 fromValue, fromType);


### PR DESCRIPTION
Skip literal vs round tripped comparison for non-orderable types in UnwrapCastInComparison
 
- Non-orderable type allows only equality checks, so round tripped comparison cannot be applicable

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(v ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
