### PR TITLE
Fix an edge case with Round function when the scaled number exceeds Double.MAX_VALUE

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
@@ -837,6 +837,13 @@ public final class MathFunctions
         if (rescaledRound != Long.MAX_VALUE) {
             return sign * (rescaledRound / factor);
         }
+        if (Double.isInfinite(rescaled)) {
+            // num has max 17 precisions, so to make round actually do something, decimals must be smaller than 17.
+            // then factor must be smaller than 10^17
+            // then in order for rescaled to be greater than Double.MAX_VALUE, num must be greater than 1.8E291 with many trailing zeros
+            // in which case, rounding is no op anyway
+            return num;
+        }
         return sign * DoubleMath.roundToBigInteger(rescaled, RoundingMode.HALF_UP).doubleValue() / factor;
     }
 
@@ -857,6 +864,11 @@ public final class MathFunctions
         long rescaledRound = Math.round(rescaled);
         if (rescaledRound != Long.MAX_VALUE) {
             result = sign * (rescaledRound / factor);
+        }
+        else if (Double.isInfinite(rescaled)) {
+            // numInFloat is max at 3.4028235e+38f, to make rescale greater than Double.MAX_VALUE, decimals must be greater than 270
+            // but numInFloat has max 8 precision, so rounding is no op
+            return num;
         }
         else {
             result = sign * (DoubleMath.roundToBigInteger(rescaled, RoundingMode.HALF_UP).doubleValue() / factor);

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathFunctions.java
@@ -1658,6 +1658,13 @@ public class TestMathFunctions
         assertThat(assertions.function("round", "DOUBLE '3000.1234567890123456789'", "16"))
                 .isEqualTo(3000.1234567890124);
 
+        // 1.8E292*10^16 is infinity.
+        assertThat(assertions.function("round", "DOUBLE '1.8E292'", "16"))
+                .isEqualTo(1.8E292);
+
+        assertThat(assertions.function("round", "DOUBLE '-1.8E292'", "16"))
+                .isEqualTo(-1.8E292);
+
         assertThat(assertions.function("round", "TINYINT '3'", "TINYINT '1'"))
                 .isEqualTo((byte) 3);
 
@@ -1701,6 +1708,13 @@ public class TestMathFunctions
         // 3000 * 10^16 exceeds Long.MAX_VALUE. Note that value has limited precision even before round is invoked
         assertThat(assertions.function("round", "REAL '3000.1234567890123456789'", "16"))
                 .isEqualTo(3000.1235f);
+
+        // 3.4028235e+38 * 10 ^ 271 is infinity
+        assertThat(assertions.function("round", "REAL '3.4028235e+38'", "271"))
+                .isEqualTo(3.4028235e+38f);
+
+        assertThat(assertions.function("round", "REAL '-3.4028235e+38'", "271"))
+                .isEqualTo(-3.4028235e+38f);
 
         assertThat(assertions.function("round", "3", "1"))
                 .isEqualTo(3);


### PR DESCRIPTION
## Description

Fix an edge case with Round function when the scaled number exceeds Double.MAX_VALUE

This issue was caused by PR https://github.com/trinodb/trino/pull/14620.

Before this PR, select round(123.4, 10000000) would return 0.0 incorrectly.

After this PR, select round(123.4, 10000000) would cause issue "input is infinite or NaN"

After this fix, it would return correctly 123.4. 

In general this PR fixes an edge case for round(a, b) if a*b^10 is exceeds Double.MAX_VALUE

## Additional context and related issues


## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

