### PR TITLE
Extend `maven-checks` job timeout by additional 5 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         java-version:
           - 17
           - 20
-    timeout-minutes: 45
+    timeout-minutes: 50
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The recent merge of https://github.com/trinodb/trino/pull/16098 increased build robustness in the event of main Ubuntu repo failures at the cost of 2-3 minutes for downloading Ubuntu mirror indexes.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

It turns out the 45 minute timeout was very close to the actual time needed to perform the entire job, and extending it is necessary to avoid cancelling the job. 
Recent failures were:

https://github.com/trinodb/trino/actions/runs/4584653136/jobs/8096275081?pr=16842
https://github.com/trinodb/trino/actions/runs/4593206872/jobs/8110920919?pr=16721

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
