### PR TITLE
Revert "Add more mirrors"

### DIFF
--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -13,12 +13,8 @@
 #
 FROM eclipse-temurin:17-jdk AS builder
 
-COPY default/apt/sources.list.d /etc/apt/sources.list.d
-
 RUN \
     set -xeu && \
-    . /etc/os-release && \
-    sed -i "s/\${UBUNTU_CODENAME}/${UBUNTU_CODENAME}/g" /etc/apt/sources.list.d/* && \
     echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
     echo 'Acquire::http::Timeout "15";' > /etc/apt/apt.conf.d/80-timeouts && \
     apt-get update -q && \
@@ -28,12 +24,8 @@ RUN \
 
 FROM eclipse-temurin:17-jdk
 
-COPY default/apt/sources.list.d /etc/apt/sources.list.d
-
 RUN \
     set -xeu && \
-    . /etc/os-release && \
-    sed -i "s/\${UBUNTU_CODENAME}/${UBUNTU_CODENAME}/g" /etc/apt/sources.list.d/* && \
     echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
     echo 'Acquire::http::Timeout "15";' > /etc/apt/apt.conf.d/80-timeouts && \
     apt-get update -q && \

--- a/core/docker/build.sh
+++ b/core/docker/build.sh
@@ -65,15 +65,12 @@ cp "$trino_client" "${WORK_DIR}/"
 tar -C "${WORK_DIR}" -xzf "${WORK_DIR}/trino-server-${TRINO_VERSION}.tar.gz"
 rm "${WORK_DIR}/trino-server-${TRINO_VERSION}.tar.gz"
 cp -R bin "${WORK_DIR}/trino-server-${TRINO_VERSION}"
-mkdir -p "${WORK_DIR}/default"
-cp -R default/etc "${WORK_DIR}/default/"
+cp -R default "${WORK_DIR}/"
 
 TAG_PREFIX="trino:${TRINO_VERSION}"
 
 for arch in "${ARCHITECTURES[@]}"; do
     echo "🫙  Building the image for $arch"
-    mkdir -p "${WORK_DIR}/default/apt/sources.list.d"
-    cp "default/apt/sources.list.d/mirrors-$arch.sources" "${WORK_DIR}/default/apt/sources.list.d/"
     docker build \
         "${WORK_DIR}" \
         --pull \
@@ -81,7 +78,6 @@ for arch in "${ARCHITECTURES[@]}"; do
         -f Dockerfile \
         -t "${TAG_PREFIX}-$arch" \
         --build-arg "TRINO_VERSION=${TRINO_VERSION}"
-    rm -fr "${WORK_DIR}/default/apt/sources.list.d"
 done
 
 echo "🧹 Cleaning up the build context directory"

--- a/core/docker/default/apt/sources.list.d/mirrors-amd64.sources
+++ b/core/docker/default/apt/sources.list.d/mirrors-amd64.sources
@@ -1,6 +1,0 @@
-Enabled: yes
-Types: deb
-URIs: https://mirrors.ocf.berkeley.edu/ubuntu/ https://mirror.kumi.systems/ubuntu/
-Suites: ${UBUNTU_CODENAME} ${UBUNTU_CODENAME}-updates ${UBUNTU_CODENAME}-backports ${UBUNTU_CODENAME}-security
-Components: main restricted universe multiverse
-Architectures: amd64

--- a/core/docker/default/apt/sources.list.d/mirrors-arm64.sources
+++ b/core/docker/default/apt/sources.list.d/mirrors-arm64.sources
@@ -1,6 +1,0 @@
-Enabled: yes
-Types: deb
-URIs: https://mirrors.ocf.berkeley.edu/ubuntu-ports/ https://mirror.kumi.systems/ubuntu-ports/
-Suites: ${UBUNTU_CODENAME} ${UBUNTU_CODENAME}-updates ${UBUNTU_CODENAME}-backports ${UBUNTU_CODENAME}-security
-Components: main restricted universe multiverse
-Architectures: arm64

--- a/core/docker/default/apt/sources.list.d/mirrors-ppc64le.sources
+++ b/core/docker/default/apt/sources.list.d/mirrors-ppc64le.sources
@@ -1,7 +1,0 @@
-Enabled: yes
-Types: deb
-URIs: https://mirrors.ocf.berkeley.edu/ubuntu-ports/ https://mirror.kumi.systems/ubuntu-ports/
-Suites: ${UBUNTU_CODENAME} ${UBUNTU_CODENAME}-updates ${UBUNTU_CODENAME}-backports ${UBUNTU_CODENAME}-security
-Components: main restricted universe multiverse
-# This is NOT a typo, Ubuntu calls "little endian" architecture "endian little"
-Architectures: ppc64el


### PR DESCRIPTION
This reverts commit 8bfe02afde3896b9b059d0f90753366fb938947c.

It was causing build problems of two kinds

1) These repositories sometimes appear not correctly signed.

    #11 33.78 E: The repository 'https://mirror.kumi.systems/ubuntu jammy InRelease' is not signed.
    #11 33.78 E: Failed to fetch https://mirror.kumi.systems/ubuntu/dists/jammy/InRelease  502  Bad Gateway [IP: 135.181.208.35 443]
    #11 33.78 E: The repository 'https://mirror.kumi.systems/ubuntu jammy-updates InRelease' is not signed.
    #11 33.78 E: Failed to fetch https://mirror.kumi.systems/ubuntu/dists/jammy-updates/InRelease  502  Bad Gateway [IP: 135.181.208.35 443]
    #11 33.78 E: The repository 'https://mirror.kumi.systems/ubuntu jammy-backports InRelease' is not signed.
    #11 33.78 E: Failed to fetch https://mirror.kumi.systems/ubuntu/dists/jammy-backports/InRelease  502  Bad Gateway [IP: 135.181.208.35 443]
    #11 33.78 E: The repository 'https://mirror.kumi.systems/ubuntu jammy-security InRelease' is not signed.
    #11 33.78 E: Failed to fetch https://mirror.kumi.systems/ubuntu/dists/jammy-security/InRelease  502  Bad Gateway [IP: 135.181.208.35 443]
    #11 33.78 E: The repository 'https://mirror.kumi.systems/ubuntu-ports jammy InRelease' is not signed.
    #11 33.78 E: Failed to fetch https://mirror.kumi.systems/ubuntu-ports/dists/jammy/InRelease  502  Bad Gateway [IP: 135.181.208.35 443]
    #11 33.78 E: The repository 'https://mirror.kumi.systems/ubuntu-ports jammy-updates InRelease' is not signed.
    #11 33.78 E: Failed to fetch https://mirror.kumi.systems/ubuntu-ports/dists/jammy-updates/InRelease  502  Bad Gateway [IP: 135.181.208.35 443]
    #11 33.78 E: Failed to fetch https://mirror.kumi.systems/ubuntu-ports/dists/jammy-backports/InRelease  502  Bad Gateway [IP: 135.181.208.35 443]
    #11 33.78 E: The repository 'https://mirror.kumi.systems/ubuntu-ports jammy-backports InRelease' is not signed.
    #11 33.78 E: Failed to fetch https://mirror.kumi.systems/ubuntu-ports/dists/jammy-security/InRelease  502  Bad Gateway [IP: 135.181.208.35 443]
    #11 33.78 E: The repository 'https://mirror.kumi.systems/ubuntu-ports jammy-security InRelease' is not signed.

2) These repositories sometimes appear to suffer from concurrency
   issues.

    E: Failed to fetch https://mirror.kumi.systems/ubuntu/dists/jammy-updates/main/binary-amd64/by-hash/SHA256/e982b491ee116748562a4208918ced995d019a31bef367749e76ba53b86c3e66  File has unexpected size (1245184 != 1255827). Mirror sync in progress? [IP: 86.106.183.57 443]




Fixes https://github.com/trinodb/trino/issues/16972
Reverts part of https://github.com/trinodb/trino/pull/16098