### PR TITLE
Add docs for property to skip glue archive

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -167,6 +167,19 @@ configuration properties as the Hive connector's Glue setup. See
     connector.name=iceberg
     iceberg.catalog.type=glue
 
+.. list-table:: Iceberg Glue catalog configuration properties
+  :widths: 35, 50, 15
+  :header-rows: 1
+
+  * - Property name
+    - Description
+    - Default
+  * - ``iceberg.glue.skip-archive``
+    - Skip archiving an old table version when creating a new version in a
+      commit. See `AWS Glue Skip Archive
+      <https://iceberg.apache.org/docs/latest/aws/#skip-archive>`_.
+    - ``false``
+
 .. _iceberg-rest-catalog:
 
 REST catalog

--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -183,7 +183,7 @@ properties:
   * - Property name
     - Description
   * - ``iceberg.rest-catalog.uri``
-    - REST server API endpoint URI (required). 
+    - REST server API endpoint URI (required).
       Example: ``http://iceberg-with-rest:8181``
   * - ``iceberg.rest-catalog.warehouse``
     - Warehouse identifier/location for the catalog (optional).
@@ -358,7 +358,7 @@ No other types are supported.
 Security
 --------
 
-The Iceberg connector allows you to choose one of several means of providing 
+The Iceberg connector allows you to choose one of several means of providing
 authorization at the catalog level.
 
 .. _iceberg-authorization:
@@ -1226,10 +1226,10 @@ Identity transforms are simply the column name. Other transforms are:
   * - ``day(ts)``
     - A partition is created for each day of each year.  The partition value is
       the integer difference in days between ``ts`` and January 1 1970.
-  * - ``hour(ts)`` 
+  * - ``hour(ts)``
     - A partition is created hour of each day.  The partition value is a
       timestamp with the minutes and seconds set to zero.
-  * - ``bucket(x, nbuckets)`` 
+  * - ``bucket(x, nbuckets)``
     - The data is hashed into the specified number of buckets.  The partition
       value is an integer hash of ``x``, with a value between 0 and
       ``nbuckets - 1`` inclusive.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

* Adds a table with a description of the `iceberg.glue.skip-archive` property to the Iceberg connector page 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

* Provides documentation for a configuration property mentioned in: https://github.com/trinodb/trino/pull/14336

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
