### PR TITLE
Add recursive member accessor `..<field>` to JSON path language

### DIFF
--- a/core/trino-main/src/main/java/io/trino/json/PathEvaluationVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/json/PathEvaluationVisitor.java
@@ -35,6 +35,7 @@ import io.trino.json.ir.IrCeilingMethod;
 import io.trino.json.ir.IrConstantJsonSequence;
 import io.trino.json.ir.IrContextVariable;
 import io.trino.json.ir.IrDatetimeMethod;
+import io.trino.json.ir.IrDescendantMemberAccessor;
 import io.trino.json.ir.IrDoubleMethod;
 import io.trino.json.ir.IrFilter;
 import io.trino.json.ir.IrFloorMethod;
@@ -646,6 +647,37 @@ class PathEvaluationVisitor
     protected List<Object> visitIrDatetimeMethod(IrDatetimeMethod node, PathEvaluationContext context) // TODO
     {
         throw new UnsupportedOperationException("date method is not yet supported");
+    }
+
+    @Override
+    protected List<Object> visitIrDescendantMemberAccessor(IrDescendantMemberAccessor node, PathEvaluationContext context)
+    {
+        List<Object> sequence = process(node.getBase(), context);
+
+        ImmutableList.Builder<Object> builder = ImmutableList.builder();
+        sequence.stream()
+                .forEach(object -> descendants(object, node.getKey(), builder));
+
+        return builder.build();
+    }
+
+    private void descendants(Object object, String key, ImmutableList.Builder<Object> builder)
+    {
+        if (object instanceof JsonNode jsonNode && jsonNode.isObject()) {
+            // prefix order: visit the enclosing object first
+            JsonNode boundValue = jsonNode.get(key);
+            if (boundValue != null) {
+                builder.add(boundValue);
+            }
+            // recurse into child nodes
+            ImmutableList.copyOf(jsonNode.fields()).stream()
+                    .forEach(field -> descendants(field.getValue(), key, builder));
+        }
+        if (object instanceof JsonNode jsonNode && jsonNode.isArray()) {
+            for (int index = 0; index < jsonNode.size(); index++) {
+                descendants(jsonNode.get(index), key, builder);
+            }
+        }
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/json/ir/IrDescendantMemberAccessor.java
+++ b/core/trino-main/src/main/java/io/trino/json/ir/IrDescendantMemberAccessor.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.json.ir;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.type.Type;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class IrDescendantMemberAccessor
+        extends IrAccessor
+{
+    private final String key;
+
+    @JsonCreator
+    public IrDescendantMemberAccessor(@JsonProperty("base") IrPathNode base, @JsonProperty("key") String key, @JsonProperty("type") Optional<Type> type)
+    {
+        super(base, type);
+        this.key = requireNonNull(key, "key is null");
+    }
+
+    @Override
+    protected <R, C> R accept(IrJsonPathVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitIrDescendantMemberAccessor(this, context);
+    }
+
+    @JsonProperty
+    public String getKey()
+    {
+        return key;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        IrDescendantMemberAccessor other = (IrDescendantMemberAccessor) obj;
+        return Objects.equals(this.base, other.base) && Objects.equals(this.key, other.key);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(base, key);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/json/ir/IrJsonPathVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/json/ir/IrJsonPathVisitor.java
@@ -102,6 +102,11 @@ public abstract class IrJsonPathVisitor<R, C>
         return visitIrMethod(node, context);
     }
 
+    protected R visitIrDescendantMemberAccessor(IrDescendantMemberAccessor node, C context)
+    {
+        return visitIrAccessor(node, context);
+    }
+
     protected R visitIrDoubleMethod(IrDoubleMethod node, C context)
     {
         return visitIrMethod(node, context);

--- a/core/trino-main/src/main/java/io/trino/json/ir/IrPathNode.java
+++ b/core/trino-main/src/main/java/io/trino/json/ir/IrPathNode.java
@@ -36,6 +36,7 @@ import static java.util.Objects.requireNonNull;
         @JsonSubTypes.Type(value = IrConstantJsonSequence.class, name = "jsonsequence"),
         @JsonSubTypes.Type(value = IrContextVariable.class, name = "contextvariable"),
         @JsonSubTypes.Type(value = IrDatetimeMethod.class, name = "datetime"),
+        @JsonSubTypes.Type(value = IrDescendantMemberAccessor.class, name = "descendantmemberaccessor"),
         @JsonSubTypes.Type(value = IrDisjunctionPredicate.class, name = "disjunction"),
         @JsonSubTypes.Type(value = IrDoubleMethod.class, name = "double"),
         @JsonSubTypes.Type(value = IrExistsPredicate.class, name = "exists"),

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/JsonPathAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/JsonPathAnalyzer.java
@@ -36,6 +36,7 @@ import io.trino.sql.jsonpath.tree.ComparisonPredicate;
 import io.trino.sql.jsonpath.tree.ConjunctionPredicate;
 import io.trino.sql.jsonpath.tree.ContextVariable;
 import io.trino.sql.jsonpath.tree.DatetimeMethod;
+import io.trino.sql.jsonpath.tree.DescendantMemberAccessor;
 import io.trino.sql.jsonpath.tree.DisjunctionPredicate;
 import io.trino.sql.jsonpath.tree.DoubleMethod;
 import io.trino.sql.jsonpath.tree.ExistsPredicate;
@@ -252,6 +253,13 @@ public class JsonPathAnalyzer
             }
             // TODO process the format template, record the processed format, and deduce the returned type
             throw semanticException(NOT_SUPPORTED, pathNode, "datetime method in JSON path is not yet supported");
+        }
+
+        @Override
+        protected Type visitDescendantMemberAccessor(DescendantMemberAccessor node, Void context)
+        {
+            process(node.getBase());
+            return null;
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/JsonPathTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/JsonPathTranslator.java
@@ -25,6 +25,7 @@ import io.trino.json.ir.IrCeilingMethod;
 import io.trino.json.ir.IrComparisonPredicate;
 import io.trino.json.ir.IrConjunctionPredicate;
 import io.trino.json.ir.IrContextVariable;
+import io.trino.json.ir.IrDescendantMemberAccessor;
 import io.trino.json.ir.IrDisjunctionPredicate;
 import io.trino.json.ir.IrDoubleMethod;
 import io.trino.json.ir.IrExistsPredicate;
@@ -59,6 +60,7 @@ import io.trino.sql.jsonpath.tree.ComparisonPredicate;
 import io.trino.sql.jsonpath.tree.ConjunctionPredicate;
 import io.trino.sql.jsonpath.tree.ContextVariable;
 import io.trino.sql.jsonpath.tree.DatetimeMethod;
+import io.trino.sql.jsonpath.tree.DescendantMemberAccessor;
 import io.trino.sql.jsonpath.tree.DisjunctionPredicate;
 import io.trino.sql.jsonpath.tree.DoubleMethod;
 import io.trino.sql.jsonpath.tree.ExistsPredicate;
@@ -224,6 +226,13 @@ class JsonPathTranslator
 
 //            IrPathNode base = process(node.getBase());
 //            return new IrDatetimeMethod(base, /*parsed format*/, Optional.ofNullable(types.get(PathNodeRef.of(node))));
+        }
+
+        @Override
+        protected IrPathNode visitDescendantMemberAccessor(DescendantMemberAccessor node, Void context)
+        {
+            IrPathNode base = process(node.getBase());
+            return new IrDescendantMemberAccessor(base, node.getKey(), Optional.ofNullable(types.get(PathNodeRef.of(node))));
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/sql/planner/PathNodes.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/PathNodes.java
@@ -23,6 +23,7 @@ import io.trino.json.ir.IrCeilingMethod;
 import io.trino.json.ir.IrComparisonPredicate;
 import io.trino.json.ir.IrConjunctionPredicate;
 import io.trino.json.ir.IrContextVariable;
+import io.trino.json.ir.IrDescendantMemberAccessor;
 import io.trino.json.ir.IrDisjunctionPredicate;
 import io.trino.json.ir.IrDoubleMethod;
 import io.trino.json.ir.IrExistsPredicate;
@@ -187,6 +188,11 @@ public class PathNodes
     public static IrPathNode memberAccessor(IrPathNode base, String key)
     {
         return new IrMemberAccessor(base, Optional.of(key), Optional.empty());
+    }
+
+    public static IrPathNode descendantMemberAccessor(IrPathNode base, String key)
+    {
+        return new IrDescendantMemberAccessor(base, key, Optional.empty());
     }
 
     public static IrPathNode jsonVariable(int index)

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonQueryFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonQueryFunction.java
@@ -423,4 +423,18 @@ public class TestJsonQueryFunction
                 "SELECT json_query('" + INPUT + "', 'lax $var' PASSING null FORMAT JSON AS \"var\" EMPTY ARRAY ON EMPTY)"))
                 .matches("VALUES cast('[]' AS  varchar)");
     }
+
+    @Test
+    public void testDescendantMemberAccessor()
+    {
+        assertThat(assertions.query("""
+                SELECT json_query(
+                                '{"a" : {"b" : 1}, "c" :  [true, {"c" : {"c" : null}}]}',
+                                'lax $..c'
+                                WITH ARRAY WRAPPER)
+                """))
+                .matches("""
+                        VALUES cast('[[true,{"c":{"c":null}}],{"c":null},null]'AS varchar)
+                        """);
+    }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestJsonPath2016TypeSerialization.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestJsonPath2016TypeSerialization.java
@@ -26,6 +26,7 @@ import io.trino.json.ir.IrCeilingMethod;
 import io.trino.json.ir.IrConstantJsonSequence;
 import io.trino.json.ir.IrContextVariable;
 import io.trino.json.ir.IrDatetimeMethod;
+import io.trino.json.ir.IrDescendantMemberAccessor;
 import io.trino.json.ir.IrDoubleMethod;
 import io.trino.json.ir.IrFloorMethod;
 import io.trino.json.ir.IrJsonNull;
@@ -148,6 +149,12 @@ public class TestJsonPath2016TypeSerialization
 
         // accessor by field name
         assertJsonRoundTrip(new IrJsonPath(true, new IrMemberAccessor(new IrJsonNull(), Optional.of("some_key"), Optional.of(BIGINT))));
+    }
+
+    @Test
+    public void testDescendantMemberAccessor()
+    {
+        assertJsonRoundTrip(new IrJsonPath(true, new IrDescendantMemberAccessor(new IrJsonNull(), "some_key", Optional.empty())));
     }
 
     @Test

--- a/core/trino-parser/src/main/antlr4/io/trino/jsonpath/JsonPath.g4
+++ b/core/trino-parser/src/main/antlr4/io/trino/jsonpath/JsonPath.g4
@@ -39,6 +39,8 @@ accessorExpression
     | accessorExpression '.' identifier                         #memberAccessor
     | accessorExpression '.' stringLiteral                      #memberAccessor
     | accessorExpression '.' '*'                                #wildcardMemberAccessor
+    | accessorExpression '..' identifier                        #descendantMemberAccessor
+    | accessorExpression '..' stringLiteral                     #descendantMemberAccessor
     | accessorExpression '[' subscript (',' subscript)* ']'     #arrayAccessor
     | accessorExpression '[' '*' ']'                            #wildcardArrayAccessor
     | accessorExpression '?' '(' predicate ')'                  #filter

--- a/core/trino-parser/src/main/java/io/trino/sql/jsonpath/PathTreeBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/jsonpath/PathTreeBuilder.java
@@ -27,6 +27,7 @@ import io.trino.sql.jsonpath.tree.ComparisonPredicate;
 import io.trino.sql.jsonpath.tree.ConjunctionPredicate;
 import io.trino.sql.jsonpath.tree.ContextVariable;
 import io.trino.sql.jsonpath.tree.DatetimeMethod;
+import io.trino.sql.jsonpath.tree.DescendantMemberAccessor;
 import io.trino.sql.jsonpath.tree.DisjunctionPredicate;
 import io.trino.sql.jsonpath.tree.DoubleMethod;
 import io.trino.sql.jsonpath.tree.ExistsPredicate;
@@ -166,6 +167,20 @@ public class PathTreeBuilder
     {
         PathNode base = visit(context.accessorExpression());
         return new MemberAccessor(base, Optional.empty());
+    }
+
+    @Override
+    public PathNode visitDescendantMemberAccessor(JsonPathParser.DescendantMemberAccessorContext context)
+    {
+        PathNode base = visit(context.accessorExpression());
+        String key;
+        if (context.stringLiteral() != null) {
+            key = unquote(context.stringLiteral().getText());
+        }
+        else {
+            key = context.identifier().getText();
+        }
+        return new DescendantMemberAccessor(base, key);
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/jsonpath/tree/DescendantMemberAccessor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/jsonpath/tree/DescendantMemberAccessor.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.jsonpath.tree;
+
+import static java.util.Objects.requireNonNull;
+
+public class DescendantMemberAccessor
+        extends Accessor
+{
+    private final String key;
+
+    public DescendantMemberAccessor(PathNode base, String key)
+    {
+        super(base);
+        this.key = requireNonNull(key, "key is null");
+    }
+
+    @Override
+    public <R, C> R accept(JsonPathTreeVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitDescendantMemberAccessor(this, context);
+    }
+
+    public String getKey()
+    {
+        return key;
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/jsonpath/tree/JsonPathTreeVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/jsonpath/tree/JsonPathTreeVisitor.java
@@ -82,6 +82,11 @@ public abstract class JsonPathTreeVisitor<R, C>
         return visitMethod(node, context);
     }
 
+    protected R visitDescendantMemberAccessor(DescendantMemberAccessor node, C context)
+    {
+        return visitAccessor(node, context);
+    }
+
     protected R visitDisjunctionPredicate(DisjunctionPredicate node, C context)
     {
         return visitPredicate(node, context);

--- a/core/trino-parser/src/test/java/io/trino/sql/jsonpath/TestPathParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/jsonpath/TestPathParser.java
@@ -25,6 +25,7 @@ import io.trino.sql.jsonpath.tree.ComparisonPredicate;
 import io.trino.sql.jsonpath.tree.ConjunctionPredicate;
 import io.trino.sql.jsonpath.tree.ContextVariable;
 import io.trino.sql.jsonpath.tree.DatetimeMethod;
+import io.trino.sql.jsonpath.tree.DescendantMemberAccessor;
 import io.trino.sql.jsonpath.tree.DisjunctionPredicate;
 import io.trino.sql.jsonpath.tree.DoubleMethod;
 import io.trino.sql.jsonpath.tree.ExistsPredicate;
@@ -255,6 +256,16 @@ public class TestPathParser
                 .isEqualTo(new JsonPath(
                         true,
                         new MemberAccessor(new ContextVariable(), Optional.of("Key Name"))));
+    }
+
+    @Test
+    public void testDescendantMemberAccessor()
+    {
+        assertThat(path("lax $..Key_Identifier"))
+                .isEqualTo(new JsonPath(true, new DescendantMemberAccessor(new ContextVariable(), "Key_Identifier")));
+
+        assertThat(path("lax $..\"Key Name\""))
+                .isEqualTo(new JsonPath(true, new DescendantMemberAccessor(new ContextVariable(), "Key Name")));
     }
 
     @Test

--- a/docs/src/main/sphinx/functions/json.rst
+++ b/docs/src/main/sphinx/functions/json.rst
@@ -225,6 +225,39 @@ The order of values returned from a single JSON object is arbitrary. The
 sub-sequences from all JSON objects are concatenated in the same order in which
 the JSON objects appear in the input sequence.
 
+descendant member accessor
+''''''''''''''''''''''''''
+
+Returns the values associated with the specified key in all JSON objects on all
+levels of nesting in the input sequence.
+
+.. code-block:: text
+
+    <path>..key
+    <path>.."key"
+
+The order of returned values is that of preorder depth first search. First, the
+enclosing object is visited, and then all child nodes are visited.
+
+This method does not perform array unwrapping in the lax mode. The results
+are the same in the lax and strict modes. The method traverses into JSON
+arrays and JSON objects. Non-structural JSON items are skipped.
+
+Let ``<path>`` be a sequence containing a JSON object:
+
+.. code-block:: text
+
+    {
+        "id" : 1,
+        "notes" : [{"type" : 1, "comment" : "foo"}, {"type" : 2, "comment" : null}],
+        "comment" : ["bar", "baz"]
+    }
+
+.. code-block:: text
+
+    <path>..comment --> ["bar", "baz"], "foo", null
+
+
 array accessor
 ''''''''''''''
 


### PR DESCRIPTION
This is an extension to SQL standard.
The standard SQL/JSON path language does not support loops or recursion. This method traverses the structure of input JSON and returns a collection of items associated with the given key from all levels of nesting.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# General
* Add recursive member accessor `..<field>` to JSON path language. ({issue}`issuenumber`)
```

Docs included.