### PR TITLE
require a space in front of timezone if there is no time information in casting string to timestamp

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/AbstractTrinoResultSet.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/AbstractTrinoResultSet.java
@@ -92,8 +92,8 @@ abstract class AbstractTrinoResultSet
 {
     private static final Pattern DATETIME_PATTERN = Pattern.compile("" +
             "(?<year>[-+]?\\d{4,})-(?<month>\\d{1,2})-(?<day>\\d{1,2})" +
-            "(?: (?<hour>\\d{1,2}):(?<minute>\\d{1,2})(?::(?<second>\\d{1,2})(?:\\.(?<fraction>\\d+))?)?)?" +
-            "\\s*(?<timezone>.+)?");
+            "( (?:(?<hour>\\d{1,2}):(?<minute>\\d{1,2})(?::(?<second>\\d{1,2})(?:\\.(?<fraction>\\d+))?)?)?" +
+            "(?:\\s*(?<timezone>.+))?)?");
 
     private static final Pattern TIME_PATTERN = Pattern.compile("(?<hour>\\d{1,2}):(?<minute>\\d{1,2}):(?<second>\\d{1,2})(?:\\.(?<fraction>\\d+))?");
     private static final Pattern TIME_WITH_TIME_ZONE_PATTERN = Pattern.compile("" +

--- a/core/trino-main/src/main/java/io/trino/type/DateTimes.java
+++ b/core/trino-main/src/main/java/io/trino/type/DateTimes.java
@@ -51,8 +51,8 @@ public final class DateTimes
 {
     public static final Pattern DATETIME_PATTERN = Pattern.compile("" +
             "(?<year>[-+]?\\d{4,})-(?<month>\\d{1,2})-(?<day>\\d{1,2})" +
-            "(?: (?<hour>\\d{1,2}):(?<minute>\\d{1,2})(?::(?<second>\\d{1,2})(?:\\.(?<fraction>\\d+))?)?)?" +
-            "\\s*(?<timezone>.+)?");
+            "( (?:(?<hour>\\d{1,2}):(?<minute>\\d{1,2})(?::(?<second>\\d{1,2})(?:\\.(?<fraction>\\d+))?)?)?" +
+            "\\s*(?<timezone>.+)?)?");
     private static final String TIMESTAMP_FORMATTER_PATTERN = "uuuu-MM-dd HH:mm:ss";
     private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern(TIMESTAMP_FORMATTER_PATTERN);
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestTimestampWithTimeZone.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestTimestampWithTimeZone.java
@@ -402,7 +402,7 @@ public class TestTimestampWithTimeZone
                 .hasType(createTimestampWithTimeZoneType(0))
                 .isEqualTo(timestampWithTimeZone(0, 2001, 1, 2, 3, 4, 0, 0, getTimeZoneKey("+07:09")));
 
-        assertThat(assertions.expression("TIMESTAMP '2001-1-2+07:09'"))
+        assertThat(assertions.expression("TIMESTAMP '2001-1-2 +07:09'"))
                 .hasType(createTimestampWithTimeZoneType(0))
                 .isEqualTo(timestampWithTimeZone(0, 2001, 1, 2, 0, 0, 0, 0, getTimeZoneKey("+07:09")));
 
@@ -434,6 +434,11 @@ public class TestTimestampWithTimeZone
         assertTrinoExceptionThrownBy(() -> assertions.expression("TIMESTAMP '-123001-01-02 03:04:05.321 Europe/Berlin'").evaluate())
                 .hasErrorCode(INVALID_LITERAL)
                 .hasMessage("line 1:12: '-123001-01-02 03:04:05.321 Europe/Berlin' is not a valid TIMESTAMP literal");
+
+        // missing space after day
+        assertTrinoExceptionThrownBy(() -> assertions.expression("TIMESTAMP '2020-13-01-12'").evaluate())
+                .hasErrorCode(INVALID_LITERAL)
+                .hasMessage("line 1:12: '2020-13-01-12' is not a valid TIMESTAMP literal");
     }
 
     @Test


### PR DESCRIPTION
## Description
This PR is a suggestion to require a space in front of timezone if there is no time information in casting string to timestamp. 

This is because one of special case of "YYYY-MM-DD.*": YYYY-MM-DD-XX is ambiguous. Some of users would use XX as hour, and result is inconsistent behavior: 

- when XX is 01, 02, it would parse it as if it is YYYY-MM-DD at timezone with -01, -02 offset
- when XX is 20, 21, it would throw an error because there is no timezone with -20 or -21 offset

Either case, it would be better not to use 'YYYY-MM-DD-XX' pattern. 

This change is simply require that there is at least one space before timezone if there is no time information

## Additional context and related issues

Other options considered but not picked:
- Make HH:mm required while keeping seconds and fraction optional. 
  - Reason not to pick: breaks ‘YYYY-MM-DD’, which is very prevalent use case
- Require time information when timezone is present. 
  - Reason not to pick: breaks ‘YYYY-MM-DD Timezone’ pattern, which is very prevalent use case
- Require that there is at least one space before timezone
  - Reason not to pick: break '2004-10-19 10:23:54+02', which is a very common format 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
Requires a space in front of timezone if there is no time information in casting string to timestamp.
```
