### PR TITLE
Improve nulls and offsets calculations in parquet reader

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
@@ -59,9 +59,18 @@ public class MapBlock
             Block valueBlock,
             MapType mapType)
     {
-        validateConstructorArguments(mapType, 0, offsets.length - 1, mapIsNull.orElse(null), offsets, keyBlock, valueBlock);
+        return fromKeyValueBlock(mapIsNull, offsets, offsets.length - 1, keyBlock, valueBlock, mapType);
+    }
 
-        int mapCount = offsets.length - 1;
+    public static MapBlock fromKeyValueBlock(
+            Optional<boolean[]> mapIsNull,
+            int[] offsets,
+            int mapCount,
+            Block keyBlock,
+            Block valueBlock,
+            MapType mapType)
+    {
+        validateConstructorArguments(mapType, 0, mapCount, mapIsNull.orElse(null), offsets, keyBlock, valueBlock);
 
         return createMapBlockInternal(
                 mapType,

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
@@ -251,6 +251,11 @@ public final class ParquetTypeUtils
         return !required && (definitionLevel == maxDefinitionLevel - 1);
     }
 
+    public static boolean isOptionalFieldValueNull(int definitionLevel, int maxDefinitionLevel)
+    {
+        return definitionLevel == maxDefinitionLevel - 1;
+    }
+
     public static long getShortDecimalValue(byte[] bytes)
     {
         return getShortDecimalValue(bytes, 0, bytes.length);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/StructColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/StructColumnReader.java
@@ -15,9 +15,10 @@ package io.trino.parquet.reader;
 
 import io.trino.parquet.Field;
 import it.unimi.dsi.fastutil.booleans.BooleanArrayList;
-import it.unimi.dsi.fastutil.booleans.BooleanList;
 
-import static io.trino.parquet.ParquetTypeUtils.isValueNull;
+import java.util.Optional;
+
+import static io.trino.parquet.ParquetTypeUtils.isOptionalFieldValueNull;
 
 public final class StructColumnReader
 {
@@ -29,20 +30,35 @@ public final class StructColumnReader
      * 2) Struct is null
      * 3) Struct is defined and not empty.
      */
-    public static BooleanList calculateStructOffsets(
+    public static RowBlockPositions calculateStructOffsets(
             Field field,
             int[] fieldDefinitionLevels,
             int[] fieldRepetitionLevels)
     {
         int maxDefinitionLevel = field.getDefinitionLevel();
         int maxRepetitionLevel = field.getRepetitionLevel();
-        BooleanList structIsNull = new BooleanArrayList();
         boolean required = field.isRequired();
+        if (required) {
+            int definedValuesCount = 0;
+            for (int i = 0; i < fieldDefinitionLevels.length; i++) {
+                if (fieldRepetitionLevels[i] <= maxRepetitionLevel) {
+                    if (fieldDefinitionLevels[i] >= maxDefinitionLevel) {
+                        // Struct is defined and not empty
+                        definedValuesCount++;
+                    }
+                }
+            }
+            return new RowBlockPositions(Optional.empty(), definedValuesCount);
+        }
+
+        int nullValuesCount = 0;
+        BooleanArrayList structIsNull = new BooleanArrayList();
         for (int i = 0; i < fieldDefinitionLevels.length; i++) {
             if (fieldRepetitionLevels[i] <= maxRepetitionLevel) {
-                if (isValueNull(required, fieldDefinitionLevels[i], maxDefinitionLevel)) {
+                if (isOptionalFieldValueNull(fieldDefinitionLevels[i], maxDefinitionLevel)) {
                     // Struct is null
                     structIsNull.add(true);
+                    nullValuesCount++;
                 }
                 else if (fieldDefinitionLevels[i] >= maxDefinitionLevel) {
                     // Struct is defined and not empty
@@ -50,6 +66,11 @@ public final class StructColumnReader
                 }
             }
         }
-        return structIsNull;
+        if (nullValuesCount == 0) {
+            return new RowBlockPositions(Optional.empty(), structIsNull.size());
+        }
+        return new RowBlockPositions(Optional.of(structIsNull.elements()), structIsNull.size());
     }
+
+    public record RowBlockPositions(Optional<boolean[]> isNull, int positionsCount) {}
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/StructColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/StructColumnReader.java
@@ -38,9 +38,6 @@ public final class StructColumnReader
         int maxRepetitionLevel = field.getRepetitionLevel();
         BooleanList structIsNull = new BooleanArrayList();
         boolean required = field.isRequired();
-        if (fieldDefinitionLevels == null) {
-            return structIsNull;
-        }
         for (int i = 0; i < fieldDefinitionLevels.length; i++) {
             if (fieldRepetitionLevels[i] <= maxRepetitionLevel) {
                 if (isValueNull(required, fieldDefinitionLevels[i], maxDefinitionLevel)) {


### PR DESCRIPTION
## Description
Avoids a few unnecessary operations when reading nested types in parquet

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
