### PR TITLE
Use OrcReader#MAX_BATCH_SIZE = 8 * 1024

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcReader.java
@@ -65,7 +65,7 @@ import static org.joda.time.DateTimeZone.UTC;
 
 public class OrcReader
 {
-    public static final int MAX_BATCH_SIZE = 8196;
+    public static final int MAX_BATCH_SIZE = 8 * 1024;
     public static final int INITIAL_BATCH_SIZE = 1;
     public static final int BATCH_SIZE_GROWTH_FACTOR = 2;
 

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestReadBloomFilter.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestReadBloomFilter.java
@@ -89,7 +89,7 @@ public class TestReadBloomFilter
 
             // without predicate a normal block will be created
             try (OrcRecordReader recordReader = createCustomOrcRecordReader(tempFile, OrcPredicate.TRUE, type, MAX_BATCH_SIZE)) {
-                assertEquals(recordReader.nextPage().getLoadedPage().getPositionCount(), 8196);
+                assertEquals(recordReader.nextPage().getLoadedPage().getPositionCount(), MAX_BATCH_SIZE);
             }
 
             // predicate for specific value within the min/max range without bloom filter being enabled
@@ -98,7 +98,7 @@ public class TestReadBloomFilter
                     .build();
 
             try (OrcRecordReader recordReader = createCustomOrcRecordReader(tempFile, noBloomFilterPredicate, type, MAX_BATCH_SIZE)) {
-                assertEquals(recordReader.nextPage().getLoadedPage().getPositionCount(), 8196);
+                assertEquals(recordReader.nextPage().getLoadedPage().getPositionCount(), MAX_BATCH_SIZE);
             }
 
             // predicate for specific value within the min/max range with bloom filter enabled, but a value not in the bloom filter
@@ -118,7 +118,7 @@ public class TestReadBloomFilter
                     .build();
 
             try (OrcRecordReader recordReader = createCustomOrcRecordReader(tempFile, matchBloomFilterPredicate, type, MAX_BATCH_SIZE)) {
-                assertEquals(recordReader.nextPage().getLoadedPage().getPositionCount(), 8196);
+                assertEquals(recordReader.nextPage().getLoadedPage().getPositionCount(), MAX_BATCH_SIZE);
             }
         }
     }


### PR DESCRIPTION
Previous value 8196 was bigger than PageProcessor#MAX_BATCH_SIZE causing PageProcessor to create small, 4 position pages every other page.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
