### PR TITLE
Avoid boxing booleans for primitive types in join

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
@@ -1031,13 +1031,18 @@ public class JoinCompiler
             BytecodeExpression rightBlock,
             BytecodeExpression rightBlockPosition)
     {
-        MethodHandle equalOperator = typeOperators.getEqualOperator(type, simpleConvention(NULLABLE_RETURN, BLOCK_POSITION, BLOCK_POSITION));
+        MethodHandle equalOperator = typeOperators.getEqualOperator(
+                type,
+                simpleConvention(type.getJavaType().isPrimitive() ? FAIL_ON_NULL : NULLABLE_RETURN, BLOCK_POSITION, BLOCK_POSITION));
         BytecodeExpression equalInvocation = invokeDynamic(
                 BOOTSTRAP_METHOD,
                 ImmutableList.of(callSiteBinder.bind(equalOperator).getBindingId()),
                 "equal",
                 equalOperator.type(),
                 leftBlock, leftBlockPosition, rightBlock, rightBlockPosition);
+        if (type.getJavaType().isPrimitive()) {
+            return equalInvocation;
+        }
         return BytecodeExpressions.equal(equalInvocation, getStatic(Boolean.class, "TRUE"));
     }
 


### PR DESCRIPTION
## Description
PagesHashStrategy#positionEqualsPositionIgnoreNulls can avoid the overhead of ValueConversions.boxBoolean for primitive types

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
