### PR TITLE
Support Databricks 12.2 LTS and disallow unsupported reader versions and features in Delta Lake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -848,6 +848,7 @@ jobs:
             - suite-delta-lake-databricks91
             - suite-delta-lake-databricks104
             - suite-delta-lake-databricks113
+            - suite-delta-lake-databricks122
             - suite-gcs
             - suite-clients
             - suite-functions
@@ -894,6 +895,11 @@ jobs:
             - suite: suite-delta-lake-databricks113
               config: hdp3
             - suite: suite-delta-lake-databricks113
+              ignore exclusion if: >-
+                ${{ secrets.DATABRICKS_TOKEN != '' }}
+            - suite: suite-delta-lake-databricks122
+              config: hdp3
+            - suite: suite-delta-lake-databricks122
               ignore exclusion if: >-
                 ${{ secrets.DATABRICKS_TOKEN != '' }}
 
@@ -992,6 +998,7 @@ jobs:
           DATABRICKS_91_JDBC_URL:
           DATABRICKS_104_JDBC_URL:
           DATABRICKS_113_JDBC_URL:
+          DATABRICKS_122_JDBC_URL:
           DATABRICKS_LOGIN:
           DATABRICKS_TOKEN:
           GCP_CREDENTIALS_KEY:
@@ -1062,6 +1069,7 @@ jobs:
           DATABRICKS_91_JDBC_URL: ${{ secrets.DATABRICKS_91_JDBC_URL }}
           DATABRICKS_104_JDBC_URL: ${{ secrets.DATABRICKS_104_JDBC_URL }}
           DATABRICKS_113_JDBC_URL: ${{ secrets.DATABRICKS_113_JDBC_URL }}
+          DATABRICKS_122_JDBC_URL: ${{ secrets.DATABRICKS_122_JDBC_URL }}
           DATABRICKS_LOGIN: token
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
           GCP_CREDENTIALS_KEY: ${{ secrets.GCP_CREDENTIALS_KEY }}

--- a/docs/src/main/sphinx/connector/delta-lake.rst
+++ b/docs/src/main/sphinx/connector/delta-lake.rst
@@ -298,8 +298,8 @@ No other types are supported.
 Security
 --------
 
-The Delta Lake connector allows you to choose one of several means of providing 
-autorization at the catalog level. You can select a different type of 
+The Delta Lake connector allows you to choose one of several means of providing
+autorization at the catalog level. You can select a different type of
 authorization check in different Delta Lake catalog files.
 
 .. _delta-lake-authorization:

--- a/docs/src/main/sphinx/connector/delta-lake.rst
+++ b/docs/src/main/sphinx/connector/delta-lake.rst
@@ -16,7 +16,7 @@ Requirements
 
 To connect to Databricks Delta Lake, you need:
 
-* Tables written by Databricks Runtime 7.3 LTS, 9.1 LTS, 10.4 LTS and 11.3 LTS are supported.
+* Tables written by Databricks Runtime 7.3 LTS, 9.1 LTS, 10.4 LTS, 11.3 LTS and 12.2 LTS are supported.
 * Deployments using AWS, HDFS, Azure Storage, and Google Cloud Storage (GCS) are
   fully supported.
 * Network access from the coordinator and workers to the Delta Lake storage.

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -286,7 +286,7 @@ public class DeltaLakeMetadata
     public static final int DEFAULT_WRITER_VERSION = 2;
     // The highest reader and writer versions Trino supports
     private static final int MAX_READER_VERSION = 3;
-    public static final int MAX_WRITER_VERSION = 4;
+    private static final int MAX_WRITER_VERSION = 4;
     private static final int CDF_SUPPORTED_WRITER_VERSION = 4;
 
     // Matches the dummy column Databricks stores in the metastore

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/ProtocolEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/ProtocolEntry.java
@@ -17,21 +17,39 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 
 import static java.lang.String.format;
 
 public class ProtocolEntry
 {
+    private static final int MIN_VERSION_SUPPORTS_READER_FEATURES = 3;
+    private static final int MIN_VERSION_SUPPORTS_WRITER_FEATURES = 7;
+
     private final int minReaderVersion;
     private final int minWriterVersion;
+    private final Optional<Set<String>> readerFeatures;
+    private final Optional<Set<String>> writerFeatures;
 
     @JsonCreator
     public ProtocolEntry(
             @JsonProperty("minReaderVersion") int minReaderVersion,
-            @JsonProperty("minWriterVersion") int minWriterVersion)
+            @JsonProperty("minWriterVersion") int minWriterVersion,
+            // The delta protocol documentation mentions that readerFeatures & writerFeatures is Array[String], but their actual implementation is Set
+            @JsonProperty("readerFeatures") Optional<Set<String>> readerFeatures,
+            @JsonProperty("writerFeatures") Optional<Set<String>> writerFeatures)
     {
         this.minReaderVersion = minReaderVersion;
         this.minWriterVersion = minWriterVersion;
+        if (minReaderVersion < MIN_VERSION_SUPPORTS_READER_FEATURES && readerFeatures.isPresent()) {
+            throw new IllegalArgumentException("readerFeatures must not exist when minReaderVersion is less than " + MIN_VERSION_SUPPORTS_READER_FEATURES);
+        }
+        if (minWriterVersion < MIN_VERSION_SUPPORTS_WRITER_FEATURES && writerFeatures.isPresent()) {
+            throw new IllegalArgumentException("writerFeatures must not exist when minWriterVersion is less than " + MIN_VERSION_SUPPORTS_WRITER_FEATURES);
+        }
+        this.readerFeatures = readerFeatures;
+        this.writerFeatures = writerFeatures;
     }
 
     @JsonProperty
@@ -46,6 +64,18 @@ public class ProtocolEntry
         return minWriterVersion;
     }
 
+    @JsonProperty
+    public Optional<Set<String>> getReaderFeatures()
+    {
+        return readerFeatures;
+    }
+
+    @JsonProperty
+    public Optional<Set<String>> getWriterFeatures()
+    {
+        return writerFeatures;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -57,18 +87,25 @@ public class ProtocolEntry
         }
         ProtocolEntry that = (ProtocolEntry) o;
         return minReaderVersion == that.minReaderVersion &&
-                minWriterVersion == that.minWriterVersion;
+                minWriterVersion == that.minWriterVersion &&
+                readerFeatures.equals(that.readerFeatures) &&
+                writerFeatures.equals(that.writerFeatures);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(minReaderVersion, minWriterVersion);
+        return Objects.hash(minReaderVersion, minWriterVersion, readerFeatures, writerFeatures);
     }
 
     @Override
     public String toString()
     {
-        return format("ProtocolEntry{minReaderVersion=%d, minWriterVersion=%d}", minReaderVersion, minWriterVersion);
+        return format(
+                "ProtocolEntry{minReaderVersion=%d, minWriterVersion=%d, readerFeatures=%s, writerFeatures=%s}",
+                minReaderVersion,
+                minWriterVersion,
+                readerFeatures,
+                writerFeatures);
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
@@ -67,6 +67,7 @@ import java.util.Set;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.plugin.deltalake.DeltaLakeColumnType.REGULAR;
 import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_BAD_DATA;
@@ -213,7 +214,7 @@ public class CheckpointEntryIterator
                 type = schemaManager.getMetadataEntryType();
                 break;
             case PROTOCOL:
-                type = schemaManager.getProtocolEntryType();
+                type = schemaManager.getProtocolEntryType(true, true);
                 break;
             case COMMIT:
                 type = schemaManager.getCommitInfoEntryType();
@@ -278,16 +279,21 @@ public class CheckpointEntryIterator
         if (block.isNull(pagePosition)) {
             return null;
         }
-        int protocolFields = 2;
+        int minProtocolFields = 2;
+        int maxProtocolFields = 4;
         Block protocolEntryBlock = block.getObject(pagePosition, Block.class);
         log.debug("Block %s has %s fields", block, protocolEntryBlock.getPositionCount());
-        if (protocolEntryBlock.getPositionCount() != protocolFields) {
+        if (protocolEntryBlock.getPositionCount() < minProtocolFields || protocolEntryBlock.getPositionCount() > maxProtocolFields) {
             throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA,
-                    format("Expected block %s to have %d children, but found %s", block, protocolFields, protocolEntryBlock.getPositionCount()));
+                    format("Expected block %s to have between %d and %d children, but found %s", block, minProtocolFields, maxProtocolFields, protocolEntryBlock.getPositionCount()));
         }
+        // The last entry should be writer feature when protocol entry size is 3 https://github.com/delta-io/delta/blob/master/PROTOCOL.md#disabled-features
+        int position = 0;
         ProtocolEntry result = new ProtocolEntry(
-                getInt(protocolEntryBlock, 0),
-                getInt(protocolEntryBlock, 1));
+                getInt(protocolEntryBlock, position++),
+                getInt(protocolEntryBlock, position++),
+                protocolEntryBlock.getPositionCount() == 4 && protocolEntryBlock.isNull(position) ? Optional.empty() : Optional.of(getList(protocolEntryBlock, position++).stream().collect(toImmutableSet())),
+                protocolEntryBlock.isNull(position) ? Optional.empty() : Optional.of(getList(protocolEntryBlock, position++).stream().collect(toImmutableSet())));
         log.debug("Result: %s", result);
         return DeltaLakeTransactionLogEntry.protocolEntry(result);
     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointSchemaManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointSchemaManager.java
@@ -53,19 +53,16 @@ public class CheckpointSchemaManager
             RowType.field("deletionTimestamp", BigintType.BIGINT),
             RowType.field("dataChange", BooleanType.BOOLEAN)));
 
-    private static final RowType PROTOCOL_ENTRY_TYPE = RowType.from(ImmutableList.of(
-            RowType.field("minReaderVersion", IntegerType.INTEGER),
-            RowType.field("minWriterVersion", IntegerType.INTEGER)));
-
     private final RowType metadataEntryType;
     private final RowType commitInfoEntryType;
+    private final ArrayType stringList;
 
     @Inject
     public CheckpointSchemaManager(TypeManager typeManager)
     {
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
 
-        ArrayType stringList = (ArrayType) this.typeManager.getType(TypeSignature.arrayType(VarcharType.VARCHAR.getTypeSignature()));
+        stringList = (ArrayType) this.typeManager.getType(TypeSignature.arrayType(VarcharType.VARCHAR.getTypeSignature()));
         MapType stringMap = (MapType) this.typeManager.getType(TypeSignature.mapType(VarcharType.VARCHAR.getTypeSignature(), VarcharType.VARCHAR.getTypeSignature()));
 
         metadataEntryType = RowType.from(ImmutableList.of(
@@ -176,9 +173,18 @@ public class CheckpointSchemaManager
         return TXN_ENTRY_TYPE;
     }
 
-    public RowType getProtocolEntryType()
+    public RowType getProtocolEntryType(boolean requireReaderFeatures, boolean requireWriterFeatures)
     {
-        return PROTOCOL_ENTRY_TYPE;
+        ImmutableList.Builder<RowType.Field> fields = ImmutableList.builder();
+        fields.add(RowType.field("minReaderVersion", IntegerType.INTEGER));
+        fields.add(RowType.field("minWriterVersion", IntegerType.INTEGER));
+        if (requireReaderFeatures) {
+            fields.add(RowType.field("readerFeatures", stringList));
+        }
+        if (requireWriterFeatures) {
+            fields.add(RowType.field("writerFeatures", stringList));
+        }
+        return RowType.from(fields.build());
     }
 
     public RowType getCommitInfoEntryType()

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
@@ -162,7 +162,7 @@ public class TestDeltaLakePageSink
                 true,
                 Optional.empty(),
                 Optional.of(false),
-                new ProtocolEntry(DEFAULT_READER_VERSION, DEFAULT_WRITER_VERSION));
+                new ProtocolEntry(DEFAULT_READER_VERSION, DEFAULT_WRITER_VERSION, Optional.empty(), Optional.empty()));
 
         DeltaLakePageSinkProvider provider = new DeltaLakePageSinkProvider(
                 new GroupByHashPageIndexerFactory(new JoinCompiler(new TypeOperators()), new BlockTypeOperators()),

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestProtocolEntry.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestProtocolEntry.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.transactionlog;
+
+import com.google.common.collect.ImmutableSet;
+import io.airlift.json.JsonCodec;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
+
+public class TestProtocolEntry
+{
+    private final JsonCodec<ProtocolEntry> codec = JsonCodec.jsonCodec(ProtocolEntry.class);
+
+    @Test
+    public void testProtocolEntryFromJson()
+    {
+        @Language("JSON")
+        String json = "{\"minReaderVersion\":2,\"minWriterVersion\":5}";
+        assertEquals(
+                codec.fromJson(json),
+                new ProtocolEntry(2, 5, Optional.empty(), Optional.empty()));
+
+        @Language("JSON")
+        String jsonWithFeatures = "{\"minReaderVersion\":3,\"minWriterVersion\":7,\"readerFeatures\":[\"deletionVectors\"],\"writerFeatures\":[\"timestampNTZ\"]}";
+        assertEquals(
+                codec.fromJson(jsonWithFeatures),
+                new ProtocolEntry(3, 7, Optional.of(ImmutableSet.of("deletionVectors")), Optional.of(ImmutableSet.of("timestampNTZ"))));
+    }
+
+    @Test
+    public void testInvalidProtocolEntryFromJson()
+    {
+        @Language("JSON")
+        String invalidMinReaderVersion = "{\"minReaderVersion\":2,\"minWriterVersion\":7,\"readerFeatures\":[\"deletionVectors\"]}";
+        assertThatThrownBy(() -> codec.fromJson(invalidMinReaderVersion))
+                .hasMessageContaining("Invalid JSON string")
+                .hasStackTraceContaining("readerFeatures must not exist when minReaderVersion is less than 3");
+
+        @Language("JSON")
+        String invalidMinWriterVersion = "{\"minReaderVersion\":3,\"minWriterVersion\":6,\"writerFeatures\":[\"timestampNTZ\"]}";
+        assertThatThrownBy(() -> codec.fromJson(invalidMinWriterVersion))
+                .hasMessageContaining("Invalid JSON string")
+                .hasStackTraceContaining("writerFeatures must not exist when minWriterVersion is less than 7");
+    }
+
+    @Test
+    public void testProtocolEntryToJson()
+    {
+        assertEquals(
+                codec.toJson(new ProtocolEntry(2, 5, Optional.empty(), Optional.empty())),
+                """
+                {
+                  "minReaderVersion" : 2,
+                  "minWriterVersion" : 5
+                }""");
+
+        assertEquals(
+                codec.toJson(new ProtocolEntry(3, 7, Optional.of(ImmutableSet.of("deletionVectors")), Optional.of(ImmutableSet.of("timestampNTZ")))),
+                """
+                {
+                  "minReaderVersion" : 3,
+                  "minWriterVersion" : 7,
+                  "readerFeatures" : [ "deletionVectors" ],
+                  "writerFeatures" : [ "timestampNTZ" ]
+                }""");
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestTableSnapshot.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestTableSnapshot.java
@@ -169,7 +169,7 @@ public class TestTableSnapshot
                             Optional.empty(),
                             null));
 
-            assertThat(entries).element(6).extracting(DeltaLakeTransactionLogEntry::getProtocol).isEqualTo(new ProtocolEntry(1, 2));
+            assertThat(entries).element(6).extracting(DeltaLakeTransactionLogEntry::getProtocol).isEqualTo(new ProtocolEntry(1, 2, Optional.empty(), Optional.empty()));
 
             assertThat(entries).element(8).extracting(DeltaLakeTransactionLogEntry::getAdd).isEqualTo(
                     new AddFileEntry(

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointBuilder.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointBuilder.java
@@ -44,8 +44,8 @@ public class TestCheckpointBuilder
         builder.addLogEntry(metadataEntry(metadata1));
         builder.addLogEntry(metadataEntry(metadata2));
 
-        ProtocolEntry protocol1 = new ProtocolEntry(1, 2);
-        ProtocolEntry protocol2 = new ProtocolEntry(3, 4);
+        ProtocolEntry protocol1 = new ProtocolEntry(1, 2, Optional.empty(), Optional.empty());
+        ProtocolEntry protocol2 = new ProtocolEntry(3, 4, Optional.empty(), Optional.empty());
         builder.addLogEntry(protocolEntry(protocol1));
         builder.addLogEntry(protocolEntry(protocol2));
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointEntryIterator.java
@@ -164,7 +164,7 @@ public class TestCheckpointEntryIterator
         assertThat(entries).element(12).extracting(DeltaLakeTransactionLogEntry::getMetaData).isEqualTo(metadataEntry);
 
         // ProtocolEntry
-        assertThat(entries).element(11).extracting(DeltaLakeTransactionLogEntry::getProtocol).isEqualTo(new ProtocolEntry(1, 2));
+        assertThat(entries).element(11).extracting(DeltaLakeTransactionLogEntry::getProtocol).isEqualTo(new ProtocolEntry(1, 2, Optional.empty(), Optional.empty()));
 
         // TransactionEntry
         // not found in the checkpoint, TODO add a test

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointWriter.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointWriter.java
@@ -120,7 +120,7 @@ public class TestCheckpointWriter
                         "configOption1", "blah",
                         "configOption2", "plah"),
                 1000);
-        ProtocolEntry protocolEntry = new ProtocolEntry(10, 20);
+        ProtocolEntry protocolEntry = new ProtocolEntry(10, 20, Optional.empty(), Optional.empty());
         TransactionEntry transactionEntry = new TransactionEntry("appId", 1, 1001);
         AddFileEntry addFileEntryJsonStats = new AddFileEntry(
                 "addFilePathJson",
@@ -246,7 +246,7 @@ public class TestCheckpointWriter
                         "configOption1", "blah",
                         "configOption2", "plah"),
                 1000);
-        ProtocolEntry protocolEntry = new ProtocolEntry(10, 20);
+        ProtocolEntry protocolEntry = new ProtocolEntry(10, 20, Optional.empty(), Optional.empty());
         TransactionEntry transactionEntry = new TransactionEntry("appId", 1, 1001);
 
         Block[] minMaxRowFieldBlocks = new Block[]{
@@ -365,7 +365,7 @@ public class TestCheckpointWriter
                 ImmutableList.of(),
                 ImmutableMap.of(),
                 1000);
-        ProtocolEntry protocolEntry = new ProtocolEntry(10, 20);
+        ProtocolEntry protocolEntry = new ProtocolEntry(10, 20, Optional.empty(), Optional.empty());
         Block[] minMaxRowFieldBlocks = new Block[]{
                 nativeValueToBlock(IntegerType.INTEGER, 1L),
                 nativeValueToBlock(createUnboundedVarcharType(), utf8Slice("a"))

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeDeltaLakeDatabricks122.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeDeltaLakeDatabricks122.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.launcher.env.environment;
+
+import com.google.inject.Inject;
+import io.trino.tests.product.launcher.docker.DockerFiles;
+import io.trino.tests.product.launcher.env.common.Standard;
+import io.trino.tests.product.launcher.env.common.TestsEnvironment;
+
+import static java.util.Objects.requireNonNull;
+
+@TestsEnvironment
+public class EnvSinglenodeDeltaLakeDatabricks122
+        extends AbstractSinglenodeDeltaLakeDatabricks
+{
+    @Inject
+    public EnvSinglenodeDeltaLakeDatabricks122(Standard standard, DockerFiles dockerFiles)
+    {
+        super(standard, dockerFiles);
+    }
+
+    @Override
+    String databricksTestJdbcUrl()
+    {
+        return requireNonNull(System.getenv("DATABRICKS_122_JDBC_URL"), "Environment DATABRICKS_122_JDBC_URL was not set");
+    }
+}

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeDatabricks104.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeDatabricks104.java
@@ -32,6 +32,7 @@ public class SuiteDeltaLakeDatabricks104
         return ImmutableList.of(
                 testOnEnvironment(EnvSinglenodeDeltaLakeDatabricks104.class)
                         .withGroups("configured_features", "delta-lake-databricks")
+                        .withExcludedGroups("delta-lake-exclude-104")
                         .withExcludedTests(getExcludedTests())
                         .build());
     }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeDatabricks122.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeDatabricks122.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.launcher.suite.suites;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.tests.product.launcher.env.EnvironmentConfig;
+import io.trino.tests.product.launcher.env.environment.EnvSinglenodeDeltaLakeDatabricks122;
+import io.trino.tests.product.launcher.suite.SuiteDeltaLakeDatabricks;
+import io.trino.tests.product.launcher.suite.SuiteTestRun;
+
+import java.util.List;
+
+import static io.trino.tests.product.launcher.suite.SuiteTestRun.testOnEnvironment;
+
+public class SuiteDeltaLakeDatabricks122
+        extends SuiteDeltaLakeDatabricks
+{
+    @Override
+    public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
+    {
+        return ImmutableList.of(
+                testOnEnvironment(EnvSinglenodeDeltaLakeDatabricks122.class)
+                        .withGroups("configured_features", "delta-lake-databricks")
+                        .withExcludedGroups("delta-lake-exclude-122")
+                        .withExcludedTests(getExcludedTests())
+                        .build());
+    }
+}

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestGroups.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestGroups.java
@@ -86,6 +86,7 @@ public final class TestGroups
     public static final String DELTA_LAKE_DATABRICKS = "delta-lake-databricks";
     public static final String DELTA_LAKE_EXCLUDE_73 = "delta-lake-exclude-73";
     public static final String DELTA_LAKE_EXCLUDE_91 = "delta-lake-exclude-91";
+    public static final String DELTA_LAKE_EXCLUDE_104 = "delta-lake-exclude-104";
     public static final String DELTA_LAKE_EXCLUDE_113 = "delta-lake-exclude-113";
     public static final String DELTA_LAKE_EXCLUDE_122 = "delta-lake-exclude-122";
     public static final String HUDI = "hudi";

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestGroups.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestGroups.java
@@ -87,6 +87,7 @@ public final class TestGroups
     public static final String DELTA_LAKE_EXCLUDE_73 = "delta-lake-exclude-73";
     public static final String DELTA_LAKE_EXCLUDE_91 = "delta-lake-exclude-91";
     public static final String DELTA_LAKE_EXCLUDE_113 = "delta-lake-exclude-113";
+    public static final String DELTA_LAKE_EXCLUDE_122 = "delta-lake-exclude-122";
     public static final String HUDI = "hudi";
     public static final String PARQUET = "parquet";
     public static final String IGNITE = "ignite";

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksCheckpointsCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksCheckpointsCompatibility.java
@@ -262,7 +262,7 @@ public class TestDeltaLakeDatabricksCheckpointsCompatibility
 
     private String getDatabricksTablePropertiesWithCheckpointInterval()
     {
-        if (databricksRuntimeVersion.equals(DATABRICKS_113_RUNTIME_VERSION)) {
+        if (databricksRuntimeVersion.isAtLeast(DATABRICKS_113_RUNTIME_VERSION)) {
             return "TBLPROPERTIES (\n" +
                     "  'delta.checkpointInterval' = '3',\n" +
                     "  'delta.minReaderVersion' = '1',\n" +

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksCreateTableAsSelectCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksCreateTableAsSelectCompatibility.java
@@ -33,6 +33,7 @@ import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_DATABRICKS;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_EXCLUDE_113;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_EXCLUDE_122;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.deltalake.TransactionLogAssertions.assertLastEntryIsCheckpointed;
 import static io.trino.tests.product.deltalake.TransactionLogAssertions.assertTransactionLogVersion;
@@ -222,8 +223,8 @@ public class TestDeltaLakeDatabricksCreateTableAsSelectCompatibility
         }
     }
 
-    // Databricks 11.3 doesn't create a checkpoint file at 'CREATE OR REPLACE TABLE' statement
-    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_113, PROFILE_SPECIFIC_TESTS})
+    // Databricks 11.3 and 12.2 don't create a checkpoint file at 'CREATE OR REPLACE TABLE' statement
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_113, DELTA_LAKE_EXCLUDE_122, PROFILE_SPECIFIC_TESTS})
     @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
     public void testReplaceTableWithSchemaChangeOnCheckpoint()
     {

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksCreateTableCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksCreateTableCompatibility.java
@@ -315,7 +315,7 @@ public class TestDeltaLakeDatabricksCreateTableCompatibility
 
     private String getDatabricksDefaultTableProperties()
     {
-        if (databricksRuntimeVersion.equals(DATABRICKS_113_RUNTIME_VERSION)) {
+        if (databricksRuntimeVersion.isAtLeast(DATABRICKS_113_RUNTIME_VERSION)) {
             return "TBLPROPERTIES (\n" +
                     "  'delta.minReaderVersion' = '1',\n" +
                     "  'delta.minWriterVersion' = '2')\n";

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksDelete.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksDelete.java
@@ -21,10 +21,15 @@ import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_DATABRICKS;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_EXCLUDE_104;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_EXCLUDE_113;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_EXCLUDE_73;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_EXCLUDE_91;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_OSS;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.DATABRICKS_COMMUNICATION_FAILURE_ISSUE;
 import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.DATABRICKS_COMMUNICATION_FAILURE_MATCH;
+import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.dropDeltaTableWithRetry;
 import static io.trino.tests.product.utils.QueryExecutors.onDelta;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 
@@ -52,5 +57,53 @@ public class TestDeltaLakeDatabricksDelete
         assertThat(onDelta().executeQuery("SELECT * FROM default." + tableName))
                 .containsOnly(row(1, 11), row(2, 12));
         onTrino().executeQuery("DROP TABLE " + tableName);
+    }
+
+    // Databricks 12.1 added support for deletion vectors
+    // TODO: Add DELTA_LAKE_OSS group once they support creating a table with deletion vectors
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, DELTA_LAKE_EXCLUDE_91, DELTA_LAKE_EXCLUDE_104, DELTA_LAKE_EXCLUDE_113, PROFILE_SPECIFIC_TESTS})
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testDeletionVectors()
+    {
+        // TODO https://github.com/trinodb/trino/issues/16903 Add support for deletionVectors reader features
+        String tableName = "test_deletion_vectors_" + randomNameSuffix();
+        onDelta().executeQuery("" +
+                "CREATE TABLE default." + tableName +
+                "         (a INT, b INT)" +
+                "         USING delta " +
+                "         LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "' " +
+                "         TBLPROPERTIES ('delta.enableDeletionVectors' = true)");
+        try {
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES (1,11), (2, 22)");
+            onDelta().executeQuery("DELETE FROM default." + tableName + " WHERE a = 2");
+
+            assertThat(onDelta().executeQuery("SELECT * FROM default." + tableName))
+                    .containsOnly(row(1, 11));
+
+            assertThat(onTrino().executeQuery("SHOW TABLES FROM delta.default"))
+                    .contains(row(tableName));
+            assertThat(onTrino().executeQuery("SELECT comment FROM information_schema.columns WHERE table_schema = 'default' AND table_name = '" + tableName + "'"))
+                    .hasNoRows();
+            assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM delta.default." + tableName))
+                    .hasMessageMatching(".* Table .* does not exist");
+            assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM delta.default.\"" + tableName + "$history\""))
+                    .hasMessageMatching(".* Table .* does not exist");
+            assertQueryFailure(() -> onTrino().executeQuery("SHOW COLUMNS FROM delta.default." + tableName))
+                    .hasMessageMatching(".* Table .* does not exist");
+            assertQueryFailure(() -> onTrino().executeQuery("DESCRIBE delta.default." + tableName))
+                    .hasMessageMatching(".* Table .* does not exist");
+            assertQueryFailure(() -> onTrino().executeQuery("INSERT INTO delta.default." + tableName + " VALUES (3, 33)"))
+                    .hasMessageMatching(".* Table .* does not exist");
+            assertQueryFailure(() -> onTrino().executeQuery("DELETE FROM delta.default." + tableName))
+                    .hasMessageMatching(".* Table .* does not exist");
+            assertQueryFailure(() -> onTrino().executeQuery("UPDATE delta.default." + tableName + " SET a = 3"))
+                    .hasMessageMatching(".* Table .* does not exist");
+            assertQueryFailure(() -> onTrino().executeQuery("MERGE INTO delta.default." + tableName + " t USING delta.default." + tableName + " s " +
+                    "ON (t.a = s.a) WHEN MATCHED THEN UPDATE SET b = -1"))
+                    .hasMessageMatching(".* Table .* does not exist");
+        }
+        finally {
+            dropDeltaTableWithRetry("default." + tableName);
+        }
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeProceduresCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeProceduresCompatibility.java
@@ -52,7 +52,7 @@ public class TestDeltaLakeProceduresCompatibility
             assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM delta.default." + tableName))
                     .hasMessageMatching(".* Table '.*' does not exist");
             assertQueryFailure(() -> onDelta().executeQuery("SELECT * FROM default." + tableName))
-                    .hasMessageMatching("(?s).* Table or view not found: .*");
+                    .hasMessageMatching("(?s).*(Table or view not found|The table or view .* cannot be found).*");
         }
         finally {
             onTrino().executeQuery("DROP TABLE IF EXISTS delta.default." + tableName);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeWriteDatabricksCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeWriteDatabricksCompatibility.java
@@ -14,11 +14,13 @@
 package io.trino.tests.product.deltalake;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import io.trino.tempto.BeforeTestWithContext;
 import io.trino.tempto.assertions.QueryAssert;
 import io.trino.testng.services.Flaky;
+import io.trino.tests.product.deltalake.util.DatabricksVersion;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.testng.annotations.DataProvider;
@@ -35,9 +37,11 @@ import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_DATABRICKS;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_EXCLUDE_73;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.deltalake.util.DatabricksVersion.DATABRICKS_122_RUNTIME_VERSION;
 import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.DATABRICKS_COMMUNICATION_FAILURE_ISSUE;
 import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.DATABRICKS_COMMUNICATION_FAILURE_MATCH;
 import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.dropDeltaTableWithRetry;
+import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.getDatabricksRuntimeVersion;
 import static io.trino.tests.product.utils.QueryExecutors.onDelta;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
@@ -367,7 +371,16 @@ public class TestDeltaLakeWriteDatabricksCompatibility
             // https://docs.delta.io/2.1.0/delta-change-data-feed.html#change-data-storage
             vacuumExecutor.accept(tableName);
 
-            Assertions.assertThat(s3.listObjectsV2(bucketName, changeDataPrefix).getObjectSummaries()).hasSize(0);
+            List<S3ObjectSummary> summaries = s3.listObjectsV2(bucketName, changeDataPrefix).getObjectSummaries();
+            Assertions.assertThat(summaries).hasSizeBetween(0, 1);
+            if (!summaries.isEmpty()) {
+                // Databricks version >= 12.2 keep an empty _change_data directory
+                DatabricksVersion databricksRuntimeVersion = getDatabricksRuntimeVersion().orElseThrow();
+                Assertions.assertThat(databricksRuntimeVersion.isAtLeast(DATABRICKS_122_RUNTIME_VERSION)).isTrue();
+                S3ObjectSummary summary = summaries.get(0);
+                Assertions.assertThat(summary.getKey()).endsWith(changeDataPrefix + "/");
+                Assertions.assertThat(summary.getSize()).isEqualTo(0);
+            }
         }
         finally {
             dropDeltaTableWithRetry("default." + tableName);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/DatabricksVersion.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/DatabricksVersion.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
 public record DatabricksVersion(int majorVersion, int minorVersion)
         implements Comparable<DatabricksVersion>
 {
+    public static final DatabricksVersion DATABRICKS_122_RUNTIME_VERSION = new DatabricksVersion(12, 2);
     public static final DatabricksVersion DATABRICKS_113_RUNTIME_VERSION = new DatabricksVersion(11, 3);
     public static final DatabricksVersion DATABRICKS_104_RUNTIME_VERSION = new DatabricksVersion(10, 4);
     public static final DatabricksVersion DATABRICKS_91_RUNTIME_VERSION = new DatabricksVersion(9, 1);


### PR DESCRIPTION
## Description

Support Databricks 12.2 LTS and disallow unsupported reader versions and features in Delta Lake
Fixes #16884

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Add support for Databricks 12.2 LTS. ({issue}`16905`)
* Disallow reading tables with [deletion vectors](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#deletion-vectors). Previously, it returned incorrect results. ({issue}`16884`)
```
