### PR TITLE
Increase dynamic filter limits for fault tolerant execution

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/DynamicFilterConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DynamicFilterConfig.java
@@ -45,7 +45,13 @@ public class DynamicFilterConfig
     private DataSize smallBroadcastMaxSizePerDriver = DataSize.of(20, KILOBYTE);
     private int smallBroadcastRangeRowLimitPerDriver = 400;
     private DataSize smallBroadcastMaxSizePerOperator = DataSize.of(200, KILOBYTE);
+    /**
+     * default value is overwritten for fault tolerant execution in {@link #applyFaultTolerantExecutionDefaults()}
+     */
     private int smallPartitionedMaxDistinctValuesPerDriver = 20;
+    /**
+     * default value is overwritten for fault tolerant execution in {@link #applyFaultTolerantExecutionDefaults()}
+     */
     private DataSize smallPartitionedMaxSizePerDriver = DataSize.of(10, KILOBYTE);
     private int smallPartitionedRangeRowLimitPerDriver = 100;
     private DataSize smallPartitionedMaxSizePerOperator = DataSize.of(100, KILOBYTE);
@@ -55,7 +61,13 @@ public class DynamicFilterConfig
     private DataSize largeBroadcastMaxSizePerDriver = DataSize.of(500, KILOBYTE);
     private int largeBroadcastRangeRowLimitPerDriver = 10_000;
     private DataSize largeBroadcastMaxSizePerOperator = DataSize.of(5, MEGABYTE);
+    /**
+     * default value is overwritten for fault tolerant execution in {@link #applyFaultTolerantExecutionDefaults()}
+     */
     private int largePartitionedMaxDistinctValuesPerDriver = 500;
+    /**
+     * default value is overwritten for fault tolerant execution in {@link #applyFaultTolerantExecutionDefaults()}
+     */
     private DataSize largePartitionedMaxSizePerDriver = DataSize.of(50, KILOBYTE);
     private int largePartitionedRangeRowLimitPerDriver = 1_000;
     private DataSize largePartitionedMaxSizePerOperator = DataSize.of(500, KILOBYTE);
@@ -331,5 +343,13 @@ public class DynamicFilterConfig
     {
         this.largeMaxSizePerFilter = largeMaxSizePerFilter;
         return this;
+    }
+
+    public void applyFaultTolerantExecutionDefaults()
+    {
+        smallPartitionedMaxDistinctValuesPerDriver = 100_000;
+        smallPartitionedMaxSizePerDriver = DataSize.of(100, KILOBYTE);
+        largePartitionedMaxDistinctValuesPerDriver = 1_000_000;
+        largePartitionedMaxSizePerDriver = DataSize.of(500, KILOBYTE);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -472,6 +472,9 @@ public class ServerMainModule
 
         // Dynamic Filtering
         configBinder(binder).bindConfig(DynamicFilterConfig.class);
+        if (retryPolicy == TASK) {
+            configBinder(binder).bindConfigDefaults(DynamicFilterConfig.class, DynamicFilterConfig::applyFaultTolerantExecutionDefaults);
+        }
 
         // dispatcher
         // TODO remove dispatcher fromm ServerMainModule, and bind dependent components only on coordinators


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In fault tolerant executions dynamic filters are collected before shuffle resulting in higher number of distinct values per driver / operator.

Increasing the limit is safe as the memory used by dynamic filters is tracked.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/trinodb/trino/issues/16104
https://github.com/trinodb/trino/pull/16110

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
