### PR TITLE
Expose planning CPU time for MYSQL event listener

### DIFF
--- a/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListener.java
+++ b/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListener.java
@@ -137,6 +137,7 @@ public class MysqlEventListener
                 stats.getResourceWaitingTime().map(Duration::toMillis).orElse(0L),
                 stats.getAnalysisTime().map(Duration::toMillis).orElse(0L),
                 stats.getPlanningTime().map(Duration::toMillis).orElse(0L),
+                stats.getPlanningCpuTime().map(Duration::toMillis).orElse(0L),
                 stats.getExecutionTime().map(Duration::toMillis).orElse(0L),
                 stats.getInputBlockedTime().map(Duration::toMillis).orElse(0L),
                 stats.getFailedInputBlockedTime().map(Duration::toMillis).orElse(0L),

--- a/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/QueryDao.java
+++ b/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/QueryDao.java
@@ -62,6 +62,7 @@ public interface QueryDao
             "  waiting_time_millis BIGINT NOT NULL,\n" +
             "  analysis_time_millis BIGINT NOT NULL,\n" +
             "  planning_time_millis BIGINT NOT NULL,\n" +
+            "  planning_cpu_time_millis BIGINT NOT NULL,\n" +
             "  execution_time_millis BIGINT NOT NULL,\n" +
             "  input_blocked_time_millis BIGINT NOT NULL,\n" +
             "  failed_input_blocked_time_millis BIGINT NOT NULL,\n" +
@@ -133,6 +134,7 @@ public interface QueryDao
             "  waiting_time_millis,\n" +
             "  analysis_time_millis,\n" +
             "  planning_time_millis,\n" +
+            "  planning_cpu_time_millis,\n" +
             "  execution_time_millis,\n" +
             "  input_blocked_time_millis,\n" +
             "  failed_input_blocked_time_millis,\n" +
@@ -201,6 +203,7 @@ public interface QueryDao
             " :waitingTimeMillis,\n" +
             " :analysisTimeMillis,\n" +
             " :planningTimeMillis,\n" +
+            " :planningCpuTimeMillis,\n" +
             " :executionTimeMillis,\n" +
             " :inputBlockedTimeMillis,\n" +
             " :failedInputBlockedTimeMillis,\n" +

--- a/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/QueryEntity.java
+++ b/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/QueryEntity.java
@@ -73,6 +73,7 @@ public class QueryEntity
     private final long waitingTimeMillis;
     private final long analysisTimeMillis;
     private final long planningTimeMillis;
+    private final long planningCpuTimeMillis;
     private final long executionTimeMillis;
     private final long inputBlockedTimeMillis;
     private final long failedInputBlockedTimeMillis;
@@ -145,6 +146,7 @@ public class QueryEntity
             long waitingTimeMillis,
             long analysisTimeMillis,
             long planningTimeMillis,
+            long planningCpuTimeMillis,
             long executionTimeMillis,
             long inputBlockedTimeMillis,
             long failedInputBlockedTimeMillis,
@@ -212,6 +214,7 @@ public class QueryEntity
         this.waitingTimeMillis = waitingTimeMillis;
         this.analysisTimeMillis = analysisTimeMillis;
         this.planningTimeMillis = planningTimeMillis;
+        this.planningCpuTimeMillis = planningCpuTimeMillis;
         this.executionTimeMillis = executionTimeMillis;
         this.inputBlockedTimeMillis = inputBlockedTimeMillis;
         this.failedInputBlockedTimeMillis = failedInputBlockedTimeMillis;
@@ -450,6 +453,11 @@ public class QueryEntity
     public long getPlanningTimeMillis()
     {
         return planningTimeMillis;
+    }
+
+    public long getPlanningCpuTimeMillis()
+    {
+        return planningCpuTimeMillis;
     }
 
     public long getExecutionTimeMillis()

--- a/plugin/trino-mysql-event-listener/src/test/java/io/trino/plugin/eventlistener/mysql/TestMysqlEventListener.java
+++ b/plugin/trino-mysql-event-listener/src/test/java/io/trino/plugin/eventlistener/mysql/TestMysqlEventListener.java
@@ -405,6 +405,7 @@ public class TestMysqlEventListener
                     assertEquals(resultSet.getLong("waiting_time_millis"), 107);
                     assertEquals(resultSet.getLong("analysis_time_millis"), 108);
                     assertEquals(resultSet.getLong("planning_time_millis"), 109);
+                    assertEquals(resultSet.getLong("planning_cpu_time_millis"), 1091);
                     assertEquals(resultSet.getLong("execution_time_millis"), 110);
                     assertEquals(resultSet.getLong("input_blocked_time_millis"), 111);
                     assertEquals(resultSet.getLong("failed_input_blocked_time_millis"), 112);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
* Follow-up PR to https://github.com/trinodb/trino/pull/15318. This PR makes the DAO in `trino-mysql-event-listener` account for planning CPU time.


(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

