### PR TITLE
Avoid array list shift in ChunkedSliceOutput

### DIFF
--- a/lib/trino-hive-formats/pom.xml
+++ b/lib/trino-hive-formats/pom.xml
@@ -114,6 +114,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.trino.hive</groupId>
             <artifactId>hive-apache</artifactId>
             <scope>test</scope>

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/compression/ChunkedSliceOutput.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/compression/ChunkedSliceOutput.java
@@ -347,8 +347,7 @@ public final class ChunkedSliceOutput
         private final int maxChunkSize;
 
         private final List<byte[]> bufferPool = new ArrayList<>();
-        private final List<byte[]> usedBuffers = new ArrayList<>();
-
+        private int usedBuffers;
         private int currentSize;
 
         public ChunkSupplier(int minChunkSize, int maxChunkSize)
@@ -363,22 +362,22 @@ public final class ChunkedSliceOutput
 
         public void reset()
         {
-            bufferPool.addAll(0, usedBuffers);
-            usedBuffers.clear();
+            usedBuffers = 0;
         }
 
         public byte[] get()
         {
             byte[] buffer;
-            if (bufferPool.isEmpty()) {
-                currentSize = min(multiplyExact(currentSize, 2), maxChunkSize);
-                buffer = new byte[currentSize];
+            if (usedBuffers == bufferPool.size()) {
+                int newSize = min(multiplyExact(currentSize, 2), maxChunkSize);
+                buffer = new byte[newSize];
+                bufferPool.add(buffer);
             }
             else {
-                buffer = bufferPool.remove(0);
-                currentSize = buffer.length;
+                buffer = bufferPool.get(usedBuffers);
             }
-            usedBuffers.add(buffer);
+            usedBuffers++;
+            currentSize = buffer.length;
             return buffer;
         }
     }

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/openxjson/TestJsonReader.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/openxjson/TestJsonReader.java
@@ -35,7 +35,7 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class JsonReaderTest
+public class TestJsonReader
 {
     @Test
     public void testJsonNull()
@@ -263,7 +263,7 @@ public class JsonReaderTest
         }
         if (value instanceof List<?> list) {
             return list.stream()
-                    .map(JsonReaderTest::toHiveEquivalent)
+                    .map(TestJsonReader::toHiveEquivalent)
                     .collect(Collectors.toCollection(ArrayList::new));
         }
         if (value instanceof JsonString jsonString) {

--- a/lib/trino-orc/src/main/java/io/trino/orc/ChunkedSliceOutput.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/ChunkedSliceOutput.java
@@ -348,8 +348,7 @@ public final class ChunkedSliceOutput
         private final int maxChunkSize;
 
         private final List<byte[]> bufferPool = new ArrayList<>();
-        private final List<byte[]> usedBuffers = new ArrayList<>();
-
+        private int usedBuffers;
         private int currentSize;
 
         public ChunkSupplier(int minChunkSize, int maxChunkSize)
@@ -364,22 +363,22 @@ public final class ChunkedSliceOutput
 
         public void reset()
         {
-            bufferPool.addAll(0, usedBuffers);
-            usedBuffers.clear();
+            usedBuffers = 0;
         }
 
         public byte[] get()
         {
             byte[] buffer;
-            if (bufferPool.isEmpty()) {
-                currentSize = min(multiplyExact(currentSize, 2), maxChunkSize);
-                buffer = new byte[currentSize];
+            if (usedBuffers == bufferPool.size()) {
+                int newSize = min(multiplyExact(currentSize, 2), maxChunkSize);
+                buffer = new byte[newSize];
+                bufferPool.add(buffer);
             }
             else {
-                buffer = bufferPool.remove(0);
-                currentSize = buffer.length;
+                buffer = bufferPool.get(usedBuffers);
             }
-            usedBuffers.add(buffer);
+            usedBuffers++;
+            currentSize = buffer.length;
             return buffer;
         }
     }


### PR DESCRIPTION
Previously, the buffer allocation would remove first element of an `ArrayList`, causing a shift of all elements. This is rather ignorable: buffers get allocated bigger and bigger, so there aren't many buffer allocations. Still, it can be avoided, by keeping buffers on one list instead of two.
