### PR TITLE
Support Kerberos Ticket Cache for trino authentication

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/KerberosAuthenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/KerberosAuthenticator.java
@@ -87,12 +87,18 @@ public class KerberosAuthenticator
                         options.put("debug", "true");
                     }
                     if (config.getKeytab() != null) {
+                        options.put("storeKey", "true");
+                        options.put("useKeyTab", "true");
                         options.put("keyTab", config.getKeytab().getAbsolutePath());
                     }
+
+                    if (config.getKeyCache() != null) {
+                        options.put("useTicketCache", "true");
+                        options.put("renewTGT", "true");
+                        options.put("ticketCache", config.getKeyCache().getAbsolutePath());
+                    }
                     options.put("isInitiator", "false");
-                    options.put("useKeyTab", "true");
                     options.put("principal", servicePrincipal);
-                    options.put("storeKey", "true");
 
                     return new AppConfigurationEntry[] {new AppConfigurationEntry(Krb5LoginModule.class.getName(), REQUIRED, options)};
                 }

--- a/core/trino-main/src/main/java/io/trino/server/security/KerberosConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/KerberosConfig.java
@@ -27,10 +27,12 @@ import static io.trino.server.security.KerberosNameType.HOSTBASED_SERVICE;
 public class KerberosConfig
 {
     public static final String HTTP_SERVER_AUTHENTICATION_KRB5_KEYTAB = "http-server.authentication.krb5.keytab";
+    public static final String HTTP_SERVER_AUTHENTICATION_KRB5_KEYCACHE = "http-server.authentication.krb5.keycache";
 
     private File kerberosConfig;
     private String serviceName;
     private File keytab;
+    private File keyCache;
     private String principalHostname;
     private KerberosNameType nameType = HOSTBASED_SERVICE;
     private Optional<String> userMappingPattern = Optional.empty();
@@ -76,6 +78,19 @@ public class KerberosConfig
     public KerberosConfig setKeytab(File keytab)
     {
         this.keytab = keytab;
+        return this;
+    }
+
+    @FileExists
+    public File getKeyCache()
+    {
+        return keyCache;
+    }
+
+    @Config("http-server.authentication.krb5.keycache")
+    public KerberosConfig setKeyCache(File keyCache)
+    {
+        this.keyCache = keyCache;
         return this;
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This pr is new feature for trino authentication using kerberos credential cache, trino only support key tab file based authentication , which if not support in large enterprises. 

## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) One new property is introduce - 'http-server.authentication.krb5.keycache'

```markdown
# Section
* Added kerberos credential cache support for authentication , Issue  12509
```
