### PR TITLE
Add support for hive.max-partitions-per-scan session property

### DIFF
--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/s3select/S3SelectTestHelper.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/s3select/S3SelectTestHelper.java
@@ -181,8 +181,7 @@ public class S3SelectTestHelper
                 this.hiveConfig.getSplitLoaderConcurrency(),
                 this.hiveConfig.getMaxSplitsPerSecond(),
                 this.hiveConfig.getRecursiveDirWalkerEnabled(),
-                TESTING_TYPE_MANAGER,
-                this.hiveConfig.getMaxPartitionsPerScan());
+                TESTING_TYPE_MANAGER);
 
         pageSourceProvider = new HivePageSourceProvider(
                 TESTING_TYPE_MANAGER,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -905,8 +905,7 @@ public abstract class AbstractTestHive
                 hiveConfig.getSplitLoaderConcurrency(),
                 hiveConfig.getMaxSplitsPerSecond(),
                 false,
-                TESTING_TYPE_MANAGER,
-                hiveConfig.getMaxPartitionsPerScan());
+                TESTING_TYPE_MANAGER);
         pageSinkProvider = new HivePageSinkProvider(
                 getDefaultHiveFileWriterFactories(hiveConfig, hdfsEnvironment),
                 new HdfsFileSystemFactory(hdfsEnvironment),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
@@ -241,8 +241,7 @@ public abstract class AbstractTestHiveFileSystem
                 config.getSplitLoaderConcurrency(),
                 config.getMaxSplitsPerSecond(),
                 config.getRecursiveDirWalkerEnabled(),
-                TESTING_TYPE_MANAGER,
-                config.getMaxPartitionsPerScan());
+                TESTING_TYPE_MANAGER);
         TypeOperators typeOperators = new TypeOperators();
         BlockTypeOperators blockTypeOperators = new BlockTypeOperators(typeOperators);
         pageSinkProvider = new HivePageSinkProvider(


### PR DESCRIPTION
Context:- Control the resource usage (control the number of S3 partitions scanned to minimize the S3 API cost according to predefined rules) via session property managers.

session-property-config.properties
[
{
"group": "global.",
"sessionProperties": {
"hive.max_partitions_per_scan": "1000"
}
},
{
"group": "global.interactive.",
"sessionProperties": {
"hive.max_partitions_per_scan": "10000"
}
},
{
"group": "global.pipeline.*",
"clientTags": ["etl"],
"sessionProperties": {
"scale_writers": "true",
"writer_min_size": "1GB",
"hive.insert_existing_partitions_behavior": "overwrite",
"hive.max_partitions_per_scan": "100000"
}
}
]

Release notes
( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:
Add support for hive.max-partitions-per-scan session property