### PR TITLE
Fix reading parquet INT32 values as short decimal

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/Int32ShortDecimalColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/Int32ShortDecimalColumnReader.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.trino.parquet.PrimitiveField;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Type;
+
+import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.Decimals.overflows;
+import static java.lang.String.format;
+
+public class Int32ShortDecimalColumnReader
+        extends PrimitiveColumnReader
+{
+    public Int32ShortDecimalColumnReader(PrimitiveField field)
+    {
+        super(field);
+    }
+
+    @Override
+    protected void readValue(BlockBuilder blockBuilder, Type trinoType)
+    {
+        if (trinoType instanceof DecimalType trinoDecimalType && trinoDecimalType.isShort()) {
+            long value = valuesReader.readInteger();
+            if (overflows(value, trinoDecimalType.getPrecision())) {
+                throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot read parquet INT32 value '%s' as DECIMAL(%s, %s)", value, trinoDecimalType.getPrecision(), trinoDecimalType.getScale()));
+            }
+
+            trinoType.writeLong(blockBuilder, value);
+        }
+        else {
+            throw new TrinoException(NOT_SUPPORTED, format("Unsupported Trino column type (%s) for Parquet column (%s)", trinoType, field.getDescriptor()));
+        }
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestingColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestingColumnReader.java
@@ -651,6 +651,8 @@ public class TestingColumnReader
                 new ColumnReaderFormat<>(FLOAT, DoubleType.DOUBLE, PLAIN_WRITER, DICTIONARY_FLOAT_WRITER, WRITE_FLOAT, ASSERT_DOUBLE_STORED_AS_FLOAT),
                 new ColumnReaderFormat<>(DOUBLE, DoubleType.DOUBLE, PLAIN_WRITER, DICTIONARY_DOUBLE_WRITER, WRITE_DOUBLE, ASSERT_DOUBLE),
                 new ColumnReaderFormat<>(INT32, decimalType(0, 8), createDecimalType(8), PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, ASSERT_INT),
+                // INT32 can be read as a ShortDecimalType in Trino without decimal logical type annotation as well
+                new ColumnReaderFormat<>(INT32, createDecimalType(8, 0), PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, ASSERT_INT),
                 new ColumnReaderFormat<>(INT32, BIGINT, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, ASSERT_LONG),
                 new ColumnReaderFormat<>(INT32, INTEGER, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, ASSERT_INT),
                 new ColumnReaderFormat<>(INT32, SMALLINT, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_SHORT, ASSERT_SHORT),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
@@ -357,6 +357,41 @@ public class ParquetTester
             ParquetSchemaOptions schemaOptions)
             throws Exception
     {
+        assertRoundTripWithHiveWriter(objectInspectors, writeValues, readValues, columnNames, columnTypes, parquetSchema, schemaOptions);
+
+        // write Trino parquet
+        for (CompressionCodec compressionCodec : writerCompressions) {
+            for (ConnectorSession session : sessions) {
+                try (TempFile tempFile = new TempFile("test", "parquet")) {
+                    OptionalInt min = stream(writeValues).mapToInt(Iterables::size).min();
+                    checkState(min.isPresent());
+                    writeParquetColumnTrino(tempFile.getFile(), columnTypes, columnNames, getIterators(readValues), min.getAsInt(), compressionCodec, schemaOptions);
+                    assertFileContents(
+                            session,
+                            tempFile.getFile(),
+                            getIterators(readValues),
+                            columnNames,
+                            columnTypes);
+                }
+            }
+        }
+    }
+
+    // Certain tests need the ability to specify a parquet schema which the writer wouldn't choose by itself based on the engine type.
+    // Explicitly provided parquetSchema is supported only by the hive writer.
+    // This method should be used when we need to assert that an exception should be thrown when reading from a file written with the specified
+    // parquetSchema to avoid getting misled due to an exception thrown when from reading the file produced by trino parquet writer which may not
+    // be following the specified parquetSchema.
+    void assertRoundTripWithHiveWriter(
+            List<ObjectInspector> objectInspectors,
+            Iterable<?>[] writeValues,
+            Iterable<?>[] readValues,
+            List<String> columnNames,
+            List<Type> columnTypes,
+            Optional<MessageType> parquetSchema,
+            ParquetSchemaOptions schemaOptions)
+            throws Exception
+    {
         for (WriterVersion version : versions) {
             for (CompressionCodec compressionCodec : compressions) {
                 for (ConnectorSession session : sessions) {
@@ -382,23 +417,6 @@ public class ParquetTester
                                 columnNames,
                                 columnTypes);
                     }
-                }
-            }
-        }
-
-        // write Trino parquet
-        for (CompressionCodec compressionCodec : writerCompressions) {
-            for (ConnectorSession session : sessions) {
-                try (TempFile tempFile = new TempFile("test", "parquet")) {
-                    OptionalInt min = stream(writeValues).mapToInt(Iterables::size).min();
-                    checkState(min.isPresent());
-                    writeParquetColumnTrino(tempFile.getFile(), columnTypes, columnNames, getIterators(readValues), min.getAsInt(), compressionCodec, schemaOptions);
-                    assertFileContents(
-                            session,
-                            tempFile.getFile(),
-                            getIterators(readValues),
-                            columnNames,
-                            columnTypes);
                 }
             }
         }


### PR DESCRIPTION
## Description
Optimized parquet reader is improved to handle reading INT32 values into a short decimals of lower precision than 10 if the value does not overflow the decimal.
Unoptimized parquet reader is fixed to apply overflow checks when reading INT32 values into a short decimal.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Hudi, Delta, Iceberg
* Fix reading INT32 values without decimal logical annotation in parquet files as a DECIMAL type in Trino. ({issue}`16938`)
```
