### PR TITLE
Add error handling for saturated floor cast

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -32,6 +32,7 @@ import io.trino.metadata.TableProceduresPropertyManager;
 import io.trino.metadata.TableProceduresRegistry;
 import io.trino.metadata.TablePropertyManager;
 import io.trino.security.AllowAllAccessControl;
+import io.trino.spi.ErrorCode;
 import io.trino.spi.TrinoException;
 import io.trino.spi.predicate.DiscreteValues;
 import io.trino.spi.predicate.Domain;
@@ -94,6 +95,7 @@ import static io.airlift.slice.SliceUtf8.lengthOfCodePoint;
 import static io.airlift.slice.SliceUtf8.setCodePointAt;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
@@ -835,8 +837,19 @@ public final class DomainTranslator
             }
             Type valueType = nullableValue.getType();
             Object value = nullableValue.getValue();
-            return floorValue(valueType, symbolExpressionType, value)
-                    .map(floorValue -> rewriteComparisonExpression(symbolExpressionType, symbolExpression, valueType, value, floorValue, comparisonOperator));
+            Optional<Object> floorValueOptional;
+            try {
+                floorValueOptional = floorValue(valueType, symbolExpressionType, value);
+            }
+            catch (TrinoException e) {
+                ErrorCode errorCode = e.getErrorCode();
+                if (INVALID_CAST_ARGUMENT.toErrorCode().equals(errorCode)) {
+                    // There's no such value at symbolExpressionType
+                    return Optional.of(FALSE_LITERAL);
+                }
+                throw e;
+            }
+            return floorValueOptional.map(floorValue -> rewriteComparisonExpression(symbolExpressionType, symbolExpression, valueType, value, floorValue, comparisonOperator));
         }
 
         private Expression rewriteComparisonExpression(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
@@ -835,6 +835,16 @@ public class TestDomainTranslator
     }
 
     @Test
+    public void testFromCoercionComparisonsWithNaN()
+    {
+        Expression nanDouble = literalEncoder.toExpression(TEST_SESSION, Double.NaN, DOUBLE);
+
+        assertPredicateIsAlwaysFalse(equal(cast(C_TINYINT, DOUBLE), nanDouble));
+        assertPredicateIsAlwaysFalse(equal(cast(C_SMALLINT, DOUBLE), nanDouble));
+        assertPredicateIsAlwaysFalse(equal(cast(C_INTEGER, DOUBLE), nanDouble));
+    }
+
+    @Test
     public void testNonImplicitCastOnSymbolSide()
     {
         // we expect TupleDomain.all here().


### PR DESCRIPTION
## Description
An exception wasn't thrown until today because of rule ordering. For example, `double NaN` can't be cast to `smallint`. Given the query `SELECT * FROM (VALUES SMALLINT '1') t(a) WHERE a IS DISTINCT FROM nan()`, the filter's predicate is replaced with `TRUE` by
`UnwrapCastInComparison.FilterExpressionRewrite` before hitting `DomainTranslator`. When manually disabling this rule, a `TrinoException` with the message `Unable to cast double NaN to smallint` is thrown by `DoubleOperators#saturatedFloorCastToLong`.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Blocking https://github.com/trinodb/trino/pull/16206

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( X ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
