### PR TITLE
Migrate some deprecated `assertExpression` method in `TestSqlParser`

### DIFF
--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -453,19 +453,26 @@ public class TestSqlParser
     @Test
     public void testArray()
     {
-        assertExpression("ARRAY []", new Array(ImmutableList.of()));
-        assertExpression("ARRAY [1, 2]", new Array(ImmutableList.of(new LongLiteral("1"), new LongLiteral("2"))));
-        assertExpression("ARRAY [1e0, 2.5e0]", new Array(ImmutableList.of(new DoubleLiteral("1.0"), new DoubleLiteral("2.5"))));
-        assertExpression("ARRAY ['hi']", new Array(ImmutableList.of(new StringLiteral("hi"))));
-        assertExpression("ARRAY ['hi', 'hello']", new Array(ImmutableList.of(new StringLiteral("hi"), new StringLiteral("hello"))));
+        assertThat(expression("ARRAY []"))
+                .isEqualTo(new Array(location(1, 1), ImmutableList.of()));
+        assertThat(expression("ARRAY [1, 2]"))
+                .isEqualTo(new Array(location(1, 1), ImmutableList.of(new LongLiteral(location(1, 8), "1"), new LongLiteral(location(1, 11), "2"))));
+        assertThat(expression("ARRAY [1e0, 2.5e0]"))
+                .isEqualTo(new Array(location(1, 1), ImmutableList.of(new DoubleLiteral(location(1, 8), "1.0"), new DoubleLiteral(location(1, 13), "2.5"))));
+        assertThat(expression("ARRAY ['hi']"))
+                .isEqualTo(new Array(location(1, 1), ImmutableList.of(new StringLiteral(location(1, 8), "hi"))));
+        assertThat(expression("ARRAY ['hi', 'hello']"))
+                .isEqualTo(new Array(location(1, 1), ImmutableList.of(new StringLiteral(location(1, 8), "hi"), new StringLiteral(location(1, 14), "hello"))));
     }
 
     @Test
     public void testArraySubscript()
     {
-        assertExpression("ARRAY [1, 2][1]", new SubscriptExpression(
-                new Array(ImmutableList.of(new LongLiteral("1"), new LongLiteral("2"))),
-                new LongLiteral("1")));
+        assertThat(expression("ARRAY [1, 2][1]"))
+                .isEqualTo(new SubscriptExpression(
+                        location(1, 1),
+                        new Array(location(1, 1), ImmutableList.of(new LongLiteral(location(1, 8), "1"), new LongLiteral(location(1, 11), "2"))),
+                        new LongLiteral(location(1, 14), "1")));
 
         assertExpression("CASE WHEN TRUE THEN ARRAY[1,2] END[1]", new SubscriptExpression(
                 new SearchedCaseExpression(
@@ -480,9 +487,16 @@ public class TestSqlParser
     @Test
     public void testRowSubscript()
     {
-        assertExpression("ROW (1, 'a', true)[1]", new SubscriptExpression(
-                new Row(ImmutableList.of(new LongLiteral("1"), new StringLiteral("a"), new BooleanLiteral("true"))),
-                new LongLiteral("1")));
+        assertThat(expression("ROW (1, 'a', true)[1]"))
+                .isEqualTo(new SubscriptExpression(
+                        location(1, 1),
+                        new Row(
+                                location(1, 1),
+                                ImmutableList.of(
+                                        new LongLiteral(location(1, 6), "1"),
+                                        new StringLiteral(location(1, 9), "a"),
+                                        new BooleanLiteral(location(1, 14), "true"))),
+                        new LongLiteral(location(1, 20), "1")));
     }
 
     @Test
@@ -560,39 +574,61 @@ public class TestSqlParser
     @Test
     public void testArithmeticUnary()
     {
-        assertExpression("9", new LongLiteral("9"));
+        assertThat(expression("9"))
+                .isEqualTo(new LongLiteral(location(1, 1), "9"));
+        assertThat(expression("+9"))
+                .isEqualTo(positive(location(1, 1), new LongLiteral(location(1, 2), "9")));
+        assertThat(expression("+ 9"))
+                .isEqualTo(positive(location(1, 1), new LongLiteral(location(1, 3), "9")));
 
-        assertExpression("+9", positive(new LongLiteral("9")));
-        assertExpression("+ 9", positive(new LongLiteral("9")));
+        assertThat(expression("++9"))
+                .isEqualTo(positive(location(1, 1), positive(location(1, 2), new LongLiteral(location(1, 3), "9"))));
+        assertThat(expression("+ +9"))
+                .isEqualTo(positive(location(1, 1), positive(location(1, 3), new LongLiteral(location(1, 4), "9"))));
+        assertThat(expression("+ + 9"))
+                .isEqualTo(positive(location(1, 1), positive(location(1, 3), new LongLiteral(location(1, 5), "9"))));
 
-        assertExpression("++9", positive(positive(new LongLiteral("9"))));
-        assertExpression("+ +9", positive(positive(new LongLiteral("9"))));
-        assertExpression("+ + 9", positive(positive(new LongLiteral("9"))));
+        assertThat(expression("+++9"))
+                .isEqualTo(positive(location(1, 1), positive(location(1, 2), positive(location(1, 3), new LongLiteral(location(1, 4), "9")))));
+        assertThat(expression("+ + +9"))
+                .isEqualTo(positive(location(1, 1), positive(location(1, 3), positive(location(1, 5), new LongLiteral(location(1, 6), "9")))));
+        assertThat(expression("+ + + 9"))
+                .isEqualTo(positive(location(1, 1), positive(location(1, 3), positive(location(1, 5), new LongLiteral(location(1, 7), "9")))));
 
-        assertExpression("+++9", positive(positive(positive(new LongLiteral("9")))));
-        assertExpression("+ + +9", positive(positive(positive(new LongLiteral("9")))));
-        assertExpression("+ + + 9", positive(positive(positive(new LongLiteral("9")))));
+        assertThat(expression("-9"))
+                .isEqualTo(new LongLiteral(location(1, 1), "-9"));
+        assertThat(expression("- 9"))
+                .isEqualTo(new LongLiteral(location(1, 1), "-9"));
 
-        assertExpression("-9", new LongLiteral("-9"));
-        assertExpression("- 9", new LongLiteral("-9"));
+        assertThat(expression("- + 9"))
+                .isEqualTo(negative(location(1, 1), positive(location(1, 3), new LongLiteral(location(1, 5), "9"))));
+        assertThat(expression("-+9"))
+                .isEqualTo(negative(location(1, 1), positive(location(1, 2), new LongLiteral(location(1, 3), "9"))));
 
-        assertExpression("- + 9", negative(positive(new LongLiteral("9"))));
-        assertExpression("-+9", negative(positive(new LongLiteral("9"))));
+        assertThat(expression("+ - + 9"))
+                .isEqualTo(positive(location(1, 1), negative(location(1, 3), positive(location(1, 5), new LongLiteral(location(1, 7), "9")))));
+        assertThat(expression("+-+9"))
+                .isEqualTo(positive(location(1, 1), negative(location(1, 2), positive(location(1, 3), new LongLiteral(location(1, 4), "9")))));
 
-        assertExpression("+ - + 9", positive(negative(positive(new LongLiteral("9")))));
-        assertExpression("+-+9", positive(negative(positive(new LongLiteral("9")))));
+        assertThat(expression("- -9"))
+                .isEqualTo(negative(location(1, 1), new LongLiteral(location(1, 3), "-9")));
+        assertThat(expression("- - 9"))
+                .isEqualTo(negative(location(1, 1), new LongLiteral(location(1, 3), "-9")));
 
-        assertExpression("- -9", negative(new LongLiteral("-9")));
-        assertExpression("- - 9", negative(new LongLiteral("-9")));
+        assertThat(expression("- + - + 9"))
+                .isEqualTo(negative(location(1, 1), positive(location(1, 3), negative(location(1, 5), positive(location(1, 7), new LongLiteral(location(1, 9), "9"))))));
+        assertThat(expression("-+-+9"))
+                .isEqualTo(negative(location(1, 1), positive(location(1, 2), negative(location(1, 3), positive(location(1, 4), new LongLiteral(location(1, 5), "9"))))));
 
-        assertExpression("- + - + 9", negative(positive(negative(positive(new LongLiteral("9"))))));
-        assertExpression("-+-+9", negative(positive(negative(positive(new LongLiteral("9"))))));
+        assertThat(expression("+ - + - + 9"))
+                .isEqualTo(positive(location(1, 1), negative(location(1, 3), positive(location(1, 5), negative(location(1, 7), positive(location(1, 9), new LongLiteral(location(1, 11), "9")))))));
+        assertThat(expression("+-+-+9"))
+                .isEqualTo(positive(location(1, 1), negative(location(1, 2), positive(location(1, 3), negative(location(1, 4), positive(location(1, 5), new LongLiteral(location(1, 6), "9")))))));
 
-        assertExpression("+ - + - + 9", positive(negative(positive(negative(positive(new LongLiteral("9")))))));
-        assertExpression("+-+-+9", positive(negative(positive(negative(positive(new LongLiteral("9")))))));
-
-        assertExpression("- - -9", negative(negative(new LongLiteral("-9"))));
-        assertExpression("- - - 9", negative(negative(new LongLiteral("-9"))));
+        assertThat(expression("- - -9"))
+                .isEqualTo(negative(location(1, 1), negative(location(1, 3), new LongLiteral(location(1, 5), "-9"))));
+        assertThat(expression("- - - 9"))
+                .isEqualTo(negative(location(1, 1), negative(location(1, 3), new LongLiteral(location(1, 5), "-9"))));
     }
 
     @Test
@@ -602,21 +638,62 @@ public class TestSqlParser
         assertInvalidExpression("coalesce(5)", "The 'coalesce' function must have at least two arguments");
         assertInvalidExpression("coalesce(1, 2) filter (where true)", "FILTER not valid for 'coalesce' function");
         assertInvalidExpression("coalesce(1, 2) OVER ()", "OVER clause not valid for 'coalesce' function");
-        assertExpression("coalesce(13, 42)", new CoalesceExpression(new LongLiteral("13"), new LongLiteral("42")));
-        assertExpression("coalesce(6, 7, 8)", new CoalesceExpression(new LongLiteral("6"), new LongLiteral("7"), new LongLiteral("8")));
-        assertExpression("coalesce(13, null)", new CoalesceExpression(new LongLiteral("13"), new NullLiteral()));
-        assertExpression("coalesce(null, 13)", new CoalesceExpression(new NullLiteral(), new LongLiteral("13")));
-        assertExpression("coalesce(null, null)", new CoalesceExpression(new NullLiteral(), new NullLiteral()));
+        assertThat(expression("coalesce(13, 42)"))
+                .isEqualTo(new CoalesceExpression(location(1, 1), ImmutableList.of(
+                        new LongLiteral(location(1, 10), "13"),
+                        new LongLiteral(location(1, 14), "42"))));
+        assertThat(expression("coalesce(6, 7, 8)"))
+                .isEqualTo(new CoalesceExpression(location(1, 1), ImmutableList.of(
+                        new LongLiteral(location(1, 10), "6"),
+                        new LongLiteral(location(1, 13), "7"),
+                        new LongLiteral(location(1, 16), "8"))));
+        assertThat(expression("coalesce(13, null)"))
+                .isEqualTo(new CoalesceExpression(location(1, 1), ImmutableList.of(
+                        new LongLiteral(location(1, 10), "13"),
+                        new NullLiteral(location(1, 14)))));
+        assertThat(expression("coalesce(null, 13)"))
+                .isEqualTo(new CoalesceExpression(location(1, 1), ImmutableList.of(
+                        new NullLiteral(location(1, 10)),
+                        new LongLiteral(location(1, 16), "13"))));
+        assertThat(expression("coalesce(null, null)"))
+                .isEqualTo(new CoalesceExpression(location(1, 1), ImmutableList.of(
+                        new NullLiteral(location(1, 10)),
+                        new NullLiteral(location(1, 16)))));
     }
 
     @Test
     public void testIf()
     {
-        assertExpression("if(true, 1, 0)", new IfExpression(new BooleanLiteral("true"), new LongLiteral("1"), new LongLiteral("0")));
-        assertExpression("if(true, 3, null)", new IfExpression(new BooleanLiteral("true"), new LongLiteral("3"), new NullLiteral()));
-        assertExpression("if(false, null, 4)", new IfExpression(new BooleanLiteral("false"), new NullLiteral(), new LongLiteral("4")));
-        assertExpression("if(false, null, null)", new IfExpression(new BooleanLiteral("false"), new NullLiteral(), new NullLiteral()));
-        assertExpression("if(true, 3)", new IfExpression(new BooleanLiteral("true"), new LongLiteral("3"), null));
+        assertThat(expression("if(true, 1, 0)"))
+                .isEqualTo(new IfExpression(
+                        location(1, 1),
+                        new BooleanLiteral(location(1, 4), "true"),
+                        new LongLiteral(location(1, 10), "1"),
+                        new LongLiteral(location(1, 13), "0")));
+        assertThat(expression("if(true, 3, null)"))
+                .isEqualTo(new IfExpression(
+                        location(1, 1),
+                        new BooleanLiteral(location(1, 4), "true"),
+                        new LongLiteral(location(1, 10), "3"),
+                        new NullLiteral(location(1, 13))));
+        assertThat(expression("if(false, null, 4)"))
+                .isEqualTo(new IfExpression(
+                        location(1, 1),
+                        new BooleanLiteral(location(1, 4), "false"),
+                        new NullLiteral(location(1, 11)),
+                        new LongLiteral(location(1, 17), "4")));
+        assertThat(expression("if(false, null, null)"))
+                .isEqualTo(new IfExpression(
+                        location(1, 1),
+                        new BooleanLiteral(location(1, 4), "false"),
+                        new NullLiteral(location(1, 11)),
+                        new NullLiteral(location(1, 17))));
+        assertThat(expression("if(true, 3)"))
+                .isEqualTo(new IfExpression(
+                        location(1, 1),
+                        new BooleanLiteral(location(1, 4), "true"),
+                        new LongLiteral(location(1, 10), "3"),
+                        null));
         assertInvalidExpression("IF(true)", "Invalid number of arguments for 'if' function");
         assertInvalidExpression("IF(true, 1, 0) FILTER (WHERE true)", "FILTER not valid for 'if' function");
         assertInvalidExpression("IF(true, 1, 0) OVER()", "OVER clause not valid for 'if' function");
@@ -625,9 +702,21 @@ public class TestSqlParser
     @Test
     public void testNullIf()
     {
-        assertExpression("nullif(42, 87)", new NullIfExpression(new LongLiteral("42"), new LongLiteral("87")));
-        assertExpression("nullif(42, null)", new NullIfExpression(new LongLiteral("42"), new NullLiteral()));
-        assertExpression("nullif(null, null)", new NullIfExpression(new NullLiteral(), new NullLiteral()));
+        assertThat(expression("nullif(42, 87)"))
+                .isEqualTo(new NullIfExpression(
+                        location(1, 1),
+                        new LongLiteral(location(1, 8), "42"),
+                        new LongLiteral(location(1, 12), "87")));
+        assertThat(expression("nullif(42, null)"))
+                .isEqualTo(new NullIfExpression(
+                        location(1, 1),
+                        new LongLiteral(location(1, 8), "42"),
+                        new NullLiteral(location(1, 12))));
+        assertThat(expression("nullif(null, null)"))
+                .isEqualTo(new NullIfExpression(
+                        location(1, 1),
+                        new NullLiteral(location(1, 8)),
+                        new NullLiteral(location(1, 14))));
         assertInvalidExpression("nullif(1)", "Invalid number of arguments for 'nullif' function");
         assertInvalidExpression("nullif(1, 2, 3)", "Invalid number of arguments for 'nullif' function");
         assertInvalidExpression("nullif(42, 87) filter (where true)", "FILTER not valid for 'nullif' function");
@@ -705,8 +794,21 @@ public class TestSqlParser
     @Test
     public void testBetween()
     {
-        assertExpression("1 BETWEEN 2 AND 3", new BetweenPredicate(new LongLiteral("1"), new LongLiteral("2"), new LongLiteral("3")));
-        assertExpression("1 NOT BETWEEN 2 AND 3", new NotExpression(new BetweenPredicate(new LongLiteral("1"), new LongLiteral("2"), new LongLiteral("3"))));
+        assertThat(expression("1 BETWEEN 2 AND 3"))
+                .isEqualTo(new BetweenPredicate(
+                        location(1, 3),
+                        new LongLiteral(location(1, 1), "1"),
+                        new LongLiteral(location(1, 11), "2"),
+                        new LongLiteral(location(1, 17), "3")));
+
+        assertThat(expression("1 NOT BETWEEN 2 AND 3"))
+                .isEqualTo(new NotExpression(
+                        location(1, 3),
+                        new BetweenPredicate(
+                                location(1, 3),
+                                new LongLiteral(location(1, 1), "1"),
+                                new LongLiteral(location(1, 15), "2"),
+                                new LongLiteral(location(1, 21), "3"))));
     }
 
     @Test
@@ -921,47 +1023,83 @@ public class TestSqlParser
                                                 new LongLiteral(location(1, 41), "8"),
                                                 new LongLiteral(location(1, 47), "9"))))));
 
-        assertExpression("1 AND 2 OR 3", LogicalExpression.or(
-                LogicalExpression.and(
-                        new LongLiteral("1"),
-                        new LongLiteral("2")),
-                new LongLiteral("3")));
+        assertThat(expression("1 AND 2 OR 3"))
+                .isEqualTo(new LogicalExpression(
+                        location(1, 1),
+                        LogicalExpression.Operator.OR,
+                        ImmutableList.of(
+                                new LogicalExpression(
+                                        location(1, 1),
+                                        LogicalExpression.Operator.AND,
+                                        ImmutableList.of(new LongLiteral(location(1, 1), "1"), new LongLiteral(location(1, 7), "2"))),
+                                new LongLiteral(location(1, 12), "3"))));
 
-        assertExpression("1 OR 2 AND 3", LogicalExpression.or(
-                new LongLiteral("1"),
-                LogicalExpression.and(
-                        new LongLiteral("2"),
-                        new LongLiteral("3"))));
+        assertThat(expression("1 OR 2 AND 3"))
+                .isEqualTo(new LogicalExpression(
+                        location(1, 1),
+                        LogicalExpression.Operator.OR,
+                        ImmutableList.of(
+                                new LongLiteral(location(1, 1), "1"),
+                                new LogicalExpression(
+                                        location(1, 6),
+                                        LogicalExpression.Operator.AND,
+                                        ImmutableList.of(new LongLiteral(location(1, 6), "2"), new LongLiteral(location(1, 12), "3"))))));
 
-        assertExpression("NOT 1 AND 2", LogicalExpression.and(
-                new NotExpression(new LongLiteral("1")),
-                new LongLiteral("2")));
+        assertThat(expression("NOT 1 AND 2"))
+                .isEqualTo(new LogicalExpression(
+                        location(1, 1),
+                        LogicalExpression.Operator.AND,
+                        ImmutableList.of(
+                                new NotExpression(location(1, 1), new LongLiteral(location(1, 5), "1")),
+                                new LongLiteral(location(1, 11), "2"))));
 
-        assertExpression("NOT 1 OR 2", LogicalExpression.or(
-                new NotExpression(new LongLiteral("1")),
-                new LongLiteral("2")));
+        assertThat(expression("NOT 1 OR 2"))
+                .isEqualTo(new LogicalExpression(
+                        location(1, 1),
+                        LogicalExpression.Operator.OR,
+                        ImmutableList.of(
+                                new NotExpression(location(1, 1), new LongLiteral(location(1, 5), "1")),
+                                new LongLiteral(location(1, 10), "2"))));
 
-        assertExpression("-1 + 2", new ArithmeticBinaryExpression(ArithmeticBinaryExpression.Operator.ADD,
-                new LongLiteral("-1"),
-                new LongLiteral("2")));
+        assertThat(expression("-1 + 2"))
+                .isEqualTo(new ArithmeticBinaryExpression(
+                        location(1, 4),
+                        ArithmeticBinaryExpression.Operator.ADD,
+                        new LongLiteral(location(1, 1), "-1"),
+                        new LongLiteral(location(1, 6), "2")));
 
-        assertExpression("1 - 2 - 3", new ArithmeticBinaryExpression(ArithmeticBinaryExpression.Operator.SUBTRACT,
-                new ArithmeticBinaryExpression(ArithmeticBinaryExpression.Operator.SUBTRACT,
-                        new LongLiteral("1"),
-                        new LongLiteral("2")),
-                new LongLiteral("3")));
+        assertThat(expression("1 - 2 - 3"))
+                .isEqualTo(new ArithmeticBinaryExpression(
+                        location(1, 7),
+                        ArithmeticBinaryExpression.Operator.SUBTRACT,
+                        new ArithmeticBinaryExpression(
+                                location(1, 3),
+                                ArithmeticBinaryExpression.Operator.SUBTRACT,
+                                new LongLiteral(location(1, 1), "1"),
+                                new LongLiteral(location(1, 5), "2")),
+                        new LongLiteral(location(1, 9), "3")));
 
-        assertExpression("1 / 2 / 3", new ArithmeticBinaryExpression(ArithmeticBinaryExpression.Operator.DIVIDE,
-                new ArithmeticBinaryExpression(ArithmeticBinaryExpression.Operator.DIVIDE,
-                        new LongLiteral("1"),
-                        new LongLiteral("2")),
-                new LongLiteral("3")));
+        assertThat(expression("1 / 2 / 3"))
+                .isEqualTo(new ArithmeticBinaryExpression(
+                        location(1, 7),
+                        ArithmeticBinaryExpression.Operator.DIVIDE,
+                        new ArithmeticBinaryExpression(
+                                location(1, 3),
+                                ArithmeticBinaryExpression.Operator.DIVIDE,
+                                new LongLiteral(location(1, 1), "1"),
+                                new LongLiteral(location(1, 5), "2")),
+                        new LongLiteral(location(1, 9), "3")));
 
-        assertExpression("1 + 2 * 3", new ArithmeticBinaryExpression(ArithmeticBinaryExpression.Operator.ADD,
-                new LongLiteral("1"),
-                new ArithmeticBinaryExpression(ArithmeticBinaryExpression.Operator.MULTIPLY,
-                        new LongLiteral("2"),
-                        new LongLiteral("3"))));
+        assertThat(expression("1 + 2 * 3"))
+                .isEqualTo(new ArithmeticBinaryExpression(
+                        location(1, 3),
+                        ArithmeticBinaryExpression.Operator.ADD,
+                        new LongLiteral(location(1, 1), "1"),
+                        new ArithmeticBinaryExpression(
+                                location(1, 7),
+                                ArithmeticBinaryExpression.Operator.MULTIPLY,
+                                new LongLiteral(location(1, 5), "2"),
+                                new LongLiteral(location(1, 9), "3"))));
     }
 
     @Test
@@ -1074,9 +1212,20 @@ public class TestSqlParser
     @Test
     public void testFormat()
     {
-        assertExpression("format('%s', 'abc')", new Format(ImmutableList.of(new StringLiteral("%s"), new StringLiteral("abc"))));
-        assertExpression("format('%d %s', 123, 'x')", new Format(ImmutableList.of(new StringLiteral("%d %s"), new LongLiteral("123"), new StringLiteral("x"))));
+        assertThat(expression("format('%s', 'abc')"))
+                .isEqualTo(new Format(
+                        location(1, 1),
+                        ImmutableList.of(
+                                new StringLiteral(location(1, 8), "%s"),
+                                new StringLiteral(location(1, 14), "abc"))));
 
+        assertThat(expression("format('%d %s', 123, 'x')"))
+                .isEqualTo(new Format(
+                        location(1, 1),
+                        ImmutableList.of(
+                                new StringLiteral(location(1, 8), "%d %s"),
+                                new LongLiteral(location(1, 17), "123"),
+                                new StringLiteral(location(1, 22), "x"))));
         assertInvalidExpression("format()", "The 'format' function must have at least two arguments");
         assertInvalidExpression("format('%s')", "The 'format' function must have at least two arguments");
     }
@@ -1084,30 +1233,41 @@ public class TestSqlParser
     @Test
     public void testCase()
     {
-        assertExpression(
-                "CASE 1 IS NULL WHEN true THEN 2 ELSE 3 END",
-                new SimpleCaseExpression(
-                        new IsNullPredicate(new LongLiteral("1")),
+        assertThat(expression("CASE 1 IS NULL WHEN true THEN 2 ELSE 3 END"))
+                .isEqualTo(new SimpleCaseExpression(
+                        location(1, 1),
+                        new IsNullPredicate(location(1, 8), new LongLiteral(location(1, 6), "1")),
                         ImmutableList.of(
                                 new WhenClause(
-                                        new BooleanLiteral("true"),
-                                        new LongLiteral("2"))),
-                        Optional.of(new LongLiteral("3"))));
+                                        location(1, 16),
+                                        new BooleanLiteral(location(1, 21), "true"),
+                                        new LongLiteral(location(1, 31), "2"))),
+                        Optional.of(new LongLiteral(location(1, 38), "3"))));
     }
 
     @Test
     public void testSearchedCase()
     {
-        assertExpression(
-                "CASE WHEN a > 3 THEN 23 WHEN b = a THEN 33 END",
-                new SearchedCaseExpression(
+        assertThat(expression("CASE WHEN a > 3 THEN 23 WHEN b = a THEN 33 END"))
+                .isEqualTo(new SearchedCaseExpression(
+                        location(1, 1),
                         ImmutableList.of(
                                 new WhenClause(
-                                        new ComparisonExpression(ComparisonExpression.Operator.GREATER_THAN, new Identifier("a"), new LongLiteral("3")),
-                                        new LongLiteral("23")),
+                                        location(1, 6),
+                                        new ComparisonExpression(
+                                                location(1, 13),
+                                                ComparisonExpression.Operator.GREATER_THAN,
+                                                new Identifier(location(1, 11), "a", false),
+                                                new LongLiteral(location(1, 15), "3")),
+                                        new LongLiteral(location(1, 22), "23")),
                                 new WhenClause(
-                                        new ComparisonExpression(ComparisonExpression.Operator.EQUAL, new Identifier("b"), new Identifier("a")),
-                                        new LongLiteral("33"))),
+                                        location(1, 25),
+                                        new ComparisonExpression(
+                                                location(1, 32),
+                                                ComparisonExpression.Operator.EQUAL,
+                                                new Identifier(location(1, 30), "b", false),
+                                                new Identifier(location(1, 34), "a", false)),
+                                        new LongLiteral(location(1, 41), "33"))),
                         Optional.empty()));
     }
 
@@ -2755,20 +2915,31 @@ public class TestSqlParser
     @Test
     public void testLambda()
     {
-        assertExpression("() -> x",
-                new LambdaExpression(
+        assertThat(expression("() -> x"))
+                .isEqualTo(new LambdaExpression(
+                        location(1, 1),
                         ImmutableList.of(),
-                        new Identifier("x")));
-        assertExpression("x -> sin(x)",
-                new LambdaExpression(
-                        ImmutableList.of(new LambdaArgumentDeclaration(identifier("x"))),
-                        new FunctionCall(QualifiedName.of("sin"), ImmutableList.of(new Identifier("x")))));
-        assertExpression("(x, y) -> mod(x, y)",
-                new LambdaExpression(
-                        ImmutableList.of(new LambdaArgumentDeclaration(identifier("x")), new LambdaArgumentDeclaration(identifier("y"))),
+                        new Identifier(location(1, 7), "x", false)));
+        assertThat(expression("x -> sin(x)"))
+                .isEqualTo(new LambdaExpression(
+                        location(1, 1),
+                        ImmutableList.of(new LambdaArgumentDeclaration(new Identifier(location(1, 1), "x", false))),
                         new FunctionCall(
-                                QualifiedName.of("mod"),
-                                ImmutableList.of(new Identifier("x"), new Identifier("y")))));
+                                location(1, 6),
+                                QualifiedName.of(ImmutableList.of(new Identifier(location(1, 6), "sin", false))),
+                                ImmutableList.of(new Identifier(location(1, 10), "x", false)))));
+        assertThat(expression("(x, y) -> mod(x, y)"))
+                .isEqualTo(new LambdaExpression(
+                        location(1, 1),
+                        ImmutableList.of(
+                                new LambdaArgumentDeclaration(new Identifier(location(1, 2), "x", false)),
+                                new LambdaArgumentDeclaration(new Identifier(location(1, 5), "y", false))),
+                        new FunctionCall(
+                                location(1, 11),
+                                QualifiedName.of(ImmutableList.of(new Identifier(location(1, 11), "mod", false))),
+                                ImmutableList.of(
+                                        new Identifier(location(1, 15), "x", false),
+                                        new Identifier(location(1, 18), "y", false)))));
     }
 
     @Test


### PR DESCRIPTION
## Description

Migrate some deprecated `assertExpression` method in `TestSqlParser`

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
