### PR TITLE
Add `toString()` method for `ForwardingInputFile` and `ForwardingOutputFile`

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/fileio/ForwardingInputFile.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/fileio/ForwardingInputFile.java
@@ -75,4 +75,10 @@ public class ForwardingInputFile
             throw new UncheckedIOException("Failed to check existence for file: " + location(), e);
         }
     }
+
+    @Override
+    public String toString()
+    {
+        return inputFile.toString();
+    }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/fileio/ForwardingOutputFile.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/fileio/ForwardingOutputFile.java
@@ -74,6 +74,12 @@ public class ForwardingOutputFile
         return new ForwardingInputFile(fileSystem.newInputFile(outputFile.location()));
     }
 
+    @Override
+    public String toString()
+    {
+        return outputFile.toString();
+    }
+
     private static class CountingPositionOutputStream
             extends PositionOutputStream
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

While dealing with failure scenarios, it is helpful to see what file is causing the issue

```
io.trino.testing.QueryFailedException: Failed to read file: ForwardingInputFile{inputFile=s3://test-bucket/tpch/corrupt_table_y4fjmbitkt-a9f1d9ebba684cd8b19ddcdc58725c68/metadata/00002-c9681ed7-843a-4484-92ed-606ef7c07e75.metadata.json}
```

instead of 

```
io.trino.testing.QueryFailedException: Failed to read file: io.trino.plugin.iceberg.fileio.ForwardingInputFile@2cdc22bb
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
