### PR TITLE
Simplify TableFunctionSplitProcessor interface

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
@@ -35,7 +35,9 @@ import io.trino.sql.planner.plan.PlanNodeId;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
@@ -71,7 +73,7 @@ public class WorkProcessorPipelineSourceOperator
     private final OperationTimer timer;
     // operator instances including source operator
     private final List<WorkProcessorOperatorContext> workProcessorOperatorContexts = new ArrayList<>();
-    private final List<Split> pendingSplits = new ArrayList<>();
+    private final Deque<Split> pendingSplits = new ArrayDeque<>();
 
     private ListenableFuture<Void> blockedFuture;
     private WorkProcessorSourceOperator sourceOperator;
@@ -502,7 +504,7 @@ public class WorkProcessorPipelineSourceOperator
                 return ProcessState.blocked(blockedOnSplits);
             }
 
-            return ProcessState.ofResult(pendingSplits.remove(0));
+            return ProcessState.ofResult(pendingSplits.remove());
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorAdapter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorAdapter.java
@@ -23,8 +23,8 @@ import io.trino.spi.Page;
 import io.trino.spi.metrics.Metrics;
 import io.trino.sql.planner.plan.PlanNodeId;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 import static io.trino.operator.WorkProcessor.ProcessState.blocked;
 import static io.trino.operator.WorkProcessor.ProcessState.finished;
@@ -237,7 +237,7 @@ public class WorkProcessorSourceOperatorAdapter
     private static class SplitBuffer
             implements WorkProcessor.Process<Split>
     {
-        private final List<Split> pendingSplits = new ArrayList<>();
+        private final Deque<Split> pendingSplits = new ArrayDeque<>();
 
         private SettableFuture<Void> blockedOnSplits = SettableFuture.create();
         private boolean noMoreSplits;
@@ -254,7 +254,7 @@ public class WorkProcessorSourceOperatorAdapter
                 return blocked(blockedOnSplits);
             }
 
-            return ofResult(pendingSplits.remove(0));
+            return ofResult(pendingSplits.remove());
         }
 
         void add(Split split)

--- a/core/trino-main/src/main/java/io/trino/operator/table/Sequence.java
+++ b/core/trino-main/src/main/java/io/trino/operator/table/Sequence.java
@@ -246,7 +246,7 @@ public class Sequence
     public static class SequenceFunctionProcessor
             implements TableFunctionSplitProcessor
     {
-        private final PageBuilder page = new PageBuilder(ImmutableList.of(BIGINT));
+        private final PageBuilder pageBuilder = new PageBuilder(ImmutableList.of(BIGINT));
         private final long step;
         private long start;
         private long stop;
@@ -264,39 +264,39 @@ public class Sequence
                 SequenceFunctionSplit sequenceSplit = (SequenceFunctionSplit) split;
                 start = sequenceSplit.getStart();
                 stop = sequenceSplit.getStop();
-                BlockBuilder block = page.getBlockBuilder(0);
-                while (start != stop && !page.isFull()) {
-                    page.declarePosition();
+                BlockBuilder block = pageBuilder.getBlockBuilder(0);
+                while (start != stop && !pageBuilder.isFull()) {
+                    pageBuilder.declarePosition();
                     BIGINT.writeLong(block, start);
                     start += step;
                 }
-                if (!page.isFull()) {
-                    page.declarePosition();
+                if (!pageBuilder.isFull()) {
+                    pageBuilder.declarePosition();
                     BIGINT.writeLong(block, start);
                     finished = true;
-                    return usedInputAndProduced(page.build());
+                    return usedInputAndProduced(pageBuilder.build());
                 }
-                return usedInputAndProduced(page.build());
+                return usedInputAndProduced(pageBuilder.build());
             }
 
             if (finished) {
                 return FINISHED;
             }
 
-            page.reset();
-            BlockBuilder block = page.getBlockBuilder(0);
-            while (start != stop && !page.isFull()) {
-                page.declarePosition();
+            pageBuilder.reset();
+            BlockBuilder block = pageBuilder.getBlockBuilder(0);
+            while (start != stop && !pageBuilder.isFull()) {
+                pageBuilder.declarePosition();
                 BIGINT.writeLong(block, start);
                 start += step;
             }
-            if (!page.isFull()) {
-                page.declarePosition();
+            if (!pageBuilder.isFull()) {
+                pageBuilder.declarePosition();
                 BIGINT.writeLong(block, start);
                 finished = true;
-                return produced(page.build());
+                return produced(pageBuilder.build());
             }
-            return produced(page.build());
+            return produced(pageBuilder.build());
         }
     }
 }

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -234,24 +234,6 @@
                                 <!-- Backwards incompatible changes since the previous release -->
                                 <!-- Any exclusions below can be deleted after each release -->
                                 <item>
-                                    <ignore>true</ignore>
-                                    <code>java.method.numberOfParametersChanged</code>
-                                    <old>method void io.trino.spi.connector.MaterializedViewFreshness::&lt;init&gt;(boolean)</old>
-                                    <new>method void io.trino.spi.connector.MaterializedViewFreshness::&lt;init&gt;(io.trino.spi.connector.MaterializedViewFreshness.Freshness, java.util.Optional&lt;java.time.Instant&gt;)</new>
-                                </item>
-                                <item>
-                                    <code>java.method.removed</code>
-                                    <old>method java.util.Optional&lt;java.util.Set&lt;io.trino.spi.connector.ColumnHandle&gt;&gt; io.trino.spi.connector.ConnectorTableProperties::getStreamPartitioningColumns()</old>
-                                    <justification>Replaced with the ConnectorTablePartitioning#singleSplitPerPartition. Soft migration is not straightforward.</justification>
-                                </item>
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.method.numberOfParametersChanged</code>
-                                    <old>method void io.trino.spi.connector.ConnectorTableProperties::&lt;init&gt;(io.trino.spi.predicate.TupleDomain&lt;io.trino.spi.connector.ColumnHandle&gt;, java.util.Optional&lt;io.trino.spi.connector.ConnectorTablePartitioning&gt;, java.util.Optional&lt;java.util.Set&lt;io.trino.spi.connector.ColumnHandle&gt;&gt;, java.util.Optional&lt;io.trino.spi.connector.DiscretePredicates&gt;, java.util.List&lt;io.trino.spi.connector.LocalProperty&lt;io.trino.spi.connector.ColumnHandle&gt;&gt;)</old>
-                                    <new>method void io.trino.spi.connector.ConnectorTableProperties::&lt;init&gt;(io.trino.spi.predicate.TupleDomain&lt;io.trino.spi.connector.ColumnHandle&gt;, java.util.Optional&lt;io.trino.spi.connector.ConnectorTablePartitioning&gt;, java.util.Optional&lt;io.trino.spi.connector.DiscretePredicates&gt;, java.util.List&lt;io.trino.spi.connector.LocalProperty&lt;io.trino.spi.connector.ColumnHandle&gt;&gt;)</new>
-                                    <justification>Replaced with the ConnectorTablePartitioning#singleSplitPerPartition. Soft migration is not straightforward.</justification>
-                                </item>
-                                <item>
                                     <regex>true</regex>
                                     <code>java.class.externalClassExposedInAPI</code>
                                     <newArchive>io.opentelemetry:opentelemetry-(api|context):.*</newArchive>

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -234,6 +234,12 @@
                                 <!-- Backwards incompatible changes since the previous release -->
                                 <!-- Any exclusions below can be deleted after each release -->
                                 <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.removed</code>
+                                    <old>interface io.trino.spi.ptf.TableFunctionSplitProcessor</old>
+                                    <justification>It is just marked @Experimental</justification>
+                                </item>
+                                <item>
                                     <regex>true</regex>
                                     <code>java.class.externalClassExposedInAPI</code>
                                     <newArchive>io.opentelemetry:opentelemetry-(api|context):.*</newArchive>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplitManager.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplitManager.java
@@ -29,7 +29,7 @@ public interface ConnectorSplitManager
         throw new UnsupportedOperationException();
     }
 
-    @Experimental(eta = "2023-03-31")
+    @Experimental(eta = "2023-07-31")
     default ConnectorSplitSource getSplits(
             ConnectorTransactionHandle transaction,
             ConnectorSession session,

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionProcessorProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionProcessorProvider.java
@@ -15,6 +15,7 @@ package io.trino.spi.ptf;
 
 import io.trino.spi.Experimental;
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplit;
 
 @Experimental(eta = "2023-07-31")
 public interface TableFunctionProcessorProvider
@@ -32,7 +33,7 @@ public interface TableFunctionProcessorProvider
      * This method returns a {@code TableFunctionSplitProcessor}. All the necessary information collected during analysis is available
      * in the form of {@link ConnectorTableFunctionHandle}. It is called once per each split processed by the table function.
      */
-    default TableFunctionSplitProcessor getSplitProcessor(ConnectorSession session, ConnectorTableFunctionHandle handle)
+    default TableFunctionSplitProcessor getSplitProcessor(ConnectorSession session, ConnectorTableFunctionHandle handle, ConnectorSplit split)
     {
         throw new UnsupportedOperationException("this table function does not process splits");
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionProcessorProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionProcessorProvider.java
@@ -16,7 +16,7 @@ package io.trino.spi.ptf;
 import io.trino.spi.Experimental;
 import io.trino.spi.connector.ConnectorSession;
 
-@Experimental(eta = "2023-03-31")
+@Experimental(eta = "2023-07-31")
 public interface TableFunctionProcessorProvider
 {
     /**

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionProcessorState.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionProcessorState.java
@@ -34,7 +34,7 @@ import static java.util.Objects.requireNonNull;
  * Note: when the input is empty, the only valid index value is null, because there are no input rows that could be attached to output. In such case, for performance
  * reasons, the validation of indexes is skipped, and all pass-through columns are filled with nulls.
  */
-@Experimental(eta = "2023-03-31")
+@Experimental(eta = "2023-07-31")
 public sealed interface TableFunctionProcessorState
         permits TableFunctionProcessorState.Blocked, TableFunctionProcessorState.Finished, TableFunctionProcessorState.Processed
 {

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionSplitProcessor.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionSplitProcessor.java
@@ -14,9 +14,6 @@
 package io.trino.spi.ptf;
 
 import io.trino.spi.Experimental;
-import io.trino.spi.connector.ConnectorSplit;
-
-import javax.annotation.Nullable;
 
 /**
  * Processes table functions splits, as returned from {@link io.trino.spi.connector.ConnectorSplitManager}
@@ -31,12 +28,8 @@ public interface TableFunctionSplitProcessor
     /**
      * This method processes a split. It is called multiple times until the whole output for the split is produced.
      *
-     * @param split a {@link ConnectorSplit} representing a subtask, or {@code null} if a split has already started to be processed,
-     * and the implementation returned a {@link TableFunctionProcessorState.Processed} with
-     * {@link TableFunctionProcessorState.Processed#isUsedInput()} being {@code true}.
      * @return {@link TableFunctionProcessorState} including the processor's state and optionally a portion of result.
-     * After the returned state is {@code FINISHED}, the method will not be called again for the split currently being processed
-     * and may be called with a new split.
+     * After the returned state is {@code FINISHED}, the method will not be called again.
      */
-    TableFunctionProcessorState process(@Nullable ConnectorSplit split);
+    TableFunctionProcessorState process();
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionSplitProcessor.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionSplitProcessor.java
@@ -13,6 +13,7 @@
  */
 package io.trino.spi.ptf;
 
+import io.trino.spi.Experimental;
 import io.trino.spi.connector.ConnectorSplit;
 
 import javax.annotation.Nullable;
@@ -24,6 +25,7 @@ import javax.annotation.Nullable;
  * Thread-safety: implementations do not have to be thread-safe. The {@link #process} method may be called from
  * multiple threads, but will never be called from two threads at the same time.
  */
+@Experimental(eta = "2023-07-31")
 public interface TableFunctionSplitProcessor
 {
     /**


### PR DESCRIPTION
The `TableFunctionSplitProcessor` is used for one split only and then
new instance of `TableFunctionSplitProcessor` is created.

Provide the split directly to
`TableFunctionProcessorProvider.getSplitProcessor` and do not provide it
to `TableFunctionProcessor.process`. This removes conditionality of
argument presence in the `process` method and so makes things simpler.
