### PR TITLE
Collect uncompressed data size for output statistics

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/buffer/PagesSerdeUtil.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/PagesSerdeUtil.java
@@ -121,6 +121,11 @@ public final class PagesSerdeUtil
         return serializedPage.getInt(SERIALIZED_PAGE_POSITION_COUNT_OFFSET);
     }
 
+    public static int getSerializedPageUncompressedSizeInBytes(Slice serializedPage)
+    {
+        return serializedPage.getInt(SERIALIZED_PAGE_UNCOMPRESSED_SIZE_OFFSET);
+    }
+
     public static boolean isSerializedPageEncrypted(Slice serializedPage)
     {
         return getSerializedPageMarkerSet(serializedPage).contains(ENCRYPTED);

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/SpoolingExchangeOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/SpoolingExchangeOutputBuffer.java
@@ -32,6 +32,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
 import static io.trino.execution.buffer.PagesSerdeUtil.getSerializedPagePositionCount;
+import static io.trino.execution.buffer.PagesSerdeUtil.getSerializedPageUncompressedSizeInBytes;
 import static java.util.Objects.requireNonNull;
 
 @ThreadSafe
@@ -193,7 +194,7 @@ public class SpoolingExchangeOutputBuffer
         checkState(sink != null, "exchangeSink is null");
         long dataSizeInBytes = 0;
         for (Slice page : pages) {
-            dataSizeInBytes += page.length();
+            dataSizeInBytes += getSerializedPageUncompressedSizeInBytes(page);
             sink.add(partition, page);
             totalRowsAdded.addAndGet(getSerializedPagePositionCount(page));
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

When exchange data is compressed heavily allocating tasks based on the compressed data size may significantly increase latency.

This effect is visible in tpcds/q24 when the inputs of a joins are well compressible and expand significantly after decompression. Yet the engine doesn't allocate enough tasks to achieve necessary level of parallelism.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/trinodb/trino/pull/16719

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
