### PR TITLE
Base jdbc MERGE support

### DIFF
--- a/docs/src/main/sphinx/connector/ignite.md
+++ b/docs/src/main/sphinx/connector/ignite.md
@@ -180,6 +180,7 @@ statements, the connector supports the following features:
 
 - {doc}`/sql/insert`
 - {doc}`/sql/update`
+- {doc}`/sql/merge`
 - {doc}`/sql/delete`
 - {doc}`/sql/create-table`
 - {doc}`/sql/create-table-as`

--- a/docs/src/main/sphinx/connector/oracle.md
+++ b/docs/src/main/sphinx/connector/oracle.md
@@ -410,6 +410,7 @@ supports the following statements:
 
 - {doc}`/sql/insert`
 - {doc}`/sql/update`
+- {doc}`/sql/merge`
 - {doc}`/sql/delete`
 - {doc}`/sql/truncate`
 - {doc}`/sql/create-table`

--- a/docs/src/main/sphinx/connector/phoenix.md
+++ b/docs/src/main/sphinx/connector/phoenix.md
@@ -277,6 +277,7 @@ statements, the connector supports the following features:
 
 - {doc}`/sql/insert`
 - {doc}`/sql/delete`
+- {doc}`/sql/update`
 - {doc}`/sql/merge`
 - {doc}`/sql/create-table`
 - {doc}`/sql/create-table-as`

--- a/docs/src/main/sphinx/connector/postgresql.md
+++ b/docs/src/main/sphinx/connector/postgresql.md
@@ -347,6 +347,7 @@ statements, the connector supports the following features:
 
 - {doc}`/sql/insert`
 - {doc}`/sql/update`
+- {doc}`/sql/merge`
 - {doc}`/sql/delete`
 - {doc}`/sql/truncate`
 - {ref}`sql-schema-table-management`

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -30,6 +30,7 @@ import io.trino.spi.connector.Assignment;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
+import io.trino.spi.connector.ConnectorMergeTableHandle;
 import io.trino.spi.connector.ConnectorOutputMetadata;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorSession;
@@ -65,6 +66,7 @@ import io.trino.spi.security.AccessDeniedException;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.statistics.ComputedStatistics;
 import io.trino.spi.statistics.TableStatistics;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 
 import java.sql.Types;
@@ -91,6 +93,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.plugin.base.expression.ConnectorExpressions.and;
 import static io.trino.plugin.base.expression.ConnectorExpressions.extractConjuncts;
+import static io.trino.plugin.jdbc.BaseJdbcClient.MERGE_ROW_ID;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_NON_TRANSIENT_ERROR;
 import static io.trino.plugin.jdbc.JdbcMetadataSessionProperties.isAggregationPushdownEnabled;
 import static io.trino.plugin.jdbc.JdbcMetadataSessionProperties.isComplexExpressionPushdown;
@@ -109,13 +112,13 @@ public class DefaultJdbcMetadata
 {
     private static final String SYNTHETIC_COLUMN_NAME_PREFIX = "_pfgnrtd_";
     private static final String DELETE_ROW_ID = "_trino_artificial_column_handle_for_delete_row_id_";
-    private static final String MERGE_ROW_ID = "$merge_row_id";
 
     private final JdbcClient jdbcClient;
     private final boolean precalculateStatisticsForPushdown;
     private final Set<JdbcQueryEventListener> jdbcQueryEventListeners;
 
-    private final AtomicReference<Runnable> rollbackAction = new AtomicReference<>();
+    private final AtomicReference<Runnable> insertRollbackAction = new AtomicReference<>();
+    private final AtomicReference<Runnable> deleteForMergeRollbackAction = new AtomicReference<>();
 
     public DefaultJdbcMetadata(JdbcClient jdbcClient, boolean precalculateStatisticsForPushdown, Set<JdbcQueryEventListener> jdbcQueryEventListeners)
     {
@@ -832,7 +835,7 @@ public class DefaultJdbcMetadata
     {
         verifyRetryMode(session, retryMode);
         JdbcOutputTableHandle handle = jdbcClient.beginCreateTable(session, tableMetadata);
-        setRollback(() -> jdbcClient.rollbackCreateTable(session, handle));
+        setInsertRollback(() -> jdbcClient.rollbackCreateTable(session, handle));
         return handle;
     }
 
@@ -887,15 +890,21 @@ public class DefaultJdbcMetadata
         }
     }
 
-    private void setRollback(Runnable action)
+    private void setInsertRollback(Runnable action)
     {
-        checkState(rollbackAction.compareAndSet(null, action), "rollback action is already set");
+        checkState(insertRollbackAction.compareAndSet(null, action), "insert rollback action is already set");
+    }
+
+    private void setDeleteForMergeRollback(Runnable action)
+    {
+        checkState(deleteForMergeRollbackAction.compareAndSet(null, action), "delete rollback action is already set");
     }
 
     @Override
     public void rollback()
     {
-        Optional.ofNullable(rollbackAction.getAndSet(null)).ifPresent(Runnable::run);
+        Optional.ofNullable(insertRollbackAction.getAndSet(null)).ifPresent(Runnable::run);
+        Optional.ofNullable(deleteForMergeRollbackAction.getAndSet(null)).ifPresent(Runnable::run);
     }
 
     @Override
@@ -907,7 +916,7 @@ public class DefaultJdbcMetadata
                 .map(JdbcColumnHandle.class::cast)
                 .collect(toImmutableList());
         JdbcOutputTableHandle handle = jdbcClient.beginInsertTable(session, (JdbcTableHandle) tableHandle, columnHandles);
-        setRollback(() -> jdbcClient.rollbackCreateTable(session, handle));
+        setInsertRollback(() -> jdbcClient.rollbackCreateTable(session, handle));
         return handle;
     }
 
@@ -926,14 +935,65 @@ public class DefaultJdbcMetadata
     }
 
     @Override
-    public ColumnHandle getMergeRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public JdbcColumnHandle getMergeRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         verify(!isTableHandleForProcedure(tableHandle), "Not a table reference: %s", tableHandle);
-        // The column is used for row-level merge, which is not supported, but it's required during analysis anyway.
+
+        JdbcTableHandle handle = (JdbcTableHandle) tableHandle;
+        List<RowType.Field> fields = jdbcClient.getPrimaryKeys(session, handle).stream()
+                .map(columnHandle -> new RowType.Field(Optional.of(columnHandle.getColumnName()), columnHandle.getColumnType()))
+                .collect(toImmutableList());
+        if (fields.isEmpty()) {
+            return new JdbcColumnHandle(
+                    MERGE_ROW_ID,
+                    new JdbcTypeHandle(Types.BIGINT, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()),
+                    BIGINT);
+        }
+
         return new JdbcColumnHandle(
                 MERGE_ROW_ID,
-                new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()),
-                BIGINT);
+                new JdbcTypeHandle(Types.ROWID, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()),
+                RowType.from(fields));
+    }
+
+    @Override
+    public ConnectorMergeTableHandle beginMerge(ConnectorSession session, ConnectorTableHandle tableHandle, RetryMode retryMode)
+    {
+        JdbcTableHandle handle = (JdbcTableHandle) tableHandle;
+        checkArgument(handle.isNamedRelation(), "Merge target must be named relation table");
+        JdbcTableHandle plainTable = handle.toPlainTableWithoutColumns();
+        JdbcColumnHandle mergeRowIdColumnHandle = getMergeRowIdColumnHandle(session, plainTable);
+        if (jdbcClient.getPrimaryKeys(session, plainTable).isEmpty()) {
+            throw new TrinoException(NOT_SUPPORTED, MODIFYING_ROWS_MESSAGE);
+        }
+
+        List<JdbcColumnHandle> columns = jdbcClient.getColumns(session, plainTable);
+        JdbcOutputTableHandle jdbcOutputTableHandle = (JdbcOutputTableHandle) beginInsert(session, plainTable, ImmutableList.copyOf(columns), retryMode);
+
+        return new JdbcMergeTableHandle(
+                jdbcClient.updatedScanColumnsForMerge(session, handle, handle.getColumns(), mergeRowIdColumnHandle),
+                jdbcOutputTableHandle,
+                beginDeleteForMerge(session, plainTable, retryMode),
+                mergeRowIdColumnHandle);
+    }
+
+    @Override
+    public void finishMerge(ConnectorSession session, ConnectorMergeTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        JdbcMergeTableHandle handle = (JdbcMergeTableHandle) tableHandle;
+        finishInsert(session, handle.getOutputTableHandle(), fragments, computedStatistics);
+        handle.getDeleteTableHandle().ifPresent(deleteTableHandle -> jdbcClient.finishDeleteTableForMerge(session, deleteTableHandle, getSuccessfulPageSinkIds(fragments)));
+    }
+
+    protected Optional<JdbcOutputTableHandle> beginDeleteForMerge(ConnectorSession session, JdbcTableHandle tableHandle, RetryMode retryMode)
+    {
+        if (retryMode == NO_RETRIES || isNonTransactionalInsert(session)) {
+            return Optional.empty();
+        }
+        verifyRetryMode(session, retryMode);
+        JdbcOutputTableHandle handle = jdbcClient.beginDeleteTableForMerge(session, tableHandle);
+        setDeleteForMergeRollback(() -> jdbcClient.rollbackCreateTable(session, handle));
+        return Optional.of(handle);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -20,6 +20,7 @@ import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitSource;
+import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.JoinStatistics;
 import io.trino.spi.connector.JoinType;
@@ -104,6 +105,12 @@ public abstract class ForwardingJdbcClient
     public List<JdbcColumnHandle> getColumns(ConnectorSession session, JdbcTableHandle tableHandle)
     {
         return delegate().getColumns(session, tableHandle);
+    }
+
+    @Override
+    public List<JdbcColumnHandle> getPrimaryKeys(ConnectorSession session, JdbcTableHandle tableHandle)
+    {
+        return delegate().getPrimaryKeys(session, tableHandle);
     }
 
     @Override
@@ -242,6 +249,18 @@ public abstract class ForwardingJdbcClient
     public void finishInsertTable(ConnectorSession session, JdbcOutputTableHandle handle, Set<Long> pageSinkIds)
     {
         delegate().finishInsertTable(session, handle, pageSinkIds);
+    }
+
+    @Override
+    public JdbcOutputTableHandle beginDeleteTableForMerge(ConnectorSession session, JdbcTableHandle tableHandle)
+    {
+        return delegate().beginDeleteTableForMerge(session, tableHandle);
+    }
+
+    @Override
+    public void finishDeleteTableForMerge(ConnectorSession session, JdbcOutputTableHandle handle, Set<Long> pageSinkIds)
+    {
+        delegate().finishDeleteTableForMerge(session, handle, pageSinkIds);
     }
 
     @Override
@@ -455,5 +474,17 @@ public abstract class ForwardingJdbcClient
     public OptionalInt getMaxColumnNameLength(ConnectorSession session)
     {
         return delegate().getMaxColumnNameLength(session);
+    }
+
+    @Override
+    public JdbcTableHandle updatedScanColumnsForMerge(ConnectorSession session, ConnectorTableHandle table, Optional<List<JdbcColumnHandle>> originalColumns, JdbcColumnHandle mergeRowIdColumnHandle)
+    {
+        return delegate().updatedScanColumnsForMerge(session, table, originalColumns, mergeRowIdColumnHandle);
+    }
+
+    @Override
+    public String buildMergeRowIdConjuncts(ConnectorSession session, List<String> mergeRowIdFieldNames, List<Type> mergeRowIdFieldTypes)
+    {
+        return delegate().buildMergeRowIdConjuncts(session, mergeRowIdFieldNames, mergeRowIdFieldTypes);
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcConnector.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcConnector.java
@@ -23,7 +23,7 @@ import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorCapabilities;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
-import io.trino.spi.connector.ConnectorRecordSetProvider;
+import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorTransactionHandle;
@@ -46,8 +46,9 @@ public class JdbcConnector
 {
     private final LifeCycleManager lifeCycleManager;
     private final ConnectorSplitManager jdbcSplitManager;
-    private final ConnectorRecordSetProvider jdbcRecordSetProvider;
     private final ConnectorPageSinkProvider jdbcPageSinkProvider;
+
+    private final ConnectorPageSourceProvider jdbcPageSourceProvider;
     private final Optional<ConnectorAccessControl> accessControl;
     private final Set<Procedure> procedures;
     private final Set<ConnectorTableFunction> connectorTableFunctions;
@@ -59,8 +60,8 @@ public class JdbcConnector
     public JdbcConnector(
             LifeCycleManager lifeCycleManager,
             ConnectorSplitManager jdbcSplitManager,
-            ConnectorRecordSetProvider jdbcRecordSetProvider,
             ConnectorPageSinkProvider jdbcPageSinkProvider,
+            ConnectorPageSourceProvider jdbcPageSourceProvider,
             Optional<ConnectorAccessControl> accessControl,
             Set<Procedure> procedures,
             Set<ConnectorTableFunction> connectorTableFunctions,
@@ -70,8 +71,8 @@ public class JdbcConnector
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.jdbcSplitManager = requireNonNull(jdbcSplitManager, "jdbcSplitManager is null");
-        this.jdbcRecordSetProvider = requireNonNull(jdbcRecordSetProvider, "jdbcRecordSetProvider is null");
         this.jdbcPageSinkProvider = requireNonNull(jdbcPageSinkProvider, "jdbcPageSinkProvider is null");
+        this.jdbcPageSourceProvider = requireNonNull(jdbcPageSourceProvider, "jdbcPageSourceProvider is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.procedures = ImmutableSet.copyOf(requireNonNull(procedures, "procedures is null"));
         this.connectorTableFunctions = ImmutableSet.copyOf(requireNonNull(connectorTableFunctions, "connectorTableFunctions is null"));
@@ -115,15 +116,15 @@ public class JdbcConnector
     }
 
     @Override
-    public ConnectorRecordSetProvider getRecordSetProvider()
-    {
-        return jdbcRecordSetProvider;
-    }
-
-    @Override
     public ConnectorPageSinkProvider getPageSinkProvider()
     {
         return jdbcPageSinkProvider;
+    }
+
+    @Override
+    public ConnectorPageSourceProvider getPageSourceProvider()
+    {
+        return jdbcPageSourceProvider;
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMergeSink.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMergeSink.java
@@ -1,0 +1,309 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.RowBlock;
+import io.trino.spi.connector.ConnectorMergeSink;
+import io.trino.spi.connector.ConnectorMergeTableHandle;
+import io.trino.spi.connector.ConnectorPageSink;
+import io.trino.spi.connector.ConnectorPageSinkId;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+public class JdbcMergeSink
+        implements ConnectorMergeSink
+{
+    private final String catalogName;
+    private final String schemaName;
+    private final String tableName;
+    private final int columnCount;
+    private final String mergeRowIdConjuncts;
+    private final List<String> mergeRowIdFieldNames;
+    private final List<Type> mergeRowIdFieldTypes;
+    private final List<Integer> reservedChannelsForUpdate;
+
+    private final ConnectorPageSinkId pageSinkId;
+    private final ConnectorPageSink insertSink;
+    private final ConnectorPageSink updateSink;
+    private final ConnectorPageSink deleteSink;
+
+    public JdbcMergeSink(JdbcClient jdbcClient, RemoteQueryModifier remoteQueryModifier, ConnectorSession session, ConnectorMergeTableHandle mergeHandle, ConnectorPageSinkId pageSinkId)
+    {
+        JdbcMergeTableHandle jdbcMergeTableHandle = (JdbcMergeTableHandle) mergeHandle;
+        JdbcOutputTableHandle jdbcOutputTableHandle = jdbcMergeTableHandle.getOutputTableHandle();
+        this.catalogName = jdbcOutputTableHandle.getCatalogName();
+        this.schemaName = jdbcOutputTableHandle.getSchemaName();
+        this.tableName = jdbcOutputTableHandle.getTableName();
+        this.columnCount = jdbcOutputTableHandle.getColumnNames().size();
+
+        ImmutableList.Builder<String> mergeRowIdFieldNamesBuilder = ImmutableList.builder();
+        ImmutableList.Builder<Type> mergeRowIdFieldTypesBuilder = ImmutableList.builder();
+        RowType mergeRowIdColumnType = (RowType) jdbcMergeTableHandle.mergeRowIdColumnHandle().getColumnType();
+        for (RowType.Field field : mergeRowIdColumnType.getFields()) {
+            checkArgument(field.getName().isPresent(), "Merge row id column field must have name");
+            mergeRowIdFieldNamesBuilder.add(field.getName().get());
+            mergeRowIdFieldTypesBuilder.add(field.getType());
+        }
+        this.mergeRowIdFieldNames = mergeRowIdFieldNamesBuilder.build();
+        this.mergeRowIdFieldTypes = mergeRowIdFieldTypesBuilder.build();
+        verify(!mergeRowIdFieldNames.isEmpty() && mergeRowIdFieldNames.size() == mergeRowIdFieldTypes.size());
+        this.mergeRowIdConjuncts = buildMergeRowIdConjuncts(session, jdbcClient);
+        this.reservedChannelsForUpdate = getReservedChannelsForUpdate(jdbcOutputTableHandle, mergeRowIdFieldNames);
+        verify(!reservedChannelsForUpdate.isEmpty(), "Update primary key itself is not supported");
+
+        this.pageSinkId = pageSinkId;
+        this.insertSink = createInsertSink(session, jdbcOutputTableHandle, jdbcClient, pageSinkId, remoteQueryModifier);
+        this.updateSink = createUpdateSink(session, jdbcOutputTableHandle, jdbcClient, pageSinkId, remoteQueryModifier);
+        this.deleteSink = createDeleteSink(session, jdbcMergeTableHandle.getDeleteTableHandle(), jdbcClient, pageSinkId, remoteQueryModifier);
+    }
+
+    protected String buildMergeRowIdConjuncts(ConnectorSession session, JdbcClient jdbcClient)
+    {
+        return jdbcClient.buildMergeRowIdConjuncts(session, mergeRowIdFieldNames, mergeRowIdFieldTypes);
+    }
+
+    protected List<Integer> getReservedChannelsForUpdate(JdbcOutputTableHandle outputTableHandle, List<String> mergeRowIdFieldNames)
+    {
+        Set<String> excludedColumnNames = ImmutableSet.copyOf(mergeRowIdFieldNames);
+        List<String> allDataColumns = outputTableHandle.getColumnNames();
+        ImmutableList.Builder<Integer> reservedChannelsBuilder = ImmutableList.builder();
+        for (int channel = 0; channel < allDataColumns.size(); channel++) {
+            String column = allDataColumns.get(channel);
+            if (!excludedColumnNames.contains(column)) {
+                reservedChannelsBuilder.add(channel);
+            }
+        }
+
+        return reservedChannelsBuilder.build();
+    }
+
+    protected ConnectorPageSink createInsertSink(
+            ConnectorSession session,
+            JdbcOutputTableHandle jdbcOutputTableHandle,
+            JdbcClient jdbcClient,
+            ConnectorPageSinkId pageSinkId,
+            RemoteQueryModifier remoteQueryModifier)
+    {
+        return new JdbcPageSink(session, jdbcOutputTableHandle, jdbcClient, pageSinkId, remoteQueryModifier);
+    }
+
+    protected ConnectorPageSink createUpdateSink(
+            ConnectorSession session,
+            JdbcOutputTableHandle jdbcOutputTableHandle,
+            JdbcClient jdbcClient,
+            ConnectorPageSinkId pageSinkId,
+            RemoteQueryModifier remoteQueryModifier)
+    {
+        ImmutableList.Builder<String> updateColumnNames = ImmutableList.builder();
+        ImmutableList.Builder<Type> updateColumnTypes = ImmutableList.builder();
+        for (int channel : reservedChannelsForUpdate) {
+            updateColumnNames.add(jdbcOutputTableHandle.getColumnNames().get(channel));
+            updateColumnTypes.add(jdbcOutputTableHandle.getColumnTypes().get(channel));
+        }
+        updateColumnNames.addAll(mergeRowIdFieldNames);
+        updateColumnTypes.addAll(mergeRowIdFieldTypes);
+
+        JdbcOutputTableHandle updateOutputTableHandle = new JdbcOutputTableHandle(
+                catalogName,
+                schemaName,
+                tableName,
+                updateColumnNames.build(),
+                updateColumnTypes.build(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+        return new UpdateSink(session, updateOutputTableHandle, jdbcClient, pageSinkId, remoteQueryModifier);
+    }
+
+    protected ConnectorPageSink createDeleteSink(
+            ConnectorSession session,
+            Optional<JdbcOutputTableHandle> jdbcDeleteOutputTableHandle,
+            JdbcClient jdbcClient,
+            ConnectorPageSinkId pageSinkId,
+            RemoteQueryModifier remoteQueryModifier)
+    {
+        if (jdbcDeleteOutputTableHandle.isPresent()) {
+            return new JdbcPageSink(session, jdbcDeleteOutputTableHandle.get(), jdbcClient, pageSinkId, remoteQueryModifier);
+        }
+
+        JdbcOutputTableHandle deleteOutputTableHandle = new JdbcOutputTableHandle(
+                catalogName,
+                schemaName,
+                tableName,
+                mergeRowIdFieldNames,
+                mergeRowIdFieldTypes,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+        return new DeleteSink(session, deleteOutputTableHandle, jdbcClient, pageSinkId, remoteQueryModifier);
+    }
+
+    private class UpdateSink
+            extends JdbcPageSink
+    {
+        public UpdateSink(ConnectorSession session, JdbcOutputTableHandle handle, JdbcClient jdbcClient, ConnectorPageSinkId pageSinkId, RemoteQueryModifier remoteQueryModifier)
+        {
+            super(session, handle, jdbcClient, pageSinkId, remoteQueryModifier);
+        }
+
+        @Override
+        protected String getSinkSql(JdbcClient jdbcClient, JdbcOutputTableHandle outputTableHandle, List<WriteFunction> columnWriters)
+        {
+            List<String> columnNames = outputTableHandle.getColumnNames();
+            checkArgument(columnNames.size() > mergeRowIdFieldNames.size(), "Update primary key itself is not supported");
+            checkArgument(columnNames.size() == columnWriters.size(), "handle and columnWriters mismatch: %s, %s", outputTableHandle, columnWriters);
+
+            ImmutableList.Builder<String> updateConjunctsBuilder = ImmutableList.builder();
+            for (int i = 0; i < columnWriters.size() - mergeRowIdFieldNames.size(); i++) {
+                updateConjunctsBuilder.add(jdbcClient.quoted(columnNames.get(i)) + " = " + columnWriters.get(i).getBindExpression());
+            }
+            return "UPDATE %s.%s SET %s WHERE %s".formatted(schemaName, tableName, Joiner.on(", ").join(updateConjunctsBuilder.build()), mergeRowIdConjuncts);
+        }
+    }
+
+    private class DeleteSink
+            extends JdbcPageSink
+    {
+        public DeleteSink(ConnectorSession session, JdbcOutputTableHandle handle, JdbcClient jdbcClient, ConnectorPageSinkId pageSinkId, RemoteQueryModifier remoteQueryModifier)
+        {
+            super(session, handle, jdbcClient, pageSinkId, remoteQueryModifier);
+        }
+
+        @Override
+        protected String getSinkSql(JdbcClient jdbcClient, JdbcOutputTableHandle outputTableHandle, List<WriteFunction> columnWriters)
+        {
+            return "DELETE FROM %s.%s WHERE %s".formatted(schemaName, tableName, mergeRowIdConjuncts);
+        }
+    }
+
+    @Override
+    public void storeMergedRows(Page page)
+    {
+        checkArgument(page.getChannelCount() == 2 + columnCount, "The page size should be 2 + columnCount (%s), but is %s", columnCount, page.getChannelCount());
+        int positionCount = page.getPositionCount();
+        Block operationBlock = page.getBlock(columnCount);
+
+        int[] dataChannel = IntStream.range(0, columnCount).toArray();
+        Page dataPage = page.getColumns(dataChannel);
+
+        int[] insertPositions = new int[positionCount];
+        int insertPositionCount = 0;
+        int[] deletePositions = new int[positionCount];
+        int deletePositionCount = 0;
+        int[] updatePositions = new int[positionCount];
+        int updatePositionCount = 0;
+
+        for (int position = 0; position < positionCount; position++) {
+            int operation = TINYINT.getByte(operationBlock, position);
+            switch (operation) {
+                case INSERT_OPERATION_NUMBER -> {
+                    insertPositions[insertPositionCount] = position;
+                    insertPositionCount++;
+                }
+                case DELETE_OPERATION_NUMBER -> {
+                    deletePositions[deletePositionCount] = position;
+                    deletePositionCount++;
+                }
+                case UPDATE_OPERATION_NUMBER -> {
+                    updatePositions[updatePositionCount] = position;
+                    updatePositionCount++;
+                }
+                default -> throw new IllegalStateException("Unexpected value: " + operation);
+            }
+        }
+
+        List<Block> rowIdFields = RowBlock.getRowFieldsFromBlock(page.getBlock(columnCount + 1));
+        appendInsertPage(dataPage, insertPositions, insertPositionCount);
+        appendDeletePage(rowIdFields, deletePositions, deletePositionCount);
+        appendUpdatePage(dataPage, rowIdFields, updatePositions, updatePositionCount);
+    }
+
+    protected void appendUpdatePage(Page dataPage, List<Block> rowIdFields, int[] updatePositions, int updatePositionCount)
+    {
+        if (updatePositionCount > 0) {
+            dataPage = dataPage.getColumns(reservedChannelsForUpdate.stream().mapToInt(Integer::intValue).toArray());
+            int columnCount = dataPage.getChannelCount();
+            Block[] updateBlocks = new Block[columnCount + rowIdFields.size()];
+            for (int channel = 0; channel < columnCount; channel++) {
+                updateBlocks[channel] = dataPage.getBlock(channel).getPositions(updatePositions, 0, updatePositionCount);
+            }
+            for (int field = 0; field < rowIdFields.size(); field++) {
+                updateBlocks[field + columnCount] = rowIdFields.get(field).getPositions(updatePositions, 0, updatePositionCount);
+            }
+
+            updateSink.appendPage(new Page(updatePositionCount, updateBlocks));
+        }
+    }
+
+    protected void appendDeletePage(List<Block> rowIdFields, int[] deletePositions, int deletePositionCount)
+    {
+        if (deletePositionCount > 0) {
+            Block[] deleteBlocks = new Block[rowIdFields.size()];
+            for (int field = 0; field < rowIdFields.size(); field++) {
+                deleteBlocks[field] = rowIdFields.get(field).getPositions(deletePositions, 0, deletePositionCount);
+            }
+
+            deleteSink.appendPage(new Page(deletePositionCount, deleteBlocks));
+        }
+    }
+
+    protected void appendInsertPage(Page dataPage, int[] insertPositions, int insertPositionCount)
+    {
+        if (insertPositionCount > 0) {
+            insertSink.appendPage(dataPage.getPositions(insertPositions, 0, insertPositionCount));
+        }
+    }
+
+    @Override
+    public CompletableFuture<Collection<Slice>> finish()
+    {
+        insertSink.finish();
+        deleteSink.finish();
+        updateSink.finish();
+
+        // pass the successful page sink id
+        Slice value = Slices.allocate(Long.BYTES);
+        value.setLong(0, pageSinkId.getId());
+        return completedFuture(ImmutableList.of(value));
+    }
+
+    @Override
+    public void abort()
+    {
+        insertSink.abort();
+        deleteSink.abort();
+        updateSink.abort();
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMergeTableHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMergeTableHandle.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.connector.ConnectorMergeTableHandle;
+
+import java.util.Optional;
+
+public class JdbcMergeTableHandle
+        implements ConnectorMergeTableHandle
+{
+    private final JdbcTableHandle tableHandle;
+    private final JdbcOutputTableHandle outputTableHandle;
+    private final Optional<JdbcOutputTableHandle> deleteTableHandle;
+    private final JdbcColumnHandle mergeRowIdColumnHandle;
+
+    public JdbcMergeTableHandle(
+            JdbcTableHandle tableHandle,
+            JdbcOutputTableHandle outputTableHandle,
+            JdbcColumnHandle mergeRowIdColumnHandle)
+    {
+        this.tableHandle = tableHandle;
+        this.outputTableHandle = outputTableHandle;
+        this.deleteTableHandle = Optional.empty();
+        this.mergeRowIdColumnHandle = mergeRowIdColumnHandle;
+    }
+
+    @JsonCreator
+    public JdbcMergeTableHandle(
+            @JsonProperty("tableHandle") JdbcTableHandle tableHandle,
+            @JsonProperty("outputTableHandle") JdbcOutputTableHandle outputTableHandle,
+            @JsonProperty("deleteTableHandle") Optional<JdbcOutputTableHandle> deleteTableHandle,
+            @JsonProperty("mergeRowIdColumnHandle") JdbcColumnHandle mergeRowIdColumnHandle)
+    {
+        this.tableHandle = tableHandle;
+        this.outputTableHandle = outputTableHandle;
+        this.deleteTableHandle = deleteTableHandle;
+        this.mergeRowIdColumnHandle = mergeRowIdColumnHandle;
+    }
+
+    @JsonProperty
+    @Override
+    public JdbcTableHandle getTableHandle()
+    {
+        return tableHandle;
+    }
+
+    @JsonProperty
+    public JdbcOutputTableHandle getOutputTableHandle()
+    {
+        return outputTableHandle;
+    }
+
+    @JsonProperty
+    public Optional<JdbcOutputTableHandle> getDeleteTableHandle()
+    {
+        return deleteTableHandle;
+    }
+
+    @JsonProperty
+    public JdbcColumnHandle mergeRowIdColumnHandle()
+    {
+        return mergeRowIdColumnHandle;
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcModule.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcModule.java
@@ -27,6 +27,7 @@ import io.trino.plugin.jdbc.logging.RemoteQueryModifierModule;
 import io.trino.plugin.jdbc.procedure.FlushJdbcMetadataCacheProcedure;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
+import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorRecordSetProvider;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.function.table.ConnectorTableFunction;
@@ -63,6 +64,7 @@ public class JdbcModule
         newOptionalBinder(binder, ConnectorSplitManager.class).setDefault().to(JdbcDynamicFilteringSplitManager.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, ConnectorRecordSetProvider.class).setDefault().to(JdbcRecordSetProvider.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, ConnectorPageSinkProvider.class).setDefault().to(JdbcPageSinkProvider.class).in(Scopes.SINGLETON);
+        newOptionalBinder(binder, ConnectorPageSourceProvider.class).setDefault().to(JdbcPageSourceProvider.class).in(Scopes.SINGLETON);
 
         binder.bind(JdbcTransactionManager.class).in(Scopes.SINGLETON);
         binder.bind(JdbcConnector.class).in(Scopes.SINGLETON);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSinkProvider.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSinkProvider.java
@@ -16,6 +16,8 @@ package io.trino.plugin.jdbc;
 import com.google.inject.Inject;
 import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
+import io.trino.spi.connector.ConnectorMergeSink;
+import io.trino.spi.connector.ConnectorMergeTableHandle;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorPageSink;
 import io.trino.spi.connector.ConnectorPageSinkId;
@@ -48,5 +50,11 @@ public class JdbcPageSinkProvider
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle tableHandle, ConnectorPageSinkId pageSinkId)
     {
         return new JdbcPageSink(session, (JdbcOutputTableHandle) tableHandle, jdbcClient, pageSinkId, queryModifier);
+    }
+
+    @Override
+    public ConnectorMergeSink createMergeSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorMergeTableHandle mergeHandle, ConnectorPageSinkId pageSinkId)
+    {
+        return new JdbcMergeSink(jdbcClient, queryModifier, session, mergeHandle, pageSinkId);
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSource.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSource.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix5;
+package io.trino.plugin.jdbc;
 
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
@@ -24,13 +24,13 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.spi.block.RowBlock.fromFieldBlocks;
 import static java.util.Objects.requireNonNull;
 
-public class PhoenixPageSource
+public class JdbcPageSource
         implements ConnectorPageSource
 {
     private final ConnectorPageSource delegate;
     private final List<ColumnAdaptation> columnAdaptations;
 
-    public PhoenixPageSource(ConnectorPageSource delegate, List<ColumnAdaptation> columnAdaptations)
+    public JdbcPageSource(ConnectorPageSource delegate, List<ColumnAdaptation> columnAdaptations)
     {
         this.delegate = delegate;
         this.columnAdaptations = columnAdaptations;

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSourceProvider.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSourceProvider.java
@@ -11,14 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix5;
+package io.trino.plugin.jdbc;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
-import io.trino.plugin.jdbc.ForRecordCursor;
-import io.trino.plugin.jdbc.JdbcColumnHandle;
-import io.trino.plugin.jdbc.JdbcRecordSetProvider;
-import io.trino.plugin.jdbc.JdbcTableHandle;
+import io.trino.plugin.jdbc.JdbcPageSource.ColumnAdaptation;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
@@ -37,43 +34,46 @@ import java.util.concurrent.ExecutorService;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterators.indexOf;
-import static io.trino.plugin.phoenix5.PhoenixClient.MERGE_ROW_ID_COLUMN_NAME;
-import static io.trino.plugin.phoenix5.PhoenixPageSource.ColumnAdaptation;
+import static io.trino.plugin.jdbc.BaseJdbcClient.MERGE_ROW_ID;
 
-public class PhoenixPageSourceProvider
+public class JdbcPageSourceProvider
         implements ConnectorPageSourceProvider
 {
     private final JdbcRecordSetProvider recordSetProvider;
-    private final PhoenixClient phoenixClient;
+    private final JdbcClient jdbcClient;
 
     @Inject
-    public PhoenixPageSourceProvider(PhoenixClient phoenixClient, @ForRecordCursor ExecutorService executor)
+    public JdbcPageSourceProvider(JdbcClient jdbcClient, @ForRecordCursor ExecutorService executor)
     {
-        this.recordSetProvider = new JdbcRecordSetProvider(phoenixClient, executor);
-        this.phoenixClient = phoenixClient;
+        this.recordSetProvider = new JdbcRecordSetProvider(jdbcClient, executor);
+        this.jdbcClient = jdbcClient;
     }
 
     @Override
     public ConnectorPageSource createPageSource(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorSplit split, ConnectorTableHandle table, List<ColumnHandle> columns, DynamicFilter dynamicFilter)
     {
+        if (table instanceof JdbcProcedureHandle procedureHandle) {
+            return new RecordPageSource(recordSetProvider.getRecordSet(transaction, session, split, procedureHandle, columns));
+        }
+
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
         List<JdbcColumnHandle> columnHandles = columns.stream()
                 .map(JdbcColumnHandle.class::cast)
                 .collect(toImmutableList());
-        int mergeRowIdChannel = indexOf(columnHandles.iterator(), column -> column.getColumnName().equalsIgnoreCase(MERGE_ROW_ID_COLUMN_NAME));
+        int mergeRowIdChannel = indexOf(columnHandles.iterator(), column -> column.getColumnName().equalsIgnoreCase(MERGE_ROW_ID));
         Optional<List<JdbcColumnHandle>> scanColumnHandles = Optional.of(columnHandles);
         if (mergeRowIdChannel != -1) {
             JdbcColumnHandle mergeRowIdColumn = columnHandles.get(mergeRowIdChannel);
-            tableHandle = phoenixClient.updatedScanColumnTable(session, tableHandle, scanColumnHandles, mergeRowIdColumn);
+            tableHandle = jdbcClient.updatedScanColumnsForMerge(session, tableHandle, scanColumnHandles, mergeRowIdColumn);
             scanColumnHandles = tableHandle.getColumns();
         }
 
-        return new PhoenixPageSource(
+        return new JdbcPageSource(
                 new RecordPageSource(recordSetProvider.getRecordSet(transaction, session, split, tableHandle, scanColumnHandles.orElse(ImmutableList.of()))),
-                getColumnAdaptations(scanColumnHandles, mergeRowIdChannel, columnHandles));
+                getColumnAdaptations(scanColumnHandles, mergeRowIdChannel, columnHandles, columns.size()));
     }
 
-    private List<ColumnAdaptation> getColumnAdaptations(Optional<List<JdbcColumnHandle>> scanColumnHandles, int mergeRowIdChannel, List<JdbcColumnHandle> columnHandles)
+    private List<ColumnAdaptation> getColumnAdaptations(Optional<List<JdbcColumnHandle>> scanColumnHandles, int mergeRowIdChannel, List<JdbcColumnHandle> columnHandles, int columnCount)
     {
         if (mergeRowIdChannel == -1) {
             return ImmutableList.of();
@@ -82,7 +82,7 @@ public class PhoenixPageSourceProvider
         List<JdbcColumnHandle> scanColumns = scanColumnHandles.get();
         checkArgument(!scanColumns.isEmpty(), "Scan column handles is empty");
         JdbcColumnHandle mergeRowIdColumn = columnHandles.get(mergeRowIdChannel);
-        ImmutableList.Builder<ColumnAdaptation> columnAdaptationBuilder = ImmutableList.builder();
+        ImmutableList.Builder<ColumnAdaptation> columnAdaptationBuilder = ImmutableList.builderWithExpectedSize(columnCount);
         for (int index = 0; index < scanColumns.size(); index++) {
             if (mergeRowIdChannel == index) {
                 columnAdaptationBuilder.add(buildMergeIdColumnAdaptation(scanColumns, mergeRowIdColumn));
@@ -92,7 +92,8 @@ public class PhoenixPageSourceProvider
         if (mergeRowIdChannel == scanColumns.size()) {
             columnAdaptationBuilder.add(buildMergeIdColumnAdaptation(scanColumns, mergeRowIdColumn));
         }
-        return columnAdaptationBuilder.build();
+        // Trim the pages. Jdbc connectors need follow the required columns strictly.
+        return columnAdaptationBuilder.build().subList(0, columnCount);
     }
 
     private ColumnAdaptation buildMergeIdColumnAdaptation(List<JdbcColumnHandle> scanColumns, JdbcColumnHandle mergeRowIdColumn)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcTableHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcTableHandle.java
@@ -146,6 +146,16 @@ public final class JdbcTableHandle
         return getRequiredNamedRelation();
     }
 
+    public JdbcTableHandle toPlainTableWithoutColumns()
+    {
+        if (!isSynthetic() && columns.isEmpty()) {
+            return this;
+        }
+
+        JdbcNamedRelationHandle requiredNamedRelation = getRequiredNamedRelation();
+        return new JdbcTableHandle(requiredNamedRelation.getSchemaTableName(), requiredNamedRelation.getRemoteTableName(), requiredNamedRelation.getComment());
+    }
+
     @JsonIgnore
     public JdbcNamedRelationHandle getRequiredNamedRelation()
     {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/JdbcClientStats.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/JdbcClientStats.java
@@ -22,6 +22,7 @@ public final class JdbcClientStats
     private final JdbcApiStats addColumn = new JdbcApiStats();
     private final JdbcApiStats beginCreateTable = new JdbcApiStats();
     private final JdbcApiStats beginInsertTable = new JdbcApiStats();
+    private final JdbcApiStats beginDeleteTableForMerge = new JdbcApiStats();
     private final JdbcApiStats buildInsertSql = new JdbcApiStats();
     private final JdbcApiStats prepareQuery = new JdbcApiStats();
     private final JdbcApiStats buildSql = new JdbcApiStats();
@@ -38,7 +39,10 @@ public final class JdbcClientStats
     private final JdbcApiStats renameSchema = new JdbcApiStats();
     private final JdbcApiStats dropTable = new JdbcApiStats();
     private final JdbcApiStats finishInsertTable = new JdbcApiStats();
+    private final JdbcApiStats finishDeleteTableForMerge = new JdbcApiStats();
     private final JdbcApiStats getColumns = new JdbcApiStats();
+
+    private final JdbcApiStats getPrimaryKeys = new JdbcApiStats();
     private final JdbcApiStats getConnectionWithHandle = new JdbcApiStats();
     private final JdbcApiStats getConnectionWithSplit = new JdbcApiStats();
     private final JdbcApiStats getConnectionWithProcedure = new JdbcApiStats();
@@ -93,6 +97,13 @@ public final class JdbcClientStats
     public JdbcApiStats getBeginInsertTable()
     {
         return beginInsertTable;
+    }
+
+    @Managed
+    @Nested
+    public JdbcApiStats getBeginDeleteTableForMerge()
+    {
+        return beginDeleteTableForMerge;
     }
 
     @Managed
@@ -209,9 +220,23 @@ public final class JdbcClientStats
 
     @Managed
     @Nested
+    public JdbcApiStats getFinishDeleteTableForMerge()
+    {
+        return finishDeleteTableForMerge;
+    }
+
+    @Managed
+    @Nested
     public JdbcApiStats getGetColumns()
     {
         return getColumns;
+    }
+
+    @Managed
+    @Nested
+    public JdbcApiStats getGetPrimaryKeys()
+    {
+        return getPrimaryKeys;
     }
 
     @Managed

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -35,6 +35,7 @@ import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitSource;
+import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.JoinStatistics;
 import io.trino.spi.connector.JoinType;
@@ -125,6 +126,12 @@ public final class StatisticsAwareJdbcClient
     public List<JdbcColumnHandle> getColumns(ConnectorSession session, JdbcTableHandle tableHandle)
     {
         return stats.getGetColumns().wrap(() -> delegate().getColumns(session, tableHandle));
+    }
+
+    @Override
+    public List<JdbcColumnHandle> getPrimaryKeys(ConnectorSession session, JdbcTableHandle tableHandle)
+    {
+        return stats.getGetPrimaryKeys().wrap(() -> delegate().getPrimaryKeys(session, tableHandle));
     }
 
     @Override
@@ -326,6 +333,18 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
+    public JdbcOutputTableHandle beginDeleteTableForMerge(ConnectorSession session, JdbcTableHandle tableHandle)
+    {
+        return stats.getBeginDeleteTableForMerge().wrap(() -> delegate().beginDeleteTableForMerge(session, tableHandle));
+    }
+
+    @Override
+    public void finishDeleteTableForMerge(ConnectorSession session, JdbcOutputTableHandle handle, Set<Long> pageSinkIds)
+    {
+        stats.getFinishDeleteTableForMerge().wrap(() -> delegate().finishDeleteTableForMerge(session, handle, pageSinkIds));
+    }
+
+    @Override
     public void dropTable(ConnectorSession session, JdbcTableHandle jdbcTableHandle)
     {
         stats.getDropTable().wrap(() -> delegate().dropTable(session, jdbcTableHandle));
@@ -347,6 +366,12 @@ public final class StatisticsAwareJdbcClient
     public String buildInsertSql(JdbcOutputTableHandle handle, List<WriteFunction> columnWriters)
     {
         return stats.getBuildInsertSql().wrap(() -> delegate().buildInsertSql(handle, columnWriters));
+    }
+
+    @Override
+    public String buildMergeRowIdConjuncts(ConnectorSession session, List<String> mergeRowIdFieldNames, List<Type> mergeRowIdFieldTypes)
+    {
+        return delegate.buildMergeRowIdConjuncts(session, mergeRowIdFieldNames, mergeRowIdFieldTypes);
     }
 
     @Override
@@ -475,5 +500,11 @@ public final class StatisticsAwareJdbcClient
     public OptionalInt getMaxColumnNameLength(ConnectorSession session)
     {
         return delegate().getMaxColumnNameLength(session);
+    }
+
+    @Override
+    public JdbcTableHandle updatedScanColumnsForMerge(ConnectorSession session, ConnectorTableHandle table, Optional<List<JdbcColumnHandle>> originalColumns, JdbcColumnHandle mergeRowIdColumnHandle)
+    {
+        return delegate().updatedScanColumnsForMerge(session, table, originalColumns, mergeRowIdColumnHandle);
     }
 }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -1567,6 +1567,10 @@ public abstract class BaseJdbcConnectorTest
     public void testUpdateRowConcurrently()
             throws Exception
     {
+        if (hasBehavior(SUPPORTS_MERGE)) {
+            abort("The connector doesn't support concurrent update of different columns in a row");
+        }
+
         // we don't support metadata update for expressions yet, remove override as soon as support will be added
         if (hasBehavior(SUPPORTS_ROW_LEVEL_UPDATE)) {
             super.testUpdateRowConcurrently();
@@ -1657,7 +1661,7 @@ public abstract class BaseJdbcConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE) && hasBehavior(SUPPORTS_UPDATE));
         try (TestTable table = new TestTable(getQueryRunner()::execute, "test_update_varchar", "(col1 INT, col2 varchar(1))", ImmutableList.of("1, 'a'", "2, 'A'"))) {
-            if (!hasBehavior(SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_INEQUALITY)) {
+            if (!hasBehavior(SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_INEQUALITY) && !hasBehavior(SUPPORTS_MERGE)) {
                 assertQueryFails("UPDATE " + table.getName() + " SET col1 = 20 WHERE col2 != 'A'", MODIFYING_ROWS_MESSAGE);
                 return;
             }
@@ -1672,7 +1676,7 @@ public abstract class BaseJdbcConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE) && hasBehavior(SUPPORTS_UPDATE));
         try (TestTable table = new TestTable(getQueryRunner()::execute, "test_update_varchar", "(col1 INT, col2 varchar(1))", ImmutableList.of("1, 'a'", "2, 'A'"))) {
-            if (!hasBehavior(SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_INEQUALITY)) {
+            if (!hasBehavior(SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_INEQUALITY) && !hasBehavior(SUPPORTS_MERGE)) {
                 assertQueryFails("UPDATE " + table.getName() + " SET col1 = 20 WHERE col2 > 'A'", MODIFYING_ROWS_MESSAGE);
                 assertQueryFails("UPDATE " + table.getName() + " SET col1 = 20 WHERE col2 < 'A'", MODIFYING_ROWS_MESSAGE);
                 return;
@@ -1765,6 +1769,41 @@ public abstract class BaseJdbcConnectorTest
         }
         assertThatThrownBy(super::testDeleteWithComplexPredicate)
                 .hasStackTraceContaining("TrinoException: " + MODIFYING_ROWS_MESSAGE);
+    }
+
+    @Test
+    @Override
+    public void testMergeLarge()
+    {
+        skipTestUnless(hasBehavior(SUPPORTS_MERGE));
+
+        String tableName = "test_merge_" + randomNameSuffix();
+        assertUpdate(createTableForWrites(format("CREATE TABLE %s (orderkey BIGINT, custkey BIGINT, totalprice DOUBLE)", tableName)));
+
+        assertUpdate(
+                format("INSERT INTO %s SELECT orderkey, custkey, totalprice FROM tpch.sf1.orders", tableName),
+                (long) computeScalar("SELECT count(*) FROM tpch.sf1.orders"));
+
+        @Language("SQL") String mergeSql = "" +
+                "MERGE INTO " + tableName + " t USING (SELECT * FROM tpch.sf1.orders) s ON (t.orderkey = s.orderkey)\n" +
+                "WHEN MATCHED AND mod(s.orderkey, 3) = 0 THEN UPDATE SET totalprice = t.totalprice + s.totalprice\n" +
+                "WHEN MATCHED AND mod(s.orderkey, 3) = 1 THEN DELETE";
+
+        assertUpdate(mergeSql, 1_000_000);
+
+        // verify deleted rows
+        assertQuery("SELECT count(*) FROM " + tableName + " WHERE mod(orderkey, 3) = 1", "SELECT 0");
+
+        // verify untouched rows
+        assertThat(query("SELECT count(*), cast(sum(totalprice) AS decimal(18,2)) FROM " + tableName + " WHERE mod(orderkey, 3) = 2"))
+                .matches("SELECT count(*), cast(sum(totalprice) AS decimal(18,2)) FROM tpch.sf1.orders WHERE mod(orderkey, 3) = 2");
+
+        // TODO investigate why sum(DOUBLE) not correct
+        // verify updated rows
+        String sql = format("SELECT count(*) FROM %s t JOIN tpch.sf1.orders s ON t.orderkey = s.orderkey WHERE mod(t.orderkey, 3) = 0 AND t.totalprice != s.totalprice * 2", tableName);
+        assertQuery(sql, "SELECT 0");
+
+        assertUpdate("DROP TABLE " + tableName);
     }
 
     @Test

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcFailureRecoveryTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcFailureRecoveryTest.java
@@ -31,6 +31,11 @@ public abstract class BaseJdbcFailureRecoveryTest
         super(retryPolicy);
     }
 
+    protected boolean supportMerge()
+    {
+        return false;
+    }
+
     @Test
     @Override
     protected void testAnalyzeTable()
@@ -59,6 +64,10 @@ public abstract class BaseJdbcFailureRecoveryTest
     @Override
     protected void testDeleteWithSubquery()
     {
+        if (supportMerge()) {
+            super.testDeleteWithSubquery();
+            return;
+        }
         assertThatThrownBy(super::testDeleteWithSubquery).hasMessageContaining(MODIFYING_ROWS_MESSAGE);
         abort("skipped");
     }
@@ -76,6 +85,10 @@ public abstract class BaseJdbcFailureRecoveryTest
     @Override
     protected void testUpdate()
     {
+        if (supportMerge()) {
+            super.testUpdate();
+            return;
+        }
         assertThatThrownBy(super::testUpdate).hasMessageContaining(MODIFYING_ROWS_MESSAGE);
         abort("skipped");
     }
@@ -84,6 +97,10 @@ public abstract class BaseJdbcFailureRecoveryTest
     @Override
     protected void testUpdateWithSubquery()
     {
+        if (supportMerge()) {
+            super.testUpdateWithSubquery();
+            return;
+        }
         assertThatThrownBy(super::testUpdateWithSubquery).hasMessageContaining(MODIFYING_ROWS_MESSAGE);
         abort("skipped");
     }
@@ -92,6 +109,10 @@ public abstract class BaseJdbcFailureRecoveryTest
     @Override
     protected void testMerge()
     {
+        if (supportMerge()) {
+            super.testMerge();
+            return;
+        }
         assertThatThrownBy(super::testMerge).hasMessageContaining(MODIFYING_ROWS_MESSAGE);
         abort("skipped");
     }

--- a/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
+++ b/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
@@ -80,10 +80,12 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiFunction;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.ignite.IgniteTableProperties.PRIMARY_KEY_PROPERTY;
 import static io.trino.plugin.jdbc.ColumnMapping.longMapping;
 import static io.trino.plugin.jdbc.DecimalConfig.DecimalMapping.ALLOW_OVERFLOW;
@@ -561,6 +563,19 @@ public class IgniteClient
                 quoted(null, handle.getSchemaName(), handle.getTableName()),
                 columns,
                 params);
+    }
+
+    @Override
+    public List<JdbcColumnHandle> getPrimaryKeys(ConnectorSession session, JdbcTableHandle tableHandle)
+    {
+        JdbcTableHandle plainTable = tableHandle.toPlainTableWithoutColumns();
+        Map<String, Object> tableProperties = getTableProperties(session, plainTable);
+        Set<String> primaryKeyNames = ImmutableSet.copyOf(IgniteTableProperties.getPrimaryKey(tableProperties));
+
+        List<JdbcColumnHandle> columns = getColumns(session, plainTable);
+        return columns.stream()
+                .filter(column -> primaryKeyNames.contains(column.getColumnName().toLowerCase(ENGLISH)))
+                .collect(toImmutableList());
     }
 
     @Override

--- a/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteMergeTableHandle.java
+++ b/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteMergeTableHandle.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix5;
+package io.trino.plugin.ignite;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -19,24 +19,15 @@ import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcMergeTableHandle;
 import io.trino.plugin.jdbc.JdbcTableHandle;
 
-public class PhoenixMergeTableHandle
+public class IgniteMergeTableHandle
         extends JdbcMergeTableHandle
 {
-    private final boolean hasRowKey;
-
     @JsonCreator
-    public PhoenixMergeTableHandle(
+    public IgniteMergeTableHandle(
             @JsonProperty("tableHandle") JdbcTableHandle tableHandle,
-            @JsonProperty("outputTableHandle") PhoenixOutputTableHandle outputTableHandle,
+            @JsonProperty("outputTableHandle") IgniteOutputTableHandle outputTableHandle,
             @JsonProperty("mergeRowIdColumnHandle") JdbcColumnHandle mergeRowIdColumnHandle)
     {
         super(tableHandle, outputTableHandle, mergeRowIdColumnHandle);
-        this.hasRowKey = outputTableHandle.rowkeyColumn().isPresent();
-    }
-
-    @JsonProperty
-    public boolean isHasRowKey()
-    {
-        return hasRowKey;
     }
 }

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteConnectorTest.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteConnectorTest.java
@@ -27,12 +27,15 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.google.common.base.Strings.nullToEmpty;
 import static io.trino.plugin.ignite.IgniteQueryRunner.createIgniteQueryRunner;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.abort;
@@ -67,7 +70,10 @@ public class TestIgniteConnectorTest
             case SUPPORTS_AGGREGATION_PUSHDOWN,
                     SUPPORTS_JOIN_PUSHDOWN,
                     SUPPORTS_PREDICATE_EXPRESSION_PUSHDOWN_WITH_LIKE,
-                    SUPPORTS_TOPN_PUSHDOWN_WITH_VARCHAR -> true;
+                    SUPPORTS_TOPN_PUSHDOWN_WITH_VARCHAR,
+                    SUPPORTS_UPDATE,
+                    SUPPORTS_ROW_LEVEL_UPDATE,
+                    SUPPORTS_MERGE -> true;
             case SUPPORTS_ADD_COLUMN_NOT_NULL_CONSTRAINT,
                     SUPPORTS_ADD_COLUMN_WITH_COMMENT,
                     SUPPORTS_AGGREGATION_PUSHDOWN_CORRELATION,
@@ -202,6 +208,81 @@ public class TestIgniteConnectorTest
             assertThat((String) computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue())
                     .isEqualTo(format(pattern, catalog, schema, tableName));
         }
+    }
+
+    @Test
+    public void testMergeWithSpecifiedRowkeys()
+    {
+        testMergeWithSpecifiedRowkeys("'customer'");
+        testMergeWithSpecifiedRowkeys("'customer_copy'");
+        testMergeWithSpecifiedRowkeys("'customer','customer_copy'");
+    }
+
+    // This method is mainly copied from BaseConnectorTest#testMergeMultipleOperations, and appended a 'customer_copy' column which is the copy of the 'customer' column for
+    // testing merge with specifying rowkeys explicitly in Ignite
+    private void testMergeWithSpecifiedRowkeys(String rowkeyDefinition)
+    {
+        int targetCustomerCount = 32;
+        String targetTable = "merge_multiple_rowkeys_specified_" + randomNameSuffix();
+        // check the upper case table name also works
+        targetTable = targetTable.toUpperCase(ENGLISH);
+        assertUpdate(createTableForWrites(format("CREATE TABLE %s (customer VARCHAR, purchases INT, zipcode INT, spouse VARCHAR, address VARCHAR, customer_copy VARCHAR) WITH (primary_key = ARRAY[%s])", targetTable, rowkeyDefinition)));
+
+        String originalInsertFirstHalf = IntStream.range(1, targetCustomerCount / 2)
+                .mapToObj(intValue -> format("('joe_%s', %s, %s, 'jan_%s', '%s Poe Ct', 'joe_%s')", intValue, 1000, 91000, intValue, intValue, intValue))
+                .collect(Collectors.joining(", "));
+        String originalInsertSecondHalf = IntStream.range(targetCustomerCount / 2, targetCustomerCount)
+                .mapToObj(intValue -> format("('joe_%s', %s, %s, 'jan_%s', '%s Poe Ct', 'joe_%s')", intValue, 2000, 92000, intValue, intValue, intValue))
+                .collect(Collectors.joining(", "));
+
+        assertUpdate(format("INSERT INTO %s (customer, purchases, zipcode, spouse, address, customer_copy) VALUES %s, %s", targetTable, originalInsertFirstHalf, originalInsertSecondHalf), targetCustomerCount - 1);
+
+        String firstMergeSource = IntStream.range(targetCustomerCount / 2, targetCustomerCount)
+                .mapToObj(intValue -> format("('joe_%s', %s, %s, 'jill_%s', '%s Eop Ct', 'joe_%s')", intValue, 3000, 83000, intValue, intValue, intValue))
+                .collect(Collectors.joining(", "));
+
+        assertUpdate(format("MERGE INTO %s t USING (VALUES %s) AS s(customer, purchases, zipcode, spouse, address, customer_copy)", targetTable, firstMergeSource) +
+                        "    ON t.customer = s.customer" +
+                        "    WHEN MATCHED THEN UPDATE SET purchases = s.purchases, zipcode = s.zipcode, spouse = s.spouse, address = s.address",
+                targetCustomerCount / 2);
+
+        assertQuery(
+                "SELECT customer, purchases, zipcode, spouse, address, customer_copy FROM " + targetTable,
+                format("VALUES %s, %s", originalInsertFirstHalf, firstMergeSource));
+
+        String nextInsert = IntStream.range(targetCustomerCount, targetCustomerCount * 3 / 2)
+                .mapToObj(intValue -> format("('jack_%s', %s, %s, 'jan_%s', '%s Poe Ct', 'jack_%s')", intValue, 4000, 74000, intValue, intValue, intValue))
+                .collect(Collectors.joining(", "));
+
+        assertUpdate(format("INSERT INTO %s (customer, purchases, zipcode, spouse, address, customer_copy) VALUES %s", targetTable, nextInsert), targetCustomerCount / 2);
+
+        String secondMergeSource = IntStream.range(1, targetCustomerCount * 3 / 2)
+                .mapToObj(intValue -> format("('joe_%s', %s, %s, 'jen_%s', '%s Poe Ct', 'joe_%s')", intValue, 5000, 85000, intValue, intValue, intValue))
+                .collect(Collectors.joining(", "));
+
+        assertUpdate(format("MERGE INTO %s t USING (VALUES %s) AS s(customer, purchases, zipcode, spouse, address, customer_copy)", targetTable, secondMergeSource) +
+                        "    ON t.customer = s.customer" +
+                        "    WHEN MATCHED AND t.zipcode = 91000 THEN DELETE" +
+                        "    WHEN MATCHED AND s.zipcode = 85000 THEN UPDATE SET zipcode = 60000" +
+                        "    WHEN MATCHED THEN UPDATE SET zipcode = s.zipcode, spouse = s.spouse, address = s.address" +
+                        "    WHEN NOT MATCHED THEN INSERT (customer, purchases, zipcode, spouse, address, customer_copy) VALUES(s.customer, s.purchases, s.zipcode, s.spouse, s.address, s.customer_copy)",
+                targetCustomerCount * 3 / 2 - 1);
+
+        String updatedBeginning = IntStream.range(targetCustomerCount / 2, targetCustomerCount)
+                .mapToObj(intValue -> format("('joe_%s', %s, %s, 'jill_%s', '%s Eop Ct', 'joe_%s')", intValue, 3000, 60000, intValue, intValue, intValue))
+                .collect(Collectors.joining(", "));
+        String updatedMiddle = IntStream.range(targetCustomerCount, targetCustomerCount * 3 / 2)
+                .mapToObj(intValue -> format("('joe_%s', %s, %s, 'jen_%s', '%s Poe Ct', 'joe_%s')", intValue, 5000, 85000, intValue, intValue, intValue))
+                .collect(Collectors.joining(", "));
+        String updatedEnd = IntStream.range(targetCustomerCount, targetCustomerCount * 3 / 2)
+                .mapToObj(intValue -> format("('jack_%s', %s, %s, 'jan_%s', '%s Poe Ct', 'jack_%s')", intValue, 4000, 74000, intValue, intValue, intValue))
+                .collect(Collectors.joining(", "));
+
+        assertQuery(
+                "SELECT customer, purchases, zipcode, spouse, address, customer_copy FROM " + targetTable,
+                format("VALUES %s, %s, %s", updatedBeginning, updatedMiddle, updatedEnd));
+
+        assertUpdate("DROP TABLE " + targetTable);
     }
 
     @Test
@@ -403,6 +484,15 @@ public class TestIgniteConnectorTest
         assertQueryFails(
                 "SELECT * FROM orders WHERE orderdate = DATE '-1996-09-14'",
                 errorMessageForDateOutOfRange("-1996-09-14"));
+    }
+
+    // TODO (https://github.com/trinodb/trino/issues/17003) Remove the test once the issue has been fixed
+    @Test
+    @Override
+    public void testDeleteWithSubquery()
+    {
+        assertThatThrownBy(super::testDeleteWithSubquery)
+                .hasStackTraceContaining("Unexpected Join over for-update table scan");
     }
 
     @Override

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorSmokeTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorSmokeTest.java
@@ -18,6 +18,7 @@ import io.trino.testing.TestingConnectorBehavior;
 import org.junit.jupiter.api.Test;
 
 import static io.trino.testing.TestingNames.randomNameSuffix;
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class BaseOracleConnectorSmokeTest
@@ -27,6 +28,9 @@ public abstract class BaseOracleConnectorSmokeTest
     protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
     {
         return switch (connectorBehavior) {
+            case SUPPORTS_UPDATE,
+                    SUPPORTS_ROW_LEVEL_UPDATE,
+                    SUPPORTS_MERGE -> true;
             case SUPPORTS_CREATE_SCHEMA,
                     SUPPORTS_RENAME_TABLE_ACROSS_SCHEMAS -> false;
             default -> super.hasBehavior(connectorBehavior);
@@ -46,5 +50,11 @@ public abstract class BaseOracleConnectorSmokeTest
         assertThat((String) computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue()).doesNotContain("COMMENT 'new comment'");
 
         assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Override
+    protected String expectedValues(String values)
+    {
+        return format("SELECT CAST(a AS DECIMAL(19,0)), CAST(b AS double) FROM (VALUES %s) AS t (a, b)", values);
     }
 }

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleFailureRecoveryTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleFailureRecoveryTest.java
@@ -55,6 +55,8 @@ public abstract class BaseOracleFailureRecoveryTest
                         .put("connection-url", oracleServer.getJdbcUrl())
                         .put("connection-user", TEST_USER)
                         .put("connection-password", TEST_PASS)
+                        // Set not use pool explicitly, avoid the test fail due to reaching the connection pool limitation
+                        .put("oracle.connection-pool.enabled", "false")
                         .buildOrThrow(),
                 requiredTpchTables,
                 runner -> {
@@ -62,6 +64,20 @@ public abstract class BaseOracleFailureRecoveryTest
                     runner.loadExchangeManager("filesystem", ImmutableMap.of(
                             "exchange.base-directories", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager"));
                 });
+    }
+
+    @Override
+    protected boolean supportMerge()
+    {
+        return true;
+    }
+
+    @Test
+    @Override
+    protected void testDeleteWithSubquery()
+    {
+        // TODO: Solve the temporary table issue
+        abort("skipped");
     }
 
     @Test

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleServer.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleServer.java
@@ -91,7 +91,8 @@ public class TestingOracleServer
             File tempFile = File.createTempFile("init-", ".sql");
 
             Files.write(Joiner.on("\n").join(
-                    format("CREATE TABLESPACE %s DATAFILE 'test_db.dat' SIZE 100M ONLINE;", TEST_TABLESPACE),
+                    // Increase datafile size, for avoiding ORA-01653 error
+                    format("CREATE TABLESPACE %s DATAFILE 'test_db.dat' SIZE 150M ONLINE;", TEST_TABLESPACE),
                     format("CREATE USER %s IDENTIFIED BY %s DEFAULT TABLESPACE %s;", TEST_USER, TEST_PASS, TEST_TABLESPACE),
                     format("GRANT UNLIMITED TABLESPACE TO %s;", TEST_USER),
                     format("GRANT CREATE SESSION TO %s;", TEST_USER),

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -48,7 +48,6 @@ import io.trino.spi.block.Block;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
@@ -58,7 +57,6 @@ import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Decimals;
-import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
@@ -126,8 +124,6 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.collect.Iterators.tryFind;
 import static io.trino.plugin.jdbc.DecimalConfig.DecimalMapping.ALLOW_OVERFLOW;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalDefaultScale;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalRounding;
@@ -213,7 +209,6 @@ import static org.apache.phoenix.util.SchemaUtil.getEscapedArgument;
 public class PhoenixClient
         extends BaseJdbcClient
 {
-    public static final String MERGE_ROW_ID_COLUMN_NAME = "$merge_row_id";
     public static final String ROWKEY = "ROWKEY";
     public static final JdbcColumnHandle ROWKEY_COLUMN_HANDLE = new JdbcColumnHandle(
             ROWKEY,
@@ -924,81 +919,11 @@ public class PhoenixClient
         }
     }
 
-    public JdbcTableHandle buildPlainTable(JdbcTableHandle handle)
+    @Override
+    public List<JdbcColumnHandle> getPrimaryKeys(ConnectorSession session, JdbcTableHandle tableHandle)
     {
-        checkArgument(handle.isNamedRelation(), "Only allow build plain table from named relation table");
-
-        SchemaTableName schemaTableName = handle.getRequiredNamedRelation().getSchemaTableName();
-        RemoteTableName remoteTableName = handle.getRequiredNamedRelation().getRemoteTableName();
-        return new JdbcTableHandle(schemaTableName, remoteTableName, Optional.empty());
-    }
-
-    public JdbcTableHandle updatedScanColumnTable(ConnectorSession session, ConnectorTableHandle table, Optional<List<JdbcColumnHandle>> originalColumns, JdbcColumnHandle mergeRowIdColumnHandle)
-    {
-        JdbcTableHandle tableHandle = (JdbcTableHandle) table;
-        if (originalColumns.isEmpty()) {
-            return tableHandle;
-        }
-        List<JdbcColumnHandle> scanColumnHandles = originalColumns.get();
-        checkArgument(!scanColumnHandles.isEmpty(), "Scan columns should not empty");
-        checkArgument(tryFind(scanColumnHandles.iterator(), column -> MERGE_ROW_ID_COLUMN_NAME.equalsIgnoreCase(column.getColumnName())).isPresent(), "Merge row id column must exist in original columns");
-
-        return new JdbcTableHandle(
-                tableHandle.getRelationHandle(),
-                tableHandle.getConstraint(),
-                tableHandle.getConstraintExpressions(),
-                tableHandle.getSortOrder(),
-                tableHandle.getLimit(),
-                Optional.of(getUpdatedScanColumnHandles(session, tableHandle, scanColumnHandles, mergeRowIdColumnHandle)),
-                tableHandle.getOtherReferencedTables(),
-                tableHandle.getNextSyntheticColumnId(),
-                tableHandle.getAuthorization(),
-                tableHandle.getUpdateAssignments());
-    }
-
-    private List<JdbcColumnHandle> getUpdatedScanColumnHandles(ConnectorSession session, JdbcTableHandle tableHandle, List<JdbcColumnHandle> scanColumnHandles, JdbcColumnHandle mergeRowIdColumnHandle)
-    {
-        RowType columnType = (RowType) mergeRowIdColumnHandle.getColumnType();
-        List<JdbcColumnHandle> primaryKeyColumnHandles = getPrimaryKeyColumnHandles(session, tableHandle);
-        Set<String> mergeRowIdFieldNames = columnType.getFields().stream()
-                .map(RowType.Field::getName)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .collect(toImmutableSet());
-        Set<String> primaryKeyColumnNames = primaryKeyColumnHandles.stream()
-                .map(JdbcColumnHandle::getColumnName)
-                .collect(toImmutableSet());
-        checkArgument(mergeRowIdFieldNames.containsAll(primaryKeyColumnNames), "Merge row id fields should contains all primary keys");
-
-        ImmutableList.Builder<JdbcColumnHandle> columnHandleBuilder = ImmutableList.builder();
-        scanColumnHandles.stream()
-                .filter(jdbcColumnHandle -> !MERGE_ROW_ID_COLUMN_NAME.equalsIgnoreCase(jdbcColumnHandle.getColumnName()))
-                .forEach(columnHandleBuilder::add);
-        // Add merge row id fields
-        for (JdbcColumnHandle columnHandle : primaryKeyColumnHandles) {
-            String columnName = columnHandle.getColumnName();
-            if (ROWKEY.equalsIgnoreCase(columnName)) {
-                checkArgument(primaryKeyColumnHandles.size() == 1, "Wrong primary keys");
-                columnHandleBuilder.add(ROWKEY_COLUMN_HANDLE);
-                break;
-            }
-
-            if (!tryFind(scanColumnHandles.iterator(), column -> column.getColumnName().equalsIgnoreCase(columnName)).isPresent()) {
-                columnHandleBuilder.add(columnHandle);
-            }
-        }
-
-        return columnHandleBuilder.build();
-    }
-
-    public List<JdbcColumnHandle> getPrimaryKeyColumnHandles(ConnectorSession session, JdbcTableHandle tableHandle)
-    {
-        if (tableHandle.getColumns().isPresent()) {
-            tableHandle = buildPlainTable(tableHandle);
-        }
-
         Map<String, Object> tableProperties = getTableProperties(session, tableHandle);
-        List<JdbcColumnHandle> primaryKeyColumnHandles = getColumns(session, tableHandle)
+        List<JdbcColumnHandle> primaryKeyColumnHandles = getColumns(session, tableHandle.toPlainTableWithoutColumns())
                 .stream()
                 .filter(columnHandle -> PhoenixColumnProperties.isPrimaryKey(columnHandle.getColumnMetadata(), tableProperties))
                 .collect(toImmutableList());

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClientModule.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClientModule.java
@@ -42,6 +42,7 @@ import io.trino.plugin.jdbc.JdbcDynamicFilteringSessionProperties;
 import io.trino.plugin.jdbc.JdbcDynamicFilteringSplitManager;
 import io.trino.plugin.jdbc.JdbcMetadataConfig;
 import io.trino.plugin.jdbc.JdbcMetadataSessionProperties;
+import io.trino.plugin.jdbc.JdbcPageSourceProvider;
 import io.trino.plugin.jdbc.JdbcWriteConfig;
 import io.trino.plugin.jdbc.JdbcWriteSessionProperties;
 import io.trino.plugin.jdbc.LazyConnectionFactory;
@@ -103,7 +104,7 @@ public class PhoenixClientModule
         binder.bind(ConnectorSplitManager.class).to(ClassLoaderSafeConnectorSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorPageSinkProvider.class).annotatedWith(ForClassLoaderSafe.class).to(PhoenixPageSinkProvider.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorPageSinkProvider.class).to(ClassLoaderSafeConnectorPageSinkProvider.class).in(Scopes.SINGLETON);
-        binder.bind(ConnectorPageSourceProvider.class).annotatedWith(ForClassLoaderSafe.class).to(PhoenixPageSourceProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectorPageSourceProvider.class).annotatedWith(ForClassLoaderSafe.class).to(JdbcPageSourceProvider.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorPageSourceProvider.class).to(ClassLoaderSafeConnectorPageSourceProvider.class).in(Scopes.SINGLETON);
 
         binder.bind(QueryBuilder.class).to(DefaultQueryBuilder.class).in(Scopes.SINGLETON);

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMergeSink.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMergeSink.java
@@ -13,216 +13,75 @@
  */
 package io.trino.plugin.phoenix5;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
-import io.airlift.slice.Slice;
 import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcMergeSink;
 import io.trino.plugin.jdbc.JdbcOutputTableHandle;
 import io.trino.plugin.jdbc.JdbcPageSink;
-import io.trino.plugin.jdbc.WriteFunction;
 import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
-import io.trino.spi.block.RowBlock;
-import io.trino.spi.connector.ConnectorMergeSink;
 import io.trino.spi.connector.ConnectorMergeTableHandle;
 import io.trino.spi.connector.ConnectorPageSink;
 import io.trino.spi.connector.ConnectorPageSinkId;
 import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.IntStream;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.phoenix5.PhoenixClient.ROWKEY;
 import static io.trino.plugin.phoenix5.PhoenixClient.ROWKEY_COLUMN_HANDLE;
-import static io.trino.spi.type.TinyintType.TINYINT;
-import static java.lang.String.format;
-import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.apache.phoenix.util.SchemaUtil.getEscapedArgument;
 
 public class PhoenixMergeSink
-        implements ConnectorMergeSink
+        extends JdbcMergeSink
 {
-    private final String schemaName;
-    private final String tableName;
     private final boolean hasRowKey;
-    private final int columnCount;
-    private final List<String> mergeRowIdFieldNames;
-
-    private final ConnectorPageSink insertSink;
-    private final ConnectorPageSink updateSink;
-    private final ConnectorPageSink deleteSink;
 
     public PhoenixMergeSink(PhoenixClient phoenixClient, RemoteQueryModifier remoteQueryModifier, ConnectorSession session, ConnectorMergeTableHandle mergeHandle, ConnectorPageSinkId pageSinkId)
     {
-        PhoenixMergeTableHandle phoenixMergeTableHandle = (PhoenixMergeTableHandle) mergeHandle;
-        PhoenixOutputTableHandle phoenixOutputTableHandle = phoenixMergeTableHandle.phoenixOutputTableHandle();
-        this.schemaName = phoenixOutputTableHandle.getSchemaName();
-        this.tableName = phoenixOutputTableHandle.getTableName();
-        this.hasRowKey = phoenixOutputTableHandle.rowkeyColumn().isPresent();
-        this.columnCount = phoenixOutputTableHandle.getColumnNames().size();
-
-        this.insertSink = new JdbcPageSink(session, phoenixOutputTableHandle, phoenixClient, pageSinkId, remoteQueryModifier);
-        this.updateSink = createUpdateSink(session, phoenixOutputTableHandle, phoenixClient, pageSinkId, remoteQueryModifier);
-
-        ImmutableList.Builder<String> mergeRowIdFieldNamesBuilder = ImmutableList.builder();
-        ImmutableList.Builder<Type> mergeRowIdFieldTypesBuilder = ImmutableList.builder();
-        RowType mergeRowIdColumnType = (RowType) phoenixMergeTableHandle.mergeRowIdColumnHandle().getColumnType();
-        for (RowType.Field field : mergeRowIdColumnType.getFields()) {
-            checkArgument(field.getName().isPresent(), "Merge row id column field must have name");
-            mergeRowIdFieldNamesBuilder.add(getEscapedArgument(field.getName().get()));
-            mergeRowIdFieldTypesBuilder.add(field.getType());
-        }
-        this.mergeRowIdFieldNames = mergeRowIdFieldNamesBuilder.build();
-        this.deleteSink = createDeleteSink(session, mergeRowIdFieldTypesBuilder.build(), phoenixClient, pageSinkId, remoteQueryModifier);
+        super(phoenixClient, remoteQueryModifier, session, mergeHandle, pageSinkId);
+        PhoenixMergeTableHandle mergeTableHandle = (PhoenixMergeTableHandle) mergeHandle;
+        this.hasRowKey = mergeTableHandle.isHasRowKey();
     }
 
-    private ConnectorPageSink createUpdateSink(
+    @Override
+    protected ConnectorPageSink createUpdateSink(
             ConnectorSession session,
-            PhoenixOutputTableHandle phoenixOutputTableHandle,
-            PhoenixClient phoenixClient,
+            JdbcOutputTableHandle jdbcOutputTableHandle,
+            JdbcClient jdbcClient,
             ConnectorPageSinkId pageSinkId,
             RemoteQueryModifier remoteQueryModifier)
     {
+        PhoenixOutputTableHandle outputTableHandle = (PhoenixOutputTableHandle) jdbcOutputTableHandle;
         ImmutableList.Builder<String> columnNamesBuilder = ImmutableList.builder();
         ImmutableList.Builder<Type> columnTypesBuilder = ImmutableList.builder();
-        columnNamesBuilder.addAll(phoenixOutputTableHandle.getColumnNames());
-        columnTypesBuilder.addAll(phoenixOutputTableHandle.getColumnTypes());
-        if (hasRowKey) {
+        columnNamesBuilder.addAll(outputTableHandle.getColumnNames());
+        columnTypesBuilder.addAll(outputTableHandle.getColumnTypes());
+        if (outputTableHandle.rowkeyColumn().isPresent()) {
             columnNamesBuilder.add(ROWKEY);
             columnTypesBuilder.add(ROWKEY_COLUMN_HANDLE.getColumnType());
         }
 
         PhoenixOutputTableHandle updateOutputTableHandle = new PhoenixOutputTableHandle(
-                schemaName,
-                tableName,
+                outputTableHandle.getSchemaName(),
+                outputTableHandle.getTableName(),
                 columnNamesBuilder.build(),
                 columnTypesBuilder.build(),
                 Optional.empty(),
                 Optional.empty());
-        return new JdbcPageSink(session, updateOutputTableHandle, phoenixClient, pageSinkId, remoteQueryModifier);
-    }
-
-    private ConnectorPageSink createDeleteSink(
-            ConnectorSession session,
-            List<Type> mergeRowIdFieldTypes,
-            PhoenixClient phoenixClient,
-            ConnectorPageSinkId pageSinkId,
-            RemoteQueryModifier remoteQueryModifier)
-    {
-        checkArgument(mergeRowIdFieldNames.size() == mergeRowIdFieldTypes.size(), "Wrong merge row column, columns and types size not match");
-        JdbcOutputTableHandle deleteOutputTableHandle = new PhoenixOutputTableHandle(
-                schemaName,
-                tableName,
-                mergeRowIdFieldNames,
-                mergeRowIdFieldTypes,
-                Optional.empty(),
-                Optional.empty());
-
-        return new DeleteSink(session, deleteOutputTableHandle, phoenixClient, pageSinkId, remoteQueryModifier);
-    }
-
-    private class DeleteSink
-            extends JdbcPageSink
-    {
-        public DeleteSink(ConnectorSession session, JdbcOutputTableHandle handle, JdbcClient jdbcClient, ConnectorPageSinkId pageSinkId, RemoteQueryModifier remoteQueryModifier)
-        {
-            super(session, handle, jdbcClient, pageSinkId, remoteQueryModifier);
-        }
-
-        @Override
-        protected String getSinkSql(JdbcClient jdbcClient, JdbcOutputTableHandle outputTableHandle, List<WriteFunction> columnWriters)
-        {
-            List<String> conjuncts = mergeRowIdFieldNames.stream()
-                    .map(name -> name + " = ? ")
-                    .collect(toImmutableList());
-            checkArgument(!conjuncts.isEmpty(), "Merge row id fields should not empty");
-            String whereCondition = Joiner.on(" AND ").join(conjuncts);
-
-            return format("DELETE FROM %s.%s WHERE %s", schemaName, tableName, whereCondition);
-        }
+        return new JdbcPageSink(session, updateOutputTableHandle, jdbcClient, pageSinkId, remoteQueryModifier);
     }
 
     @Override
-    public void storeMergedRows(Page page)
+    protected void appendUpdatePage(Page dataPage, List<Block> rowIdFields, int[] updatePositions, int updatePositionCount)
     {
-        checkArgument(page.getChannelCount() == 2 + columnCount, "The page size should be 2 + columnCount (%s), but is %s", columnCount, page.getChannelCount());
-        int positionCount = page.getPositionCount();
-        Block operationBlock = page.getBlock(columnCount);
-
-        int[] dataChannel = IntStream.range(0, columnCount).toArray();
-        Page dataPage = page.getColumns(dataChannel);
-
-        int[] insertPositions = new int[positionCount];
-        int insertPositionCount = 0;
-        int[] deletePositions = new int[positionCount];
-        int deletePositionCount = 0;
-        int[] updatePositions = new int[positionCount];
-        int updatePositionCount = 0;
-
-        for (int position = 0; position < positionCount; position++) {
-            int operation = TINYINT.getByte(operationBlock, position);
-            switch (operation) {
-                case INSERT_OPERATION_NUMBER -> {
-                    insertPositions[insertPositionCount] = position;
-                    insertPositionCount++;
-                }
-                case DELETE_OPERATION_NUMBER -> {
-                    deletePositions[deletePositionCount] = position;
-                    deletePositionCount++;
-                }
-                case UPDATE_OPERATION_NUMBER -> {
-                    updatePositions[updatePositionCount] = position;
-                    updatePositionCount++;
-                }
-                default -> throw new IllegalStateException("Unexpected value: " + operation);
-            }
+        if (!hasRowKey) {
+            // Upsert directly
+            appendInsertPage(dataPage, updatePositions, updatePositionCount);
+            return;
         }
 
-        if (insertPositionCount > 0) {
-            insertSink.appendPage(dataPage.getPositions(insertPositions, 0, insertPositionCount));
-        }
-
-        List<Block> rowIdFields = RowBlock.getRowFieldsFromBlock(page.getBlock(columnCount + 1));
-        if (deletePositionCount > 0) {
-            Block[] deleteBlocks = new Block[rowIdFields.size()];
-            for (int field = 0; field < rowIdFields.size(); field++) {
-                deleteBlocks[field] = rowIdFields.get(field).getPositions(deletePositions, 0, deletePositionCount);
-            }
-            deleteSink.appendPage(new Page(deletePositionCount, deleteBlocks));
-        }
-
-        if (updatePositionCount > 0) {
-            Page updatePage = dataPage.getPositions(updatePositions, 0, updatePositionCount);
-            if (hasRowKey) {
-                updatePage = updatePage.appendColumn(rowIdFields.get(0).getPositions(updatePositions, 0, updatePositionCount));
-            }
-
-            updateSink.appendPage(updatePage);
-        }
-    }
-
-    @Override
-    public CompletableFuture<Collection<Slice>> finish()
-    {
-        insertSink.finish();
-        deleteSink.finish();
-        updateSink.finish();
-        return completedFuture(ImmutableList.of());
-    }
-
-    @Override
-    public void abort()
-    {
-        insertSink.abort();
-        deleteSink.abort();
-        updateSink.abort();
+        super.appendUpdatePage(dataPage, rowIdFields, updatePositions, updatePositionCount);
     }
 }

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
@@ -19,10 +19,10 @@ import io.airlift.slice.Slice;
 import io.trino.plugin.base.mapping.IdentifierMapping;
 import io.trino.plugin.jdbc.DefaultJdbcMetadata;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcMergeTableHandle;
 import io.trino.plugin.jdbc.JdbcNamedRelationHandle;
 import io.trino.plugin.jdbc.JdbcQueryEventListener;
 import io.trino.plugin.jdbc.JdbcTableHandle;
-import io.trino.plugin.jdbc.JdbcTypeHandle;
 import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.AggregateFunction;
@@ -47,11 +47,9 @@ import io.trino.spi.expression.Constant;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.statistics.ComputedStatistics;
-import io.trino.spi.type.RowType;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.sql.Types;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -59,11 +57,9 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.phoenix5.MetadataUtil.getEscapedTableName;
 import static io.trino.plugin.phoenix5.MetadataUtil.toTrinoSchemaName;
-import static io.trino.plugin.phoenix5.PhoenixClient.MERGE_ROW_ID_COLUMN_NAME;
 import static io.trino.plugin.phoenix5.PhoenixErrorCode.PHOENIX_METADATA_ERROR;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.connector.RetryMode.NO_RETRIES;
@@ -223,6 +219,7 @@ public class PhoenixMetadata
 
         List<JdbcColumnHandle> columnHandles = columns.stream()
                 .map(JdbcColumnHandle.class::cast)
+                .filter(columnHandle -> !ROWKEY.equalsIgnoreCase(columnHandle.getColumnName()))
                 .collect(toImmutableList());
 
         RemoteTableName remoteTableName = handle.asPlainTable().getRemoteTableName();
@@ -286,38 +283,10 @@ public class PhoenixMetadata
     }
 
     @Override
-    public JdbcColumnHandle getMergeRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public PhoenixMergeTableHandle beginMerge(ConnectorSession session, ConnectorTableHandle tableHandle, RetryMode retryMode)
     {
-        JdbcTableHandle handle = (JdbcTableHandle) tableHandle;
-
-        List<RowType.Field> fields = phoenixClient.getPrimaryKeyColumnHandles(session, handle).stream()
-                .map(columnHandle -> new RowType.Field(Optional.of(columnHandle.getColumnName()), columnHandle.getColumnType()))
-                .collect(toImmutableList());
-        verify(!fields.isEmpty(), "Phoenix primary key is empty");
-
-        return new JdbcColumnHandle(
-                MERGE_ROW_ID_COLUMN_NAME,
-                new JdbcTypeHandle(Types.ROWID, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()),
-                RowType.from(fields));
-    }
-
-    @Override
-    public ConnectorMergeTableHandle beginMerge(ConnectorSession session, ConnectorTableHandle tableHandle, RetryMode retryMode)
-    {
-        JdbcTableHandle handle = (JdbcTableHandle) tableHandle;
-        checkArgument(handle.isNamedRelation(), "Merge target must be named relation table");
-        JdbcTableHandle plainTable = phoenixClient.buildPlainTable(handle);
-        JdbcColumnHandle mergeRowIdColumnHandle = getMergeRowIdColumnHandle(session, plainTable);
-
-        List<JdbcColumnHandle> columns = phoenixClient.getColumns(session, plainTable).stream()
-                .filter(column -> !ROWKEY.equalsIgnoreCase(column.getColumnName()))
-                .collect(toImmutableList());
-        PhoenixOutputTableHandle phoenixOutputTableHandle = (PhoenixOutputTableHandle) beginInsert(session, plainTable, ImmutableList.copyOf(columns), retryMode);
-
-        return new PhoenixMergeTableHandle(
-                phoenixClient.updatedScanColumnTable(session, handle, handle.getColumns(), mergeRowIdColumnHandle),
-                phoenixOutputTableHandle,
-                mergeRowIdColumnHandle);
+        JdbcMergeTableHandle mergeTableHandle = (JdbcMergeTableHandle) super.beginMerge(session, tableHandle, retryMode);
+        return new PhoenixMergeTableHandle(mergeTableHandle.getTableHandle(), (PhoenixOutputTableHandle) mergeTableHandle.getOutputTableHandle(), mergeTableHandle.mergeRowIdColumnHandle());
     }
 
     @Override

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixPageSinkProvider.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixPageSinkProvider.java
@@ -16,41 +16,24 @@ package io.trino.plugin.phoenix5;
 import com.google.inject.Inject;
 import io.trino.plugin.jdbc.JdbcPageSinkProvider;
 import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
-import io.trino.spi.connector.ConnectorInsertTableHandle;
 import io.trino.spi.connector.ConnectorMergeSink;
 import io.trino.spi.connector.ConnectorMergeTableHandle;
-import io.trino.spi.connector.ConnectorOutputTableHandle;
-import io.trino.spi.connector.ConnectorPageSink;
 import io.trino.spi.connector.ConnectorPageSinkId;
-import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 
 public class PhoenixPageSinkProvider
-        implements ConnectorPageSinkProvider
+        extends JdbcPageSinkProvider
 {
-    private final JdbcPageSinkProvider delegate;
     private final PhoenixClient jdbcClient;
     private final RemoteQueryModifier remoteQueryModifier;
 
     @Inject
     public PhoenixPageSinkProvider(PhoenixClient jdbcClient, RemoteQueryModifier remoteQueryModifier)
     {
-        this.delegate = new JdbcPageSinkProvider(jdbcClient, remoteQueryModifier);
+        super(jdbcClient, remoteQueryModifier);
         this.jdbcClient = jdbcClient;
         this.remoteQueryModifier = remoteQueryModifier;
-    }
-
-    @Override
-    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle, ConnectorPageSinkId pageSinkId)
-    {
-        return delegate.createPageSink(transactionHandle, session, outputTableHandle, pageSinkId);
-    }
-
-    @Override
-    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle, ConnectorPageSinkId pageSinkId)
-    {
-        return delegate.createPageSink(transactionHandle, session, insertTableHandle, pageSinkId);
     }
 
     @Override

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
@@ -532,13 +532,6 @@ public class TestPhoenixConnectorTest
     }
 
     @Test
-    @Override
-    public void testUpdateRowConcurrently()
-    {
-        abort("Phoenix doesn't support concurrent update of different columns in a row");
-    }
-
-    @Test
     public void testSchemaOperations()
     {
         assertUpdate("CREATE SCHEMA new_schema");

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/BasePostgresFailureRecoveryTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/BasePostgresFailureRecoveryTest.java
@@ -38,6 +38,12 @@ public abstract class BasePostgresFailureRecoveryTest
     }
 
     @Override
+    protected boolean supportMerge()
+    {
+        return true;
+    }
+
+    @Override
     protected QueryRunner createQueryRunner(
             List<TpchTable<?>> requiredTpchTables,
             Map<String, String> configProperties,

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -111,7 +111,10 @@ public class TestPostgreSqlConnectorTest
                     SUPPORTS_JOIN_PUSHDOWN,
                     SUPPORTS_JOIN_PUSHDOWN_WITH_VARCHAR_EQUALITY,
                     SUPPORTS_TOPN_PUSHDOWN,
-                    SUPPORTS_TOPN_PUSHDOWN_WITH_VARCHAR -> true;
+                    SUPPORTS_TOPN_PUSHDOWN_WITH_VARCHAR,
+                    SUPPORTS_UPDATE,
+                    SUPPORTS_ROW_LEVEL_UPDATE,
+                    SUPPORTS_MERGE -> true;
             case SUPPORTS_ADD_COLUMN_WITH_COMMENT,
                     SUPPORTS_CREATE_TABLE_WITH_COLUMN_COMMENT,
                     SUPPORTS_JOIN_PUSHDOWN_WITH_FULL_JOIN,
@@ -120,6 +123,16 @@ public class TestPostgreSqlConnectorTest
                     SUPPORTS_ROW_TYPE -> false;
             default -> super.hasBehavior(connectorBehavior);
         };
+    }
+
+    // Override for change priority to let the method run behind the call of getRemoteDatabaseEvents.
+    // This because the test will generate large amount logs that would cause OOM while calling getRemoteDatabaseEvents
+    // after this test.
+    @Test
+    @Override
+    public void testMergeLarge()
+    {
+        super.testMergeLarge();
     }
 
     @Override

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionCreation.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionCreation.java
@@ -41,7 +41,6 @@ import static io.airlift.configuration.ConfigurationAwareModule.combine;
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.plugin.postgresql.PostgreSqlQueryRunner.createSession;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
-import static io.trino.spi.connector.ConnectorMetadata.MODIFYING_ROWS_MESSAGE;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.tpch.TpchTable.NATION;
 import static io.trino.tpch.TpchTable.REGION;
@@ -83,7 +82,7 @@ public class TestPostgreSqlJdbcConnectionCreation
         assertJdbcConnections("INSERT INTO copy_of_nation SELECT * FROM nation", 6, Optional.empty());
         assertJdbcConnections("DELETE FROM copy_of_nation WHERE nationkey = 3", 1, Optional.empty());
         assertJdbcConnections("UPDATE copy_of_nation SET name = 'POLAND' WHERE nationkey = 1", 1, Optional.empty());
-        assertJdbcConnections("MERGE INTO copy_of_nation n USING region r ON r.regionkey= n.regionkey WHEN MATCHED THEN DELETE", 1, Optional.of(MODIFYING_ROWS_MESSAGE));
+        assertJdbcConnections("MERGE INTO copy_of_nation n USING region r ON r.regionkey= n.regionkey WHEN MATCHED THEN DELETE", 15, Optional.empty());
         assertJdbcConnections("DROP TABLE copy_of_nation", 1, Optional.empty());
         assertJdbcConnections("SHOW SCHEMAS", 1, Optional.empty());
         assertJdbcConnections("SHOW TABLES", 1, Optional.empty());

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
@@ -192,7 +192,7 @@ public abstract class BaseConnectorSmokeTest
 
         try (TestTable table = new TestTable(getQueryRunner()::execute, "test_insert_", getCreateTableDefaultDefinition())) {
             assertUpdate("INSERT INTO " + table.getName() + " (a, b) VALUES (42, -38.5), (13, 99.9)", 2);
-            assertThat(query("SELECT CAST(a AS bigint), b FROM " + table.getName()))
+            assertThat(query("SELECT a, b FROM " + table.getName()))
                     .matches(expectedValues("(42, -38.5), (13, 99.9)"));
         }
     }

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -4434,7 +4434,8 @@ public abstract class BaseConnectorTest
             assertUpdate("DELETE FROM " + table.getName() + " WHERE EXISTS(SELECT 1)", "SELECT count(*) - 1 FROM orders");
         }
 
-        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_delete_correlated_exists_subquery", "AS SELECT * FROM nation")) {
+        // TODO (https://github.com/trinodb/trino/issues/5901) Use longer table name once Oracle version is updated, test delete correlated exists subquery
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_dce_subquery", "AS SELECT * FROM nation")) {
             // delete using correlated EXISTS subquery
             assertUpdate(format("DELETE FROM %1$s WHERE EXISTS(SELECT regionkey FROM region WHERE regionkey = %1$s.regionkey AND name LIKE 'A%%')", table.getName()), 15);
             assertQuery(
@@ -4442,7 +4443,8 @@ public abstract class BaseConnectorTest
                     "SELECT * FROM nation WHERE regionkey IN (SELECT regionkey FROM region WHERE name NOT LIKE 'A%')");
         }
 
-        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_delete_correlated_exists_subquery", "AS SELECT * FROM nation")) {
+        // TODO (https://github.com/trinodb/trino/issues/5901) Use longer table name once Oracle version is updated, test delete correlated exists subquery
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_dce_subquery", "AS SELECT * FROM nation")) {
             // delete using correlated IN subquery
             assertUpdate(format("DELETE FROM %1$s WHERE regionkey IN (SELECT regionkey FROM region WHERE regionkey = %1$s.regionkey AND name LIKE 'A%%')", table.getName()), 15);
             assertQuery(
@@ -4926,7 +4928,8 @@ public abstract class BaseConnectorTest
             return;
         }
 
-        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_update_with_predicates", "(a INT, b INT, c INT)")) {
+        // TODO (https://github.com/trinodb/trino/issues/5901) Use longer table name once Oracle version is updated
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_update_preds_", "(a INT, b INT, c INT)")) {
             String tableName = table.getName();
             assertUpdate("INSERT INTO " + tableName + " VALUES (1, 2, 3), (11, 12, 13), (21, 22, 23)", 3);
             assertUpdate("UPDATE " + tableName + " SET a = a - 1 WHERE c = 3", 1);
@@ -4989,7 +4992,8 @@ public abstract class BaseConnectorTest
             return;
         }
 
-        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_update_all_columns", "(a INT, b INT, c INT)")) {
+        // TODO (https://github.com/trinodb/trino/issues/5901) Use longer table name once Oracle version is updated
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_update_all_", "(a INT, b INT, c INT)")) {
             String tableName = table.getName();
             assertUpdate("INSERT INTO " + tableName + " VALUES (1, 2, 3), (11, 12, 13), (21, 22, 23)", 3);
             assertUpdate("UPDATE " + tableName + " SET a = a + 1, b = b - 1, c = c * 2", 3);
@@ -5709,8 +5713,9 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE) && hasBehavior(SUPPORTS_CREATE_TABLE_WITH_DATA));
 
-        String target = "merge_target_with_ctas_" + randomNameSuffix();
-        String source = "merge_source_with_ctas_" + randomNameSuffix();
+        // TODO (https://github.com/trinodb/trino/issues/5901) Use longer table name once Oracle version is updated
+        String target = "test_md_ctas_target_" + randomNameSuffix();
+        String source = "test_me_ctas_source_" + randomNameSuffix();
         @Language("SQL") String createTableSql = """
                 CREATE TABLE %s AS
                 SELECT * FROM (
@@ -5804,8 +5809,9 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "merge_various_target_" + randomNameSuffix();
-        String sourceTable = "merge_various_source_" + randomNameSuffix();
+        // TODO (https://github.com/trinodb/trino/issues/5901) Use longer table name once Oracle version is updated
+        String targetTable = "test_mv_target_" + randomNameSuffix();
+        String sourceTable = "test_mv_source_" + randomNameSuffix();
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (customer VARCHAR, purchase VARCHAR)", targetTable)));
 
         assertUpdate(format("INSERT INTO %s (customer, purchase) VALUES ('Dave', 'dates'), ('Lou', 'limes'), ('Carol', 'candles')", targetTable), 3);
@@ -5922,7 +5928,7 @@ public abstract class BaseConnectorTest
         String targetTable = "merge_inserts_" + randomNameSuffix();
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)", targetTable)));
 
-        assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 11, 'Antioch'), ('Bill', 7, 'Buena')", targetTable), 2);
+        assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 11, 'Antioch')", targetTable), 1);
 
         assertUpdate(format("MERGE INTO %s t USING ", targetTable) +
                         "(VALUES ('Carol', 9, 'Centreville'), ('Dave', 22, 'Darbyshire')) AS s(customer, purchases, address)" +
@@ -5930,7 +5936,7 @@ public abstract class BaseConnectorTest
                         "    WHEN NOT MATCHED THEN INSERT (customer, purchases, address) VALUES(s.customer, s.purchases, s.address)",
                 2);
 
-        assertQuery("SELECT * FROM " + targetTable, "VALUES ('Aaron', 11, 'Antioch'), ('Bill', 7, 'Buena'), ('Carol', 9, 'Centreville'), ('Dave', 22, 'Darbyshire')");
+        assertQuery("SELECT * FROM " + targetTable, "VALUES ('Aaron', 11, 'Antioch'), ('Carol', 9, 'Centreville'), ('Dave', 22, 'Darbyshire')");
 
         assertUpdate("DROP TABLE " + targetTable);
     }
@@ -5984,8 +5990,9 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "merge_all_columns_updated_target_" + randomNameSuffix();
-        String sourceTable = "merge_all_columns_updated_source_" + randomNameSuffix();
+        // TODO (https://github.com/trinodb/trino/issues/5901) Use longer table name once Oracle version is updated
+        String targetTable = "test_macu_target_" + randomNameSuffix();
+        String sourceTable = "test_macu_source_" + randomNameSuffix();
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)", targetTable)));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Dave', 11, 'Devon'), ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Buena'), ('Carol', 3, 'Cambridge')", targetTable), 4);
@@ -6009,8 +6016,9 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "merge_all_matches_deleted_target_" + randomNameSuffix();
-        String sourceTable = "merge_all_matches_deleted_source_" + randomNameSuffix();
+        // TODO (https://github.com/trinodb/trino/issues/5901) Use longer table name once Oracle version is updated
+        String targetTable = "test_mamd_target_" + randomNameSuffix();
+        String sourceTable = "test_mamd_source_" + randomNameSuffix();
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)", targetTable)));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Buena'), ('Carol', 3, 'Cambridge'), ('Dave', 11, 'Devon')", targetTable), 4);
@@ -6034,8 +6042,9 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "merge_multiple_fail_target_" + randomNameSuffix();
-        String sourceTable = "merge_multiple_fail_source_" + randomNameSuffix();
+        // TODO (https://github.com/trinodb/trino/issues/5901) Use longer table name once Oracle version is updated
+        String targetTable = "test_mmf_target_" + randomNameSuffix();
+        String sourceTable = "test_mmf_source_" + randomNameSuffix();
 
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)", targetTable)));
 
@@ -6063,7 +6072,8 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "merge_strange_capitalization_" + randomNameSuffix();
+        // TODO (https://github.com/trinodb/trino/issues/5901) Use longer table name once Oracle version is updated
+        String targetTable = "test_mqwsc_target_" + randomNameSuffix();
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)", targetTable)));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Buena'), ('Carol', 3, 'Cambridge'), ('Dave', 11, 'Devon')", targetTable), 4);
@@ -6086,8 +6096,9 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "test_without_aliases_target_" + randomNameSuffix();
-        String sourceTable = "test_without_aliases_source_" + randomNameSuffix();
+        // TODO (https://github.com/trinodb/trino/issues/5901) Use longer table name once Oracle version is updated
+        String targetTable = "test_mwta_target_" + randomNameSuffix();
+        String sourceTable = "test_mwta_source_" + randomNameSuffix();
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)", targetTable)));
 
         assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Buena'), ('Carol', 3, 'Cambridge'), ('Dave', 11, 'Devon')", targetTable), 4);
@@ -6114,8 +6125,9 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "merge_predicates_target_" + randomNameSuffix();
-        String sourceTable = "merge_predicates_source_" + randomNameSuffix();
+        // TODO (https://github.com/trinodb/trino/issues/5901) Use longer table name once Oracle version is updated
+        String targetTable = "test_mwup_target_" + randomNameSuffix();
+        String sourceTable = "test_mwup_source_" + randomNameSuffix();
 
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (id INT, customer VARCHAR, purchases INT, address VARCHAR)", targetTable)));
 
@@ -6162,8 +6174,9 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE));
 
-        String targetTable = "merge_predicates_target_" + randomNameSuffix();
-        String sourceTable = "merge_predicates_source_" + randomNameSuffix();
+        // TODO (https://github.com/trinodb/trino/issues/5901) Use longer table name once Oracle version is updated
+        String targetTable = "test_mwsup_target_" + randomNameSuffix();
+        String sourceTable = "test_mwsup_source_" + randomNameSuffix();
 
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (id INT, customer VARCHAR, purchases INT, address VARCHAR)", targetTable)));
 
@@ -6248,7 +6261,8 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE) && hasBehavior(SUPPORTS_NOT_NULL_CONSTRAINT));
 
-        String targetTable = "merge_non_nullable_target_" + randomNameSuffix();
+        // TODO (https://github.com/trinodb/trino/issues/5901) Use longer table name once Oracle version is updated
+        String targetTable = "test_mnnc_target_" + randomNameSuffix();
 
         assertUpdate(createTableForWrites(format("CREATE TABLE %s (nation_name VARCHAR, region_name VARCHAR NOT NULL)", targetTable)));
 
@@ -6284,7 +6298,8 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_MERGE) && hasBehavior(SUPPORTS_NOT_NULL_CONSTRAINT));
 
-        String targetTable = "merge_update_columns_reversed_" + randomNameSuffix();
+        // TODO (https://github.com/trinodb/trino/issues/5901) Use longer table name once Oracle version is updated
+        String targetTable = "test_mucr_target_" + randomNameSuffix();
         assertUpdate(createTableForWrites("CREATE TABLE " + targetTable + " (a, b, c) AS VALUES (1, 2, 3)"), 1);
         assertUpdate("""
                         MERGE INTO %s t USING (VALUES(1)) AS s(a) ON (t.a = s.a)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
https://github.com/trinodb/trino/issues/16709

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
This pr is going to support MERGE for jdbc based connectors, follows the https://github.com/trinodb/trino/pull/16693. Here are some major changes made in this pr:
**JdbcClient & BaseJdbcClient:**
1. Add `getPrimaryKeys` method to get primary keys for the merge target table, the method must not return empty if the connector declares supporting merge. The default implementation in `BaseJdbcClient`, and extracted function `extractJdbcHandlesFromResultSet` from `getColumns` for reuse it. Currently we use primary keys for perform delete and update for the merge.
2. Using return result of `getPrimaryKeys` to check if the connector support merge.
3. Add methods `beginDeleteTableForMerge` and `finishDeleteTableForMerge` for supporting FTE about the merge, the logic will be used if the connector supports retry and use transactional insert. The default implementation in `BaseJdbcClient` : 
	1. `beginDeleteTableForMerge` method uses primary keys to build a temporary table
	2. `finishDeleteTableForMerge` uses syntax `DELETE FROM merge_target WHERE EXISTS (SELECT 1 FROM (temp_table_data ) temp WHERE "getConjunctsBetweenTargetAndTemporaryTable(merge_target, temp)" )` to perform actual delete.
	   
	    `temp_table_data` is the sth like `SELECT * FROM temp_table WHERE EXISTS (SELECT 1 FROM page_sink_table WHERE page_sink_table.id_column = temp_table.id_column)` The logic is the same as original `INSERT` operation that using temporary table(`INSERT INTO insert_target SELECT * FROM temp_table WHERE EXISTS (SELECT 1 FROM page_sink_table WHERE page_sink_table.id_column = temp_table.id_column)`), the `temp_table` is built in `beginDeleteTableForMerge`
	   
	   The connectors returns special primary keys that can not build temporary table with get primary keys directly , i.e PostgreSql returns `ctid` as the primary key, it is a hidden column for every table, while building temporary table storing the column data we need to rename the special column for avoiding conflicts, in PostgreSql we build the temporary table with column name `ctid_for_delete_merge` to store the `ctid` values, then use `getConjunctsBetweenTargetAndTemporaryTable` to use correct column name to build the condition between target and temp table .
	   
4. Add method `buildMergeRowIdConjuncts` for the connectors that not support(or disable) building temporary table to perform delete,  the method builds the `WHERE`  condition for clause `DELETE FROM merge_target WHERE...` using primary keys (called in `JdbcMergeSink` )
5. The method `updateScanColumnsForMerge` is the same as we support merge in [Phoenix](https://github.com/trinodb/trino/pull/16693), it updates the scans for including the all the primary keys if possible.

**DefaultJdbcMetadata**:
1. Add a `deleteForMergeRollbackAction` field for the rollback about the delete operation if the connectors supports delete using temporary table.
2. The method `getMergeRowIdColumnHandle` will check if the connector support merge, if yes it will return the column handle that composed by the primary keys(returned by getPrimaryKeys in client)
3. `beginMerge` will pass the all the infos that needed by the merge, it's similar to we do in Phoenix connector, the difference is we add a `beginDeleteMerge` process for connectors that will use temporary table to perform delete.
4. `finishMerge` calls the `finishInsert` and `finishDeleteForMerge` 

**JdbcMergeSink**: 
It's moved from the [Phoenix](https://github.com/trinodb/trino/pull/16693) implementation, difference are:

- the creating delete sink will return the insert sink with the temporary table handle if the connectors support delete using temporary table.
- The update will use syntax `UPDATE merge_target SET reserved_columns WHERE...`, the `reserved_columns` are the columns who are not the primary keys, the values come from channels that provided by `getReservedChannelsForUpdate` , and the `WHERE` condition is built by `jdbcClient.buildMergeRowIdConjuncts`.

**The connectors:**
Implementation about the `getPrimaryKeys` :
- PostgreSql using the `ctid` 
- Oracle using the `ROWID` 
- Ignite using the primary keys defined in table
- Phoenix using the `rowkey` defined in table
Other Jdbc connectors Like Mysql actual can perform the merge as long as the table has defined the primary key, but since it is not forced by the connector, we currently let the `BaseJdbcClient.supportsMerge`  return  false by default and not declare it supports merge. 

**Tests:**
PostgreSql and Oracle support FTE, so the defined the `supportMerge` in the `BaseJdbcFailureRecoveryTest` for indicating the behavior, aslo update the test cases through the method in `BaseJdbcFailureRecoveryTest`.
Adjust lots of merge tests in Oracle due to naming length constraints.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Base Jdbc
* Support SQL MERGE for base jdbc connectors ({issue}`16709`)
* Support update/merge for PostgreSql
* Support update/merge for Ignite
* Support update/merge for Oracle
* Update Phoenix merge implementation by reusing base Jdbc merge implementation.
```
