### PR TITLE
Fix output rendering issue in docs

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -255,7 +255,7 @@ Hive connector documentation.
       - JVM default
     * - ``hive.timestamp-precision``
       - Specifies the precision to use for Hive columns of type ``timestamp``.
-        Possible values are ``MILLISECONDS``, ``MICROSECONDS`` and``NANOSECONDS``.
+        Possible values are ``MILLISECONDS``, ``MICROSECONDS`` and ``NANOSECONDS``.
         Values with higher precision than configured are rounded.
       - ``MILLISECONDS``
     * - ``hive.temporary-staging-directory-enabled``


### PR DESCRIPTION
## Description

Instead of the code font .. normal font and quotes were rendered since a space was missing in the source.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
