### PR TITLE
Fix query failure when unsupported check constraint exists in Delta

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/expression/SparkExpressionParser.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/expression/SparkExpressionParser.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.deltalake.expression;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.trino.spi.TrinoException;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -27,7 +26,6 @@ import org.antlr.v4.runtime.misc.ParseCancellationException;
 import java.util.function.Function;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 
 public final class SparkExpressionParser
 {
@@ -44,13 +42,8 @@ public final class SparkExpressionParser
 
     public static String toTrinoExpression(String sparkExpression)
     {
-        try {
-            SparkExpression expression = createExpression(sparkExpression);
-            return SparkExpressionConverter.toTrinoExpression(expression);
-        }
-        catch (ParsingException e) {
-            throw new TrinoException(NOT_SUPPORTED, "Unsupported Spark expression: " + sparkExpression, e);
-        }
+        SparkExpression expression = createExpression(sparkExpression);
+        return SparkExpressionConverter.toTrinoExpression(expression);
     }
 
     @VisibleForTesting

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/expression/TestSparkExpressions.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/expression/TestSparkExpressions.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.deltalake.expression;
 
-import io.trino.spi.TrinoException;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
@@ -209,7 +208,7 @@ public class TestSparkExpressions
     private static void assertParseFailure(@Language("SQL") String sparkExpression)
     {
         assertThatThrownBy(() -> toTrinoExpression(sparkExpression))
-                .isInstanceOf(TrinoException.class)
-                .hasMessageContaining("Unsupported Spark expression: " + sparkExpression);
+                .isInstanceOf(ParsingException.class)
+                .hasMessageContaining("Cannot parse Spark expression");
     }
 }


### PR DESCRIPTION
## Description

Fixes #16865

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Fix query failure when unsupported expressions exist in check constraints. ({issue}`16865`)
```
