### PR TITLE
Fill in missing unit test for ScaledPipelinedOutputBufferManager

### DIFF
--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestBroadcastPipelinedOutputBufferManager.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestBroadcastPipelinedOutputBufferManager.java
@@ -54,7 +54,7 @@ public class TestBroadcastPipelinedOutputBufferManager
 
         // try to set no more buffers again, which should not result in an error
         // and output buffers should not change
-        hashOutputBufferManager.addOutputBuffer(new OutputBufferId(6));
+        hashOutputBufferManager.noMoreBuffers();
         assertEquals(hashOutputBufferManager.getOutputBuffers(), expectedOutputBuffers);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestPartitionedPipelinedOutputBufferManager.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestPartitionedPipelinedOutputBufferManager.java
@@ -47,10 +47,9 @@ public class TestPartitionedPipelinedOutputBufferManager
                 .hasMessage("Unexpected new output buffer 5");
         assertOutputBuffers(hashOutputBufferManager.getOutputBuffers());
 
-        // try to a buffer out side of the partition range, which should result in an error
-        assertThatThrownBy(() -> hashOutputBufferManager.addOutputBuffer(new OutputBufferId(6)))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Unexpected new output buffer 6");
+        // try to set no more buffers again, which should not result in an error
+        // and output buffers should not change
+        hashOutputBufferManager.noMoreBuffers();
         assertOutputBuffers(hashOutputBufferManager.getOutputBuffers());
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestScaledPipelinedOutputBufferManager.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestScaledPipelinedOutputBufferManager.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.scheduler;
+
+import io.trino.execution.buffer.PipelinedOutputBuffers;
+import org.testng.annotations.Test;
+
+import static io.trino.execution.buffer.PipelinedOutputBuffers.BufferType.ARBITRARY;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Tests for {@link ScaledPipelinedOutputBufferManager}.
+ */
+public class TestScaledPipelinedOutputBufferManager
+{
+    @Test
+    public void test()
+    {
+        ScaledPipelinedOutputBufferManager scaledPipelinedOutputBufferManager = new ScaledPipelinedOutputBufferManager();
+        assertEquals(scaledPipelinedOutputBufferManager.getOutputBuffers(), PipelinedOutputBuffers.createInitial(ARBITRARY));
+
+        scaledPipelinedOutputBufferManager.addOutputBuffer(new PipelinedOutputBuffers.OutputBufferId(0));
+        PipelinedOutputBuffers expectedOutputBuffers = PipelinedOutputBuffers.createInitial(ARBITRARY).withBuffer(new PipelinedOutputBuffers.OutputBufferId(0), 0);
+        assertEquals(scaledPipelinedOutputBufferManager.getOutputBuffers(), expectedOutputBuffers);
+
+        scaledPipelinedOutputBufferManager.addOutputBuffer(new PipelinedOutputBuffers.OutputBufferId(1));
+        scaledPipelinedOutputBufferManager.addOutputBuffer(new PipelinedOutputBuffers.OutputBufferId(2));
+
+        expectedOutputBuffers = expectedOutputBuffers.withBuffer(new PipelinedOutputBuffers.OutputBufferId(1), 1);
+        expectedOutputBuffers = expectedOutputBuffers.withBuffer(new PipelinedOutputBuffers.OutputBufferId(2), 2);
+        assertEquals(scaledPipelinedOutputBufferManager.getOutputBuffers(), expectedOutputBuffers);
+
+        // set no more buffers
+        scaledPipelinedOutputBufferManager.addOutputBuffer(new PipelinedOutputBuffers.OutputBufferId(3));
+        scaledPipelinedOutputBufferManager.noMoreBuffers();
+        expectedOutputBuffers = expectedOutputBuffers.withBuffer(new PipelinedOutputBuffers.OutputBufferId(3), 3);
+        expectedOutputBuffers = expectedOutputBuffers.withNoMoreBufferIds();
+        assertEquals(scaledPipelinedOutputBufferManager.getOutputBuffers(), expectedOutputBuffers);
+
+        // try to add another buffer, which should not result in an error
+        // and output buffers should not change
+        scaledPipelinedOutputBufferManager.addOutputBuffer(new PipelinedOutputBuffers.OutputBufferId(5));
+        assertEquals(scaledPipelinedOutputBufferManager.getOutputBuffers(), expectedOutputBuffers);
+
+        // try to set no more buffers again, which should not result in an error
+        // and output buffers should not change
+        scaledPipelinedOutputBufferManager.noMoreBuffers();
+        assertEquals(scaledPipelinedOutputBufferManager.getOutputBuffers(), expectedOutputBuffers);
+    }
+}


### PR DESCRIPTION
## Description
- Fix incorrect test logic of setting `noMoreBuffers` again for `Broadcast` and `Partitioned` `OutputBufferManager`.
- It seems that we don't have test case for `ScaledPipelinedOutputBufferManager`. This PR introduce test case for it.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
