### PR TITLE
Rename class implementing Hive's flush_metadata_cache

### DIFF
--- a/core/docker/container-test.sh
+++ b/core/docker/container-test.sh
@@ -38,7 +38,7 @@ function test_trino_starts {
     trap - EXIT
 
     if ! [[ ${RESULT} == '"success"' ]]; then
-        echo "🚨 Test query didn't return expected result (\"success\")" >&2
+        echo "🚨 Test query didn't return expected result (\"success\"): [${RESULT}]" >&2
         return 1
     fi
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/DecoratedHiveMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/DecoratedHiveMetastoreModule.java
@@ -23,7 +23,7 @@ import io.trino.plugin.hive.metastore.cache.CachingHiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.cache.ImpersonationCachingConfig;
 import io.trino.plugin.hive.metastore.cache.SharedHiveMetastoreCache;
 import io.trino.plugin.hive.metastore.cache.SharedHiveMetastoreCache.CachingHiveMetastoreFactory;
-import io.trino.plugin.hive.metastore.procedure.FlushHiveMetastoreCacheProcedure;
+import io.trino.plugin.hive.metastore.procedure.FlushMetadataCacheProcedure;
 import io.trino.plugin.hive.metastore.recording.RecordingHiveMetastoreDecoratorModule;
 import io.trino.spi.procedure.Procedure;
 import io.trino.spi.security.ConnectorIdentity;
@@ -64,7 +64,7 @@ public class DecoratedHiveMetastoreModule
                 .as(generator -> generator.generatedNameOf(CachingHiveMetastore.class));
 
         if (installFlushMetadataCacheProcedure) {
-            newSetBinder(binder, Procedure.class).addBinding().toProvider(FlushHiveMetastoreCacheProcedure.class).in(Scopes.SINGLETON);
+            newSetBinder(binder, Procedure.class).addBinding().toProvider(FlushMetadataCacheProcedure.class).in(Scopes.SINGLETON);
         }
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/procedure/FlushMetadataCacheProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/procedure/FlushMetadataCacheProcedure.java
@@ -35,7 +35,7 @@ import static java.lang.invoke.MethodHandles.lookup;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
-public class FlushHiveMetastoreCacheProcedure
+public class FlushMetadataCacheProcedure
         implements Provider<Procedure>
 {
     private static final String PROCEDURE_NAME = "flush_metadata_cache";
@@ -73,7 +73,7 @@ public class FlushHiveMetastoreCacheProcedure
 
     static {
         try {
-            FLUSH_HIVE_METASTORE_CACHE = lookup().unreflect(FlushHiveMetastoreCacheProcedure.class.getMethod(
+            FLUSH_HIVE_METASTORE_CACHE = lookup().unreflect(FlushMetadataCacheProcedure.class.getMethod(
                     "flushMetadataCache", String.class, String.class, List.class, List.class, List.class, List.class));
         }
         catch (ReflectiveOperationException e) {
@@ -84,7 +84,7 @@ public class FlushHiveMetastoreCacheProcedure
     private final Optional<CachingHiveMetastore> cachingHiveMetastore;
 
     @Inject
-    public FlushHiveMetastoreCacheProcedure(Optional<CachingHiveMetastore> cachingHiveMetastore)
+    public FlushMetadataCacheProcedure(Optional<CachingHiveMetastore> cachingHiveMetastore)
     {
         this.cachingHiveMetastore = requireNonNull(cachingHiveMetastore, "cachingHiveMetastore is null");
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/procedure/FlushMetadataCacheProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/procedure/FlushMetadataCacheProcedure.java
@@ -16,6 +16,7 @@ package io.trino.plugin.hive.metastore.procedure;
 import com.google.common.collect.ImmutableList;
 import io.trino.plugin.hive.HiveErrorCode;
 import io.trino.plugin.hive.metastore.cache.CachingHiveMetastore;
+import io.trino.spi.StandardErrorCode;
 import io.trino.spi.TrinoException;
 import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.procedure.Procedure;
@@ -153,9 +154,7 @@ public class FlushMetadataCacheProcedure
             }
         }
         else {
-            throw new TrinoException(
-                    HiveErrorCode.HIVE_METASTORE_ERROR,
-                    "Illegal parameter set passed. " + PROCEDURE_USAGE_EXAMPLES);
+            throw new TrinoException(StandardErrorCode.INVALID_PROCEDURE_ARGUMENT, "Illegal parameter set passed. " + PROCEDURE_USAGE_EXAMPLES);
         }
     }
 


### PR DESCRIPTION
Name it consistently with the procedure name.
