### PR TITLE
479 fix json object traversal

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonArrayFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonArrayFunction.java
@@ -13,6 +13,7 @@
  */
 package io.trino.sql.query;
 
+import io.trino.Session;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -194,5 +195,25 @@ public class TestJsonArrayFunction
         assertThat(assertions.query(
                 "SELECT json_array(true RETURNING varbinary FORMAT JSON ENCODING UTF32)"))
                 .matches("VALUES " + varbinaryLiteral);
+    }
+
+    @Test
+    public void testNestedAggregation()
+    {
+        assertThat(assertions.query("""
+                SELECT json_array('x', max(a))
+                FROM (VALUES ('abc'), ('def')) t(a)
+                """))
+                .matches("VALUES VARCHAR '[\"x\",\"def\"]'");
+    }
+
+    @Test
+    public void testParameters()
+    {
+        Session session = Session.builder(assertions.getDefaultSession())
+                .addPreparedStatement("my_query", "SELECT json_array(?, ?)")
+                .build();
+        assertThat(assertions.query(session, "EXECUTE my_query USING 'a', 1"))
+                .matches("VALUES VARCHAR '[\"a\",1]'");
     }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -1157,6 +1157,11 @@ public abstract class AstVisitor<R, C>
         return visitExpression(node, context);
     }
 
+    protected R visitJsonObjectMember(JsonObjectMember node, C context)
+    {
+        return visitNode(node, context);
+    }
+
     protected R visitJsonArray(JsonArray node, C context)
     {
         return visitExpression(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -1167,6 +1167,11 @@ public abstract class AstVisitor<R, C>
         return visitExpression(node, context);
     }
 
+    protected R visitJsonArrayElement(JsonArrayElement node, C context)
+    {
+        return visitNode(node, context);
+    }
+
     protected R visitEmptyTableTreatment(EmptyTableTreatment node, C context)
     {
         return visitNode(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -968,6 +968,15 @@ public abstract class DefaultTraversalVisitor<C>
     }
 
     @Override
+    protected Void visitJsonObjectMember(JsonObjectMember node, C context)
+    {
+        process(node.getKey(), context);
+        process(node.getValue(), context);
+
+        return null;
+    }
+
+    @Override
     protected Void visitJsonArray(JsonArray node, C context)
     {
         for (JsonArrayElement element : node.getElements()) {

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -987,6 +987,14 @@ public abstract class DefaultTraversalVisitor<C>
     }
 
     @Override
+    protected Void visitJsonArrayElement(JsonArrayElement node, C context)
+    {
+        process(node.getValue(), context);
+
+        return null;
+    }
+
+    @Override
     protected Void visitTableFunctionInvocation(TableFunctionInvocation node, C context)
     {
         for (TableFunctionArgument argument : node.getArguments()) {

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/JsonArrayElement.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/JsonArrayElement.java
@@ -61,6 +61,12 @@ public class JsonArrayElement
     }
 
     @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitJsonArrayElement(this, context);
+    }
+
+    @Override
     public List<? extends Node> getChildren()
     {
         return ImmutableList.of(value);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/JsonObjectMember.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/JsonObjectMember.java
@@ -69,6 +69,12 @@ public class JsonObjectMember
     }
 
     @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitJsonObjectMember(this, context);
+    }
+
+    @Override
     public List<? extends Node> getChildren()
     {
         return ImmutableList.of(key, value);


### PR DESCRIPTION
Before this change, `JsonObject` members and `JsonArray` elements were not visited
in `AstVisitor`. As a result, aggregations or parameters inside them were not supported.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
fixes https://github.com/trinodb/trino/issues/16523
fixes https://github.com/trinodb/trino/issues/16489


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# General
* Support aggregate functions and parameters in arguments of  json_object and json_array functions. ({issue}`16523`, `16489`)
```
