### PR TITLE
Handle cast null in domain translator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -476,6 +476,15 @@ public final class DomainTranslator
         }
 
         @Override
+        protected ExtractionResult visitCast(Cast node, Boolean context)
+        {
+            if (node.getExpression() instanceof NullLiteral) {
+                return new ExtractionResult(TupleDomain.none(), TRUE_LITERAL);
+            }
+            return super.visitCast(node, context);
+        }
+
+        @Override
         protected ExtractionResult visitNotExpression(NotExpression node, Boolean complement)
         {
             return process(node.getValue(), !complement);

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
@@ -599,6 +599,13 @@ public class TestDomainTranslator
     }
 
     @Test
+    public void testFromCastOfNullPredicate()
+    {
+        assertPredicateIsAlwaysFalse(cast(nullLiteral(), BOOLEAN));
+        assertPredicateIsAlwaysFalse(not(cast(nullLiteral(), BOOLEAN)));
+    }
+
+    @Test
     public void testFromNotPredicate()
     {
         assertUnsupportedPredicate(not(and(equal(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT))));

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
@@ -1154,12 +1154,51 @@ public class TestLogicalPlanner
                 "SELECT * FROM nation WHERE 1 = 0",
                 output(
                         values("nationkey", "name", "regionkey", "comment")));
+    }
+
+    @Test
+    public void testRemovesNullFilter()
+    {
         assertPlan(
                 "SELECT * FROM nation WHERE null",
                 output(
                         values("nationkey", "name", "regionkey", "comment")));
         assertPlan(
+                "SELECT * FROM nation WHERE NOT null",
+                output(
+                        values("nationkey", "name", "regionkey", "comment")));
+        assertPlan(
+                "SELECT * FROM nation WHERE CAST(null AS BOOLEAN)",
+                output(
+                        values("nationkey", "name", "regionkey", "comment")));
+        assertPlan(
+                "SELECT * FROM nation WHERE NOT CAST(null AS BOOLEAN)",
+                output(
+                        values("nationkey", "name", "regionkey", "comment")));
+        assertPlan(
                 "SELECT * FROM nation WHERE nationkey = null",
+                output(
+                        values("nationkey", "name", "regionkey", "comment")));
+        assertPlan(
+                "SELECT * FROM nation WHERE nationkey = CAST(null AS BIGINT)",
+                output(
+                        values("nationkey", "name", "regionkey", "comment")));
+        assertPlan(
+                "SELECT * FROM nation WHERE nationkey < null OR nationkey > null",
+                output(
+                        values("nationkey", "name", "regionkey", "comment")));
+        assertPlan(
+                "SELECT * FROM nation WHERE nationkey = 19 AND CAST(null AS BOOLEAN)",
+                output(
+                        values("nationkey", "name", "regionkey", "comment")));
+    }
+
+    @Test
+    public void testRemovesFalseFilter()
+    {
+        // Regression test for https://github.com/trinodb/trino/issues/16515
+        assertPlan(
+                "SELECT * FROM nation WHERE CAST(name AS varchar(1)) = 'PO'",
                 output(
                         values("nationkey", "name", "regionkey", "comment")));
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateIntoTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateIntoTableScan.java
@@ -117,7 +117,7 @@ public class TestPushPredicateIntoTableScan
     }
 
     @Test
-    public void doesNotFireIfNoTableScan()
+    public void testDoesNotFireIfNoTableScan()
     {
         tester().assertThat(pushPredicateIntoTableScan)
                 .on(p -> p.values(p.symbol("a", BIGINT)))
@@ -125,7 +125,7 @@ public class TestPushPredicateIntoTableScan
     }
 
     @Test
-    public void eliminateTableScanWhenNoLayoutExist()
+    public void testEliminateTableScanWhenNoLayoutExist()
     {
         tester().assertThat(pushPredicateIntoTableScan)
                 .on(p -> p.filter(expression("orderstatus = 'G'"),
@@ -137,7 +137,7 @@ public class TestPushPredicateIntoTableScan
     }
 
     @Test
-    public void replaceWithExistsWhenNoLayoutExist()
+    public void testReplaceWithExistsWhenNoLayoutExist()
     {
         ColumnHandle columnHandle = new TpchColumnHandle("nationkey", BIGINT);
         tester().assertThat(pushPredicateIntoTableScan)
@@ -152,7 +152,7 @@ public class TestPushPredicateIntoTableScan
     }
 
     @Test
-    public void consumesDeterministicPredicateIfNewDomainIsSame()
+    public void testConsumesDeterministicPredicateIfNewDomainIsSame()
     {
         ColumnHandle columnHandle = new TpchColumnHandle("nationkey", BIGINT);
         tester().assertThat(pushPredicateIntoTableScan)
@@ -170,7 +170,7 @@ public class TestPushPredicateIntoTableScan
     }
 
     @Test
-    public void consumesDeterministicPredicateIfNewDomainIsWider()
+    public void testConsumesDeterministicPredicateIfNewDomainIsWider()
     {
         ColumnHandle columnHandle = new TpchColumnHandle("nationkey", BIGINT);
         tester().assertThat(pushPredicateIntoTableScan)
@@ -188,7 +188,7 @@ public class TestPushPredicateIntoTableScan
     }
 
     @Test
-    public void consumesDeterministicPredicateIfNewDomainIsNarrower()
+    public void testConsumesDeterministicPredicateIfNewDomainIsNarrower()
     {
         Type orderStatusType = createVarcharType(1);
         ColumnHandle columnHandle = new TpchColumnHandle("orderstatus", orderStatusType);
@@ -206,7 +206,7 @@ public class TestPushPredicateIntoTableScan
     }
 
     @Test
-    public void doesNotConsumeRemainingPredicateIfNewDomainIsWider()
+    public void testDoesNotConsumeRemainingPredicateIfNewDomainIsWider()
     {
         ColumnHandle columnHandle = new TpchColumnHandle("nationkey", BIGINT);
         tester().assertThat(pushPredicateIntoTableScan)
@@ -268,7 +268,7 @@ public class TestPushPredicateIntoTableScan
     }
 
     @Test
-    public void doesNotFireOnNonDeterministicPredicate()
+    public void testDoesNotFireOnNonDeterministicPredicate()
     {
         ColumnHandle columnHandle = new TpchColumnHandle("nationkey", BIGINT);
         tester().assertThat(pushPredicateIntoTableScan)
@@ -288,7 +288,7 @@ public class TestPushPredicateIntoTableScan
     }
 
     @Test
-    public void doesNotFireIfRuleNotChangePlan()
+    public void testDoesNotFireIfRuleNotChangePlan()
     {
         tester().assertThat(pushPredicateIntoTableScan)
                 .on(p -> p.filter(expression("nationkey % 17 =  BIGINT '44' AND nationkey % 15 =  BIGINT '43'"),
@@ -301,7 +301,7 @@ public class TestPushPredicateIntoTableScan
     }
 
     @Test
-    public void ruleAddedTableLayoutToFilterTableScan()
+    public void testRuleAddedTableLayoutToFilterTableScan()
     {
         Map<String, Domain> filterConstraint = ImmutableMap.of("orderstatus", singleValue(createVarcharType(1), utf8Slice("F")));
         tester().assertThat(pushPredicateIntoTableScan)
@@ -315,7 +315,7 @@ public class TestPushPredicateIntoTableScan
     }
 
     @Test
-    public void nonDeterministicPredicate()
+    public void testNonDeterministicPredicate()
     {
         Type orderStatusType = createVarcharType(1);
         tester().assertThat(pushPredicateIntoTableScan)

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -54,6 +54,7 @@ import java.util.stream.Collectors;
 
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.expression.Constant.FALSE;
 import static io.trino.spi.expression.StandardFunctions.AND_FUNCTION_NAME;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -1029,8 +1030,14 @@ public interface ConnectorMetadata
      */
     default Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
     {
+        // applyFilter is expected not to be invoked with a "false" constraint
         if (constraint.getSummary().isNone()) {
             throw new IllegalArgumentException("constraint summary is NONE");
+        }
+        if (FALSE.equals(constraint.getExpression())) {
+            // DomainTranslator translates FALSE expressions into TupleDomain.none() (via Visitor#visitBooleanLiteral)
+            // so the remaining expression shouldn't be FALSE and therefore the translated connectorExpression shouldn't be FALSE either.
+            throw new IllegalArgumentException("constraint expression is FALSE");
         }
         return Optional.empty();
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -1029,7 +1029,7 @@ public interface ConnectorMetadata
      */
     default Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
     {
-        if (constraint.getSummary().getDomains().isEmpty()) {
+        if (constraint.getSummary().isNone()) {
             throw new IllegalArgumentException("constraint summary is NONE");
         }
         return Optional.empty();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ExpressionConverter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ExpressionConverter.java
@@ -55,7 +55,7 @@ public final class ExpressionConverter
         if (tupleDomain.isAll()) {
             return alwaysTrue();
         }
-        if (tupleDomain.getDomains().isEmpty()) {
+        if (tupleDomain.isNone()) {
             return alwaysFalse();
         }
         Map<IcebergColumnHandle, Domain> domainMap = tupleDomain.getDomains().get();

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -707,7 +707,7 @@ public class TestPostgreSqlConnectorTest
         assertThat(query("SELECT * FROM nation WHERE nationkey != 3 OR regionkey != 4")).isFullyPushedDown();
         assertThat(query("SELECT * FROM nation WHERE name = 'ALGERIA' OR regionkey = 4")).isFullyPushedDown();
         assertThat(query("SELECT * FROM nation WHERE name IS NULL OR regionkey = 4")).isFullyPushedDown();
-        assertThat(query("SELECT * FROM nation WHERE name = NULL OR regionkey = 4")).isNotFullyPushedDown(FilterNode.class); // TODO `name = NULL` should be eliminated by the engine
+        assertThat(query("SELECT * FROM nation WHERE name = NULL OR regionkey = 4")).isFullyPushedDown();
     }
 
     @Test


### PR DESCRIPTION
## Description
Fixes https://github.com/trinodb/trino/issues/15555, fixes https://github.com/trinodb/trino/issues/16515.
For queries such: `SELECT * FROM nation WHERE nationkey = null AND regionkey = 4`, the pushed down constraint in `applyFilter()` is `Constraint[summary=<...>, expression=null::boolean]`.
This fix avoids the pushdown and replaces the filter with empty values.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Blocking https://github.com/trinodb/trino/pull/16206

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( X ) Release notes are required, with the following suggested text:

```markdown
# General
* Avoid null predicate pushdown. ({issue}`15555`, {issue}`16515`)
```