### PR TITLE
Add OpenTelemetry tracing

### DIFF
--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -369,6 +369,12 @@
 
         <!-- used by tests but also needed transitively -->
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna-platform</artifactId>
             <scope>runtime</scope>
@@ -446,12 +452,6 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -193,6 +193,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>tracing</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
         </dependency>
 
@@ -289,6 +294,16 @@
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-jackson</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
         </dependency>
 
         <dependency>

--- a/core/trino-main/src/main/java/io/trino/SessionRepresentation.java
+++ b/core/trino-main/src/main/java/io/trino/SessionRepresentation.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
+import io.opentelemetry.api.trace.Span;
 import io.trino.metadata.SessionPropertyManager;
 import io.trino.spi.QueryId;
 import io.trino.spi.security.BasicPrincipal;
@@ -42,6 +43,7 @@ import static java.util.Objects.requireNonNull;
 public final class SessionRepresentation
 {
     private final String queryId;
+    private final Span querySpan;
     private final Optional<TransactionId> transactionId;
     private final boolean clientTransactionSupport;
     private final String user;
@@ -71,6 +73,7 @@ public final class SessionRepresentation
     @JsonCreator
     public SessionRepresentation(
             @JsonProperty("queryId") String queryId,
+            @JsonProperty("querySpan") Span querySpan,
             @JsonProperty("transactionId") Optional<TransactionId> transactionId,
             @JsonProperty("clientTransactionSupport") boolean clientTransactionSupport,
             @JsonProperty("user") String user,
@@ -98,6 +101,7 @@ public final class SessionRepresentation
             @JsonProperty("protocolName") String protocolName)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
+        this.querySpan = requireNonNull(querySpan, "querySpan is null");
         this.transactionId = requireNonNull(transactionId, "transactionId is null");
         this.clientTransactionSupport = clientTransactionSupport;
         this.user = requireNonNull(user, "user is null");
@@ -134,6 +138,12 @@ public final class SessionRepresentation
     public String getQueryId()
     {
         return queryId;
+    }
+
+    @JsonProperty
+    public Span getQuerySpan()
+    {
+        return querySpan;
     }
 
     @JsonProperty
@@ -317,6 +327,7 @@ public final class SessionRepresentation
     {
         return new Session(
                 new QueryId(queryId),
+                querySpan,
                 transactionId,
                 clientTransactionSupport,
                 toIdentity(extraCredentials),

--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorContextInstance.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorContextInstance.java
@@ -13,6 +13,8 @@
  */
 package io.trino.connector;
 
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
 import io.trino.spi.NodeManager;
 import io.trino.spi.PageIndexerFactory;
 import io.trino.spi.PageSorter;
@@ -31,6 +33,8 @@ import static java.util.Objects.requireNonNull;
 public class ConnectorContextInstance
         implements ConnectorContext
 {
+    private final OpenTelemetry openTelemetry;
+    private final Tracer tracer;
     private final NodeManager nodeManager;
     private final VersionEmbedder versionEmbedder;
     private final TypeManager typeManager;
@@ -43,6 +47,8 @@ public class ConnectorContextInstance
 
     public ConnectorContextInstance(
             CatalogHandle catalogHandle,
+            OpenTelemetry openTelemetry,
+            Tracer tracer,
             NodeManager nodeManager,
             VersionEmbedder versionEmbedder,
             TypeManager typeManager,
@@ -51,6 +57,8 @@ public class ConnectorContextInstance
             PageIndexerFactory pageIndexerFactory,
             Supplier<ClassLoader> duplicatePluginClassLoaderFactory)
     {
+        this.openTelemetry = requireNonNull(openTelemetry, "openTelemetry is null");
+        this.tracer = requireNonNull(tracer, "tracer is null");
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.versionEmbedder = requireNonNull(versionEmbedder, "versionEmbedder is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
@@ -59,6 +67,18 @@ public class ConnectorContextInstance
         this.pageIndexerFactory = requireNonNull(pageIndexerFactory, "pageIndexerFactory is null");
         this.duplicatePluginClassLoaderFactory = requireNonNull(duplicatePluginClassLoaderFactory, "duplicatePluginClassLoaderFactory is null");
         this.catalogHandle = requireNonNull(catalogHandle, "catalogHandle is null");
+    }
+
+    @Override
+    public OpenTelemetry getOpenTelemetry()
+    {
+        return openTelemetry;
+    }
+
+    @Override
+    public Tracer getTracer()
+    {
+        return tracer;
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorServices.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorServices.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import io.airlift.log.Logger;
+import io.opentelemetry.api.trace.Tracer;
 import io.trino.metadata.CatalogMetadata.SecurityManagement;
 import io.trino.metadata.CatalogProcedures;
 import io.trino.metadata.CatalogTableFunctions;
@@ -62,6 +63,7 @@ public class ConnectorServices
 {
     private static final Logger log = Logger.get(ConnectorServices.class);
 
+    private final Tracer tracer;
     private final CatalogHandle catalogHandle;
     private final Connector connector;
     private final Runnable afterShutdown;
@@ -87,8 +89,9 @@ public class ConnectorServices
 
     private final AtomicBoolean shutdown = new AtomicBoolean();
 
-    public ConnectorServices(CatalogHandle catalogHandle, Connector connector, Runnable afterShutdown)
+    public ConnectorServices(Tracer tracer, CatalogHandle catalogHandle, Connector connector, Runnable afterShutdown)
     {
+        this.tracer = requireNonNull(tracer, "tracer is null");
         this.catalogHandle = requireNonNull(catalogHandle, "catalogHandle is null");
         this.connector = requireNonNull(connector, "connector is null");
         this.afterShutdown = requireNonNull(afterShutdown, "afterShutdown is null");
@@ -205,6 +208,11 @@ public class ConnectorServices
         Set<ConnectorCapabilities> capabilities = connector.getCapabilities();
         requireNonNull(capabilities, format("Connector '%s' returned a null capabilities set", catalogHandle));
         this.capabilities = capabilities;
+    }
+
+    public Tracer getTracer()
+    {
+        return tracer;
     }
 
     public CatalogHandle getCatalogHandle()

--- a/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogFactory.java
+++ b/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogFactory.java
@@ -154,7 +154,7 @@ public class DefaultCatalogFactory
 
     private CatalogConnector createCatalog(CatalogHandle catalogHandle, ConnectorName connectorName, Connector connector, Runnable destroy, Optional<CatalogProperties> catalogProperties)
     {
-        Tracer tracer = openTelemetry.getTracer("trino.catalog." + catalogHandle.getCatalogName());
+        Tracer tracer = createTracer(catalogHandle);
 
         ConnectorServices catalogConnector = new ConnectorServices(
                 tracer,
@@ -207,6 +207,8 @@ public class DefaultCatalogFactory
     {
         ConnectorContext context = new ConnectorContextInstance(
                 catalogHandle,
+                openTelemetry,
+                createTracer(catalogHandle),
                 new ConnectorAwareNodeManager(nodeManager, nodeInfo.getEnvironment(), catalogHandle, schedulerIncludeCoordinator),
                 versionEmbedder,
                 typeManager,
@@ -218,6 +220,11 @@ public class DefaultCatalogFactory
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(connectorFactory.getClass().getClassLoader())) {
             return connectorFactory.create(catalogName, properties, context);
         }
+    }
+
+    private Tracer createTracer(CatalogHandle catalogHandle)
+    {
+        return openTelemetry.getTracer("trino.catalog." + catalogHandle.getCatalogName());
     }
 
     private static class InternalConnectorFactory

--- a/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
@@ -16,6 +16,10 @@ package io.trino.dispatcher;
 import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
 import io.trino.Session;
 import io.trino.execution.QueryIdGenerator;
 import io.trino.execution.QueryInfo;
@@ -52,6 +56,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.execution.QueryState.QUEUED;
 import static io.trino.execution.QueryState.RUNNING;
 import static io.trino.spi.StandardErrorCode.QUERY_TEXT_TOO_LARGE;
+import static io.trino.tracing.ScopedSpan.scopedSpan;
 import static io.trino.util.StatementUtils.getQueryType;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -67,6 +72,7 @@ public class DispatchManager
     private final SessionSupplier sessionSupplier;
     private final SessionPropertyDefaults sessionPropertyDefaults;
     private final SessionPropertyManager sessionPropertyManager;
+    private final Tracer tracer;
 
     private final int maxQueryLength;
 
@@ -87,6 +93,7 @@ public class DispatchManager
             SessionSupplier sessionSupplier,
             SessionPropertyDefaults sessionPropertyDefaults,
             SessionPropertyManager sessionPropertyManager,
+            Tracer tracer,
             QueryManagerConfig queryManagerConfig,
             DispatchExecutor dispatchExecutor)
     {
@@ -99,6 +106,7 @@ public class DispatchManager
         this.sessionSupplier = requireNonNull(sessionSupplier, "sessionSupplier is null");
         this.sessionPropertyDefaults = requireNonNull(sessionPropertyDefaults, "sessionPropertyDefaults is null");
         this.sessionPropertyManager = sessionPropertyManager;
+        this.tracer = requireNonNull(tracer, "tracer is null");
 
         this.maxQueryLength = queryManagerConfig.getMaxQueryLength();
 
@@ -131,9 +139,10 @@ public class DispatchManager
         return queryIdGenerator.createNextQueryId();
     }
 
-    public ListenableFuture<Void> createQuery(QueryId queryId, Slug slug, SessionContext sessionContext, String query)
+    public ListenableFuture<Void> createQuery(QueryId queryId, Span querySpan, Slug slug, SessionContext sessionContext, String query)
     {
         requireNonNull(queryId, "queryId is null");
+        requireNonNull(querySpan, "querySpan is null");
         requireNonNull(sessionContext, "sessionContext is null");
         requireNonNull(query, "query is null");
         checkArgument(!query.isEmpty(), "query must not be empty string");
@@ -143,14 +152,18 @@ public class DispatchManager
         // Using NonCancellationPropagatingFuture is not enough; it does not propagate cancel to wrapped future
         // but it would still return true on call to isCancelled() after cancel() is called on it.
         DispatchQueryCreationFuture queryCreationFuture = new DispatchQueryCreationFuture();
-        dispatchExecutor.execute(() -> {
-            try {
-                createQueryInternal(queryId, slug, sessionContext, query, resourceGroupManager);
+        dispatchExecutor.execute(Context.current().wrap(() -> {
+            Span span = tracer.spanBuilder("dispatch")
+                    .addLink(Span.current().getSpanContext())
+                    .setParent(Context.current().with(querySpan))
+                    .startSpan();
+            try (var ignored = scopedSpan(span)) {
+                createQueryInternal(queryId, querySpan, slug, sessionContext, query, resourceGroupManager);
             }
             finally {
                 queryCreationFuture.set(null);
             }
-        });
+        }));
         return queryCreationFuture;
     }
 
@@ -158,7 +171,7 @@ public class DispatchManager
      * Creates and registers a dispatch query with the query tracker.  This method will never fail to register a query with the query
      * tracker.  If an error occurs while creating a dispatch query, a failed dispatch will be created and registered.
      */
-    private <C> void createQueryInternal(QueryId queryId, Slug slug, SessionContext sessionContext, String query, ResourceGroupManager<C> resourceGroupManager)
+    private <C> void createQueryInternal(QueryId queryId, Span querySpan, Slug slug, SessionContext sessionContext, String query, ResourceGroupManager<C> resourceGroupManager)
     {
         Session session = null;
         PreparedQuery preparedQuery = null;
@@ -170,7 +183,7 @@ public class DispatchManager
             }
 
             // decode session
-            session = sessionSupplier.createSession(queryId, sessionContext);
+            session = sessionSupplier.createSession(queryId, querySpan, sessionContext);
 
             // check query execute permissions
             accessControl.checkCanExecuteQuery(sessionContext.getIdentity());
@@ -223,6 +236,9 @@ public class DispatchManager
             Optional<String> preparedSql = Optional.ofNullable(preparedQuery).flatMap(PreparedQuery::getPrepareSql);
             DispatchQuery failedDispatchQuery = failedDispatchQueryFactory.createFailedDispatchQuery(session, query, preparedSql, Optional.empty(), throwable);
             queryCreated(failedDispatchQuery);
+            querySpan.setStatus(StatusCode.ERROR, throwable.getMessage())
+                    .recordException(throwable)
+                    .end();
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/MemoryTrackingRemoteTaskFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/MemoryTrackingRemoteTaskFactory.java
@@ -15,6 +15,7 @@ package io.trino.execution;
 
 import com.google.common.collect.Multimap;
 import io.airlift.units.DataSize;
+import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.execution.NodeTaskMap.PartitionedSplitCountTracker;
 import io.trino.execution.StateMachine.StateChangeListener;
@@ -45,6 +46,7 @@ public class MemoryTrackingRemoteTaskFactory
     @Override
     public RemoteTask createRemoteTask(
             Session session,
+            Span stageSpan,
             TaskId taskId,
             InternalNode node,
             PlanFragment fragment,
@@ -55,7 +57,9 @@ public class MemoryTrackingRemoteTaskFactory
             Optional<DataSize> estimatedMemory,
             boolean summarizeTaskInfo)
     {
-        RemoteTask task = remoteTaskFactory.createRemoteTask(session,
+        RemoteTask task = remoteTaskFactory.createRemoteTask(
+                session,
+                stageSpan,
                 taskId,
                 node,
                 fragment,

--- a/core/trino-main/src/main/java/io/trino/execution/RemoteTaskFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RemoteTaskFactory.java
@@ -15,6 +15,7 @@ package io.trino.execution;
 
 import com.google.common.collect.Multimap;
 import io.airlift.units.DataSize;
+import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.execution.NodeTaskMap.PartitionedSplitCountTracker;
 import io.trino.execution.buffer.OutputBuffers;
@@ -31,6 +32,7 @@ public interface RemoteTaskFactory
 {
     RemoteTask createRemoteTask(
             Session session,
+            Span stageSpan,
             TaskId taskId,
             InternalNode node,
             PlanFragment fragment,

--- a/core/trino-main/src/main/java/io/trino/execution/SplitRunner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SplitRunner.java
@@ -15,12 +15,17 @@ package io.trino.execution;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.trace.Span;
 
 import java.io.Closeable;
 
 public interface SplitRunner
         extends Closeable
 {
+    int getPipelineId();
+
+    Span getPipelineSpan();
+
     boolean isFinished();
 
     ListenableFuture<Void> processFor(Duration duration);

--- a/core/trino-main/src/main/java/io/trino/execution/executor/PrioritizedSplitRunner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/PrioritizedSplitRunner.java
@@ -21,7 +21,11 @@ import io.airlift.stats.CounterStat;
 import io.airlift.stats.CpuTimer;
 import io.airlift.stats.TimeStat;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
 import io.trino.execution.SplitRunner;
+import io.trino.tracing.TrinoAttributes;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -29,6 +33,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.trino.operator.Operator.NOT_BLOCKED;
+import static io.trino.tracing.ScopedSpan.scopedSpan;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -50,6 +55,9 @@ public class PrioritizedSplitRunner
     private final long workerId;
     private final SplitRunner split;
 
+    private final Span splitSpan;
+
+    private final Tracer tracer;
     private final Ticker ticker;
 
     private final SettableFuture<Void> finishedFuture = SettableFuture.create();
@@ -75,7 +83,10 @@ public class PrioritizedSplitRunner
 
     PrioritizedSplitRunner(
             TaskHandle taskHandle,
+            int splitId,
             SplitRunner split,
+            Span splitSpan,
+            Tracer tracer,
             Ticker ticker,
             CounterStat globalCpuTimeMicros,
             CounterStat globalScheduledTimeMicros,
@@ -83,8 +94,10 @@ public class PrioritizedSplitRunner
             TimeStat unblockedQuantaWallTime)
     {
         this.taskHandle = requireNonNull(taskHandle, "taskHandle is null");
-        this.splitId = taskHandle.getNextSplitId();
+        this.splitId = splitId;
         this.split = requireNonNull(split, "split is null");
+        this.splitSpan = requireNonNull(splitSpan, "splitSpan is null");
+        this.tracer = requireNonNull(tracer, "tracer is null");
         this.ticker = requireNonNull(ticker, "ticker is null");
         this.workerId = NEXT_WORKER_ID.getAndIncrement();
         this.globalCpuTimeMicros = requireNonNull(globalCpuTimeMicros, "globalCpuTimeMicros is null");
@@ -119,6 +132,12 @@ public class PrioritizedSplitRunner
         catch (RuntimeException e) {
             log.error(e, "Error closing split for task %s", taskHandle.getTaskId());
         }
+        finally {
+            splitSpan.setAttribute(TrinoAttributes.SPLIT_SCHEDULED_TIME_NANOS, getScheduledNanos());
+            splitSpan.setAttribute(TrinoAttributes.SPLIT_CPU_TIME_NANOS, getCpuTimeNanos());
+            splitSpan.setAttribute(TrinoAttributes.SPLIT_WAIT_TIME_NANOS, getWaitNanos());
+            splitSpan.end();
+        }
     }
 
     public long getCreatedNanos()
@@ -152,7 +171,11 @@ public class PrioritizedSplitRunner
 
     public ListenableFuture<Void> process()
     {
-        try {
+        Span span = tracer.spanBuilder("process")
+                .setParent(Context.current().with(splitSpan))
+                .startSpan();
+
+        try (var ignored = scopedSpan(span)) {
             long startNanos = ticker.read();
             start.compareAndSet(0, startNanos);
             lastReady.compareAndSet(0, startNanos);
@@ -184,6 +207,10 @@ public class PrioritizedSplitRunner
 
             globalCpuTimeMicros.update(quantaCpuNanos / 1000);
             globalScheduledTimeMicros.update(quantaScheduledNanos / 1000);
+
+            span.setAttribute(TrinoAttributes.SPLIT_CPU_TIME_NANOS, quantaCpuNanos);
+            span.setAttribute(TrinoAttributes.SPLIT_SCHEDULED_TIME_NANOS, quantaScheduledNanos);
+            span.setAttribute(TrinoAttributes.SPLIT_BLOCKED, blocked != NOT_BLOCKED);
 
             return blocked;
         }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenTaskSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenTaskSourceFactory.java
@@ -15,6 +15,7 @@ package io.trino.execution.scheduler;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
+import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.execution.ForQueryExecution;
 import io.trino.execution.QueryManagerConfig;
@@ -106,6 +107,7 @@ public class EventDrivenTaskSourceFactory
 
     public EventDrivenTaskSource create(
             Session session,
+            Span stageSpan,
             PlanFragment fragment,
             Map<PlanFragmentId, Exchange> sourceExchanges,
             FaultTolerantPartitioningScheme sourcePartitioningScheme,
@@ -125,7 +127,7 @@ public class EventDrivenTaskSourceFactory
                 tableExecuteContextManager,
                 sourceExchanges,
                 remoteSources.build(),
-                () -> splitSourceFactory.createSplitSources(session, fragment),
+                () -> splitSourceFactory.createSplitSources(session, stageSpan, fragment),
                 createSplitAssigner(
                         session,
                         fragment,

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedStageExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedStageExecution.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import io.airlift.log.Logger;
+import io.opentelemetry.api.trace.Span;
 import io.trino.exchange.DirectExchangeInput;
 import io.trino.execution.ExecutionFailureInfo;
 import io.trino.execution.RemoteTask;
@@ -550,6 +551,12 @@ public class PipelinedStageExecution
     public int getAttemptId()
     {
         return attempt;
+    }
+
+    @Override
+    public Span getStageSpan()
+    {
+        return stage.getStageSpan();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/StageExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/StageExecution.java
@@ -14,6 +14,7 @@
 package io.trino.execution.scheduler;
 
 import com.google.common.collect.Multimap;
+import io.opentelemetry.api.trace.Span;
 import io.trino.execution.ExecutionFailureInfo;
 import io.trino.execution.RemoteTask;
 import io.trino.execution.StageId;
@@ -35,6 +36,8 @@ public interface StageExecution
     StageId getStageId();
 
     int getAttemptId();
+
+    Span getStageSpan();
 
     PlanFragment getFragment();
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/StageManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/StageManager.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.graph.Traverser;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.trace.Tracer;
 import io.trino.Session;
 import io.trino.execution.BasicStageStats;
 import io.trino.execution.NodeTaskMap;
@@ -65,6 +66,7 @@ class StageManager
             Metadata metadata,
             RemoteTaskFactory taskFactory,
             NodeTaskMap nodeTaskMap,
+            Tracer tracer,
             SplitSchedulerStats schedulerStats,
             SubPlan planTree,
             boolean summarizeTaskInfo)
@@ -88,6 +90,7 @@ class StageManager
                     summarizeTaskInfo,
                     nodeTaskMap,
                     queryStateMachine.getStateMachineExecutor(),
+                    tracer,
                     schedulerStats);
             StageId stageId = stage.getStageId();
             stages.put(stageId, stage);

--- a/core/trino-main/src/main/java/io/trino/metadata/Catalog.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Catalog.java
@@ -134,7 +134,11 @@ public class Catalog
             transactionHandle = connector.beginTransaction(isolationLevel, readOnly, autoCommitContext);
         }
 
-        return new CatalogTransaction(connectorServices.getCatalogHandle(), connector, transactionHandle);
+        return new CatalogTransaction(
+                connectorServices.getTracer(),
+                connectorServices.getCatalogHandle(),
+                connector,
+                transactionHandle);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/server/NoOpSessionSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/server/NoOpSessionSupplier.java
@@ -13,6 +13,7 @@
  */
 package io.trino.server;
 
+import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.spi.QueryId;
 
@@ -23,7 +24,7 @@ public class NoOpSessionSupplier
         implements SessionSupplier
 {
     @Override
-    public Session createSession(QueryId queryId, SessionContext context)
+    public Session createSession(QueryId queryId, Span querySpan, SessionContext context)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-main/src/main/java/io/trino/server/PluginManager.java
+++ b/core/trino-main/src/main/java/io/trino/server/PluginManager.java
@@ -72,6 +72,8 @@ public class PluginManager
             .add("com.fasterxml.jackson.annotation.")
             .add("io.airlift.slice.")
             .add("org.openjdk.jol.")
+            .add("io.opentelemetry.api.")
+            .add("io.opentelemetry.context.")
             .build();
 
     private static final Logger log = Logger.get(PluginManager.class);

--- a/core/trino-main/src/main/java/io/trino/server/QuerySessionSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/server/QuerySessionSupplier.java
@@ -13,6 +13,7 @@
  */
 package io.trino.server;
 
+import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.SessionPropertyManager;
@@ -69,7 +70,7 @@ public class QuerySessionSupplier
     }
 
     @Override
-    public Session createSession(QueryId queryId, SessionContext context)
+    public Session createSession(QueryId queryId, Span querySpan, SessionContext context)
     {
         Identity identity = context.getIdentity();
         accessControl.checkCanSetUser(identity.getPrincipal(), identity.getUser());
@@ -90,6 +91,7 @@ public class QuerySessionSupplier
 
         SessionBuilder sessionBuilder = Session.builder(sessionPropertyManager)
                 .setQueryId(queryId)
+                .setQuerySpan(querySpan)
                 .setIdentity(identity)
                 .setPath(context.getPath().or(() -> defaultPath).map(SqlPath::new))
                 .setSource(context.getSource())

--- a/core/trino-main/src/main/java/io/trino/server/Server.java
+++ b/core/trino-main/src/main/java/io/trino/server/Server.java
@@ -38,6 +38,7 @@ import io.airlift.log.Logger;
 import io.airlift.node.NodeModule;
 import io.airlift.openmetrics.JmxOpenMetricsModule;
 import io.airlift.tracetoken.TraceTokenModule;
+import io.airlift.tracing.TracingModule;
 import io.trino.client.NodeVersion;
 import io.trino.connector.CatalogManagerConfig;
 import io.trino.connector.CatalogManagerConfig.CatalogMangerKind;
@@ -112,6 +113,7 @@ public class Server
                 new JmxOpenMetricsModule(),
                 new LogJmxModule(),
                 new TraceTokenModule(),
+                new TracingModule("trino", trinoVersion),
                 new EventModule(),
                 new JsonEventModule(),
                 new ServerSecurityModule(),

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -141,6 +141,8 @@ import io.trino.sql.planner.OptimizerConfig;
 import io.trino.sql.planner.RuleStatsRecorder;
 import io.trino.sql.planner.TypeAnalyzer;
 import io.trino.sql.tree.Expression;
+import io.trino.tracing.ForTracing;
+import io.trino.tracing.TracingMetadata;
 import io.trino.type.BlockTypeOperators;
 import io.trino.type.InternalTypeManager;
 import io.trino.type.JsonPath2016Type;
@@ -368,7 +370,8 @@ public class ServerMainModule
 
         // metadata
         binder.bind(MetadataManager.class).in(Scopes.SINGLETON);
-        binder.bind(Metadata.class).to(MetadataManager.class).in(Scopes.SINGLETON);
+        binder.bind(Metadata.class).annotatedWith(ForTracing.class).to(MetadataManager.class).in(Scopes.SINGLETON);
+        binder.bind(Metadata.class).to(TracingMetadata.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, SystemSecurityMetadata.class)
                 .setDefault()
                 .to(DisabledSystemSecurityMetadata.class)

--- a/core/trino-main/src/main/java/io/trino/server/SessionSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/server/SessionSupplier.java
@@ -13,10 +13,11 @@
  */
 package io.trino.server;
 
+import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.spi.QueryId;
 
 public interface SessionSupplier
 {
-    Session createSession(QueryId queryId, SessionContext context);
+    Session createSession(QueryId queryId, Span querySpan, SessionContext context);
 }

--- a/core/trino-main/src/main/java/io/trino/server/TaskResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/TaskResource.java
@@ -151,8 +151,10 @@ public class TaskResource
             return;
         }
 
-        TaskInfo taskInfo = taskManager.updateTask(session,
+        TaskInfo taskInfo = taskManager.updateTask(
+                session,
                 taskId,
+                taskUpdateRequest.getStageSpan(),
                 taskUpdateRequest.getFragment(),
                 taskUpdateRequest.getSplitAssignments(),
                 taskUpdateRequest.getOutputIds(),

--- a/core/trino-main/src/main/java/io/trino/server/TaskUpdateRequest.java
+++ b/core/trino-main/src/main/java/io/trino/server/TaskUpdateRequest.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
+import io.opentelemetry.api.trace.Span;
 import io.trino.SessionRepresentation;
 import io.trino.execution.SplitAssignment;
 import io.trino.execution.buffer.OutputBuffers;
@@ -36,6 +37,7 @@ public class TaskUpdateRequest
     private final SessionRepresentation session;
     // extraCredentials is stored separately from SessionRepresentation to avoid being leaked
     private final Map<String, String> extraCredentials;
+    private final Span stageSpan;
     private final Optional<PlanFragment> fragment;
     private final List<SplitAssignment> splitAssignments;
     private final OutputBuffers outputIds;
@@ -46,6 +48,7 @@ public class TaskUpdateRequest
     public TaskUpdateRequest(
             @JsonProperty("session") SessionRepresentation session,
             @JsonProperty("extraCredentials") Map<String, String> extraCredentials,
+            @JsonProperty("stageSpan") Span stageSpan,
             @JsonProperty("fragment") Optional<PlanFragment> fragment,
             @JsonProperty("splitAssignments") List<SplitAssignment> splitAssignments,
             @JsonProperty("outputIds") OutputBuffers outputIds,
@@ -54,6 +57,7 @@ public class TaskUpdateRequest
     {
         requireNonNull(session, "session is null");
         requireNonNull(extraCredentials, "extraCredentials is null");
+        requireNonNull(stageSpan, "stageSpan is null");
         requireNonNull(fragment, "fragment is null");
         requireNonNull(splitAssignments, "splitAssignments is null");
         requireNonNull(outputIds, "outputIds is null");
@@ -62,6 +66,7 @@ public class TaskUpdateRequest
 
         this.session = session;
         this.extraCredentials = extraCredentials;
+        this.stageSpan = stageSpan;
         this.fragment = fragment;
         this.splitAssignments = ImmutableList.copyOf(splitAssignments);
         this.outputIds = outputIds;
@@ -79,6 +84,12 @@ public class TaskUpdateRequest
     public Map<String, String> getExtraCredentials()
     {
         return extraCredentials;
+    }
+
+    @JsonProperty
+    public Span getStageSpan()
+    {
+        return stageSpan;
     }
 
     @JsonProperty

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/DynamicFiltersFetcher.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/DynamicFiltersFetcher.java
@@ -20,6 +20,7 @@ import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.Request;
 import io.airlift.json.JsonCodec;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.trace.SpanBuilder;
 import io.trino.execution.DynamicFiltersCollector.VersionedDynamicFilterDomains;
 import io.trino.execution.TaskId;
 import io.trino.server.DynamicFilterService;
@@ -30,6 +31,7 @@ import java.net.URI;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.google.common.net.MediaType.JSON_UTF_8;
@@ -52,6 +54,7 @@ class DynamicFiltersFetcher
     private final Duration refreshMaxWait;
     private final Executor executor;
     private final HttpClient httpClient;
+    private final Supplier<SpanBuilder> spanBuilderFactory;
     private final RequestErrorTracker errorTracker;
     private final RemoteTaskStats stats;
     private final DynamicFilterService dynamicFilterService;
@@ -73,6 +76,7 @@ class DynamicFiltersFetcher
             JsonCodec<VersionedDynamicFilterDomains> dynamicFilterDomainsCodec,
             Executor executor,
             HttpClient httpClient,
+            Supplier<SpanBuilder> spanBuilderFactory,
             Duration maxErrorDuration,
             ScheduledExecutorService errorScheduledExecutor,
             RemoteTaskStats stats,
@@ -87,6 +91,7 @@ class DynamicFiltersFetcher
 
         this.executor = requireNonNull(executor, "executor is null");
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.spanBuilderFactory = requireNonNull(spanBuilderFactory, "spanBuilderFactory is null");
 
         this.errorTracker = new RequestErrorTracker(taskId, taskUri, maxErrorDuration, errorScheduledExecutor, "getting dynamic filter domains");
         this.stats = requireNonNull(stats, "stats is null");
@@ -142,6 +147,7 @@ class DynamicFiltersFetcher
                 .setHeader(CONTENT_TYPE, JSON_UTF_8.toString())
                 .setHeader(TRINO_CURRENT_VERSION, Long.toString(localDynamicFiltersVersion))
                 .setHeader(TRINO_MAX_WAIT, refreshMaxWait.toString())
+                .setSpanBuilder(spanBuilderFactory.get())
                 .build();
 
         errorTracker.startRequest();

--- a/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
@@ -36,6 +36,7 @@ import io.airlift.json.JsonModule;
 import io.airlift.node.testing.TestingNodeModule;
 import io.airlift.openmetrics.JmxOpenMetricsModule;
 import io.airlift.tracetoken.TraceTokenModule;
+import io.airlift.tracing.TracingModule;
 import io.trino.connector.CatalogManagerModule;
 import io.trino.connector.ConnectorName;
 import io.trino.connector.ConnectorServicesProvider;
@@ -131,6 +132,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class TestingTrinoServer
         implements Closeable
 {
+    private static final String VERSION = "testversion";
+
     public static TestingTrinoServer create()
     {
         return builder().build();
@@ -262,10 +265,11 @@ public class TestingTrinoServer
                 .add(new JmxOpenMetricsModule())
                 .add(new EventModule())
                 .add(new TraceTokenModule())
+                .add(new TracingModule("trino", VERSION))
                 .add(new ServerSecurityModule())
                 .add(new CatalogManagerModule())
                 .add(new TransactionManagerModule())
-                .add(new ServerMainModule("testversion"))
+                .add(new ServerMainModule(VERSION))
                 .add(new TestingWarningCollectorModule())
                 .add(binder -> {
                     binder.bind(EventListenerConfig.class).in(Scopes.SINGLETON);

--- a/core/trino-main/src/main/java/io/trino/split/SplitManager.java
+++ b/core/trino-main/src/main/java/io/trino/split/SplitManager.java
@@ -13,6 +13,9 @@
  */
 package io.trino.split;
 
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
 import io.trino.Session;
 import io.trino.connector.CatalogServiceProvider;
 import io.trino.execution.QueryManagerConfig;
@@ -24,8 +27,11 @@ import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.DynamicFilter;
+import io.trino.tracing.TrinoAttributes;
 
 import javax.inject.Inject;
+
+import java.util.Optional;
 
 import static io.trino.SystemSessionProperties.isAllowPushdownIntoConnectors;
 import static java.util.Objects.requireNonNull;
@@ -33,17 +39,20 @@ import static java.util.Objects.requireNonNull;
 public class SplitManager
 {
     private final CatalogServiceProvider<ConnectorSplitManager> splitManagerProvider;
+    private final Tracer tracer;
     private final int minScheduleSplitBatchSize;
 
     @Inject
-    public SplitManager(CatalogServiceProvider<ConnectorSplitManager> splitManagerProvider, QueryManagerConfig config)
+    public SplitManager(CatalogServiceProvider<ConnectorSplitManager> splitManagerProvider, Tracer tracer, QueryManagerConfig config)
     {
         this.splitManagerProvider = requireNonNull(splitManagerProvider, "splitManagerProvider is null");
+        this.tracer = requireNonNull(tracer, "tracer is null");
         this.minScheduleSplitBatchSize = config.getMinScheduleSplitBatchSize();
     }
 
     public SplitSource getSplits(
             Session session,
+            Span parentSpan,
             TableHandle table,
             DynamicFilter dynamicFilter,
             Constraint constraint)
@@ -64,13 +73,22 @@ public class SplitManager
                 constraint);
 
         SplitSource splitSource = new ConnectorAwareSplitSource(catalogHandle, source);
+
+        Span span = splitSourceSpan(parentSpan, catalogHandle);
+
         if (minScheduleSplitBatchSize > 1) {
+            splitSource = new TracingSplitSource(splitSource, tracer, Optional.empty(), "split-batch");
             splitSource = new BufferingSplitSource(splitSource, minScheduleSplitBatchSize);
+            splitSource = new TracingSplitSource(splitSource, tracer, Optional.of(span), "split-buffer");
         }
+        else {
+            splitSource = new TracingSplitSource(splitSource, tracer, Optional.of(span), "split-batch");
+        }
+
         return splitSource;
     }
 
-    public SplitSource getSplits(Session session, TableFunctionHandle function)
+    public SplitSource getSplits(Session session, Span parentSpan, TableFunctionHandle function)
     {
         CatalogHandle catalogHandle = function.getCatalogHandle();
         ConnectorSplitManager splitManager = splitManagerProvider.getService(catalogHandle);
@@ -81,6 +99,17 @@ public class SplitManager
                 function.getSchemaFunctionName(),
                 function.getFunctionHandle());
 
-        return new ConnectorAwareSplitSource(catalogHandle, source);
+        SplitSource splitSource = new ConnectorAwareSplitSource(catalogHandle, source);
+
+        Span span = splitSourceSpan(parentSpan, catalogHandle);
+        return new TracingSplitSource(splitSource, tracer, Optional.of(span), "split-buffer");
+    }
+
+    private Span splitSourceSpan(Span querySpan, CatalogHandle catalogHandle)
+    {
+        return tracer.spanBuilder("split-source")
+                .setParent(Context.current().with(querySpan))
+                .setAttribute(TrinoAttributes.CATALOG, catalogHandle.getCatalogName())
+                .startSpan();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/split/TracingSplitSource.java
+++ b/core/trino-main/src/main/java/io/trino/split/TracingSplitSource.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.split;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.trino.spi.connector.CatalogHandle;
+import io.trino.tracing.TrinoAttributes;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static java.util.Objects.requireNonNull;
+
+public class TracingSplitSource
+        implements SplitSource
+{
+    private final SplitSource source;
+    private final Tracer tracer;
+    private final Optional<Span> parentSpan;
+    private final String spanName;
+
+    public TracingSplitSource(SplitSource source, Tracer tracer, Optional<Span> parentSpan, String spanName)
+    {
+        this.source = requireNonNull(source, "source is null");
+        this.tracer = requireNonNull(tracer, "tracer is null");
+        this.parentSpan = requireNonNull(parentSpan, "parentSpan is null");
+        this.spanName = requireNonNull(spanName, "spanName is null");
+    }
+
+    @Override
+    public CatalogHandle getCatalogHandle()
+    {
+        return source.getCatalogHandle();
+    }
+
+    @Override
+    public ListenableFuture<SplitBatch> getNextBatch(int maxSize)
+    {
+        Span span = tracer.spanBuilder(spanName)
+                .setParent(parentSpan.map(Context.current()::with).orElse(Context.current()))
+                .setAttribute(TrinoAttributes.SPLIT_BATCH_MAX_SIZE, (long) maxSize)
+                .startSpan();
+
+        ListenableFuture<SplitBatch> future;
+        try (var ignored = span.makeCurrent()) {
+            future = source.getNextBatch(maxSize);
+        }
+        catch (Throwable t) {
+            span.end();
+            throw t;
+        }
+
+        Futures.addCallback(future, new FutureCallback<>()
+        {
+            @Override
+            public void onSuccess(SplitBatch batch)
+            {
+                span.setAttribute(TrinoAttributes.SPLIT_BATCH_RESULT_SIZE, batch.getSplits().size());
+                span.end();
+            }
+
+            @Override
+            public void onFailure(Throwable t)
+            {
+                span.end();
+            }
+        }, directExecutor());
+
+        return future;
+    }
+
+    @Override
+    public void close()
+    {
+        try (source) {
+            parentSpan.ifPresent(Span::end);
+        }
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return source.isFinished();
+    }
+
+    @Override
+    public Optional<List<Object>> getTableExecuteSplitsInfo()
+    {
+        return source.getTableExecuteSplitsInfo();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/PlannerContext.java
+++ b/core/trino-main/src/main/java/io/trino/sql/PlannerContext.java
@@ -13,6 +13,7 @@
  */
 package io.trino.sql;
 
+import io.opentelemetry.api.trace.Tracer;
 import io.trino.metadata.FunctionManager;
 import io.trino.metadata.Metadata;
 import io.trino.spi.block.BlockEncodingSerde;
@@ -39,19 +40,22 @@ public class PlannerContext
     private final BlockEncodingSerde blockEncodingSerde;
     private final TypeManager typeManager;
     private final FunctionManager functionManager;
+    private final Tracer tracer;
 
     @Inject
     public PlannerContext(Metadata metadata,
             TypeOperators typeOperators,
             BlockEncodingSerde blockEncodingSerde,
             TypeManager typeManager,
-            FunctionManager functionManager)
+            FunctionManager functionManager,
+            Tracer tracer)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
         this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.functionManager = requireNonNull(functionManager, "functionManager is null");
+        this.tracer = requireNonNull(tracer, "tracer is null");
     }
 
     public Metadata getMetadata()
@@ -77,5 +81,10 @@ public class PlannerContext
     public FunctionManager getFunctionManager()
     {
         return functionManager;
+    }
+
+    public Tracer getTracer()
+    {
+        return tracer;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analyzer.java
@@ -47,7 +47,7 @@ public class Analyzer
     private final List<Expression> parameters;
     private final Map<NodeRef<Parameter>, Expression> parameterLookup;
     private final WarningCollector warningCollector;
-    private PlanOptimizersStatsCollector planOptimizersStatsCollector;
+    private final PlanOptimizersStatsCollector planOptimizersStatsCollector;
     private final StatementRewrite statementRewrite;
 
     Analyzer(

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analyzer.java
@@ -15,6 +15,9 @@ package io.trino.sql.analyzer;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
 import io.trino.Session;
 import io.trino.execution.querystats.PlanOptimizersStatsCollector;
 import io.trino.execution.warnings.WarningCollector;
@@ -37,6 +40,7 @@ import static io.trino.sql.analyzer.ExpressionTreeUtils.extractExpressions;
 import static io.trino.sql.analyzer.ExpressionTreeUtils.extractWindowExpressions;
 import static io.trino.sql.analyzer.QueryType.OTHERS;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static io.trino.tracing.ScopedSpan.scopedSpan;
 import static java.util.Objects.requireNonNull;
 
 public class Analyzer
@@ -48,6 +52,7 @@ public class Analyzer
     private final Map<NodeRef<Parameter>, Expression> parameterLookup;
     private final WarningCollector warningCollector;
     private final PlanOptimizersStatsCollector planOptimizersStatsCollector;
+    private final Tracer tracer;
     private final StatementRewrite statementRewrite;
 
     Analyzer(
@@ -58,6 +63,7 @@ public class Analyzer
             Map<NodeRef<Parameter>, Expression> parameterLookup,
             WarningCollector warningCollector,
             PlanOptimizersStatsCollector planOptimizersStatsCollector,
+            Tracer tracer,
             StatementRewrite statementRewrite)
     {
         this.session = requireNonNull(session, "session is null");
@@ -67,12 +73,18 @@ public class Analyzer
         this.parameterLookup = parameterLookup;
         this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
         this.planOptimizersStatsCollector = requireNonNull(planOptimizersStatsCollector, "planOptimizersStatsCollector is null");
+        this.tracer = requireNonNull(tracer, "tracer is null");
         this.statementRewrite = requireNonNull(statementRewrite, "statementRewrite is null");
     }
 
     public Analysis analyze(Statement statement)
     {
-        return analyze(statement, OTHERS);
+        Span span = tracer.spanBuilder("analyzer")
+                .setParent(Context.current().with(session.getQuerySpan()))
+                .startSpan();
+        try (var ignored = scopedSpan(span)) {
+            return analyze(statement, OTHERS);
+        }
     }
 
     public Analysis analyze(Statement statement, QueryType queryType)
@@ -80,15 +92,21 @@ public class Analyzer
         Statement rewrittenStatement = statementRewrite.rewrite(analyzerFactory, session, statement, parameters, parameterLookup, warningCollector, planOptimizersStatsCollector);
         Analysis analysis = new Analysis(rewrittenStatement, parameterLookup, queryType);
         StatementAnalyzer analyzer = statementAnalyzerFactory.createStatementAnalyzer(analysis, session, warningCollector, CorrelationSupport.ALLOWED);
-        analyzer.analyze(rewrittenStatement, Optional.empty());
 
-        // check column access permissions for each table
-        analysis.getTableColumnReferences().forEach((accessControlInfo, tableColumnReferences) ->
-                tableColumnReferences.forEach((tableName, columns) ->
-                        accessControlInfo.getAccessControl().checkCanSelectFromColumns(
-                                accessControlInfo.getSecurityContext(session.getRequiredTransactionId(), session.getQueryId()),
-                                tableName,
-                                columns)));
+        try (var ignored = scopedSpan(tracer, "analyze")) {
+            analyzer.analyze(rewrittenStatement, Optional.empty());
+        }
+
+        try (var ignored = scopedSpan(tracer, "access-control")) {
+            // check column access permissions for each table
+            analysis.getTableColumnReferences().forEach((accessControlInfo, tableColumnReferences) ->
+                    tableColumnReferences.forEach((tableName, columns) ->
+                            accessControlInfo.getAccessControl().checkCanSelectFromColumns(
+                                    accessControlInfo.getSecurityContext(session.getRequiredTransactionId(), session.getQueryId()),
+                                    tableName,
+                                    columns)));
+        }
+
         return analysis;
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/AnalyzerFactory.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/AnalyzerFactory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.sql.analyzer;
 
+import io.opentelemetry.api.trace.Tracer;
 import io.trino.Session;
 import io.trino.execution.querystats.PlanOptimizersStatsCollector;
 import io.trino.execution.warnings.WarningCollector;
@@ -32,12 +33,14 @@ public class AnalyzerFactory
 {
     private final StatementAnalyzerFactory statementAnalyzerFactory;
     private final StatementRewrite statementRewrite;
+    private final Tracer tracer;
 
     @Inject
-    public AnalyzerFactory(StatementAnalyzerFactory statementAnalyzerFactory, StatementRewrite statementRewrite)
+    public AnalyzerFactory(StatementAnalyzerFactory statementAnalyzerFactory, StatementRewrite statementRewrite, Tracer tracer)
     {
         this.statementAnalyzerFactory = requireNonNull(statementAnalyzerFactory, "statementAnalyzerFactory is null");
         this.statementRewrite = requireNonNull(statementRewrite, "statementRewrite is null");
+        this.tracer = requireNonNull(tracer, "tracer is null");
     }
 
     public Analyzer createAnalyzer(
@@ -55,6 +58,7 @@ public class AnalyzerFactory
                 parameterLookup,
                 warningCollector,
                 planOptimizersStatsCollector,
+                tracer,
                 statementRewrite);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -689,7 +689,7 @@ public class LocalExecutionPlanner
             else {
                 operatorFactories = toOperatorFactories(operatorFactoriesWithTypes);
             }
-            driverFactories.add(new DriverFactory(getNextPipelineId(), inputDriver, outputDriver, operatorFactories, driverInstances));
+            addDriverFactory(inputDriver, outputDriver, operatorFactories, driverInstances);
         }
 
         private List<OperatorFactory> handleLateMaterialization(List<OperatorFactoryWithTypes> operatorFactories)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ExtractSpatialJoins.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ExtractSpatialJoins.java
@@ -81,7 +81,6 @@ import static io.trino.SystemSessionProperties.isSpatialJoinEnabled;
 import static io.trino.matching.Capture.newCapture;
 import static io.trino.spi.StandardErrorCode.INVALID_SPATIAL_PARTITIONING;
 import static io.trino.spi.connector.Constraint.alwaysTrue;
-import static io.trino.spi.connector.DynamicFilter.EMPTY;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -467,7 +466,7 @@ public class ExtractSpatialJoins
         ColumnHandle kdbTreeColumn = Iterables.getOnlyElement(visibleColumnHandles);
 
         Optional<KdbTree> kdbTree = Optional.empty();
-        try (SplitSource splitSource = splitManager.getSplits(session, tableHandle, EMPTY, alwaysTrue())) {
+        try (SplitSource splitSource = splitManager.getSplits(session, session.getQuerySpan(), tableHandle, DynamicFilter.EMPTY, alwaysTrue())) {
             while (!Thread.currentThread().isInterrupted()) {
                 SplitBatch splitBatch = getFutureValue(splitSource.getNextBatch(1000));
                 List<Split> splits = splitBatch.getSplits();

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -20,6 +20,7 @@ import com.google.common.io.Closer;
 import io.airlift.node.NodeInfo;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.trino.FeaturesConfig;
@@ -409,6 +410,7 @@ public class LocalQueryRunner
                 pageIndexerFactory,
                 nodeInfo,
                 testingVersionEmbedder(),
+                OpenTelemetry.noop(),
                 transactionManager,
                 typeManager,
                 nodeSchedulerConfig));

--- a/core/trino-main/src/main/java/io/trino/testing/TestingConnectorContext.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingConnectorContext.java
@@ -13,6 +13,9 @@
  */
 package io.trino.testing;
 
+import io.airlift.tracing.Tracing;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
 import io.trino.connector.ConnectorAwareNodeManager;
 import io.trino.metadata.InMemoryNodeManager;
 import io.trino.operator.GroupByHashPageIndexerFactory;
@@ -47,6 +50,18 @@ public final class TestingConnectorContext
         TypeOperators typeOperators = new TypeOperators();
         pageIndexerFactory = new GroupByHashPageIndexerFactory(new JoinCompiler(typeOperators), new BlockTypeOperators(typeOperators));
         nodeManager = new ConnectorAwareNodeManager(new InMemoryNodeManager(), "testenv", TEST_CATALOG_HANDLE, true);
+    }
+
+    @Override
+    public OpenTelemetry getOpenTelemetry()
+    {
+        return OpenTelemetry.noop();
+    }
+
+    @Override
+    public Tracer getTracer()
+    {
+        return Tracing.noopTracer();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/tracing/ForTracing.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/ForTracing.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tracing;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForTracing {}

--- a/core/trino-main/src/main/java/io/trino/tracing/ScopedSpan.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/ScopedSpan.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tracing;
+
+import com.google.errorprone.annotations.MustBeClosed;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+
+import static java.util.Objects.requireNonNull;
+
+public final class ScopedSpan
+        implements AutoCloseable
+{
+    private final Span span;
+    private final Scope scope;
+
+    @SuppressWarnings("MustBeClosedChecker")
+    private ScopedSpan(Span span)
+    {
+        this.span = requireNonNull(span, "span is null");
+        this.scope = span.makeCurrent();
+    }
+
+    @Override
+    public void close()
+    {
+        try {
+            scope.close();
+        }
+        finally {
+            span.end();
+        }
+    }
+
+    @MustBeClosed
+    public static ScopedSpan scopedSpan(Tracer tracer, String name)
+    {
+        return scopedSpan(tracer.spanBuilder(name).startSpan());
+    }
+
+    @MustBeClosed
+    public static ScopedSpan scopedSpan(Span span)
+    {
+        return new ScopedSpan(span);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -1,0 +1,1280 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tracing;
+
+import io.airlift.slice.Slice;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.trino.spi.connector.AggregateFunction;
+import io.trino.spi.connector.AggregationApplicationResult;
+import io.trino.spi.connector.BeginTableExecuteResult;
+import io.trino.spi.connector.CatalogSchemaName;
+import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorAnalyzeMetadata;
+import io.trino.spi.connector.ConnectorInsertTableHandle;
+import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
+import io.trino.spi.connector.ConnectorMergeTableHandle;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorOutputMetadata;
+import io.trino.spi.connector.ConnectorOutputTableHandle;
+import io.trino.spi.connector.ConnectorPartitioningHandle;
+import io.trino.spi.connector.ConnectorResolvedIndex;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableExecuteHandle;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTableLayout;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorTableProperties;
+import io.trino.spi.connector.ConnectorTableSchema;
+import io.trino.spi.connector.ConnectorTableVersion;
+import io.trino.spi.connector.ConnectorViewDefinition;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.connector.ConstraintApplicationResult;
+import io.trino.spi.connector.JoinApplicationResult;
+import io.trino.spi.connector.JoinCondition;
+import io.trino.spi.connector.JoinStatistics;
+import io.trino.spi.connector.JoinType;
+import io.trino.spi.connector.LimitApplicationResult;
+import io.trino.spi.connector.MaterializedViewFreshness;
+import io.trino.spi.connector.ProjectionApplicationResult;
+import io.trino.spi.connector.RetryMode;
+import io.trino.spi.connector.RowChangeParadigm;
+import io.trino.spi.connector.SampleApplicationResult;
+import io.trino.spi.connector.SampleType;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SchemaTablePrefix;
+import io.trino.spi.connector.SortItem;
+import io.trino.spi.connector.SystemTable;
+import io.trino.spi.connector.TableColumnsMetadata;
+import io.trino.spi.connector.TableFunctionApplicationResult;
+import io.trino.spi.connector.TableScanRedirectApplicationResult;
+import io.trino.spi.connector.TopNApplicationResult;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.function.AggregationFunctionMetadata;
+import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionDependencyDeclaration;
+import io.trino.spi.function.FunctionId;
+import io.trino.spi.function.FunctionMetadata;
+import io.trino.spi.function.SchemaFunctionName;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.ptf.ConnectorTableFunctionHandle;
+import io.trino.spi.security.GrantInfo;
+import io.trino.spi.security.Privilege;
+import io.trino.spi.security.RoleGrant;
+import io.trino.spi.security.TrinoPrincipal;
+import io.trino.spi.statistics.ComputedStatistics;
+import io.trino.spi.statistics.TableStatistics;
+import io.trino.spi.statistics.TableStatisticsMetadata;
+import io.trino.spi.type.Type;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static io.airlift.tracing.Tracing.attribute;
+import static io.trino.tracing.ScopedSpan.scopedSpan;
+import static java.util.Objects.requireNonNull;
+
+public class TracingConnectorMetadata
+        implements ConnectorMetadata
+{
+    private final Tracer tracer;
+    private final String catalogName;
+    private final ConnectorMetadata delegate;
+
+    public TracingConnectorMetadata(Tracer tracer, String catalogName, ConnectorMetadata delegate)
+    {
+        this.tracer = requireNonNull(tracer, "tracer is null");
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    public boolean schemaExists(ConnectorSession session, String schemaName)
+    {
+        Span span = startSpan("schemaExists", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.schemaExists(session, schemaName);
+        }
+    }
+
+    @Override
+    public List<String> listSchemaNames(ConnectorSession session)
+    {
+        Span span = startSpan("listSchemaNames");
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listSchemaNames(session);
+        }
+    }
+
+    @Override
+    public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
+    {
+        Span span = startSpan("getTableHandle", tableName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getTableHandle(session, tableName);
+        }
+    }
+
+    @Override
+    public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName, Optional<ConnectorTableVersion> startVersion, Optional<ConnectorTableVersion> endVersion)
+    {
+        Span span = startSpan("getTableHandle", tableName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getTableHandle(session, tableName, startVersion, endVersion);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorTableExecuteHandle> getTableHandleForExecute(ConnectorSession session, ConnectorTableHandle tableHandle, String procedureName, Map<String, Object> executeProperties, RetryMode retryMode)
+    {
+        Span span = startSpan("getTableHandleForExecute", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getTableHandleForExecute(session, tableHandle, procedureName, executeProperties, retryMode);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorTableLayout> getLayoutForTableExecute(ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle)
+    {
+        Span span = startSpan("getLayoutForTableExecute", tableExecuteHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getLayoutForTableExecute(session, tableExecuteHandle);
+        }
+    }
+
+    @Override
+    public BeginTableExecuteResult<ConnectorTableExecuteHandle, ConnectorTableHandle> beginTableExecute(ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle, ConnectorTableHandle updatedSourceTableHandle)
+    {
+        Span span = startSpan("beginTableExecute", tableExecuteHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.beginTableExecute(session, tableExecuteHandle, updatedSourceTableHandle);
+        }
+    }
+
+    @Override
+    public void finishTableExecute(ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle, Collection<Slice> fragments, List<Object> tableExecuteState)
+    {
+        Span span = startSpan("finishTableExecute", tableExecuteHandle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.finishTableExecute(session, tableExecuteHandle, fragments, tableExecuteState);
+        }
+    }
+
+    @Override
+    public void executeTableExecute(ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle)
+    {
+        Span span = startSpan("executeTableExecute", tableExecuteHandle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.executeTableExecute(session, tableExecuteHandle);
+        }
+    }
+
+    @Override
+    public Optional<SystemTable> getSystemTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        Span span = startSpan("getSystemTable", tableName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getSystemTable(session, tableName);
+        }
+    }
+
+    @Override
+    public ConnectorTableHandle makeCompatiblePartitioning(ConnectorSession session, ConnectorTableHandle tableHandle, ConnectorPartitioningHandle partitioningHandle)
+    {
+        Span span = startSpan("makeCompatiblePartitioning", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.makeCompatiblePartitioning(session, tableHandle, partitioningHandle);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorPartitioningHandle> getCommonPartitioningHandle(ConnectorSession session, ConnectorPartitioningHandle left, ConnectorPartitioningHandle right)
+    {
+        Span span = startSpan("getCommonPartitioning");
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getCommonPartitioningHandle(session, left, right);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public SchemaTableName getSchemaTableName(ConnectorSession session, ConnectorTableHandle table)
+    {
+        Span span = startSpan("getSchemaTableName", table);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getSchemaTableName(session, table);
+        }
+    }
+
+    @Override
+    public ConnectorTableSchema getTableSchema(ConnectorSession session, ConnectorTableHandle table)
+    {
+        Span span = startSpan("getTableSchema", table);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getTableSchema(session, table);
+        }
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
+    {
+        Span span = startSpan("getTableMetadata", table);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getTableMetadata(session, table);
+        }
+    }
+
+    @Override
+    public Optional<Object> getInfo(ConnectorTableHandle table)
+    {
+        Span span = startSpan("getInfo", table);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getInfo(table);
+        }
+    }
+
+    @Override
+    public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
+    {
+        Span span = startSpan("listTables");
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listTables(session, schemaName);
+        }
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        Span span = startSpan("getColumnHandles", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getColumnHandles(session, tableHandle);
+        }
+    }
+
+    @Override
+    public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
+    {
+        Span span = startSpan("getColumnMetadata", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getColumnMetadata(session, tableHandle, columnHandle);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        Span span = startSpan("listTableColumns", prefix);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listTableColumns(session, prefix);
+        }
+    }
+
+    @Override
+    public Iterator<TableColumnsMetadata> streamTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        Span span = startSpan("streamTableColumns", prefix);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.streamTableColumns(session, prefix);
+        }
+    }
+
+    @Override
+    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        Span span = startSpan("getTableStatistics", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getTableStatistics(session, tableHandle);
+        }
+    }
+
+    @Override
+    public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties, TrinoPrincipal owner)
+    {
+        Span span = startSpan("createSchema", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.createSchema(session, schemaName, properties, owner);
+        }
+    }
+
+    @Override
+    public void dropSchema(ConnectorSession session, String schemaName)
+    {
+        Span span = startSpan("dropSchema", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.dropSchema(session, schemaName);
+        }
+    }
+
+    @Override
+    public void renameSchema(ConnectorSession session, String source, String target)
+    {
+        Span span = startSpan("renameSchema", source);
+        try (var ignored = scopedSpan(span)) {
+            delegate.renameSchema(session, source, target);
+        }
+    }
+
+    @Override
+    public void setSchemaAuthorization(ConnectorSession session, String schemaName, TrinoPrincipal principal)
+    {
+        Span span = startSpan("setSchemaAuthorization", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.setSchemaAuthorization(session, schemaName, principal);
+        }
+    }
+
+    @Override
+    public void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
+    {
+        Span span = startSpan("createTable", tableMetadata.getTable());
+        try (var ignored = scopedSpan(span)) {
+            delegate.createTable(session, tableMetadata, ignoreExisting);
+        }
+    }
+
+    @Override
+    public void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        Span span = startSpan("dropTable", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.dropTable(session, tableHandle);
+        }
+    }
+
+    @Override
+    public void truncateTable(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        Span span = startSpan("truncateTable", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.truncateTable(session, tableHandle);
+        }
+    }
+
+    @Override
+    public void renameTable(ConnectorSession session, ConnectorTableHandle tableHandle, SchemaTableName newTableName)
+    {
+        Span span = startSpan("renameTable", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.renameTable(session, tableHandle, newTableName);
+        }
+    }
+
+    @Override
+    public void setTableProperties(ConnectorSession session, ConnectorTableHandle tableHandle, Map<String, Optional<Object>> properties)
+    {
+        Span span = startSpan("setTableProperties", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.setTableProperties(session, tableHandle, properties);
+        }
+    }
+
+    @Override
+    public void setTableComment(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<String> comment)
+    {
+        Span span = startSpan("setTableComment", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.setTableComment(session, tableHandle, comment);
+        }
+    }
+
+    @Override
+    public void setViewComment(ConnectorSession session, SchemaTableName viewName, Optional<String> comment)
+    {
+        Span span = startSpan("setViewComment", viewName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.setViewComment(session, viewName, comment);
+        }
+    }
+
+    @Override
+    public void setViewColumnComment(ConnectorSession session, SchemaTableName viewName, String columnName, Optional<String> comment)
+    {
+        Span span = startSpan("setViewColumnComment", viewName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.setViewColumnComment(session, viewName, columnName, comment);
+        }
+    }
+
+    @Override
+    public void setColumnComment(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle column, Optional<String> comment)
+    {
+        Span span = startSpan("setColumnComment", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.setColumnComment(session, tableHandle, column, comment);
+        }
+    }
+
+    @Override
+    public void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
+    {
+        Span span = startSpan("addColumn", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.addColumn(session, tableHandle, column);
+        }
+    }
+
+    @Override
+    public void setColumnType(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle column, Type type)
+    {
+        Span span = startSpan("setColumnType", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.setColumnType(session, tableHandle, column, type);
+        }
+    }
+
+    @Override
+    public void setTableAuthorization(ConnectorSession session, SchemaTableName tableName, TrinoPrincipal principal)
+    {
+        Span span = startSpan("setTableAuthorization", tableName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.setTableAuthorization(session, tableName, principal);
+        }
+    }
+
+    @Override
+    public void renameColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle source, String target)
+    {
+        Span span = startSpan("renameColumn", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.renameColumn(session, tableHandle, source, target);
+        }
+    }
+
+    @Override
+    public void dropColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle column)
+    {
+        Span span = startSpan("dropColumn", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.dropColumn(session, tableHandle, column);
+        }
+    }
+
+    @Override
+    public void dropField(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle column, List<String> fieldPath)
+    {
+        Span span = startSpan("dropField", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.dropField(session, tableHandle, column, fieldPath);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorTableLayout> getNewTableLayout(ConnectorSession session, ConnectorTableMetadata tableMetadata)
+    {
+        Span span = startSpan("getNewTableLayout", tableMetadata.getTable());
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getNewTableLayout(session, tableMetadata);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorTableLayout> getInsertLayout(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        Span span = startSpan("getInsertLayout", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getInsertLayout(session, tableHandle);
+        }
+    }
+
+    @Override
+    public TableStatisticsMetadata getStatisticsCollectionMetadataForWrite(ConnectorSession session, ConnectorTableMetadata tableMetadata)
+    {
+        Span span = startSpan("getStatisticsCollectionMetadataForWrite", tableMetadata.getTable());
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getStatisticsCollectionMetadataForWrite(session, tableMetadata);
+        }
+    }
+
+    @Override
+    public ConnectorAnalyzeMetadata getStatisticsCollectionMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, Map<String, Object> analyzeProperties)
+    {
+        Span span = startSpan("getStatisticsCollectionMetadata", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getStatisticsCollectionMetadata(session, tableHandle, analyzeProperties);
+        }
+    }
+
+    @Override
+    public ConnectorTableHandle beginStatisticsCollection(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        Span span = startSpan("beginStatisticsCollection", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.beginStatisticsCollection(session, tableHandle);
+        }
+    }
+
+    @Override
+    public void finishStatisticsCollection(ConnectorSession session, ConnectorTableHandle tableHandle, Collection<ComputedStatistics> computedStatistics)
+    {
+        Span span = startSpan("finishStatisticsCollection", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.finishStatisticsCollection(session, tableHandle, computedStatistics);
+        }
+    }
+
+    @Override
+    public ConnectorOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorTableLayout> layout, RetryMode retryMode)
+    {
+        Span span = startSpan("beginCreateTable", tableMetadata.getTable());
+        try (var ignored = scopedSpan(span)) {
+            return delegate.beginCreateTable(session, tableMetadata, layout, retryMode);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        Span span = startSpan("finishCreateTable");
+        if (span.isRecording()) {
+            span.setAttribute(TrinoAttributes.HANDLE, tableHandle.toString());
+        }
+        try (var ignored = scopedSpan(span)) {
+            return delegate.finishCreateTable(session, tableHandle, fragments, computedStatistics);
+        }
+    }
+
+    @Override
+    public void beginQuery(ConnectorSession session)
+    {
+        Span span = startSpan("beginQuery");
+        try (var ignored = scopedSpan(span)) {
+            delegate.beginQuery(session);
+        }
+    }
+
+    @Override
+    public void cleanupQuery(ConnectorSession session)
+    {
+        Span span = startSpan("cleanupQuery");
+        try (var ignored = scopedSpan(span)) {
+            delegate.cleanupQuery(session);
+        }
+    }
+
+    @Override
+    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> columns, RetryMode retryMode)
+    {
+        Span span = startSpan("beginInsert", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.beginInsert(session, tableHandle, columns, retryMode);
+        }
+    }
+
+    @Override
+    public boolean supportsMissingColumnsOnInsert()
+    {
+        Span span = startSpan("supportsMissingColumnsOnInsert");
+        try (var ignored = scopedSpan(span)) {
+            return delegate.supportsMissingColumnsOnInsert();
+        }
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        Span span = startSpan("finishInsert");
+        if (span.isRecording()) {
+            span.setAttribute(TrinoAttributes.HANDLE, insertHandle.toString());
+        }
+        try (var ignored = scopedSpan(span)) {
+            return delegate.finishInsert(session, insertHandle, fragments, computedStatistics);
+        }
+    }
+
+    @Override
+    public boolean delegateMaterializedViewRefreshToConnector(ConnectorSession session, SchemaTableName viewName)
+    {
+        Span span = startSpan("delegateMaterializedViewRefreshToConnector", viewName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.delegateMaterializedViewRefreshToConnector(session, viewName);
+        }
+    }
+
+    @Override
+    public CompletableFuture<?> refreshMaterializedView(ConnectorSession session, SchemaTableName viewName)
+    {
+        Span span = startSpan("refreshMaterializedView", viewName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.refreshMaterializedView(session, viewName);
+        }
+    }
+
+    @Override
+    public ConnectorInsertTableHandle beginRefreshMaterializedView(ConnectorSession session, ConnectorTableHandle tableHandle, List<ConnectorTableHandle> sourceTableHandles, RetryMode retryMode)
+    {
+        Span span = startSpan("beginRefreshMaterializedView", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.beginRefreshMaterializedView(session, tableHandle, sourceTableHandles, retryMode);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishRefreshMaterializedView(ConnectorSession session, ConnectorTableHandle tableHandle, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics, List<ConnectorTableHandle> sourceTableHandles)
+    {
+        Span span = startSpan("finishRefreshMaterializedView", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.finishRefreshMaterializedView(session, tableHandle, insertHandle, fragments, computedStatistics, sourceTableHandles);
+        }
+    }
+
+    @Override
+    public RowChangeParadigm getRowChangeParadigm(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        Span span = startSpan("getRowChangeParadigm", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getRowChangeParadigm(session, tableHandle);
+        }
+    }
+
+    @Override
+    public ColumnHandle getMergeRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        Span span = startSpan("getMergeRowIdColumnHandle", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getMergeRowIdColumnHandle(session, tableHandle);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorPartitioningHandle> getUpdateLayout(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        Span span = startSpan("getUpdateLayout", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getUpdateLayout(session, tableHandle);
+        }
+    }
+
+    @Override
+    public ConnectorMergeTableHandle beginMerge(ConnectorSession session, ConnectorTableHandle tableHandle, RetryMode retryMode)
+    {
+        Span span = startSpan("beginMerge", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.beginMerge(session, tableHandle, retryMode);
+        }
+    }
+
+    @Override
+    public void finishMerge(ConnectorSession session, ConnectorMergeTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        Span span = startSpan("finishMerge", tableHandle.getTableHandle());
+        try (var ignored = scopedSpan(span)) {
+            delegate.finishMerge(session, tableHandle, fragments, computedStatistics);
+        }
+    }
+
+    @Override
+    public void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, boolean replace)
+    {
+        Span span = startSpan("createView", viewName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.createView(session, viewName, definition, replace);
+        }
+    }
+
+    @Override
+    public void renameView(ConnectorSession session, SchemaTableName source, SchemaTableName target)
+    {
+        Span span = startSpan("renameView", source);
+        try (var ignored = scopedSpan(span)) {
+            delegate.renameView(session, source, target);
+        }
+    }
+
+    @Override
+    public void setViewAuthorization(ConnectorSession session, SchemaTableName viewName, TrinoPrincipal principal)
+    {
+        Span span = startSpan("setViewAuthorization", viewName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.setViewAuthorization(session, viewName, principal);
+        }
+    }
+
+    @Override
+    public void dropView(ConnectorSession session, SchemaTableName viewName)
+    {
+        Span span = startSpan("dropView", viewName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.dropView(session, viewName);
+        }
+    }
+
+    @Override
+    public List<SchemaTableName> listViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        Span span = startSpan("listViews", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listViews(session, schemaName);
+        }
+    }
+
+    @Override
+    public Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        Span span = startSpan("getViews", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getViews(session, schemaName);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorViewDefinition> getView(ConnectorSession session, SchemaTableName viewName)
+    {
+        Span span = startSpan("getView", viewName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getView(session, viewName);
+        }
+    }
+
+    @SuppressWarnings("removal")
+    @Override
+    public Map<String, Object> getSchemaProperties(ConnectorSession session, CatalogSchemaName schemaName)
+    {
+        Span span = startSpan("getSchemaProperties", schemaName.getSchemaName());
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getSchemaProperties(session, schemaName);
+        }
+    }
+
+    @Override
+    public Map<String, Object> getSchemaProperties(ConnectorSession session, String schemaName)
+    {
+        Span span = startSpan("getSchemaProperties", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getSchemaProperties(session, schemaName);
+        }
+    }
+
+    @SuppressWarnings("removal")
+    @Override
+    public Optional<TrinoPrincipal> getSchemaOwner(ConnectorSession session, CatalogSchemaName schemaName)
+    {
+        Span span = startSpan("getSchemaOwner", schemaName.getSchemaName());
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getSchemaOwner(session, schemaName);
+        }
+    }
+
+    @Override
+    public Optional<TrinoPrincipal> getSchemaOwner(ConnectorSession session, String schemaName)
+    {
+        Span span = startSpan("getSchemaOwner", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getSchemaOwner(session, schemaName);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorTableHandle> applyDelete(ConnectorSession session, ConnectorTableHandle handle)
+    {
+        Span span = startSpan("applyDelete", handle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applyDelete(session, handle);
+        }
+    }
+
+    @Override
+    public OptionalLong executeDelete(ConnectorSession session, ConnectorTableHandle handle)
+    {
+        Span span = startSpan("executeDelete", handle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.executeDelete(session, handle);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorResolvedIndex> resolveIndex(ConnectorSession session, ConnectorTableHandle tableHandle, Set<ColumnHandle> indexableColumns, Set<ColumnHandle> outputColumns, TupleDomain<ColumnHandle> tupleDomain)
+    {
+        Span span = startSpan("resolveIndex", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.resolveIndex(session, tableHandle, indexableColumns, outputColumns, tupleDomain);
+        }
+    }
+
+    @Override
+    public Collection<FunctionMetadata> listFunctions(ConnectorSession session, String schemaName)
+    {
+        Span span = startSpan("listFunctions", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listFunctions(session, schemaName);
+        }
+    }
+
+    @Override
+    public Collection<FunctionMetadata> getFunctions(ConnectorSession session, SchemaFunctionName name)
+    {
+        Span span = startSpan("getFunctions", name.getSchemaName())
+                .setAttribute(TrinoAttributes.FUNCTION, name.getFunctionName());
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getFunctions(session, name);
+        }
+    }
+
+    @Override
+    public FunctionMetadata getFunctionMetadata(ConnectorSession session, FunctionId functionId)
+    {
+        Span span = startSpan("getFunctionMetadata", functionId);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getFunctionMetadata(session, functionId);
+        }
+    }
+
+    @Override
+    public AggregationFunctionMetadata getAggregationFunctionMetadata(ConnectorSession session, FunctionId functionId)
+    {
+        Span span = startSpan("getAggregationFunctionMetadata", functionId);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getAggregationFunctionMetadata(session, functionId);
+        }
+    }
+
+    @Override
+    public FunctionDependencyDeclaration getFunctionDependencies(ConnectorSession session, FunctionId functionId, BoundSignature boundSignature)
+    {
+        Span span = startSpan("getFunctionDependencies", functionId);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getFunctionDependencies(session, functionId, boundSignature);
+        }
+    }
+
+    @Override
+    public boolean roleExists(ConnectorSession session, String role)
+    {
+        Span span = startSpan("roleExists");
+        try (var ignored = scopedSpan(span)) {
+            return delegate.roleExists(session, role);
+        }
+    }
+
+    @Override
+    public void createRole(ConnectorSession session, String role, Optional<TrinoPrincipal> grantor)
+    {
+        Span span = startSpan("createRole");
+        try (var ignored = scopedSpan(span)) {
+            delegate.createRole(session, role, grantor);
+        }
+    }
+
+    @Override
+    public void dropRole(ConnectorSession session, String role)
+    {
+        Span span = startSpan("dropRole");
+        try (var ignored = scopedSpan(span)) {
+            delegate.dropRole(session, role);
+        }
+    }
+
+    @Override
+    public Set<String> listRoles(ConnectorSession session)
+    {
+        Span span = startSpan("listRoles");
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listRoles(session);
+        }
+    }
+
+    @Override
+    public Set<RoleGrant> listRoleGrants(ConnectorSession session, TrinoPrincipal principal)
+    {
+        Span span = startSpan("listRoleGrants");
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listRoleGrants(session, principal);
+        }
+    }
+
+    @Override
+    public void grantRoles(ConnectorSession connectorSession, Set<String> roles, Set<TrinoPrincipal> grantees, boolean adminOption, Optional<TrinoPrincipal> grantor)
+    {
+        Span span = startSpan("grantRoles");
+        try (var ignored = scopedSpan(span)) {
+            delegate.grantRoles(connectorSession, roles, grantees, adminOption, grantor);
+        }
+    }
+
+    @Override
+    public void revokeRoles(ConnectorSession connectorSession, Set<String> roles, Set<TrinoPrincipal> grantees, boolean adminOption, Optional<TrinoPrincipal> grantor)
+    {
+        Span span = startSpan("revokeRoles");
+        try (var ignored = scopedSpan(span)) {
+            delegate.revokeRoles(connectorSession, roles, grantees, adminOption, grantor);
+        }
+    }
+
+    @Override
+    public Set<RoleGrant> listApplicableRoles(ConnectorSession session, TrinoPrincipal principal)
+    {
+        Span span = startSpan("listApplicableRoles");
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listApplicableRoles(session, principal);
+        }
+    }
+
+    @Override
+    public Set<String> listEnabledRoles(ConnectorSession session)
+    {
+        Span span = startSpan("listEnabledRoles");
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listEnabledRoles(session);
+        }
+    }
+
+    @Override
+    public void grantSchemaPrivileges(ConnectorSession session, String schemaName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        Span span = startSpan("grantSchemaPrivileges", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.grantSchemaPrivileges(session, schemaName, privileges, grantee, grantOption);
+        }
+    }
+
+    @Override
+    public void denySchemaPrivileges(ConnectorSession session, String schemaName, Set<Privilege> privileges, TrinoPrincipal grantee)
+    {
+        Span span = startSpan("denySchemaPrivileges", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.denySchemaPrivileges(session, schemaName, privileges, grantee);
+        }
+    }
+
+    @Override
+    public void revokeSchemaPrivileges(ConnectorSession session, String schemaName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        Span span = startSpan("revokeSchemaPrivileges", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.revokeSchemaPrivileges(session, schemaName, privileges, grantee, grantOption);
+        }
+    }
+
+    @Override
+    public void grantTablePrivileges(ConnectorSession session, SchemaTableName tableName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        Span span = startSpan("grantTablePrivileges", tableName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.grantTablePrivileges(session, tableName, privileges, grantee, grantOption);
+        }
+    }
+
+    @Override
+    public void denyTablePrivileges(ConnectorSession session, SchemaTableName tableName, Set<Privilege> privileges, TrinoPrincipal grantee)
+    {
+        Span span = startSpan("denyTablePrivileges", tableName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.denyTablePrivileges(session, tableName, privileges, grantee);
+        }
+    }
+
+    @Override
+    public void revokeTablePrivileges(ConnectorSession session, SchemaTableName tableName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        Span span = startSpan("revokeTablePrivileges", tableName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.revokeTablePrivileges(session, tableName, privileges, grantee, grantOption);
+        }
+    }
+
+    @Override
+    public List<GrantInfo> listTablePrivileges(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        Span span = startSpan("listTablePrivileges", prefix);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listTablePrivileges(session, prefix);
+        }
+    }
+
+    @Override
+    public ConnectorTableProperties getTableProperties(ConnectorSession session, ConnectorTableHandle table)
+    {
+        Span span = startSpan("getTableProperties", table);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getTableProperties(session, table);
+        }
+    }
+
+    @Override
+    public Optional<LimitApplicationResult<ConnectorTableHandle>> applyLimit(ConnectorSession session, ConnectorTableHandle handle, long limit)
+    {
+        Span span = startSpan("applyLimit", handle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applyLimit(session, handle, limit);
+        }
+    }
+
+    @Override
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
+    {
+        Span span = startSpan("applyFilter", handle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applyFilter(session, handle, constraint);
+        }
+    }
+
+    @Override
+    public Optional<ProjectionApplicationResult<ConnectorTableHandle>> applyProjection(ConnectorSession session, ConnectorTableHandle handle, List<ConnectorExpression> projections, Map<String, ColumnHandle> assignments)
+    {
+        Span span = startSpan("applyProjection", handle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applyProjection(session, handle, projections, assignments);
+        }
+    }
+
+    @Override
+    public Optional<SampleApplicationResult<ConnectorTableHandle>> applySample(ConnectorSession session, ConnectorTableHandle handle, SampleType sampleType, double sampleRatio)
+    {
+        Span span = startSpan("applySample", handle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applySample(session, handle, sampleType, sampleRatio);
+        }
+    }
+
+    @Override
+    public Optional<AggregationApplicationResult<ConnectorTableHandle>> applyAggregation(ConnectorSession session, ConnectorTableHandle handle, List<AggregateFunction> aggregates, Map<String, ColumnHandle> assignments, List<List<ColumnHandle>> groupingSets)
+    {
+        Span span = startSpan("applyAggregation", handle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applyAggregation(session, handle, aggregates, assignments, groupingSets);
+        }
+    }
+
+    @Override
+    public Optional<JoinApplicationResult<ConnectorTableHandle>> applyJoin(ConnectorSession session, JoinType joinType, ConnectorTableHandle left, ConnectorTableHandle right, ConnectorExpression joinCondition, Map<String, ColumnHandle> leftAssignments, Map<String, ColumnHandle> rightAssignments, JoinStatistics statistics)
+    {
+        Span span = startSpan("applyJoin");
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applyJoin(session, joinType, left, right, joinCondition, leftAssignments, rightAssignments, statistics);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public Optional<JoinApplicationResult<ConnectorTableHandle>> applyJoin(ConnectorSession session, JoinType joinType, ConnectorTableHandle left, ConnectorTableHandle right, List<JoinCondition> joinConditions, Map<String, ColumnHandle> leftAssignments, Map<String, ColumnHandle> rightAssignments, JoinStatistics statistics)
+    {
+        Span span = startSpan("applyJoin");
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applyJoin(session, joinType, left, right, joinConditions, leftAssignments, rightAssignments, statistics);
+        }
+    }
+
+    @Override
+    public Optional<TopNApplicationResult<ConnectorTableHandle>> applyTopN(ConnectorSession session, ConnectorTableHandle handle, long topNCount, List<SortItem> sortItems, Map<String, ColumnHandle> assignments)
+    {
+        Span span = startSpan("applyTopN", handle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applyTopN(session, handle, topNCount, sortItems, assignments);
+        }
+    }
+
+    @Override
+    public Optional<TableFunctionApplicationResult<ConnectorTableHandle>> applyTableFunction(ConnectorSession session, ConnectorTableFunctionHandle handle)
+    {
+        Span span = startSpan("applyTableFunction");
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applyTableFunction(session, handle);
+        }
+    }
+
+    @Override
+    public void validateScan(ConnectorSession session, ConnectorTableHandle handle)
+    {
+        Span span = startSpan("validateScan", handle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.validateScan(session, handle);
+        }
+    }
+
+    @Override
+    public void createMaterializedView(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
+    {
+        Span span = startSpan("createMaterializedView", viewName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.createMaterializedView(session, viewName, definition, replace, ignoreExisting);
+        }
+    }
+
+    @Override
+    public void dropMaterializedView(ConnectorSession session, SchemaTableName viewName)
+    {
+        Span span = startSpan("dropMaterializedView", viewName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.dropMaterializedView(session, viewName);
+        }
+    }
+
+    @Override
+    public List<SchemaTableName> listMaterializedViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        Span span = startSpan("listMaterializedViews", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listMaterializedViews(session, schemaName);
+        }
+    }
+
+    @Override
+    public Map<SchemaTableName, ConnectorMaterializedViewDefinition> getMaterializedViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        Span span = startSpan("getMaterializedViews", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getMaterializedViews(session, schemaName);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(ConnectorSession session, SchemaTableName viewName)
+    {
+        Span span = startSpan("getMaterializedView", viewName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getMaterializedView(session, viewName);
+        }
+    }
+
+    @Override
+    public MaterializedViewFreshness getMaterializedViewFreshness(ConnectorSession session, SchemaTableName name)
+    {
+        Span span = startSpan("getMaterializedViewFreshness", name);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getMaterializedViewFreshness(session, name);
+        }
+    }
+
+    @Override
+    public void renameMaterializedView(ConnectorSession session, SchemaTableName source, SchemaTableName target)
+    {
+        Span span = startSpan("renameMaterializedView", source);
+        try (var ignored = scopedSpan(span)) {
+            delegate.renameMaterializedView(session, source, target);
+        }
+    }
+
+    @Override
+    public void setMaterializedViewProperties(ConnectorSession session, SchemaTableName viewName, Map<String, Optional<Object>> properties)
+    {
+        Span span = startSpan("setMaterializedViewProperties", viewName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.setMaterializedViewProperties(session, viewName, properties);
+        }
+    }
+
+    @Override
+    public Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        Span span = startSpan("applyTableScanRedirect", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applyTableScanRedirect(session, tableHandle);
+        }
+    }
+
+    @Override
+    public Optional<CatalogSchemaTableName> redirectTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        Span span = startSpan("redirectTable", tableName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.redirectTable(session, tableName);
+        }
+    }
+
+    @Override
+    public boolean supportsReportingWrittenBytes(ConnectorSession session, SchemaTableName schemaTableName, Map<String, Object> tableProperties)
+    {
+        Span span = startSpan("supportsReportingWrittenBytes", schemaTableName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.supportsReportingWrittenBytes(session, schemaTableName, tableProperties);
+        }
+    }
+
+    @Override
+    public boolean supportsReportingWrittenBytes(ConnectorSession session, ConnectorTableHandle connectorTableHandle)
+    {
+        Span span = startSpan("supportsReportingWrittenBytes", connectorTableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.supportsReportingWrittenBytes(session, connectorTableHandle);
+        }
+    }
+
+    @Override
+    public OptionalInt getMaxWriterTasks(ConnectorSession session)
+    {
+        Span span = startSpan("getMaxWriterTasks");
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getMaxWriterTasks(session);
+        }
+    }
+
+    private Span startSpan(String methodName)
+    {
+        return tracer.spanBuilder("ConnectorMetadata." + methodName)
+                .setAttribute(TrinoAttributes.CATALOG, catalogName)
+                .startSpan();
+    }
+
+    private Span startSpan(String methodName, String schemaName)
+    {
+        return startSpan(methodName)
+                .setAttribute(TrinoAttributes.SCHEMA, schemaName);
+    }
+
+    private Span startSpan(String methodName, Optional<String> schemaName)
+    {
+        return startSpan(methodName)
+                .setAllAttributes(attribute(TrinoAttributes.SCHEMA, schemaName));
+    }
+
+    private Span startSpan(String methodName, SchemaTableName table)
+    {
+        return startSpan(methodName)
+                .setAttribute(TrinoAttributes.SCHEMA, table.getSchemaName())
+                .setAttribute(TrinoAttributes.TABLE, table.getTableName());
+    }
+
+    private Span startSpan(String methodName, SchemaTablePrefix prefix)
+    {
+        return startSpan(methodName)
+                .setAllAttributes(attribute(TrinoAttributes.SCHEMA, prefix.getSchema()))
+                .setAllAttributes(attribute(TrinoAttributes.TABLE, prefix.getTable()));
+    }
+
+    private Span startSpan(String methodName, ConnectorTableHandle handle)
+    {
+        Span span = startSpan(methodName);
+        if (span.isRecording()) {
+            span.setAttribute(TrinoAttributes.HANDLE, handle.toString());
+        }
+        return span;
+    }
+
+    private Span startSpan(String methodName, ConnectorTableExecuteHandle handle)
+    {
+        Span span = startSpan(methodName);
+        if (span.isRecording()) {
+            span.setAttribute(TrinoAttributes.HANDLE, handle.toString());
+        }
+        return span;
+    }
+
+    private Span startSpan(String methodName, FunctionId functionId)
+    {
+        Span span = startSpan(methodName);
+        if (span.isRecording()) {
+            span.setAttribute(TrinoAttributes.FUNCTION, functionId.toString());
+        }
+        return span;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -1313,7 +1313,8 @@ public class TracingMetadata
 
     private Span startSpan(String methodName)
     {
-        return tracer.spanBuilder("Metadata." + methodName).startSpan();
+        return tracer.spanBuilder("Metadata." + methodName)
+                .startSpan();
     }
 
     private Span startSpan(String methodName, String catalogName)

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -1,0 +1,1399 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tracing;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.slice.Slice;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.trino.Session;
+import io.trino.metadata.AnalyzeMetadata;
+import io.trino.metadata.AnalyzeTableHandle;
+import io.trino.metadata.CatalogInfo;
+import io.trino.metadata.InsertTableHandle;
+import io.trino.metadata.MaterializedViewDefinition;
+import io.trino.metadata.MergeHandle;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.OperatorNotFoundException;
+import io.trino.metadata.OutputTableHandle;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.metadata.QualifiedTablePrefix;
+import io.trino.metadata.RedirectionAwareTableHandle;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.ResolvedIndex;
+import io.trino.metadata.TableExecuteHandle;
+import io.trino.metadata.TableFunctionHandle;
+import io.trino.metadata.TableHandle;
+import io.trino.metadata.TableLayout;
+import io.trino.metadata.TableMetadata;
+import io.trino.metadata.TableProperties;
+import io.trino.metadata.TableSchema;
+import io.trino.metadata.TableVersion;
+import io.trino.metadata.ViewDefinition;
+import io.trino.metadata.ViewInfo;
+import io.trino.spi.connector.AggregateFunction;
+import io.trino.spi.connector.AggregationApplicationResult;
+import io.trino.spi.connector.BeginTableExecuteResult;
+import io.trino.spi.connector.CatalogHandle;
+import io.trino.spi.connector.CatalogSchemaName;
+import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorCapabilities;
+import io.trino.spi.connector.ConnectorOutputMetadata;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.connector.ConstraintApplicationResult;
+import io.trino.spi.connector.JoinApplicationResult;
+import io.trino.spi.connector.JoinStatistics;
+import io.trino.spi.connector.JoinType;
+import io.trino.spi.connector.LimitApplicationResult;
+import io.trino.spi.connector.MaterializedViewFreshness;
+import io.trino.spi.connector.ProjectionApplicationResult;
+import io.trino.spi.connector.RowChangeParadigm;
+import io.trino.spi.connector.SampleApplicationResult;
+import io.trino.spi.connector.SampleType;
+import io.trino.spi.connector.SortItem;
+import io.trino.spi.connector.SystemTable;
+import io.trino.spi.connector.TableColumnsMetadata;
+import io.trino.spi.connector.TableFunctionApplicationResult;
+import io.trino.spi.connector.TableScanRedirectApplicationResult;
+import io.trino.spi.connector.TopNApplicationResult;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.function.AggregationFunctionMetadata;
+import io.trino.spi.function.FunctionMetadata;
+import io.trino.spi.function.OperatorType;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.security.GrantInfo;
+import io.trino.spi.security.Identity;
+import io.trino.spi.security.Privilege;
+import io.trino.spi.security.RoleGrant;
+import io.trino.spi.security.TrinoPrincipal;
+import io.trino.spi.statistics.ComputedStatistics;
+import io.trino.spi.statistics.TableStatistics;
+import io.trino.spi.statistics.TableStatisticsMetadata;
+import io.trino.spi.type.Type;
+import io.trino.sql.analyzer.TypeSignatureProvider;
+import io.trino.sql.planner.PartitioningHandle;
+import io.trino.sql.tree.QualifiedName;
+
+import javax.inject.Inject;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.Set;
+
+import static io.airlift.tracing.Tracing.attribute;
+import static io.trino.tracing.ScopedSpan.scopedSpan;
+import static java.util.Objects.requireNonNull;
+
+public class TracingMetadata
+        implements Metadata
+{
+    private final Tracer tracer;
+    private final Metadata delegate;
+
+    @Inject
+    public TracingMetadata(Tracer tracer, @ForTracing Metadata delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.tracer = requireNonNull(tracer, "tracer is null");
+    }
+
+    @VisibleForTesting
+    public Metadata getDelegate()
+    {
+        return delegate;
+    }
+
+    @Override
+    public Set<ConnectorCapabilities> getConnectorCapabilities(Session session, CatalogHandle catalogHandle)
+    {
+        Span span = startSpan("getConnectorCapabilities", catalogHandle.getCatalogName());
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getConnectorCapabilities(session, catalogHandle);
+        }
+    }
+
+    @Override
+    public boolean catalogExists(Session session, String catalogName)
+    {
+        Span span = startSpan("catalogExists", catalogName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.catalogExists(session, catalogName);
+        }
+    }
+
+    @Override
+    public boolean schemaExists(Session session, CatalogSchemaName schema)
+    {
+        Span span = startSpan("schemaExists", schema);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.schemaExists(session, schema);
+        }
+    }
+
+    @Override
+    public List<String> listSchemaNames(Session session, String catalogName)
+    {
+        Span span = startSpan("listSchemaNames", catalogName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listSchemaNames(session, catalogName);
+        }
+    }
+
+    @Override
+    public Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName)
+    {
+        Span span = startSpan("getTableHandle", tableName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getTableHandle(session, tableName);
+        }
+    }
+
+    @Override
+    public Optional<SystemTable> getSystemTable(Session session, QualifiedObjectName tableName)
+    {
+        Span span = startSpan("getSystemTable", tableName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getSystemTable(session, tableName);
+        }
+    }
+
+    @Override
+    public Optional<TableExecuteHandle> getTableHandleForExecute(Session session, TableHandle tableHandle, String procedureName, Map<String, Object> executeProperties)
+    {
+        Span span = startSpan("getTableHandleForExecute", tableHandle)
+                .setAttribute(TrinoAttributes.PROCEDURE, procedureName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getTableHandleForExecute(session, tableHandle, procedureName, executeProperties);
+        }
+    }
+
+    @Override
+    public Optional<TableLayout> getLayoutForTableExecute(Session session, TableExecuteHandle tableExecuteHandle)
+    {
+        Span span = startSpan("getLayoutForTableExecute", tableExecuteHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getLayoutForTableExecute(session, tableExecuteHandle);
+        }
+    }
+
+    @Override
+    public BeginTableExecuteResult<TableExecuteHandle, TableHandle> beginTableExecute(Session session, TableExecuteHandle handle, TableHandle updatedSourceTableHandle)
+    {
+        Span span = startSpan("beginTableExecute", handle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.beginTableExecute(session, handle, updatedSourceTableHandle);
+        }
+    }
+
+    @Override
+    public void finishTableExecute(Session session, TableExecuteHandle handle, Collection<Slice> fragments, List<Object> tableExecuteState)
+    {
+        Span span = startSpan("finishTableExecute", handle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.finishTableExecute(session, handle, fragments, tableExecuteState);
+        }
+    }
+
+    @Override
+    public void executeTableExecute(Session session, TableExecuteHandle handle)
+    {
+        Span span = startSpan("executeTableExecute", handle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.executeTableExecute(session, handle);
+        }
+    }
+
+    @Override
+    public TableProperties getTableProperties(Session session, TableHandle handle)
+    {
+        Span span = startSpan("getTableProperties", handle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getTableProperties(session, handle);
+        }
+    }
+
+    @Override
+    public TableHandle makeCompatiblePartitioning(Session session, TableHandle table, PartitioningHandle partitioningHandle)
+    {
+        Span span = startSpan("makeCompatiblePartitioning", table);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.makeCompatiblePartitioning(session, table, partitioningHandle);
+        }
+    }
+
+    @Override
+    public Optional<PartitioningHandle> getCommonPartitioning(Session session, PartitioningHandle left, PartitioningHandle right)
+    {
+        Span span = startSpan("getCommonPartitioning");
+        if (span.isRecording() && left.getCatalogHandle().equals(right.getCatalogHandle()) && left.getCatalogHandle().isPresent()) {
+            span.setAttribute(TrinoAttributes.CATALOG, left.getCatalogHandle().get().getCatalogName());
+        }
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getCommonPartitioning(session, left, right);
+        }
+    }
+
+    @Override
+    public Optional<Object> getInfo(Session session, TableHandle handle)
+    {
+        Span span = startSpan("getInfo", handle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getInfo(session, handle);
+        }
+    }
+
+    @Override
+    public TableSchema getTableSchema(Session session, TableHandle tableHandle)
+    {
+        Span span = startSpan("getTableSchema", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getTableSchema(session, tableHandle);
+        }
+    }
+
+    @Override
+    public TableMetadata getTableMetadata(Session session, TableHandle tableHandle)
+    {
+        Span span = startSpan("getTableMetadata", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getTableMetadata(session, tableHandle);
+        }
+    }
+
+    @Override
+    public TableStatistics getTableStatistics(Session session, TableHandle tableHandle)
+    {
+        Span span = startSpan("getTableStatistics", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getTableStatistics(session, tableHandle);
+        }
+    }
+
+    @Override
+    public List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix)
+    {
+        Span span = startSpan("listTables", prefix);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listTables(session, prefix);
+        }
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles(Session session, TableHandle tableHandle)
+    {
+        Span span = startSpan("getColumnHandles", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getColumnHandles(session, tableHandle);
+        }
+    }
+
+    @Override
+    public ColumnMetadata getColumnMetadata(Session session, TableHandle tableHandle, ColumnHandle columnHandle)
+    {
+        Span span = startSpan("getColumnMetadata", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getColumnMetadata(session, tableHandle, columnHandle);
+        }
+    }
+
+    @Override
+    public List<TableColumnsMetadata> listTableColumns(Session session, QualifiedTablePrefix prefix)
+    {
+        Span span = startSpan("listTableColumns", prefix);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listTableColumns(session, prefix);
+        }
+    }
+
+    @Override
+    public void createSchema(Session session, CatalogSchemaName schema, Map<String, Object> properties, TrinoPrincipal principal)
+    {
+        Span span = startSpan("createSchema", schema);
+        try (var ignored = scopedSpan(span)) {
+            delegate.createSchema(session, schema, properties, principal);
+        }
+    }
+
+    @Override
+    public void dropSchema(Session session, CatalogSchemaName schema)
+    {
+        Span span = startSpan("dropSchema", schema);
+        try (var ignored = scopedSpan(span)) {
+            delegate.dropSchema(session, schema);
+        }
+    }
+
+    @Override
+    public void renameSchema(Session session, CatalogSchemaName source, String target)
+    {
+        Span span = startSpan("renameSchema", source);
+        try (var ignored = scopedSpan(span)) {
+            delegate.renameSchema(session, source, target);
+        }
+    }
+
+    @Override
+    public void setSchemaAuthorization(Session session, CatalogSchemaName source, TrinoPrincipal principal)
+    {
+        Span span = startSpan("setSchemaAuthorization", source);
+        try (var ignored = scopedSpan(span)) {
+            delegate.setSchemaAuthorization(session, source, principal);
+        }
+    }
+
+    @Override
+    public void createTable(Session session, String catalogName, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
+    {
+        Span span = startSpan("createTable", catalogName, tableMetadata);
+        try (var ignored = scopedSpan(span)) {
+            delegate.createTable(session, catalogName, tableMetadata, ignoreExisting);
+        }
+    }
+
+    @Override
+    public void renameTable(Session session, TableHandle tableHandle, CatalogSchemaTableName currentTableName, QualifiedObjectName newTableName)
+    {
+        Span span = startSpan("renameTable", currentTableName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.renameTable(session, tableHandle, currentTableName, newTableName);
+        }
+    }
+
+    @Override
+    public void setTableProperties(Session session, TableHandle tableHandle, Map<String, Optional<Object>> properties)
+    {
+        Span span = startSpan("setTableProperties", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.setTableProperties(session, tableHandle, properties);
+        }
+    }
+
+    @Override
+    public void setTableComment(Session session, TableHandle tableHandle, Optional<String> comment)
+    {
+        Span span = startSpan("setTableComment", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.setTableComment(session, tableHandle, comment);
+        }
+    }
+
+    @Override
+    public void setViewComment(Session session, QualifiedObjectName viewName, Optional<String> comment)
+    {
+        Span span = startSpan("setViewComment", viewName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.setViewComment(session, viewName, comment);
+        }
+    }
+
+    @Override
+    public void setViewColumnComment(Session session, QualifiedObjectName viewName, String columnName, Optional<String> comment)
+    {
+        Span span = startSpan("setViewColumnComment", viewName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.setViewColumnComment(session, viewName, columnName, comment);
+        }
+    }
+
+    @Override
+    public void setColumnComment(Session session, TableHandle tableHandle, ColumnHandle column, Optional<String> comment)
+    {
+        Span span = startSpan("setColumnComment", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.setColumnComment(session, tableHandle, column, comment);
+        }
+    }
+
+    @Override
+    public void renameColumn(Session session, TableHandle tableHandle, CatalogSchemaTableName table, ColumnHandle source, String target)
+    {
+        Span span = startSpan("renameColumn", table);
+        try (var ignored = scopedSpan(span)) {
+            delegate.renameColumn(session, tableHandle, table, source, target);
+        }
+    }
+
+    @Override
+    public void addColumn(Session session, TableHandle tableHandle, CatalogSchemaTableName table, ColumnMetadata column)
+    {
+        Span span = startSpan("addColumn", table);
+        try (var ignored = scopedSpan(span)) {
+            delegate.addColumn(session, tableHandle, table, column);
+        }
+    }
+
+    @Override
+    public void setColumnType(Session session, TableHandle tableHandle, ColumnHandle column, Type type)
+    {
+        Span span = startSpan("setColumnType", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.setColumnType(session, tableHandle, column, type);
+        }
+    }
+
+    @Override
+    public void setTableAuthorization(Session session, CatalogSchemaTableName table, TrinoPrincipal principal)
+    {
+        Span span = startSpan("setTableAuthorization", table);
+        try (var ignored = scopedSpan(span)) {
+            delegate.setTableAuthorization(session, table, principal);
+        }
+    }
+
+    @Override
+    public void dropColumn(Session session, TableHandle tableHandle, CatalogSchemaTableName table, ColumnHandle column)
+    {
+        Span span = startSpan("dropColumn", table);
+        try (var ignored = scopedSpan(span)) {
+            delegate.dropColumn(session, tableHandle, table, column);
+        }
+    }
+
+    @Override
+    public void dropField(Session session, TableHandle tableHandle, ColumnHandle column, List<String> fieldPath)
+    {
+        Span span = startSpan("dropField", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.dropField(session, tableHandle, column, fieldPath);
+        }
+    }
+
+    @Override
+    public void dropTable(Session session, TableHandle tableHandle, CatalogSchemaTableName tableName)
+    {
+        Span span = startSpan("dropTable", tableName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.dropTable(session, tableHandle, tableName);
+        }
+    }
+
+    @Override
+    public void truncateTable(Session session, TableHandle tableHandle)
+    {
+        Span span = startSpan("truncateTable", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            delegate.truncateTable(session, tableHandle);
+        }
+    }
+
+    @Override
+    public Optional<TableLayout> getNewTableLayout(Session session, String catalogName, ConnectorTableMetadata tableMetadata)
+    {
+        Span span = startSpan("getNewTableLayout", catalogName, tableMetadata);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getNewTableLayout(session, catalogName, tableMetadata);
+        }
+    }
+
+    @Override
+    public OutputTableHandle beginCreateTable(Session session, String catalogName, ConnectorTableMetadata tableMetadata, Optional<TableLayout> layout)
+    {
+        Span span = startSpan("beginCreateTable", catalogName, tableMetadata);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.beginCreateTable(session, catalogName, tableMetadata, layout);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishCreateTable(Session session, OutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        Span span = startSpan("finishCreateTable", tableHandle.getCatalogHandle().getCatalogName());
+        if (span.isRecording()) {
+            span.setAttribute(TrinoAttributes.TABLE, tableHandle.getConnectorHandle().toString());
+        }
+        try (var ignored = scopedSpan(span)) {
+            return delegate.finishCreateTable(session, tableHandle, fragments, computedStatistics);
+        }
+    }
+
+    @Override
+    public Optional<TableLayout> getInsertLayout(Session session, TableHandle target)
+    {
+        Span span = startSpan("getInsertLayout", target);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getInsertLayout(session, target);
+        }
+    }
+
+    @Override
+    public TableStatisticsMetadata getStatisticsCollectionMetadataForWrite(Session session, CatalogHandle catalogHandle, ConnectorTableMetadata tableMetadata)
+    {
+        Span span = startSpan("getStatisticsCollectionMetadataForWrite", catalogHandle.getCatalogName(), tableMetadata);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getStatisticsCollectionMetadataForWrite(session, catalogHandle, tableMetadata);
+        }
+    }
+
+    @Override
+    public AnalyzeMetadata getStatisticsCollectionMetadata(Session session, TableHandle tableHandle, Map<String, Object> analyzeProperties)
+    {
+        Span span = startSpan("getStatisticsCollectionMetadata", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getStatisticsCollectionMetadata(session, tableHandle, analyzeProperties);
+        }
+    }
+
+    @Override
+    public AnalyzeTableHandle beginStatisticsCollection(Session session, TableHandle tableHandle)
+    {
+        Span span = startSpan("beginStatisticsCollection", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.beginStatisticsCollection(session, tableHandle);
+        }
+    }
+
+    @Override
+    public void finishStatisticsCollection(Session session, AnalyzeTableHandle tableHandle, Collection<ComputedStatistics> computedStatistics)
+    {
+        Span span = startSpan("finishStatisticsCollection", tableHandle.getCatalogHandle().getCatalogName());
+        if (span.isRecording()) {
+            span.setAttribute(TrinoAttributes.TABLE, tableHandle.getConnectorHandle().toString());
+        }
+        try (var ignored = scopedSpan(span)) {
+            delegate.finishStatisticsCollection(session, tableHandle, computedStatistics);
+        }
+    }
+
+    @Override
+    public void cleanupQuery(Session session)
+    {
+        Span span = startSpan("cleanupQuery");
+        try (var ignored = scopedSpan(span)) {
+            delegate.cleanupQuery(session);
+        }
+    }
+
+    @Override
+    public InsertTableHandle beginInsert(Session session, TableHandle tableHandle, List<ColumnHandle> columns)
+    {
+        Span span = startSpan("beginInsert", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.beginInsert(session, tableHandle, columns);
+        }
+    }
+
+    @Override
+    public boolean supportsMissingColumnsOnInsert(Session session, TableHandle tableHandle)
+    {
+        Span span = startSpan("supportsMissingColumnsOnInsert", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.supportsMissingColumnsOnInsert(session, tableHandle);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishInsert(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        Span span = startSpan("finishInsert", tableHandle.getCatalogHandle().getCatalogName());
+        if (span.isRecording()) {
+            span.setAttribute(TrinoAttributes.TABLE, tableHandle.getConnectorHandle().toString());
+        }
+        try (var ignored = scopedSpan(span)) {
+            return delegate.finishInsert(session, tableHandle, fragments, computedStatistics);
+        }
+    }
+
+    @Override
+    public boolean delegateMaterializedViewRefreshToConnector(Session session, QualifiedObjectName viewName)
+    {
+        Span span = startSpan("delegateMaterializedViewRefreshToConnector", viewName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.delegateMaterializedViewRefreshToConnector(session, viewName);
+        }
+    }
+
+    @Override
+    public ListenableFuture<Void> refreshMaterializedView(Session session, QualifiedObjectName viewName)
+    {
+        Span span = startSpan("refreshMaterializedView", viewName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.refreshMaterializedView(session, viewName);
+        }
+    }
+
+    @Override
+    public InsertTableHandle beginRefreshMaterializedView(Session session, TableHandle tableHandle, List<TableHandle> sourceTableHandles)
+    {
+        Span span = startSpan("beginRefreshMaterializedView", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.beginRefreshMaterializedView(session, tableHandle, sourceTableHandles);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishRefreshMaterializedView(Session session, TableHandle tableHandle, InsertTableHandle insertTableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics, List<TableHandle> sourceTableHandles)
+    {
+        Span span = startSpan("finishRefreshMaterializedView", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.finishRefreshMaterializedView(session, tableHandle, insertTableHandle, fragments, computedStatistics, sourceTableHandles);
+        }
+    }
+
+    @Override
+    public Optional<TableHandle> applyDelete(Session session, TableHandle tableHandle)
+    {
+        Span span = startSpan("applyDelete", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applyDelete(session, tableHandle);
+        }
+    }
+
+    @Override
+    public OptionalLong executeDelete(Session session, TableHandle tableHandle)
+    {
+        Span span = startSpan("executeDelete", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.executeDelete(session, tableHandle);
+        }
+    }
+
+    @Override
+    public RowChangeParadigm getRowChangeParadigm(Session session, TableHandle tableHandle)
+    {
+        Span span = startSpan("getRowChangeParadigm", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getRowChangeParadigm(session, tableHandle);
+        }
+    }
+
+    @Override
+    public ColumnHandle getMergeRowIdColumnHandle(Session session, TableHandle tableHandle)
+    {
+        Span span = startSpan("getMergeRowIdColumnHandle", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getMergeRowIdColumnHandle(session, tableHandle);
+        }
+    }
+
+    @Override
+    public Optional<PartitioningHandle> getUpdateLayout(Session session, TableHandle tableHandle)
+    {
+        Span span = startSpan("getUpdateLayout", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getUpdateLayout(session, tableHandle);
+        }
+    }
+
+    @Override
+    public MergeHandle beginMerge(Session session, TableHandle tableHandle)
+    {
+        Span span = startSpan("beginMerge", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.beginMerge(session, tableHandle);
+        }
+    }
+
+    @Override
+    public void finishMerge(Session session, MergeHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        Span span = startSpan("finishMerge", tableHandle.getTableHandle().getCatalogHandle().getCatalogName());
+        if (span.isRecording()) {
+            span.setAttribute(TrinoAttributes.TABLE, tableHandle.getTableHandle().getConnectorHandle().toString());
+        }
+        try (var ignored = scopedSpan(span)) {
+            delegate.finishMerge(session, tableHandle, fragments, computedStatistics);
+        }
+    }
+
+    @Override
+    public Optional<CatalogHandle> getCatalogHandle(Session session, String catalogName)
+    {
+        Span span = startSpan("getCatalogHandle", catalogName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getCatalogHandle(session, catalogName);
+        }
+    }
+
+    @Override
+    public List<CatalogInfo> listCatalogs(Session session)
+    {
+        Span span = startSpan("listCatalogs");
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listCatalogs(session);
+        }
+    }
+
+    @Override
+    public List<QualifiedObjectName> listViews(Session session, QualifiedTablePrefix prefix)
+    {
+        Span span = startSpan("listViews", prefix);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listViews(session, prefix);
+        }
+    }
+
+    @Override
+    public Map<QualifiedObjectName, ViewInfo> getViews(Session session, QualifiedTablePrefix prefix)
+    {
+        Span span = startSpan("getViews", prefix);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getViews(session, prefix);
+        }
+    }
+
+    @Override
+    public boolean isView(Session session, QualifiedObjectName viewName)
+    {
+        Span span = startSpan("isView", viewName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.isView(session, viewName);
+        }
+    }
+
+    @Override
+    public Optional<ViewDefinition> getView(Session session, QualifiedObjectName viewName)
+    {
+        Span span = startSpan("getView", viewName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getView(session, viewName);
+        }
+    }
+
+    @Override
+    public Map<String, Object> getSchemaProperties(Session session, CatalogSchemaName schemaName)
+    {
+        Span span = startSpan("getSchemaProperties", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getSchemaProperties(session, schemaName);
+        }
+    }
+
+    @Override
+    public Optional<TrinoPrincipal> getSchemaOwner(Session session, CatalogSchemaName schemaName)
+    {
+        Span span = startSpan("getSchemaOwner", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getSchemaOwner(session, schemaName);
+        }
+    }
+
+    @Override
+    public void createView(Session session, QualifiedObjectName viewName, ViewDefinition definition, boolean replace)
+    {
+        Span span = startSpan("createView", viewName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.createView(session, viewName, definition, replace);
+        }
+    }
+
+    @Override
+    public void renameView(Session session, QualifiedObjectName existingViewName, QualifiedObjectName newViewName)
+    {
+        Span span = startSpan("renameView", existingViewName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.renameView(session, existingViewName, newViewName);
+        }
+    }
+
+    @Override
+    public void setViewAuthorization(Session session, CatalogSchemaTableName view, TrinoPrincipal principal)
+    {
+        Span span = startSpan("setViewAuthorization", view);
+        try (var ignored = scopedSpan(span)) {
+            delegate.setViewAuthorization(session, view, principal);
+        }
+    }
+
+    @Override
+    public void dropView(Session session, QualifiedObjectName viewName)
+    {
+        Span span = startSpan("dropView", viewName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.dropView(session, viewName);
+        }
+    }
+
+    @Override
+    public Optional<ResolvedIndex> resolveIndex(Session session, TableHandle tableHandle, Set<ColumnHandle> indexableColumns, Set<ColumnHandle> outputColumns, TupleDomain<ColumnHandle> tupleDomain)
+    {
+        Span span = startSpan("resolveIndex", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.resolveIndex(session, tableHandle, indexableColumns, outputColumns, tupleDomain);
+        }
+    }
+
+    @Override
+    public Optional<LimitApplicationResult<TableHandle>> applyLimit(Session session, TableHandle table, long limit)
+    {
+        Span span = startSpan("applyLimit", table);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applyLimit(session, table, limit);
+        }
+    }
+
+    @Override
+    public Optional<ConstraintApplicationResult<TableHandle>> applyFilter(Session session, TableHandle table, Constraint constraint)
+    {
+        Span span = startSpan("applyFilter", table);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applyFilter(session, table, constraint);
+        }
+    }
+
+    @Override
+    public Optional<ProjectionApplicationResult<TableHandle>> applyProjection(Session session, TableHandle table, List<ConnectorExpression> projections, Map<String, ColumnHandle> assignments)
+    {
+        Span span = startSpan("applyProjection", table);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applyProjection(session, table, projections, assignments);
+        }
+    }
+
+    @Override
+    public Optional<SampleApplicationResult<TableHandle>> applySample(Session session, TableHandle table, SampleType sampleType, double sampleRatio)
+    {
+        Span span = startSpan("applySample", table);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applySample(session, table, sampleType, sampleRatio);
+        }
+    }
+
+    @Override
+    public Optional<AggregationApplicationResult<TableHandle>> applyAggregation(Session session, TableHandle table, List<AggregateFunction> aggregations, Map<String, ColumnHandle> assignments, List<List<ColumnHandle>> groupingSets)
+    {
+        Span span = startSpan("applyAggregation", table);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applyAggregation(session, table, aggregations, assignments, groupingSets);
+        }
+    }
+
+    @Override
+    public Optional<JoinApplicationResult<TableHandle>> applyJoin(Session session, JoinType joinType, TableHandle left, TableHandle right, ConnectorExpression joinCondition, Map<String, ColumnHandle> leftAssignments, Map<String, ColumnHandle> rightAssignments, JoinStatistics statistics)
+    {
+        Span span = startSpan("applyJoin");
+        if (span.isRecording() && left.getCatalogHandle().equals(right.getCatalogHandle())) {
+            span.setAttribute(TrinoAttributes.CATALOG, left.getCatalogHandle().getCatalogName());
+        }
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applyJoin(session, joinType, left, right, joinCondition, leftAssignments, rightAssignments, statistics);
+        }
+    }
+
+    @Override
+    public Optional<TopNApplicationResult<TableHandle>> applyTopN(Session session, TableHandle handle, long topNCount, List<SortItem> sortItems, Map<String, ColumnHandle> assignments)
+    {
+        Span span = startSpan("applyTopN", handle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applyTopN(session, handle, topNCount, sortItems, assignments);
+        }
+    }
+
+    @Override
+    public Optional<TableFunctionApplicationResult<TableHandle>> applyTableFunction(Session session, TableFunctionHandle handle)
+    {
+        Span span = startSpan("applyTableFunction")
+                .setAttribute(TrinoAttributes.CATALOG, handle.getCatalogHandle().getCatalogName())
+                .setAttribute(TrinoAttributes.SCHEMA, handle.getSchemaFunctionName().getSchemaName())
+                .setAttribute(TrinoAttributes.FUNCTION, handle.getSchemaFunctionName().getFunctionName());
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applyTableFunction(session, handle);
+        }
+    }
+
+    @Override
+    public void validateScan(Session session, TableHandle table)
+    {
+        Span span = startSpan("validateScan", table);
+        try (var ignored = scopedSpan(span)) {
+            delegate.validateScan(session, table);
+        }
+    }
+
+    @Override
+    public boolean isCatalogManagedSecurity(Session session, String catalog)
+    {
+        Span span = startSpan("isCatalogManagedSecurity", catalog);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.isCatalogManagedSecurity(session, catalog);
+        }
+    }
+
+    @Override
+    public boolean roleExists(Session session, String role, Optional<String> catalog)
+    {
+        Span span = getStartSpan("roleExists", catalog);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.roleExists(session, role, catalog);
+        }
+    }
+
+    @Override
+    public void createRole(Session session, String role, Optional<TrinoPrincipal> grantor, Optional<String> catalog)
+    {
+        Span span = getStartSpan("createRole", catalog);
+        try (var ignored = scopedSpan(span)) {
+            delegate.createRole(session, role, grantor, catalog);
+        }
+    }
+
+    @Override
+    public void dropRole(Session session, String role, Optional<String> catalog)
+    {
+        Span span = getStartSpan("dropRole", catalog);
+        try (var ignored = scopedSpan(span)) {
+            delegate.dropRole(session, role, catalog);
+        }
+    }
+
+    @Override
+    public Set<String> listRoles(Session session, Optional<String> catalog)
+    {
+        Span span = getStartSpan("listRoles", catalog);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listRoles(session, catalog);
+        }
+    }
+
+    @Override
+    public Set<RoleGrant> listRoleGrants(Session session, Optional<String> catalog, TrinoPrincipal principal)
+    {
+        Span span = getStartSpan("listRoleGrants", catalog);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listRoleGrants(session, catalog, principal);
+        }
+    }
+
+    @Override
+    public void grantRoles(Session session, Set<String> roles, Set<TrinoPrincipal> grantees, boolean adminOption, Optional<TrinoPrincipal> grantor, Optional<String> catalog)
+    {
+        Span span = getStartSpan("grantRoles", catalog);
+        try (var ignored = scopedSpan(span)) {
+            delegate.grantRoles(session, roles, grantees, adminOption, grantor, catalog);
+        }
+    }
+
+    @Override
+    public void revokeRoles(Session session, Set<String> roles, Set<TrinoPrincipal> grantees, boolean adminOption, Optional<TrinoPrincipal> grantor, Optional<String> catalog)
+    {
+        Span span = getStartSpan("revokeRoles", catalog);
+        try (var ignored = scopedSpan(span)) {
+            delegate.revokeRoles(session, roles, grantees, adminOption, grantor, catalog);
+        }
+    }
+
+    @Override
+    public Set<RoleGrant> listApplicableRoles(Session session, TrinoPrincipal principal, Optional<String> catalog)
+    {
+        Span span = getStartSpan("listApplicableRoles", catalog);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listApplicableRoles(session, principal, catalog);
+        }
+    }
+
+    @Override
+    public Set<String> listEnabledRoles(Identity identity)
+    {
+        Span span = startSpan("listEnabledRoles");
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listEnabledRoles(identity);
+        }
+    }
+
+    @Override
+    public Set<String> listEnabledRoles(Session session, String catalog)
+    {
+        Span span = startSpan("listEnabledRoles", catalog);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listEnabledRoles(session, catalog);
+        }
+    }
+
+    @Override
+    public void grantSchemaPrivileges(Session session, CatalogSchemaName schemaName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        Span span = startSpan("grantSchemaPrivileges", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.grantSchemaPrivileges(session, schemaName, privileges, grantee, grantOption);
+        }
+    }
+
+    @Override
+    public void denySchemaPrivileges(Session session, CatalogSchemaName schemaName, Set<Privilege> privileges, TrinoPrincipal grantee)
+    {
+        Span span = startSpan("denySchemaPrivileges", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.denySchemaPrivileges(session, schemaName, privileges, grantee);
+        }
+    }
+
+    @Override
+    public void revokeSchemaPrivileges(Session session, CatalogSchemaName schemaName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        Span span = startSpan("revokeSchemaPrivileges", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.revokeSchemaPrivileges(session, schemaName, privileges, grantee, grantOption);
+        }
+    }
+
+    @Override
+    public void grantTablePrivileges(Session session, QualifiedObjectName tableName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        Span span = startSpan("grantTablePrivileges", tableName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.grantTablePrivileges(session, tableName, privileges, grantee, grantOption);
+        }
+    }
+
+    @Override
+    public void denyTablePrivileges(Session session, QualifiedObjectName tableName, Set<Privilege> privileges, TrinoPrincipal grantee)
+    {
+        Span span = startSpan("denyTablePrivileges", tableName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.denyTablePrivileges(session, tableName, privileges, grantee);
+        }
+    }
+
+    @Override
+    public void revokeTablePrivileges(Session session, QualifiedObjectName tableName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        Span span = startSpan("revokeTablePrivileges", tableName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.revokeTablePrivileges(session, tableName, privileges, grantee, grantOption);
+        }
+    }
+
+    @Override
+    public List<GrantInfo> listTablePrivileges(Session session, QualifiedTablePrefix prefix)
+    {
+        Span span = startSpan("listTablePrivileges", prefix);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listTablePrivileges(session, prefix);
+        }
+    }
+
+    @Override
+    public Collection<FunctionMetadata> listFunctions(Session session)
+    {
+        Span span = startSpan("listFunctions");
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listFunctions(session);
+        }
+    }
+
+    @Override
+    public ResolvedFunction decodeFunction(QualifiedName name)
+    {
+        // no tracing since it doesn't call any connector
+        return delegate.decodeFunction(name);
+    }
+
+    @Override
+    public ResolvedFunction resolveFunction(Session session, QualifiedName name, List<TypeSignatureProvider> parameterTypes)
+    {
+        Span span = startSpan("resolveFunction")
+                .setAllAttributes(attribute(TrinoAttributes.FUNCTION, extractFunctionName(name)));
+        try (var ignored = scopedSpan(span)) {
+            return delegate.resolveFunction(session, name, parameterTypes);
+        }
+    }
+
+    @Override
+    public ResolvedFunction resolveOperator(Session session, OperatorType operatorType, List<? extends Type> argumentTypes)
+            throws OperatorNotFoundException
+    {
+        // no tracing since it doesn't call any connector
+        return delegate.resolveOperator(session, operatorType, argumentTypes);
+    }
+
+    @Override
+    public ResolvedFunction getCoercion(Session session, Type fromType, Type toType)
+    {
+        // no tracing since it doesn't call any connector
+        return delegate.getCoercion(session, fromType, toType);
+    }
+
+    @Override
+    public ResolvedFunction getCoercion(Session session, OperatorType operatorType, Type fromType, Type toType)
+    {
+        // no tracing since it doesn't call any connector
+        return delegate.getCoercion(session, operatorType, fromType, toType);
+    }
+
+    @Override
+    public ResolvedFunction getCoercion(Session session, QualifiedName name, Type fromType, Type toType)
+    {
+        // no tracing since it doesn't call any connector
+        return delegate.getCoercion(session, name, fromType, toType);
+    }
+
+    @Override
+    public boolean isAggregationFunction(Session session, QualifiedName name)
+    {
+        Span span = startSpan("isAggregationFunction")
+                .setAllAttributes(attribute(TrinoAttributes.FUNCTION, extractFunctionName(name)));
+        try (var ignored = scopedSpan(span)) {
+            return delegate.isAggregationFunction(session, name);
+        }
+    }
+
+    @Override
+    public FunctionMetadata getFunctionMetadata(Session session, ResolvedFunction resolvedFunction)
+    {
+        Span span = startSpan("getFunctionMetadata")
+                .setAttribute(TrinoAttributes.CATALOG, resolvedFunction.getCatalogHandle().getCatalogName())
+                .setAttribute(TrinoAttributes.FUNCTION, resolvedFunction.getSignature().getName());
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getFunctionMetadata(session, resolvedFunction);
+        }
+    }
+
+    @Override
+    public AggregationFunctionMetadata getAggregationFunctionMetadata(Session session, ResolvedFunction resolvedFunction)
+    {
+        Span span = startSpan("getAggregationFunctionMetadata")
+                .setAttribute(TrinoAttributes.CATALOG, resolvedFunction.getCatalogHandle().getCatalogName())
+                .setAttribute(TrinoAttributes.FUNCTION, resolvedFunction.getSignature().getName());
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getAggregationFunctionMetadata(session, resolvedFunction);
+        }
+    }
+
+    @Override
+    public void createMaterializedView(Session session, QualifiedObjectName viewName, MaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
+    {
+        Span span = startSpan("createMaterializedView", viewName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.createMaterializedView(session, viewName, definition, replace, ignoreExisting);
+        }
+    }
+
+    @Override
+    public void dropMaterializedView(Session session, QualifiedObjectName viewName)
+    {
+        Span span = startSpan("dropMaterializedView", viewName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.dropMaterializedView(session, viewName);
+        }
+    }
+
+    @Override
+    public List<QualifiedObjectName> listMaterializedViews(Session session, QualifiedTablePrefix prefix)
+    {
+        Span span = startSpan("listMaterializedViews", prefix);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listMaterializedViews(session, prefix);
+        }
+    }
+
+    @Override
+    public Map<QualifiedObjectName, ViewInfo> getMaterializedViews(Session session, QualifiedTablePrefix prefix)
+    {
+        Span span = startSpan("getMaterializedViews", prefix);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getMaterializedViews(session, prefix);
+        }
+    }
+
+    @Override
+    public boolean isMaterializedView(Session session, QualifiedObjectName viewName)
+    {
+        Span span = startSpan("isMaterializedView", viewName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.isMaterializedView(session, viewName);
+        }
+    }
+
+    @Override
+    public Optional<MaterializedViewDefinition> getMaterializedView(Session session, QualifiedObjectName viewName)
+    {
+        Span span = startSpan("getMaterializedView", viewName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getMaterializedView(session, viewName);
+        }
+    }
+
+    @Override
+    public MaterializedViewFreshness getMaterializedViewFreshness(Session session, QualifiedObjectName name)
+    {
+        Span span = startSpan("getMaterializedViewFreshness", name);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getMaterializedViewFreshness(session, name);
+        }
+    }
+
+    @Override
+    public void renameMaterializedView(Session session, QualifiedObjectName existingViewName, QualifiedObjectName newViewName)
+    {
+        Span span = startSpan("renameMaterializedView", existingViewName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.renameMaterializedView(session, existingViewName, newViewName);
+        }
+    }
+
+    @Override
+    public void setMaterializedViewProperties(Session session, QualifiedObjectName viewName, Map<String, Optional<Object>> properties)
+    {
+        Span span = startSpan("setMaterializedViewProperties", viewName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.setMaterializedViewProperties(session, viewName, properties);
+        }
+    }
+
+    @Override
+    public Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(Session session, TableHandle tableHandle)
+    {
+        Span span = startSpan("applyTableScanRedirect", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applyTableScanRedirect(session, tableHandle);
+        }
+    }
+
+    @Override
+    public RedirectionAwareTableHandle getRedirectionAwareTableHandle(Session session, QualifiedObjectName tableName)
+    {
+        Span span = startSpan("getRedirectionAwareTableHandle", tableName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getRedirectionAwareTableHandle(session, tableName);
+        }
+    }
+
+    @Override
+    public RedirectionAwareTableHandle getRedirectionAwareTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion)
+    {
+        Span span = startSpan("getRedirectionAwareTableHandle", tableName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getRedirectionAwareTableHandle(session, tableName, startVersion, endVersion);
+        }
+    }
+
+    @Override
+    public boolean supportsReportingWrittenBytes(Session session, TableHandle tableHandle)
+    {
+        Span span = startSpan("supportsReportingWrittenBytes", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.supportsReportingWrittenBytes(session, tableHandle);
+        }
+    }
+
+    @Override
+    public boolean supportsReportingWrittenBytes(Session session, QualifiedObjectName tableName, Map<String, Object> tableProperties)
+    {
+        Span span = startSpan("supportsReportingWrittenBytes", tableName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.supportsReportingWrittenBytes(session, tableName, tableProperties);
+        }
+    }
+
+    @Override
+    public Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion)
+    {
+        Span span = startSpan("getTableHandle", tableName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getTableHandle(session, tableName, startVersion, endVersion);
+        }
+    }
+
+    @Override
+    public OptionalInt getMaxWriterTasks(Session session, String catalogName)
+    {
+        Span span = startSpan("getMaxWriterTasks", catalogName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getMaxWriterTasks(session, catalogName);
+        }
+    }
+
+    private Span startSpan(String methodName)
+    {
+        return tracer.spanBuilder("Metadata." + methodName).startSpan();
+    }
+
+    private Span startSpan(String methodName, String catalogName)
+    {
+        return startSpan(methodName)
+                .setAttribute(TrinoAttributes.CATALOG, catalogName);
+    }
+
+    private Span getStartSpan(String methodName, Optional<String> catalog)
+    {
+        return startSpan(methodName)
+                .setAllAttributes(attribute(TrinoAttributes.CATALOG, catalog));
+    }
+
+    private Span startSpan(String methodName, CatalogSchemaName schema)
+    {
+        return startSpan(methodName)
+                .setAttribute(TrinoAttributes.CATALOG, schema.getCatalogName())
+                .setAttribute(TrinoAttributes.SCHEMA, schema.getSchemaName());
+    }
+
+    private Span startSpan(String methodName, QualifiedObjectName table)
+    {
+        return startSpan(methodName)
+                .setAttribute(TrinoAttributes.CATALOG, table.getCatalogName())
+                .setAttribute(TrinoAttributes.SCHEMA, table.getSchemaName())
+                .setAttribute(TrinoAttributes.TABLE, table.getObjectName());
+    }
+
+    private Span startSpan(String methodName, CatalogSchemaTableName table)
+    {
+        return startSpan(methodName)
+                .setAttribute(TrinoAttributes.CATALOG, table.getCatalogName())
+                .setAttribute(TrinoAttributes.SCHEMA, table.getSchemaTableName().getSchemaName())
+                .setAttribute(TrinoAttributes.TABLE, table.getSchemaTableName().getTableName());
+    }
+
+    private Span startSpan(String methodName, QualifiedTablePrefix prefix)
+    {
+        return startSpan(methodName)
+                .setAttribute(TrinoAttributes.CATALOG, prefix.getCatalogName())
+                .setAllAttributes(attribute(TrinoAttributes.SCHEMA, prefix.getSchemaName()))
+                .setAllAttributes(attribute(TrinoAttributes.TABLE, prefix.getTableName()));
+    }
+
+    private Span startSpan(String methodName, String catalogName, ConnectorTableMetadata tableMetadata)
+    {
+        return startSpan(methodName)
+                .setAttribute(TrinoAttributes.CATALOG, catalogName)
+                .setAttribute(TrinoAttributes.SCHEMA, tableMetadata.getTable().getSchemaName())
+                .setAttribute(TrinoAttributes.TABLE, tableMetadata.getTable().getTableName());
+    }
+
+    private Span startSpan(String methodName, TableHandle handle)
+    {
+        Span span = startSpan(methodName);
+        if (span.isRecording()) {
+            span.setAttribute(TrinoAttributes.CATALOG, handle.getCatalogHandle().getCatalogName());
+            span.setAttribute(TrinoAttributes.HANDLE, handle.getConnectorHandle().toString());
+        }
+        return span;
+    }
+
+    private Span startSpan(String methodName, TableExecuteHandle handle)
+    {
+        Span span = startSpan(methodName);
+        if (span.isRecording()) {
+            span.setAttribute(TrinoAttributes.CATALOG, handle.getCatalogHandle().getCatalogName());
+            span.setAttribute(TrinoAttributes.HANDLE, handle.getConnectorHandle().toString());
+        }
+        return span;
+    }
+
+    private static Optional<String> extractFunctionName(QualifiedName name)
+    {
+        try {
+            return Optional.of(ResolvedFunction.extractFunctionName(name));
+        }
+        catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/tracing/TrinoAttributes.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TrinoAttributes.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tracing;
+
+import io.opentelemetry.api.common.AttributeKey;
+
+import java.util.List;
+
+import static io.opentelemetry.api.common.AttributeKey.booleanKey;
+import static io.opentelemetry.api.common.AttributeKey.longKey;
+import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+public final class TrinoAttributes
+{
+    private TrinoAttributes() {}
+
+    public static final AttributeKey<String> QUERY_ID = stringKey("trino.query_id");
+    public static final AttributeKey<String> STAGE_ID = stringKey("trino.stage_id");
+    public static final AttributeKey<String> TASK_ID = stringKey("trino.task_id");
+    public static final AttributeKey<String> PIPELINE_ID = stringKey("trino.pipeline_id");
+    public static final AttributeKey<String> SPLIT_ID = stringKey("trino.split_id");
+
+    public static final AttributeKey<String> QUERY_TYPE = stringKey("trino.query_type");
+
+    public static final AttributeKey<Long> ERROR_CODE = longKey("trino.error_code");
+    public static final AttributeKey<String> ERROR_NAME = stringKey("trino.error_name");
+    public static final AttributeKey<String> ERROR_TYPE = stringKey("trino.error_type");
+
+    public static final AttributeKey<String> CATALOG = stringKey("trino.catalog");
+    public static final AttributeKey<String> SCHEMA = stringKey("trino.schema");
+    public static final AttributeKey<String> TABLE = stringKey("trino.table");
+
+    public static final AttributeKey<String> OPTIMIZER_NAME = stringKey("trino.optimizer");
+    public static final AttributeKey<List<String>> OPTIMIZER_RULES = stringArrayKey("trino.optimizer.rules");
+
+    public static final AttributeKey<Long> SPLIT_BATCH_MAX_SIZE = longKey("trino.split_batch.max_size");
+    public static final AttributeKey<Long> SPLIT_BATCH_RESULT_SIZE = longKey("trino.split_batch.result_size");
+
+    public static final AttributeKey<Long> SPLIT_SCHEDULED_TIME_NANOS = longKey("trino.split.scheduled_time_nanos");
+    public static final AttributeKey<Long> SPLIT_CPU_TIME_NANOS = longKey("trino.split.cpu_time_nanos");
+    public static final AttributeKey<Long> SPLIT_WAIT_TIME_NANOS = longKey("trino.split.wait_time_nanos");
+    public static final AttributeKey<Boolean> SPLIT_BLOCKED = booleanKey("trino.split.blocked");
+
+    public static final AttributeKey<String> EVENT_STATE = stringKey("state");
+}

--- a/core/trino-main/src/main/java/io/trino/tracing/TrinoAttributes.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TrinoAttributes.java
@@ -41,6 +41,9 @@ public final class TrinoAttributes
     public static final AttributeKey<String> CATALOG = stringKey("trino.catalog");
     public static final AttributeKey<String> SCHEMA = stringKey("trino.schema");
     public static final AttributeKey<String> TABLE = stringKey("trino.table");
+    public static final AttributeKey<String> PROCEDURE = stringKey("trino.procedure");
+    public static final AttributeKey<String> FUNCTION = stringKey("trino.function");
+    public static final AttributeKey<String> HANDLE = stringKey("trino.handle");
 
     public static final AttributeKey<String> OPTIMIZER_NAME = stringKey("trino.optimizer");
     public static final AttributeKey<List<String>> OPTIMIZER_RULES = stringArrayKey("trino.optimizer.rules");

--- a/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
@@ -24,6 +24,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.stats.TestingGcMonitor;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.cost.StatsAndCosts;
 import io.trino.exchange.ExchangeManagerRegistry;
@@ -127,12 +128,24 @@ public class MockRemoteTaskFactory
         for (Split sourceSplit : splits) {
             initialSplits.put(sourceId, sourceSplit);
         }
-        return createRemoteTask(TEST_SESSION, taskId, newNode, testFragment, initialSplits.build(), PipelinedOutputBuffers.createInitial(BROADCAST), partitionedSplitCountTracker, ImmutableSet.of(), Optional.empty(), true);
+        return createRemoteTask(
+                TEST_SESSION,
+                Span.getInvalid(),
+                taskId,
+                newNode,
+                testFragment,
+                initialSplits.build(),
+                PipelinedOutputBuffers.createInitial(BROADCAST),
+                partitionedSplitCountTracker,
+                ImmutableSet.of(),
+                Optional.empty(),
+                true);
     }
 
     @Override
     public MockRemoteTask createRemoteTask(
             Session session,
+            Span stageSpan,
             TaskId taskId,
             InternalNode node,
             PlanFragment fragment,

--- a/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
@@ -16,6 +16,7 @@ package io.trino.execution;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.json.ObjectMapperProvider;
+import io.opentelemetry.api.trace.Span;
 import io.trino.client.NodeVersion;
 import io.trino.connector.CatalogServiceProvider;
 import io.trino.cost.StatsAndCosts;
@@ -182,7 +183,7 @@ public final class TaskTestUtils
 
     public static TaskInfo updateTask(SqlTask sqlTask, List<SplitAssignment> splitAssignments, OutputBuffers outputBuffers)
     {
-        return sqlTask.updateTask(TEST_SESSION, Optional.of(PLAN_FRAGMENT), splitAssignments, outputBuffers, ImmutableMap.of());
+        return sqlTask.updateTask(TEST_SESSION, Span.getInvalid(), Optional.of(PLAN_FRAGMENT), splitAssignments, outputBuffers, ImmutableMap.of());
     }
 
     public static SplitMonitor createTestSplitMonitor()

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateMaterializedViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateMaterializedViewTask.java
@@ -148,7 +148,8 @@ public class TestCreateMaterializedViewTask
                 new AllowAllAccessControl(),
                 queryRunner.getTablePropertyManager(),
                 queryRunner.getAnalyzePropertyManager()),
-                new StatementRewrite(ImmutableSet.of()));
+                new StatementRewrite(ImmutableSet.of()),
+                plannerContext.getTracer());
         queryStateMachine = stateMachine(transactionManager, createTestMetadataManager(), new AllowAllAccessControl());
     }
 
@@ -276,7 +277,7 @@ public class TestCreateMaterializedViewTask
                 accessControl,
                 new TablePropertyManager(CatalogServiceProvider.fail()),
                 new AnalyzePropertyManager(CatalogServiceProvider.fail()));
-        AnalyzerFactory analyzerFactory = new AnalyzerFactory(statementAnalyzerFactory, new StatementRewrite(ImmutableSet.of()));
+        AnalyzerFactory analyzerFactory = new AnalyzerFactory(statementAnalyzerFactory, new StatementRewrite(ImmutableSet.of()), plannerContext.getTracer());
         assertThatThrownBy(() -> getFutureValue(new CreateMaterializedViewTask(plannerContext, accessControl, parser, analyzerFactory, materializedViewPropertyManager)
                 .execute(statement, queryStateMachine, ImmutableList.of(), WarningCollector.NOOP)))
                 .isInstanceOf(AccessDeniedException.class)

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateViewTask.java
@@ -63,7 +63,8 @@ public class TestCreateViewTask
                         new AllowAllAccessControl(),
                         new TablePropertyManager(CatalogServiceProvider.fail()),
                         new AnalyzePropertyManager(CatalogServiceProvider.fail())),
-                new StatementRewrite(ImmutableSet.of()));
+                new StatementRewrite(ImmutableSet.of()),
+                plannerContext.getTracer());
         QualifiedObjectName tableName = qualifiedObjectName("mock_table");
         metadata.createTable(testSession, CATALOG_NAME, someTable(tableName), false);
     }

--- a/core/trino-main/src/test/java/io/trino/execution/TestMemoryRevokingScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestMemoryRevokingScheduler.java
@@ -50,6 +50,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.airlift.concurrent.Threads.threadsNamed;
+import static io.airlift.tracing.Tracing.noopTracer;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.execution.SqlTask.createSqlTask;
@@ -98,6 +99,7 @@ public class TestMemoryRevokingScheduler
                 taskExecutor,
                 planner,
                 createTestSplitMonitor(),
+                noopTracer(),
                 new TaskManagerConfig());
 
         allOperatorContexts = null;
@@ -267,6 +269,7 @@ public class TestMemoryRevokingScheduler
                 location,
                 "fake",
                 queryContext,
+                noopTracer(),
                 sqlTaskExecutionFactory,
                 executor,
                 sqlTask -> {},

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryInfo.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryInfo.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.execution.QueryState.FINISHED;
+import static io.trino.tracing.TracingJsonCodec.tracingJsonCodecFactory;
 import static org.testng.Assert.assertEquals;
 
 public class TestQueryInfo
@@ -42,7 +43,7 @@ public class TestQueryInfo
     @Test
     public void testQueryInfoRoundTrip()
     {
-        JsonCodec<QueryInfo> codec = JsonCodec.jsonCodec(QueryInfo.class);
+        JsonCodec<QueryInfo> codec = tracingJsonCodecFactory().jsonCodec(QueryInfo.class);
         QueryInfo expected = createQueryInfo();
         QueryInfo actual = codec.fromJson(codec.toJsonBytes(expected));
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlStage.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlStage.java
@@ -53,6 +53,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.tracing.Tracing.noopTracer;
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.execution.SqlStage.createSqlStage;
 import static io.trino.execution.buffer.PipelinedOutputBuffers.BufferType.ARBITRARY;
@@ -117,6 +118,7 @@ public class TestSqlStage
                 true,
                 nodeTaskMap,
                 executor,
+                noopTracer(),
                 new SplitSchedulerStats());
 
         // add listener that fetches stage info when the final status is available

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
@@ -24,6 +24,7 @@ import io.airlift.slice.Slice;
 import io.airlift.stats.TestingGcMonitor;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.trace.Span;
 import io.trino.execution.buffer.BufferResult;
 import io.trino.execution.buffer.BufferState;
 import io.trino.execution.buffer.OutputBuffer;
@@ -66,6 +67,7 @@ import java.util.function.Supplier;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.concurrent.Threads.threadsNamed;
 import static io.airlift.slice.SizeOf.instanceSize;
+import static io.airlift.tracing.Tracing.noopTracer;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.SessionTestUtils.TEST_SESSION;
@@ -136,10 +138,12 @@ public class TestSqlTaskExecution
             SqlTaskExecution sqlTaskExecution = new SqlTaskExecution(
                     taskStateMachine,
                     taskContext,
+                    Span.getInvalid(),
                     outputBuffer,
                     localExecutionPlan,
                     taskExecutor,
                     createTestSplitMonitor(),
+                    noopTracer(),
                     taskNotificationExecutor);
             sqlTaskExecution.start();
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestStageStateMachine.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestStageStateMachine.java
@@ -15,6 +15,7 @@ package io.trino.execution;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.api.trace.Span;
 import io.trino.cost.StatsAndCosts;
 import io.trino.execution.scheduler.SplitSchedulerStats;
 import io.trino.sql.planner.Partitioning;
@@ -35,6 +36,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.tracing.Tracing.noopTracer;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
@@ -236,7 +238,14 @@ public class TestStageStateMachine
 
     private StageStateMachine createStageStateMachine()
     {
-        return new StageStateMachine(STAGE_ID, PLAN_FRAGMENT, ImmutableMap.of(), executor, new SplitSchedulerStats());
+        return new StageStateMachine(
+                STAGE_ID,
+                PLAN_FRAGMENT,
+                ImmutableMap.of(),
+                executor,
+                noopTracer(),
+                Span.getInvalid(),
+                new SplitSchedulerStats());
     }
 
     private static PlanFragment createValuesPlan()

--- a/core/trino-main/src/test/java/io/trino/execution/TestingRemoteTaskFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestingRemoteTaskFactory.java
@@ -23,6 +23,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.stats.TDigest;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.execution.NodeTaskMap.PartitionedSplitCountTracker;
 import io.trino.execution.StateMachine.StateChangeListener;
@@ -71,6 +72,7 @@ public class TestingRemoteTaskFactory
     @Override
     public synchronized RemoteTask createRemoteTask(
             Session session,
+            Span stageSpan,
             TaskId taskId,
             InternalNode node,
             PlanFragment fragment,

--- a/core/trino-main/src/test/java/io/trino/execution/executor/SimulationSplit.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/SimulationSplit.java
@@ -16,6 +16,7 @@ package io.trino.execution.executor;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.trace.Span;
 import io.trino.execution.SplitRunner;
 
 import java.util.concurrent.RejectedExecutionException;
@@ -109,6 +110,18 @@ abstract class SimulationSplit
         waitNanos.addAndGet(System.nanoTime() - lastReadyTime.get());
         killed.set(true);
         task.setKilled();
+    }
+
+    @Override
+    public int getPipelineId()
+    {
+        return 0;
+    }
+
+    @Override
+    public Span getPipelineSpan()
+    {
+        return Span.getInvalid();
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/execution/executor/TestTaskExecutor.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/TestTaskExecutor.java
@@ -19,6 +19,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.testing.TestingTicker;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.trace.Span;
 import io.trino.execution.SplitRunner;
 import io.trino.execution.StageId;
 import io.trino.execution.TaskId;
@@ -625,6 +626,18 @@ public class TestTaskExecutor
         public String getInfo()
         {
             return "testing-split";
+        }
+
+        @Override
+        public int getPipelineId()
+        {
+            return 0;
+        }
+
+        @Override
+        public Span getPipelineSpan()
+        {
+            return Span.getInvalid();
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestScaledWriterScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestScaledWriterScheduler.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.trace.Span;
 import io.trino.client.NodeVersion;
 import io.trino.cost.StatsAndCosts;
 import io.trino.execution.ExecutionFailureInfo;
@@ -280,6 +281,12 @@ public class TestScaledWriterScheduler
 
         @Override
         public int getAttemptId()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Span getStageSpan()
         {
             throw new UnsupportedOperationException();
         }

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -80,6 +80,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.tracing.Tracing.noopTracer;
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.execution.scheduler.NodeSchedulerConfig.SplitsBalancingPolicy.NODE;
 import static io.trino.execution.scheduler.NodeSchedulerConfig.SplitsBalancingPolicy.STAGE;
@@ -757,6 +758,7 @@ public class TestSourcePartitionedScheduler
                 true,
                 nodeTaskMap,
                 queryExecutor,
+                noopTracer(),
                 new SplitSchedulerStats());
         ImmutableMap.Builder<PlanFragmentId, PipelinedOutputBufferManager> outputBuffers = ImmutableMap.builder();
         outputBuffers.put(fragment.getId(), new PartitionedPipelinedOutputBufferManager(FIXED_HASH_DISTRIBUTION, 1));

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/policy/TestPhasedExecutionSchedule.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/policy/TestPhasedExecutionSchedule.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.graph.EndpointPair;
 import com.google.common.graph.Graph;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.opentelemetry.api.trace.Span;
 import io.trino.execution.DynamicFilterConfig;
 import io.trino.execution.ExecutionFailureInfo;
 import io.trino.execution.RemoteTask;
@@ -330,6 +331,12 @@ public class TestPhasedExecutionSchedule
 
         @Override
         public int getAttemptId()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Span getStageSpan()
         {
             throw new UnsupportedOperationException();
         }

--- a/core/trino-main/src/test/java/io/trino/server/TestQueryResource.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestQueryResource.java
@@ -41,7 +41,6 @@ import static io.airlift.http.client.Request.Builder.preparePut;
 import static io.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
 import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
 import static io.airlift.json.JsonCodec.jsonCodec;
-import static io.airlift.json.JsonCodec.listJsonCodec;
 import static io.airlift.testing.Closeables.closeAll;
 import static io.trino.client.ProtocolHeaders.TRINO_HEADERS;
 import static io.trino.execution.QueryState.FAILED;
@@ -54,6 +53,7 @@ import static io.trino.spi.StandardErrorCode.USER_CANCELED;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.KILL_QUERY;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.VIEW_QUERY;
 import static io.trino.testing.TestingAccessControlManager.privilege;
+import static io.trino.tracing.TracingJsonCodec.tracingJsonCodecFactory;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -66,6 +66,8 @@ import static org.testng.Assert.fail;
 @Test(singleThreaded = true)
 public class TestQueryResource
 {
+    private static final JsonCodec<List<BasicQueryInfo>> BASIC_QUERY_INFO_CODEC = tracingJsonCodecFactory().listJsonCodec(BasicQueryInfo.class);
+
     private HttpClient client;
     private TestingTrinoServer server;
 
@@ -286,7 +288,7 @@ public class TestQueryResource
                 .setUri(server.resolve(path))
                 .setHeader(TRINO_HEADERS.requestUser(), "unknown")
                 .build();
-        return client.execute(request, createJsonResponseHandler(listJsonCodec(BasicQueryInfo.class)));
+        return client.execute(request, createJsonResponseHandler(BASIC_QUERY_INFO_CODEC));
     }
 
     private static void assertStateCounts(Iterable<BasicQueryInfo> infos, int expectedFinished, int expectedFailed, int expectedRunning)

--- a/core/trino-main/src/test/java/io/trino/server/TestQuerySessionSupplier.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestQuerySessionSupplier.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
 import io.airlift.jaxrs.testing.GuavaMultivaluedMap;
+import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.SessionPropertyManager;
@@ -79,7 +80,7 @@ public class TestQuerySessionSupplier
     {
         SessionContext context = SESSION_CONTEXT_FACTORY.createSessionContext(TEST_HEADERS, Optional.empty(), Optional.of("testRemote"), Optional.empty());
         QuerySessionSupplier sessionSupplier = createSessionSupplier(new SqlEnvironmentConfig());
-        Session session = sessionSupplier.createSession(new QueryId("test_query_id"), context);
+        Session session = sessionSupplier.createSession(new QueryId("test_query_id"), Span.getInvalid(), context);
 
         assertEquals(session.getQueryId(), new QueryId("test_query_id"));
         assertEquals(session.getUser(), "testUser");
@@ -142,7 +143,7 @@ public class TestQuerySessionSupplier
                 .build());
         SessionContext context = SESSION_CONTEXT_FACTORY.createSessionContext(headers, Optional.empty(), Optional.of("remoteAddress"), Optional.empty());
         QuerySessionSupplier sessionSupplier = createSessionSupplier(new SqlEnvironmentConfig());
-        assertThatThrownBy(() -> sessionSupplier.createSession(new QueryId("test_query_id"), context))
+        assertThatThrownBy(() -> sessionSupplier.createSession(new QueryId("test_query_id"), Span.getInvalid(), context))
                 .isInstanceOf(TrinoException.class)
                 .hasMessage("Time zone not supported: unknown_timezone");
     }
@@ -237,7 +238,7 @@ public class TestQuerySessionSupplier
         MultivaluedMap<String, String> headerMap = new GuavaMultivaluedMap<>(headers);
         SessionContext context = SESSION_CONTEXT_FACTORY.createSessionContext(headerMap, Optional.empty(), Optional.of("testRemote"), Optional.empty());
         QuerySessionSupplier sessionSupplier = createSessionSupplier(config);
-        return sessionSupplier.createSession(new QueryId("test_query_id"), context);
+        return sessionSupplier.createSession(new QueryId("test_query_id"), Span.getInvalid(), context);
     }
 
     private static QuerySessionSupplier createSessionSupplier(SqlEnvironmentConfig config)

--- a/core/trino-main/src/test/java/io/trino/server/TestQueryStateInfoResource.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestQueryStateInfoResource.java
@@ -44,6 +44,7 @@ import static io.trino.execution.QueryState.FAILED;
 import static io.trino.execution.QueryState.RUNNING;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.VIEW_QUERY;
 import static io.trino.testing.TestingAccessControlManager.privilege;
+import static io.trino.tracing.TracingJsonCodec.tracingJsonCodecFactory;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -57,6 +58,7 @@ public class TestQueryStateInfoResource
 {
     private static final String LONG_LASTING_QUERY = "SELECT * FROM tpch.sf1.lineitem";
     private static final JsonCodec<QueryResults> QUERY_RESULTS_JSON_CODEC = jsonCodec(QueryResults.class);
+    private static final JsonCodec<List<BasicQueryInfo>> BASIC_QUERY_INFO_CODEC = tracingJsonCodecFactory().listJsonCodec(BasicQueryInfo.class);
 
     private TestingTrinoServer server;
     private HttpClient client;
@@ -94,7 +96,7 @@ public class TestQueryStateInfoResource
                             .setUri(uriBuilderFrom(server.getBaseUrl()).replacePath("/v1/query").build())
                             .setHeader(TRINO_HEADERS.requestUser(), "unknown")
                             .build(),
-                    createJsonResponseHandler(listJsonCodec(BasicQueryInfo.class)));
+                    createJsonResponseHandler(BASIC_QUERY_INFO_CODEC));
             if (queryInfos.size() == 2) {
                 if (queryInfos.stream().allMatch(info -> info.getState() == RUNNING)) {
                     break;

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -7058,7 +7058,7 @@ public class TestAnalyzer
                 tablePropertyManager,
                 analyzePropertyManager,
                 new TableProceduresPropertyManager(CatalogServiceProvider.fail("procedures are not supported in testing analyzer")));
-        AnalyzerFactory analyzerFactory = new AnalyzerFactory(statementAnalyzerFactory, statementRewrite);
+        AnalyzerFactory analyzerFactory = new AnalyzerFactory(statementAnalyzerFactory, statementRewrite, plannerContext.getTracer());
         return analyzerFactory.createAnalyzer(
                 session,
                 emptyList(),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestingPlannerContext.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestingPlannerContext.java
@@ -46,6 +46,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.tracing.Tracing.noopTracer;
 import static io.trino.client.NodeVersion.UNKNOWN;
 import static java.util.Objects.requireNonNull;
 
@@ -144,7 +145,8 @@ public final class TestingPlannerContext
                     typeOperators,
                     blockEncodingSerde,
                     typeManager,
-                    functionManager);
+                    functionManager,
+                    noopTracer());
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/tracing/TestTracingConnectorMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/tracing/TestTracingConnectorMetadata.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tracing;
+
+import io.trino.spi.connector.ConnectorMetadata;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
+
+public class TestTracingConnectorMetadata
+{
+    @Test
+    public void testEverythingImplemented()
+    {
+        assertAllMethodsOverridden(ConnectorMetadata.class, TracingConnectorMetadata.class);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/tracing/TestTracingMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/tracing/TestTracingMetadata.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tracing;
+
+import io.trino.metadata.Metadata;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
+
+public class TestTracingMetadata
+{
+    @Test
+    public void testEverythingImplemented()
+    {
+        assertAllMethodsOverridden(Metadata.class, TracingMetadata.class);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/tracing/TracingJsonCodec.java
+++ b/core/trino-main/src/test/java/io/trino/tracing/TracingJsonCodec.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tracing;
+
+import io.airlift.json.JsonCodecFactory;
+import io.airlift.json.ObjectMapperProvider;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+
+import java.util.Map;
+
+import static io.airlift.tracing.SpanSerialization.SpanDeserializer;
+import static io.airlift.tracing.SpanSerialization.SpanSerializer;
+
+public final class TracingJsonCodec
+{
+    private TracingJsonCodec() {}
+
+    public static JsonCodecFactory tracingJsonCodecFactory()
+    {
+        return new JsonCodecFactory(tracingObjectMapperProvider());
+    }
+
+    public static ObjectMapperProvider tracingObjectMapperProvider()
+    {
+        return new ObjectMapperProvider()
+                .withJsonSerializers(Map.of(Span.class, new SpanSerializer(OpenTelemetry.noop())))
+                .withJsonDeserializers(Map.of(Span.class, new SpanDeserializer(OpenTelemetry.noop())));
+    }
+}

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -36,7 +36,17 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- used by slice and must be listed for plugin dependency enforcer -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
@@ -240,6 +250,12 @@
                                     <old>method void io.trino.spi.connector.ConnectorTableProperties::&lt;init&gt;(io.trino.spi.predicate.TupleDomain&lt;io.trino.spi.connector.ColumnHandle&gt;, java.util.Optional&lt;io.trino.spi.connector.ConnectorTablePartitioning&gt;, java.util.Optional&lt;java.util.Set&lt;io.trino.spi.connector.ColumnHandle&gt;&gt;, java.util.Optional&lt;io.trino.spi.connector.DiscretePredicates&gt;, java.util.List&lt;io.trino.spi.connector.LocalProperty&lt;io.trino.spi.connector.ColumnHandle&gt;&gt;)</old>
                                     <new>method void io.trino.spi.connector.ConnectorTableProperties::&lt;init&gt;(io.trino.spi.predicate.TupleDomain&lt;io.trino.spi.connector.ColumnHandle&gt;, java.util.Optional&lt;io.trino.spi.connector.ConnectorTablePartitioning&gt;, java.util.Optional&lt;io.trino.spi.connector.DiscretePredicates&gt;, java.util.List&lt;io.trino.spi.connector.LocalProperty&lt;io.trino.spi.connector.ColumnHandle&gt;&gt;)</new>
                                     <justification>Replaced with the ConnectorTablePartitioning#singleSplitPerPartition. Soft migration is not straightforward.</justification>
+                                </item>
+                                <item>
+                                    <regex>true</regex>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <newArchive>io.opentelemetry:opentelemetry-(api|context):.*</newArchive>
+                                    <justification>Trino SPI depends on OpenTelemetry</justification>
                                 </item>
                             </differences>
                         </revapi.differences>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorContext.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorContext.java
@@ -13,6 +13,8 @@
  */
 package io.trino.spi.connector;
 
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
 import io.trino.spi.NodeManager;
 import io.trino.spi.PageIndexerFactory;
 import io.trino.spi.PageSorter;
@@ -22,6 +24,16 @@ import io.trino.spi.type.TypeManager;
 public interface ConnectorContext
 {
     default CatalogHandle getCatalogHandle()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    default OpenTelemetry getOpenTelemetry()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    default Tracer getTracer()
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-spi/src/test/java/io/trino/spi/testing/InterfaceTestUtils.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/testing/InterfaceTestUtils.java
@@ -26,8 +26,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Sets.difference;
 import static com.google.common.reflect.Reflection.newProxy;
 import static java.lang.String.format;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
 
 public final class InterfaceTestUtils
 {
@@ -86,7 +86,7 @@ public final class InterfaceTestUtils
             }
             C forwardingInstance = forwardingInstanceFactory.apply(
                     newProxy(iface, (proxy, expectedMethod, expectedArguments) -> {
-                        assertEquals(actualMethod.getName(), expectedMethod.getName());
+                        assertThat(actualMethod.getName()).isEqualTo(expectedMethod.getName());
                         // TODO assert arguments
 
                         if (actualMethod.getReturnType().isPrimitive()) {

--- a/lib/trino-filesystem/pom.xml
+++ b/lib/trino-filesystem/pom.xml
@@ -37,6 +37,21 @@
             <artifactId>guava</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+        </dependency>
+
         <!-- used by tests but also needed transitively -->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -45,6 +60,13 @@
         </dependency>
 
         <!-- for testing -->
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/FileSystemAttributes.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/FileSystemAttributes.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.tracing;
+
+import io.opentelemetry.api.common.AttributeKey;
+
+import static io.opentelemetry.api.common.AttributeKey.longKey;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+public final class FileSystemAttributes
+{
+    private FileSystemAttributes() {}
+
+    public static final AttributeKey<String> FILE_LOCATION = stringKey("trino.file.location");
+    public static final AttributeKey<Long> FILE_SIZE = longKey("trino.file.size");
+    public static final AttributeKey<Long> FILE_LOCATION_COUNT = longKey("trino.file.location_count");
+    public static final AttributeKey<Long> FILE_READ_SIZE = longKey("trino.file.read_size");
+    public static final AttributeKey<Long> FILE_READ_POSITION = longKey("trino.file.read_position");
+}

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/Tracing.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/Tracing.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.tracing;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+
+import java.util.Optional;
+
+final class Tracing
+{
+    private Tracing() {}
+
+    public static <T> Attributes attribute(AttributeKey<T> key, Optional<T> optionalValue)
+    {
+        return optionalValue.map(value -> Attributes.of(key, value))
+                .orElseGet(Attributes::empty);
+    }
+
+    public static <E extends Exception> void withTracing(Span span, CheckedRunnable<E> runnable)
+            throws E
+    {
+        withTracing(span, () -> {
+            runnable.run();
+            return null;
+        });
+    }
+
+    public static <T, E extends Exception> T withTracing(Span span, CheckedSupplier<T, E> supplier)
+            throws E
+    {
+        try (var ignored = span.makeCurrent()) {
+            return supplier.get();
+        }
+        catch (Throwable t) {
+            span.setStatus(StatusCode.ERROR, t.getMessage());
+            span.recordException(t, Attributes.of(SemanticAttributes.EXCEPTION_ESCAPED, true));
+            throw t;
+        }
+        finally {
+            span.end();
+        }
+    }
+
+    public interface CheckedRunnable<E extends Exception>
+    {
+        void run()
+                throws E;
+    }
+
+    public interface CheckedSupplier<T, E extends Exception>
+    {
+        T get()
+                throws E;
+    }
+}

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingFileSystem.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.tracing;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.trino.filesystem.FileIterator;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoOutputFile;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Optional;
+
+import static io.trino.filesystem.tracing.Tracing.withTracing;
+import static java.util.Objects.requireNonNull;
+
+final class TracingFileSystem
+        implements TrinoFileSystem
+{
+    private final Tracer tracer;
+    private final TrinoFileSystem delegate;
+
+    public TracingFileSystem(Tracer tracer, TrinoFileSystem delegate)
+    {
+        this.tracer = requireNonNull(tracer, "tracer is null");
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(String location)
+    {
+        return new TracingInputFile(tracer, delegate.newInputFile(location), Optional.empty());
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(String location, long length)
+    {
+        return new TracingInputFile(tracer, delegate.newInputFile(location, length), Optional.of(length));
+    }
+
+    @Override
+    public TrinoOutputFile newOutputFile(String location)
+    {
+        return new TracingOutputFile(tracer, delegate.newOutputFile(location));
+    }
+
+    @Override
+    public void deleteFile(String location)
+            throws IOException
+    {
+        Span span = tracer.spanBuilder("FileSystem.deleteFile")
+                .setAttribute(FileSystemAttributes.FILE_LOCATION, location)
+                .startSpan();
+        withTracing(span, () -> delegate.deleteFile(location));
+    }
+
+    @Override
+    public void deleteFiles(Collection<String> locations)
+            throws IOException
+    {
+        Span span = tracer.spanBuilder("FileSystem.deleteFiles")
+                .setAttribute(FileSystemAttributes.FILE_LOCATION_COUNT, (long) locations.size())
+                .startSpan();
+        withTracing(span, () -> delegate.deleteFiles(locations));
+    }
+
+    @Override
+    public void deleteDirectory(String location)
+            throws IOException
+    {
+        Span span = tracer.spanBuilder("FileSystem.deleteDirectory")
+                .setAttribute(FileSystemAttributes.FILE_LOCATION, location)
+                .startSpan();
+        withTracing(span, () -> delegate.deleteDirectory(location));
+    }
+
+    @Override
+    public void renameFile(String source, String target)
+            throws IOException
+    {
+        Span span = tracer.spanBuilder("FileSystem.renameFile")
+                .setAttribute(FileSystemAttributes.FILE_LOCATION, source)
+                .startSpan();
+        withTracing(span, () -> delegate.renameFile(source, target));
+    }
+
+    @Override
+    public FileIterator listFiles(String location)
+            throws IOException
+    {
+        Span span = tracer.spanBuilder("FileSystem.listFiles")
+                .setAttribute(FileSystemAttributes.FILE_LOCATION, location)
+                .startSpan();
+        return withTracing(span, () -> delegate.listFiles(location));
+    }
+}

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingFileSystemFactory.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingFileSystemFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.tracing;
+
+import io.opentelemetry.api.trace.Tracer;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.security.ConnectorIdentity;
+
+import static java.util.Objects.requireNonNull;
+
+public final class TracingFileSystemFactory
+        implements TrinoFileSystemFactory
+{
+    private final Tracer tracer;
+    private final TrinoFileSystemFactory delegate;
+
+    public TracingFileSystemFactory(Tracer tracer, TrinoFileSystemFactory delegate)
+    {
+        this.tracer = requireNonNull(tracer, "tracer is null");
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    public TrinoFileSystem create(ConnectorIdentity identity)
+    {
+        return new TracingFileSystem(tracer, delegate.create(identity));
+    }
+
+    @Override
+    public TrinoFileSystem create(ConnectorSession session)
+    {
+        return new TracingFileSystem(tracer, delegate.create(session));
+    }
+}

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingInput.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingInput.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.tracing;
+
+import io.airlift.slice.Slice;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.Tracer;
+import io.trino.filesystem.TrinoInput;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static io.trino.filesystem.tracing.Tracing.attribute;
+import static io.trino.filesystem.tracing.Tracing.withTracing;
+import static java.util.Objects.requireNonNull;
+
+final class TracingInput
+        implements TrinoInput
+{
+    private final Tracer tracer;
+    private final TrinoInput delegate;
+    private final String location;
+    private final Optional<Long> fileLength;
+
+    public TracingInput(Tracer tracer, TrinoInput delegate, String location, Optional<Long> fileLength)
+    {
+        this.tracer = requireNonNull(tracer, "tracer is null");
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.location = requireNonNull(location, "location is null");
+        this.fileLength = requireNonNull(fileLength, "fileLength is null");
+    }
+
+    @Override
+    public void readFully(long position, byte[] buffer, int bufferOffset, int bufferLength)
+            throws IOException
+    {
+        Span span = spanBuilder("Input.readFully", bufferLength)
+                .setAttribute(FileSystemAttributes.FILE_READ_POSITION, position)
+                .startSpan();
+        withTracing(span, () -> delegate.readFully(position, buffer, bufferOffset, bufferLength));
+    }
+
+    @Override
+    public int readTail(byte[] buffer, int bufferOffset, int bufferLength)
+            throws IOException
+    {
+        Span span = spanBuilder("Input.readTail", bufferLength)
+                .startSpan();
+        return withTracing(span, () -> delegate.readTail(buffer, bufferOffset, bufferLength));
+    }
+
+    @Override
+    public Slice readFully(long position, int length)
+            throws IOException
+    {
+        Span span = spanBuilder("Input.readFully", length)
+                .setAttribute(FileSystemAttributes.FILE_READ_POSITION, position)
+                .startSpan();
+        return withTracing(span, () -> delegate.readFully(position, length));
+    }
+
+    @Override
+    public Slice readTail(int length)
+            throws IOException
+    {
+        Span span = spanBuilder("Input.readTail", length)
+                .startSpan();
+        return withTracing(span, () -> delegate.readTail(length));
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        delegate.close();
+    }
+
+    private SpanBuilder spanBuilder(String name, long readLength)
+    {
+        return tracer.spanBuilder(name)
+                .setAttribute(FileSystemAttributes.FILE_LOCATION, location)
+                .setAllAttributes(attribute(FileSystemAttributes.FILE_SIZE, fileLength))
+                .setAttribute(FileSystemAttributes.FILE_READ_SIZE, readLength);
+    }
+}

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingInputFile.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingInputFile.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.tracing;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoInputStream;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Optional;
+
+import static io.trino.filesystem.tracing.Tracing.attribute;
+import static io.trino.filesystem.tracing.Tracing.withTracing;
+import static java.util.Objects.requireNonNull;
+
+final class TracingInputFile
+        implements TrinoInputFile
+{
+    private final Tracer tracer;
+    private final TrinoInputFile delegate;
+    private final Optional<Long> length;
+
+    public TracingInputFile(Tracer tracer, TrinoInputFile delegate, Optional<Long> length)
+    {
+        this.tracer = requireNonNull(tracer, "tracer is null");
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.length = requireNonNull(length, "length is null");
+    }
+
+    @Override
+    public TrinoInput newInput()
+            throws IOException
+    {
+        Span span = tracer.spanBuilder("InputFile.newInput")
+                .setAttribute(FileSystemAttributes.FILE_LOCATION, location())
+                .setAllAttributes(attribute(FileSystemAttributes.FILE_SIZE, length))
+                .startSpan();
+        return withTracing(span, () -> new TracingInput(tracer, delegate.newInput(), location(), length));
+    }
+
+    @Override
+    public TrinoInputStream newStream()
+            throws IOException
+    {
+        Span span = tracer.spanBuilder("InputFile.newStream")
+                .setAttribute(FileSystemAttributes.FILE_LOCATION, location())
+                .setAllAttributes(attribute(FileSystemAttributes.FILE_SIZE, length))
+                .startSpan();
+        return withTracing(span, delegate::newStream);
+    }
+
+    @Override
+    public long length()
+            throws IOException
+    {
+        // skip tracing if length is cached, but delegate anyway
+        if (length.isPresent()) {
+            return delegate.length();
+        }
+
+        Span span = tracer.spanBuilder("InputFile.length")
+                .setAttribute(FileSystemAttributes.FILE_LOCATION, location())
+                .startSpan();
+        return withTracing(span, delegate::length);
+    }
+
+    @Override
+    public Instant lastModified()
+            throws IOException
+    {
+        Span span = tracer.spanBuilder("InputFile.lastModified")
+                .setAttribute(FileSystemAttributes.FILE_LOCATION, location())
+                .startSpan();
+        return withTracing(span, delegate::lastModified);
+    }
+
+    @Override
+    public boolean exists()
+            throws IOException
+    {
+        Span span = tracer.spanBuilder("InputFile.exists")
+                .setAttribute(FileSystemAttributes.FILE_LOCATION, location())
+                .startSpan();
+        return withTracing(span, delegate::exists);
+    }
+
+    @Override
+    public String location()
+    {
+        return delegate.location();
+    }
+}

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingOutputFile.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingOutputFile.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.tracing;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.trino.filesystem.TrinoOutputFile;
+import io.trino.memory.context.AggregatedMemoryContext;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static io.trino.filesystem.tracing.Tracing.withTracing;
+import static java.util.Objects.requireNonNull;
+
+final class TracingOutputFile
+        implements TrinoOutputFile
+{
+    private final Tracer tracer;
+    private final TrinoOutputFile delegate;
+
+    public TracingOutputFile(Tracer tracer, TrinoOutputFile delegate)
+    {
+        this.tracer = requireNonNull(tracer, "tracer is null");
+        this.delegate = requireNonNull(delegate, "delete is null");
+    }
+
+    @Override
+    public OutputStream create()
+            throws IOException
+    {
+        Span span = tracer.spanBuilder("OutputFile.create")
+                .setAttribute(FileSystemAttributes.FILE_LOCATION, location())
+                .startSpan();
+        return withTracing(span, () -> delegate.create());
+    }
+
+    @Override
+    public OutputStream createOrOverwrite()
+            throws IOException
+    {
+        Span span = tracer.spanBuilder("OutputFile.createOrOverwrite")
+                .setAttribute(FileSystemAttributes.FILE_LOCATION, location())
+                .startSpan();
+        return withTracing(span, () -> delegate.createOrOverwrite());
+    }
+
+    @Override
+    public OutputStream create(AggregatedMemoryContext memoryContext)
+            throws IOException
+    {
+        Span span = tracer.spanBuilder("OutputFile.create")
+                .setAttribute(FileSystemAttributes.FILE_LOCATION, location())
+                .startSpan();
+        return withTracing(span, () -> delegate.create(memoryContext));
+    }
+
+    @Override
+    public OutputStream createOrOverwrite(AggregatedMemoryContext memoryContext)
+            throws IOException
+    {
+        Span span = tracer.spanBuilder("OutputFile.createOrOverwrite")
+                .setAttribute(FileSystemAttributes.FILE_LOCATION, location())
+                .startSpan();
+        return withTracing(span, () -> delegate.createOrOverwrite(memoryContext));
+    }
+
+    @Override
+    public String location()
+    {
+        return delegate.location();
+    }
+}

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/tracing/TestTracing.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/tracing/TestTracing.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.tracing;
+
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoOutputFile;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
+
+public class TestTracing
+{
+    @Test
+    public void testEverythingImplemented()
+    {
+        assertAllMethodsOverridden(TrinoFileSystemFactory.class, TracingFileSystemFactory.class);
+        assertAllMethodsOverridden(TrinoFileSystem.class, TracingFileSystem.class);
+        assertAllMethodsOverridden(TrinoInputFile.class, TracingInputFile.class);
+        assertAllMethodsOverridden(TrinoInput.class, TracingInput.class);
+        assertAllMethodsOverridden(TrinoOutputFile.class, TracingOutputFile.class);
+    }
+}

--- a/lib/trino-hdfs/pom.xml
+++ b/lib/trino-hdfs/pom.xml
@@ -89,6 +89,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>

--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileSystemModule.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileSystemModule.java
@@ -15,7 +15,11 @@ package io.trino.filesystem.hdfs;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import io.opentelemetry.api.trace.Tracer;
 import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.tracing.TracingFileSystemFactory;
 
 import static com.google.inject.Scopes.SINGLETON;
 
@@ -25,6 +29,13 @@ public class HdfsFileSystemModule
     @Override
     public void configure(Binder binder)
     {
-        binder.bind(TrinoFileSystemFactory.class).to(HdfsFileSystemFactory.class).in(SINGLETON);
+        binder.bind(HdfsFileSystemFactory.class).in(SINGLETON);
+    }
+
+    @Provides
+    @Singleton
+    public TrinoFileSystemFactory createFileSystemFactory(Tracer tracer, HdfsFileSystemFactory delegate)
+    {
+        return new TracingFileSystemFactory(tracer, delegate);
     }
 }

--- a/lib/trino-hdfs/src/main/java/io/trino/hdfs/HdfsEnvironment.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/hdfs/HdfsEnvironment.java
@@ -13,6 +13,8 @@
  */
 package io.trino.hdfs;
 
+import com.google.common.annotations.VisibleForTesting;
+import io.opentelemetry.api.OpenTelemetry;
 import io.trino.hadoop.HadoopNative;
 import io.trino.hdfs.authentication.GenericExceptionAction;
 import io.trino.hdfs.authentication.HdfsAuthentication;
@@ -28,6 +30,7 @@ import javax.inject.Inject;
 import java.io.IOException;
 import java.util.Optional;
 
+import static io.trino.hdfs.FileSystemUtils.getRawFileSystem;
 import static java.util.Objects.requireNonNull;
 
 public class HdfsEnvironment
@@ -37,18 +40,27 @@ public class HdfsEnvironment
         FileSystemManager.registerCache(TrinoFileSystemCache.INSTANCE);
     }
 
+    private final OpenTelemetry openTelemetry;
     private final HdfsConfiguration hdfsConfiguration;
     private final HdfsAuthentication hdfsAuthentication;
     private final Optional<FsPermission> newDirectoryPermissions;
     private final boolean newFileInheritOwnership;
     private final boolean verifyChecksum;
 
+    @VisibleForTesting
+    public HdfsEnvironment(HdfsConfiguration hdfsConfiguration, HdfsConfig config, HdfsAuthentication hdfsAuthentication)
+    {
+        this(OpenTelemetry.noop(), hdfsConfiguration, config, hdfsAuthentication);
+    }
+
     @Inject
     public HdfsEnvironment(
+            OpenTelemetry openTelemetry,
             HdfsConfiguration hdfsConfiguration,
             HdfsConfig config,
             HdfsAuthentication hdfsAuthentication)
     {
+        this.openTelemetry = requireNonNull(openTelemetry, "openTelemetry is null");
         this.hdfsConfiguration = requireNonNull(hdfsConfiguration, "hdfsConfiguration is null");
         this.newFileInheritOwnership = config.isNewFileInheritOwnership();
         this.verifyChecksum = config.isVerifyChecksum();
@@ -73,6 +85,9 @@ public class HdfsEnvironment
         return hdfsAuthentication.doAs(identity, () -> {
             FileSystem fileSystem = path.getFileSystem(configuration);
             fileSystem.setVerifyChecksum(verifyChecksum);
+            if (getRawFileSystem(fileSystem) instanceof OpenTelemetryAwareFileSystem fs) {
+                fs.setOpenTelemetry(openTelemetry);
+            }
             return fileSystem;
         });
     }

--- a/lib/trino-hdfs/src/main/java/io/trino/hdfs/OpenTelemetryAwareFileSystem.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/hdfs/OpenTelemetryAwareFileSystem.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hdfs;
+
+import io.opentelemetry.api.OpenTelemetry;
+
+public interface OpenTelemetryAwareFileSystem
+{
+    void setOpenTelemetry(OpenTelemetry openTelemetry);
+}

--- a/plugin/trino-accumulo/pom.xml
+++ b/plugin/trino-accumulo/pom.xml
@@ -227,6 +227,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-atop/pom.xml
+++ b/plugin/trino-atop/pom.xml
@@ -107,6 +107,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -283,6 +283,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-blackhole/pom.xml
+++ b/plugin/trino-blackhole/pom.xml
@@ -71,6 +71,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-cassandra/pom.xml
+++ b/plugin/trino-cassandra/pom.xml
@@ -146,6 +146,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-clickhouse/pom.xml
+++ b/plugin/trino-clickhouse/pom.xml
@@ -97,6 +97,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -208,6 +208,12 @@
             <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Trino SPI -->
         <dependency>
             <groupId>io.trino</groupId>

--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -208,12 +208,6 @@
             <scope>runtime</scope>
         </dependency>
 
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-api</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
         <!-- Trino SPI -->
         <dependency>
             <groupId>io.trino</groupId>
@@ -230,6 +224,18 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/InternalDeltaLakeConnectorFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/InternalDeltaLakeConnectorFactory.java
@@ -22,6 +22,8 @@ import io.airlift.bootstrap.Bootstrap;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.event.client.EventModule;
 import io.airlift.json.JsonModule;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.hdfs.HdfsFileSystemModule;
 import io.trino.hdfs.HdfsModule;
@@ -98,6 +100,8 @@ public final class InternalDeltaLakeConnectorFactory
                     new DeltaLakeModule(),
                     new DeltaLakeSecurityModule(),
                     binder -> {
+                        binder.bind(OpenTelemetry.class).toInstance(context.getOpenTelemetry());
+                        binder.bind(Tracer.class).toInstance(context.getTracer());
                         binder.bind(NodeVersion.class).toInstance(new NodeVersion(context.getNodeManager().getCurrentNode().getVersion()));
                         binder.bind(NodeManager.class).toInstance(context.getNodeManager());
                         binder.bind(TypeManager.class).toInstance(context.getTypeManager());

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeDynamicFiltering.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeDynamicFiltering.java
@@ -16,6 +16,7 @@ package io.trino.plugin.deltalake;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.execution.DynamicFilterConfig;
 import io.trino.execution.QueryStats;
@@ -131,7 +132,7 @@ public class TestDeltaLakeDynamicFiltering
         Optional<TableHandle> tableHandle = runner.getMetadata().getTableHandle(session, tableName);
         assertTrue(tableHandle.isPresent());
         SplitSource splitSource = runner.getSplitManager()
-                .getSplits(session, tableHandle.get(), new IncompleteDynamicFilter(), alwaysTrue());
+                .getSplits(session, Span.getInvalid(), tableHandle.get(), new IncompleteDynamicFilter(), alwaysTrue());
         List<Split> splits = new ArrayList<>();
         while (!splitSource.isFinished()) {
             splits.addAll(splitSource.getNextBatch(1000).get().getSplits());

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
@@ -19,10 +19,11 @@ import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Provides;
+import com.google.inject.Scopes;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
+import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
-import io.trino.filesystem.hdfs.HdfsFileSystemModule;
 import io.trino.hdfs.HdfsEnvironment;
 import io.trino.plugin.base.CatalogName;
 import io.trino.plugin.deltalake.metastore.DeltaLakeMetastore;
@@ -163,7 +164,7 @@ public class TestDeltaLakeMetadata
                 // test setup
                 binder -> {
                     binder.bind(HdfsEnvironment.class).toInstance(HDFS_ENVIRONMENT);
-                    binder.install(new HdfsFileSystemModule());
+                    binder.bind(TrinoFileSystemFactory.class).to(HdfsFileSystemFactory.class).in(Scopes.SINGLETON);
                 },
                 new AbstractModule()
                 {

--- a/plugin/trino-druid/pom.xml
+++ b/plugin/trino-druid/pom.xml
@@ -90,6 +90,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-elasticsearch/pom.xml
+++ b/plugin/trino-elasticsearch/pom.xml
@@ -259,6 +259,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-example-http/pom.xml
+++ b/plugin/trino-example-http/pom.xml
@@ -91,6 +91,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-example-jdbc/pom.xml
+++ b/plugin/trino-example-jdbc/pom.xml
@@ -82,6 +82,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-exchange-filesystem/pom.xml
+++ b/plugin/trino-exchange-filesystem/pom.xml
@@ -330,6 +330,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-exchange-hdfs/pom.xml
+++ b/plugin/trino-exchange-hdfs/pom.xml
@@ -102,6 +102,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-geospatial/pom.xml
+++ b/plugin/trino-geospatial/pom.xml
@@ -75,6 +75,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-google-sheets/pom.xml
+++ b/plugin/trino-google-sheets/pom.xml
@@ -153,6 +153,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-hive-hadoop2/pom.xml
+++ b/plugin/trino-hive-hadoop2/pom.xml
@@ -127,6 +127,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -231,6 +231,16 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-aws-sdk-1.11</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>it.unimi.dsi</groupId>
             <artifactId>fastutil</artifactId>
         </dependency>

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
@@ -20,8 +20,6 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import io.airlift.event.client.EventClient;
-import io.trino.filesystem.TrinoFileSystemFactory;
-import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
 import io.trino.hdfs.TrinoFileSystemCache;
 import io.trino.hdfs.TrinoFileSystemCacheStats;
 import io.trino.plugin.base.CatalogName;
@@ -127,7 +125,6 @@ public class HiveModule
                 .as(generator -> generator.generatedNameOf(io.trino.plugin.hive.fs.TrinoFileSystemCache.class));
 
         configBinder(binder).bindConfig(HiveFormatsConfig.class);
-        binder.bind(TrinoFileSystemFactory.class).to(HdfsFileSystemFactory.class).in(Scopes.SINGLETON);
 
         Multibinder<HivePageSourceFactory> pageSourceFactoryBinder = newSetBinder(binder, HivePageSourceFactory.class);
         pageSourceFactoryBinder.addBinding().to(CsvPageSourceFactory.class).in(Scopes.SINGLETON);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveConnectorFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveConnectorFactory.java
@@ -23,6 +23,8 @@ import io.airlift.bootstrap.Bootstrap;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.event.client.EventModule;
 import io.airlift.json.JsonModule;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
 import io.trino.filesystem.hdfs.HdfsFileSystemModule;
 import io.trino.hdfs.HdfsModule;
 import io.trino.hdfs.authentication.HdfsAuthenticationModule;
@@ -123,6 +125,8 @@ public final class InternalHiveConnectorFactory
                     new HiveProcedureModule(),
                     new MBeanServerModule(),
                     binder -> {
+                        binder.bind(OpenTelemetry.class).toInstance(context.getOpenTelemetry());
+                        binder.bind(Tracer.class).toInstance(context.getTracer());
                         binder.bind(NodeVersion.class).toInstance(new NodeVersion(context.getNodeManager().getCurrentNode().getVersion()));
                         binder.bind(NodeManager.class).toInstance(context.getNodeManager());
                         binder.bind(VersionEmbedder.class).toInstance(context.getVersionEmbedder());

--- a/plugin/trino-http-event-listener/pom.xml
+++ b/plugin/trino-http-event-listener/pom.xml
@@ -103,6 +103,18 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>io.trino</groupId>

--- a/plugin/trino-hudi/pom.xml
+++ b/plugin/trino-hudi/pom.xml
@@ -262,6 +262,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/InternalHudiConnectorFactory.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/InternalHudiConnectorFactory.java
@@ -21,6 +21,8 @@ import io.airlift.bootstrap.Bootstrap;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.event.client.EventModule;
 import io.airlift.json.JsonModule;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
 import io.trino.filesystem.hdfs.HdfsFileSystemModule;
 import io.trino.hdfs.HdfsModule;
 import io.trino.hdfs.authentication.HdfsAuthenticationModule;
@@ -76,6 +78,8 @@ public final class InternalHudiConnectorFactory
                     new HdfsFileSystemModule(),
                     new MBeanServerModule(),
                     binder -> {
+                        binder.bind(OpenTelemetry.class).toInstance(context.getOpenTelemetry());
+                        binder.bind(Tracer.class).toInstance(context.getTracer());
                         binder.bind(NodeVersion.class).toInstance(new NodeVersion(context.getNodeManager().getCurrentNode().getVersion()));
                         binder.bind(NodeManager.class).toInstance(context.getNodeManager());
                         binder.bind(TypeManager.class).toInstance(context.getTypeManager());

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -333,6 +333,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/InternalIcebergConnectorFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/InternalIcebergConnectorFactory.java
@@ -21,6 +21,8 @@ import io.airlift.bootstrap.Bootstrap;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.event.client.EventModule;
 import io.airlift.json.JsonModule;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.hdfs.HdfsFileSystemModule;
 import io.trino.hdfs.HdfsModule;
@@ -93,6 +95,8 @@ public final class InternalIcebergConnectorFactory
                     new HdfsAuthenticationModule(),
                     new MBeanServerModule(),
                     binder -> {
+                        binder.bind(OpenTelemetry.class).toInstance(context.getOpenTelemetry());
+                        binder.bind(Tracer.class).toInstance(context.getTracer());
                         binder.bind(NodeVersion.class).toInstance(new NodeVersion(context.getNodeManager().getCurrentNode().getVersion()));
                         binder.bind(NodeManager.class).toInstance(context.getNodeManager());
                         binder.bind(TypeManager.class).toInstance(context.getTypeManager());

--- a/plugin/trino-ignite/pom.xml
+++ b/plugin/trino-ignite/pom.xml
@@ -117,6 +117,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-jmx/pom.xml
+++ b/plugin/trino-jmx/pom.xml
@@ -105,6 +105,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-kafka/pom.xml
+++ b/plugin/trino-kafka/pom.xml
@@ -198,6 +198,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-kinesis/pom.xml
+++ b/plugin/trino-kinesis/pom.xml
@@ -143,6 +143,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-kudu/pom.xml
+++ b/plugin/trino-kudu/pom.xml
@@ -107,6 +107,12 @@
             <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Trino SPI -->
         <dependency>
             <groupId>io.trino</groupId>

--- a/plugin/trino-kudu/pom.xml
+++ b/plugin/trino-kudu/pom.xml
@@ -107,12 +107,6 @@
             <scope>runtime</scope>
         </dependency>
 
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-api</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
         <!-- Trino SPI -->
         <dependency>
             <groupId>io.trino</groupId>
@@ -129,6 +123,18 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduIntegrationDynamicFilter.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduIntegrationDynamicFilter.java
@@ -16,6 +16,7 @@ package io.trino.plugin.kudu;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
+import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.execution.QueryStats;
 import io.trino.metadata.QualifiedObjectName;
@@ -101,7 +102,7 @@ public class TestKuduIntegrationDynamicFilter
         Optional<TableHandle> tableHandle = runner.getMetadata().getTableHandle(session, tableName);
         assertTrue(tableHandle.isPresent());
         SplitSource splitSource = runner.getSplitManager()
-                .getSplits(session, tableHandle.get(), new IncompleteDynamicFilter(), alwaysTrue());
+                .getSplits(session, Span.getInvalid(), tableHandle.get(), new IncompleteDynamicFilter(), alwaysTrue());
         List<Split> splits = new ArrayList<>();
         while (!splitSource.isFinished()) {
             splits.addAll(splitSource.getNextBatch(1000).get().getSplits());

--- a/plugin/trino-local-file/pom.xml
+++ b/plugin/trino-local-file/pom.xml
@@ -86,6 +86,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-mariadb/pom.xml
+++ b/plugin/trino-mariadb/pom.xml
@@ -91,6 +91,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-memory/pom.xml
+++ b/plugin/trino-memory/pom.xml
@@ -103,6 +103,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-ml/pom.xml
+++ b/plugin/trino-ml/pom.xml
@@ -82,6 +82,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-mongodb/pom.xml
+++ b/plugin/trino-mongodb/pom.xml
@@ -128,6 +128,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-mysql-event-listener/pom.xml
+++ b/plugin/trino-mysql-event-listener/pom.xml
@@ -99,6 +99,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-mysql/pom.xml
+++ b/plugin/trino-mysql/pom.xml
@@ -105,6 +105,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-oracle/pom.xml
+++ b/plugin/trino-oracle/pom.xml
@@ -116,6 +116,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-password-authenticators/pom.xml
+++ b/plugin/trino-password-authenticators/pom.xml
@@ -99,6 +99,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-phoenix5/pom.xml
+++ b/plugin/trino-phoenix5/pom.xml
@@ -159,6 +159,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-pinot/pom.xml
+++ b/plugin/trino-pinot/pom.xml
@@ -520,6 +520,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-postgresql/pom.xml
+++ b/plugin/trino-postgresql/pom.xml
@@ -118,6 +118,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-prometheus/pom.xml
+++ b/plugin/trino-prometheus/pom.xml
@@ -135,6 +135,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-raptor-legacy/pom.xml
+++ b/plugin/trino-raptor-legacy/pom.xml
@@ -182,6 +182,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-redis/pom.xml
+++ b/plugin/trino-redis/pom.xml
@@ -134,6 +134,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-redshift/pom.xml
+++ b/plugin/trino-redshift/pom.xml
@@ -103,6 +103,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-resource-group-managers/pom.xml
+++ b/plugin/trino-resource-group-managers/pom.xml
@@ -158,6 +158,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-session-property-managers/pom.xml
+++ b/plugin/trino-session-property-managers/pom.xml
@@ -139,6 +139,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-singlestore/pom.xml
+++ b/plugin/trino-singlestore/pom.xml
@@ -103,6 +103,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-sqlserver/pom.xml
+++ b/plugin/trino-sqlserver/pom.xml
@@ -120,6 +120,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-thrift/pom.xml
+++ b/plugin/trino-thrift/pom.xml
@@ -148,6 +148,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-tpcds/pom.xml
+++ b/plugin/trino-tpcds/pom.xml
@@ -105,6 +105,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-tpch/pom.xml
+++ b/plugin/trino-tpch/pom.xml
@@ -62,6 +62,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>134</version>
+        <version>135</version>
     </parent>
 
     <groupId>io.trino</groupId>
@@ -70,10 +70,8 @@
         <dep.iceberg.version>1.1.0</dep.iceberg.version>
         <dep.protobuf.version>3.22.2</dep.protobuf.version>
         <dep.wire.version>4.5.0</dep.wire.version>
-        <dep.kotlin.version>1.8.0</dep.kotlin.version>
         <dep.netty.version>4.1.79.Final</dep.netty.version>
         <dep.jna.version>5.13.0</dep.jna.version>
-        <dep.slf4j.version>2.0.7</dep.slf4j.version>
 
         <dep.docker.images.version>79</dep.docker.images.version>
 
@@ -1927,24 +1925,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib</artifactId>
-                <version>${dep.kotlin.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-common</artifactId>
-                <version>${dep.kotlin.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-jdk8</artifactId>
-                <version>${dep.kotlin.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.locationtech.jts</groupId>
                 <artifactId>jts-core</artifactId>
                 <version>1.16.1</version>
@@ -2364,14 +2344,6 @@
                 <groupId>ca.vanzyl.provisio.maven.plugins</groupId>
                 <artifactId>provisio-maven-plugin</artifactId>
                 <extensions>true</extensions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration combine.children="append">
-                    <fork>false</fork>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -864,7 +864,7 @@
             <dependency>
                 <groupId>io.airlift.discovery</groupId>
                 <artifactId>discovery-server</artifactId>
-                <version>1.32</version>
+                <version>1.33</version>
                 <exclusions>
                     <exclusion>
                         <groupId>io.airlift</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dep.accumulo.version>1.10.2</dep.accumulo.version>
         <dep.accumulo-hadoop.version>2.7.7-1</dep.accumulo-hadoop.version>
         <dep.antlr.version>4.11.1</dep.antlr.version>
-        <dep.airlift.version>228</dep.airlift.version>
+        <dep.airlift.version>229</dep.airlift.version>
         <dep.arrow.version>9.0.0</dep.arrow.version>
         <dep.avro.version>1.11.1</dep.avro.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
@@ -831,8 +831,10 @@
 
             <dependency>
                 <groupId>io.airlift</groupId>
-                <artifactId>bootstrap</artifactId>
+                <artifactId>bom</artifactId>
+                <type>pom</type>
                 <version>${dep.airlift.version}</version>
+                <scope>import</scope>
             </dependency>
 
             <dependency>
@@ -843,140 +845,14 @@
 
             <dependency>
                 <groupId>io.airlift</groupId>
-                <artifactId>concurrent</artifactId>
-                <version>${dep.airlift.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>configuration</artifactId>
-                <version>${dep.airlift.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>dbpool</artifactId>
-                <version>${dep.airlift.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>discovery</artifactId>
-                <version>${dep.airlift.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>event</artifactId>
-                <version>${dep.airlift.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>http-client</artifactId>
-                <version>${dep.airlift.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>http-server</artifactId>
-                <version>${dep.airlift.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>jaxrs</artifactId>
-                <version>${dep.airlift.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>jaxrs-testing</artifactId>
-                <version>${dep.airlift.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.hamcrest</groupId>
-                        <artifactId>hamcrest</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>jmx</artifactId>
-                <version>${dep.airlift.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>jmx-http</artifactId>
-                <version>${dep.airlift.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.airlift</groupId>
                 <artifactId>joni</artifactId>
                 <version>2.1.5.3</version>
             </dependency>
 
             <dependency>
                 <groupId>io.airlift</groupId>
-                <artifactId>json</artifactId>
-                <version>${dep.airlift.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>log</artifactId>
-                <version>${dep.airlift.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>log-manager</artifactId>
-                <version>${dep.airlift.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>node</artifactId>
-                <version>${dep.airlift.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>openmetrics</artifactId>
-                <version>${dep.airlift.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.airlift</groupId>
                 <artifactId>parameternames</artifactId>
                 <version>1.4</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>security</artifactId>
-                <version>${dep.airlift.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>stats</artifactId>
-                <version>${dep.airlift.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>testing</artifactId>
-                <version>${dep.airlift.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>trace-token</artifactId>
-                <version>${dep.airlift.version}</version>
             </dependency>
 
             <dependency>

--- a/service/trino-proxy/pom.xml
+++ b/service/trino-proxy/pom.xml
@@ -90,6 +90,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>tracing</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
         </dependency>
 

--- a/service/trino-proxy/src/main/java/io/trino/proxy/TrinoProxy.java
+++ b/service/trino-proxy/src/main/java/io/trino/proxy/TrinoProxy.java
@@ -25,10 +25,15 @@ import io.airlift.log.LogJmxModule;
 import io.airlift.log.Logger;
 import io.airlift.node.NodeModule;
 import io.airlift.tracetoken.TraceTokenModule;
+import io.airlift.tracing.TracingModule;
 import org.weakref.jmx.guice.MBeanModule;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
 
 public final class TrinoProxy
 {
+    private static final String VERSION = firstNonNull(TrinoProxy.class.getPackage().getImplementationVersion(), "unknown");
+
     private TrinoProxy() {}
 
     public static void start(Module... extraModules)
@@ -42,6 +47,7 @@ public final class TrinoProxy
                 .add(new JmxModule())
                 .add(new LogJmxModule())
                 .add(new TraceTokenModule())
+                .add(new TracingModule("trino-proxy", VERSION))
                 .add(new EventModule())
                 .add(new ProxyModule())
                 .add(extraModules)

--- a/testing/trino-benchmark/pom.xml
+++ b/testing/trino-benchmark/pom.xml
@@ -83,6 +83,11 @@
             <artifactId>guava</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+
         <!-- for benchmark run -->
         <dependency>
             <groupId>io.airlift</groupId>

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/AbstractOperatorBenchmark.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/AbstractOperatorBenchmark.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Iterables;
 import io.airlift.stats.CpuTimer;
 import io.airlift.stats.TestingGcMonitor;
 import io.airlift.units.DataSize;
+import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.execution.StageId;
 import io.trino.execution.TaskId;
@@ -82,7 +83,6 @@ import static io.trino.SystemSessionProperties.getFilterAndProjectMinOutputPageR
 import static io.trino.SystemSessionProperties.getFilterAndProjectMinOutputPageSize;
 import static io.trino.execution.executor.PrioritizedSplitRunner.SPLIT_RUN_QUANTA;
 import static io.trino.spi.connector.Constraint.alwaysTrue;
-import static io.trino.spi.connector.DynamicFilter.EMPTY;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.trino.sql.planner.TypeAnalyzer.createTestingTypeAnalyzer;
@@ -209,7 +209,7 @@ public abstract class AbstractOperatorBenchmark
 
     private Split getLocalQuerySplit(Session session, TableHandle handle)
     {
-        SplitSource splitSource = localQueryRunner.getSplitManager().getSplits(session, handle, EMPTY, alwaysTrue());
+        SplitSource splitSource = localQueryRunner.getSplitManager().getSplits(session, Span.getInvalid(), handle, DynamicFilter.EMPTY, alwaysTrue());
         List<Split> splits = new ArrayList<>();
         while (!splitSource.isFinished()) {
             splits.addAll(getNextBatch(splitSource));

--- a/testing/trino-testing/pom.xml
+++ b/testing/trino-testing/pom.xml
@@ -136,6 +136,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Ordering;
+import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.SystemSessionProperties;
 import io.trino.spi.session.PropertyMetadata;
@@ -5332,6 +5333,7 @@ public abstract class AbstractTestEngineOnlyQueries
     {
         Session session = new Session(
                 getSession().getQueryId(),
+                Span.getInvalid(),
                 Optional.empty(),
                 getSession().isClientTransactionSupport(),
                 getSession().getIdentity(),

--- a/testing/trino-tests/pom.xml
+++ b/testing/trino-tests/pom.xml
@@ -101,6 +101,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
             <scope>runtime</scope>

--- a/testing/trino-tests/src/test/java/io/trino/execution/QueryRunnerUtil.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/QueryRunnerUtil.java
@@ -14,6 +14,7 @@
 package io.trino.execution;
 
 import com.google.common.collect.ImmutableSet;
+import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.dispatcher.DispatchManager;
 import io.trino.server.BasicQueryInfo;
@@ -35,7 +36,7 @@ public final class QueryRunnerUtil
     public static QueryId createQuery(DistributedQueryRunner queryRunner, Session session, String sql)
     {
         DispatchManager dispatchManager = queryRunner.getCoordinator().getDispatchManager();
-        getFutureValue(dispatchManager.createQuery(session.getQueryId(), Slug.createNew(), TestingSessionContext.fromSession(session), sql));
+        getFutureValue(dispatchManager.createQuery(session.getQueryId(), Span.getInvalid(), Slug.createNew(), TestingSessionContext.fromSession(session), sql));
         return session.getQueryId();
     }
 

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataManager.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataManager.java
@@ -31,6 +31,7 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.TestingSessionContext;
 import io.trino.tests.tpch.TpchQueryRunnerBuilder;
+import io.trino.tracing.TracingMetadata;
 import io.trino.transaction.TransactionBuilder;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.AfterClass;
@@ -88,7 +89,7 @@ public class TestMetadataManager
             }
         });
         queryRunner.createCatalog("upper_case_schema_catalog", "mock");
-        metadataManager = (MetadataManager) queryRunner.getMetadata();
+        metadataManager = (MetadataManager) ((TracingMetadata) queryRunner.getMetadata()).getDelegate();
     }
 
     @AfterClass(alwaysRun = true)

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataManager.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataManager.java
@@ -15,6 +15,7 @@ package io.trino.tests;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.api.trace.Span;
 import io.trino.connector.MockConnectorFactory;
 import io.trino.connector.MockConnectorTableHandle;
 import io.trino.dispatcher.DispatchManager;
@@ -138,6 +139,7 @@ public class TestMetadataManager
         QueryId queryId = dispatchManager.createQueryId();
         dispatchManager.createQuery(
                 queryId,
+                Span.getInvalid(),
                 Slug.createNew(),
                 TestingSessionContext.fromSession(TEST_SESSION),
                 "SELECT * FROM lineitem")

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestQueryManager.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestQueryManager.java
@@ -13,6 +13,7 @@
  */
 package io.trino.tests;
 
+import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.client.ClientCapabilities;
 import io.trino.dispatcher.DispatchManager;
@@ -73,6 +74,7 @@ public class TestQueryManager
         QueryId queryId = dispatchManager.createQueryId();
         dispatchManager.createQuery(
                 queryId,
+                Span.getInvalid(),
                 Slug.createNew(),
                 TestingSessionContext.fromSession(TEST_SESSION),
                 "SELECT * FROM lineitem")


### PR DESCRIPTION
## Description

Add initial, experimental support for distributed tracing using [OpenTelemetry](https://opentelemetry.io/). This adds [traces](https://opentelemetry.io/docs/concepts/signals/traces/) for queries with [spans](https://opentelemetry.io/docs/concepts/signals/traces/#spans) for analysis, planning, optimization, split generation, tasks, remote tasks, local planning, metadata, HTTP client requests, JAX-RS endpoints, etc.

Connectors can participate in tracing using the OpenTelemetry API. As a proof-of-concept, `TrinoFileSystem` and the `S3` file system code are instrumented for the Hive, Iceberg, Delta Lake and Hudi connectors.

## Usage

Enable tracing in Trino and configure the [OLTP/gRPC endpoint](https://opentelemetry.io/docs/reference/specification/protocol/otlp/):

```properties
tracing.enabled=true
tracing.exporter.endpoint=http://localhost:4317
```

For easy testing on a single machine, such as when running `IcebergMinioQueryRunnerMain`, you can run [Jaeger](https://www.jaegertracing.io/docs/latest/getting-started/) in Docker:

```bash
docker run -e COLLECTOR_OTLP_ENABLED=true -p 16686:16686 -p 4317:4317 jaegertracing/all-in-one:latest
```

Open `http://localhost:16686` in your browser to view the Jaeger UI.

## Additional context and related issues

* Depends on https://github.com/airlift/airlift/pull/1055
* Depends on https://github.com/airlift/discovery/pull/49
* Fixes https://github.com/trinodb/trino/issues/1826
* Fixes https://github.com/trinodb/trino/issues/4207

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Add experimental support for tracing using [OpenTelemetry](https://opentelemetry.io/).
  Enable tracing by setting `tracing.enabled=true` and configure the 
  [OLTP/gRPC endpoint](https://opentelemetry.io/docs/reference/specification/protocol/otlp/)
  endpoint by setting `tracing.exporter.endpoint` to override
  the default of `http://localhost:4317` if needed. The functionality, span names, attributes, etc.,
  are experimental and subject to change. ({issue}`16950`)
```
