### PR TITLE
Support char type text for lpad function

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
@@ -714,6 +714,16 @@ public final class StringFunctions
     @ScalarFunction("lpad")
     @LiteralParameters({"x", "y"})
     @SqlType(StandardTypes.VARCHAR)
+    public static Slice leftPad(@LiteralParameter("x") long x, @SqlType("char(x)") Slice text, @SqlType(StandardTypes.BIGINT) long targetLength, @SqlType("varchar(y)") Slice padString)
+    {
+        text = padSpaces(text, toIntExact(x));
+        return leftPad(text, targetLength, padString);
+    }
+
+    @Description("Pads a string on the left")
+    @ScalarFunction("lpad")
+    @LiteralParameters({"x", "y"})
+    @SqlType(StandardTypes.VARCHAR)
     public static Slice leftPad(@SqlType("varchar(x)") Slice text, @SqlType(StandardTypes.BIGINT) long targetLength, @SqlType("varchar(y)") Slice padString)
     {
         return pad(text, targetLength, padString, 0);

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
@@ -2096,6 +2096,17 @@ public class TestStringFunctions
 
         assertTrinoExceptionThrownBy(assertions.function("lpad", "'abc'", Long.toString(maxSize + 1), "''")::evaluate)
                 .hasMessage("Target length must be in the range [0.." + maxSize + "]");
+
+        assertThat(assertions.function("lpad", "CHAR 'abc   '", "6", "'def'"))
+                .matches("VARCHAR 'abc   '");
+        assertThat(assertions.function("lpad", "CHAR 'abc   '", "4", "'def'"))
+                .matches("VARCHAR 'abc '");
+        assertThat(assertions.function("lpad", "CHAR 'abc   '", "8", "'def'"))
+                .matches("VARCHAR 'deabc   '");
+        assertThat(assertions.function("lpad", "CHAR 'abc   '", "10", "'def'"))
+                .matches("VARCHAR 'defdabc   '");
+        assertThat(assertions.function("lpad", "CAST('abc' AS char(6))", "10", "'def'"))
+                .matches("VARCHAR 'defdabc   '");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

As a temporary solution while fixing the coercion from char to varchar, adding lpad function signature that supports CHAR as input type for the string to be compatible with previous behavior.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Related issue: https://github.com/trinodb/trino/issues/9031

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
