### PR TITLE
Fix adjusted queue size calculation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroupManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroupManager.java
@@ -15,6 +15,7 @@ package io.trino.execution.resourcegroups;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.Ints;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.airlift.node.NodeInfo;
@@ -273,7 +274,10 @@ public final class InternalResourceGroupManager<C>
     private static int getQueriesQueuedOnInternal(InternalResourceGroup resourceGroup)
     {
         if (resourceGroup.subGroups().isEmpty()) {
-            return Math.min(resourceGroup.getQueuedQueries(), resourceGroup.getSoftConcurrencyLimit() - resourceGroup.getRunningQueries());
+            return Ints.constrainToRange(
+                    resourceGroup.getQueuedQueries(),
+                    0,
+                    Math.max(0, resourceGroup.getSoftConcurrencyLimit() - resourceGroup.getRunningQueries()));
         }
 
         int queriesQueuedInternal = 0;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Bringing a fix from equivalent https://github.com/prestodb/presto/commit/6b5268a82095d8a5c6ea5dcca662eaa681ab5b60


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
In situations that number of running queries > soft concurrency limit, the adjusted queue size is negative.
This is incorrect - since if 1 RG gets a good share of resources when the cluster is free and holds onto
it, in that situation we should not have that 1 RG's negative quota impact other users, it just means
that the adjusted queue size for that RG is 0 - no waiting



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
