### PR TITLE
Add support for timestamp to varchar coercer in hive tables

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
@@ -71,6 +71,7 @@ import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.SYNTHESIZED;
 import static io.trino.plugin.hive.HiveColumnHandle.isRowIdColumnHandle;
 import static io.trino.plugin.hive.HivePageSourceProvider.ColumnMapping.toColumnHandles;
 import static io.trino.plugin.hive.HivePageSourceProvider.ColumnMappingKind.PREFILLED;
+import static io.trino.plugin.hive.HiveSessionProperties.getTimestampPrecision;
 import static io.trino.plugin.hive.util.HiveBucketing.HiveBucketFilter;
 import static io.trino.plugin.hive.util.HiveBucketing.getHiveBucketFilter;
 import static io.trino.plugin.hive.util.HiveUtil.getPrefilledColumnValue;
@@ -243,6 +244,7 @@ public class HivePageSourceProvider
                         bucketValidator,
                         adapter,
                         typeManager,
+                        getTimestampPrecision(session),
                         pageSource));
             }
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/TimestampCoercer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/TimestampCoercer.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.coercions;
+
+import io.airlift.slice.Slices;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.VarcharType;
+
+import java.time.LocalDateTime;
+import java.time.chrono.IsoChronology;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
+import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static io.trino.spi.type.Varchars.truncateToLength;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
+import static java.lang.Math.toIntExact;
+import static java.time.ZoneOffset.UTC;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+
+public final class TimestampCoercer
+{
+    private static final DateTimeFormatter LOCAL_DATE_TIME = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE)
+            .appendLiteral(' ')
+            .append(ISO_LOCAL_TIME)
+            .toFormatter()
+            .withChronology(IsoChronology.INSTANCE);
+
+    private TimestampCoercer() {}
+
+    public static class ShortTimestampToVarcharCoercer
+            extends TypeCoercer<TimestampType, VarcharType>
+    {
+        public ShortTimestampToVarcharCoercer(TimestampType fromType, VarcharType toType)
+        {
+            super(fromType, toType);
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            long epochMicros = fromType.getLong(block, position);
+            long epochSecond = floorDiv(epochMicros, MICROSECONDS_PER_SECOND);
+            int nanoFraction = floorMod(epochMicros, MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND;
+            toType.writeSlice(
+                    blockBuilder,
+                    truncateToLength(
+                            Slices.utf8Slice(
+                                    LOCAL_DATE_TIME.format(LocalDateTime.ofEpochSecond(epochSecond, nanoFraction, UTC))),
+                            toType));
+        }
+    }
+
+    public static class LongTimestampToVarcharCoercer
+            extends TypeCoercer<TimestampType, VarcharType>
+    {
+        public LongTimestampToVarcharCoercer(TimestampType fromType, VarcharType toType)
+        {
+            super(fromType, toType);
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            LongTimestamp timestamp = (LongTimestamp) fromType.getObject(block, position);
+
+            long epochSecond = floorDiv(timestamp.getEpochMicros(), MICROSECONDS_PER_SECOND);
+            long microsFraction = floorMod(timestamp.getEpochMicros(), MICROSECONDS_PER_SECOND);
+            // Hive timestamp has nanoseconds precision, so no truncation here
+            long nanosFraction = (microsFraction * NANOSECONDS_PER_MICROSECOND) + (timestamp.getPicosOfMicro() / PICOSECONDS_PER_NANOSECOND);
+
+            toType.writeSlice(
+                    blockBuilder,
+                    truncateToLength(
+                            Slices.utf8Slice(
+                                    LOCAL_DATE_TIME.format(LocalDateTime.ofEpochSecond(epochSecond, toIntExact(nanosFraction), UTC))),
+                            toType));
+        }
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/TypeCoercer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/TypeCoercer.java
@@ -49,4 +49,14 @@ public abstract class TypeCoercer<F extends Type, T extends Type>
     }
 
     protected abstract void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position);
+
+    public Type getFromType()
+    {
+        return fromType;
+    }
+
+    public Type getToType()
+    {
+        return toType;
+    }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
@@ -42,6 +42,7 @@ import io.trino.plugin.hive.ReaderColumns;
 import io.trino.plugin.hive.ReaderPageSource;
 import io.trino.plugin.hive.acid.AcidSchema;
 import io.trino.plugin.hive.acid.AcidTransaction;
+import io.trino.plugin.hive.coercions.TypeCoercer;
 import io.trino.plugin.hive.orc.OrcPageSource.ColumnAdaptation;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorPageSource;
@@ -49,7 +50,6 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.EmptyPageSource;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
-import io.trino.spi.security.ConnectorIdentity;
 import io.trino.spi.type.Type;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -91,11 +91,13 @@ import static io.trino.plugin.hive.HiveSessionProperties.getOrcMaxMergeDistance;
 import static io.trino.plugin.hive.HiveSessionProperties.getOrcMaxReadBlockSize;
 import static io.trino.plugin.hive.HiveSessionProperties.getOrcStreamBufferSize;
 import static io.trino.plugin.hive.HiveSessionProperties.getOrcTinyStripeThreshold;
+import static io.trino.plugin.hive.HiveSessionProperties.getTimestampPrecision;
 import static io.trino.plugin.hive.HiveSessionProperties.isOrcBloomFiltersEnabled;
 import static io.trino.plugin.hive.HiveSessionProperties.isOrcNestedLazy;
 import static io.trino.plugin.hive.HiveSessionProperties.isUseOrcColumnNames;
 import static io.trino.plugin.hive.orc.OrcPageSource.ColumnAdaptation.mergedRowColumns;
 import static io.trino.plugin.hive.orc.OrcPageSource.handleException;
+import static io.trino.plugin.hive.orc.OrcTypeTranslator.createCoercer;
 import static io.trino.plugin.hive.util.AcidTables.isFullAcidTable;
 import static io.trino.plugin.hive.util.HiveClassNames.ORC_SERDE_CLASS;
 import static io.trino.plugin.hive.util.HiveUtil.getDeserializerClassName;
@@ -200,7 +202,7 @@ public class OrcPageSourceFactory
         }
 
         ConnectorPageSource orcPageSource = createOrcPageSource(
-                session.getIdentity(),
+                session,
                 path,
                 start,
                 length,
@@ -230,7 +232,7 @@ public class OrcPageSourceFactory
     }
 
     private ConnectorPageSource createOrcPageSource(
-            ConnectorIdentity identity,
+            ConnectorSession session,
             Path path,
             long start,
             long length,
@@ -257,7 +259,7 @@ public class OrcPageSourceFactory
 
         boolean originalFilesPresent = acidInfo.isPresent() && !acidInfo.get().getOriginalFiles().isEmpty();
         try {
-            TrinoFileSystem fileSystem = fileSystemFactory.create(identity);
+            TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity());
             TrinoInputFile inputFile = fileSystem.newInputFile(path.toString());
             orcDataSource = new HdfsOrcDataSource(
                     new OrcDataSourceId(path.toString()),
@@ -364,9 +366,16 @@ public class OrcPageSourceFactory
                 Type readType = column.getType();
                 if (orcColumn != null) {
                     int sourceIndex = fileReadColumns.size();
-                    columnAdaptations.add(ColumnAdaptation.sourceColumn(sourceIndex));
+                    Optional<TypeCoercer<?, ?>> coercer = createCoercer(orcColumn.getColumnType(), readType, getTimestampPrecision(session));
+                    if (coercer.isPresent()) {
+                        fileReadTypes.add(coercer.get().getFromType());
+                        columnAdaptations.add(ColumnAdaptation.coercedColumn(sourceIndex, coercer.get()));
+                    }
+                    else {
+                        columnAdaptations.add(ColumnAdaptation.sourceColumn(sourceIndex));
+                        fileReadTypes.add(readType);
+                    }
                     fileReadColumns.add(orcColumn);
-                    fileReadTypes.add(readType);
                     fileReadLayouts.add(projectedLayout);
 
                     // Add predicates on top-level and nested columns
@@ -399,7 +408,7 @@ public class OrcPageSourceFactory
                     new OrcDeletedRows(
                             path.getName(),
                             new OrcDeleteDeltaPageSourceFactory(options, stats),
-                            identity,
+                            session.getIdentity(),
                             fileSystemFactory,
                             info,
                             bucketNumber,
@@ -412,7 +421,7 @@ public class OrcPageSourceFactory
                             acidInfo.get().getOriginalFiles(),
                             path,
                             fileSystemFactory,
-                            identity,
+                            session.getIdentity(),
                             options,
                             stats));
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcTypeTranslator.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcTypeTranslator.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.orc;
+
+import io.trino.orc.metadata.OrcType.OrcTypeKind;
+import io.trino.plugin.hive.HiveTimestampPrecision;
+import io.trino.plugin.hive.coercions.TimestampCoercer.LongTimestampToVarcharCoercer;
+import io.trino.plugin.hive.coercions.TimestampCoercer.ShortTimestampToVarcharCoercer;
+import io.trino.plugin.hive.coercions.TypeCoercer;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+
+import java.util.Optional;
+
+import static io.trino.spi.type.TimestampType.createTimestampType;
+
+public final class OrcTypeTranslator
+{
+    private OrcTypeTranslator() {}
+
+    public static Optional<TypeCoercer<? extends Type, ? extends Type>> createCoercer(OrcTypeKind fromOrcType, Type toTrinoType, HiveTimestampPrecision timestampPrecision)
+    {
+        if (fromOrcType.equals(OrcTypeKind.TIMESTAMP) && toTrinoType instanceof VarcharType varcharType) {
+            TimestampType timestampType = createTimestampType(timestampPrecision.getPrecision());
+            if (timestampType.isShort()) {
+                return Optional.of(new ShortTimestampToVarcharCoercer(timestampType, varcharType));
+            }
+            return Optional.of(new LongTimestampToVarcharCoercer(timestampType, varcharType));
+        }
+        return Optional.empty();
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
@@ -34,6 +34,7 @@ import static io.trino.plugin.hive.HiveType.HIVE_FLOAT;
 import static io.trino.plugin.hive.HiveType.HIVE_INT;
 import static io.trino.plugin.hive.HiveType.HIVE_LONG;
 import static io.trino.plugin.hive.HiveType.HIVE_SHORT;
+import static io.trino.plugin.hive.HiveType.HIVE_TIMESTAMP;
 import static io.trino.plugin.hive.util.HiveUtil.extractStructFieldTypes;
 import static java.lang.Math.min;
 import static java.lang.String.format;
@@ -68,7 +69,7 @@ public final class HiveCoercionPolicy
             return toType instanceof CharType;
         }
         if (toType instanceof VarcharType) {
-            return fromHiveType.equals(HIVE_BYTE) || fromHiveType.equals(HIVE_SHORT) || fromHiveType.equals(HIVE_INT) || fromHiveType.equals(HIVE_LONG) || fromType instanceof DecimalType;
+            return fromHiveType.equals(HIVE_BYTE) || fromHiveType.equals(HIVE_SHORT) || fromHiveType.equals(HIVE_INT) || fromHiveType.equals(HIVE_LONG) || fromHiveType.equals(HIVE_TIMESTAMP) || fromType instanceof DecimalType;
         }
         if (fromHiveType.equals(HIVE_BYTE)) {
             return toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestTimestampCoercer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestTimestampCoercer.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.coercions;
+
+import io.airlift.slice.Slices;
+import io.trino.plugin.hive.HiveTimestampPrecision;
+import io.trino.spi.block.Block;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.SqlTimestamp;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDateTime;
+
+import static io.trino.plugin.hive.HivePageSource.createCoercer;
+import static io.trino.plugin.hive.HiveTimestampPrecision.MICROSECONDS;
+import static io.trino.plugin.hive.HiveTimestampPrecision.NANOSECONDS;
+import static io.trino.plugin.hive.HiveType.toHiveType;
+import static io.trino.spi.predicate.Utils.blockToNativeValue;
+import static io.trino.spi.predicate.Utils.nativeValueToBlock;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_PICOS;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static java.time.ZoneOffset.UTC;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestTimestampCoercer
+{
+    @Test(dataProvider = "timestampValuesProvider")
+    public void testShortTimestampToVarchar(String timestampValue, String hiveTimestampValue)
+    {
+        LocalDateTime localDateTime = LocalDateTime.parse(timestampValue);
+        SqlTimestamp timestamp = SqlTimestamp.fromSeconds(TIMESTAMP_MICROS.getPrecision(), localDateTime.toEpochSecond(UTC), localDateTime.get(NANO_OF_SECOND));
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createUnboundedVarcharType(), hiveTimestampValue);
+    }
+
+    @Test(dataProvider = "timestampValuesProvider")
+    public void testLongTimestampToVarchar(String timestampValue, String hiveTimestampValue)
+    {
+        LocalDateTime localDateTime = LocalDateTime.parse(timestampValue);
+        SqlTimestamp timestamp = SqlTimestamp.fromSeconds(TIMESTAMP_PICOS.getPrecision(), localDateTime.toEpochSecond(UTC), localDateTime.get(NANO_OF_SECOND));
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, new LongTimestamp(timestamp.getEpochMicros(), timestamp.getPicosOfMicros()), createUnboundedVarcharType(), hiveTimestampValue);
+    }
+
+    @Test
+    public void testShortTimestampToSmallerVarchar()
+    {
+        LocalDateTime localDateTime = LocalDateTime.parse("2023-04-11T05:16:12.345678");
+        SqlTimestamp timestamp = SqlTimestamp.fromSeconds(TIMESTAMP_MICROS.getPrecision(), localDateTime.toEpochSecond(UTC), localDateTime.get(NANO_OF_SECOND));
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(1), "2");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(2), "20");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(3), "202");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(4), "2023");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(5), "2023-");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(6), "2023-0");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(7), "2023-04");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(8), "2023-04-");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(9), "2023-04-1");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(10), "2023-04-11");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(11), "2023-04-11 ");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(12), "2023-04-11 0");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(13), "2023-04-11 05");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(14), "2023-04-11 05:");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(15), "2023-04-11 05:1");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(16), "2023-04-11 05:16");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(17), "2023-04-11 05:16:");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(18), "2023-04-11 05:16:1");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(19), "2023-04-11 05:16:12");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(20), "2023-04-11 05:16:12.");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(21), "2023-04-11 05:16:12.3");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(22), "2023-04-11 05:16:12.34");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(23), "2023-04-11 05:16:12.345");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(24), "2023-04-11 05:16:12.3456");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(25), "2023-04-11 05:16:12.34567");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(26), "2023-04-11 05:16:12.345678");
+        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(27), "2023-04-11 05:16:12.345678");
+    }
+
+    @Test
+    public void testLongTimestampToSmallerVarchar()
+    {
+        LocalDateTime localDateTime = LocalDateTime.parse("2023-04-11T05:16:12.345678876");
+        SqlTimestamp timestamp = SqlTimestamp.fromSeconds(TIMESTAMP_PICOS.getPrecision(), localDateTime.toEpochSecond(UTC), localDateTime.get(NANO_OF_SECOND));
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, new LongTimestamp(timestamp.getEpochMicros(), timestamp.getPicosOfMicros()), createVarcharType(27), "2023-04-11 05:16:12.3456788");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, new LongTimestamp(timestamp.getEpochMicros(), timestamp.getPicosOfMicros()), createVarcharType(28), "2023-04-11 05:16:12.34567887");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, new LongTimestamp(timestamp.getEpochMicros(), timestamp.getPicosOfMicros()), createVarcharType(29), "2023-04-11 05:16:12.345678876");
+    }
+
+    @DataProvider
+    public Object[][] timestampValuesProvider()
+    {
+        return new Object[][] {
+                // before epoch
+                {"1958-01-01T13:18:03.123", "1958-01-01 13:18:03.123"},
+                // after epoch
+                {"2019-03-18T10:01:17.987", "2019-03-18 10:01:17.987"},
+                // time doubled in JVM zone
+                {"2018-10-28T01:33:17.456", "2018-10-28 01:33:17.456"},
+                // time doubled in JVM zone
+                {"2018-10-28T03:33:33.333", "2018-10-28 03:33:33.333"},
+                // epoch
+                {"1970-01-01T00:00:00.000", "1970-01-01 00:00:00"},
+                // time gap in JVM zone
+                {"1970-01-01T00:13:42.000", "1970-01-01 00:13:42"},
+                {"2018-04-01T02:13:55.123", "2018-04-01 02:13:55.123"},
+                // time gap in Vilnius
+                {"2018-03-25T03:17:17.000", "2018-03-25 03:17:17"},
+                // time gap in Kathmandu
+                {"1986-01-01T00:13:07.000", "1986-01-01 00:13:07"},
+                // before epoch with second fraction
+                {"1969-12-31T23:59:59.123456", "1969-12-31 23:59:59.123456"}
+        };
+    }
+
+    public static void assertShortTimestampToVarcharCoercions(TimestampType fromType, Long valueToBeCoerced, VarcharType toType, String expectedValue)
+    {
+        assertCoercions(fromType, valueToBeCoerced, toType, Slices.utf8Slice(expectedValue), MICROSECONDS);
+    }
+
+    public static void assertLongTimestampToVarcharCoercions(TimestampType fromType, LongTimestamp valueToBeCoerced, VarcharType toType, String expectedValue)
+    {
+        assertCoercions(fromType, valueToBeCoerced, toType, Slices.utf8Slice(expectedValue), NANOSECONDS);
+    }
+
+    public static void assertCoercions(Type fromType, Object valueToBeCoerced, Type toType, Object expectedValue, HiveTimestampPrecision timestampPrecision)
+    {
+        Block coercedValue = createCoercer(TESTING_TYPE_MANAGER, toHiveType(fromType), toHiveType(toType), timestampPrecision).orElseThrow()
+                .apply(nativeValueToBlock(fromType, valueToBeCoerced));
+        assertThat(blockToNativeValue(toType, coercedValue))
+                .isEqualTo(expectedValue);
+    }
+}

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/configs/ConfigHdp3.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/configs/ConfigHdp3.java
@@ -18,6 +18,7 @@ import io.trino.tests.product.launcher.env.Environment;
 
 import javax.inject.Inject;
 
+import static io.trino.tests.product.launcher.env.EnvironmentContainers.HADOOP;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.TRINO;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
@@ -56,6 +57,8 @@ public class ConfigHdp3
                         "/docker/presto-init.d/presto-init-hdp3.sh");
             }
         });
+        // When hive performs implicit coercion to/from timestamp for ORC files, it depends on timezone of the HiveServer
+        builder.configureContainer(HADOOP, container -> container.withEnv("TZ", "UTC"));
     }
 
     @Override

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestHiveCoercion.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestHiveCoercion.java
@@ -111,6 +111,9 @@ public abstract class BaseTestHiveCoercion
                 "varchar_to_smaller_varchar",
                 "char_to_bigger_char",
                 "char_to_smaller_char",
+                "timestamp_to_string",
+                "timestamp_to_bounded_varchar",
+                "timestamp_to_smaller_varchar",
                 "id");
 
         Function<Engine, Map<String, List<Object>>> expected = engine -> expectedValuesForEngineProvider(engine, tableName, decimalToFloatVal, floatToDecimalVal);
@@ -167,6 +170,9 @@ public abstract class BaseTestHiveCoercion
                         "  'abc', " +
                         "  'abc', " +
                         "  'abc', " +
+                        "  TIMESTAMP '2121-07-15 15:30:12.123', " +
+                        "  TIMESTAMP '2121-07-15 15:30:12.123', " +
+                        "  TIMESTAMP '2121-07-15 15:30:12.123', " +
                         "  1), " +
                         "(" +
                         "  CAST(ROW (NULL, 1, -100, -2323, -12345, 2) AS ROW(keep VARCHAR, ti2si TINYINT, si2int SMALLINT, int2bi INTEGER, bi2vc BIGINT, lower2uppercase BIGINT)), " +
@@ -197,6 +203,9 @@ public abstract class BaseTestHiveCoercion
                         "  '\uD83D\uDCB0\uD83D\uDCB0\uD83D\uDCB0', " +
                         "  '\uD83D\uDCB0\uD83D\uDCB0\uD83D\uDCB0', " +
                         "  '\uD83D\uDCB0\uD83D\uDCB0\uD83D\uDCB0', " +
+                        "  TIMESTAMP '1970-01-01 00:00:00.123', " +
+                        "  TIMESTAMP '1970-01-01 00:00:00.123', " +
+                        "  TIMESTAMP '1970-01-01 00:00:00.123', " +
                         "  1)",
                 tableName,
                 floatToDoubleType));
@@ -340,6 +349,15 @@ public abstract class BaseTestHiveCoercion
                 .put("char_to_smaller_char", ImmutableList.of(
                         "ab",
                         "\uD83D\uDCB0\uD83D\uDCB0"))
+                .put("timestamp_to_string", ImmutableList.of(
+                        "2121-07-15 15:30:12.123",
+                        "1970-01-01 00:00:00.123"))
+                .put("timestamp_to_bounded_varchar", ImmutableList.of(
+                        "2121-07-15 15:30:12.123",
+                        "1970-01-01 00:00:00.123"))
+                .put("timestamp_to_smaller_varchar", ImmutableList.of(
+                        "2121",
+                        "1970"))
                 .put("id", ImmutableList.of(
                         1,
                         1))
@@ -564,6 +582,9 @@ public abstract class BaseTestHiveCoercion
                 row("varchar_to_smaller_varchar", "varchar(2)"),
                 row("char_to_bigger_char", "char(4)"),
                 row("char_to_smaller_char", "char(2)"),
+                row("timestamp_to_string", "varchar"),
+                row("timestamp_to_bounded_varchar", "varchar(30)"),
+                row("timestamp_to_smaller_varchar", "varchar(4)"),
                 row("id", "bigint"));
     }
 
@@ -612,6 +633,9 @@ public abstract class BaseTestHiveCoercion
                 .put("char_to_smaller_char", CHAR)
                 .put("id", BIGINT)
                 .put("nested_field", BIGINT)
+                .put("timestamp_to_string", VARCHAR)
+                .put("timestamp_to_bounded_varchar", VARCHAR)
+                .put("timestamp_to_smaller_varchar", VARCHAR)
                 .buildOrThrow();
 
         assertThat(queryResult)
@@ -650,6 +674,9 @@ public abstract class BaseTestHiveCoercion
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN varchar_to_smaller_varchar varchar_to_smaller_varchar varchar(2)", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN char_to_bigger_char char_to_bigger_char char(4)", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN char_to_smaller_char char_to_smaller_char char(2)", tableName));
+        onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN timestamp_to_string timestamp_to_string string", tableName));
+        onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN timestamp_to_bounded_varchar timestamp_to_bounded_varchar varchar(30)", tableName));
+        onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN timestamp_to_smaller_varchar timestamp_to_smaller_varchar varchar(4)", tableName));
     }
 
     protected static TableInstance<?> mutableTableInstanceOf(TableDefinition tableDefinition)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnPartitionedTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnPartitionedTable.java
@@ -98,7 +98,10 @@ public class TestHiveCoercionOnPartitionedTable
                         "    varchar_to_bigger_varchar          VARCHAR(3)," +
                         "    varchar_to_smaller_varchar         VARCHAR(3)," +
                         "    char_to_bigger_char                CHAR(3)," +
-                        "    char_to_smaller_char               CHAR(3)" +
+                        "    char_to_smaller_char               CHAR(3)," +
+                        "    timestamp_to_string                TIMESTAMP," +
+                        "    timestamp_to_bounded_varchar       TIMESTAMP," +
+                        "    timestamp_to_smaller_varchar       TIMESTAMP" +
                         ") " +
                         "PARTITIONED BY (id BIGINT) " +
                         rowFormat.map(s -> format("ROW FORMAT %s ", s)).orElse("") +

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
@@ -72,6 +72,9 @@ public class TestHiveCoercionOnUnpartitionedTable
                             varchar_to_smaller_varchar         VARCHAR(3),
                             char_to_bigger_char                CHAR(3),
                             char_to_smaller_char               CHAR(3),
+                            timestamp_to_string                TIMESTAMP,
+                            timestamp_to_bounded_varchar       TIMESTAMP,
+                            timestamp_to_smaller_varchar       TIMESTAMP,
                             id                                 BIGINT)
                        STORED AS\s""" + fileFormat);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Add support for timestamp to varchar coercer in hive tables. In case of partitioned table it is supported by most of the format and in case of unpartitioned tables only ORC format is supported as of now. 

The coercion that was supported as of current master for unpartitioned tables are inherently supported by the `ColumnReader` and this PR introduces a framework which maps a `OrcTypeKind` to a corresponding `TrinoType` and also re-uses the `TypeCoercer` used by partitioned tables. 



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Add support for timestamp to varchar coercer in hive tables
```
