### PR TITLE
Support char type datetime for date_parse function

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
@@ -52,6 +52,7 @@ import java.util.Locale;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.operator.scalar.QuarterOfYearDateTimeField.QUARTER_OF_YEAR;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.type.Chars.padSpaces;
 import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.trino.spi.type.Int128Math.rescale;
 import static io.trino.spi.type.TimeZoneKey.getTimeZoneKeyForOffset;
@@ -368,6 +369,15 @@ public final class DateTimeFunctions
                 .withLocale(locale);
 
         return utf8Slice(formatter.print(timestamp));
+    }
+
+    @ScalarFunction
+    @LiteralParameters({"x", "y"})
+    @SqlType("timestamp(3)") // TODO: increase precision?
+    public static long dateParse(@LiteralParameter("x") Long x, ConnectorSession session, @SqlType("char(x)") Slice dateTime, @SqlType("varchar(y)") Slice formatString)
+    {
+        dateTime = padSpaces(dateTime, x.intValue());
+        return dateParse(session, dateTime, formatString);
     }
 
     @ScalarFunction

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestDateTimeFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestDateTimeFunctions.java
@@ -888,6 +888,13 @@ public class TestDateTimeFunctions
 
         assertTrinoExceptionThrownBy(() -> assertions.function("date_parse", "'1970-01-01'", "''").evaluate())
                 .hasMessage("Both printing and parsing not supported");
+
+        assertThat(assertions.function("date_parse", "char '10/Jan/2023:23:55:02    '", "'%d/%b/%Y:%H:%i:%s    '"))
+                .matches("TIMESTAMP '2023-01-10 23:55:02.000'");
+        assertTrinoExceptionThrownBy(() -> assertions.function("date_parse", "char '10/Jan/2023:23:55:02    '", "'%d/%b/%Y:%H:%i:%s'").evaluate())
+                .hasMessage("Invalid format: \"10/Jan/2023:23:55:02    \" is malformed at \"    \"");
+        assertTrinoExceptionThrownBy(() -> assertions.function("date_parse", "char '10/Jan/2023:23:55:02'", "'%d/%b/%Y:%H:%i:%s    '").evaluate())
+                .hasMessage("Invalid format: \"10/Jan/2023:23:55:02\" is too short");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

As a temporary solution while fixing the coercion from char to varchar, adding date_parse function signature that supports CHAR as input type for the datetime string to be compatible with previous behavior.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Related issue: https://github.com/trinodb/trino/issues/9031

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
