### PR TITLE
Add oneof support for Protobuf via Confluent Schema Registry

### DIFF
--- a/lib/trino-record-decoder/pom.xml
+++ b/lib/trino-record-decoder/pom.xml
@@ -55,6 +55,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.wire</groupId>
             <artifactId>wire-runtime-jvm</artifactId>
         </dependency>
@@ -119,6 +124,18 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-protobuf-provider</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/protobuf/ProtobufRowDecoder.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/protobuf/ProtobufRowDecoder.java
@@ -17,6 +17,7 @@ import com.google.protobuf.DynamicMessage;
 import io.trino.decoder.DecoderColumnHandle;
 import io.trino.decoder.FieldValueProvider;
 import io.trino.decoder.RowDecoder;
+import io.trino.spi.type.TypeManager;
 
 import java.util.Map;
 import java.util.Optional;
@@ -34,13 +35,13 @@ public class ProtobufRowDecoder
     private final DynamicMessageProvider dynamicMessageProvider;
     private final Map<DecoderColumnHandle, ProtobufColumnDecoder> columnDecoders;
 
-    public ProtobufRowDecoder(DynamicMessageProvider dynamicMessageProvider, Set<DecoderColumnHandle> columns)
+    public ProtobufRowDecoder(DynamicMessageProvider dynamicMessageProvider, Set<DecoderColumnHandle> columns, TypeManager typeManager)
     {
         this.dynamicMessageProvider = requireNonNull(dynamicMessageProvider, "dynamicMessageSupplier is null");
         this.columnDecoders = columns.stream()
                 .collect(toImmutableMap(
                         identity(),
-                        ProtobufColumnDecoder::new));
+                        column -> new ProtobufColumnDecoder(column, typeManager)));
     }
 
     @Override

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/protobuf/ProtobufRowDecoderFactory.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/protobuf/ProtobufRowDecoderFactory.java
@@ -17,6 +17,7 @@ import io.trino.decoder.DecoderColumnHandle;
 import io.trino.decoder.RowDecoder;
 import io.trino.decoder.RowDecoderFactory;
 import io.trino.decoder.protobuf.DynamicMessageProvider.Factory;
+import io.trino.spi.type.TypeManager;
 
 import javax.inject.Inject;
 
@@ -32,11 +33,13 @@ public class ProtobufRowDecoderFactory
     public static final String DEFAULT_MESSAGE = "schema";
 
     private final Factory dynamicMessageProviderFactory;
+    private final TypeManager typeManager;
 
     @Inject
-    public ProtobufRowDecoderFactory(Factory dynamicMessageProviderFactory)
+    public ProtobufRowDecoderFactory(Factory dynamicMessageProviderFactory, TypeManager typeManager)
     {
         this.dynamicMessageProviderFactory = requireNonNull(dynamicMessageProviderFactory, "dynamicMessageProviderFactory is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
     }
 
     @Override
@@ -44,6 +47,7 @@ public class ProtobufRowDecoderFactory
     {
         return new ProtobufRowDecoder(
                 dynamicMessageProviderFactory.create(Optional.ofNullable(decoderParams.get("dataSchema"))),
-                columns);
+                columns,
+                typeManager);
     }
 }

--- a/lib/trino-record-decoder/src/test/resources/decoder/protobuf/test_oneof.proto
+++ b/lib/trino-record-decoder/src/test/resources/decoder/protobuf/test_oneof.proto
@@ -1,0 +1,45 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+
+message schema {
+    enum Number {
+        ZERO = 0;
+        ONE = 1;
+        TWO = 2;
+    };
+    message Row {
+        string string_column = 1;
+        uint32 integer_column = 2;
+        uint64 long_column = 3;
+        double double_column = 4;
+        float float_column = 5;
+        bool boolean_column = 6;
+        Number number_column = 7;
+        google.protobuf.Timestamp timestamp_column = 8;
+        bytes bytes_column = 9;
+    };
+    message NestedRow {
+        repeated Row nested_list = 1;
+        map<string, Row> nested_map = 2;
+        Row row = 3;
+    };
+    oneof testOneofColumn {
+        string stringColumn = 1;
+        uint32 integerColumn = 2;
+        uint64 longColumn = 3;
+        double doubleColumn = 4;
+        float floatColumn = 5;
+        bool booleanColumn = 6;
+        Number numberColumn = 7;
+        google.protobuf.Timestamp timestampColumn = 8;
+        bytes bytesColumn = 9;
+        Row rowColumn = 10;
+        NestedRow nestedRowColumn = 11;
+    }
+    oneof testOneofColumn2 {
+        string stringColumn2 = 12;
+        uint32 integerColumn2 = 23;
+    }
+    string column = 14;
+}

--- a/plugin/trino-kafka/src/test/resources/protobuf/test_oneof.proto
+++ b/plugin/trino-kafka/src/test/resources/protobuf/test_oneof.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+
+message schema {
+    enum Number {
+        ZERO = 0;
+        ONE = 1;
+        TWO = 2;
+    };
+    message Row {
+        string string_column = 1;
+        uint32 integer_column = 2;
+        uint64 long_column = 3;
+        double double_column = 4;
+        float float_column = 5;
+        bool boolean_column = 6;
+        Number number_column = 7;
+        google.protobuf.Timestamp timestamp_column = 8;
+        bytes bytes_column = 9;
+    };
+    message NestedRow {
+        repeated Row nested_list = 1;
+        map<string, Row> nested_map = 2;
+        Row row = 3;
+    };
+    oneof testOneofColumn {
+        string stringColumn = 1;
+        uint32 integerColumn = 2;
+        uint64 longColumn = 3;
+        double doubleColumn = 4;
+        float floatColumn = 5;
+        bool booleanColumn = 6;
+        Number numberColumn = 7;
+        google.protobuf.Timestamp timestampColumn = 8;
+        bytes bytesColumn = 9;
+        Row rowColumn = 10;
+        NestedRow nestedRowColumn = 11;
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This adds Kafka connector support for Protobuf  `oneOf` data types by encoding them as a JSON object.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Protobuf `oneOf` data types are a single field in the message that can hold one value of multiple fields (of varying types) per the schema definition. This adds support for these data types by encoding the entire `oneOf` field as a JSON object where each field name is a key in the JSON object where all values, except one, are `null`. The value that is set corresponds to the set value in the `DynamicMessage` that is processed in the message.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# Kafka Connector
* Added support for `oneof` Protobuf types when using the Confluent table description provider
```
