### PR TITLE
Rewrite lambda arguments in ExpressionTreeRewriter

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
@@ -652,9 +652,19 @@ public final class ExpressionTreeRewriter<C>
                 }
             }
 
+            List<LambdaArgumentDeclaration> arguments = node.getArguments().stream()
+                    .map(LambdaArgumentDeclaration::getName)
+                    .map(Identifier::getValue)
+                    .map(SymbolReference::new)
+                    .map(expression -> rewrite(expression, context.get()))
+                    .map(SymbolReference::getName)
+                    .map(Identifier::new)
+                    .map(LambdaArgumentDeclaration::new)
+                    .collect(toImmutableList());
+
             Expression body = rewrite(node.getBody(), context.get());
             if (body != node.getBody()) {
-                return new LambdaExpression(node.getArguments(), body);
+                return new LambdaExpression(arguments, body);
             }
 
             return node;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Consistently rewrite both lambda arguments and lambda body.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

fixes https://github.com/trinodb/trino/issues/16989

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# General
* Fix failure of recursive queries involving lambda. ({issue}`16989`)
```
