### PR TITLE
Support writing nested timestamp with time zone in Delta Lake

### DIFF
--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestBinPackingNodeAllocator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestBinPackingNodeAllocator.java
@@ -475,7 +475,7 @@ public class TestBinPackingNodeAllocator
             assertAcquired(acquire4, NODE_1);
             acquire4.attachTaskId(taskId(4));
 
-            // fifth allocation of 16 should should no longer fit on NODE_1. There is 16GB unreserved but only 15GB taking runtime usage into account
+            // fifth allocation of 16 should no longer fit on NODE_1. There is 16GB unreserved but only 15GB taking runtime usage into account
             NodeAllocator.NodeLease acquire5 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE));
             assertNotAcquired(acquire5);
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeCdfPageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeCdfPageSink.java
@@ -19,6 +19,7 @@ import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.spi.PageIndexerFactory;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
 
 import java.util.List;
 import java.util.OptionalInt;
@@ -34,6 +35,7 @@ public class DeltaLakeCdfPageSink
     public static final String CHANGE_DATA_FOLDER_NAME = "_change_data";
 
     public DeltaLakeCdfPageSink(
+            TypeOperators typeOperators,
             List<DeltaLakeColumnHandle> inputColumns,
             List<String> originalPartitionColumns,
             PageIndexerFactory pageIndexerFactory,
@@ -47,6 +49,7 @@ public class DeltaLakeCdfPageSink
             String trinoVersion)
     {
         super(
+                typeOperators,
                 inputColumns,
                 originalPartitionColumns,
                 pageIndexerFactory,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
@@ -19,6 +19,7 @@ import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.spi.PageIndexerFactory;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
 
 import java.util.List;
 
@@ -28,6 +29,7 @@ public class DeltaLakePageSink
         extends AbstractDeltaLakePageSink
 {
     public DeltaLakePageSink(
+            TypeOperators typeOperators,
             List<DeltaLakeColumnHandle> inputColumns,
             List<String> originalPartitionColumns,
             PageIndexerFactory pageIndexerFactory,
@@ -40,6 +42,7 @@ public class DeltaLakePageSink
             String trinoVersion)
     {
         super(
+                typeOperators,
                 inputColumns,
                 originalPartitionColumns,
                 pageIndexerFactory,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSinkProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSinkProvider.java
@@ -90,6 +90,7 @@ public class DeltaLakePageSinkProvider
     {
         DeltaLakeOutputTableHandle tableHandle = (DeltaLakeOutputTableHandle) outputTableHandle;
         return new DeltaLakePageSink(
+                typeManager.getTypeOperators(),
                 tableHandle.getInputColumns(),
                 tableHandle.getPartitionedBy(),
                 pageIndexerFactory,
@@ -107,6 +108,7 @@ public class DeltaLakePageSinkProvider
     {
         DeltaLakeInsertTableHandle tableHandle = (DeltaLakeInsertTableHandle) insertTableHandle;
         return new DeltaLakePageSink(
+                typeManager.getTypeOperators(),
                 tableHandle.getInputColumns(),
                 tableHandle.getMetadataEntry().getOriginalPartitionColumns(),
                 pageIndexerFactory,
@@ -127,6 +129,7 @@ public class DeltaLakePageSinkProvider
             case OPTIMIZE:
                 DeltaTableOptimizeHandle optimizeHandle = (DeltaTableOptimizeHandle) executeHandle.getProcedureHandle();
                 return new DeltaLakePageSink(
+                        typeManager.getTypeOperators(),
                         optimizeHandle.getTableColumns(),
                         optimizeHandle.getOriginalPartitionColumns(),
                         pageIndexerFactory,
@@ -150,6 +153,7 @@ public class DeltaLakePageSinkProvider
         ConnectorPageSink pageSink = createPageSink(transactionHandle, session, tableHandle, pageSinkId);
 
         return new DeltaLakeMergeSink(
+                typeManager.getTypeOperators(),
                 fileSystemFactory,
                 session,
                 parquetDateTimeZone,
@@ -182,6 +186,7 @@ public class DeltaLakePageSinkProvider
                 .collect(toImmutableList());
 
         return new DeltaLakeCdfPageSink(
+                typeManager.getTypeOperators(),
                 allColumns,
                 metadataEntry.getOriginalPartitionColumns(),
                 pageIndexerFactory,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTypes.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTypes.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
+
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+
+public final class DeltaLakeTypes
+{
+    private DeltaLakeTypes() {}
+
+    public static Type toParquetType(TypeOperators typeOperators, Type type)
+    {
+        if (type instanceof TimestampWithTimeZoneType timestamp) {
+            verify(timestamp.getPrecision() == 3, "Unsupported type: %s", type);
+            return TIMESTAMP_MILLIS;
+        }
+        if (type instanceof ArrayType arrayType) {
+            return new ArrayType(toParquetType(typeOperators, arrayType.getElementType()));
+        }
+        if (type instanceof MapType mapType) {
+            return new MapType(toParquetType(typeOperators, mapType.getKeyType()), toParquetType(typeOperators, mapType.getValueType()), typeOperators);
+        }
+        if (type instanceof RowType rowType) {
+            return RowType.from(rowType.getFields().stream()
+                    .map(field -> RowType.field(field.getName().orElseThrow(), toParquetType(typeOperators, field.getType())))
+                    .collect(toImmutableList()));
+        }
+        return type;
+    }
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
@@ -16,7 +16,6 @@ package io.trino.plugin.deltalake;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoInputFile;
@@ -28,10 +27,18 @@ import io.trino.plugin.hive.FileFormatDataSourceStats;
 import io.trino.plugin.hive.FileWriter;
 import io.trino.plugin.hive.parquet.TrinoParquetDataSource;
 import io.trino.spi.Page;
+import io.trino.spi.block.ArrayBlock;
 import io.trino.spi.block.Block;
+import io.trino.spi.block.ColumnarArray;
+import io.trino.spi.block.ColumnarMap;
+import io.trino.spi.block.ColumnarRow;
 import io.trino.spi.block.LazyBlock;
 import io.trino.spi.block.LazyBlockLoader;
 import io.trino.spi.block.LongArrayBlock;
+import io.trino.spi.block.RowBlock;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
 import org.apache.parquet.column.statistics.Statistics;
@@ -46,7 +53,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
+import java.util.function.Function;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
@@ -57,6 +64,9 @@ import static io.trino.filesystem.Locations.appendPath;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeParquetStatisticsUtils.hasInvalidStatistics;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeParquetStatisticsUtils.jsonEncodeMax;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeParquetStatisticsUtils.jsonEncodeMin;
+import static io.trino.spi.block.ColumnarArray.toColumnarArray;
+import static io.trino.spi.block.ColumnarMap.toColumnarMap;
+import static io.trino.spi.block.ColumnarRow.toColumnarRow;
 import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static java.util.Objects.requireNonNull;
@@ -73,7 +83,7 @@ public class DeltaLakeWriter
     private final List<String> partitionValues;
     private final DeltaLakeWriterStats stats;
     private final long creationTime;
-    private final Set<Integer> timestampColumnIndices;
+    private final Map<Integer, Function<Block, Block>> coercers;
     private final List<DeltaLakeColumnHandle> columnHandles;
 
     private long rowCount;
@@ -99,13 +109,14 @@ public class DeltaLakeWriter
         this.creationTime = Instant.now().toEpochMilli();
         this.columnHandles = requireNonNull(columnHandles, "columnHandles is null");
 
-        ImmutableSet.Builder<Integer> timestampColumnIndices = ImmutableSet.builder();
+        ImmutableMap.Builder<Integer, Function<Block, Block>> coercers = ImmutableMap.builder();
         for (int i = 0; i < columnHandles.size(); i++) {
-            if (columnHandles.get(i).getType() instanceof TimestampWithTimeZoneType) {
-                timestampColumnIndices.add(i);
+            Optional<Function<Block, Block>> coercer = createCoercer(columnHandles.get(i).getType());
+            if (coercer.isPresent()) {
+                coercers.put(i, coercer.get());
             }
         }
-        this.timestampColumnIndices = timestampColumnIndices.build();
+        this.coercers = coercers.buildOrThrow();
         this.dataFileType = dataFileType;
     }
 
@@ -125,14 +136,15 @@ public class DeltaLakeWriter
     public void appendRows(Page originalPage)
     {
         Page page = originalPage;
-        if (timestampColumnIndices.size() > 0) {
+        if (coercers.size() > 0) {
             Block[] translatedBlocks = new Block[originalPage.getChannelCount()];
             for (int index = 0; index < translatedBlocks.length; index++) {
                 Block originalBlock = originalPage.getBlock(index);
-                if (timestampColumnIndices.contains(index)) {
+                Function<Block, Block> coercer = coercers.get(index);
+                if (coercer != null) {
                     translatedBlocks[index] = new LazyBlock(
                             originalBlock.getPositionCount(),
-                            new TimestampTranslationBlockLoader(originalBlock));
+                            new CoercionLazyBlockLoader(originalBlock, coercer));
                 }
                 else {
                     translatedBlocks[index] = originalBlock;
@@ -264,39 +276,159 @@ public class DeltaLakeWriter
                 .toString();
     }
 
-    private static final class TimestampTranslationBlockLoader
+    private static Optional<Function<Block, Block>> createCoercer(Type type)
+    {
+        if (type instanceof ArrayType arrayType) {
+            return createCoercer(arrayType.getElementType()).map(ArrayCoercer::new);
+        }
+        if (type instanceof MapType mapType) {
+            return Optional.of(new MapCoercer(mapType));
+        }
+        if (type instanceof RowType rowType) {
+            return Optional.of(new RowCoercer(rowType));
+        }
+        if (type instanceof TimestampWithTimeZoneType) {
+            return Optional.of(new TimestampCoercer());
+        }
+        return Optional.empty();
+    }
+
+    private static class ArrayCoercer
+            implements Function<Block, Block>
+    {
+        private final Function<Block, Block> elementCoercer;
+
+        public ArrayCoercer(Function<Block, Block> elementCoercer)
+        {
+            this.elementCoercer = requireNonNull(elementCoercer, "elementCoercer is null");
+        }
+
+        @Override
+        public Block apply(Block block)
+        {
+            ColumnarArray arrayBlock = toColumnarArray(block);
+            Block elementsBlock = elementCoercer.apply(arrayBlock.getElementsBlock());
+            boolean[] valueIsNull = new boolean[arrayBlock.getPositionCount()];
+            int[] offsets = new int[arrayBlock.getPositionCount() + 1];
+            for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
+                valueIsNull[i] = arrayBlock.isNull(i);
+                offsets[i + 1] = offsets[i] + arrayBlock.getLength(i);
+            }
+            return ArrayBlock.fromElementBlock(arrayBlock.getPositionCount(), Optional.of(valueIsNull), offsets, elementsBlock);
+        }
+    }
+
+    private static class MapCoercer
+            implements Function<Block, Block>
+    {
+        private final MapType mapType;
+        private final Optional<Function<Block, Block>> keyCoercer;
+        private final Optional<Function<Block, Block>> valueCoercer;
+
+        public MapCoercer(MapType mapType)
+        {
+            this.mapType = requireNonNull(mapType, "mapType is null");
+            keyCoercer = createCoercer(mapType.getKeyType());
+            valueCoercer = createCoercer(mapType.getValueType());
+        }
+
+        @Override
+        public Block apply(Block block)
+        {
+            ColumnarMap mapBlock = toColumnarMap(block);
+            Block keysBlock = keyCoercer.isEmpty() ? mapBlock.getKeysBlock() : keyCoercer.get().apply(mapBlock.getKeysBlock());
+            Block valuesBlock = valueCoercer.isEmpty() ? mapBlock.getValuesBlock() : valueCoercer.get().apply(mapBlock.getValuesBlock());
+            boolean[] valueIsNull = new boolean[mapBlock.getPositionCount()];
+            int[] offsets = new int[mapBlock.getPositionCount() + 1];
+            for (int i = 0; i < mapBlock.getPositionCount(); i++) {
+                valueIsNull[i] = mapBlock.isNull(i);
+                offsets[i + 1] = offsets[i] + mapBlock.getEntryCount(i);
+            }
+            return mapType.createBlockFromKeyValue(Optional.of(valueIsNull), offsets, keysBlock, valuesBlock);
+        }
+    }
+
+    private static class RowCoercer
+            implements Function<Block, Block>
+    {
+        private final List<Optional<Function<Block, Block>>> fieldCoercers;
+
+        public RowCoercer(RowType rowType)
+        {
+            fieldCoercers = rowType.getTypeParameters().stream()
+                    .map(DeltaLakeWriter::createCoercer)
+                    .collect(toImmutableList());
+        }
+
+        @Override
+        public Block apply(Block block)
+        {
+            ColumnarRow rowBlock = toColumnarRow(block);
+            Block[] fields = new Block[fieldCoercers.size()];
+            for (int i = 0; i < fieldCoercers.size(); i++) {
+                Optional<Function<Block, Block>> coercer = fieldCoercers.get(i);
+                if (coercer.isPresent()) {
+                    fields[i] = coercer.get().apply(rowBlock.getField(i));
+                }
+                else {
+                    fields[i] = rowBlock.getField(i);
+                }
+            }
+            boolean[] valueIsNull = null;
+            if (rowBlock.mayHaveNull()) {
+                valueIsNull = new boolean[rowBlock.getPositionCount()];
+                for (int i = 0; i < rowBlock.getPositionCount(); i++) {
+                    valueIsNull[i] = rowBlock.isNull(i);
+                }
+            }
+            return RowBlock.fromFieldBlocks(rowBlock.getPositionCount(), Optional.ofNullable(valueIsNull), fields);
+        }
+    }
+
+    private static class TimestampCoercer
+            implements Function<Block, Block>
+    {
+        @Override
+        public Block apply(Block block)
+        {
+            int positionCount = block.getPositionCount();
+            long[] values = new long[positionCount];
+            boolean mayHaveNulls = block.mayHaveNull();
+            boolean[] valueIsNull = mayHaveNulls ? new boolean[positionCount] : null;
+
+            for (int position = 0; position < positionCount; position++) {
+                if (mayHaveNulls && block.isNull(position)) {
+                    valueIsNull[position] = true;
+                    continue;
+                }
+                values[position] = MILLISECONDS.toMicros(unpackMillisUtc(TIMESTAMP_TZ_MILLIS.getLong(block, position)));
+            }
+            return new LongArrayBlock(positionCount, Optional.ofNullable(valueIsNull), values);
+        }
+    }
+
+    private static final class CoercionLazyBlockLoader
             implements LazyBlockLoader
     {
-        private Block originalBlock;
+        private final Function<Block, Block> coercer;
+        private Block block;
 
-        public TimestampTranslationBlockLoader(Block originalBlock)
+        public CoercionLazyBlockLoader(Block block, Function<Block, Block> coercer)
         {
-            this.originalBlock = requireNonNull(originalBlock, "originalBlock is null");
+            this.block = requireNonNull(block, "block is null");
+            this.coercer = requireNonNull(coercer, "coercer is null");
         }
 
         @Override
         public Block load()
         {
-            checkState(originalBlock != null, "Already loaded");
+            checkState(block != null, "Already loaded");
 
-            int positionCount = originalBlock.getPositionCount();
-            long[] values = new long[positionCount];
-            boolean mayHaveNulls = originalBlock.mayHaveNull();
-            boolean[] valueIsNull = mayHaveNulls ? new boolean[positionCount] : null;
+            Block loaded = coercer.apply(block.getLoadedBlock());
+            // clear reference to loader to free resources, since load was successful
+            block = null;
 
-            for (int position = 0; position < positionCount; position++) {
-                if (mayHaveNulls && originalBlock.isNull(position)) {
-                    valueIsNull[position] = true;
-                    continue;
-                }
-                values[position] = MILLISECONDS.toMicros(unpackMillisUtc(TIMESTAMP_TZ_MILLIS.getLong(originalBlock, position)));
-            }
-            Block mapped;
-            mapped = new LongArrayBlock(positionCount, Optional.ofNullable(valueIsNull), values);
-            // clear reference to Block to free resources, since load was successful
-            originalBlock = null;
-
-            return mapped;
+            return loaded;
         }
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
@@ -267,12 +267,6 @@ public final class DeltaLakeSchemaSupport
 
     private static void validateType(Optional<Type> rootType, Type type)
     {
-        rootType.ifPresent(root -> {
-            if (type instanceof TimestampWithTimeZoneType) {
-                throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Nested TIMESTAMP types are not supported, invalid type: " + root);
-            }
-        });
-
         if (HiveUtil.isStructuralType(type)) {
             validateStructuralType(Optional.of(rootType.orElse(type)), type);
         }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -1439,7 +1439,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
         registerTableFromResources(tableName, "databricks/pruning/parquet_struct_statistics", getQueryRunner());
         String transactionLogDirectory = format("%s/_delta_log", tableName);
 
-        // there should should be one checkpoint already (created by DB)
+        // there should be one checkpoint already (created by DB)
         assertThat(listCheckpointFiles(transactionLogDirectory)).hasSize(1);
         testCountQuery(format("SELECT count(*) FROM %s WHERE l = 0", tableName), 3, 3);
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestDeltaLakeSchemaSupport.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestDeltaLakeSchemaSupport.java
@@ -58,6 +58,7 @@ import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_SECONDS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_SECONDS;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -252,7 +253,10 @@ public class TestDeltaLakeSchemaSupport
                 {DATE},
                 {VARCHAR},
                 {DecimalType.createDecimalType(3)},
-                {TIMESTAMP_TZ_MILLIS}};
+                {TIMESTAMP_TZ_MILLIS},
+                {new MapType(TIMESTAMP_TZ_MILLIS, TIMESTAMP_TZ_MILLIS, new TypeOperators())},
+                {RowType.anonymous(ImmutableList.of(TIMESTAMP_TZ_MILLIS))},
+                {new ArrayType(TIMESTAMP_TZ_MILLIS)}};
     }
 
     @Test(dataProvider = "unsupportedTypes")
@@ -275,15 +279,15 @@ public class TestDeltaLakeSchemaSupport
     @Test(dataProvider = "unsupportedNestedTimestamp")
     public void testTimestampNestedInStructTypeIsNotSupported(Type type)
     {
-        assertThatCode(() -> DeltaLakeSchemaSupport.validateType(type)).hasMessage("Nested TIMESTAMP types are not supported, invalid type: " + type);
+        assertThatCode(() -> DeltaLakeSchemaSupport.validateType(type)).hasMessage("Unsupported type: timestamp(0) with time zone");
     }
 
     @DataProvider(name = "unsupportedNestedTimestamp")
     public static Object[][] unsupportedNestedTimestamp()
     {
         return new Object[][] {
-                {new MapType(TIMESTAMP_TZ_MILLIS, TIMESTAMP_TZ_MILLIS, new TypeOperators())},
-                {RowType.anonymous(ImmutableList.of(TIMESTAMP_TZ_MILLIS))},
-                {new ArrayType(TIMESTAMP_TZ_MILLIS)}};
+                {new MapType(TIMESTAMP_TZ_SECONDS, TIMESTAMP_TZ_SECONDS, new TypeOperators())},
+                {RowType.anonymous(ImmutableList.of(TIMESTAMP_TZ_SECONDS))},
+                {new ArrayType(TIMESTAMP_TZ_SECONDS)}};
     }
 }


### PR DESCRIPTION
## Description

Support nested timestamp with time zone in Delta Lake

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Support writing `timestamp with time zone` type in `array`, `map` and `row` types. ({issue}`16826`)
```
