### PR TITLE
Set min validation to 1 for config 'hive.fs.cache.max-size'

### DIFF
--- a/lib/trino-hdfs/src/main/java/io/trino/hdfs/HdfsConfig.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/hdfs/HdfsConfig.java
@@ -231,6 +231,7 @@ public class HdfsConfig
         return this;
     }
 
+    @Min(1)
     public int getFileSystemMaxCacheSize()
     {
         return fileSystemMaxCacheSize;


### PR DESCRIPTION
## Description
If the config 'hive.fs.cache.max-size' is set to 0, and when the Filesystem object is loaded the first time, we get an exception "FileSystem max cache size has been reached: 0".

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
