### PR TITLE
Test SHOW TABLES after relation creation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/testing/MaterializedResult.java
+++ b/core/trino-main/src/main/java/io/trino/testing/MaterializedResult.java
@@ -51,6 +51,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -59,6 +60,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -82,6 +84,7 @@ import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.type.JsonType.JSON;
 import static java.lang.Float.floatToRawIntBits;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 public class MaterializedResult
@@ -224,6 +227,53 @@ public class MaterializedResult
                 .add("updateCount", updateCount.isPresent() ? updateCount.getAsLong() : null)
                 .omitNullValues()
                 .toString();
+    }
+
+    public MaterializedResult exceptColumns(String... columnNamesToExclude)
+    {
+        validateIfColumnsPresent(columnNamesToExclude);
+        checkArgument(columnNamesToExclude.length > 0, "At least one column must be excluded");
+        checkArgument(columnNamesToExclude.length < getColumnNames().size(), "All columns cannot be excluded");
+        return projected(((Predicate<String>) Set.of(columnNamesToExclude)::contains).negate());
+    }
+
+    public MaterializedResult project(String... columnNamesToInclude)
+    {
+        validateIfColumnsPresent(columnNamesToInclude);
+        checkArgument(columnNamesToInclude.length > 0, "At least one column must be projected");
+        return projected(Set.of(columnNamesToInclude)::contains);
+    }
+
+    private void validateIfColumnsPresent(String... columns)
+    {
+        Set<String> columnNames = ImmutableSet.copyOf(getColumnNames());
+        for (String column : columns) {
+            checkArgument(columnNames.contains(column), "[%s] column is not present in %s".formatted(column, columnNames));
+        }
+    }
+
+    private MaterializedResult projected(Predicate<String> columnFilter)
+    {
+        List<String> columnNames = getColumnNames();
+        Map<Integer, String> columnsIndexToNameMap = new HashMap<>();
+        for (int i = 0; i < columnNames.size(); i++) {
+            String columnName = columnNames.get(i);
+            if (columnFilter.test(columnName)) {
+                columnsIndexToNameMap.put(i, columnName);
+            }
+        }
+
+        return new MaterializedResult(
+                getMaterializedRows().stream()
+                        .map(row -> new MaterializedRow(
+                                row.getPrecision(),
+                                columnsIndexToNameMap.keySet().stream()
+                                        .map(row::getField)
+                                        .collect(toList()))) // values are nullable
+                        .collect(toImmutableList()),
+                columnsIndexToNameMap.keySet().stream()
+                        .map(getTypes()::get)
+                        .collect(toImmutableList()));
     }
 
     public Stream<Object> getOnlyColumn()

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -3519,14 +3519,16 @@ public abstract class BaseConnectorTest
         String catalogName = getSession().getCatalog().orElseThrow();
         String schemaName = getSession().getSchema().orElseThrow();
         try (TestTable table = new TestTable(getQueryRunner()::execute, "test_comment_", "(a integer)")) {
+            // comment initially not set
+            assertThat(getTableComment(catalogName, schemaName, table.getName())).isEqualTo(null);
+
             // comment set
             assertUpdate("COMMENT ON TABLE " + table.getName() + " IS 'new comment'");
             assertThat((String) computeScalar("SHOW CREATE TABLE " + table.getName())).contains("COMMENT 'new comment'");
             assertThat(getTableComment(catalogName, schemaName, table.getName())).isEqualTo("new comment");
             assertThat(query(
                     "SELECT table_name, comment FROM system.metadata.table_comments " +
-                            "WHERE catalog_name = '" + catalogName + "' AND " +
-                            "schema_name = '" + schemaName + "'"))
+                            "WHERE catalog_name = '" + catalogName + "' AND schema_name = '" + schemaName + "'")) // without table_name filter
                     .skippingTypesCheck()
                     .containsAll("VALUES ('" + table.getName() + "', 'new comment')");
 


### PR DESCRIPTION
Move `AbstractTestQueries.testShowTables` to
`AbstractTestEngineOnlyQueries`.
Add `BaseConnectorTest.testShowTables` testing `SHOW TABLES` with a
connector after a table or view is created in the connector.