### PR TITLE
Ensure test threads termination even when test overridden

### DIFF
--- a/lib/trino-collect/src/test/java/io/trino/collect/cache/TestEmptyCache.java
+++ b/lib/trino-collect/src/test/java/io/trino/collect/cache/TestEmptyCache.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertTrue;
 
 public class TestEmptyCache
 {
@@ -80,7 +81,7 @@ public class TestEmptyCache
         }
         finally {
             executor.shutdownNow();
-            executor.awaitTermination(10, SECONDS);
+            assertTrue(executor.awaitTermination(10, SECONDS));
         }
     }
 }

--- a/lib/trino-collect/src/test/java/io/trino/collect/cache/TestEvictableCache.java
+++ b/lib/trino-collect/src/test/java/io/trino/collect/cache/TestEvictableCache.java
@@ -343,7 +343,7 @@ public class TestEvictableCache
         }
         finally {
             executor.shutdownNow();
-            executor.awaitTermination(10, SECONDS);
+            assertTrue(executor.awaitTermination(10, SECONDS));
         }
     }
 
@@ -407,7 +407,7 @@ public class TestEvictableCache
         }
         finally {
             executor.shutdownNow();
-            executor.awaitTermination(10, SECONDS);
+            assertTrue(executor.awaitTermination(10, SECONDS));
         }
     }
 
@@ -473,7 +473,7 @@ public class TestEvictableCache
         }
         finally {
             executor.shutdownNow();
-            executor.awaitTermination(10, SECONDS);
+            assertTrue(executor.awaitTermination(10, SECONDS));
         }
     }
 
@@ -543,7 +543,7 @@ public class TestEvictableCache
         }
         finally {
             executor.shutdownNow();
-            executor.awaitTermination(10, SECONDS);
+            assertTrue(executor.awaitTermination(10, SECONDS));
         }
     }
 

--- a/lib/trino-collect/src/test/java/io/trino/collect/cache/TestEvictableLoadingCache.java
+++ b/lib/trino-collect/src/test/java/io/trino/collect/cache/TestEvictableLoadingCache.java
@@ -466,7 +466,7 @@ public class TestEvictableLoadingCache
         }
         finally {
             executor.shutdownNow();
-            executor.awaitTermination(10, SECONDS);
+            assertTrue(executor.awaitTermination(10, SECONDS));
         }
     }
 
@@ -521,7 +521,7 @@ public class TestEvictableLoadingCache
         }
         finally {
             executor.shutdownNow();
-            executor.awaitTermination(10, SECONDS);
+            assertTrue(executor.awaitTermination(10, SECONDS));
         }
     }
 
@@ -599,7 +599,7 @@ public class TestEvictableLoadingCache
         }
         finally {
             executor.shutdownNow();
-            executor.awaitTermination(10, SECONDS);
+            assertTrue(executor.awaitTermination(10, SECONDS));
         }
     }
 
@@ -672,7 +672,7 @@ public class TestEvictableLoadingCache
         }
         finally {
             executor.shutdownNow();
-            executor.awaitTermination(10, SECONDS);
+            assertTrue(executor.awaitTermination(10, SECONDS));
         }
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
@@ -1046,7 +1046,7 @@ public class TestCachingHiveMetastore
             getPartitionsByNamesFinishedLatch.countDown();
 
             executor.shutdownNow();
-            executor.awaitTermination(10, SECONDS);
+            assertTrue(executor.awaitTermination(10, SECONDS));
         }
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -144,7 +144,7 @@ public abstract class BaseIcebergConnectorSmokeTest
         }
         finally {
             executor.shutdownNow();
-            executor.awaitTermination(10, SECONDS);
+            assertTrue(executor.awaitTermination(10, SECONDS));
         }
     }
 


### PR DESCRIPTION
For example `BaseSqlServerConnectorTest` overrides
`testReadMetadataWithRelationsConcurrentModifications`. Before the
change, the test invocation could leave background task running,
eventually leading to failure during `AbstractTestQueryFramework.close`
(in `checkQueryInfosFinal()`).

Fixes https://github.com/trinodb/trino/issues/15430 