### PR TITLE
Update Oracle JDBC driver version to 21.9.0.0

### DIFF
--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -191,7 +191,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
             <version>${dep.oracle.version}</version>
             <scope>test</scope>

--- a/plugin/trino-oracle/pom.xml
+++ b/plugin/trino-oracle/pom.xml
@@ -49,13 +49,13 @@
         </dependency>
 
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
             <version>${dep.oracle.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ucp</artifactId>
             <version>${dep.oracle.version}</version>
         </dependency>
@@ -84,7 +84,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.nls</groupId>
             <artifactId>orai18n</artifactId>
             <version>${dep.oracle.version}</version>
             <scope>runtime</scope>

--- a/plugin/trino-resource-group-managers/pom.xml
+++ b/plugin/trino-resource-group-managers/pom.xml
@@ -120,7 +120,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
             <version>${dep.oracle.version}</version>
             <scope>runtime</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dep.aws-sdk.version>1.12.261</dep.aws-sdk.version>
         <dep.okhttp.version>3.14.9</dep.okhttp.version>
         <dep.jsonwebtoken.version>0.11.5</dep.jsonwebtoken.version>
-        <dep.oracle.version>19.3.0.0</dep.oracle.version>
+        <dep.oracle.version>21.9.0.0</dep.oracle.version>
         <dep.drift.version>1.14</dep.drift.version>
         <dep.tempto.version>191</dep.tempto.version>
         <dep.gcs.version>2.2.8</dep.gcs.version>


### PR DESCRIPTION
## Description

Update Oracle JDBC driver version to 21.9.0.0
This upgrade supports additional config properties using connection url.
For instance, #16812 can be:
```
jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=host)(PORT=5521))(CONNECT_DATA= (SERVICE_NAME=servicename))(Security=(ENCRYPTION_CLIENT=REQUESTED)))
```
https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_NET_ENCRYPTION_LEVEL

Fixes #16812

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
