### PR TITLE
Implement Insert into Kafka

### DIFF
--- a/docs/src/main/sphinx/connector/kafka.md
+++ b/docs/src/main/sphinx/connector/kafka.md
@@ -1098,6 +1098,7 @@ The Kafka connector contains the following decoders:
 - `json` - Kafka message is parsed as JSON, and JSON fields are mapped to table columns.
 - `avro` - Kafka message is parsed based on an Avro schema, and Avro fields are mapped to table columns.
 - `protobuf` - Kafka message is parsed based on a Protobuf schema, and Protobuf fields are mapped to table columns.
+- `kafka` - Kafka key is encoded in the table name. 
 
 :::{note}
 If no table definition file exists for a table, the `dummy` decoder is used,
@@ -1431,6 +1432,35 @@ The schema evolution behavior is as follows:
 
 - Protobuf Timestamp has a nanosecond precision but Trino supports
   decoding/encoding at microsecond precision.
+
+#### Kafka key decoder
+
+The Kafka key decoder converts the bytes representing a key by
+encoding the column name and type in the table name.
+
+The key is encoded in the table name as follows:
+
+`"<tablename>"&key-column=<name>:<trino type>"`
+
+Note: the double quotes are required when using the above format.
+
+Here is an example:
+```sql
+SELECT my_key, message_field1, message_field2
+FROM kafka.default."mytable&key-column=my_key:bigint"
+```
+
+The following table lists the supported Trino types which can be used and the equivalent Avro field types:
+
+| Trino data type | Allowed Avro data type |
+|-----------------|------------------------|
+| `BIGINT`        | `LONG`                 |
+| `INTEGER`       | `INT`                  |
+| `DOUBLE`        | `DOUBLE`               |
+| `BOOLEAN`       | `BOOLEAN`              |
+| `REAL`          | `FLOAT`                |
+| `VARCHAR`       | `STRING`               |
+| `VARBINARY`     | `BYTES`                |
 
 (kafka-sql-support)=
 

--- a/lib/trino-record-decoder/src/test/java/io/trino/decoder/avro/TestAvroDecoder.java
+++ b/lib/trino-record-decoder/src/test/java/io/trino/decoder/avro/TestAvroDecoder.java
@@ -68,10 +68,15 @@ import static io.trino.decoder.util.DecoderTestUtil.checkIsNull;
 import static io.trino.decoder.util.DecoderTestUtil.checkValue;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeType.TIME_MICROS;
+import static io.trino.spi.type.TimeType.TIME_MILLIS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.TypeSignature.mapType;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
@@ -378,6 +383,102 @@ public class TestAvroDecoder
         Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "id", "\"long\"", 493857959588286460L);
 
         checkValue(decodedRow, row, 493857959588286460L);
+    }
+
+    @Test
+    public void testTimestampMicrosDecodedAsTimestampMicros()
+    {
+        DecoderTestColumnHandle row = new DecoderTestColumnHandle(0, "row", TIMESTAMP_MICROS, "id", null, null, false, false, false);
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "id", "{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", 1699037730000L);
+        checkValue(decodedRow, row, 1699037730000L);
+    }
+
+    @Test
+    public void testTimestampMicrosDecodedAsBigint()
+    {
+        DecoderTestColumnHandle row = new DecoderTestColumnHandle(0, "row", BIGINT, "id", null, null, false, false, false);
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "id", "{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", 1699037730000L);
+        checkValue(decodedRow, row, 1699037730000L);
+    }
+
+    @Test
+    public void testTimestampMillisDecodedAsTimestampMillis()
+    {
+        DecoderTestColumnHandle row = new DecoderTestColumnHandle(0, "row", TIMESTAMP_MILLIS, "id", null, null, false, false, false);
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "id", "{\"type\": \"long\", \"logicalType\": \"timestamp-millis\"}", 1699037730000L);
+        checkValue(decodedRow, row, 1699037730000000L);
+    }
+
+    @Test
+    public void testTimestampMillisDecodedAsBigint()
+    {
+        DecoderTestColumnHandle row = new DecoderTestColumnHandle(0, "row", BIGINT, "id", null, null, false, false, false);
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "id", "{\"type\": \"long\", \"logicalType\": \"timestamp-millis\"}", 1699037730000L);
+        checkValue(decodedRow, row, 1699037730000L);
+    }
+
+    @Test
+    public void testTimeMicrosDecodedAsTimeMicros()
+    {
+        DecoderTestColumnHandle row = new DecoderTestColumnHandle(0, "row", TIME_MICROS, "id", null, null, false, false, false);
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "id", "{\"type\": \"long\", \"logicalType\": \"time-micros\"}", 1699037730L);
+        checkValue(decodedRow, row, 1699037730000000L);
+    }
+
+    @Test
+    public void testTimeMicrosDecodedAsBigint()
+    {
+        DecoderTestColumnHandle row = new DecoderTestColumnHandle(0, "row", BIGINT, "id", null, null, false, false, false);
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "id", "{\"type\": \"long\", \"logicalType\": \"time-micros\"}", 1699037730L);
+        checkValue(decodedRow, row, 1699037730L);
+    }
+
+    @Test
+    public void testTimeMillisDecodedAsTimeMillis()
+    {
+        DecoderTestColumnHandle row = new DecoderTestColumnHandle(0, "row", TIME_MILLIS, "id", null, null, false, false, false);
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "id", "{\"type\": \"int\", \"logicalType\": \"time-millis\"}", 1699037730);
+        checkValue(decodedRow, row, 1699037730000000000L);
+    }
+
+    @Test
+    public void testTimeMillisDecodedAsInteger()
+    {
+        DecoderTestColumnHandle row = new DecoderTestColumnHandle(0, "row", INTEGER, "id", null, null, false, false, false);
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "id", "{\"type\": \"int\", \"logicalType\": \"time-millis\"}", 1699037730);
+        checkValue(decodedRow, row, 1699037730);
+    }
+
+    @Test
+    public void testTimeMillisDecodedAsBigint()
+    {
+        DecoderTestColumnHandle row = new DecoderTestColumnHandle(0, "row", BIGINT, "id", null, null, false, false, false);
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "id", "{\"type\": \"int\", \"logicalType\": \"time-millis\"}", 1699037730);
+        checkValue(decodedRow, row, 1699037730L);
+    }
+
+    @Test
+    public void testDateDecodedAsDate()
+    {
+        DecoderTestColumnHandle row = new DecoderTestColumnHandle(0, "row", DATE, "id", null, null, false, false, false);
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "id", "{\"type\": \"int\", \"logicalType\": \"date\"}", 1000);
+        checkValue(decodedRow, row, 1000);
+    }
+
+    @Test
+    public void testDateDecodedAsInteger()
+    {
+        DecoderTestColumnHandle row = new DecoderTestColumnHandle(0, "row", DATE, "id", null, null, false, false, false);
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "id", "{\"type\": \"int\", \"logicalType\": \"date\"}", 1000);
+        checkValue(decodedRow, row, 1000);
+    }
+
+    @Test
+    public void testDateDecodedAsBigint()
+    {
+        DecoderTestColumnHandle row = new DecoderTestColumnHandle(0, "row", DATE, "id", null, null, false, false, false);
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "id", "{\"type\": \"int\", \"logicalType\": \"date\"}", 1000);
+        checkValue(decodedRow, row, 1000L);
     }
 
     @Test

--- a/plugin/trino-kafka/pom.xml
+++ b/plugin/trino-kafka/pom.xml
@@ -75,7 +75,17 @@
 
         <dependency>
             <groupId>io.confluent</groupId>
+            <artifactId>kafka-avro-serializer</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-serializer</artifactId>
         </dependency>
 
         <dependency>
@@ -218,12 +228,6 @@
 
         <dependency>
             <groupId>io.confluent</groupId>
-            <artifactId>kafka-avro-serializer</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.confluent</groupId>
             <artifactId>kafka-json-schema-serializer</artifactId>
             <!-- This is under Confluent Community License and it should not be used with compile scope -->
             <scope>test</scope>
@@ -246,12 +250,6 @@
             <groupId>io.confluent</groupId>
             <artifactId>kafka-protobuf-types</artifactId>
             <!-- This is under Confluent Community License and it should not be used with compile scope -->
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-schema-serializer</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaMetadata.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaMetadata.java
@@ -100,6 +100,7 @@ public class KafkaMetadata
                         kafkaTopicDescription.getMessage().flatMap(KafkaTopicFieldGroup::getDataSchema),
                         kafkaTopicDescription.getKey().flatMap(KafkaTopicFieldGroup::getSubject),
                         kafkaTopicDescription.getMessage().flatMap(KafkaTopicFieldGroup::getSubject),
+                        kafkaTopicDescription.getKeyColumn(),
                         getColumnHandles(session, schemaTableName).values().stream()
                                 .map(KafkaColumnHandle.class::cast)
                                 .collect(toImmutableList()),
@@ -249,6 +250,7 @@ public class KafkaMetadata
                 handle.getMessageDataSchemaLocation(),
                 handle.getKeySubject(),
                 handle.getMessageSubject(),
+                handle.getKeyColumn(),
                 handle.getColumns(),
                 newDomain);
 
@@ -289,6 +291,7 @@ public class KafkaMetadata
                 table.getMessageDataSchemaLocation(),
                 table.getKeySubject(),
                 table.getMessageSubject(),
+                table.getKeyColumn(),
                 actualColumns,
                 TupleDomain.none());
     }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaPageSink.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaPageSink.java
@@ -126,7 +126,13 @@ public class KafkaPageSink
             keyBytes = keyEncoder.toByteArray();
             messageBytes = messageEncoder.toByteArray();
 
-            expectedWrittenBytes += keyBytes.length + messageBytes.length;
+            /**
+             * KafkaProducerBatch returns -1 for bytes length if data is null
+             * @see org.apache.kafka.clients.producer.internals.ProducerBatch#tryAppend
+             */
+            int keyBytesLength = keyBytes == null ? -1 : keyBytes.length;
+            int messageBytesLength = messageBytes == null ? -1 : messageBytes.length;
+            expectedWrittenBytes += keyBytesLength + messageBytesLength;
 
             producer.send(new ProducerRecord<>(topicName, keyBytes, messageBytes), producerCallback);
         }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaTableHandle.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaTableHandle.java
@@ -54,6 +54,7 @@ public final class KafkaTableHandle
     private final Optional<String> messageDataSchemaLocation;
     private final Optional<String> keySubject;
     private final Optional<String> messageSubject;
+    private final Optional<KafkaColumnHandle> keyColumn;
     private final List<KafkaColumnHandle> columns;
     private final TupleDomain<ColumnHandle> constraint;
 
@@ -68,6 +69,7 @@ public final class KafkaTableHandle
             @JsonProperty("messageDataSchemaLocation") Optional<String> messageDataSchemaLocation,
             @JsonProperty("keySubject") Optional<String> keySubject,
             @JsonProperty("messageSubject") Optional<String> messageSubject,
+            @JsonProperty("keyColumn") Optional<KafkaColumnHandle> keyColumn,
             @JsonProperty("columns") List<KafkaColumnHandle> columns,
             @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint)
     {
@@ -80,6 +82,7 @@ public final class KafkaTableHandle
         this.messageDataSchemaLocation = requireNonNull(messageDataSchemaLocation, "messageDataSchemaLocation is null");
         this.keySubject = requireNonNull(keySubject, "keySubject is null");
         this.messageSubject = requireNonNull(messageSubject, "messageSubject is null");
+        this.keyColumn = requireNonNull(keyColumn, "keyColumn is null");
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
         this.constraint = requireNonNull(constraint, "constraint is null");
     }
@@ -139,6 +142,12 @@ public final class KafkaTableHandle
     }
 
     @JsonProperty
+    public Optional<KafkaColumnHandle> getKeyColumn()
+    {
+        return keyColumn;
+    }
+
+    @JsonProperty
     public List<KafkaColumnHandle> getColumns()
     {
         return columns;
@@ -168,6 +177,7 @@ public final class KafkaTableHandle
                 messageDataSchemaLocation,
                 keySubject,
                 messageSubject,
+                keyColumn,
                 columns,
                 constraint);
     }
@@ -192,6 +202,7 @@ public final class KafkaTableHandle
                 && Objects.equals(this.messageDataSchemaLocation, other.messageDataSchemaLocation)
                 && Objects.equals(this.keySubject, other.keySubject)
                 && Objects.equals(this.messageSubject, other.messageSubject)
+                && Objects.equals(this.keyColumn, other.keyColumn)
                 && Objects.equals(this.columns, other.columns)
                 && Objects.equals(this.constraint, other.constraint);
     }
@@ -209,6 +220,7 @@ public final class KafkaTableHandle
                 .add("messageDataSchemaLocation", messageDataSchemaLocation)
                 .add("keySubject", keySubject)
                 .add("messageSubject", messageSubject)
+                .add("keyColumn", keyColumn)
                 .add("columns", columns)
                 .add("constraint", constraint)
                 .toString();

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaTopicDescription.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaTopicDescription.java
@@ -34,6 +34,7 @@ public class KafkaTopicDescription
     private final Optional<String> schemaName;
     private final Optional<KafkaTopicFieldGroup> key;
     private final Optional<KafkaTopicFieldGroup> message;
+    private final Optional<KafkaColumnHandle> keyColumn;
 
     @JsonCreator
     public KafkaTopicDescription(
@@ -41,7 +42,8 @@ public class KafkaTopicDescription
             @JsonProperty("schemaName") Optional<String> schemaName,
             @JsonProperty("topicName") String topicName,
             @JsonProperty("key") Optional<KafkaTopicFieldGroup> key,
-            @JsonProperty("message") Optional<KafkaTopicFieldGroup> message)
+            @JsonProperty("message") Optional<KafkaTopicFieldGroup> message,
+            @JsonProperty("keyColumn") Optional<KafkaColumnHandle> keyColumn)
     {
         checkArgument(!isNullOrEmpty(tableName), "tableName is null or is empty");
         this.tableName = tableName;
@@ -49,6 +51,7 @@ public class KafkaTopicDescription
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.key = requireNonNull(key, "key is null");
         this.message = requireNonNull(message, "message is null");
+        this.keyColumn = requireNonNull(keyColumn, "keyColumn is null");
     }
 
     @JsonProperty
@@ -81,10 +84,16 @@ public class KafkaTopicDescription
         return message;
     }
 
+    @JsonProperty
+    public Optional<KafkaColumnHandle> getKeyColumn()
+    {
+        return keyColumn;
+    }
+
     @Override
     public int hashCode()
     {
-        return Objects.hash(tableName, topicName, schemaName, key, message);
+        return Objects.hash(tableName, topicName, schemaName, key, message, keyColumn);
     }
 
     @Override
@@ -102,7 +111,8 @@ public class KafkaTopicDescription
                 Objects.equals(this.topicName, other.topicName) &&
                 Objects.equals(this.schemaName, other.schemaName) &&
                 Objects.equals(this.key, other.key) &&
-                Objects.equals(this.message, other.message);
+                Objects.equals(this.message, other.message) &&
+                Objects.equals(this.keyColumn, other.keyColumn);
     }
 
     @Override
@@ -114,6 +124,7 @@ public class KafkaTopicDescription
                 .add("schemaName", schemaName)
                 .add("key", key)
                 .add("message", message)
+                .add("keyColumn", keyColumn)
                 .toString();
     }
 }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/decoder/EmptyFieldHandlingAvroRowDecoder.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/decoder/EmptyFieldHandlingAvroRowDecoder.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.decoder;
+
+import io.trino.decoder.DecoderColumnHandle;
+import io.trino.decoder.FieldValueProvider;
+import io.trino.decoder.RowDecoder;
+import io.trino.spi.block.RowBlockBuilder;
+import io.trino.spi.block.SqlRow;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.plugin.kafka.schema.confluent.AvroSchemaConverter.EMPTY_FIELD_MARKER;
+import static io.trino.plugin.kafka.schema.confluent.AvroSchemaConverter.EMPTY_FIELD_MARKER_TYPE;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static java.util.Objects.requireNonNull;
+
+public class EmptyFieldHandlingAvroRowDecoder
+        implements RowDecoder
+{
+    public static final String NAME = "avro";
+
+    private static final SqlRow EMPTY_FIELD_MARKER_ROW;
+
+    static {
+        RowBlockBuilder blockBuilder = EMPTY_FIELD_MARKER_TYPE.createBlockBuilder(null, 1);
+        blockBuilder.buildEntry(fieldBuilders -> {
+            fieldBuilders.get(0).appendNull();
+        });
+        EMPTY_FIELD_MARKER_ROW = blockBuilder.build().getObject(0, SqlRow.class);
+    }
+
+    private static final FieldValueProvider EMPY_FIELD_MARKER_VALUE_PROVIDER = new EmptyFieldMarkerValueProvider();
+
+    private final RowDecoder delegate;
+
+    public EmptyFieldHandlingAvroRowDecoder(RowDecoder delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    public Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(byte[] data)
+    {
+        return delegate.decodeRow(data).map(decodedRow -> decodedRow.entrySet().stream()
+                .map(this::replaceEmptyFieldMarkerValueProvider)
+                .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+
+    private Map.Entry<DecoderColumnHandle, FieldValueProvider> replaceEmptyFieldMarkerValueProvider(Map.Entry<DecoderColumnHandle, FieldValueProvider> field)
+    {
+        if (isEmptyFieldMarkerType(field.getKey().getType())) {
+            return new AbstractMap.SimpleImmutableEntry<>(field.getKey(), EMPY_FIELD_MARKER_VALUE_PROVIDER);
+        }
+        return field;
+    }
+
+    // An avro record with no fields is encoded as a row which has exactly one field named "$empty_field_marker" with boolean type.
+    private boolean isEmptyFieldMarkerType(Type type)
+    {
+        if (!(type instanceof RowType)) {
+            return false;
+        }
+        RowType rowType = (RowType) type;
+        if (rowType.getFields().size() != 1) {
+            return false;
+        }
+        RowType.Field field = rowType.getFields().get(0);
+        return field.getType() == BOOLEAN && field.getName().map(name -> name.equals(EMPTY_FIELD_MARKER)).orElse(false);
+    }
+
+    private static final class EmptyFieldMarkerValueProvider
+            extends FieldValueProvider
+    {
+        @Override
+        public Object getObject()
+        {
+            return EMPTY_FIELD_MARKER_ROW;
+        }
+
+        @Override
+        public boolean isNull()
+        {
+            return false;
+        }
+    }
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/decoder/EmptyFieldHandlingAvroRowDecoderFactory.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/decoder/EmptyFieldHandlingAvroRowDecoderFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.decoder;
+
+import com.google.inject.Inject;
+import io.trino.decoder.RowDecoder;
+import io.trino.decoder.RowDecoderFactory;
+import io.trino.decoder.RowDecoderSpec;
+import io.trino.decoder.avro.AvroRowDecoderFactory;
+import io.trino.spi.connector.ConnectorSession;
+
+import static io.trino.plugin.kafka.schema.confluent.AvroSchemaConverter.EmptyFieldStrategy.MARK;
+import static io.trino.plugin.kafka.schema.confluent.ConfluentSessionProperties.getEmptyFieldStrategy;
+import static java.util.Objects.requireNonNull;
+
+public class EmptyFieldHandlingAvroRowDecoderFactory
+        implements RowDecoderFactory
+{
+    private final AvroRowDecoderFactory delegate;
+
+    @Inject
+    public EmptyFieldHandlingAvroRowDecoderFactory(AvroRowDecoderFactory delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    public RowDecoder create(ConnectorSession session, RowDecoderSpec rowDecoderSpec)
+    {
+        RowDecoder rowDecoder = delegate.create(session, rowDecoderSpec);
+        if (getEmptyFieldStrategy(session) == MARK) {
+            return new EmptyFieldHandlingAvroRowDecoder(rowDecoder);
+        }
+        return rowDecoder;
+    }
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/decoder/KafkaRowDecoderFactory.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/decoder/KafkaRowDecoderFactory.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.decoder;
+
+import io.trino.decoder.RowDecoder;
+import io.trino.decoder.RowDecoderFactory;
+import io.trino.decoder.RowDecoderSpec;
+import io.trino.decoder.avro.AvroDeserializer;
+import io.trino.decoder.avro.SingleValueRowDecoder;
+import io.trino.decoder.dummy.DummyRowDecoderFactory;
+import io.trino.spi.connector.ConnectorSession;
+import org.apache.avro.Schema;
+import org.apache.kafka.common.serialization.ByteBufferDeserializer;
+import org.apache.kafka.common.serialization.DoubleDeserializer;
+import org.apache.kafka.common.serialization.FloatDeserializer;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.decoder.avro.AvroRowDecoderFactory.DATA_SCHEMA;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class KafkaRowDecoderFactory
+        implements RowDecoderFactory
+{
+    public static final String NAME = "kafka";
+
+    private static final LongDeserializer LONG_DESERIALIZER = new LongDeserializer();
+    private static final IntegerDeserializer INTEGER_DESERIALIZER = new IntegerDeserializer();
+    private static final FloatDeserializer FLOAT_DESERIALIZER = new FloatDeserializer();
+    private static final DoubleDeserializer DOUBLE_DESERIALIZER = new DoubleDeserializer();
+    private static final StringDeserializer STRING_DESERIALIZER = new StringDeserializer();
+    private static final ByteBufferDeserializer BYTE_BUFFER_DESERIALIZER = new ByteBufferDeserializer();
+
+    @Override
+    public RowDecoder create(ConnectorSession session, RowDecoderSpec rowDecoderSpec)
+    {
+        requireNonNull(rowDecoderSpec, "rowDecoderSpec is null");
+        if (rowDecoderSpec.columns().isEmpty()) {
+            // For select count(*)
+            return DummyRowDecoderFactory.DECODER_INSTANCE;
+        }
+        String dataSchema = requireNonNull(rowDecoderSpec.decoderParams().get(DATA_SCHEMA), format("%s cannot be null", DATA_SCHEMA));
+        Schema parsedSchema = (new Schema.Parser()).parse(dataSchema);
+        AvroDeserializer<Object> avroDeserializer = null;
+        switch (parsedSchema.getType()) {
+            case LONG:
+                avroDeserializer = data -> LONG_DESERIALIZER.deserialize(null, data);
+                break;
+            case INT:
+                avroDeserializer = data -> INTEGER_DESERIALIZER.deserialize(null, data);
+                break;
+            case BOOLEAN:
+                avroDeserializer = data -> data[0] != 0;
+                break;
+            case STRING:
+                avroDeserializer = data -> STRING_DESERIALIZER.deserialize(null, data);
+                break;
+            case FLOAT:
+                avroDeserializer = data -> FLOAT_DESERIALIZER.deserialize(null, data);
+                break;
+            case DOUBLE:
+                avroDeserializer = data -> DOUBLE_DESERIALIZER.deserialize(null, data);
+                break;
+            case BYTES:
+                avroDeserializer = data -> BYTE_BUFFER_DESERIALIZER.deserialize(null, data);
+                break;
+            default:
+        }
+        if (avroDeserializer == null) {
+            throw new UnsupportedOperationException(format("Unexpected schema '%s'", parsedSchema));
+        }
+
+        return new SingleValueRowDecoder(new NullConvertingAvroDeserializer(avroDeserializer), getOnlyElement(rowDecoderSpec.columns()));
+    }
+
+    private static class NullConvertingAvroDeserializer
+            implements AvroDeserializer<Object>
+    {
+        private final AvroDeserializer<Object> delegate;
+
+        public NullConvertingAvroDeserializer(AvroDeserializer<Object> delegate)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        public Object deserialize(byte[] data)
+        {
+            if (data.length == 0) {
+                return null;
+            }
+            return delegate.deserialize(data);
+        }
+    }
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/dummy/DummyRowEncoder.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/dummy/DummyRowEncoder.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.encoder.dummy;
+
+import io.trino.plugin.kafka.encoder.RowEncoder;
+import io.trino.spi.block.Block;
+
+public class DummyRowEncoder
+        implements RowEncoder
+{
+    public static final String NAME = "dummy";
+
+    @Override
+    public void appendColumnValue(Block block, int position) {}
+
+    @Override
+    public byte[] toByteArray()
+    {
+        return null;
+    }
+
+    @Override
+    public void close() {}
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/dummy/DummyRowEncoderFactory.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/dummy/DummyRowEncoderFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.encoder.dummy;
+
+import io.trino.plugin.kafka.encoder.RowEncoder;
+import io.trino.plugin.kafka.encoder.RowEncoderFactory;
+import io.trino.plugin.kafka.encoder.RowEncoderSpec;
+import io.trino.spi.connector.ConnectorSession;
+
+public class DummyRowEncoderFactory
+        implements RowEncoderFactory
+{
+    private static final RowEncoder ENCODER_INSTANCE = new DummyRowEncoder();
+
+    @Override
+    public RowEncoder create(ConnectorSession session, RowEncoderSpec rowEncoderSpec)
+    {
+        return ENCODER_INSTANCE;
+    }
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/kafka/KafkaSerializerRowEncoder.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/kafka/KafkaSerializerRowEncoder.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.encoder.kafka;
+
+import io.trino.plugin.kafka.encoder.AbstractRowEncoder;
+import io.trino.plugin.kafka.encoder.EncoderColumnHandle;
+import io.trino.plugin.kafka.encoder.RowEncoder;
+import io.trino.plugin.kafka.encoder.RowEncoderFactory;
+import io.trino.plugin.kafka.encoder.RowEncoderSpec;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.type.SqlDate;
+import io.trino.spi.type.SqlTime;
+import io.trino.spi.type.SqlTimeWithTimeZone;
+import io.trino.spi.type.SqlTimestamp;
+import io.trino.spi.type.SqlTimestampWithTimeZone;
+import io.trino.spi.type.TimeType;
+import org.apache.avro.Schema;
+import org.apache.kafka.common.serialization.ByteBufferSerializer;
+import org.apache.kafka.common.serialization.DoubleSerializer;
+import org.apache.kafka.common.serialization.FloatSerializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.plugin.kafka.schema.TrinoToAvroSchemaConverter.fromTrinoType;
+import static io.trino.spi.type.TimeType.TIME_MICROS;
+import static io.trino.spi.type.TimeType.TIME_MILLIS;
+import static io.trino.spi.type.TimestampType.MAX_SHORT_PRECISION;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+// Used to serialize single value keys not registered with schema registry
+public class KafkaSerializerRowEncoder
+        extends AbstractRowEncoder
+{
+    public static final String NAME = "kafka";
+    private static final LongSerializer LONG_SERIALIZER = new LongSerializer();
+    private static final IntegerSerializer INTEGER_SERIALIZER = new IntegerSerializer();
+    private static final DoubleSerializer DOUBLE_SERIALIZER = new DoubleSerializer();
+    private static final FloatSerializer FLOAT_SERIALIZER = new FloatSerializer();
+    // TODO: Support more encodings, currently only UTF8 is supported
+    private static final StringSerializer STRING_SERIALIZER = new StringSerializer();
+    private static final ByteBufferSerializer BYTE_BUFFER_SERIALIZER = new ByteBufferSerializer();
+    private static final int MAX_PRECISION = 12;
+    private static final byte[] SERIALIZED_TRUE = new byte[]{1};
+    private static final byte[] SERIALIZED_FALSE = new byte[]{0};
+
+    private final String topic;
+    private byte[] data;
+    private boolean isNull;
+
+    public KafkaSerializerRowEncoder(ConnectorSession session, List<EncoderColumnHandle> columnHandles, String topic)
+    {
+        super(session, columnHandles);
+        checkState(columnHandles.size() == 1, "Multiple columns");
+        Schema schema = fromTrinoType(getOnlyElement(columnHandles).getType());
+        checkState(schema.getType() != Schema.Type.RECORD && schema.getType() != Schema.Type.MAP && schema.getType() != Schema.Type.ARRAY, "Unsupported error message '%s'", schema.getType());
+        this.topic = requireNonNull(topic, "topic is null");
+    }
+
+    private void checkIsNotSet()
+    {
+        checkState(data == null && !isNull, "Data is already set");
+    }
+
+    @Override
+    public void appendColumnValue(Block block, int position)
+    {
+        checkIsNotSet();
+        super.appendColumnValue(block, position);
+    }
+
+    @Override
+    protected void appendNullValue()
+    {
+        isNull = true;
+    }
+
+    @Override
+    protected void appendLong(long value)
+    {
+        data = LONG_SERIALIZER.serialize(topic, value);
+    }
+
+    @Override
+    protected void appendInt(int value)
+    {
+        data = INTEGER_SERIALIZER.serialize(topic, value);
+    }
+
+    @Override
+    protected void appendShort(short value)
+    {
+        data = INTEGER_SERIALIZER.serialize(topic, (int) value);
+    }
+
+    @Override
+    protected void appendByte(byte value)
+    {
+        data = new byte[]{value};
+    }
+
+    @Override
+    protected void appendDouble(double value)
+    {
+        data = DOUBLE_SERIALIZER.serialize(topic, value);
+    }
+
+    @Override
+    protected void appendFloat(float value)
+    {
+        data = FLOAT_SERIALIZER.serialize(topic, value);
+    }
+
+    @Override
+    protected void appendBoolean(boolean value)
+    {
+        // This is how KafkaAvroSerializer serializes booleans
+        data = value ? SERIALIZED_TRUE : SERIALIZED_FALSE;
+    }
+
+    @Override
+    protected void appendString(String value)
+    {
+        data = STRING_SERIALIZER.serialize(topic, value);
+    }
+
+    @Override
+    protected void appendByteBuffer(ByteBuffer value)
+    {
+        data = BYTE_BUFFER_SERIALIZER.serialize(topic, value);
+    }
+
+    @Override
+    protected void appendSqlDate(SqlDate value)
+    {
+        data = INTEGER_SERIALIZER.serialize(topic, value.getDays());
+    }
+
+    @Override
+    protected void appendSqlTime(SqlTime value)
+    {
+        // Need to determine the precision based on the string value.
+        TimeType type = (TimeType) columnHandles.get(currentColumnIndex).getType();
+        if (type.getPrecision() == TIME_MILLIS.getPrecision()) {
+            data = INTEGER_SERIALIZER.serialize(topic, toIntExact(value.getPicos() / PICOSECONDS_PER_MILLISECOND));
+        }
+        else if (type.getPrecision() == TIME_MICROS.getPrecision()) {
+            data = LONG_SERIALIZER.serialize(topic, value.getPicos() / PICOSECONDS_PER_MICROSECOND);
+        }
+        else {
+            throw new UnsupportedOperationException(format("Unsupported type '%s' for column '%s'", value.getClass().getName(), columnHandles.get(currentColumnIndex).getName()));
+        }
+    }
+
+    @Override
+    protected void appendSqlTimeWithTimeZone(SqlTimeWithTimeZone value)
+    {
+        throw new UnsupportedOperationException(format("Unsupported type '%s' for column '%s'", value.getClass().getName(), columnHandles.get(currentColumnIndex).getName()));
+    }
+
+    @Override
+    protected void appendSqlTimestamp(SqlTimestamp value)
+    {
+        checkState(value.getPrecision() <= MAX_SHORT_PRECISION, "Unsupported precision for timestamp type '%s' must be between 0 and %s", value.getPrecision(), MAX_SHORT_PRECISION);
+        if (value.getPrecision() == TIMESTAMP_MILLIS.getPrecision()) {
+            data = LONG_SERIALIZER.serialize(topic, value.getMillis());
+        }
+        else if (value.getPrecision() == TIMESTAMP_MICROS.getPrecision()) {
+            data = LONG_SERIALIZER.serialize(topic, value.getEpochMicros());
+        }
+        else {
+            throw new UnsupportedOperationException(format("Unsupported type '%s' for column '%s'", value.getClass().getName(), columnHandles.get(currentColumnIndex).getName()));
+        }
+    }
+
+    @Override
+    protected void appendSqlTimestampWithTimeZone(SqlTimestampWithTimeZone value)
+    {
+        throw new UnsupportedOperationException(format("Unsupported type '%s' for column '%s'", value.getClass().getName(), columnHandles.get(currentColumnIndex).getName()));
+    }
+
+    @Override
+    protected void appendArray(List<Object> value)
+    {
+        throw new UnsupportedOperationException(format("Unsupported type '%s' for column '%s'", value.getClass().getName(), columnHandles.get(currentColumnIndex).getName()));
+    }
+
+    @Override
+    protected void appendMap(Map<Object, Object> value)
+    {
+        throw new UnsupportedOperationException(format("Unsupported type '%s' for column '%s'", value.getClass().getName(), columnHandles.get(currentColumnIndex).getName()));
+    }
+
+    @Override
+    protected void appendRow(List<Object> value)
+    {
+        throw new UnsupportedOperationException(format("Unsupported type '%s' for column '%s'", value.getClass().getName(), columnHandles.get(currentColumnIndex).getName()));
+    }
+
+    @Override
+    public byte[] toByteArray()
+    {
+        checkState(data != null || isNull, "Data is not set");
+        byte[] result = data;
+        data = null;
+        isNull = false;
+        resetColumnIndex();
+        return result;
+    }
+
+    public static class Factory
+            implements RowEncoderFactory
+    {
+        @Override
+        public RowEncoder create(ConnectorSession session, RowEncoderSpec rowEncoderSpec)
+        {
+            return new KafkaSerializerRowEncoder(session, rowEncoderSpec.columnHandles(), rowEncoderSpec.topic());
+        }
+    }
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/TrinoToAvroSchemaConverter.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/TrinoToAvroSchemaConverter.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.schema;
+
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.DateType;
+import io.trino.spi.type.DoubleType;
+import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.RealType;
+import io.trino.spi.type.SmallintType;
+import io.trino.spi.type.TimeType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TinyintType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.spi.type.VarcharType;
+import org.apache.avro.Schema;
+
+import static io.trino.spi.type.TimeType.TIME_MICROS;
+import static io.trino.spi.type.TimeType.TIME_MILLIS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static java.lang.String.format;
+import static org.apache.avro.LogicalTypes.date;
+import static org.apache.avro.LogicalTypes.timeMicros;
+import static org.apache.avro.LogicalTypes.timeMillis;
+import static org.apache.avro.LogicalTypes.timestampMicros;
+import static org.apache.avro.LogicalTypes.timestampMillis;
+
+public class TrinoToAvroSchemaConverter
+{
+    private TrinoToAvroSchemaConverter() {}
+
+    public static Schema fromTrinoType(Type trinoType)
+    {
+        if (trinoType instanceof BigintType) {
+            return Schema.create(Schema.Type.LONG);
+        }
+        else if (trinoType instanceof IntegerType || trinoType instanceof SmallintType || trinoType instanceof TinyintType) {
+            return Schema.create(Schema.Type.INT);
+        }
+        else if (trinoType instanceof VarcharType) {
+            return Schema.create(Schema.Type.STRING);
+        }
+        else if (trinoType instanceof BooleanType) {
+            return Schema.create(Schema.Type.BOOLEAN);
+        }
+        else if (trinoType instanceof DoubleType) {
+            return Schema.create(Schema.Type.DOUBLE);
+        }
+        else if (trinoType instanceof RealType) {
+            return Schema.create(Schema.Type.FLOAT);
+        }
+        else if (trinoType instanceof VarbinaryType) {
+            return Schema.create(Schema.Type.BYTES);
+        }
+        else if (trinoType instanceof DateType) {
+            return date().addToSchema(Schema.create(Schema.Type.INT));
+        }
+        else if (isTimestampMillisType(trinoType)) {
+            return timestampMillis().addToSchema(Schema.create(Schema.Type.LONG));
+        }
+        else if (isTimestampMicrosType(trinoType)) {
+            return timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
+        }
+        else if (isTimeMillisType(trinoType)) {
+            return timeMillis().addToSchema(Schema.create(Schema.Type.INT));
+        }
+        else if (isTimeMicrosType(trinoType)) {
+            return timeMicros().addToSchema(Schema.create(Schema.Type.LONG));
+        }
+        else {
+            throw new UnsupportedOperationException(format("Unsupported type for single value key column: %s", trinoType));
+        }
+    }
+
+    private static boolean isTimestampMillisType(Type type)
+    {
+        if (!(type instanceof TimestampType)) {
+            return false;
+        }
+        TimestampType timestampType = (TimestampType) type;
+        return timestampType.getPrecision() == TIMESTAMP_MILLIS.getPrecision();
+    }
+
+    private static boolean isTimestampMicrosType(Type type)
+    {
+        if (!(type instanceof TimestampType)) {
+            return false;
+        }
+        TimestampType timestampType = (TimestampType) type;
+        return timestampType.getPrecision() == TIMESTAMP_MICROS.getPrecision();
+    }
+
+    private static boolean isTimeMillisType(Type type)
+    {
+        if (!(type instanceof TimeType)) {
+            return false;
+        }
+        TimeType timestampType = (TimeType) type;
+        return timestampType.getPrecision() == TIME_MILLIS.getPrecision();
+    }
+
+    private static boolean isTimeMicrosType(Type type)
+    {
+        if (!(type instanceof TimeType)) {
+            return false;
+        }
+        TimeType timestampType = (TimeType) type;
+        return timestampType.getPrecision() == TIME_MICROS.getPrecision();
+    }
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/AbstractConfluentRowEncoder.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/AbstractConfluentRowEncoder.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.schema.confluent;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Shorts;
+import com.google.common.primitives.SignedBytes;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import io.trino.plugin.kafka.encoder.EncoderColumnHandle;
+import io.trino.plugin.kafka.encoder.RowEncoder;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.SqlMap;
+import io.trino.spi.block.SqlRow;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.SqlDate;
+import io.trino.spi.type.SqlTime;
+import io.trino.spi.type.SqlTimestamp;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.spi.type.VarcharType;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecordBuilder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.plugin.kafka.schema.confluent.AvroSchemaConverter.EMPTY_FIELD_MARKER;
+import static io.trino.plugin.kafka.schema.confluent.AvroSchemaConverter.EmptyFieldStrategy.MARK;
+import static io.trino.plugin.kafka.schema.confluent.ConfluentSessionProperties.getEmptyFieldStrategy;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeType.TIME_MICROS;
+import static io.trino.spi.type.TimeType.TIME_MILLIS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.apache.avro.Schema.Type.ENUM;
+
+public abstract class AbstractConfluentRowEncoder
+        implements RowEncoder
+{
+    protected final Schema schema;
+    protected final ConnectorSession session;
+    private int currentColumnIndex;
+    protected final List<EncoderColumnHandle> columnHandles;
+    private final KafkaAvroSerializer kafkaAvroSerializer;
+    private final String topic;
+
+    public AbstractConfluentRowEncoder(ConnectorSession session, List<EncoderColumnHandle> columnHandles, Schema schema, KafkaAvroSerializer kafkaAvroSerializer, String topic)
+    {
+        this.schema = requireNonNull(schema, "schema is null");
+        this.session = requireNonNull(session, "session is null");
+        requireNonNull(columnHandles, "columnHandles is null");
+        this.columnHandles = ImmutableList.copyOf(columnHandles);
+        this.currentColumnIndex = 0;
+        this.kafkaAvroSerializer = requireNonNull(kafkaAvroSerializer, "kafkaAvroSerializer is null");
+        this.topic = requireNonNull(topic, "topic is null");
+    }
+
+    protected abstract Object buildRow();
+
+    protected byte[] serialize(Object object)
+    {
+        return kafkaAvroSerializer.serialize(topic, object);
+    }
+
+    protected abstract void addValue(Block block, int position);
+
+    @Override
+    public void appendColumnValue(Block block, int position)
+    {
+        checkArgument(getCurrentColumnIndex() < columnHandles.size(), format("currentColumnIndex '%d' is greater than number of columns '%d'", getCurrentColumnIndex(), columnHandles.size()));
+        addValue(block, position);
+        currentColumnIndex++;
+    }
+
+    protected Object getValue(Type type, Block block, int position, Schema fieldSchema)
+    {
+        if (block.isNull(position)) {
+            checkState(fieldSchema.isNullable(), "Unexpected null value for non-nullable schema '%s'", fieldSchema.toString(true));
+            return null;
+        }
+        // Since the value is non-null, if this a union, extract complex type
+        fieldSchema = extractBaseType(fieldSchema);
+
+        if (type == BOOLEAN) {
+            return type.getObjectValue(session, block, position);
+        }
+        else if (type == BIGINT) {
+            return type.getLong(block, position);
+        }
+        else if (type == INTEGER) {
+            return toIntExact(type.getLong(block, position));
+        }
+        else if (type == SMALLINT) {
+            return Shorts.checkedCast(type.getLong(block, position));
+        }
+        else if (type == TINYINT) {
+            return SignedBytes.checkedCast(type.getLong(block, position));
+        }
+        else if (type == DOUBLE) {
+            return type.getDouble(block, position);
+        }
+        else if (type == REAL) {
+            return intBitsToFloat(toIntExact(type.getLong(block, position)));
+        }
+        else if (type == DATE) {
+            return ((SqlDate) type.getObjectValue(session, block, position)).getDays();
+        }
+        else if (type == TIME_MILLIS) {
+            return toIntExact(((SqlTime) type.getObjectValue(session, block, position)).getPicos() / PICOSECONDS_PER_MILLISECOND);
+        }
+        else if (type == TIME_MICROS) {
+            return ((SqlTime) type.getObjectValue(session, block, position)).getPicos() / PICOSECONDS_PER_MICROSECOND;
+        }
+        else if (type == TIMESTAMP_MILLIS) {
+            return ((SqlTimestamp) type.getObjectValue(session, block, position)).getMillis();
+        }
+        else if (type == TIMESTAMP_MICROS) {
+            return ((SqlTimestamp) type.getObjectValue(session, block, position)).getEpochMicros();
+        }
+        else if (type instanceof VarcharType) {
+            if (fieldSchema.getType() == ENUM) {
+                return new GenericData.EnumSymbol(fieldSchema, type.getSlice(block, position).toStringUtf8());
+            }
+            return type.getSlice(block, position).toStringUtf8();
+        }
+        else if (type instanceof VarbinaryType) {
+            return type.getSlice(block, position).toByteBuffer();
+        }
+        else if (type instanceof ArrayType) {
+            ArrayType arrayType = (ArrayType) type;
+            Type elementType = arrayType.getElementType();
+            Block arrayBlock = block.getObject(position, Block.class);
+            List<Object> list = new ArrayList(arrayBlock.getPositionCount());
+            Schema elementAvroType = fieldSchema.getElementType();
+            for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
+                list.add(getValue(elementType, arrayBlock, i, elementAvroType));
+            }
+            // Cannot use guava ImmutableList as this list may contain null values
+            return Collections.unmodifiableList(list);
+        }
+        else if (type instanceof MapType) {
+            MapType mapType = (MapType) type;
+            SqlMap sqlMap = block.getObject(position, SqlMap.class);
+            Schema valueSchema = fieldSchema.getValueType();
+            Type valueType = mapType.getValueType();
+            Map<String, Object> map = new HashMap<>();
+            for (int index = 0; index < sqlMap.getSize(); index++) {
+                String key = VARCHAR.getSlice(sqlMap.getRawKeyBlock(), sqlMap.getRawOffset() + index).toStringUtf8();
+                Object value = getValue(valueType, sqlMap.getRawValueBlock(), sqlMap.getRawOffset() + index, valueSchema);
+                map.put(key, value);
+            }
+            // Cannot use guava ImmutableMap as this map may contain null values
+            return Collections.unmodifiableMap(map);
+        }
+        else if (type instanceof RowType) {
+            RowType rowType = (RowType) type;
+            GenericRecordBuilder recordBuilder = new GenericRecordBuilder(fieldSchema);
+            // If the avro schema is a record with no fields and the empty field strategy is ADD_DUMMY, ignore the dummy value being inserted.
+            if (!isEmptyStruct(fieldSchema, rowType)) {
+                checkState(rowType.getFields().size() == fieldSchema.getFields().size(), "Mismatch in number of fields in row and schema");
+                SqlRow sqlRow = block.getObject(position, SqlRow.class);
+                for (int index = 0; index < rowType.getFields().size(); index++) {
+                    RowType.Field field = rowType.getFields().get(index);
+                    Schema.Field avroField = fieldSchema.getFields().get(index);
+                    Schema avroFieldSchema = avroField.schema();
+                    Object value = getValue(field.getType(), sqlRow.getRawFieldBlock(index), sqlRow.getRawIndex() + 0, avroFieldSchema);
+                    recordBuilder.set(avroField, value);
+                }
+            }
+            return recordBuilder.build();
+        }
+        throw new UnsupportedOperationException(format("Unsupported type '%s'", type));
+    }
+
+    @VisibleForTesting
+    public static Schema extractBaseType(Schema schema)
+    {
+        requireNonNull(schema, "schema is null");
+        if (!schema.isUnion()) {
+            return schema;
+        }
+        List<Schema> baseSchema = schema.getTypes().stream()
+                .filter(fieldSchema -> fieldSchema.getType() != Schema.Type.NULL)
+                .map(nonNullSchema -> {
+                    if (nonNullSchema.isUnion()) {
+                        return extractBaseType(nonNullSchema);
+                    }
+                    return nonNullSchema;
+                })
+                .collect(Collectors.toList());
+        checkState(baseSchema.size() == 1, "union with different non-null types not supported");
+        return getOnlyElement(baseSchema);
+    }
+
+    private boolean isEmptyStruct(Schema schema, Type type)
+    {
+        // If the avro schema is a record with no fields and the empty field strategy is ADD_DUMMY
+        checkState(schema.getType() == Schema.Type.RECORD, "Unexpected type '%s' for record schema", schema.getType());
+        checkState(type instanceof RowType, "Unexpected type '%s' for trino struct field", type.getTypeId());
+        if (schema.getFields().isEmpty() && getEmptyFieldStrategy(session) == MARK) {
+            RowType rowType = (RowType) type;
+            if (rowType.getFields().size() == 1) {
+                RowType.Field field = getOnlyElement(rowType.getFields());
+                if (field.getName().isPresent() && field.getName().get().equals(EMPTY_FIELD_MARKER)) {
+                    return field.getType() instanceof BooleanType;
+                }
+            }
+        }
+        return false;
+    }
+
+    private void resetColumnIndex()
+    {
+        currentColumnIndex = 0;
+    }
+
+    protected int getCurrentColumnIndex()
+    {
+        return currentColumnIndex;
+    }
+
+    @Override
+    public byte[] toByteArray()
+    {
+        byte[] bytes = kafkaAvroSerializer.serialize(topic, buildRow());
+        resetColumnIndex();
+        return bytes;
+    }
+
+    @Override
+    public void close() {}
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/AvroConfluentContentSchemaProvider.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/AvroConfluentContentSchemaProvider.java
@@ -44,7 +44,7 @@ public class AvroConfluentContentSchemaProvider
     protected Optional<String> readSchema(Optional<String> dataSchemaLocation, Optional<String> subject)
     {
         if (subject.isEmpty()) {
-            return Optional.empty();
+            return dataSchemaLocation;
         }
         checkState(dataSchemaLocation.isEmpty(), "Unexpected parameter: dataSchemaLocation");
         try {

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/AvroSchemaConverter.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/AvroSchemaConverter.java
@@ -58,9 +58,9 @@ import static org.apache.avro.Schema.Type.UNION;
 
 public class AvroSchemaConverter
 {
-    public static final String DUMMY_FIELD_NAME = "$empty_field_marker";
+    public static final String EMPTY_FIELD_MARKER = "$empty_field_marker";
 
-    public static final RowType DUMMY_ROW_TYPE = RowType.from(ImmutableList.of(new RowType.Field(Optional.of(DUMMY_FIELD_NAME), BooleanType.BOOLEAN)));
+    public static final RowType EMPTY_FIELD_MARKER_TYPE = RowType.from(ImmutableList.of(new RowType.Field(Optional.of(EMPTY_FIELD_MARKER), BooleanType.BOOLEAN)));
 
     public enum EmptyFieldStrategy
     {
@@ -210,7 +210,7 @@ public class AvroSchemaConverter
                 case IGNORE:
                     return Optional.empty();
                 case MARK:
-                    return Optional.of(DUMMY_ROW_TYPE);
+                    return Optional.of(EMPTY_FIELD_MARKER_TYPE);
                 case FAIL:
                     throw new IllegalStateException(format("Struct type has no valid fields for schema: '%s'", schema));
             }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentGenericRecordRowEncoder.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentGenericRecordRowEncoder.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.schema.confluent;
+
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import io.trino.plugin.kafka.encoder.EncoderColumnHandle;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.type.Type;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.plugin.kafka.schema.confluent.AvroSchemaParser.getFields;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.UnaryOperator.identity;
+
+public class ConfluentGenericRecordRowEncoder
+        extends AbstractConfluentRowEncoder
+{
+    private GenericRecordBuilder recordBuilder;
+    private final List<Schema.Field> fields;
+
+    public ConfluentGenericRecordRowEncoder(ConnectorSession session, List<EncoderColumnHandle> columnHandles, Schema schema, KafkaAvroSerializer kafkaAvroSerializer, String topic)
+    {
+        super(session, columnHandles, schema, kafkaAvroSerializer, topic);
+        this.recordBuilder = new GenericRecordBuilder(schema);
+        checkState(schema.getType() == Schema.Type.RECORD, "Unexpected schema type: '%s' should be RECORD", schema.getType());
+        Map<String, Schema.Field> fieldMap = getFields(session, schema).stream()
+                .collect(toImmutableMap(field -> field.name().toLowerCase(ENGLISH), identity()));
+        checkState(columnHandles.size() == fieldMap.size(), "Mismatch between trino and avro schema field count");
+        fields = columnHandles.stream().map(handle -> fieldMap.get(handle.getName().toLowerCase(ENGLISH))).collect(toImmutableList());
+    }
+
+    @Override
+    protected Object buildRow()
+    {
+        GenericRecord record = recordBuilder.build();
+        recordBuilder = new GenericRecordBuilder(schema);
+        return record;
+    }
+
+    @Override
+    protected void addValue(Block block, int position)
+    {
+        Type type = columnHandles.get(getCurrentColumnIndex()).getType();
+        Schema.Field field = requireNonNull(fields.get(getCurrentColumnIndex()), format("Field not found in schema for column: '%s'", columnHandles.get(getCurrentColumnIndex())));
+        if (!block.isNull(position)) {
+            recordBuilder.set(field, getValue(type, block, position, field.schema()));
+        }
+    }
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentModule.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentModule.java
@@ -52,6 +52,9 @@ import io.trino.plugin.kafka.decoder.KafkaRowDecoderFactory;
 import io.trino.plugin.kafka.encoder.DispatchingRowEncoderFactory;
 import io.trino.plugin.kafka.encoder.RowEncoderFactory;
 import io.trino.plugin.kafka.encoder.avro.AvroRowEncoder;
+import io.trino.plugin.kafka.encoder.dummy.DummyRowEncoder;
+import io.trino.plugin.kafka.encoder.dummy.DummyRowEncoderFactory;
+import io.trino.plugin.kafka.encoder.kafka.KafkaSerializerRowEncoder;
 import io.trino.plugin.kafka.encoder.protobuf.ProtobufRowEncoder;
 import io.trino.plugin.kafka.encoder.protobuf.ProtobufSchemaParser;
 import io.trino.plugin.kafka.schema.ContentSchemaProvider;
@@ -169,12 +172,12 @@ public class ConfluentModule
         public void configure(Binder binder)
         {
             MapBinder<String, RowEncoderFactory> encoderFactoriesByName = encoderFactory(binder);
-            encoderFactoriesByName.addBinding(AvroRowEncoder.NAME).toInstance((session, rowEncoderSpec) -> {
-                throw new TrinoException(NOT_SUPPORTED, "Insert not supported");
-            });
+            encoderFactoriesByName.addBinding(AvroRowEncoder.NAME).to(ConfluentRowEncoderFactory.class).in(SINGLETON);
+            encoderFactoriesByName.addBinding(KafkaSerializerRowEncoder.NAME).to(KafkaSerializerRowEncoder.Factory.class).in(SINGLETON);
             encoderFactoriesByName.addBinding(ProtobufRowEncoder.NAME).toInstance((session, rowEncoderSpec) -> {
                 throw new TrinoException(NOT_SUPPORTED, "Insert is not supported for schema registry based tables");
             });
+            encoderFactoriesByName.addBinding(DummyRowEncoder.NAME).to(DummyRowEncoderFactory.class).in(SINGLETON);
             binder.bind(DispatchingRowEncoderFactory.class).in(SINGLETON);
         }
     }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentModule.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentModule.java
@@ -46,6 +46,9 @@ import io.trino.decoder.protobuf.DynamicMessageProvider;
 import io.trino.decoder.protobuf.ProtobufRowDecoder;
 import io.trino.decoder.protobuf.ProtobufRowDecoderFactory;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
+import io.trino.plugin.kafka.decoder.EmptyFieldHandlingAvroRowDecoder;
+import io.trino.plugin.kafka.decoder.EmptyFieldHandlingAvroRowDecoderFactory;
+import io.trino.plugin.kafka.decoder.KafkaRowDecoderFactory;
 import io.trino.plugin.kafka.encoder.DispatchingRowEncoderFactory;
 import io.trino.plugin.kafka.encoder.RowEncoderFactory;
 import io.trino.plugin.kafka.encoder.avro.AvroRowEncoder;
@@ -144,9 +147,11 @@ public class ConfluentModule
         {
             binder.bind(AvroReaderSupplier.Factory.class).to(ConfluentAvroReaderSupplier.Factory.class).in(Scopes.SINGLETON);
             binder.bind(AvroDeserializer.Factory.class).to(AvroBytesDeserializer.Factory.class).in(Scopes.SINGLETON);
-            newMapBinder(binder, String.class, RowDecoderFactory.class).addBinding(AvroRowDecoderFactory.NAME).to(AvroRowDecoderFactory.class).in(Scopes.SINGLETON);
+            binder.bind(AvroRowDecoderFactory.class).in(Scopes.SINGLETON);
+            newMapBinder(binder, String.class, RowDecoderFactory.class).addBinding(EmptyFieldHandlingAvroRowDecoder.NAME).to(EmptyFieldHandlingAvroRowDecoderFactory.class).in(Scopes.SINGLETON);
             newMapBinder(binder, String.class, RowDecoderFactory.class).addBinding(ProtobufRowDecoder.NAME).to(ProtobufRowDecoderFactory.class).in(Scopes.SINGLETON);
             newMapBinder(binder, String.class, RowDecoderFactory.class).addBinding(DummyRowDecoder.NAME).to(DummyRowDecoderFactory.class).in(SINGLETON);
+            newMapBinder(binder, String.class, RowDecoderFactory.class).addBinding(KafkaRowDecoderFactory.NAME).to(KafkaRowDecoderFactory.class).in(SINGLETON);
             binder.bind(DispatchingRowDecoderFactory.class).in(SINGLETON);
 
             configBinder(binder).bindConfig(ProtobufAnySupportConfig.class);

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentRowEncoderFactory.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentRowEncoderFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.schema.confluent;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import io.trino.plugin.kafka.encoder.KafkaFieldType;
+import io.trino.plugin.kafka.encoder.RowEncoder;
+import io.trino.plugin.kafka.encoder.RowEncoderFactory;
+import io.trino.plugin.kafka.encoder.RowEncoderSpec;
+import io.trino.spi.HostAddress;
+import io.trino.spi.connector.ConnectorSession;
+import org.apache.avro.Schema;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG;
+import static java.util.Objects.requireNonNull;
+import static org.apache.avro.Schema.Type.RECORD;
+
+public class ConfluentRowEncoderFactory
+        implements RowEncoderFactory
+{
+    private final SchemaRegistryClient schemaRegistryClient;
+    private final List<String> schemaRegistryUrls;
+
+    @Inject
+    public ConfluentRowEncoderFactory(SchemaRegistryClient schemaRegistryClient, ConfluentSchemaRegistryConfig config)
+    {
+        this.schemaRegistryClient = requireNonNull(schemaRegistryClient, "schemaRegistryClient is null");
+        requireNonNull(config, "config is null");
+        this.schemaRegistryUrls = config.getConfluentSchemaRegistryUrls().stream().map(HostAddress::getHostText)
+                .collect(toImmutableList());
+    }
+
+    @Override
+    public RowEncoder create(ConnectorSession session, RowEncoderSpec rowEncoderSpec)
+    {
+        requireNonNull(rowEncoderSpec, "rowEncoderSpec is null");
+        checkState(rowEncoderSpec.dataSchema().isPresent(), "dataSchema is empty");
+        Schema parsedSchema = new Schema.Parser().parse(rowEncoderSpec.dataSchema().get());
+        KafkaAvroSerializer kafkaAvroSerializer = new KafkaAvroSerializer(schemaRegistryClient);
+        boolean isKey = rowEncoderSpec.kafkaFieldType() == KafkaFieldType.KEY;
+        kafkaAvroSerializer.configure(ImmutableMap.of(SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrls), isKey);
+        if (parsedSchema.getType() == RECORD) {
+            return new ConfluentGenericRecordRowEncoder(session, rowEncoderSpec.columnHandles(), parsedSchema, kafkaAvroSerializer, rowEncoderSpec.topic());
+        }
+        return new ConfluentSingleValueRowEncoder(session, rowEncoderSpec.columnHandles(), parsedSchema, kafkaAvroSerializer, rowEncoderSpec.topic());
+    }
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentSingleValueRowEncoder.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentSingleValueRowEncoder.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.schema.confluent;
+
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import io.trino.plugin.kafka.encoder.EncoderColumnHandle;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarbinaryType;
+import org.apache.avro.Schema;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.EncoderFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Iterables.getOnlyElement;
+
+public class ConfluentSingleValueRowEncoder
+        extends AbstractConfluentRowEncoder
+{
+    private static final ThreadLocal<BinaryEncoder> reuseEncoder = ThreadLocal.withInitial(() -> null);
+
+    private Object singleValue;
+
+    public ConfluentSingleValueRowEncoder(ConnectorSession session, List<EncoderColumnHandle> columnHandles, Schema schema, KafkaAvroSerializer kafkaAvroSerializer, String topic)
+    {
+        super(session, columnHandles, schema, kafkaAvroSerializer, topic);
+        checkState(schema.getType() != Schema.Type.RECORD, "Unexpected RECORD type for single value schema");
+        checkState(columnHandles.size() == 1, "Unexpected size for single value field");
+    }
+
+    @Override
+    protected void addValue(Block block, int position)
+    {
+        Type type = getOnlyElement(columnHandles).getType();
+        singleValue = getValue(type, block, position, schema);
+    }
+
+    @Override
+    protected Object getValue(Type type, Block block, int position, Schema fieldSchema)
+    {
+        Object value = super.getValue(type, block, position, schema);
+        if (type instanceof VarbinaryType) {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            BinaryEncoder encoder = EncoderFactory.get().directBinaryEncoder(outputStream, reuseEncoder.get());
+            reuseEncoder.set(encoder);
+            try {
+                encoder.writeBytes((ByteBuffer) value);
+                encoder.flush();
+                return outputStream.toByteArray();
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+        return value;
+    }
+
+    @Override
+    protected Object buildRow()
+    {
+        Object value = singleValue;
+        singleValue = null;
+        return value;
+    }
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/file/FileTableDescriptionSupplier.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/file/FileTableDescriptionSupplier.java
@@ -114,7 +114,8 @@ public class FileTableDescriptionSupplier
                             Optional.ofNullable(tableName.getSchemaName()),
                             definedTable,
                             Optional.of(new KafkaTopicFieldGroup(DummyRowDecoder.NAME, Optional.empty(), Optional.empty(), ImmutableList.of())),
-                            Optional.of(new KafkaTopicFieldGroup(DummyRowDecoder.NAME, Optional.empty(), Optional.empty(), ImmutableList.of()))));
+                            Optional.of(new KafkaTopicFieldGroup(DummyRowDecoder.NAME, Optional.empty(), Optional.empty(), ImmutableList.of())),
+                            Optional.empty()));
                 }
             }
 

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/file/FileWriteContentSchemaProvider.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/file/FileWriteContentSchemaProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.schema.file;
+
+import io.trino.plugin.kafka.KafkaTableHandle;
+import io.trino.plugin.kafka.schema.ContentSchemaProvider;
+import io.trino.spi.TrinoException;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import static io.trino.plugin.kafka.KafkaErrorCode.KAFKA_SCHEMA_ERROR;
+import static java.lang.String.format;
+
+public class FileWriteContentSchemaProvider
+        implements ContentSchemaProvider
+{
+    @Override
+    public Optional<String> getKey(KafkaTableHandle tableHandle)
+    {
+        return getDataSchema(tableHandle.getKeyDataSchemaLocation());
+    }
+
+    @Override
+    public Optional<String> getMessage(KafkaTableHandle tableHandle)
+    {
+        return getDataSchema(tableHandle.getMessageDataSchemaLocation());
+    }
+
+    private static Optional<String> getDataSchema(Optional<String> dataSchemaLocation)
+    {
+        return dataSchemaLocation.map(location -> {
+            try {
+                return Files.readString(Paths.get(location));
+            }
+            catch (IOException e) {
+                throw new TrinoException(KAFKA_SCHEMA_ERROR, format("Unable to read data schema at '%s'", location), e);
+            }
+        });
+    }
+}

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/KafkaQueryRunner.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/KafkaQueryRunner.java
@@ -180,7 +180,8 @@ public final class KafkaQueryRunner
                 Optional.of(table.getSchemaName()),
                 table.toString(),
                 key,
-                message);
+                message,
+                Optional.empty());
     }
 
     private static Map<SchemaTableName, KafkaTopicDescription> createTpchTopicDescriptions(TypeManager typeManager, Iterable<TpchTable<?>> tables)

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaConnectorTest.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaConnectorTest.java
@@ -119,7 +119,7 @@ public class TestKafkaConnectorTest
                                         createOneFieldDescription("boolean_short", BOOLEAN, "45", "SHORT"),
                                         createOneFieldDescription("boolean_byte", BOOLEAN, "47", "BYTE")))))
                 .put(new SchemaTableName("default", headersTopic),
-                        new KafkaTopicDescription(headersTopic, Optional.empty(), headersTopic, Optional.empty(), Optional.empty()))
+                        new KafkaTopicDescription(headersTopic, Optional.empty(), headersTopic, Optional.empty(), Optional.empty(), Optional.empty()))
                 .putAll(createJsonDateTimeTestTopic())
                 .put(TABLE_INSERT_NEGATIVE_DATE, createDescription(
                         TABLE_INSERT_NEGATIVE_DATE,
@@ -572,7 +572,8 @@ public class TestKafkaConnectorTest
                                         field.getType(),
                                         field.getDataFormat(),
                                         field.getFormatHint()))
-                                .collect(toImmutableList()))))));
+                                .collect(toImmutableList()))),
+                        Optional.empty())));
     }
 
     private static final class JsonDateTimeTestCase

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaWithConfluentConnectorTest.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaWithConfluentConnectorTest.java
@@ -1,0 +1,1502 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.BaseEncoding;
+import dev.failsafe.Failsafe;
+import dev.failsafe.RetryPolicy;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import io.trino.Session;
+import io.trino.plugin.kafka.schema.confluent.KafkaWithConfluentSchemaRegistryQueryRunner;
+import io.trino.spi.type.SqlDate;
+import io.trino.spi.type.SqlTime;
+import io.trino.spi.type.SqlTimestamp;
+import io.trino.spi.type.SqlVarbinary;
+import io.trino.spi.type.Type;
+import io.trino.sql.query.QueryAssertions;
+import io.trino.testing.BaseConnectorTest;
+import io.trino.testing.MaterializedResult;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.TestingConnectorBehavior;
+import io.trino.testing.kafka.TestingKafka;
+import io.trino.testng.services.ManageTestResources;
+import io.trino.type.DateTimes;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.DoubleSerializer;
+import org.apache.kafka.common.serialization.FloatSerializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG;
+import static io.trino.plugin.kafka.schema.confluent.AbstractConfluentRowEncoder.extractBaseType;
+import static io.trino.plugin.kafka.schema.confluent.AvroSchemaConverter.EMPTY_FIELD_MARKER;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.TimeType.TIME_MICROS;
+import static io.trino.spi.type.TimeType.TIME_MILLIS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.testing.MaterializedResult.resultBuilder;
+import static io.trino.tpch.TpchTable.CUSTOMER;
+import static io.trino.tpch.TpchTable.LINE_ITEM;
+import static io.trino.tpch.TpchTable.NATION;
+import static io.trino.tpch.TpchTable.ORDERS;
+import static io.trino.tpch.TpchTable.PART;
+import static io.trino.tpch.TpchTable.PART_SUPPLIER;
+import static io.trino.tpch.TpchTable.REGION;
+import static io.trino.tpch.TpchTable.SUPPLIER;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
+import static org.apache.avro.LogicalTypes.timeMicros;
+import static org.apache.avro.LogicalTypes.timeMillis;
+import static org.apache.avro.LogicalTypes.timestampMicros;
+import static org.apache.avro.LogicalTypes.timestampMillis;
+import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertTrue;
+
+public class TestKafkaWithConfluentConnectorTest
+        extends BaseConnectorTest
+{
+    @ManageTestResources.Suppress(because = "This class is stateless.")
+    private static final RetryPolicy<Object> RETRY_POLICY = RetryPolicy.builder()
+            .withMaxAttempts(10)
+            .withDelay(Duration.ofMillis(100))
+            .build();
+
+    @ManageTestResources.Suppress(because = "This class is stateless, it just invokes one method.")
+    private static final LongSerializer LONG_SERIALIZER = new LongSerializer();
+    @ManageTestResources.Suppress(because = "This class is stateless, it just invokes one method.")
+    private static final IntegerSerializer INTEGER_SERIALIZER = new IntegerSerializer();
+
+    private TestingKafka testingKafka;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        testingKafka = closeAfterClass(TestingKafka.createWithSchemaRegistry());
+        return KafkaWithConfluentSchemaRegistryQueryRunner.builder(testingKafka)
+                .setTables(ImmutableList.of(ORDERS, LINE_ITEM, NATION, REGION, PART, PART_SUPPLIER, SUPPLIER, CUSTOMER))
+                .setExtraKafkaProperties(ImmutableMap.<String, String>builder()
+                        .put("kafka.confluent-subjects-cache-refresh-interval", "1ms")
+                        .buildOrThrow())
+                .build();
+    }
+
+    @Override
+    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
+    {
+        return switch (connectorBehavior) {
+            case SUPPORTS_ADD_COLUMN,
+                    SUPPORTS_AGGREGATION_PUSHDOWN,
+                    SUPPORTS_COMMENT_ON_COLUMN,
+                    SUPPORTS_COMMENT_ON_TABLE,
+                    SUPPORTS_CREATE_SCHEMA,
+                    SUPPORTS_CREATE_TABLE,
+                    SUPPORTS_CREATE_TABLE_WITH_DATA,
+                    SUPPORTS_DELETE,
+                    SUPPORTS_TRUNCATE,
+                    SUPPORTS_INSERT,
+                    SUPPORTS_UPDATE,
+                    SUPPORTS_RENAME_COLUMN,
+                    SUPPORTS_RENAME_TABLE,
+                    SUPPORTS_ROW_TYPE,
+                    SUPPORTS_SET_COLUMN_TYPE,
+                    SUPPORTS_TOPN_PUSHDOWN,
+                    SUPPORTS_MERGE,
+                    SUPPORTS_CREATE_MATERIALIZED_VIEW,
+                    SUPPORTS_CREATE_FEDERATED_MATERIALIZED_VIEW,
+                    SUPPORTS_COMMENT_ON_VIEW,
+                    SUPPORTS_CREATE_VIEW -> false;
+            default -> super.hasBehavior(connectorBehavior);
+        };
+    }
+
+    @Override
+    protected MaterializedResult getDescribeOrdersResult()
+    {
+        return resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("orderkey", "bigint", "", "")
+                .row("custkey", "bigint", "", "")
+                .row("orderstatus", "varchar", "", "")
+                .row("totalprice", "double", "", "")
+                .row("orderdate", "date", "", "")
+                .row("orderpriority", "varchar", "", "")
+                .row("clerk", "varchar", "", "")
+                .row("shippriority", "integer", "", "")
+                .row("comment", "varchar", "", "")
+                .build();
+    }
+
+    @Test
+    @Override
+    public void testShowCreateTable()
+    {
+        String catalog = getSession().getCatalog().orElseThrow();
+        String schema = getSession().getSchema().orElseThrow();
+        assertThat(computeScalar("SHOW CREATE TABLE orders"))
+                // If the connector reports additional column properties, the expected value needs to be adjusted in the test subclass
+                .isEqualTo(format("""
+                                CREATE TABLE %s.%s.orders (
+                                   orderkey bigint,
+                                   custkey bigint,
+                                   orderstatus varchar,
+                                   totalprice double,
+                                   orderdate date,
+                                   orderpriority varchar,
+                                   clerk varchar,
+                                   shippriority integer,
+                                   comment varchar
+                                )""",
+                        catalog, schema));
+    }
+
+    @Override
+    public void testInsert()
+    {
+        // Cannot call the super method as it will insert a row and cause other tests to fail.
+        throw new SkipException("Insert tests do not work without create table");
+    }
+
+    @Override
+    public void testInsertNegativeDate()
+    {
+        // Cannot call the super method as it will insert a row and cause other tests to fail.
+        throw new SkipException("Insert tests do not work without create table");
+    }
+
+    @Test
+    public void testConfluentPrimitiveMessage()
+    {
+        Schema schema = SchemaBuilder.record("test").fields()
+                .name("string_col").type().optional().stringType()
+                .name("bool_col").type().optional().booleanType()
+                .name("int_col").type().optional().intType()
+                .name("long_col").type().optional().longType()
+                .name("float_col").type().optional().floatType()
+                .name("double_col").type().optional().doubleType()
+                .name("bytes_col").type().optional().bytesType()
+                .name("enum_col").type().optional().enumeration("color").symbols("BLUE", "YELLOW", "RED")
+                .endRecord();
+        String topic = "primitive-" + UUID.randomUUID();
+        String tableName = toDoubleQuoted(topic);
+        String keyColumnName = toDoubleQuoted(topic + "-key");
+
+        testingKafka.sendMessages(Stream.of(new ProducerRecord<Long, GenericRecord>(topic, 1L, new GenericRecordBuilder(schema)
+                        .set("string_col", "string_1")
+                        .set("bool_col", true)
+                        .set("int_col", -123)
+                        .set("long_col", 123L)
+                        .set("float_col", -1.5F)
+                        .set("double_col", 2.5D)
+                        .set("bytes_col", ByteBuffer.wrap(new byte[] {1, 2, 3}))
+                        .set("enum_col", new GenericData.EnumSymbol(extractBaseType(schema.getField("enum_col").schema()), "YELLOW"))
+                        .build())),
+                schemaRegistryAwareProducer(testingKafka)
+                        .put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .buildOrThrow());
+        waitUntilTableExists(topic);
+        QueryAssertions queryAssertions = new QueryAssertions(getQueryRunner());
+        queryAssertions.query("SELECT " + keyColumnName + ", string_col, bool_col, int_col, long_col, float_col, double_col, bytes_col, enum_col FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1'," +
+                        "  VARCHAR 'string_1'," +
+                        "  true," +
+                        "  INTEGER '-123'," +
+                        "  BIGINT '123'," +
+                        "  REAL '-1.5'," +
+                        "  DOUBLE '2.5'," +
+                        "  X'01 02 03'," +
+                        "  VARCHAR 'YELLOW')");
+        assertUpdate("INSERT INTO " + tableName + " (" + keyColumnName + ", string_col, bool_col, int_col, long_col, float_col, double_col, bytes_col, enum_col)" +
+                        "  VALUES (BIGINT '2'," +
+                        "  VARCHAR 'string_2'," +
+                        "  false," +
+                        "  INTEGER '-124'," +
+                        "  BIGINT '124'," +
+                        "  REAL '-2.5'," +
+                        "  DOUBLE '3.5'," +
+                        "  X'02 03 04'," +
+                        "  VARCHAR 'RED')," +
+                        "  (BIGINT '3'," +
+                        "  VARCHAR 'string_3'," +
+                        "  true," +
+                        "  INTEGER '-125'," +
+                        "  BIGINT '125'," +
+                        "  REAL '-3.5'," +
+                        "  DOUBLE '4.5'," +
+                        "  X'03 04 05'," +
+                        "  VARCHAR 'BLUE')," +
+                        "  (BIGINT '4'," +
+                        "  CAST(NULL AS VARCHAR)," +
+                        "  CAST(NULL AS BOOLEAN)," +
+                        "  CAST(NULL AS INTEGER)," +
+                        "  CAST(NULL AS BIGINT)," +
+                        "  CAST(NULL AS REAL)," +
+                        "  CAST(NULL AS DOUBLE)," +
+                        "  CAST(NULL AS VARBINARY)," +
+                        "  CAST(NULL AS VARCHAR))",
+                3);
+        queryAssertions.query("SELECT " + keyColumnName + ", string_col, bool_col, int_col, long_col, float_col, double_col, bytes_col, enum_col FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1'," +
+                        "  VARCHAR 'string_1'," +
+                        "  true," +
+                        "  INTEGER '-123'," +
+                        "  BIGINT '123'," +
+                        "  REAL '-1.5'," +
+                        "  DOUBLE '2.5'," +
+                        "  X'01 02 03'," +
+                        "  VARCHAR 'YELLOW')," +
+                        "  (BIGINT '2'," +
+                        "  VARCHAR 'string_2'," +
+                        "  false," +
+                        "  INTEGER '-124'," +
+                        "  BIGINT '124'," +
+                        "  REAL '-2.5'," +
+                        "  DOUBLE '3.5'," +
+                        "  X'02 03 04'," +
+                        "  VARCHAR 'RED')," +
+                        "  (BIGINT '3'," +
+                        "  VARCHAR 'string_3'," +
+                        "  true," +
+                        "  INTEGER '-125'," +
+                        "  BIGINT '125'," +
+                        "  REAL '-3.5'," +
+                        "  DOUBLE '4.5'," +
+                        "  X'03 04 05'," +
+                        "  VARCHAR 'BLUE')," +
+                        "  (BIGINT '4'," +
+                        "  CAST(NULL AS VARCHAR)," +
+                        "  CAST(NULL AS BOOLEAN)," +
+                        "  CAST(NULL AS INTEGER)," +
+                        "  CAST(NULL AS BIGINT)," +
+                        "  CAST(NULL AS REAL)," +
+                        "  CAST(NULL AS DOUBLE)," +
+                        "  CAST(NULL AS VARBINARY)," +
+                        "  CAST(NULL AS VARCHAR))");
+    }
+
+    @Test
+    public void testConfluentArrayMessage()
+    {
+        String topic = "primitive-array-" + UUID.randomUUID();
+        String tableName = toDoubleQuoted(topic);
+        String keyColumnName = toDoubleQuoted(topic + "-key");
+
+        Schema schema = SchemaBuilder.record("test").fields()
+                .name("string_array_col").type().optional().array().items().nullable().stringType()
+                .name("bool_array_col").type().optional().array().items().nullable().booleanType()
+                .name("int_array_col").type().optional().array().items().nullable().intType()
+                .name("long_array_col").type().optional().array().items().nullable().longType()
+                .name("float_array_col").type().optional().array().items().nullable().floatType()
+                .name("double_array_col").type().optional().array().items().nullable().doubleType()
+                .name("bytes_array_col").type().optional().array().items().nullable().bytesType()
+                .endRecord();
+        testingKafka.sendMessages(Stream.of(new ProducerRecord<Long, GenericRecord>(topic, 1L, new GenericRecordBuilder(schema)
+                        .set("string_array_col", Arrays.asList("string_1", "string_2", "string_3"))
+                        .set("bool_array_col", Arrays.asList(true, false, true))
+                        .set("int_array_col", Arrays.asList(-123, 124, -125))
+                        .set("long_array_col", Arrays.asList(123L, -124L, 125L))
+                        .set("float_array_col", Arrays.asList(-1.5F, 2.5F, -3.5F))
+                        .set("double_array_col", Arrays.asList(2.5D, -3.5D, 4.5D))
+                        .set("bytes_array_col", Arrays.asList(ByteBuffer.wrap(new byte[] {1, 2, 3}), ByteBuffer.wrap(new byte[] {2, 3, 4}), ByteBuffer.wrap(new byte[] {3, 4, 5})))
+                        .build())),
+                schemaRegistryAwareProducer(testingKafka)
+                        .put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .buildOrThrow());
+        waitUntilTableExists(topic);
+        QueryAssertions queryAssertions = new QueryAssertions(getQueryRunner());
+        queryAssertions.query("SELECT " + keyColumnName + ", string_array_col, bool_array_col, int_array_col, long_array_col, float_array_col, double_array_col, bytes_array_col FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1'," +
+                        "  CAST(ARRAY['string_1', 'string_2', 'string_3'] AS ARRAY(VARCHAR))," +
+                        "  CAST(ARRAY[true, false, true] AS ARRAY(BOOLEAN))," +
+                        "  CAST(ARRAY[-123, 124, -125] AS ARRAY(INTEGER))," +
+                        "  CAST(ARRAY[123, -124, 125] AS ARRAY(BIGINT))," +
+                        "  CAST(ARRAY[-1.5, 2.5, -3.5] AS ARRAY(REAL))," +
+                        "  CAST(ARRAY[2.5, -3.5, 4.5] AS ARRAY(DOUBLE))," +
+                        "  CAST(ARRAY[X'01 02 03', X'02 03 04', X'03 04 05'] AS ARRAY(VARBINARY)))");
+        assertUpdate("INSERT INTO " + tableName + " (" + keyColumnName + ", string_array_col, bool_array_col, int_array_col, long_array_col, float_array_col, double_array_col, bytes_array_col)" +
+                "  VALUES (BIGINT '2'," +
+                "  CAST(ARRAY['string_1', NULL, 'string_3'] AS ARRAY(VARCHAR))," +
+                "  CAST(ARRAY[false, NULL, false] AS ARRAY(BOOLEAN))," +
+                "  CAST(ARRAY[-223, NULL, -225] AS ARRAY(INTEGER))," +
+                "  CAST(ARRAY[223, NULL, 225] AS ARRAY(BIGINT))," +
+                "  CAST(ARRAY[-2.5, NULL, -4.5] AS ARRAY(REAL))," +
+                "  CAST(ARRAY[3.53, NULL, 5.53] AS ARRAY(DOUBLE))," +
+                "  CAST(ARRAY[X'11 12 13', NULL, X'13 14 15'] AS ARRAY(VARBINARY)))," +
+                "  (BIGINT '3'," +
+                "  CAST(ARRAY['string_1', 'string_2', 'string_3'] AS ARRAY(VARCHAR))," +
+                "  CAST(ARRAY[true, true, false] AS ARRAY(BOOLEAN))," +
+                "  CAST(ARRAY[-323, 324, -325] AS ARRAY(INTEGER))," +
+                "  CAST(ARRAY[323, -324, 325] AS ARRAY(BIGINT))," +
+                "  CAST(ARRAY[-3.5, 4.5, -5.5] AS ARRAY(REAL))," +
+                "  CAST(ARRAY[3.5, -4.5, 5.5] AS ARRAY(DOUBLE))," +
+                "  CAST(ARRAY[X'21 22 03', X'22 23 24', X'23 24 25'] AS ARRAY(VARBINARY)))", 2);
+        queryAssertions.query("SELECT " + keyColumnName + ", string_array_col, bool_array_col, int_array_col, long_array_col, float_array_col, double_array_col, bytes_array_col FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1'," +
+                        "  CAST(ARRAY['string_1', 'string_2', 'string_3'] AS ARRAY(VARCHAR))," +
+                        "  CAST(ARRAY[true, false, true] AS ARRAY(BOOLEAN))," +
+                        "  CAST(ARRAY[-123, 124, -125] AS ARRAY(INTEGER))," +
+                        "  CAST(ARRAY[123, -124, 125] AS ARRAY(BIGINT))," +
+                        "  CAST(ARRAY[-1.5, 2.5, -3.5] AS ARRAY(REAL))," +
+                        "  CAST(ARRAY[2.5, -3.5, 4.5] AS ARRAY(DOUBLE))," +
+                        "  CAST(ARRAY[X'01 02 03', X'02 03 04', X'03 04 05'] AS ARRAY(VARBINARY)))," +
+                        "  (BIGINT '2'," +
+                        "  CAST(ARRAY['string_1', NULL, 'string_3'] AS ARRAY(VARCHAR))," +
+                        "  CAST(ARRAY[false, NULL, false] AS ARRAY(BOOLEAN))," +
+                        "  CAST(ARRAY[-223, NULL, -225] AS ARRAY(INTEGER))," +
+                        "  CAST(ARRAY[223, NULL, 225] AS ARRAY(BIGINT))," +
+                        "  CAST(ARRAY[-2.5, NULL, -4.5] AS ARRAY(REAL))," +
+                        "  CAST(ARRAY[3.53, NULL, 5.53] AS ARRAY(DOUBLE))," +
+                        "  CAST(ARRAY[X'11 12 13', NULL, X'13 14 15'] AS ARRAY(VARBINARY)))," +
+                        "  (BIGINT '3'," +
+                        "  CAST(ARRAY['string_1', 'string_2', 'string_3'] AS ARRAY(VARCHAR))," +
+                        "  CAST(ARRAY[true, true, false] AS ARRAY(BOOLEAN))," +
+                        "  CAST(ARRAY[-323, 324, -325] AS ARRAY(INTEGER))," +
+                        "  CAST(ARRAY[323, -324, 325] AS ARRAY(BIGINT))," +
+                        "  CAST(ARRAY[-3.5, 4.5, -5.5] AS ARRAY(REAL))," +
+                        "  CAST(ARRAY[3.5, -4.5, 5.5] AS ARRAY(DOUBLE))," +
+                        "  CAST(ARRAY[X'21 22 03', X'22 23 24', X'23 24 25'] AS ARRAY(VARBINARY)))");
+    }
+
+    @Test
+    public void testConfluentMapMessage()
+    {
+        String topic = "primitive-map-" + UUID.randomUUID();
+        String tableName = toDoubleQuoted(topic);
+        String keyColumnName = toDoubleQuoted(topic + "-key");
+
+        Schema schema = SchemaBuilder.record("test").fields()
+                .name("string_map_col").type().optional().map().values().nullable().stringType()
+                .name("bool_map_col").type().optional().map().values().nullable().booleanType()
+                .name("int_map_col").type().optional().map().values().nullable().intType()
+                .name("long_map_col").type().optional().map().values().nullable().longType()
+                .name("float_map_col").type().optional().map().values().nullable().floatType()
+                .name("double_map_col").type().optional().map().values().nullable().doubleType()
+                .name("bytes_map_col").type().optional().map().values().nullable().bytesType()
+                .endRecord();
+        testingKafka.sendMessages(Stream.of(new ProducerRecord<Long, GenericRecord>(topic, 1L, new GenericRecordBuilder(schema)
+                        .set("string_map_col", ImmutableMap.of("key1", "val1", "key2", "val2", "key3", "val3"))
+                        .set("bool_map_col", ImmutableMap.of("key1", true, "key2", false, "key3", true))
+                        .set("int_map_col", ImmutableMap.of("key1", -123, "key2", 124, "key3", -125))
+                        .set("long_map_col", ImmutableMap.of("key1", 123L, "key2", -124L, "key3", 125L))
+                        .set("float_map_col", ImmutableMap.of("key1", -1.5F, "key2", 2.5F, "key3", -3.5F))
+                        .set("double_map_col", ImmutableMap.of("key1", 2.5D, "key2", -3.5D, "key3", 4.5D))
+                        .set("bytes_map_col", ImmutableMap.of("key1", ByteBuffer.wrap(new byte[] {1, 2, 3}), "key2", ByteBuffer.wrap(new byte[] {2, 3, 4}), "key3", ByteBuffer.wrap(new byte[] {3, 4, 5})))
+                        .build())),
+                schemaRegistryAwareProducer(testingKafka)
+                        .put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .buildOrThrow());
+        waitUntilTableExists(topic);
+        QueryAssertions queryAssertions = new QueryAssertions(getQueryRunner());
+        queryAssertions.query("SELECT " + keyColumnName + ", string_map_col, bool_map_col, int_map_col, long_map_col, float_map_col, double_map_col, bytes_map_col FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1'," +
+                        "  CAST(MAP(ARRAY['key1', 'key2', 'key3'], ARRAY['val1', 'val2', 'val3']) AS MAP(VARCHAR, VARCHAR))," +
+                        "  CAST(MAP(ARRAY['key1', 'key2', 'key3'], ARRAY[true, false, true]) AS MAP(VARCHAR, BOOLEAN))," +
+                        "  CAST(MAP(ARRAY['key1', 'key2', 'key3'], ARRAY[-123, 124, -125]) AS MAP(VARCHAR, INTEGER))," +
+                        "  CAST(MAP(ARRAY['key1', 'key2', 'key3'], ARRAY[123, -124, 125]) AS MAP(VARCHAR, BIGINT))," +
+                        "  CAST(MAP(ARRAY['key1', 'key2', 'key3'], ARRAY[-1.5, 2.5, -3.5]) AS MAP(VARCHAR, REAL))," +
+                        "  CAST(MAP(ARRAY['key1', 'key2', 'key3'], ARRAY[2.5, -3.5, 4.5]) AS MAP(VARCHAR, DOUBLE))," +
+                        "  CAST(MAP(ARRAY['key1', 'key2', 'key3'], ARRAY[X'01 02 03', X'02 03 04', X'03 04 05']) AS MAP(VARCHAR, VARBINARY)))");
+
+        assertUpdate("INSERT INTO " + tableName + " (" + keyColumnName + ", string_map_col, bool_map_col, int_map_col, long_map_col, float_map_col, double_map_col, bytes_map_col)" +
+                        "  VALUES (BIGINT '2'," +
+                        "  CAST(MAP(ARRAY['key11', 'key12', 'key13'], ARRAY['val11', NULL, 'val13']) AS MAP(VARCHAR, VARCHAR))," +
+                        "  CAST(MAP(ARRAY['key11', 'key12', 'key13'], ARRAY[false, NULL, false]) AS MAP(VARCHAR, BOOLEAN))," +
+                        "  CAST(MAP(ARRAY['key11', 'key12', 'key13'], ARRAY[-223, NULL, -225]) AS MAP(VARCHAR, INTEGER))," +
+                        "  CAST(MAP(ARRAY['key11', 'key12', 'key13'], ARRAY[223, NULL, 225]) AS MAP(VARCHAR, BIGINT))," +
+                        "  CAST(MAP(ARRAY['key11', 'key12', 'key13'], ARRAY[-2.5, NULL, -4.5]) AS MAP(VARCHAR, REAL))," +
+                        "  CAST(MAP(ARRAY['key11', 'key12', 'key13'], ARRAY[3.5, NULL, 5.5]) AS MAP(VARCHAR, DOUBLE))," +
+                        "  CAST(MAP(ARRAY['key11', 'key12', 'key13'], ARRAY[X'11 12 13', NULL, X'13 14 15']) AS MAP(VARCHAR, VARBINARY)))," +
+                        "  (BIGINT '3'," +
+                        "  CAST(MAP(ARRAY['key21', 'key22', 'key23'], ARRAY['val21', 'val22', 'val23']) AS MAP(VARCHAR, VARCHAR))," +
+                        "  CAST(MAP(ARRAY['key21', 'key22', 'key23'], ARRAY[true, true, false]) AS MAP(VARCHAR, BOOLEAN))," +
+                        "  CAST(MAP(ARRAY['key21', 'key22', 'key23'], ARRAY[-323, 324, -325]) AS MAP(VARCHAR, INTEGER))," +
+                        "  CAST(MAP(ARRAY['key21', 'key22', 'key23'], ARRAY[323, -324, 325]) AS MAP(VARCHAR, BIGINT))," +
+                        "  CAST(MAP(ARRAY['key21', 'key22', 'key23'], ARRAY[-3.5, 4.5, -5.5]) AS MAP(VARCHAR, REAL))," +
+                        "  CAST(MAP(ARRAY['key21', 'key22', 'key23'], ARRAY[4.5, -5.5, 6.5]) AS MAP(VARCHAR, DOUBLE))," +
+                        "  CAST(MAP(ARRAY['key21', 'key22', 'key23'], ARRAY[X'21 22 23', X'22 23 24', X'23 24 25']) AS MAP(VARCHAR, VARBINARY)))",
+                2);
+        queryAssertions.query("SELECT " + keyColumnName + ", string_map_col, bool_map_col, int_map_col, long_map_col, float_map_col, double_map_col, bytes_map_col FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1'," +
+                        "  CAST(MAP(ARRAY['key1', 'key2', 'key3'], ARRAY['val1', 'val2', 'val3']) AS MAP(VARCHAR, VARCHAR))," +
+                        "  CAST(MAP(ARRAY['key1', 'key2', 'key3'], ARRAY[true, false, true]) AS MAP(VARCHAR, BOOLEAN))," +
+                        "  CAST(MAP(ARRAY['key1', 'key2', 'key3'], ARRAY[-123, 124, -125]) AS MAP(VARCHAR, INTEGER))," +
+                        "  CAST(MAP(ARRAY['key1', 'key2', 'key3'], ARRAY[123, -124, 125]) AS MAP(VARCHAR, BIGINT))," +
+                        "  CAST(MAP(ARRAY['key1', 'key2', 'key3'], ARRAY[-1.5, 2.5, -3.5]) AS MAP(VARCHAR, REAL))," +
+                        "  CAST(MAP(ARRAY['key1', 'key2', 'key3'], ARRAY[2.5, -3.5, 4.5]) AS MAP(VARCHAR, DOUBLE))," +
+                        "  CAST(MAP(ARRAY['key1', 'key2', 'key3'], ARRAY[X'01 02 03', X'02 03 04', X'03 04 05']) AS MAP(VARCHAR, VARBINARY)))," +
+                        "  (BIGINT '2'," +
+                        "  CAST(MAP(ARRAY['key11', 'key12', 'key13'], ARRAY['val11', NULL, 'val13']) AS MAP(VARCHAR, VARCHAR))," +
+                        "  CAST(MAP(ARRAY['key11', 'key12', 'key13'], ARRAY[false, NULL, false]) AS MAP(VARCHAR, BOOLEAN))," +
+                        "  CAST(MAP(ARRAY['key11', 'key12', 'key13'], ARRAY[-223, NULL, -225]) AS MAP(VARCHAR, INTEGER))," +
+                        "  CAST(MAP(ARRAY['key11', 'key12', 'key13'], ARRAY[223, NULL, 225]) AS MAP(VARCHAR, BIGINT))," +
+                        "  CAST(MAP(ARRAY['key11', 'key12', 'key13'], ARRAY[-2.5, NULL, -4.5]) AS MAP(VARCHAR, REAL))," +
+                        "  CAST(MAP(ARRAY['key11', 'key12', 'key13'], ARRAY[3.5, NULL, 5.5]) AS MAP(VARCHAR, DOUBLE))," +
+                        "  CAST(MAP(ARRAY['key11', 'key12', 'key13'], ARRAY[X'11 12 13', NULL, X'13 14 15']) AS MAP(VARCHAR, VARBINARY)))," +
+                        "  (BIGINT '3'," +
+                        "  CAST(MAP(ARRAY['key21', 'key22', 'key23'], ARRAY['val21', 'val22', 'val23']) AS MAP(VARCHAR, VARCHAR))," +
+                        "  CAST(MAP(ARRAY['key21', 'key22', 'key23'], ARRAY[true, true, false]) AS MAP(VARCHAR, BOOLEAN))," +
+                        "  CAST(MAP(ARRAY['key21', 'key22', 'key23'], ARRAY[-323, 324, -325]) AS MAP(VARCHAR, INTEGER))," +
+                        "  CAST(MAP(ARRAY['key21', 'key22', 'key23'], ARRAY[323, -324, 325]) AS MAP(VARCHAR, BIGINT))," +
+                        "  CAST(MAP(ARRAY['key21', 'key22', 'key23'], ARRAY[-3.5, 4.5, -5.5]) AS MAP(VARCHAR, REAL))," +
+                        "  CAST(MAP(ARRAY['key21', 'key22', 'key23'], ARRAY[4.5, -5.5, 6.5]) AS MAP(VARCHAR, DOUBLE))," +
+                        "  CAST(MAP(ARRAY['key21', 'key22', 'key23'], ARRAY[X'21 22 23', X'22 23 24', X'23 24 25']) AS MAP(VARCHAR, VARBINARY)))");
+    }
+
+    @Test
+    public void testConfluentNestedPrimitiveRowMessage()
+    {
+        String topic = "nested-row-" + UUID.randomUUID();
+        String tableName = toDoubleQuoted(topic);
+        String keyColumnName = toDoubleQuoted(topic + "-key");
+
+        Schema schema = SchemaBuilder.record("test").fields()
+                .name("record_field").type().optional().record("sub_record").fields()
+                .name("string_col").type().optional().stringType()
+                .name("bool_col").type().optional().booleanType()
+                .name("int_col").type().optional().intType()
+                .name("long_col").type().optional().longType()
+                .name("float_col").type().optional().floatType()
+                .name("double_col").type().optional().doubleType()
+                .name("bytes_col").type().optional().bytesType()
+                .endRecord()
+                .endRecord();
+
+        Schema nestedSchema = extractBaseType(schema.getField("record_field").schema());
+
+        testingKafka.sendMessages(Stream.of(new ProducerRecord<Long, GenericRecord>(topic, 1L,
+                        new GenericRecordBuilder(schema)
+                                .set("record_field", new GenericRecordBuilder(nestedSchema)
+                                        .set("string_col", "string_1")
+                                        .set("bool_col", true)
+                                        .set("int_col", -123)
+                                        .set("long_col", 123L)
+                                        .set("float_col", -1.5F)
+                                        .set("double_col", 2.5D)
+                                        .set("bytes_col", ByteBuffer.wrap(new byte[] {1, 2, 3}))
+                                        .build())
+                                .build())),
+                schemaRegistryAwareProducer(testingKafka)
+                        .put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .buildOrThrow());
+        waitUntilTableExists(topic);
+        QueryAssertions queryAssertions = new QueryAssertions(getQueryRunner());
+        queryAssertions.query("SELECT " + keyColumnName + ", record_field FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1'," +
+                        "  CAST(ROW('string_1', true, -123, 123, -1.5, 2.5, X'01 02 03') AS " +
+                        "  ROW(string_col VARCHAR," +
+                        "  bool_col BOOLEAN," +
+                        "  int_col INTEGER," +
+                        "  long_col BIGINT," +
+                        "  float_col REAL," +
+                        "  double_col DOUBLE," +
+                        "  bytes_col VARBINARY)))");
+
+        assertUpdate("INSERT INTO " + tableName + " (" + keyColumnName + ", record_field)" +
+                        "  VALUES (BIGINT '2'," +
+                        "  ROW('string_2', false, -124, 124, -2.5, 3.5, X'02 03 04'))," +
+                        "  (BIGINT '3'," +
+                        "  ROW('string_3', true, -125, 125, -3.5, 4.5, X'03 04 05'))," +
+                        "  (BIGINT '4'," +
+                        "  CAST(NULL AS ROW(VARCHAR, BOOLEAN, INTEGER, BIGINT, REAL, DOUBLE, VARBINARY)))," +
+                        "  (BIGINT '5'," +
+                        "  CAST(ROW(NULL, NULL, NULL, NULL, NULL, NULL, NULL) AS ROW(VARCHAR, BOOLEAN, INTEGER, BIGINT, REAL, DOUBLE, VARBINARY)))",
+                4);
+        queryAssertions.query("SELECT " + keyColumnName + ", record_field FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1'," +
+                        "  CAST(ROW('string_1', true, -123, 123, -1.5, 2.5, X'01 02 03') AS " +
+                        "  ROW(string_col VARCHAR," +
+                        "  bool_col BOOLEAN," +
+                        "  int_col INTEGER," +
+                        "  long_col BIGINT," +
+                        "  float_col REAL," +
+                        "  double_col DOUBLE," +
+                        "  bytes_col VARBINARY)))," +
+                        "  (BIGINT '2'," +
+                        "  CAST(ROW('string_2', false, -124, 124, -2.5, 3.5, X'02 03 04') AS " +
+                        "  ROW(string_col VARCHAR," +
+                        "  bool_col BOOLEAN," +
+                        "  int_col INTEGER," +
+                        "  long_col BIGINT," +
+                        "  float_col REAL," +
+                        "  double_col DOUBLE," +
+                        "  bytes_col VARBINARY)))," +
+                        "  (BIGINT '3'," +
+                        "  CAST(ROW('string_3', true, -125, 125, -3.5, 4.5, X'03 04 05') AS " +
+                        "  ROW(string_col VARCHAR," +
+                        "  bool_col BOOLEAN," +
+                        "  int_col INTEGER," +
+                        "  long_col BIGINT," +
+                        "  float_col REAL," +
+                        "  double_col DOUBLE," +
+                        "  bytes_col VARBINARY)))," +
+                        "  (BIGINT '4'," +
+                        "  CAST(NULL AS" +
+                        "  ROW(string_col VARCHAR," +
+                        "  bool_col BOOLEAN," +
+                        "  int_col INTEGER," +
+                        "  long_col BIGINT," +
+                        "  float_col REAL," +
+                        "  double_col DOUBLE," +
+                        "  bytes_col VARBINARY)))," +
+                        "  (BIGINT '5'," +
+                        "  CAST(ROW(NULL, NULL, NULL, NULL, NULL, NULL, NULL) AS" +
+                        "  ROW(string_col VARCHAR," +
+                        "  bool_col BOOLEAN," +
+                        "  int_col INTEGER," +
+                        "  long_col BIGINT," +
+                        "  float_col REAL," +
+                        "  double_col DOUBLE," +
+                        "  bytes_col VARBINARY)))");
+    }
+
+    @Test
+    public void testEmptyStructWithMarkStrategy()
+    {
+        /**
+         * Avro allows records with no fields. Although it is not a recommended practice,
+         * this can occur when converting from a protobuf.
+         *
+         * Test using the MARK strategy which adds a dummy field.
+         * This will return the empty struct with a dummy field, so it does not throw and error:
+         * RowType must have a non-empty field list.
+         */
+
+        String topic = "empty-struct-add-dummy-" + UUID.randomUUID();
+        String tableName = toDoubleQuoted(topic);
+        String keyColumnName = toDoubleQuoted(topic + "-key");
+
+        Schema schema = SchemaBuilder.record("test").fields()
+                .name("record_field").type().optional().record("sub_record").fields()
+                .endRecord()
+                .endRecord();
+
+        Schema recordField = extractBaseType(schema.getField("record_field").schema());
+
+        testingKafka.sendMessages(Stream.of(new ProducerRecord<Long, GenericRecord>(topic, 1L,
+                        new GenericRecordBuilder(schema)
+                                .set("record_field", new GenericRecordBuilder(recordField).build())
+                                .build())),
+                schemaRegistryAwareProducer(testingKafka)
+                        .put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .buildOrThrow());
+        Session addDummySession = Session.builder(getQueryRunner().getDefaultSession())
+                .setCatalogSessionProperty("kafka", "empty_field_strategy", "MARK").build();
+        waitUntilTableExists(addDummySession, topic);
+
+        QueryAssertions queryAssertions = new QueryAssertions(getQueryRunner());
+        queryAssertions.query(addDummySession, "SELECT %s, record_field FROM %s".formatted(keyColumnName, tableName))
+                .assertThat()
+                .matches("""
+                        VALUES (CAST(1 AS BIGINT),
+                        CAST(ROW(NULL) AS ROW("%s" BOOLEAN)))""".formatted(EMPTY_FIELD_MARKER));
+        assertUpdate(addDummySession, """
+                INSERT INTO %s (%s, record_field)
+                VALUES (CAST(2 AS BIGINT),
+                ROW(NULL)),
+                (CAST(3 AS BIGINT),
+                ROW(NULL))""".formatted(tableName, keyColumnName), 2);
+        queryAssertions.query(addDummySession, "SELECT %s, record_field FROM %s".formatted(keyColumnName, tableName))
+                .assertThat()
+                .matches("""
+                        VALUES (CAST(1 AS BIGINT),
+                        CAST(ROW(NULL) AS ROW("%1$s" BOOLEAN))),
+                        (CAST(2 AS BIGINT),
+                        CAST(ROW(NULL) AS ROW("%1$s" BOOLEAN))),
+                        (CAST(3 AS BIGINT),
+                        CAST(ROW(NULL) AS ROW("%1$s" BOOLEAN)))""".formatted(EMPTY_FIELD_MARKER));
+    }
+
+    @Test
+    public void testEmptyStructWithIgnoreStrategy()
+    {
+        /**
+         * Avro allows records with no fields. Although it is not a recommended practice,
+         * this can occur when converting from a protobuf.
+         *
+         * The default empty struct strategy is to ignore these fields.
+         */
+
+        String topic = "empty-struct-ignore-" + UUID.randomUUID();
+        String tableName = toDoubleQuoted(topic);
+        String keyColumnName = toDoubleQuoted(topic + "-key");
+
+        Schema schema = SchemaBuilder.record("test").fields()
+                .name("string_col").type().optional().stringType()
+                .name("record_field").type().optional().record("sub_record").fields()
+                .endRecord()
+                .endRecord();
+
+        testingKafka.sendMessages(Stream.of(new ProducerRecord<Long, GenericRecord>(topic, 1L,
+                        new GenericRecordBuilder(schema)
+                                .set("string_col", "string_1")
+                                .build())),
+                schemaRegistryAwareProducer(testingKafka)
+                        .put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .buildOrThrow());
+        waitUntilTableExists(topic);
+
+        QueryAssertions queryAssertions = new QueryAssertions(getQueryRunner());
+        queryAssertions.query("SELECT " + keyColumnName + ", string_col FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (CAST(1 AS BIGINT)," +
+                        "  VARCHAR 'string_1')");
+        assertUpdate("INSERT INTO " + tableName + " (" + keyColumnName + ", string_col)" +
+                "  VALUES (CAST(2 AS BIGINT)," +
+                "  VARCHAR 'string_2')," +
+                "  (CAST(3 AS BIGINT)," +
+                "  VARCHAR 'string_3')", 2);
+        queryAssertions.query("SELECT " + keyColumnName + ", string_col FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (CAST(1 AS BIGINT)," +
+                        "  VARCHAR 'string_1')," +
+                        "  (CAST(2 AS BIGINT)," +
+                        "  VARCHAR 'string_2')," +
+                        "  (CAST(3 AS BIGINT)," +
+                        "  VARCHAR 'string_3')");
+    }
+
+    @Test
+    public void testBoundaryValues()
+    {
+        // Test Nan, -Infinity, +Infinity, -0, 0, min and max values for numeric data types.
+        Schema schema = SchemaBuilder.record("test").fields()
+                .name("int_col").type().optional().intType()
+                .name("long_col").type().optional().longType()
+                .name("float_col").type().optional().floatType()
+                .name("double_col").type().optional().doubleType()
+                .endRecord();
+        String topic = "boundary-" + UUID.randomUUID();
+        String tableName = toDoubleQuoted(topic);
+        String keyColumnName = toDoubleQuoted(topic + "-key");
+
+        testingKafka.sendMessages(Stream.of(new ProducerRecord<Long, GenericRecord>(topic, 1L, new GenericRecordBuilder(schema)
+                        .set("int_col", -0)
+                        .set("long_col", -0L)
+                        .set("float_col", -0.0F)
+                        .set("double_col", -0.0D)
+                        .build())),
+                schemaRegistryAwareProducer(testingKafka)
+                        .put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .buildOrThrow());
+        waitUntilTableExists(topic);
+        QueryAssertions queryAssertions = new QueryAssertions(getQueryRunner());
+        queryAssertions.query("SELECT " + keyColumnName + ", int_col, long_col, float_col, double_col FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1'," +
+                        "  INTEGER '0'," +
+                        "  BIGINT '0'," +
+                        "  REAL '-0.0'," +
+                        "  DOUBLE '-0.0')");
+        assertUpdate("INSERT INTO " + tableName + " (" + keyColumnName + ", int_col, long_col, float_col, double_col)" +
+                        "  VALUES (BIGINT '2'," +
+                        "  INTEGER '" + Integer.MIN_VALUE + "'," +
+                        "  BIGINT '" + Long.MIN_VALUE + "'," +
+                        "  REAL '" + Float.MIN_VALUE + "'," +
+                        "  DOUBLE '" + Double.MIN_VALUE + "')," +
+                        "  (BIGINT '3'," +
+                        "  INTEGER '" + Integer.MAX_VALUE + "'," +
+                        "  BIGINT '" + Long.MAX_VALUE + "'," +
+                        "  REAL '" + Float.MAX_VALUE + "'," +
+                        "  DOUBLE '" + Double.MAX_VALUE + "')," +
+                        "  (BIGINT '4'," +
+                        "  INTEGER '" + Integer.MIN_VALUE + "'," +
+                        "  BIGINT '" + Long.MIN_VALUE + "'," +
+                        "  REAL '" + Float.NEGATIVE_INFINITY + "'," +
+                        "  DOUBLE '" + Double.NEGATIVE_INFINITY + "')," +
+                        "  (BIGINT '5'," +
+                        "  INTEGER '" + Integer.MAX_VALUE + "'," +
+                        "  BIGINT '" + Long.MAX_VALUE + "'," +
+                        "  REAL '" + Float.POSITIVE_INFINITY + "'," +
+                        "  DOUBLE '" + Double.POSITIVE_INFINITY + "')," +
+                        "  (BIGINT '6'," +
+                        "  INTEGER '" + Integer.MAX_VALUE + "'," +
+                        "  BIGINT '" + Long.MAX_VALUE + "'," +
+                        "  REAL '" + Float.NaN + "'," +
+                        "  DOUBLE '" + Double.NaN + "')",
+                5);
+        queryAssertions.query("SELECT " + keyColumnName + ", int_col, long_col, float_col, double_col FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1'," +
+                        "  INTEGER '0'," +
+                        "  BIGINT '0'," +
+                        "  REAL '-0.0'," +
+                        "  DOUBLE '-0.0')," +
+                        "  (BIGINT '2'," +
+                        "  INTEGER '" + Integer.MIN_VALUE + "'," +
+                        "  BIGINT '" + Long.MIN_VALUE + "'," +
+                        "  REAL '" + Float.MIN_VALUE + "'," +
+                        "  DOUBLE '" + Double.MIN_VALUE + "')," +
+                        "  (BIGINT '3'," +
+                        "  INTEGER '" + Integer.MAX_VALUE + "'," +
+                        "  BIGINT '" + Long.MAX_VALUE + "'," +
+                        "  REAL '" + Float.MAX_VALUE + "'," +
+                        "  DOUBLE '" + Double.MAX_VALUE + "')," +
+                        "  (BIGINT '4'," +
+                        "  INTEGER '" + Integer.MIN_VALUE + "'," +
+                        "  BIGINT '" + Long.MIN_VALUE + "'," +
+                        "  REAL '" + Float.NEGATIVE_INFINITY + "'," +
+                        "  DOUBLE '" + Double.NEGATIVE_INFINITY + "')," +
+                        "  (BIGINT '5'," +
+                        "  INTEGER '" + Integer.MAX_VALUE + "'," +
+                        "  BIGINT '" + Long.MAX_VALUE + "'," +
+                        "  REAL '" + Float.POSITIVE_INFINITY + "'," +
+                        "  DOUBLE '" + Double.POSITIVE_INFINITY + "')," +
+                        "  (BIGINT '6'," +
+                        "  INTEGER '" + Integer.MAX_VALUE + "'," +
+                        "  BIGINT '" + Long.MAX_VALUE + "'," +
+                        "  REAL '" + Float.NaN + "'," +
+                        "  DOUBLE '" + Double.NaN + "')");
+    }
+
+    @Test
+    public void testNestedArrayMessages()
+    {
+        String topic = "array-of-array-" + UUID.randomUUID();
+        String tableName = toDoubleQuoted(topic);
+        String keyColumnName = toDoubleQuoted(topic + "-key");
+
+        Schema schema = SchemaBuilder.record("nested").fields()
+                .name("array_array").type().optional().array().items().nullable().array().items().nullable().stringType()
+                .endRecord();
+
+        testingKafka.sendMessages(Stream.of(new ProducerRecord<Long, GenericRecord>(topic, 1L,
+                        new GenericRecordBuilder(schema)
+                                .set("array_array", Arrays.asList(Arrays.asList("string_1", null, "string_2")))
+                                .build())),
+                schemaRegistryAwareProducer(testingKafka)
+                        .put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .buildOrThrow());
+        waitUntilTableExists(topic);
+        QueryAssertions queryAssertions = new QueryAssertions(getQueryRunner());
+        queryAssertions.query("SELECT " + keyColumnName + ", array_array FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1', CAST(ARRAY[ARRAY['string_1', NULL, 'string_2']] AS ARRAY(ARRAY(VARCHAR))))");
+        assertUpdate("INSERT INTO " + tableName + " (" + keyColumnName + ", array_array)" +
+                        "  VALUES (BIGINT '2', CAST(ARRAY[ARRAY['string_3', NULL, 'string_4']] AS ARRAY(ARRAY(VARCHAR))))," +
+                        "  (BIGINT '3', CAST(ARRAY[ARRAY['string_5', NULL, 'string_6']] AS ARRAY(ARRAY(VARCHAR))))",
+                2);
+        queryAssertions.query("SELECT " + keyColumnName + ", array_array FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1', CAST(ARRAY[ARRAY['string_1', NULL, 'string_2']] AS ARRAY(ARRAY(VARCHAR))))," +
+                        "  (BIGINT '2', CAST(ARRAY[ARRAY['string_3', NULL, 'string_4']] AS ARRAY(ARRAY(VARCHAR))))," +
+                        "  (BIGINT '3', CAST(ARRAY[ARRAY['string_5', NULL, 'string_6']] AS ARRAY(ARRAY(VARCHAR))))");
+
+        topic = "array-of-map-" + UUID.randomUUID();
+        tableName = toDoubleQuoted(topic);
+        keyColumnName = toDoubleQuoted(topic + "-key");
+
+        schema = SchemaBuilder.record("nested").fields()
+                .name("array_map").type().optional().array().items().nullable().map().values().nullable().stringType()
+                .endRecord();
+
+        testingKafka.sendMessages(Stream.of(new ProducerRecord<Long, GenericRecord>(topic, 1L,
+                        new GenericRecordBuilder(schema)
+                                .set("array_map", Arrays.asList(ImmutableMap.of("key_1", "value_1", "key_2", "value_2")))
+                                .build())),
+                schemaRegistryAwareProducer(testingKafka)
+                        .put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .buildOrThrow());
+        waitUntilTableExists(topic);
+        queryAssertions.query("SELECT " + keyColumnName + ", array_map FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1', CAST(ARRAY[MAP(ARRAY['key_1', 'key_2'], ARRAY['value_1', 'value_2'])] AS ARRAY(MAP(VARCHAR, VARCHAR))))");
+        assertUpdate("INSERT INTO " + tableName + " (" + keyColumnName + ", array_map)" +
+                        "  VALUES (BIGINT '2', CAST(ARRAY[MAP(ARRAY['key_3', 'key_4'], ARRAY['value_3', 'value_4'])] AS ARRAY(MAP(VARCHAR, VARCHAR))))," +
+                        "  (BIGINT '3', CAST(ARRAY[MAP(ARRAY['key_5', 'key_6'], ARRAY['value_5', 'value_6'])] AS ARRAY(MAP(VARCHAR, VARCHAR))))",
+                2);
+        queryAssertions.query("SELECT " + keyColumnName + ", array_map FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1', CAST(ARRAY[MAP(ARRAY['key_1', 'key_2'], ARRAY['value_1', 'value_2'])] AS ARRAY(MAP(VARCHAR, VARCHAR))))," +
+                        "  (BIGINT '2', CAST(ARRAY[MAP(ARRAY['key_3', 'key_4'], ARRAY['value_3', 'value_4'])] AS ARRAY(MAP(VARCHAR, VARCHAR))))," +
+                        "  (BIGINT '3', CAST(ARRAY[MAP(ARRAY['key_5', 'key_6'], ARRAY['value_5', 'value_6'])] AS ARRAY(MAP(VARCHAR, VARCHAR))))");
+
+        topic = "array-of-row-" + UUID.randomUUID();
+        tableName = toDoubleQuoted(topic);
+        keyColumnName = toDoubleQuoted(topic + "-key");
+
+        schema = SchemaBuilder.record("nested").fields()
+                .name("array_row").type().optional().array().items().nullable()
+                .record("row").fields().name("string_col").type().optional().stringType().endRecord()
+                .endRecord();
+        Schema nestedSchema = extractBaseType(extractBaseType(schema.getField("array_row").schema()).getElementType());
+        testingKafka.sendMessages(Stream.of(new ProducerRecord<Long, GenericRecord>(topic, 1L,
+                        new GenericRecordBuilder(schema)
+                                .set("array_row", Arrays.asList(new GenericRecordBuilder(nestedSchema)
+                                        .set("string_col", "string_1")
+                                        .build()))
+                                .build())),
+                schemaRegistryAwareProducer(testingKafka)
+                        .put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .buildOrThrow());
+        waitUntilTableExists(topic);
+        queryAssertions.query("SELECT " + keyColumnName + ", array_row FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1', CAST(ARRAY[ROW('string_1')] AS ARRAY(ROW(string_col VARCHAR))))");
+        assertUpdate("INSERT INTO " + tableName + " (" + keyColumnName + ", array_row)" +
+                        "  VALUES (BIGINT '2', CAST(ARRAY[ROW('string_2')] AS ARRAY(ROW(string_col VARCHAR))))," +
+                        "  (BIGINT '3', CAST(ARRAY[ROW('string_3')] AS ARRAY(ROW(string_col VARCHAR))))",
+                2);
+        queryAssertions.query("SELECT " + keyColumnName + ", array_row FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1', CAST(ARRAY[ROW('string_1')] AS ARRAY(ROW(string_col VARCHAR))))," +
+                        "  (BIGINT '2', CAST(ARRAY[ROW('string_2')] AS ARRAY(ROW(string_col VARCHAR))))," +
+                        "  (BIGINT '3', CAST(ARRAY[ROW('string_3')] AS ARRAY(ROW(string_col VARCHAR))))");
+    }
+
+    @Test
+    public void testNestedMapMessages()
+    {
+        String topic = "map-of-array-" + UUID.randomUUID();
+        String tableName = toDoubleQuoted(topic);
+        String keyColumnName = toDoubleQuoted(topic + "-key");
+
+        Schema schema = SchemaBuilder.record("nested").fields()
+                .name("map_array").type().optional().map().values().nullable().array().items().nullable().stringType()
+                .endRecord();
+
+        testingKafka.sendMessages(Stream.of(new ProducerRecord<Long, GenericRecord>(topic, 1L,
+                        new GenericRecordBuilder(schema)
+                                .set("map_array", ImmutableMap.of("key_1", Arrays.asList("string_1", null, "string_2")))
+                                .build())),
+                schemaRegistryAwareProducer(testingKafka)
+                        .put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .buildOrThrow());
+        waitUntilTableExists(topic);
+        QueryAssertions queryAssertions = new QueryAssertions(getQueryRunner());
+        queryAssertions.query("SELECT " + keyColumnName + ", map_array FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1', CAST(MAP(ARRAY['key_1'], ARRAY[ARRAY['string_1', NULL, 'string_2']]) AS MAP(VARCHAR, ARRAY(VARCHAR))))");
+        assertUpdate("INSERT INTO " + tableName + " (" + keyColumnName + ", map_array)" +
+                        "  VALUES (BIGINT '2', CAST(MAP(ARRAY['key_2'], ARRAY[ARRAY['string_3', NULL, 'string_4']]) AS MAP(VARCHAR, ARRAY(VARCHAR))))," +
+                        "  (BIGINT '3', CAST(MAP(ARRAY['key_3'], ARRAY[ARRAY['string_5', NULL, 'string_6']]) AS MAP(VARCHAR, ARRAY(VARCHAR))))",
+                2);
+        queryAssertions.query("SELECT " + keyColumnName + ", map_array FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1', CAST(MAP(ARRAY['key_1'], ARRAY[ARRAY['string_1', NULL, 'string_2']]) AS MAP(VARCHAR, ARRAY(VARCHAR))))," +
+                        "  (BIGINT '2', CAST(MAP(ARRAY['key_2'], ARRAY[ARRAY['string_3', NULL, 'string_4']]) AS MAP(VARCHAR, ARRAY(VARCHAR))))," +
+                        "  (BIGINT '3', CAST(MAP(ARRAY['key_3'], ARRAY[ARRAY['string_5', NULL, 'string_6']]) AS MAP(VARCHAR, ARRAY(VARCHAR))))");
+
+        topic = "map-of-map-" + UUID.randomUUID();
+        tableName = toDoubleQuoted(topic);
+        keyColumnName = toDoubleQuoted(topic + "-key");
+
+        schema = SchemaBuilder.record("nested").fields()
+                .name("map_map").type().optional().map().values().nullable().map().values().nullable().stringType()
+                .endRecord();
+
+        testingKafka.sendMessages(Stream.of(new ProducerRecord<Long, GenericRecord>(topic, 1L,
+                        new GenericRecordBuilder(schema)
+                                .set("map_map", ImmutableMap.of("key_1", ImmutableMap.of("key_1", "value_1", "key_2", "value_2")))
+                                .build())),
+                schemaRegistryAwareProducer(testingKafka)
+                        .put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .buildOrThrow());
+        waitUntilTableExists(topic);
+        queryAssertions.query("SELECT " + keyColumnName + ", map_map FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1', CAST(MAP(ARRAY['key_1'], ARRAY[MAP(ARRAY['key_1', 'key_2'], ARRAY['value_1', 'value_2'])]) AS MAP(VARCHAR, MAP(VARCHAR, VARCHAR))))");
+        assertUpdate("INSERT INTO " + tableName + " (" + keyColumnName + ", map_map)" +
+                        "  VALUES (BIGINT '2', CAST(MAP(ARRAY['key_2'], ARRAY[MAP(ARRAY['key_1', 'key_2'], ARRAY['value_1', 'value_2'])]) AS MAP(VARCHAR, MAP(VARCHAR, VARCHAR))))," +
+                        "  (BIGINT '3', CAST(MAP(ARRAY['key_3'], ARRAY[MAP(ARRAY['key_1', 'key_2'], ARRAY['value_1', 'value_2'])]) AS MAP(VARCHAR, MAP(VARCHAR, VARCHAR))))",
+                2);
+        queryAssertions.query("SELECT " + keyColumnName + ", map_map FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1', CAST(MAP(ARRAY['key_1'], ARRAY[MAP(ARRAY['key_1', 'key_2'], ARRAY['value_1', 'value_2'])]) AS MAP(VARCHAR, MAP(VARCHAR, VARCHAR))))," +
+                        "  (BIGINT '2', CAST(MAP(ARRAY['key_2'], ARRAY[MAP(ARRAY['key_1', 'key_2'], ARRAY['value_1', 'value_2'])]) AS MAP(VARCHAR, MAP(VARCHAR, VARCHAR))))," +
+                        "  (BIGINT '3', CAST(MAP(ARRAY['key_3'], ARRAY[MAP(ARRAY['key_1', 'key_2'], ARRAY['value_1', 'value_2'])]) AS MAP(VARCHAR, MAP(VARCHAR, VARCHAR))))");
+
+        topic = "map-of-row-" + UUID.randomUUID();
+        tableName = toDoubleQuoted(topic);
+        keyColumnName = toDoubleQuoted(topic + "-key");
+
+        schema = SchemaBuilder.record("nested").fields()
+                .name("map_row").type().optional().map().values().nullable()
+                .record("row").fields().name("string_col").type().optional().stringType().endRecord()
+                .endRecord();
+        Schema nestedSchema = extractBaseType(extractBaseType(schema.getField("map_row").schema()).getValueType());
+        testingKafka.sendMessages(Stream.of(new ProducerRecord<Long, GenericRecord>(topic, 1L,
+                        new GenericRecordBuilder(schema)
+                                .set("map_row", ImmutableMap.of("key_1", new GenericRecordBuilder(nestedSchema)
+                                        .set("string_col", "string_1")
+                                        .build()))
+                                .build())),
+                schemaRegistryAwareProducer(testingKafka)
+                        .put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .buildOrThrow());
+        waitUntilTableExists(topic);
+        queryAssertions.query("SELECT " + keyColumnName + ", map_row FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1', CAST(MAP(ARRAY['key_1'], ARRAY[ROW('string_1')]) AS MAP(VARCHAR, ROW(string_col VARCHAR))))");
+        assertUpdate("INSERT INTO " + tableName + " (" + keyColumnName + ", map_row)" +
+                        "  VALUES (BIGINT '2', CAST(MAP(ARRAY['key_2'], ARRAY[ROW('string_1')]) AS MAP(VARCHAR, ROW(string_col VARCHAR))))," +
+                        "  (BIGINT '3', CAST(MAP(ARRAY['key_3'], ARRAY[ROW('string_1')]) AS MAP(VARCHAR, ROW(string_col VARCHAR))))",
+                2);
+        queryAssertions.query("SELECT " + keyColumnName + ", map_row FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1', CAST(MAP(ARRAY['key_1'], ARRAY[ROW('string_1')]) AS MAP(VARCHAR, ROW(string_col VARCHAR))))," +
+                        "  (BIGINT '2', CAST(MAP(ARRAY['key_2'], ARRAY[ROW('string_1')]) AS MAP(VARCHAR, ROW(string_col VARCHAR))))," +
+                        "  (BIGINT '3', CAST(MAP(ARRAY['key_3'], ARRAY[ROW('string_1')]) AS MAP(VARCHAR, ROW(string_col VARCHAR))))");
+    }
+
+    @Test
+    public void testNestedRowMessages()
+    {
+        String topic = "row-of-array-" + UUID.randomUUID();
+        String tableName = toDoubleQuoted(topic);
+        String keyColumnName = toDoubleQuoted(topic + "-key");
+
+        Schema schema = SchemaBuilder.record("nested").fields()
+                .name("row_array").type().optional()
+                .record("row").fields().name("array_field").type()
+                .optional().array().items().nullable().stringType().endRecord()
+                .endRecord();
+
+        Schema nestedSchema = extractBaseType(schema.getField("row_array").schema());
+        testingKafka.sendMessages(Stream.of(new ProducerRecord<Long, GenericRecord>(topic, 1L,
+                        new GenericRecordBuilder(schema)
+                                .set("row_array", new GenericRecordBuilder(nestedSchema)
+                                        .set("array_field", Arrays.asList("string_1", null, "string_2"))
+                                        .build())
+                                .build())),
+                schemaRegistryAwareProducer(testingKafka)
+                        .put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .buildOrThrow());
+        waitUntilTableExists(topic);
+        QueryAssertions queryAssertions = new QueryAssertions(getQueryRunner());
+        queryAssertions.query("SELECT " + keyColumnName + ", row_array FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1', CAST(ROW(ARRAY['string_1', NULL, 'string_2']) AS ROW(array_field ARRAY(VARCHAR))))");
+        assertUpdate("INSERT INTO " + tableName + " (" + keyColumnName + ", row_array)" +
+                        "  VALUES (BIGINT '2', CAST(ROW(ARRAY['string_3', NULL, 'string_4']) AS ROW(array_field ARRAY(VARCHAR))))," +
+                        "  (BIGINT '3', CAST(ROW(ARRAY['string_5', NULL, 'string_6']) AS ROW(array_field ARRAY(VARCHAR))))",
+                2);
+        queryAssertions.query("SELECT " + keyColumnName + ", row_array FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1', CAST(ROW(ARRAY['string_1', NULL, 'string_2']) AS ROW(array_field ARRAY(VARCHAR))))," +
+                        "  (BIGINT '2', CAST(ROW(ARRAY['string_3', NULL, 'string_4']) AS ROW(array_field ARRAY(VARCHAR))))," +
+                        "  (BIGINT '3', CAST(ROW(ARRAY['string_5', NULL, 'string_6']) AS ROW(array_field ARRAY(VARCHAR))))");
+
+        topic = "row-of-map-" + UUID.randomUUID();
+        tableName = toDoubleQuoted(topic);
+        keyColumnName = toDoubleQuoted(topic + "-key");
+
+        schema = SchemaBuilder.record("nested").fields()
+                .name("row_map").type().optional().record("row").fields()
+                .name("map_field").type().nullable().map().values().stringType().noDefault().endRecord()
+                .endRecord();
+
+        nestedSchema = extractBaseType(schema.getField("row_map").schema());
+        testingKafka.sendMessages(Stream.of(new ProducerRecord<Long, GenericRecord>(topic, 1L,
+                        new GenericRecordBuilder(schema)
+                                .set("row_map", new GenericRecordBuilder(nestedSchema)
+                                        .set("map_field", ImmutableMap.of("key_1", "value_1", "key_2", "value_2"))
+                                        .build())
+                                .build())),
+                schemaRegistryAwareProducer(testingKafka)
+                        .put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .buildOrThrow());
+        waitUntilTableExists(topic);
+        queryAssertions.query("SELECT " + keyColumnName + ", row_map FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1', CAST(ROW(MAP(ARRAY['key_1', 'key_2'], ARRAY['value_1', 'value_2'])) AS ROW(map_field MAP(VARCHAR, VARCHAR))))");
+        assertUpdate("INSERT INTO " + tableName + " (" + keyColumnName + ", row_map)" +
+                        "  VALUES (BIGINT '2', CAST(ROW(MAP(ARRAY['key_3', 'key_4'], ARRAY['value_3', 'value_4'])) AS ROW(map_field MAP(VARCHAR, VARCHAR))))," +
+                        "  (BIGINT '3', CAST(ROW(MAP(ARRAY['key_5', 'key_6'], ARRAY['value_5', 'value_6'])) AS ROW(map_field MAP(VARCHAR, VARCHAR))))",
+                2);
+        queryAssertions.query("SELECT " + keyColumnName + ", row_map FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1', CAST(ROW(MAP(ARRAY['key_1', 'key_2'], ARRAY['value_1', 'value_2'])) AS ROW(map_field MAP(VARCHAR, VARCHAR))))," +
+                        "  (BIGINT '2', CAST(ROW(MAP(ARRAY['key_3', 'key_4'], ARRAY['value_3', 'value_4'])) AS ROW(map_field MAP(VARCHAR, VARCHAR))))," +
+                        "  (BIGINT '3', CAST(ROW(MAP(ARRAY['key_5', 'key_6'], ARRAY['value_5', 'value_6'])) AS ROW(map_field MAP(VARCHAR, VARCHAR))))");
+
+        // Row of row is tested in testConfluentNestedPrimitiveRowMessage
+        // Test deeply nested values:
+        topic = "array-map-row-array" + UUID.randomUUID();
+        tableName = toDoubleQuoted(topic);
+        keyColumnName = toDoubleQuoted(topic + "-key");
+
+        schema = SchemaBuilder.record("nested").fields()
+                .name("array_map_row_array").type().optional().array().items().nullable()
+                .map().values().nullable()
+                .record("row").fields().name("array_field").type().optional().array().items().nullable().stringType().endRecord()
+                .endRecord();
+        nestedSchema = extractBaseType(extractBaseType(extractBaseType(schema.getField("array_map_row_array").schema()).getElementType()).getValueType());
+        testingKafka.sendMessages(Stream.of(new ProducerRecord<Long, GenericRecord>(topic, 1L,
+                        new GenericRecordBuilder(schema)
+                                .set("array_map_row_array", Arrays.asList(ImmutableMap.of("key_1", new GenericRecordBuilder(nestedSchema)
+                                        .set("array_field", Arrays.asList("string_1"))
+                                        .build())))
+                                .build())),
+                schemaRegistryAwareProducer(testingKafka)
+                        .put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .buildOrThrow());
+        waitUntilTableExists(topic);
+        queryAssertions.query("SELECT " + keyColumnName + ", array_map_row_array FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1', CAST(ARRAY[MAP(ARRAY['key_1'], ARRAY[ROW(ARRAY['string_1'])])] AS ARRAY(MAP(VARCHAR, ROW(array_field ARRAY(VARCHAR))))))");
+        assertUpdate("INSERT INTO " + tableName + " (" + keyColumnName + ", array_map_row_array)" +
+                        "  VALUES (BIGINT '2', CAST(ARRAY[MAP(ARRAY['key_2'], ARRAY[ROW(ARRAY['string_2'])])] AS ARRAY(MAP(VARCHAR, ROW(array_field ARRAY(VARCHAR))))))," +
+                        "  (BIGINT '3', CAST(ARRAY[MAP(ARRAY['key_3'], ARRAY[ROW(ARRAY['string_3'])])] AS ARRAY(MAP(VARCHAR, ROW(array_field ARRAY(VARCHAR))))))",
+                2);
+        queryAssertions.query("SELECT " + keyColumnName + ", array_map_row_array FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1', CAST(ARRAY[MAP(ARRAY['key_1'], ARRAY[ROW(ARRAY['string_1'])])] AS ARRAY(MAP(VARCHAR, ROW(array_field ARRAY(VARCHAR))))))," +
+                        "  (BIGINT '2', CAST(ARRAY[MAP(ARRAY['key_2'], ARRAY[ROW(ARRAY['string_2'])])] AS ARRAY(MAP(VARCHAR, ROW(array_field ARRAY(VARCHAR))))))," +
+                        "  (BIGINT '3', CAST(ARRAY[MAP(ARRAY['key_3'], ARRAY[ROW(ARRAY['string_3'])])] AS ARRAY(MAP(VARCHAR, ROW(array_field ARRAY(VARCHAR))))))");
+    }
+
+    @Test
+    public void testTemporalTypes()
+    {
+        String topic = "temporal-types-" + UUID.randomUUID();
+        String tableName = toDoubleQuoted(topic);
+        String keyColumnName = toDoubleQuoted(topic + "-key");
+        Schema schema = SchemaBuilder.record("temporal").fields()
+                .name("date_field").type(LogicalTypes.date().addToSchema(Schema.create(Schema.Type.INT))).noDefault()
+                .name("timestamp_millis").type(timestampMillis().addToSchema(Schema.create(Schema.Type.LONG))).noDefault()
+                .name("timestamp_micros").type(timestampMicros().addToSchema(Schema.create(Schema.Type.LONG))).noDefault()
+                .name("time_millis").type(timeMillis().addToSchema(Schema.create(Schema.Type.INT))).noDefault()
+                .name("time_micros").type(timeMicros().addToSchema(Schema.create(Schema.Type.LONG))).noDefault()
+                .endRecord();
+        testingKafka.sendMessages(Stream.of(new ProducerRecord<Long, GenericRecord>(topic, 1L,
+                        new GenericRecordBuilder(schema)
+                                .set("date_field", new SqlDate(1111).getDays())
+                                .set("timestamp_millis", SqlTimestamp.fromMillis(TIMESTAMP_MILLIS.getPrecision(), 1111L).getMillis())
+                                .set("timestamp_micros", SqlTimestamp.newInstance(TIMESTAMP_MICROS.getPrecision(), 1111L, 0).getEpochMicros())
+                                .set("time_millis", 1111)
+                                .set("time_micros", 1111L)
+                                .build())),
+                schemaRegistryAwareProducer(testingKafka)
+                        .put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .buildOrThrow());
+        waitUntilTableExists(topic);
+        QueryAssertions queryAssertions = new QueryAssertions(getQueryRunner());
+        queryAssertions.query("SELECT " + keyColumnName + ", date_field, timestamp_millis, timestamp_micros, time_millis, time_micros FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (BIGINT '1', CAST(%s AS %s), CAST(%s AS %s), CAST(%s AS %s), CAST(%s AS %s), CAST(%s AS %s))".formatted(
+                        toSingleQuotedOrNullLiteral(new SqlDate(1111)),
+                        DATE.getDisplayName(),
+                        toSingleQuotedOrNullLiteral(SqlTimestamp.fromMillis(TIMESTAMP_MILLIS.getPrecision(), 1111L)),
+                        TIMESTAMP_MILLIS.getDisplayName(),
+                        toSingleQuotedOrNullLiteral(SqlTimestamp.newInstance(TIMESTAMP_MICROS.getPrecision(), 1111L, 0)),
+                        TIMESTAMP_MICROS.getDisplayName(),
+                        toSingleQuotedOrNullLiteral(SqlTime.newInstance(TIME_MILLIS.getPrecision(), 1111L * PICOSECONDS_PER_MILLISECOND)),
+                        TIME_MILLIS.getDisplayName(),
+                        toSingleQuotedOrNullLiteral(SqlTime.newInstance(TIME_MICROS.getPrecision(), 1111L * PICOSECONDS_PER_MICROSECOND)),
+                        TIME_MICROS.getDisplayName()));
+        assertUpdate("""
+                        INSERT INTO %s (%s, date_field, timestamp_millis, timestamp_micros, time_millis, time_micros)
+                          VALUES (%s, CAST(%s AS %s), CAST(%s AS %s), CAST(%s AS %s), CAST(%s AS %s), CAST(%s AS %s)),
+                          (%s, CAST(%s AS %s), CAST(%s AS %s), CAST(%s AS %s), CAST(%s AS %s), CAST(%s AS %s))""".formatted(tableName,
+                keyColumnName,
+                "BIGINT '2'",
+                toSingleQuotedOrNullLiteral(new SqlDate(1112)),
+                DATE.getDisplayName(),
+                toSingleQuotedOrNullLiteral(SqlTimestamp.fromMillis(TIMESTAMP_MILLIS.getPrecision(), 1112)),
+                TIMESTAMP_MILLIS.getDisplayName(),
+                toSingleQuotedOrNullLiteral(SqlTimestamp.newInstance(TIMESTAMP_MICROS.getPrecision(), 1112L, 0)),
+                TIMESTAMP_MICROS.getDisplayName(),
+                toSingleQuotedOrNullLiteral(SqlTime.newInstance(TIME_MILLIS.getPrecision(), 1112L * PICOSECONDS_PER_MILLISECOND)),
+                TIME_MILLIS.getDisplayName(),
+                toSingleQuotedOrNullLiteral(SqlTime.newInstance(TIME_MICROS.getPrecision(), 1112L * PICOSECONDS_PER_MICROSECOND)),
+                TIME_MICROS.getDisplayName(),
+                "BIGINT '3'",
+                toSingleQuotedOrNullLiteral(new SqlDate(1113)),
+                DATE.getDisplayName(),
+                toSingleQuotedOrNullLiteral(SqlTimestamp.fromMillis(TIMESTAMP_MILLIS.getPrecision(), 1113)),
+                TIMESTAMP_MILLIS.getDisplayName(),
+                toSingleQuotedOrNullLiteral(SqlTimestamp.newInstance(TIMESTAMP_MICROS.getPrecision(), 1113L, 0)),
+                TIMESTAMP_MICROS.getDisplayName(),
+                toSingleQuotedOrNullLiteral(SqlTime.newInstance(TIME_MILLIS.getPrecision(), 1113L * PICOSECONDS_PER_MILLISECOND)),
+                TIME_MILLIS.getDisplayName(),
+                toSingleQuotedOrNullLiteral(SqlTime.newInstance(TIME_MICROS.getPrecision(), 1113L * PICOSECONDS_PER_MICROSECOND)),
+                TIME_MICROS.getDisplayName()), 2);
+
+        queryAssertions.query("SELECT " + keyColumnName + ", date_field, timestamp_millis, timestamp_micros, time_millis, time_micros FROM " + tableName)
+                .assertThat()
+                .matches("""
+                        VALUES (%s, CAST(%s AS %s), CAST(%s AS %s), CAST(%s AS %s), CAST(%s AS %s), CAST(%s AS %s)),
+                          (%s, CAST(%s AS %s), CAST(%s AS %s), CAST(%s AS %s), CAST(%s AS %s), CAST(%s AS %s)),
+                          (%s, CAST(%s AS %s), CAST(%s AS %s), CAST(%s AS %s), CAST(%s AS %s), CAST(%s AS %s))""".formatted("BIGINT '1'",
+                        toSingleQuotedOrNullLiteral(new SqlDate(1111)),
+                        DATE.getDisplayName(),
+                        toSingleQuotedOrNullLiteral(SqlTimestamp.fromMillis(TIMESTAMP_MILLIS.getPrecision(), 1111)),
+                        TIMESTAMP_MILLIS.getDisplayName(),
+                        toSingleQuotedOrNullLiteral(SqlTimestamp.newInstance(TIMESTAMP_MICROS.getPrecision(), 1111L, 0)),
+                        TIMESTAMP_MICROS.getDisplayName(),
+                        toSingleQuotedOrNullLiteral(SqlTime.newInstance(TIME_MILLIS.getPrecision(), 1111L * PICOSECONDS_PER_MILLISECOND)),
+                        TIME_MILLIS.getDisplayName(),
+                        toSingleQuotedOrNullLiteral(SqlTime.newInstance(TIME_MICROS.getPrecision(), 1111L * PICOSECONDS_PER_MICROSECOND)),
+                        TIME_MICROS.getDisplayName(),
+                        "BIGINT '2'",
+                        toSingleQuotedOrNullLiteral(new SqlDate(1112)),
+                        DATE.getDisplayName(),
+                        toSingleQuotedOrNullLiteral(SqlTimestamp.fromMillis(TIMESTAMP_MILLIS.getPrecision(), 1112)),
+                        TIMESTAMP_MILLIS.getDisplayName(),
+                        toSingleQuotedOrNullLiteral(SqlTimestamp.newInstance(TIMESTAMP_MICROS.getPrecision(), 1112L, 0)),
+                        TIMESTAMP_MICROS.getDisplayName(),
+                        toSingleQuotedOrNullLiteral(SqlTime.newInstance(TIME_MILLIS.getPrecision(), 1112L * PICOSECONDS_PER_MILLISECOND)),
+                        TIME_MILLIS.getDisplayName(),
+                        toSingleQuotedOrNullLiteral(SqlTime.newInstance(TIME_MICROS.getPrecision(), 1112L * PICOSECONDS_PER_MICROSECOND)),
+                        TIME_MICROS.getDisplayName(),
+                        "BIGINT '3'",
+                        toSingleQuotedOrNullLiteral(new SqlDate(1113)),
+                        DATE.getDisplayName(),
+                        toSingleQuotedOrNullLiteral(SqlTimestamp.fromMillis(TIMESTAMP_MILLIS.getPrecision(), 1113)),
+                        TIMESTAMP_MILLIS.getDisplayName(),
+                        toSingleQuotedOrNullLiteral(SqlTimestamp.newInstance(TIMESTAMP_MICROS.getPrecision(), 1113L, 0)),
+                        TIMESTAMP_MICROS.getDisplayName(),
+                        toSingleQuotedOrNullLiteral(SqlTime.newInstance(TIME_MILLIS.getPrecision(), 1113L * PICOSECONDS_PER_MILLISECOND)),
+                        TIME_MILLIS.getDisplayName(),
+                        toSingleQuotedOrNullLiteral(SqlTime.newInstance(TIME_MICROS.getPrecision(), 1113L * PICOSECONDS_PER_MICROSECOND)),
+                        TIME_MICROS.getDisplayName()));
+    }
+
+    @Test
+    public void testSupportedConfluentPrimitiveKeys()
+    {
+        testConfluentPrimitiveKey(VARBINARY, serializeBytes(ByteBuffer.wrap(new byte[] {1, 2, 3})),
+                serializeBytes(ByteBuffer.wrap(new byte[] {2, 3, 4})),
+                serializeBytes(ByteBuffer.wrap(new byte[] {3, 4, 5})));
+        testConfluentPrimitiveKey(VARCHAR, "string_1", "string_2", "string_3");
+        testConfluentPrimitiveKey(BIGINT, 1L, 2L, 3L);
+        testConfluentPrimitiveKey(DOUBLE, 1.5D, -2.5D, 3.5D);
+        testConfluentPrimitiveKey(BOOLEAN, false, true, false);
+        testConfluentPrimitiveKey(REAL, -1.5F, 2.5F, -3.5F);
+        testConfluentPrimitiveKey(INTEGER, 1, 2, 3);
+        Schema enumSchema = SchemaBuilder.enumeration("color").symbols("BLUE", "YELLOW", "RED");
+        testConfluentPrimitiveKey(VARCHAR, enumSymbol(enumSchema, "YELLOW"), enumSymbol(enumSchema, "RED"), enumSymbol(enumSchema, "BLUE"));
+    }
+
+    @Test
+    public void testSupportedKeyColumnTypes()
+    {
+        testKey(VARCHAR, StringSerializer.class, "string_1", "string_2");
+        testKey(VARBINARY, SqlVarbinarySerializer.class, new SqlVarbinary(new byte[] {1, 2, 3}), new SqlVarbinary(new byte[] {2, 3, 4}));
+        testKey(DATE, SqlDateSerializer.class, new SqlDate(50), new SqlDate(51));
+        testKey(TIMESTAMP_MICROS, SqlTimeStampMicrosSerializer.class, SqlTimestamp.newInstance(TIMESTAMP_MICROS.getPrecision(), 1111L, 0), SqlTimestamp.newInstance(TIMESTAMP_MICROS.getPrecision(), 1112L, 0));
+        // Time millis avro logical type is for underlying integer type only so result needs to be converted in the column decoder: https://avro.apache.org/docs/1.11.0/spec.html#Time+%28millisecond+precision%29
+        testKey(TIME_MILLIS, SqlTimeMillisSerializer.class, SqlTime.newInstance(TIME_MILLIS.getPrecision(), 1111L * DateTimes.PICOSECONDS_PER_MILLISECOND), SqlTime.newInstance(TIME_MILLIS.getPrecision(), 1112L * DateTimes.PICOSECONDS_PER_MILLISECOND));
+        testKey(TIMESTAMP_MILLIS, SqlTimeStampMillisSerializer.class, SqlTimestamp.fromMillis(TIMESTAMP_MILLIS.getPrecision(), 1111L), SqlTimestamp.fromMillis(TIMESTAMP_MILLIS.getPrecision(), 1112L));
+        testKey(TIME_MICROS, SqlTimeMicrosSerializer.class, SqlTime.newInstance(TIME_MICROS.getPrecision(), 1111L * DateTimes.PICOSECONDS_PER_MICROSECOND), SqlTime.newInstance(TIME_MICROS.getPrecision(), 1112L * DateTimes.PICOSECONDS_PER_MICROSECOND));
+        testKey(BIGINT, LongSerializer.class, 1L, 2L);
+        testKey(INTEGER, IntegerSerializer.class, 1, 2);
+        testKey(REAL, FloatSerializer.class, -1.5F, 2.5F);
+        testKey(DOUBLE, DoubleSerializer.class, 1.5D, 2.5D);
+        testKey(BOOLEAN, BooleanSerializer.class, false, true);
+    }
+
+    public static class BooleanSerializer
+            implements Serializer<Boolean>
+    {
+        private static final byte[] SERIALIZED_TRUE = new byte[]{1};
+        private static final byte[] SERIALIZED_FALSE = new byte[]{0};
+
+        @Override
+        public byte[] serialize(String topic, Boolean data)
+        {
+            if (data == null) {
+                return null;
+            }
+            return data ? SERIALIZED_TRUE : SERIALIZED_FALSE;
+        }
+    }
+
+    public static class SqlDateSerializer
+            implements Serializer<SqlDate>
+    {
+        @Override
+        public byte[] serialize(String topic, SqlDate data)
+        {
+            if (data == null) {
+                return null;
+            }
+            return INTEGER_SERIALIZER.serialize(topic, data.getDays());
+        }
+    }
+
+    public static class SqlTimeStampMillisSerializer
+            implements Serializer<SqlTimestamp>
+    {
+        @Override
+        public byte[] serialize(String topic, SqlTimestamp data)
+        {
+            if (data == null) {
+                return null;
+            }
+            return LONG_SERIALIZER.serialize(topic, data.getMillis());
+        }
+    }
+
+    public static class SqlTimeStampMicrosSerializer
+            implements Serializer<SqlTimestamp>
+    {
+        @Override
+        public byte[] serialize(String topic, SqlTimestamp data)
+        {
+            if (data == null) {
+                return null;
+            }
+            return LONG_SERIALIZER.serialize(topic, data.getEpochMicros());
+        }
+    }
+
+    public static class SqlTimeMillisSerializer
+            implements Serializer<SqlTime>
+    {
+        @Override
+        public byte[] serialize(String topic, SqlTime data)
+        {
+            if (data == null) {
+                return null;
+            }
+            return INTEGER_SERIALIZER.serialize(topic, toIntExact(data.getPicos() / DateTimes.PICOSECONDS_PER_MILLISECOND));
+        }
+    }
+
+    public static class SqlTimeMicrosSerializer
+            implements Serializer<SqlTime>
+    {
+        @Override
+        public byte[] serialize(String topic, SqlTime data)
+        {
+            if (data == null) {
+                return null;
+            }
+            return LONG_SERIALIZER.serialize(topic, data.getPicos() / DateTimes.PICOSECONDS_PER_MICROSECOND);
+        }
+    }
+
+    public static class SqlVarbinarySerializer
+            implements Serializer<SqlVarbinary>
+    {
+        @Override
+        public byte[] serialize(String topic, SqlVarbinary data)
+        {
+            if (data == null) {
+                return null;
+            }
+            return data.getBytes();
+        }
+    }
+
+    private <T> void testKey(Type keyType, Class<? extends Serializer> keySerializerClass, T firstValue, T secondValue)
+    {
+        String topic = "topic-" + getDisplayNameForTopic(keyType) + "-" + UUID.randomUUID();
+        String tableName = toDoubleQuoted(topic + "&key-column=key_col:" + keyType.getDisplayName());
+        Schema schema = SchemaBuilder.record("test").fields()
+                .name("string_optional_field").type().optional().stringType()
+                .endRecord();
+        testingKafka.sendMessages(Stream.of(new ProducerRecord<T, GenericRecord>(topic, firstValue, new GenericRecordBuilder(schema).build())), schemaRegistryAwareProducer(testingKafka)
+                .put(KEY_SERIALIZER_CLASS_CONFIG, keySerializerClass.getName())
+                .put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                .buildOrThrow());
+        waitUntilTableExists(topic);
+        QueryAssertions queryAssertions = new QueryAssertions(getQueryRunner());
+
+        queryAssertions.query("SELECT key_col, string_optional_field FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (CAST(" + toSingleQuotedOrNullLiteral(firstValue) + " AS " + keyType.getDisplayName() + "), CAST(NULL AS VARCHAR))");
+        assertUpdate("INSERT INTO " + tableName + " (key_col) VALUES" +
+                "  (CAST(" + toSingleQuotedOrNullLiteral(secondValue) + " AS " + keyType.getDisplayName() + "))," +
+                "  (CAST(NULL AS " + keyType.getDisplayName() + "))", 2);
+        queryAssertions.query("SELECT key_col, string_optional_field FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (CAST(" + toSingleQuotedOrNullLiteral(firstValue) + " AS " + keyType.getDisplayName() + "), CAST(NULL AS VARCHAR))," +
+                        "  (CAST(" + toSingleQuotedOrNullLiteral(secondValue) + " AS " + keyType.getDisplayName() + "), CAST(NULL AS VARCHAR))," +
+                        "  (CAST(NULL AS " + keyType.getDisplayName() + "), CAST(NULL AS VARCHAR))");
+    }
+
+    private static String getDisplayNameForTopic(Type type)
+    {
+        return type.getDisplayName().replaceAll("[()]", "_");
+    }
+
+    private byte[] serializeBytes(ByteBuffer byteBuffer)
+    {
+        // Varbinary needs to be serialized using the avro encoder.
+        // The returned array prepends the length with zigzag varint encoding
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        BinaryEncoder encoder = EncoderFactory.get().directBinaryEncoder(outputStream, null);
+        try {
+            encoder.writeBytes(byteBuffer);
+            encoder.flush();
+            return outputStream.toByteArray();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private <T> void testConfluentPrimitiveKey(Type keyType, T firstValue, T secondValue, T thirdValue)
+    {
+        String topic = "primitive-key-" + getDisplayNameForTopic(keyType) + "-" + UUID.randomUUID();
+        String tableName = toDoubleQuoted(topic);
+        Schema schema = SchemaBuilder.record("test").fields()
+                .name("string_optional_field").type().optional().stringType()
+                .endRecord();
+        testingKafka.sendMessages(Stream.of(new ProducerRecord<T, GenericRecord>(topic, firstValue, new GenericRecordBuilder(schema).build())), schemaRegistryAwareProducer(testingKafka)
+                .put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                .put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                .buildOrThrow());
+        waitUntilTableExists(topic);
+        QueryAssertions queryAssertions = new QueryAssertions(getQueryRunner());
+        String keyColumnName = toDoubleQuoted(topic + "-key");
+        queryAssertions.query("SELECT " + keyColumnName + ", string_optional_field FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (CAST(" + toSingleQuotedOrNullLiteral(firstValue) + " AS " + keyType.getDisplayName() + "), CAST(NULL AS VARCHAR))");
+        assertUpdate("INSERT INTO " + tableName + " (" + keyColumnName + ") VALUES" +
+                        "  (CAST(" + toSingleQuotedOrNullLiteral(secondValue) + " AS " + keyType.getDisplayName() + "))," +
+                        "  (CAST(" + toSingleQuotedOrNullLiteral(thirdValue) + " AS " + keyType.getDisplayName() + "))",
+                2);
+
+        queryAssertions.query("SELECT " + keyColumnName + ", string_optional_field FROM " + tableName)
+                .assertThat()
+                .matches("VALUES (CAST(" + toSingleQuotedOrNullLiteral(firstValue) + " AS " + keyType.getDisplayName() + "), CAST(NULL AS VARCHAR))," +
+                        "  (CAST(" + toSingleQuotedOrNullLiteral(secondValue) + " AS " + keyType.getDisplayName() + "), CAST(NULL AS VARCHAR))," +
+                        "  (CAST(" + toSingleQuotedOrNullLiteral(thirdValue) + " AS " + keyType.getDisplayName() + "), CAST(NULL AS VARCHAR))");
+    }
+
+    private static GenericData.EnumSymbol enumSymbol(Schema enumSchema, String symbol)
+    {
+        return new GenericData.EnumSymbol(enumSchema, symbol);
+    }
+
+    protected static ImmutableMap.Builder<String, String> schemaRegistryAwareProducer(TestingKafka testingKafka)
+    {
+        return ImmutableMap.<String, String>builder()
+                .put(SCHEMA_REGISTRY_URL_CONFIG, testingKafka.getSchemaRegistryConnectString());
+    }
+
+    protected static String toDoubleQuoted(String tableName)
+    {
+        return format("\"%s\"", tableName);
+    }
+
+    protected String toSingleQuotedOrNullLiteral(Object value)
+    {
+        if (value == null) {
+            return "NULL";
+        }
+        if (value instanceof SqlVarbinary) {
+            return "X'" + BaseEncoding.base16().encode(((SqlVarbinary) value).getBytes()) + "'";
+        }
+        else if (value instanceof byte[]) {
+            return "X'" + BaseEncoding.base16().encode(deserializeBytes((byte[]) value)) + "'";
+        }
+        return "'" + value + "'";
+    }
+
+    protected byte[] deserializeBytes(byte[] bytes)
+    {
+        // Varbinary need to be deserialized using avro decoder.
+        BinaryDecoder decoder = DecoderFactory.get().directBinaryDecoder(new ByteArrayInputStream(bytes), null);
+        try {
+            return decoder.readBytes(null).array();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    protected void waitUntilTableExists(String tableName)
+    {
+        waitUntilTableExists(getQueryRunner().getDefaultSession(), tableName);
+    }
+
+    protected void waitUntilTableExists(Session session, String tableName)
+    {
+        Failsafe.with(RETRY_POLICY)
+                .run(() -> assertTrue(schemaExists()));
+        Failsafe.with(RETRY_POLICY)
+                .run(() -> assertTrue(tableExists(session, tableName)));
+    }
+
+    protected boolean schemaExists()
+    {
+        return getQueryRunner().execute(format(
+                        "SHOW SCHEMAS FROM %s LIKE '%s'",
+                        getSession().getCatalog().orElseThrow(),
+                        getSession().getSchema().orElseThrow()))
+                .getRowCount() == 1;
+    }
+
+    protected boolean tableExists(Session session, String tableName)
+    {
+        return getQueryRunner().execute(session, format("SHOW TABLES LIKE '%s'", tableName.toLowerCase(ENGLISH))).getRowCount() == 1;
+    }
+}

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/KafkaWithConfluentSchemaRegistryQueryRunner.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/KafkaWithConfluentSchemaRegistryQueryRunner.java
@@ -13,17 +13,39 @@
  */
 package io.trino.plugin.kafka.schema.confluent;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Resources;
 import io.airlift.log.Logger;
 import io.airlift.log.Logging;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.trino.plugin.kafka.KafkaConnectorFactory;
 import io.trino.plugin.kafka.KafkaQueryRunnerBuilder;
+import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.kafka.TestingKafka;
+import io.trino.tpch.TpchColumn;
+import io.trino.tpch.TpchTable;
+import org.apache.avro.Schema;
 
+import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
+import static io.airlift.units.Duration.nanosSince;
+import static io.trino.plugin.kafka.schema.confluent.ConfluentModule.createSchemaRegistryClient;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.joining;
 
 public final class KafkaWithConfluentSchemaRegistryQueryRunner
 {
+    private static final Logger log = Logger.get(KafkaWithConfluentSchemaRegistryQueryRunner.class);
+
     private KafkaWithConfluentSchemaRegistryQueryRunner() {}
 
     private static final String DEFAULT_SCHEMA = "default";
@@ -36,19 +58,65 @@ public final class KafkaWithConfluentSchemaRegistryQueryRunner
     public static class Builder
             extends KafkaQueryRunnerBuilder
     {
+        private List<TpchTable<?>> tables = ImmutableList.of();
+
         protected Builder(TestingKafka testingKafka)
         {
             super(testingKafka, DEFAULT_SCHEMA);
         }
 
+        public Builder setTables(Iterable<TpchTable<?>> tables)
+        {
+            this.tables = ImmutableList.copyOf(requireNonNull(tables, "tables is null"));
+            return this;
+        }
+
         @Override
         public void preInit(DistributedQueryRunner queryRunner)
         {
+            queryRunner.installPlugin(new TpchPlugin());
+            queryRunner.createCatalog("tpch", "tpch");
             Map<String, String> properties = new HashMap<>(extraKafkaProperties);
             properties.putIfAbsent("kafka.table-description-supplier", "confluent");
             properties.putIfAbsent("kafka.confluent-schema-registry-url", testingKafka.getSchemaRegistryConnectString());
             properties.putIfAbsent("kafka.protobuf-any-support-enabled", "true");
             setExtraKafkaProperties(properties);
+        }
+
+        @Override
+        public void postInit(DistributedQueryRunner queryRunner)
+        {
+            log.info("Loading data...");
+            long startTime = System.nanoTime();
+            SchemaRegistryClient schemaRegistryClient = createSchemaRegistryClient(new ConfluentSchemaRegistryConfig().setConfluentSchemaRegistryUrls(testingKafka.getSchemaRegistryConnectString()),
+                    Set.of(),
+                    Set.of(),
+                    KafkaConnectorFactory.class.getClassLoader());
+            for (TpchTable<?> table : tables) {
+                long start = System.nanoTime();
+                log.info("Running import for %s", table.getTableName());
+                createSubjectForTpchTable(table, schemaRegistryClient);
+                String columnList = table.getColumns().stream()
+                        .map(TpchColumn::getSimplifiedColumnName)
+                        .collect(joining(","));
+                queryRunner.execute("""
+                    INSERT INTO %1$s (%2$s)
+                    SELECT %2$s
+                    FROM tpch.tiny.%1$s""".formatted(table.getTableName(), columnList));
+                log.info("Imported %s in %s", table.getTableName(), nanosSince(start).convertToMostSuccinctTimeUnit());
+            }
+            log.info("Loading complete in %s", nanosSince(startTime).toString(SECONDS));
+        }
+
+        private void createSubjectForTpchTable(TpchTable<?> table, SchemaRegistryClient schemaRegistryClient)
+        {
+            try {
+                AvroSchema schema = new AvroSchema(new Schema.Parser().parse(Resources.toString(Resources.getResource(KafkaWithConfluentSchemaRegistryQueryRunner.class, "/tpch_avro/%s.avsc".formatted(table.getTableName())), UTF_8)));
+                schemaRegistryClient.register("%s-value".formatted(table.getTableName()), schema);
+            }
+            catch (RestClientException | IOException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestAvroConfluentContentSchemaProvider.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestAvroConfluentContentSchemaProvider.java
@@ -47,10 +47,10 @@ public class TestAvroConfluentContentSchemaProvider
         Schema schema = getAvroSchema();
         mockSchemaRegistryClient.register(SUBJECT_NAME, schema);
         AvroConfluentContentSchemaProvider avroConfluentSchemaProvider = new AvroConfluentContentSchemaProvider(mockSchemaRegistryClient);
-        KafkaTableHandle tableHandle = new KafkaTableHandle("default", TOPIC, TOPIC, AvroRowDecoderFactory.NAME, AvroRowDecoderFactory.NAME, Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(SUBJECT_NAME), ImmutableList.of(), TupleDomain.all());
+        KafkaTableHandle tableHandle = new KafkaTableHandle("default", TOPIC, TOPIC, AvroRowDecoderFactory.NAME, AvroRowDecoderFactory.NAME, Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(SUBJECT_NAME), Optional.empty(), ImmutableList.of(), TupleDomain.all());
         assertEquals(avroConfluentSchemaProvider.getMessage(tableHandle), Optional.of(schema).map(Schema::toString));
         assertEquals(avroConfluentSchemaProvider.getKey(tableHandle), Optional.empty());
-        KafkaTableHandle invalidTableHandle = new KafkaTableHandle("default", TOPIC, TOPIC, AvroRowDecoderFactory.NAME, AvroRowDecoderFactory.NAME, Optional.empty(), Optional.empty(), Optional.empty(), Optional.of("another-schema"), ImmutableList.of(), TupleDomain.all());
+        KafkaTableHandle invalidTableHandle = new KafkaTableHandle("default", TOPIC, TOPIC, AvroRowDecoderFactory.NAME, AvroRowDecoderFactory.NAME, Optional.empty(), Optional.empty(), Optional.empty(), Optional.of("another-schema"), Optional.empty(), ImmutableList.of(), TupleDomain.all());
         assertThatThrownBy(() -> avroConfluentSchemaProvider.getMessage(invalidTableHandle))
                 .isInstanceOf(TrinoException.class)
                 .hasMessage("Could not resolve schema for the 'another-schema' subject");

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestAvroSchemaConverter.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestAvroSchemaConverter.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static io.trino.plugin.kafka.schema.confluent.AvroSchemaConverter.DUMMY_FIELD_NAME;
+import static io.trino.plugin.kafka.schema.confluent.AvroSchemaConverter.EMPTY_FIELD_MARKER;
 import static io.trino.plugin.kafka.schema.confluent.AvroSchemaConverter.EmptyFieldStrategy.FAIL;
 import static io.trino.plugin.kafka.schema.confluent.AvroSchemaConverter.EmptyFieldStrategy.IGNORE;
 import static io.trino.plugin.kafka.schema.confluent.AvroSchemaConverter.EmptyFieldStrategy.MARK;
@@ -288,9 +288,9 @@ public class TestAvroSchemaConverter
 
         List<Type> typesForAddDummyStrategy = ImmutableList.<Type>builder()
                 .add(INTEGER)
-                .add(RowType.from(ImmutableList.of(new RowType.Field(Optional.of(DUMMY_FIELD_NAME), BOOLEAN))))
-                .add(new ArrayType(RowType.from(ImmutableList.of(new RowType.Field(Optional.of(DUMMY_FIELD_NAME), BOOLEAN)))))
-                .add(createType(RowType.from(ImmutableList.of(new RowType.Field(Optional.of(DUMMY_FIELD_NAME), BOOLEAN)))))
+                .add(RowType.from(ImmutableList.of(new RowType.Field(Optional.of(EMPTY_FIELD_MARKER), BOOLEAN))))
+                .add(new ArrayType(RowType.from(ImmutableList.of(new RowType.Field(Optional.of(EMPTY_FIELD_MARKER), BOOLEAN)))))
+                .add(createType(RowType.from(ImmutableList.of(new RowType.Field(Optional.of(EMPTY_FIELD_MARKER), BOOLEAN)))))
                 .build();
 
         assertEquals(new AvroSchemaConverter(new TestingTypeManager(), MARK).convertAvroSchema(schema), typesForAddDummyStrategy);
@@ -318,9 +318,9 @@ public class TestAvroSchemaConverter
                 .hasMessage("Struct type has no valid fields for schema: '%s'", SchemaBuilder.record("nested_record").fields().endRecord());
 
         List<Type> typesForAddDummyStrategy = ImmutableList.<Type>builder()
-                .add(RowType.from(ImmutableList.of(new RowType.Field(Optional.of(DUMMY_FIELD_NAME), BOOLEAN))))
-                .add(new ArrayType(RowType.from(ImmutableList.of(new RowType.Field(Optional.of(DUMMY_FIELD_NAME), BOOLEAN)))))
-                .add(createType(RowType.from(ImmutableList.of(new RowType.Field(Optional.of(DUMMY_FIELD_NAME), BOOLEAN)))))
+                .add(RowType.from(ImmutableList.of(new RowType.Field(Optional.of(EMPTY_FIELD_MARKER), BOOLEAN))))
+                .add(new ArrayType(RowType.from(ImmutableList.of(new RowType.Field(Optional.of(EMPTY_FIELD_MARKER), BOOLEAN)))))
+                .add(createType(RowType.from(ImmutableList.of(new RowType.Field(Optional.of(EMPTY_FIELD_MARKER), BOOLEAN)))))
                 .build();
 
         assertEquals(new AvroSchemaConverter(new TestingTypeManager(), MARK).convertAvroSchema(schema), typesForAddDummyStrategy);

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestConfluentSchemaRegistryTableDescriptionSupplier.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestConfluentSchemaRegistryTableDescriptionSupplier.java
@@ -69,7 +69,8 @@ public class TestConfluentSchemaRegistryTableDescriptionSupplier
                                 Optional.empty(),
                                 Optional.of(getTopicFieldGroup(
                                         subject,
-                                        ImmutableList.of(getFieldDescription("col1", INTEGER), getFieldDescription("col2", createUnboundedVarcharType()))))));
+                                        ImmutableList.of(getFieldDescription("col1", INTEGER), getFieldDescription("col2", createUnboundedVarcharType())))),
+                                Optional.empty()));
     }
 
     @Test
@@ -94,6 +95,7 @@ public class TestConfluentSchemaRegistryTableDescriptionSupplier
                                 Optional.of(getTopicFieldGroup(
                                         subject,
                                         ImmutableList.of(getFieldDescription("col1", INTEGER), getFieldDescription("col2", createUnboundedVarcharType())))),
+                                Optional.empty(),
                                 Optional.empty()));
     }
 
@@ -143,7 +145,8 @@ public class TestConfluentSchemaRegistryTableDescriptionSupplier
                                 Optional.empty(),
                                 Optional.of(getTopicFieldGroup(
                                         subject,
-                                        ImmutableList.of(getFieldDescription("col1", INTEGER), getFieldDescription("col2", createUnboundedVarcharType()))))));
+                                        ImmutableList.of(getFieldDescription("col1", INTEGER), getFieldDescription("col2", createUnboundedVarcharType())))),
+                                Optional.empty()));
 
         assertThat(getKafkaTopicDescription(
                 tableDescriptionSupplier,
@@ -156,7 +159,8 @@ public class TestConfluentSchemaRegistryTableDescriptionSupplier
                                 Optional.empty(),
                                 Optional.of(getTopicFieldGroup(
                                         overriddenSubject,
-                                        ImmutableList.of(getFieldDescription("overridden_col1", INTEGER), getFieldDescription("overridden_col2", createUnboundedVarcharType()))))));
+                                        ImmutableList.of(getFieldDescription("overridden_col1", INTEGER), getFieldDescription("overridden_col2", createUnboundedVarcharType())))),
+                                Optional.empty()));
     }
 
     @Test
@@ -196,7 +200,8 @@ public class TestConfluentSchemaRegistryTableDescriptionSupplier
                 SCHEMA_REGISTRY_CLIENT,
                 ImmutableMap.of("AVRO", new AvroSchemaParser(new TestingTypeManager())),
                 DEFAULT_NAME,
-                new Duration(1, SECONDS));
+                new Duration(1, SECONDS),
+                new TestingTypeManager());
     }
 
     private static Schema getAvroSchema(String topicName, String columnNamePrefix)

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestKafkaWithConfluentSchemaRegistryMinimalFunctionality.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestKafkaWithConfluentSchemaRegistryMinimalFunctionality.java
@@ -207,27 +207,6 @@ public class TestKafkaWithConfluentSchemaRegistryMinimalFunctionality
     }
 
     @Test
-    public void testUnsupportedInsert()
-    {
-        String topicName = "topic-unsupported-insert-" + randomNameSuffix();
-
-        assertNotExists(topicName);
-
-        List<ProducerRecord<Long, GenericRecord>> messages = createMessages(topicName, MESSAGE_COUNT, true);
-        testingKafka.sendMessages(
-                messages.stream(),
-                schemaRegistryAwareProducer(testingKafka)
-                        .put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
-                        .put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
-                        .buildOrThrow());
-
-        waitUntilTableExists(topicName);
-
-        assertThatThrownBy(() -> getQueryRunner().execute(format("INSERT INTO %s VALUES(0, 0, '')", toDoubleQuoted(topicName))))
-                .hasMessage("Insert not supported");
-    }
-
-    @Test
     public void testUnsupportedFormat()
     {
         String topicName = "topic-unsupported-format-" + randomNameSuffix();

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/util/TestUtils.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/util/TestUtils.java
@@ -41,14 +41,14 @@ public final class TestUtils
 
         return new AbstractMap.SimpleImmutableEntry<>(
                 schemaTableName,
-                new KafkaTopicDescription(schemaTableName.getTableName(), Optional.of(schemaTableName.getSchemaName()), topicName, tpchTemplate.getKey(), tpchTemplate.getMessage()));
+                new KafkaTopicDescription(schemaTableName.getTableName(), Optional.of(schemaTableName.getSchemaName()), topicName, tpchTemplate.getKey(), tpchTemplate.getMessage(), Optional.empty()));
     }
 
     public static Map.Entry<SchemaTableName, KafkaTopicDescription> createEmptyTopicDescription(String topicName, SchemaTableName schemaTableName)
     {
         return new AbstractMap.SimpleImmutableEntry<>(
                 schemaTableName,
-                new KafkaTopicDescription(schemaTableName.getTableName(), Optional.of(schemaTableName.getSchemaName()), topicName, Optional.empty(), Optional.empty()));
+                new KafkaTopicDescription(schemaTableName.getTableName(), Optional.of(schemaTableName.getSchemaName()), topicName, Optional.empty(), Optional.empty(), Optional.empty()));
     }
 
     public static KafkaTopicDescription createDescription(SchemaTableName schemaTableName, KafkaTopicFieldDescription key, List<KafkaTopicFieldDescription> fields)
@@ -58,12 +58,13 @@ public final class TestUtils
                 Optional.of(schemaTableName.getSchemaName()),
                 schemaTableName.getTableName(),
                 Optional.of(new KafkaTopicFieldGroup("json", Optional.empty(), Optional.empty(), ImmutableList.of(key))),
-                Optional.of(new KafkaTopicFieldGroup("json", Optional.empty(), Optional.empty(), fields)));
+                Optional.of(new KafkaTopicFieldGroup("json", Optional.empty(), Optional.empty(), fields)),
+                Optional.empty());
     }
 
     public static KafkaTopicDescription createDescription(String name, String schema, String topic, Optional<KafkaTopicFieldGroup> message)
     {
-        return new KafkaTopicDescription(name, Optional.of(schema), topic, Optional.empty(), message);
+        return new KafkaTopicDescription(name, Optional.of(schema), topic, Optional.empty(), message, Optional.empty());
     }
 
     public static Optional<KafkaTopicFieldGroup> createFieldGroup(String dataFormat, List<KafkaTopicFieldDescription> fields)

--- a/plugin/trino-kafka/src/test/resources/tpch_avro/customer.avsc
+++ b/plugin/trino-kafka/src/test/resources/tpch_avro/customer.avsc
@@ -1,0 +1,37 @@
+{
+    "type" : "record",
+    "name" : "customer",
+    "fields" : [ {
+        "name" : "custkey",
+        "type" : [ "null", "long" ],
+        "default" : null
+    }, {
+        "name" : "name",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name" : "address",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name" : "nationkey",
+        "type" : [ "null", "long" ],
+        "default" : null
+    }, {
+        "name" : "phone",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name" : "acctbal",
+        "type" : [ "null", "double" ],
+        "default" : null
+    }, {
+        "name" : "mktsegment",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name" : "comment",
+        "type" : [ "null", "string" ],
+        "default" : null
+    } ]
+}

--- a/plugin/trino-kafka/src/test/resources/tpch_avro/lineitem.avsc
+++ b/plugin/trino-kafka/src/test/resources/tpch_avro/lineitem.avsc
@@ -1,0 +1,69 @@
+{
+    "type" : "record",
+    "name" : "lineitem",
+    "fields" : [ {
+        "name" : "orderkey",
+        "type" : [ "null", "long" ],
+        "default" : null
+    }, {
+        "name" : "partkey",
+        "type" : [ "null", "long" ],
+        "default" : null
+    }, {
+        "name" : "suppkey",
+        "type" : [ "null", "long" ],
+        "default" : null
+    }, {
+        "name" : "linenumber",
+        "type" : [ "null", "int" ],
+        "default" : null
+    }, {
+        "name" : "quantity",
+        "type" : [ "null", "double" ],
+        "default" : null
+    }, {
+        "name" : "extendedprice",
+        "type" : [ "null", "double" ],
+        "default" : null
+    }, {
+        "name" : "discount",
+        "type" : [ "null", "double" ],
+        "default" : null
+    }, {
+        "name" : "tax",
+        "type" : [ "null", "double" ],
+        "default" : null
+    }, {
+        "name" : "returnflag",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name" : "linestatus",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name" : "shipdate",
+        "type" : [ "null", {"type": "int", "logicalType": "date"} ],
+        "default" : null
+    }, {
+        "name" : "commitdate",
+        "type" : [ "null", {"type": "int", "logicalType": "date"} ],
+        "default" : null
+    }, {
+        "name" : "receiptdate",
+        "type" : [ "null", {"type": "int", "logicalType": "date"} ],
+        "default" : null
+    }, {
+        "name" : "shipinstruct",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name" : "shipmode",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name" : "comment",
+        "type" : [ "null", "string" ],
+        "default" : null
+    } ]
+}

--- a/plugin/trino-kafka/src/test/resources/tpch_avro/nation.avsc
+++ b/plugin/trino-kafka/src/test/resources/tpch_avro/nation.avsc
@@ -1,0 +1,21 @@
+{
+    "type" : "record",
+    "name" : "nation",
+    "fields" : [ {
+        "name" : "nationkey",
+        "type" : [ "null", "long" ],
+        "default" : null
+    }, {
+        "name" : "name",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name" : "regionkey",
+        "type" : [ "null", "long" ],
+        "default" : null
+    }, {
+        "name" : "comment",
+        "type" : [ "null", "string" ],
+        "default" : null
+    } ]
+}

--- a/plugin/trino-kafka/src/test/resources/tpch_avro/orders.avsc
+++ b/plugin/trino-kafka/src/test/resources/tpch_avro/orders.avsc
@@ -1,0 +1,41 @@
+{
+    "type" : "record",
+    "name" : "orders",
+    "fields" : [ {
+        "name" : "orderkey",
+        "type" : [ "null", "long" ],
+        "default" : null
+    }, {
+        "name" : "custkey",
+        "type" : [ "null", "long" ],
+        "default" : null
+    }, {
+        "name" : "orderstatus",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name" : "totalprice",
+        "type" : [ "null", "double" ],
+        "default" : null
+    }, {
+        "name" : "orderdate",
+        "type" : [ "null", {"type": "int", "logicalType": "date"} ],
+        "default" : null
+    }, {
+        "name" : "orderpriority",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name" : "clerk",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name" : "shippriority",
+        "type" : [ "null", "int" ],
+        "default" : null
+    }, {
+        "name" : "comment",
+        "type" : [ "null", "string" ],
+        "default" : null
+    } ]
+}

--- a/plugin/trino-kafka/src/test/resources/tpch_avro/part.avsc
+++ b/plugin/trino-kafka/src/test/resources/tpch_avro/part.avsc
@@ -1,0 +1,41 @@
+{
+    "type" : "record",
+    "name" : "part",
+    "fields" : [ {
+        "name" : "partkey",
+        "type" : [ "null", "long" ],
+        "default" : null
+    }, {
+        "name" : "name",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name" : "mfgr",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name" : "brand",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name" : "type",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name" : "size",
+        "type" : [ "null", "int" ],
+        "default" : null
+    }, {
+        "name" : "container",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name" : "retailprice",
+        "type" : [ "null", "double" ],
+        "default" : null
+    }, {
+        "name" : "comment",
+        "type" : [ "null", "string" ],
+        "default" : null
+    } ]
+}

--- a/plugin/trino-kafka/src/test/resources/tpch_avro/partsupp.avsc
+++ b/plugin/trino-kafka/src/test/resources/tpch_avro/partsupp.avsc
@@ -1,0 +1,25 @@
+{
+    "type" : "record",
+    "name" : "partsupp",
+    "fields" : [ {
+        "name" : "partkey",
+        "type" : [ "null", "long" ],
+        "default" : null
+    }, {
+        "name" : "suppkey",
+        "type" : [ "null", "long" ],
+        "default" : null
+    }, {
+        "name" : "availqty",
+        "type" : [ "null", "int" ],
+        "default" : null
+    }, {
+        "name" : "supplycost",
+        "type" : [ "null", "double" ],
+        "default" : null
+    },  {
+        "name" : "comment",
+        "type" : [ "null", "string" ],
+        "default" : null
+    } ]
+}

--- a/plugin/trino-kafka/src/test/resources/tpch_avro/region.avsc
+++ b/plugin/trino-kafka/src/test/resources/tpch_avro/region.avsc
@@ -1,0 +1,17 @@
+{
+    "type" : "record",
+    "name" : "region",
+    "fields" : [ {
+        "name" : "regionkey",
+        "type" : [ "null", "long" ],
+        "default" : null
+    }, {
+        "name" : "name",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name" : "comment",
+        "type" : [ "null", "string" ],
+        "default" : null
+    } ]
+}

--- a/plugin/trino-kafka/src/test/resources/tpch_avro/supplier.avsc
+++ b/plugin/trino-kafka/src/test/resources/tpch_avro/supplier.avsc
@@ -1,0 +1,33 @@
+{
+    "type" : "record",
+    "name" : "supplier",
+    "fields" : [ {
+        "name" : "suppkey",
+        "type" : [ "null", "long" ],
+        "default" : null
+    }, {
+        "name" : "name",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name" : "address",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name" : "nationkey",
+        "type" : [ "null", "long" ],
+        "default" : null
+    }, {
+        "name" : "phone",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name" : "acctbal",
+        "type" : [ "null", "double" ],
+        "default" : null
+    },  {
+        "name" : "comment",
+        "type" : [ "null", "string" ],
+        "default" : null
+    } ]
+}


### PR DESCRIPTION
Convert key columns to KafkaColumnHandle

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Rewrite of #7407

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Rewriting commit by commit from the previous attempt.
Once the approach looks good we can reopen and overwrite the original PR or convert this one to a non-draft PR.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:
Add the syntax for specifying the key subject, value subject and key columns:
key-subject, value-subject: when a SubjectNameStrategy other than TopicName is used
key-columns: specify key column name and type when schema registry is not used for the key, ex. a simple long or string key type (this is a common use case).

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
