### PR TITLE
Add feature to support options in dynamic table in Pinot connector

### DIFF
--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotMetadata.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotMetadata.java
@@ -253,6 +253,7 @@ public class PinotMetadata
                     dynamicTable.get().getOrderBy(),
                     OptionalLong.of(limit),
                     dynamicTable.get().getOffset(),
+                    dynamicTable.get().getOptions(),
                     dynamicTable.get().getQuery()));
         }
 
@@ -413,6 +414,7 @@ public class PinotMetadata
                 ImmutableList.of(),
                 limitForDynamicTable,
                 OptionalLong.empty(),
+                Optional.empty(),
                 newQuery);
         tableHandle = new PinotTableHandle(tableHandle.getSchemaName(), tableHandle.getTableName(), tableHandle.getConstraint(), tableHandle.getLimit(), Optional.of(dynamicTable));
 

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/DynamicTable.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/DynamicTable.java
@@ -41,6 +41,8 @@ public final class DynamicTable
     private final List<PinotColumnHandle> aggregateColumns;
     private final Optional<String> havingExpression;
 
+    private final Optional<String> options;
+
     // semantically sorting is applied after aggregation
     private final List<OrderByExpression> orderBy;
 
@@ -64,6 +66,7 @@ public final class DynamicTable
             @JsonProperty("orderBy") List<OrderByExpression> orderBy,
             @JsonProperty("limit") OptionalLong limit,
             @JsonProperty("offset") OptionalLong offset,
+            @JsonProperty("options") Optional<String> options,
             @JsonProperty("query") String query)
     {
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -76,6 +79,7 @@ public final class DynamicTable
         this.orderBy = ImmutableList.copyOf(requireNonNull(orderBy, "orderBy is null"));
         this.limit = requireNonNull(limit, "limit is null");
         this.offset = requireNonNull(offset, "offset is null");
+        this.options = requireNonNull(options, "options is null");
         this.query = requireNonNull(query, "query is null");
         this.isAggregateInProjections = projections.stream()
                 .anyMatch(PinotColumnHandle::isAggregate);
@@ -147,6 +151,12 @@ public final class DynamicTable
         return query;
     }
 
+    @JsonProperty
+    public Optional<String> getOptions()
+    {
+        return options;
+    }
+
     public boolean isAggregateInProjections()
     {
         return isAggregateInProjections;
@@ -170,6 +180,7 @@ public final class DynamicTable
                 groupingColumns.equals(that.groupingColumns) &&
                 aggregateColumns.equals(that.aggregateColumns) &&
                 havingExpression.equals(that.havingExpression) &&
+                options.equals(that.options) &&
                 orderBy.equals(that.orderBy) &&
                 limit.equals(that.limit) &&
                 offset.equals(that.offset) &&
@@ -179,7 +190,7 @@ public final class DynamicTable
     @Override
     public int hashCode()
     {
-        return Objects.hash(tableName, projections, filter, groupingColumns, aggregateColumns, havingExpression, orderBy, limit, offset, query);
+        return Objects.hash(tableName, projections, filter, groupingColumns, aggregateColumns, havingExpression, orderBy, limit, offset, options, query);
     }
 
     @Override
@@ -195,6 +206,7 @@ public final class DynamicTable
                 .add("orderBy", orderBy)
                 .add("limit", limit)
                 .add("offset", offset)
+                .add("options", options)
                 .add("query", query)
                 .toString();
     }

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/DynamicTableBuilder.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/DynamicTableBuilder.java
@@ -51,6 +51,7 @@ import static io.trino.plugin.pinot.query.PinotExpressionRewriter.rewriteExpress
 import static io.trino.plugin.pinot.query.PinotPatterns.WILDCARD;
 import static io.trino.plugin.pinot.query.PinotSqlFormatter.formatExpression;
 import static io.trino.plugin.pinot.query.PinotSqlFormatter.formatFilter;
+import static io.trino.plugin.pinot.query.PinotSqlFormatter.formatOptions;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -75,6 +76,7 @@ public final class DynamicTableBuilder
         requireNonNull(schemaTableName, "schemaTableName is null");
         requireNonNull(typeConverter, "typeConverter is null");
         String query = schemaTableName.getTableName();
+
         BrokerRequest request = CalciteSqlCompiler.compileToBrokerRequest(query);
         PinotQuery pinotQuery = request.getPinotQuery();
         QueryContext queryContext = QueryContextConverterUtils.getQueryContext(pinotQuery);
@@ -127,7 +129,13 @@ public final class DynamicTableBuilder
             filter = Optional.of(formatted);
         }
 
-        return new DynamicTable(pinotTableName, suffix, selectColumns, filter, groupByColumns, ImmutableList.of(), havingExpression, orderBy, OptionalLong.of(queryContext.getLimit()), getOffset(queryContext), query);
+        Optional<String> queryOption = Optional.empty();
+        if (pinotQuery.queryOptions != null) {
+            String formatted = formatOptions(pinotQuery.queryOptions);
+            queryOption = Optional.of(formatted);
+        }
+
+        return new DynamicTable(pinotTableName, suffix, selectColumns, filter, groupByColumns, ImmutableList.of(), havingExpression, orderBy, OptionalLong.of(queryContext.getLimit()), getOffset(queryContext), queryOption, query);
     }
 
     private static List<PinotColumnHandle> getPinotColumns(SchemaTableName schemaTableName, List<ExpressionContext> expressions, List<String> aliases, Map<String, ColumnHandle> columnHandles, PinotTypeResolver pinotTypeResolver, Map<String, PinotColumnNameAndTrinoType> aggregateTypes)

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/DynamicTablePqlExtractor.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/DynamicTablePqlExtractor.java
@@ -75,6 +75,7 @@ public final class DynamicTablePqlExtractor
                             .map(DynamicTablePqlExtractor::convertOrderByExpressionToPql)
                             .collect(joining(", ")));
         }
+
         if (table.getLimit().isPresent()) {
             builder.append(" LIMIT ");
             if (table.getOffset().isPresent()) {
@@ -82,6 +83,9 @@ public final class DynamicTablePqlExtractor
                         .append(", ");
             }
             builder.append(table.getLimit().getAsLong());
+        }
+        if (!table.getOptions().isEmpty()) {
+            builder.append(table.getOptions().get());
         }
         return builder.toString();
     }

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotSqlFormatter.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotSqlFormatter.java
@@ -23,6 +23,7 @@ import io.trino.plugin.pinot.PinotException;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
+import java.util.stream.Collectors;
 import org.apache.pinot.common.function.TransformFunctionType;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FilterContext;
@@ -36,7 +37,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotSqlFormatter.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotSqlFormatter.java
@@ -36,6 +36,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -153,6 +154,14 @@ public class PinotSqlFormatter
             return result.get();
         }
         throw new PinotException(PINOT_INVALID_PQL_GENERATED, Optional.empty(), format("Unexpected filter type: '%s'", filterContext.getType()));
+    }
+
+    static String formatOptions(Map<String, String> queryOptions)
+    {
+        String options = queryOptions.keySet().stream()
+                .map(key -> " OPTION(" + key + "=" + queryOptions.get(key) + ")")
+                .collect(Collectors.joining(","));
+        return options;
     }
 
     private static String formatPredicate(Predicate predicate, Context context)

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestDynamicTable.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestDynamicTable.java
@@ -456,7 +456,7 @@ public class TestDynamicTable
         String tableName = realtimeOnlyTable.getTableName();
         List<String> columnNames = getColumnNames(tableName);
         String tableNameWithSuffix = tableName + REALTIME_SUFFIX;
-        String query = "select %s from %s limit 10 option(skipupsert=true)".formatted(join(", ", columnNames), tableNameWithSuffix);
+        String query = "SELECT %s FROM %s LIMIT 10 OPTION(skipupsert=true)".formatted(join(", ", columnNames), tableNameWithSuffix);
         DynamicTable dynamicTable = buildFromPql(pinotMetadata, new SchemaTableName("default", query), mockClusterInfoFetcher, TESTING_TYPE_CONVERTER);
         Optional<String> expectedOption = Optional.of(" OPTION(skipUpsert=true)");
         assertEquals(dynamicTable.getOptions(), expectedOption);
@@ -468,7 +468,7 @@ public class TestDynamicTable
         String tableName = realtimeOnlyTable.getTableName();
         List<String> columnNames = getColumnNames(tableName);
         String tableNameWithSuffix = tableName + REALTIME_SUFFIX;
-        String query = "select %s from %s limit 10 option(skipUpsert=true,enableNullHandling=true)".formatted(join(", ", columnNames), tableNameWithSuffix);
+        String query = "SELECT %s FROM %s LIMIT 10 OPTION(skipUpsert=true, enableNullHandling=true)".formatted(join(", ", columnNames), tableNameWithSuffix);
         DynamicTable dynamicTable = buildFromPql(pinotMetadata, new SchemaTableName("default", query), mockClusterInfoFetcher, TESTING_TYPE_CONVERTER);
         Optional<String> expectedOption = Optional.of(" OPTION(enableNullHandling=true), OPTION(skipUpsert=true)");
         assertEquals(dynamicTable.getOptions(), expectedOption);


### PR DESCRIPTION
Add support to OPTION for Pinot connector (https://docs.pinot.apache.org/users/user-guide-query/query-options) when using passthrought query.

My main idea under this PR is to be able to pass -> OPTION(skipUpsert=true) to my pinot cluster.

Before PR

`select id from table  limit 10 OPTION(skipUpsert=true)`
translated to
`select id from ressources  limit 10`

After dev

`select id from table  limit 10 OPTION(skipUpsert=true)`
translated to
`select id from table  limit 10 OPTION(skipUpsert=true)`

Limitation multiple OPTION are only suported using OPTION(skipUpsert=true,opt2=val2) multiple option statement will be rejected.


<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
