### PR TITLE
Implement Dereference pushdown for the Delta Lake connector

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.rst
+++ b/docs/src/main/sphinx/connector/delta-lake.rst
@@ -190,6 +190,9 @@ configure processing of Parquet files.
     * - ``parquet_writer_batch_size``
       - Maximum number of rows processed by the Parquet writer in a batch.
       - ``10000``
+    * - ``projection_pushdown_enabled``
+      - Read only projected fields from row columns while performing ``SELECT`` queries
+      - ``true``
 
 .. _delta-lake-type-mapping:
 
@@ -929,4 +932,7 @@ connector.
         property to ``false`` to disable the optimized parquet reader by default
         for structural data types. The equivalent catalog session property is
         ``parquet_optimized_nested_reader_enabled``.
+      - ``true``
+    * - ``delta.projection-pushdown-enabled``
+      - Read only projected fields from row columns while performing ``SELECT`` queries
       - ``true``

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
@@ -155,16 +155,17 @@ public abstract class AbstractDeltaLakePageSink
             DeltaLakeColumnHandle column = inputColumns.get(inputIndex);
             switch (column.getColumnType()) {
                 case PARTITION_KEY:
-                    int partitionPosition = canonicalToOriginalPartitionPositions.get(column.getName());
+                    int partitionPosition = canonicalToOriginalPartitionPositions.get(column.getColumnName());
                     partitionColumnInputIndex[partitionPosition] = inputIndex;
-                    originalPartitionColumnNames[partitionPosition] = canonicalToOriginalPartitionColumns.get(column.getName());
-                    partitionColumnTypes[partitionPosition] = column.getType();
+                    originalPartitionColumnNames[partitionPosition] = canonicalToOriginalPartitionColumns.get(column.getColumnName());
+                    partitionColumnTypes[partitionPosition] = column.getBaseType();
                     break;
                 case REGULAR:
+                    verify(column.isBaseColumn(), "Unexpected dereference: %s", column);
                     dataColumnHandles.add(column);
                     dataColumnsInputIndex.add(inputIndex);
-                    dataColumnNames.add(column.getPhysicalName());
-                    dataColumnTypes.add(column.getPhysicalType());
+                    dataColumnNames.add(column.getBasePhysicalColumnName());
+                    dataColumnTypes.add(column.getBasePhysicalType());
                     break;
                 case SYNTHESIZED:
                     processSynthesizedColumn(column);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeBucketFunction.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeBucketFunction.java
@@ -22,6 +22,7 @@ import java.lang.invoke.MethodHandle;
 import java.util.List;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
@@ -37,7 +38,8 @@ public class DeltaLakeBucketFunction
     public DeltaLakeBucketFunction(TypeOperators typeOperators, List<DeltaLakeColumnHandle> partitioningColumns, int bucketCount)
     {
         this.hashCodeInvokers = partitioningColumns.stream()
-                .map(DeltaLakeColumnHandle::getType)
+                .peek(column -> verify(column.isBaseColumn(), "Unexpected dereference: %s", column))
+                .map(DeltaLakeColumnHandle::getBaseType)
                 .map(type -> typeOperators.getHashCodeOperator(type, simpleConvention(FAIL_ON_NULL, BLOCK_POSITION)))
                 .collect(toImmutableList());
         this.bucketCount = bucketCount;

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeColumnHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeColumnHandle.java
@@ -183,4 +183,9 @@ public class DeltaLakeColumnHandle
     {
         return new DeltaLakeColumnHandle(FILE_MODIFIED_TIME_COLUMN_NAME, FILE_MODIFIED_TIME_TYPE, OptionalInt.empty(), FILE_MODIFIED_TIME_COLUMN_NAME, FILE_MODIFIED_TIME_TYPE, SYNTHESIZED);
     }
+
+    public static DeltaLakeColumnHandle mergeRowIdColumnHandle()
+    {
+        return new DeltaLakeColumnHandle(ROW_ID_COLUMN_NAME, MERGE_ROW_ID_TYPE, OptionalInt.empty(), ROW_ID_COLUMN_NAME, MERGE_ROW_ID_TYPE, SYNTHESIZED);
+    }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeColumnHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeColumnHandle.java
@@ -25,6 +25,7 @@ import java.util.OptionalInt;
 
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
 import static io.airlift.slice.SizeOf.instanceSize;
+import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.plugin.deltalake.DeltaHiveTypeTranslator.toHiveType;
 import static io.trino.plugin.deltalake.DeltaLakeColumnType.SYNTHESIZED;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -142,7 +143,10 @@ public class DeltaLakeColumnHandle
     public long getRetainedSizeInBytes()
     {
         // type is not accounted for as the instances are cached (by TypeRegistry) and shared
-        return INSTANCE_SIZE + estimatedSizeOf(name);
+        return INSTANCE_SIZE
+                + estimatedSizeOf(name)
+                + sizeOf(fieldId)
+                + estimatedSizeOf(physicalName);
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeColumnHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeColumnHandle.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.deltalake;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.spi.connector.ColumnHandle;
@@ -23,10 +24,13 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.plugin.deltalake.DeltaHiveTypeTranslator.toHiveType;
+import static io.trino.plugin.deltalake.DeltaLakeColumnType.REGULAR;
 import static io.trino.plugin.deltalake.DeltaLakeColumnType.SYNTHESIZED;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.RowType.field;
@@ -56,70 +60,80 @@ public class DeltaLakeColumnHandle
     public static final String FILE_MODIFIED_TIME_COLUMN_NAME = "$file_modified_time";
     public static final Type FILE_MODIFIED_TIME_TYPE = TIMESTAMP_TZ_MILLIS;
 
-    private final String name;
-    private final Type type;
-    private final OptionalInt fieldId;
+    private final String baseColumnName;
+    private final Type baseType;
+    private final OptionalInt baseFieldId;
     // Hold field names in Parquet files
     // The value is same as 'name' when the column mapping mode is none
     // The value is same as 'delta.columnMapping.physicalName' when the column mapping mode is id or name. e.g. col-6707cc9e-f3aa-4e6b-b8ef-1b03d3475680
-    private final String physicalName;
+    private final String basePhysicalColumnName;
     // Hold type in Parquet files
     // The value is same as 'type' when the column mapping mode is none
     // The value is same as 'delta.columnMapping.physicalName' when the column mapping mode is id or name. e.g. row(col-5924c8b3-04cf-4146-abb5-2c229e7ff708 integer)
-    private final Type physicalType;
+    private final Type basePhysicalType;
     private final DeltaLakeColumnType columnType;
+    private final Optional<DeltaLakeColumnProjectionInfo> projectionInfo;
 
     @JsonCreator
     public DeltaLakeColumnHandle(
-            @JsonProperty("name") String name,
-            @JsonProperty("type") Type type,
-            @JsonProperty("fieldId") OptionalInt fieldId,
-            @JsonProperty("physicalName") String physicalName,
-            @JsonProperty("physicalType") Type physicalType,
-            @JsonProperty("columnType") DeltaLakeColumnType columnType)
+            @JsonProperty("baseColumnName") String baseColumnName,
+            @JsonProperty("baseType") Type baseType,
+            @JsonProperty("baseFieldId") OptionalInt baseFieldId,
+            @JsonProperty("basePhysicalColumnName") String basePhysicalColumnName,
+            @JsonProperty("basePhysicalType") Type basePhysicalType,
+            @JsonProperty("columnType") DeltaLakeColumnType columnType,
+            @JsonProperty("projectionInfo") Optional<DeltaLakeColumnProjectionInfo> projectionInfo)
     {
-        this.name = requireNonNull(name, "name is null");
-        this.type = requireNonNull(type, "type is null");
-        this.fieldId = requireNonNull(fieldId, "fieldId is null");
-        this.physicalName = requireNonNull(physicalName, "physicalName is null");
-        this.physicalType = requireNonNull(physicalType, "physicalType is null");
+        this.baseColumnName = requireNonNull(baseColumnName, "baseColumnName is null");
+        this.baseType = requireNonNull(baseType, "baseType is null");
+        this.baseFieldId = requireNonNull(baseFieldId, "baseFieldId is null");
+        this.basePhysicalColumnName = requireNonNull(basePhysicalColumnName, "basePhysicalColumnName is null");
+        this.basePhysicalType = requireNonNull(basePhysicalType, "basePhysicalType is null");
         this.columnType = requireNonNull(columnType, "columnType is null");
+        checkArgument(projectionInfo.isEmpty() || columnType == REGULAR, "Projection info present for column type: %s", columnType);
+        this.projectionInfo = projectionInfo;
     }
 
     @JsonProperty
-    public String getName()
+    public String getBaseColumnName()
     {
-        return name;
+        return baseColumnName;
     }
 
     @JsonProperty
-    public Type getType()
+    public Type getBaseType()
     {
-        return type;
+        return baseType;
     }
 
     @JsonProperty
-    public OptionalInt getFieldId()
+    public OptionalInt getBaseFieldId()
     {
-        return fieldId;
+        return baseFieldId;
     }
 
     @JsonProperty
-    public String getPhysicalName()
+    public String getBasePhysicalColumnName()
     {
-        return physicalName;
+        return basePhysicalColumnName;
     }
 
     @JsonProperty
-    public Type getPhysicalType()
+    public Type getBasePhysicalType()
     {
-        return physicalType;
+        return basePhysicalType;
     }
 
     @JsonProperty
     public DeltaLakeColumnType getColumnType()
     {
         return columnType;
+    }
+
+    @JsonProperty
+    public Optional<DeltaLakeColumnProjectionInfo> getProjectionInfo()
+    {
+        return projectionInfo;
     }
 
     @Override
@@ -132,64 +146,88 @@ public class DeltaLakeColumnHandle
             return false;
         }
         DeltaLakeColumnHandle other = (DeltaLakeColumnHandle) obj;
-        return Objects.equals(this.name, other.name) &&
-                Objects.equals(this.type, other.type) &&
-                Objects.equals(this.fieldId, other.fieldId) &&
-                Objects.equals(this.physicalName, other.physicalName) &&
-                Objects.equals(this.physicalType, other.physicalType) &&
-                this.columnType == other.columnType;
+        return Objects.equals(this.baseColumnName, other.baseColumnName) &&
+                Objects.equals(this.baseType, other.baseType) &&
+                Objects.equals(this.baseFieldId, other.baseFieldId) &&
+                Objects.equals(this.basePhysicalColumnName, other.basePhysicalColumnName) &&
+                Objects.equals(this.basePhysicalType, other.basePhysicalType) &&
+                this.columnType == other.columnType &&
+                Objects.equals(this.projectionInfo, other.projectionInfo);
+    }
+
+    @JsonIgnore
+    public String getColumnName()
+    {
+        checkState(isBaseColumn(), "Unexpected dereference: %s", this);
+        return baseColumnName;
+    }
+
+    @JsonIgnore
+    public String getQualifiedPhysicalName()
+    {
+        return projectionInfo.map(projectionInfo -> basePhysicalColumnName + "#" + projectionInfo.getPartialName())
+                .orElse(basePhysicalColumnName);
     }
 
     public long getRetainedSizeInBytes()
     {
         // type is not accounted for as the instances are cached (by TypeRegistry) and shared
         return INSTANCE_SIZE
-                + estimatedSizeOf(name)
-                + sizeOf(fieldId)
-                + estimatedSizeOf(physicalName);
+                + estimatedSizeOf(baseColumnName)
+                + sizeOf(baseFieldId)
+                + estimatedSizeOf(basePhysicalColumnName)
+                + projectionInfo.map(DeltaLakeColumnProjectionInfo::getRetainedSizeInBytes).orElse(0L);
+    }
+
+    @JsonIgnore
+    public boolean isBaseColumn()
+    {
+        return projectionInfo.isEmpty();
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, type, fieldId, physicalName, physicalType, columnType);
+        return Objects.hash(baseColumnName, baseType, baseFieldId, basePhysicalColumnName, basePhysicalType, columnType, projectionInfo);
     }
 
     @Override
     public String toString()
     {
-        return name + ":" + type.getDisplayName() + ":" + columnType;
+        return getQualifiedPhysicalName() +
+                ":" + projectionInfo.map(DeltaLakeColumnProjectionInfo::getType).orElse(baseType).getDisplayName() +
+                ":" + columnType;
     }
 
     public HiveColumnHandle toHiveColumnHandle()
     {
         return new HiveColumnHandle(
-                physicalName, // this name is used for accessing Parquet files, so it should be physical name
+                basePhysicalColumnName, // this name is used for accessing Parquet files, so it should be physical name
                 0, // hiveColumnIndex; we provide fake value because we always find columns by name
-                toHiveType(physicalType),
-                physicalType,
-                Optional.empty(),
+                toHiveType(basePhysicalType),
+                basePhysicalType,
+                projectionInfo.map(DeltaLakeColumnProjectionInfo::toHiveColumnProjectionInfo),
                 columnType.toHiveColumnType(),
                 Optional.empty());
     }
 
     public static DeltaLakeColumnHandle pathColumnHandle()
     {
-        return new DeltaLakeColumnHandle(PATH_COLUMN_NAME, PATH_TYPE, OptionalInt.empty(), PATH_COLUMN_NAME, PATH_TYPE, SYNTHESIZED);
+        return new DeltaLakeColumnHandle(PATH_COLUMN_NAME, PATH_TYPE, OptionalInt.empty(), PATH_COLUMN_NAME, PATH_TYPE, SYNTHESIZED, Optional.empty());
     }
 
     public static DeltaLakeColumnHandle fileSizeColumnHandle()
     {
-        return new DeltaLakeColumnHandle(FILE_SIZE_COLUMN_NAME, FILE_SIZE_TYPE, OptionalInt.empty(), FILE_SIZE_COLUMN_NAME, FILE_SIZE_TYPE, SYNTHESIZED);
+        return new DeltaLakeColumnHandle(FILE_SIZE_COLUMN_NAME, FILE_SIZE_TYPE, OptionalInt.empty(), FILE_SIZE_COLUMN_NAME, FILE_SIZE_TYPE, SYNTHESIZED, Optional.empty());
     }
 
     public static DeltaLakeColumnHandle fileModifiedTimeColumnHandle()
     {
-        return new DeltaLakeColumnHandle(FILE_MODIFIED_TIME_COLUMN_NAME, FILE_MODIFIED_TIME_TYPE, OptionalInt.empty(), FILE_MODIFIED_TIME_COLUMN_NAME, FILE_MODIFIED_TIME_TYPE, SYNTHESIZED);
+        return new DeltaLakeColumnHandle(FILE_MODIFIED_TIME_COLUMN_NAME, FILE_MODIFIED_TIME_TYPE, OptionalInt.empty(), FILE_MODIFIED_TIME_COLUMN_NAME, FILE_MODIFIED_TIME_TYPE, SYNTHESIZED, Optional.empty());
     }
 
     public static DeltaLakeColumnHandle mergeRowIdColumnHandle()
     {
-        return new DeltaLakeColumnHandle(ROW_ID_COLUMN_NAME, MERGE_ROW_ID_TYPE, OptionalInt.empty(), ROW_ID_COLUMN_NAME, MERGE_ROW_ID_TYPE, SYNTHESIZED);
+        return new DeltaLakeColumnHandle(ROW_ID_COLUMN_NAME, MERGE_ROW_ID_TYPE, OptionalInt.empty(), ROW_ID_COLUMN_NAME, MERGE_ROW_ID_TYPE, SYNTHESIZED, Optional.empty());
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeColumnProjectionInfo.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeColumnProjectionInfo.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.SizeOf;
+import io.trino.plugin.hive.HiveColumnProjectionInfo;
+import io.trino.spi.type.Type;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
+import static io.trino.plugin.deltalake.DeltaHiveTypeTranslator.toHiveType;
+import static java.util.Objects.requireNonNull;
+
+public class DeltaLakeColumnProjectionInfo
+{
+    private static final int INSTANCE_SIZE = instanceSize(DeltaLakeColumnProjectionInfo.class);
+
+    private final Type type;
+    private final List<Integer> dereferenceIndices;
+    private final List<String> dereferencePhysicalNames;
+
+    @JsonCreator
+    public DeltaLakeColumnProjectionInfo(
+            @JsonProperty("type") Type type,
+            @JsonProperty("dereferenceIndices") List<Integer> dereferenceIndices,
+            @JsonProperty("dereferencePhysicalNames") List<String> dereferencePhysicalNames)
+    {
+        this.type = requireNonNull(type, "type is null");
+        requireNonNull(dereferenceIndices, "dereferenceIndices is null");
+        requireNonNull(dereferencePhysicalNames, "dereferencePhysicalNames is null");
+        checkArgument(dereferenceIndices.size() > 0, "dereferenceIndices should not be empty");
+        checkArgument(dereferencePhysicalNames.size() > 0, "dereferencePhysicalNames should not be empty");
+        checkArgument(dereferenceIndices.size() == dereferencePhysicalNames.size(), "dereferenceIndices and dereferencePhysicalNames should have the same sizes");
+        this.dereferenceIndices = ImmutableList.copyOf(dereferenceIndices);
+        this.dereferencePhysicalNames = ImmutableList.copyOf(dereferencePhysicalNames);
+    }
+
+    @JsonProperty
+    public Type getType()
+    {
+        return type;
+    }
+
+    @JsonProperty
+    public List<Integer> getDereferenceIndices()
+    {
+        return dereferenceIndices;
+    }
+
+    @JsonProperty
+    public List<String> getDereferencePhysicalNames()
+    {
+        return dereferencePhysicalNames;
+    }
+
+    @JsonIgnore
+    public String getPartialName()
+    {
+        return String.join("#", dereferencePhysicalNames);
+    }
+
+    @JsonIgnore
+    public long getRetainedSizeInBytes()
+    {
+        // type is not accounted for as the instances are cached (by TypeRegistry) and shared
+        return INSTANCE_SIZE
+                + estimatedSizeOf(dereferenceIndices, SizeOf::sizeOf)
+                + estimatedSizeOf(dereferencePhysicalNames, SizeOf::estimatedSizeOf);
+    }
+
+    public HiveColumnProjectionInfo toHiveColumnProjectionInfo()
+    {
+        return new HiveColumnProjectionInfo(dereferenceIndices, dereferencePhysicalNames, toHiveType(type), type);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DeltaLakeColumnProjectionInfo that = (DeltaLakeColumnProjectionInfo) o;
+        return Objects.equals(this.type, that.type)
+                && Objects.equals(this.dereferenceIndices, that.dereferenceIndices)
+                && Objects.equals(this.dereferencePhysicalNames, that.dereferencePhysicalNames);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(type, dereferenceIndices, dereferencePhysicalNames);
+    }
+
+    @Override
+    public String toString()
+    {
+        return getPartialName() + ":" + type.getDisplayName();
+    }
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
@@ -77,6 +77,7 @@ public class DeltaLakeConfig
     private boolean uniqueTableLocation = true;
     private boolean legacyCreateTableWithExistingLocationEnabled;
     private boolean registerTableProcedureEnabled;
+    private boolean projectionPushdownEnabled = true;
 
     public Duration getMetadataCacheTtl()
     {
@@ -473,6 +474,19 @@ public class DeltaLakeConfig
     public DeltaLakeConfig setRegisterTableProcedureEnabled(boolean registerTableProcedureEnabled)
     {
         this.registerTableProcedureEnabled = registerTableProcedureEnabled;
+        return this;
+    }
+
+    public boolean isProjectionPushdownEnabled()
+    {
+        return projectionPushdownEnabled;
+    }
+
+    @Config("delta.projection-pushdown-enabled")
+    @ConfigDescription("Read only required fields from a struct")
+    public DeltaLakeConfig setProjectionPushdownEnabled(boolean projectionPushdownEnabled)
+    {
+        this.projectionPushdownEnabled = projectionPushdownEnabled;
         return this;
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -1340,12 +1340,12 @@ public class DeltaLakeMetadata
         // This check acts as a safeguard in cases where the input columns may differ from the table metadata case-sensitively
         checkAllColumnsPassedOnInsert(tableMetadata, inputColumns);
 
-        return createInsertHandle(session, retryMode, table, inputColumns, tableMetadata);
+        return createInsertHandle(session, retryMode, table, inputColumns);
     }
 
-    private DeltaLakeInsertTableHandle createInsertHandle(ConnectorSession session, RetryMode retryMode, DeltaLakeTableHandle table, List<DeltaLakeColumnHandle> inputColumns, ConnectorTableMetadata tableMetadata)
+    private DeltaLakeInsertTableHandle createInsertHandle(ConnectorSession session, RetryMode retryMode, DeltaLakeTableHandle table, List<DeltaLakeColumnHandle> inputColumns)
     {
-        String tableLocation = getLocation(tableMetadata.getProperties());
+        String tableLocation = table.getLocation();
         try {
             TrinoFileSystem fileSystem = fileSystemFactory.create(session);
             return new DeltaLakeInsertTableHandle(
@@ -1508,13 +1508,11 @@ public class DeltaLakeMetadata
         }
         checkWriteSupported(session, handle);
 
-        ConnectorTableMetadata tableMetadata = getTableMetadata(session, handle);
-
         List<DeltaLakeColumnHandle> inputColumns = getColumns(handle.getMetadataEntry()).stream()
                 .filter(column -> column.getColumnType() != SYNTHESIZED)
                 .collect(toImmutableList());
 
-        DeltaLakeInsertTableHandle insertHandle = createInsertHandle(session, retryMode, handle, inputColumns, tableMetadata);
+        DeltaLakeInsertTableHandle insertHandle = createInsertHandle(session, retryMode, handle, inputColumns);
 
         return new DeltaLakeMergeTableHandle(handle, insertHandle);
     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -169,10 +169,9 @@ import static io.trino.plugin.deltalake.DataFileInfo.DataFileType.DATA;
 import static io.trino.plugin.deltalake.DeltaLakeAnalyzeProperties.getColumnNames;
 import static io.trino.plugin.deltalake.DeltaLakeAnalyzeProperties.getFilesModifiedAfterProperty;
 import static io.trino.plugin.deltalake.DeltaLakeColumnHandle.FILE_MODIFIED_TIME_COLUMN_NAME;
-import static io.trino.plugin.deltalake.DeltaLakeColumnHandle.MERGE_ROW_ID_TYPE;
-import static io.trino.plugin.deltalake.DeltaLakeColumnHandle.ROW_ID_COLUMN_NAME;
 import static io.trino.plugin.deltalake.DeltaLakeColumnHandle.fileModifiedTimeColumnHandle;
 import static io.trino.plugin.deltalake.DeltaLakeColumnHandle.fileSizeColumnHandle;
+import static io.trino.plugin.deltalake.DeltaLakeColumnHandle.mergeRowIdColumnHandle;
 import static io.trino.plugin.deltalake.DeltaLakeColumnHandle.pathColumnHandle;
 import static io.trino.plugin.deltalake.DeltaLakeColumnType.PARTITION_KEY;
 import static io.trino.plugin.deltalake.DeltaLakeColumnType.REGULAR;
@@ -1473,7 +1472,7 @@ public class DeltaLakeMetadata
     @Override
     public ColumnHandle getMergeRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        return new DeltaLakeColumnHandle(ROW_ID_COLUMN_NAME, MERGE_ROW_ID_TYPE, OptionalInt.empty(), ROW_ID_COLUMN_NAME, MERGE_ROW_ID_TYPE, SYNTHESIZED);
+        return mergeRowIdColumnHandle();
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputTableHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputTableHandle.java
@@ -92,7 +92,7 @@ public class DeltaLakeOutputTableHandle
     {
         return getInputColumns().stream()
                 .filter(column -> column.getColumnType() == PARTITION_KEY)
-                .map(DeltaLakeColumnHandle::getName)
+                .map(DeltaLakeColumnHandle::getColumnName)
                 .collect(toImmutableList());
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSinkProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSinkProvider.java
@@ -38,6 +38,7 @@ import org.joda.time.DateTimeZone;
 import javax.inject.Inject;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 
@@ -186,7 +187,8 @@ public class DeltaLakePageSinkProvider
                         metadata.getFieldId(),
                         metadata.getPhysicalName(),
                         metadata.getPhysicalColumnType(),
-                        partitionKeys.contains(metadata.getName()) ? PARTITION_KEY : REGULAR))
+                        partitionKeys.contains(metadata.getName()) ? PARTITION_KEY : REGULAR,
+                        Optional.empty()))
                 .collect(toImmutableList());
         List<DeltaLakeColumnHandle> allColumns = ImmutableList.<DeltaLakeColumnHandle>builder()
                 .addAll(tableColumns)
@@ -196,7 +198,8 @@ public class DeltaLakePageSinkProvider
                         OptionalInt.empty(),
                         CHANGE_TYPE_COLUMN_NAME,
                         VARCHAR,
-                        REGULAR))
+                        REGULAR,
+                        Optional.empty()))
                 .build();
         Location tableLocation = Location.of(mergeTableHandle.getTableHandle().getLocation());
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSource.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSource.java
@@ -15,6 +15,7 @@ package io.trino.plugin.deltalake;
 
 import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
+import io.trino.plugin.hive.ReaderProjectionsAdapter;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
@@ -61,6 +62,7 @@ public class DeltaLakePageSource
     private final Block pathBlock;
     private final Block partitionsBlock;
     private final ConnectorPageSource delegate;
+    private final Optional<ReaderProjectionsAdapter> projectionsAdapter;
 
     public DeltaLakePageSource(
             List<DeltaLakeColumnHandle> columns,
@@ -68,6 +70,7 @@ public class DeltaLakePageSource
             Map<String, Optional<String>> partitionKeys,
             Optional<List<String>> partitionValues,
             ConnectorPageSource delegate,
+            Optional<ReaderProjectionsAdapter> projectionsAdapter,
             String path,
             long fileSize,
             long fileModifiedTime)
@@ -75,6 +78,7 @@ public class DeltaLakePageSource
         int size = columns.size();
         requireNonNull(partitionKeys, "partitionKeys is null");
         this.delegate = requireNonNull(delegate, "delegate is null");
+        this.projectionsAdapter = requireNonNull(projectionsAdapter, "projectionsAdapter is null");
 
         this.prefilledBlocks = new Block[size];
         this.delegateIndexes = new int[size];
@@ -87,34 +91,34 @@ public class DeltaLakePageSource
         Block partitionsBlock = null;
 
         for (DeltaLakeColumnHandle column : columns) {
-            if (partitionKeys.containsKey(column.getPhysicalName())) {
-                Type type = column.getType();
-                Object prefilledValue = deserializePartitionValue(column, partitionKeys.get(column.getPhysicalName()));
+            if (column.isBaseColumn() && partitionKeys.containsKey(column.getBasePhysicalColumnName())) {
+                Type type = column.getBaseType();
+                Object prefilledValue = deserializePartitionValue(column, partitionKeys.get(column.getBasePhysicalColumnName()));
                 prefilledBlocks[outputIndex] = Utils.nativeValueToBlock(type, prefilledValue);
                 delegateIndexes[outputIndex] = -1;
             }
-            else if (column.getName().equals(PATH_COLUMN_NAME)) {
+            else if (column.getBaseColumnName().equals(PATH_COLUMN_NAME)) {
                 prefilledBlocks[outputIndex] = Utils.nativeValueToBlock(PATH_TYPE, utf8Slice(path));
                 delegateIndexes[outputIndex] = -1;
             }
-            else if (column.getName().equals(FILE_SIZE_COLUMN_NAME)) {
+            else if (column.getBaseColumnName().equals(FILE_SIZE_COLUMN_NAME)) {
                 prefilledBlocks[outputIndex] = Utils.nativeValueToBlock(FILE_SIZE_TYPE, fileSize);
                 delegateIndexes[outputIndex] = -1;
             }
-            else if (column.getName().equals(FILE_MODIFIED_TIME_COLUMN_NAME)) {
+            else if (column.getBaseColumnName().equals(FILE_MODIFIED_TIME_COLUMN_NAME)) {
                 long packedTimestamp = packDateTimeWithZone(fileModifiedTime, UTC_KEY);
                 prefilledBlocks[outputIndex] = Utils.nativeValueToBlock(FILE_MODIFIED_TIME_TYPE, packedTimestamp);
                 delegateIndexes[outputIndex] = -1;
             }
-            else if (column.getName().equals(ROW_ID_COLUMN_NAME)) {
+            else if (column.getBaseColumnName().equals(ROW_ID_COLUMN_NAME)) {
                 rowIdIndex = outputIndex;
                 pathBlock = Utils.nativeValueToBlock(VARCHAR, utf8Slice(path));
                 partitionsBlock = Utils.nativeValueToBlock(VARCHAR, wrappedBuffer(PARTITIONS_CODEC.toJsonBytes(partitionValues.orElseThrow(() -> new IllegalStateException("partitionValues not provided")))));
                 delegateIndexes[outputIndex] = delegateIndex;
                 delegateIndex++;
             }
-            else if (missingColumnNames.contains(column.getName())) {
-                prefilledBlocks[outputIndex] = Utils.nativeValueToBlock(column.getType(), null);
+            else if (missingColumnNames.contains(column.getBaseColumnName())) {
+                prefilledBlocks[outputIndex] = Utils.nativeValueToBlock(column.getBaseType(), null);
                 delegateIndexes[outputIndex] = -1;
             }
             else {
@@ -160,6 +164,9 @@ public class DeltaLakePageSource
             Page dataPage = delegate.getNextPage();
             if (dataPage == null) {
                 return null;
+            }
+            if (projectionsAdapter.isPresent()) {
+                dataPage = projectionsAdapter.get().adaptPage(dataPage);
             }
             int batchSize = dataPage.getPositionCount();
             Block[] blocks = new Block[prefilledBlocks.length];

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
@@ -64,6 +64,7 @@ public final class DeltaLakeSessionProperties
     public static final String EXTENDED_STATISTICS_ENABLED = "extended_statistics_enabled";
     public static final String EXTENDED_STATISTICS_COLLECT_ON_WRITE = "extended_statistics_collect_on_write";
     public static final String LEGACY_CREATE_TABLE_WITH_EXISTING_LOCATION_ENABLED = "legacy_create_table_with_existing_location_enabled";
+    private static final String PROJECTION_PUSHDOWN_ENABLED = "projection_pushdown_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -185,6 +186,11 @@ public final class DeltaLakeSessionProperties
                                 throw new TrinoException(INVALID_SESSION_PROPERTY, "Unsupported codec: LZ4");
                             }
                         },
+                        false),
+                booleanProperty(
+                        PROJECTION_PUSHDOWN_ENABLED,
+                        "Read only required fields from a struct",
+                        deltaLakeConfig.isProjectionPushdownEnabled(),
                         false));
     }
 
@@ -283,5 +289,10 @@ public final class DeltaLakeSessionProperties
     public static HiveCompressionCodec getCompressionCodec(ConnectorSession session)
     {
         return session.getProperty(COMPRESSION_CODEC, HiveCompressionCodec.class);
+    }
+
+    public static boolean isProjectionPushdownEnabled(ConnectorSession session)
+    {
+        return session.getProperty(PROJECTION_PUSHDOWN_ENABLED, Boolean.class);
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
@@ -155,7 +155,7 @@ public class DeltaLakeSplitManager
                 nonPartitionConstraint.getDomains().orElseThrow().keySet().stream(),
                 columnsCoveredByDynamicFilter.stream()
                         .map(DeltaLakeColumnHandle.class::cast))
-                .map(column -> column.getName().toLowerCase(ENGLISH)) // TODO is DeltaLakeColumnHandle.name normalized?
+                .map(column -> column.getBaseColumnName().toLowerCase(ENGLISH)) // TODO is DeltaLakeColumnHandle.name normalized?
                 .collect(toImmutableSet());
         List<DeltaLakeColumnMetadata> schema = extractSchema(tableHandle.getMetadataEntry(), typeManager);
         List<DeltaLakeColumnMetadata> predicatedColumns = schema.stream()
@@ -199,10 +199,10 @@ public class DeltaLakeSplitManager
                         Map<String, Optional<String>> partitionValues = addAction.getCanonicalPartitionValues();
                         Map<ColumnHandle, NullableValue> deserializedValues = constraint.getPredicateColumns().orElseThrow().stream()
                                 .map(DeltaLakeColumnHandle.class::cast)
-                                .filter(column -> partitionValues.containsKey(column.getName()))
+                                .filter(column -> column.isBaseColumn() && partitionValues.containsKey(column.getBaseColumnName()))
                                 .collect(toImmutableMap(identity(), column -> new NullableValue(
-                                        column.getType(),
-                                        deserializePartitionValue(column, partitionValues.get(column.getName())))));
+                                        column.getBaseType(),
+                                        deserializePartitionValue(column, partitionValues.get(column.getBaseColumnName())))));
                         if (!constraint.predicate().get().test(deserializedValues)) {
                             return Stream.empty();
                         }
@@ -235,7 +235,7 @@ public class DeltaLakeSplitManager
         for (Map.Entry<DeltaLakeColumnHandle, Domain> enforcedDomainsEntry : domains.entrySet()) {
             DeltaLakeColumnHandle partitionColumn = enforcedDomainsEntry.getKey();
             Domain partitionDomain = enforcedDomainsEntry.getValue();
-            if (!partitionDomain.includesNullableValue(deserializePartitionValue(partitionColumn, partitionKeys.get(partitionColumn.getPhysicalName())))) {
+            if (!partitionDomain.includesNullableValue(deserializePartitionValue(partitionColumn, partitionKeys.get(partitionColumn.getBasePhysicalColumnName())))) {
                 return false;
             }
         }
@@ -246,7 +246,7 @@ public class DeltaLakeSplitManager
     {
         return effectivePredicate.getDomains()
                 .flatMap(domains -> Optional.ofNullable(domains.get(pathColumnHandle())))
-                .orElseGet(() -> Domain.all(pathColumnHandle().getType()));
+                .orElseGet(() -> Domain.all(pathColumnHandle().getBaseType()));
     }
 
     private static boolean pathMatchesPredicate(Domain pathDomain, String path)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
@@ -111,7 +111,7 @@ public class DeltaLakeWriter
 
         ImmutableMap.Builder<Integer, Function<Block, Block>> coercers = ImmutableMap.builder();
         for (int i = 0; i < columnHandles.size(); i++) {
-            Optional<Function<Block, Block>> coercer = createCoercer(columnHandles.get(i).getType());
+            Optional<Function<Block, Block>> coercer = createCoercer(columnHandles.get(i).getBaseType());
             if (coercer.isPresent()) {
                 coercers.put(i, coercer.get());
             }
@@ -186,8 +186,8 @@ public class DeltaLakeWriter
             throws IOException
     {
         TrinoInputFile inputFile = fileSystem.newInputFile(rootTableLocation.appendPath(relativeFilePath));
-        List<String> dataColumnNames = columnHandles.stream().map(DeltaLakeColumnHandle::getPhysicalName).collect(toImmutableList());
-        List<Type> dataColumnTypes = columnHandles.stream().map(DeltaLakeColumnHandle::getPhysicalType).collect(toImmutableList());
+        List<String> dataColumnNames = columnHandles.stream().map(DeltaLakeColumnHandle::getBasePhysicalColumnName).collect(toImmutableList());
+        List<Type> dataColumnTypes = columnHandles.stream().map(DeltaLakeColumnHandle::getBasePhysicalType).collect(toImmutableList());
         return new DataFileInfo(
                 relativeFilePath,
                 getWrittenBytes(),

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
@@ -137,7 +137,7 @@ public final class DeltaLakeSchemaSupport
         }
         return schema.stream()
                 .filter(entry -> canonicalPartitionColumns.contains(entry.getName()))
-                .map(entry -> new DeltaLakeColumnHandle(entry.getName(), entry.getType(), OptionalInt.empty(), entry.getPhysicalName(), entry.getPhysicalColumnType(), PARTITION_KEY))
+                .map(entry -> new DeltaLakeColumnHandle(entry.getName(), entry.getType(), OptionalInt.empty(), entry.getPhysicalName(), entry.getPhysicalColumnType(), PARTITION_KEY, Optional.empty()))
                 .collect(toImmutableList());
     }
 
@@ -165,10 +165,10 @@ public final class DeltaLakeSchemaSupport
 
         schema.put("fields", columns.stream()
                 .map(column -> {
-                    String columnName = column.getName();
+                    String columnName = column.getColumnName();
                     return serializeStructField(
-                            column.getName(),
-                            column.getType(),
+                            columnName,
+                            column.getBaseType(),
                             columnComments.get(columnName),
                             columnNullability.get(columnName),
                             columnMetadata.get(columnName));

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogParser.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogParser.java
@@ -53,6 +53,7 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Function;
 
+import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.getTransactionLogDir;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.getTransactionLogJsonEntryPath;
@@ -163,7 +164,8 @@ public final class TransactionLogParser
 
     public static Object deserializeColumnValue(DeltaLakeColumnHandle column, String valueString, Function<String, Long> timestampReader)
     {
-        Type type = column.getType();
+        verify(column.isBaseColumn(), "Unexpected dereference: %s", column);
+        Type type = column.getBaseType();
         try {
             if (type.equals(BOOLEAN)) {
                 if (valueString.equalsIgnoreCase("true")) {
@@ -208,13 +210,13 @@ public final class TransactionLogParser
         catch (RuntimeException e) {
             throw new TrinoException(
                     GENERIC_INTERNAL_ERROR,
-                    format("Unable to parse value [%s] from column %s with type %s", valueString, column.getName(), column.getType()),
+                    format("Unable to parse value [%s] from column %s with type %s", valueString, column.getBaseColumnName(), column.getBaseType()),
                     e);
         }
         // Anything else is not a supported DeltaLake column
         throw new TrinoException(
                 GENERIC_INTERNAL_ERROR,
-                format("Unable to parse value [%s] from column %s with type %s", valueString, column.getName(), column.getType()));
+                format("Unable to parse value [%s] from column %s with type %s", valueString, column.getBaseColumnName(), column.getBaseType()));
     }
 
     static Optional<LastCheckpoint> readLastCheckpoint(TrinoFileSystem fileSystem, String tableLocation)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
@@ -222,7 +222,7 @@ public class CheckpointEntryIterator
             default:
                 throw new IllegalArgumentException("Unsupported Delta Lake checkpoint entry type: " + entryType);
         }
-        return new DeltaLakeColumnHandle(entryType.getColumnName(), type, OptionalInt.empty(), entryType.getColumnName(), type, REGULAR);
+        return new DeltaLakeColumnHandle(entryType.getColumnName(), type, OptionalInt.empty(), entryType.getColumnName(), type, REGULAR, Optional.empty());
     }
 
     private DeltaLakeTransactionLogEntry buildCommitInfoEntry(ConnectorSession session, Block block, int pagePosition)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeJsonFileStatistics.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeJsonFileStatistics.java
@@ -112,22 +112,31 @@ public class DeltaLakeJsonFileStatistics
     @Override
     public Optional<Object> getMaxColumnValue(DeltaLakeColumnHandle columnHandle)
     {
-        Optional<Object> value = getStat(columnHandle.getPhysicalName(), maxValues);
+        if (!columnHandle.isBaseColumn()) {
+            return Optional.empty();
+        }
+        Optional<Object> value = getStat(columnHandle.getBasePhysicalColumnName(), maxValues);
         return value.flatMap(o -> deserializeStatisticsValue(columnHandle, String.valueOf(o)));
     }
 
     @Override
     public Optional<Object> getMinColumnValue(DeltaLakeColumnHandle columnHandle)
     {
-        Optional<Object> value = getStat(columnHandle.getPhysicalName(), minValues);
+        if (!columnHandle.isBaseColumn()) {
+            return Optional.empty();
+        }
+        Optional<Object> value = getStat(columnHandle.getBasePhysicalColumnName(), minValues);
         return value.flatMap(o -> deserializeStatisticsValue(columnHandle, String.valueOf(o)));
     }
 
     private Optional<Object> deserializeStatisticsValue(DeltaLakeColumnHandle columnHandle, String statValue)
     {
+        if (!columnHandle.isBaseColumn()) {
+            return Optional.empty();
+        }
         Object columnValue = deserializeColumnValue(columnHandle, statValue, DeltaLakeJsonFileStatistics::readStatisticsTimestamp);
 
-        Type columnType = columnHandle.getType();
+        Type columnType = columnHandle.getBaseType();
         if (columnType.equals(DATE)) {
             long epochDate = (long) columnValue;
             if (LocalDate.ofEpochDay(epochDate).isBefore(START_OF_MODERN_ERA)) {

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeParquetFileStatistics.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeParquetFileStatistics.java
@@ -82,13 +82,19 @@ public class DeltaLakeParquetFileStatistics
     @Override
     public Optional<Object> getMaxColumnValue(DeltaLakeColumnHandle columnHandle)
     {
-        return getStat(columnHandle.getPhysicalName(), maxValues);
+        if (!columnHandle.isBaseColumn()) {
+            return Optional.empty();
+        }
+        return getStat(columnHandle.getBasePhysicalColumnName(), maxValues);
     }
 
     @Override
     public Optional<Object> getMinColumnValue(DeltaLakeColumnHandle columnHandle)
     {
-        return getStat(columnHandle.getPhysicalName(), minValues);
+        if (!columnHandle.isBaseColumn()) {
+            return Optional.empty();
+        }
+        return getStat(columnHandle.getBasePhysicalColumnName(), minValues);
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -2013,6 +2013,47 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
         assertUpdate("DROP TABLE " + tableName);
     }
 
+    @Test
+    public void testProjectionPushdownMultipleRows()
+    {
+        String tableName = "test_projection_pushdown_multiple_rows_" + randomNameSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName +
+                " (id BIGINT, nested1 ROW(child1 BIGINT, child2 VARCHAR, child3 INT), nested2 ROW(child1 DOUBLE, child2 BOOLEAN, child3 DATE))");
+        assertUpdate("INSERT INTO " + tableName + " VALUES" +
+                        " (100, ROW(10, 'a', 100), ROW(10.10, true, DATE '2023-04-19'))," +
+                        " (3, ROW(30, 'to_be_deleted', 300), ROW(30.30, false, DATE '2000-04-16'))," +
+                        " (2, ROW(20, 'b', 200), ROW(20.20, false, DATE '1990-04-20'))," +
+                        " (4, ROW(40, NULL, 400), NULL)," +
+                        " (5, NULL, ROW(NULL, true, NULL))",
+                5);
+        assertUpdate("UPDATE " + tableName + " SET id = 1 WHERE nested2.child3 = DATE '2023-04-19'", 1);
+        assertUpdate("DELETE FROM " + tableName + " WHERE nested1.child1 = 30 AND nested2.child2 = false", 1);
+
+        // Select one field from one row field
+        assertQuery("SELECT id, nested1.child1 FROM " + tableName, "VALUES (1, 10), (2, 20), (4, 40), (5, NULL)");
+        assertQuery("SELECT nested2.child3, id FROM " + tableName, "VALUES (DATE '2023-04-19', 1), (DATE '1990-04-20', 2), (NULL, 4), (NULL, 5)");
+
+        // Select one field each from multiple row fields
+        assertQuery("SELECT nested2.child1, id, nested1.child2 FROM " + tableName, "VALUES (10.10, 1, 'a'), (20.20, 2, 'b'), (NULL, 4, NULL), (NULL, 5, NULL)");
+
+        // Select multiple fields from one row field
+        assertQuery("SELECT nested1.child3, id, nested1.child2 FROM " + tableName, "VALUES (100, 1, 'a'), (200, 2, 'b'), (400, 4, NULL), (NULL, 5, NULL)");
+        assertQuery(
+                "SELECT nested2.child2, nested2.child3, id FROM " + tableName,
+                "VALUES (true, DATE '2023-04-19' , 1), (false, DATE '1990-04-20', 2), (NULL, NULL, 4), (true, NULL, 5)");
+
+        // Select multiple fields from multiple row fields
+        assertQuery(
+                "SELECT id, nested2.child1, nested1.child3, nested2.child2, nested1.child1 FROM " + tableName,
+                "VALUES (1, 10.10, 100, true, 10), (2, 20.20, 200, false, 20), (4, NULL, 400, NULL, 40), (5, NULL, NULL, true, NULL)");
+
+        // Select only nested fields
+        assertQuery("SELECT nested2.child2, nested1.child3 FROM " + tableName, "VALUES (true, 100), (false, 200), (NULL, 400), (true, NULL)");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
     private Set<String> getActiveFiles(String tableName)
     {
         return getActiveFiles(tableName, getQueryRunner().getDefaultSession());

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
@@ -67,7 +67,8 @@ public class TestDeltaLakeConfig
                 .setTargetMaxFileSize(DataSize.of(1, GIGABYTE))
                 .setUniqueTableLocation(true)
                 .setLegacyCreateTableWithExistingLocationEnabled(false)
-                .setRegisterTableProcedureEnabled(false));
+                .setRegisterTableProcedureEnabled(false)
+                .setProjectionPushdownEnabled(true));
     }
 
     @Test
@@ -103,6 +104,7 @@ public class TestDeltaLakeConfig
                 .put("delta.unique-table-location", "false")
                 .put("delta.legacy-create-table-with-existing-location.enabled", "true")
                 .put("delta.register-table-procedure.enabled", "true")
+                .put("delta.projection-pushdown-enabled", "false")
                 .buildOrThrow();
 
         DeltaLakeConfig expected = new DeltaLakeConfig()
@@ -134,7 +136,8 @@ public class TestDeltaLakeConfig
                 .setTargetMaxFileSize(DataSize.of(2, GIGABYTE))
                 .setUniqueTableLocation(false)
                 .setLegacyCreateTableWithExistingLocationEnabled(true)
-                .setRegisterTableProcedureEnabled(true);
+                .setRegisterTableProcedureEnabled(true)
+                .setProjectionPushdownEnabled(false);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -49,6 +49,7 @@ import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.DataProviders.toDataProvider;
 import static io.trino.testing.MaterializedResult.resultBuilder;
+import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_CREATE_SCHEMA;
 import static io.trino.testing.TestingNames.randomNameSuffix;
@@ -942,6 +943,280 @@ public class TestDeltaLakeConnectorTest
         assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES change_data_feed_enabled = true");
         assertThat((String) computeScalar("SHOW CREATE TABLE " + tableName))
                 .contains("change_data_feed_enabled = true");
+    }
+
+    @Test
+    public void testProjectionPushdown()
+    {
+        String tableName = "test_projection_pushdown_" + randomNameSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName + " (id BIGINT, root ROW(f1 BIGINT, f2 BIGINT))");
+        assertUpdate("INSERT INTO " + tableName + " VALUES (1, ROW(1, 2)), (1, NULl), (1, ROW(NULL, 4))", 3);
+
+        assertQuery("SELECT root.f1, id FROM " + tableName, "VALUES (1, 1), (NULL, 1), (NULL, 1)");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testProjectionPushdownOnPartitionedTables()
+    {
+        String tableNamePartitionAtBeginning = "test_table_with_partition_at_beginning_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableNamePartitionAtBeginning + " (id BIGINT, root ROW(f1 BIGINT, f2 BIGINT)) WITH (partitioned_by = ARRAY['id'])");
+        assertUpdate("INSERT INTO " + tableNamePartitionAtBeginning + " VALUES (1, ROW(1, 2)), (1, ROW(2, 3)), (1, ROW(3, 4))", 3);
+        assertQuery("SELECT root.f1, id, root.f2 FROM " + tableNamePartitionAtBeginning, "VALUES (1, 1, 2), (2, 1, 3), (3, 1, 4)");
+        assertUpdate("DROP TABLE " + tableNamePartitionAtBeginning);
+
+        String tableNamePartitioningAtEnd = "tes_table_with_partition_at_end_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableNamePartitioningAtEnd + " (root ROW(f1 BIGINT, f2 BIGINT), id BIGINT) WITH (partitioned_by = ARRAY['id'])");
+        assertUpdate("INSERT INTO " + tableNamePartitioningAtEnd + " VALUES (ROW(1, 2), 1), (ROW(2, 3), 1), (ROW(3, 4), 1)", 3);
+        assertQuery("SELECT root.f2, id, root.f1 FROM " + tableNamePartitioningAtEnd, "VALUES (2, 1, 1), (3, 1, 2), (4, 1, 3)");
+        assertUpdate("DROP TABLE " + tableNamePartitioningAtEnd);
+    }
+
+    @Test
+    public void testProjectionWithCaseSensitiveField()
+    {
+        // TODO consider moving this in BaseConnectorTest
+        String tableName = "test_projection_with_case_sensitive_field_" + randomNameSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName + " (id INT, a ROW(\"UPPER_CASE\" INT, \"lower_case\" INT, \"MiXeD_cAsE\" INT))");
+        assertUpdate("INSERT INTO " + tableName + " VALUES (1, ROW(2, 3, 4)), (5, ROW(6, 7, 8))", 2);
+
+        String expected = "VALUES (2, 3, 4), (6, 7, 8)";
+        assertQuery("SELECT a.UPPER_CASE, a.lower_case, a.MiXeD_cAsE FROM " + tableName, expected);
+        assertQuery("SELECT a.upper_case, a.lower_case, a.mixed_case FROM " + tableName, expected);
+        assertQuery("SELECT a.UPPER_CASE, a.LOWER_CASE, a.MIXED_CASE FROM " + tableName, expected);
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testProjectionPushdownMultipleRows()
+    {
+        String tableName = "test_projection_pushdown_multiple_rows_" + randomNameSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName +
+                " (id BIGINT, nested1 ROW(child1 BIGINT, child2 VARCHAR, child3 INT), nested2 ROW(child1 DOUBLE, child2 BOOLEAN, child3 DATE))");
+        assertUpdate("INSERT INTO " + tableName + " VALUES" +
+                        " (1, ROW(10, 'a', 100), ROW(10.10, true, DATE '2023-04-19'))," +
+                        " (2, ROW(20, 'b', 200), ROW(20.20, false, DATE '1990-04-20'))," +
+                        " (4, ROW(40, NULL, 400), NULL)," +
+                        " (5, NULL, ROW(NULL, true, NULL))",
+                4);
+
+        // Select one field from one row field
+        assertQuery("SELECT id, nested1.child1 FROM " + tableName, "VALUES (1, 10), (2, 20), (4, 40), (5, NULL)");
+        assertQuery("SELECT nested2.child3, id FROM " + tableName, "VALUES (DATE '2023-04-19', 1), (DATE '1990-04-20', 2), (NULL, 4), (NULL, 5)");
+
+        // Select one field each from multiple row fields
+        assertQuery("SELECT nested2.child1, id, nested1.child2 FROM " + tableName, "VALUES (10.10, 1, 'a'), (20.20, 2, 'b'), (NULL, 4, NULL), (NULL, 5, NULL)");
+
+        // Select multiple fields from one row field
+        assertQuery("SELECT nested1.child3, id, nested1.child2 FROM " + tableName, "VALUES (100, 1, 'a'), (200, 2, 'b'), (400, 4, NULL), (NULL, 5, NULL)");
+        assertQuery(
+                "SELECT nested2.child2, nested2.child3, id FROM " + tableName,
+                "VALUES (true, DATE '2023-04-19' , 1), (false, DATE '1990-04-20', 2), (NULL, NULL, 4), (true, NULL, 5)");
+
+        // Select multiple fields from multiple row fields
+        assertQuery(
+                "SELECT id, nested2.child1, nested1.child3, nested2.child2, nested1.child1 FROM " + tableName,
+                "VALUES (1, 10.10, 100, true, 10), (2, 20.20, 200, false, 20), (4, NULL, 400, NULL, 40), (5, NULL, NULL, true, NULL)");
+
+        // Select only nested fields
+        assertQuery("SELECT nested2.child2, nested1.child3 FROM " + tableName, "VALUES (true, 100), (false, 200), (NULL, 400), (true, NULL)");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testReadHighlyNestedData()
+    {
+        // TODO consider moving this in BaseConnectorTest
+        String tableName = "test_highly_nested_data_" + randomNameSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName + " (id INT, row1_t ROW(f1 INT, f2 INT, row2_t ROW (f1 INT, f2 INT, row3_t ROW(f1 INT, f2 INT))))");
+        assertUpdate("INSERT INTO " + tableName + " VALUES (1, ROW(2, 3, ROW(4, 5, ROW(6, 7)))), (11, ROW(12, 13, ROW(14, 15, ROW(16, 17))))", 2);
+        assertUpdate("INSERT INTO " + tableName + " VALUES (21, ROW(22, 23, ROW(24, 25, ROW(26, 27))))", 1);
+
+        // Test select projected columns, with and without their parent column
+        assertQuery("SELECT id, row1_t.row2_t.row3_t.f2 FROM " + tableName, "VALUES (1, 7), (11, 17), (21, 27)");
+        assertQuery("SELECT id, row1_t.row2_t.row3_t.f2, CAST(row1_t AS JSON) FROM " + tableName,
+                "VALUES (1, 7, '{\"f1\":2,\"f2\":3,\"row2_t\":{\"f1\":4,\"f2\":5,\"row3_t\":{\"f1\":6,\"f2\":7}}}'), " +
+                        "(11, 17, '{\"f1\":12,\"f2\":13,\"row2_t\":{\"f1\":14,\"f2\":15,\"row3_t\":{\"f1\":16,\"f2\":17}}}'), " +
+                        "(21, 27, '{\"f1\":22,\"f2\":23,\"row2_t\":{\"f1\":24,\"f2\":25,\"row3_t\":{\"f1\":26,\"f2\":27}}}')");
+
+        // Test predicates on immediate child column and deeper nested column
+        assertQuery("SELECT id, CAST(row1_t.row2_t.row3_t AS JSON) FROM " + tableName + " WHERE row1_t.row2_t.row3_t.f2 = 27", "VALUES (21, '{\"f1\":26,\"f2\":27}')");
+        assertQuery("SELECT id, CAST(row1_t.row2_t.row3_t AS JSON) FROM " + tableName + " WHERE row1_t.row2_t.row3_t.f2 > 20", "VALUES (21, '{\"f1\":26,\"f2\":27}')");
+        assertQuery("SELECT id, CAST(row1_t AS JSON) FROM " + tableName + " WHERE row1_t.row2_t.row3_t.f2 = 27",
+                "VALUES (21, '{\"f1\":22,\"f2\":23,\"row2_t\":{\"f1\":24,\"f2\":25,\"row3_t\":{\"f1\":26,\"f2\":27}}}')");
+        assertQuery("SELECT id, CAST(row1_t AS JSON) FROM " + tableName + " WHERE row1_t.row2_t.row3_t.f2 > 20",
+                "VALUES (21, '{\"f1\":22,\"f2\":23,\"row2_t\":{\"f1\":24,\"f2\":25,\"row3_t\":{\"f1\":26,\"f2\":27}}}')");
+
+        // Test predicates on parent columns
+        assertQuery("SELECT id, row1_t.row2_t.row3_t.f1 FROM " + tableName + " WHERE row1_t.row2_t.row3_t = ROW(16, 17)", "VALUES (11, 16)");
+        assertQuery("SELECT id, row1_t.row2_t.row3_t.f1 FROM " + tableName + " WHERE row1_t = ROW(22, 23, ROW(24, 25, ROW(26, 27)))", "VALUES (21, 26)");
+
+        // Explain highly nested select
+        assertExplain(
+                "EXPLAIN SELECT id, row1_t.row2_t.row3_t.f1, row1_t.row2_t.f1, row1_t.row2_t.row3_t.f2 FROM " + tableName + " WHERE row1_t.row2_t.row3_t.f2 = 27",
+                "ScanFilter\\[table = (.*), filterPredicate = \\(\"row1_t#row2_t#row3_t#f2\" = 27\\)]",
+                "id(.*) := id:integer:REGULAR",
+                "row1_t#row2_t#f1 := row1_t#row2_t#f1:integer:REGULAR",
+                "row1_t#row2_t#row3_t#f1 := row1_t#row2_t#row3_t#f1:integer:REGULAR",
+                "row1_t#row2_t#row3_t#f2 := row1_t#row2_t#row3_t#f2:integer:REGULAR");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testProjectionPushdownReadsLessData()
+    {
+        // TODO consider moving this in BaseConnectorTest
+        String tableName = "test_projection_pushdown_reads_less_data_" + randomNameSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName + " (id INT, root ROW(leaf1 BIGINT, leaf2 BIGINT))");
+        assertUpdate("INSERT INTO " + tableName + " SELECT val, ROW(val + 1, val + 2) FROM UNNEST(SEQUENCE(1, 10)) AS t(val)", 10);
+
+        MaterializedResult expectedResult = computeActual("SELECT val + 2 FROM UNNEST(SEQUENCE(1, 10)) AS t(val)");
+        String selectQuery = "SELECT root.leaf2 FROM " + tableName;
+        Session sessionWithoutPushdown = Session.builder(getSession())
+                .setCatalogSessionProperty(getSession().getCatalog().orElseThrow(), "projection_pushdown_enabled", "false")
+                .build();
+
+        assertQueryStats(
+                getSession(),
+                selectQuery,
+                statsWithPushdown -> {
+                    DataSize physicalInputDataSizeWithPushdown = statsWithPushdown.getPhysicalInputDataSize();
+                    DataSize processedDataSizeWithPushdown = statsWithPushdown.getProcessedInputDataSize();
+                    assertQueryStats(
+                            sessionWithoutPushdown,
+                            selectQuery,
+                            statsWithoutPushdown -> {
+                                assertThat(statsWithoutPushdown.getPhysicalInputDataSize()).isGreaterThan(physicalInputDataSizeWithPushdown);
+                                assertThat(statsWithoutPushdown.getProcessedInputDataSize()).isGreaterThan(processedDataSizeWithPushdown);
+                            },
+                            results -> assertEquals(results.getOnlyColumnAsSet(), expectedResult.getOnlyColumnAsSet()));
+                },
+                results -> assertEquals(results.getOnlyColumnAsSet(), expectedResult.getOnlyColumnAsSet()));
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testProjectionPushdownPhysicalInputSize()
+    {
+        // TODO consider moving this in BaseConnectorTest
+        String tableName = "test_projection_pushdown_physical_input_size_" + randomNameSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName + " (id INT, root ROW(leaf1 BIGINT, leaf2 BIGINT))");
+        assertUpdate("INSERT INTO " + tableName + " SELECT val, ROW(val + 1, val + 2) FROM UNNEST(SEQUENCE(1, 10)) AS t(val)", 10);
+
+        // Verify that the physical input size is smaller when reading the root.leaf1 field compared to reading the root field
+        assertQueryStats(
+                getSession(),
+                "SELECT root FROM " + tableName,
+                statsWithSelectRootField -> {
+                    assertQueryStats(
+                            getSession(),
+                            "SELECT root.leaf1 FROM " + tableName,
+                            statsWithSelectLeafField -> {
+                                assertThat(statsWithSelectLeafField.getPhysicalInputDataSize()).isLessThan(statsWithSelectRootField.getPhysicalInputDataSize());
+                            },
+                            results -> assertEquals(results.getOnlyColumnAsSet(), computeActual("SELECT val + 1 FROM UNNEST(SEQUENCE(1, 10)) AS t(val)").getOnlyColumnAsSet()));
+                },
+                results -> assertEquals(results.getOnlyColumnAsSet(), computeActual("SELECT ROW(val + 1, val + 2) FROM UNNEST(SEQUENCE(1, 10)) AS t(val)").getOnlyColumnAsSet()));
+
+        // Verify that the physical input size is the same when reading the root field compared to reading both the root and root.leaf1 fields
+        assertQueryStats(
+                getSession(),
+                "SELECT root FROM " + tableName,
+                statsWithSelectRootField -> {
+                    assertQueryStats(
+                            getSession(),
+                            "SELECT root, root.leaf1 FROM " + tableName,
+                            statsWithSelectRootAndLeafField -> {
+                                assertThat(statsWithSelectRootAndLeafField.getPhysicalInputDataSize()).isEqualTo(statsWithSelectRootField.getPhysicalInputDataSize());
+                            },
+                            results -> assertEqualsIgnoreOrder(results.getMaterializedRows(), computeActual("SELECT ROW(val + 1, val + 2), val + 1 FROM UNNEST(SEQUENCE(1, 10)) AS t(val)").getMaterializedRows()));
+                },
+                results -> assertEquals(results.getOnlyColumnAsSet(), computeActual("SELECT ROW(val + 1, val + 2) FROM UNNEST(SEQUENCE(1, 10)) AS t(val)").getOnlyColumnAsSet()));
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testProjectionPushdownColumnReorderInSchemaAndDataFile()
+    {
+        try (TestTable testTable = new TestTable(getQueryRunner()::execute,
+                "test_projection_pushdown_column_reorder_",
+                "(id BIGINT, nested1 ROW(a BIGINT, b VARCHAR, c INT), nested2 ROW(d DOUBLE, e BOOLEAN, f DATE))")) {
+            assertUpdate("INSERT INTO " + testTable.getName() + " VALUES (100, ROW(10, 'a', 100), ROW(10.10, true, DATE '2023-04-19'))", 1);
+            String tableDataFile = ((String) computeScalar("SELECT \"$path\" FROM " + testTable.getName()))
+                    .replaceFirst("s3://" + BUCKET_NAME, "");
+
+            try (TestTable temporaryTable = new TestTable(
+                    getQueryRunner()::execute,
+                    "test_projection_pushdown_column_reorder_temporary_",
+                    "(nested2 ROW(d DOUBLE, e BOOLEAN, f DATE), id BIGINT, nested1 ROW(a BIGINT, b VARCHAR, c INT))")) {
+                assertUpdate("INSERT INTO " + temporaryTable.getName() + " VALUES (ROW(10.10, true, DATE '2023-04-19'), 100, ROW(10, 'a', 100))", 1);
+
+                String temporaryDataFile = ((String) computeScalar("SELECT \"$path\" FROM " + temporaryTable.getName()))
+                        .replaceFirst("s3://" + BUCKET_NAME, "");
+
+                // Replace table1 data file with table2 data file, so that the table's schema and data's schema has different column order
+                hiveMinioDataLake.getMinioClient().copyObject(BUCKET_NAME, temporaryDataFile, BUCKET_NAME, tableDataFile);
+            }
+
+            assertThat(query("SELECT nested2.e, nested1.a, nested2.f, nested1.b, id FROM " + testTable.getName()))
+                    .isFullyPushedDown();
+        }
+    }
+
+    @Test
+    public void testProjectionPushdownExplain()
+    {
+        String tableName = "test_projection_pushdown_explain_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (id BIGINT, root ROW(f1 BIGINT, f2 BIGINT)) WITH (partitioned_by = ARRAY['id'])");
+
+        assertExplain(
+                "EXPLAIN SELECT root.f2 FROM " + tableName,
+                "TableScan\\[table = (.*)]",
+                "root#f2 := root#f2:bigint:REGULAR");
+
+        Session sessionWithoutPushdown = Session.builder(getSession())
+                .setCatalogSessionProperty(getSession().getCatalog().orElseThrow(), "projection_pushdown_enabled", "false")
+                .build();
+        assertExplain(
+                sessionWithoutPushdown,
+                "EXPLAIN SELECT root.f2 FROM " + tableName,
+                "ScanProject\\[table = (.*)]",
+                "expr := \"root\"\\[2]",
+                "root := root:row\\(f1 bigint, f2 bigint\\):REGULAR");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testProjectionPushdownNonPrimitiveTypeExplain()
+    {
+        String tableName = "test_projection_pushdown_non_primtive_type_" + randomNameSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName +
+                " (id BIGINT, _row ROW(child BIGINT), _array ARRAY(ROW(child BIGINT)), _map MAP(BIGINT, BIGINT))");
+
+        assertExplain(
+                "EXPLAIN SELECT id, _row.child, _array[1].child, _map[1] FROM " + tableName,
+                "ScanProject\\[table = (.*)]",
+                "expr(.*) := \"_array(.*)\"\\[BIGINT '1']\\[1]",
+                "id(.*) := id:bigint:REGULAR",
+                // _array:array\\(row\\(child bigint\\)\\) is a symbol name, not a dereference expression.
+                "_array(.*) := _array:array\\(row\\(child bigint\\)\\):REGULAR",
+                "_map(.*) := _map:map\\(bigint, bigint\\):REGULAR",
+                "_row#child := _row#child:bigint:REGULAR");
+
+        assertUpdate("DROP TABLE " + tableName);
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeCreateTableStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeCreateTableStatistics.java
@@ -89,14 +89,14 @@ public class TestDeltaLakeCreateTableStatistics
             assertThat(entry.getStats()).isPresent();
             DeltaLakeFileStatistics fileStatistics = entry.getStats().get();
 
-            DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle("d", createUnboundedVarcharType(), OptionalInt.empty(), "d", createUnboundedVarcharType(), REGULAR);
+            DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle("d", createUnboundedVarcharType(), OptionalInt.empty(), "d", createUnboundedVarcharType(), REGULAR, Optional.empty());
             assertEquals(fileStatistics.getNumRecords(), Optional.of(2L));
             assertEquals(fileStatistics.getMinColumnValue(columnHandle), Optional.of(utf8Slice("foo")));
             assertEquals(fileStatistics.getMaxColumnValue(columnHandle), Optional.of(utf8Slice("moo")));
             assertEquals(fileStatistics.getNullCount("d"), Optional.of(0L));
 
             for (String complexColumn : ImmutableList.of("a", "b", "c")) {
-                columnHandle = new DeltaLakeColumnHandle(complexColumn, createUnboundedVarcharType(), OptionalInt.empty(), complexColumn, createUnboundedVarcharType(), REGULAR);
+                columnHandle = new DeltaLakeColumnHandle(complexColumn, createUnboundedVarcharType(), OptionalInt.empty(), complexColumn, createUnboundedVarcharType(), REGULAR, Optional.empty());
                 assertThat(fileStatistics.getMaxColumnValue(columnHandle)).isEmpty();
                 assertThat(fileStatistics.getMinColumnValue(columnHandle)).isEmpty();
                 assertThat(fileStatistics.getNullCount(complexColumn)).isEmpty();
@@ -115,7 +115,7 @@ public class TestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_double";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, OptionalInt.empty(), columnName, DoubleType.DOUBLE, REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, OptionalInt.empty(), columnName, DoubleType.DOUBLE, REGULAR, Optional.empty());
         try (TestTable table = new TestTable("test_nan_", ImmutableList.of(columnName), format("VALUES CAST(nan() AS %1$s), CAST(0.0 AS %1$s)", type))) {
             List<AddFileEntry> addFileEntries = getAddFileEntries(table.getName());
             AddFileEntry entry = getOnlyElement(addFileEntries);
@@ -134,7 +134,7 @@ public class TestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_double";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, OptionalInt.empty(), columnName, DoubleType.DOUBLE, REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, OptionalInt.empty(), columnName, DoubleType.DOUBLE, REGULAR, Optional.empty());
         try (TestTable table = new TestTable(
                 "test_inf_",
                 ImmutableList.of(columnName),
@@ -156,7 +156,7 @@ public class TestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_double";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, OptionalInt.empty(), columnName, DoubleType.DOUBLE, REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, OptionalInt.empty(), columnName, DoubleType.DOUBLE, REGULAR, Optional.empty());
         try (TestTable table = new TestTable(
                 "test_inf_nan_",
                 ImmutableList.of(columnName),
@@ -178,7 +178,7 @@ public class TestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_double";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, OptionalInt.empty(), columnName, DoubleType.DOUBLE, REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, OptionalInt.empty(), columnName, DoubleType.DOUBLE, REGULAR, Optional.empty());
         try (TestTable table = new TestTable(
                 "test_nan_positive_",
                 ImmutableList.of(columnName),
@@ -200,7 +200,7 @@ public class TestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_double";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, OptionalInt.empty(), columnName, DoubleType.DOUBLE, REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, OptionalInt.empty(), columnName, DoubleType.DOUBLE, REGULAR, Optional.empty());
         try (TestTable table = new TestTable(
                 "test_nan_positive_",
                 ImmutableList.of(columnName),
@@ -246,7 +246,7 @@ public class TestDeltaLakeCreateTableStatistics
         String negative = "-1" + "0".repeat(precision - scale) + "." + "0".repeat(scale - 1) + "1";
 
         String columnName = "t_decimal";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DecimalType.createDecimalType(precision, scale), OptionalInt.empty(), columnName, DecimalType.createDecimalType(precision, scale), REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DecimalType.createDecimalType(precision, scale), OptionalInt.empty(), columnName, DecimalType.createDecimalType(precision, scale), REGULAR, Optional.empty());
         try (TestTable table = new TestTable(
                 "test_decimal_records_",
                 ImmutableList.of(columnName),
@@ -278,7 +278,7 @@ public class TestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_double";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, OptionalInt.empty(), columnName, DoubleType.DOUBLE, REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, OptionalInt.empty(), columnName, DoubleType.DOUBLE, REGULAR, Optional.empty());
         try (TestTable table = new TestTable("test_null_records_", ImmutableList.of(columnName), "VALUES null, 0, null, 1")) {
             List<AddFileEntry> addFileEntries = getAddFileEntries(table.getName());
             AddFileEntry entry = getOnlyElement(addFileEntries);
@@ -297,7 +297,7 @@ public class TestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_varchar";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, createUnboundedVarcharType(), OptionalInt.empty(), columnName, createUnboundedVarcharType(), REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, createUnboundedVarcharType(), OptionalInt.empty(), columnName, createUnboundedVarcharType(), REGULAR, Optional.empty());
         try (TestTable table = new TestTable(
                 "test_only_null_records_",
                 ImmutableList.of(columnName),
@@ -319,7 +319,7 @@ public class TestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_date";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DateType.DATE, OptionalInt.empty(), columnName, DateType.DATE, REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DateType.DATE, OptionalInt.empty(), columnName, DateType.DATE, REGULAR, Optional.empty());
         try (TestTable table = new TestTable(
                 "test_date_records_",
                 ImmutableList.of(columnName),
@@ -341,7 +341,7 @@ public class TestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_timestamp";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, TIMESTAMP_TZ_MILLIS, OptionalInt.empty(), columnName, TIMESTAMP_TZ_MILLIS, REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, TIMESTAMP_TZ_MILLIS, OptionalInt.empty(), columnName, TIMESTAMP_TZ_MILLIS, REGULAR, Optional.empty());
         try (TestTable table = new TestTable(
                 "test_timestamp_records_",
                 ImmutableList.of(columnName),
@@ -367,7 +367,7 @@ public class TestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_string";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, createUnboundedVarcharType(), OptionalInt.empty(), columnName, createUnboundedVarcharType(), REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, createUnboundedVarcharType(), OptionalInt.empty(), columnName, createUnboundedVarcharType(), REGULAR, Optional.empty());
         try (TestTable table = new TestTable("test_unicode_", ImmutableList.of(columnName), "VALUES 'ab\uFAD8', 'ab\uD83D\uDD74'")) {
             List<AddFileEntry> addFileEntries = getAddFileEntries(table.getName());
             AddFileEntry entry = getOnlyElement(addFileEntries);
@@ -386,7 +386,7 @@ public class TestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_string";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, createUnboundedVarcharType(), OptionalInt.empty(), columnName, createUnboundedVarcharType(), REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, createUnboundedVarcharType(), OptionalInt.empty(), columnName, createUnboundedVarcharType(), REGULAR, Optional.empty());
         String partitionColumn = "t_int";
 
         try (TestTable table = new TestTable(
@@ -421,7 +421,7 @@ public class TestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "key";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, OptionalInt.empty(), columnName, DoubleType.DOUBLE, REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, OptionalInt.empty(), columnName, DoubleType.DOUBLE, REGULAR, Optional.empty());
         try (TestTable table = new TestTable(
                 "test_multi_file_table_nan_value_",
                 ImmutableList.of(columnName),

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
@@ -56,6 +56,7 @@ import io.trino.spi.type.BooleanType;
 import io.trino.spi.type.DateType;
 import io.trino.spi.type.DoubleType;
 import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.VarcharType;
 import io.trino.testing.TestingConnectorContext;
@@ -74,17 +75,19 @@ import java.util.OptionalInt;
 import java.util.Set;
 import java.util.UUID;
 
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.airlift.testing.Closeables.closeAll;
 import static io.trino.plugin.deltalake.DeltaLakeColumnType.REGULAR;
+import static io.trino.plugin.deltalake.DeltaTestingConnectorSession.SESSION;
 import static io.trino.plugin.hive.HiveTableProperties.PARTITIONED_BY_PROPERTY;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.spi.security.PrincipalType.USER;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
-import static io.trino.testing.TestingConnectorSession.SESSION;
 import static java.nio.file.Files.createTempDirectory;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -99,23 +102,63 @@ public class TestDeltaLakeMetadata
     private static final ColumnMetadata TIMESTAMP_COLUMN = new ColumnMetadata("timestamp_column", TIMESTAMP_MILLIS);
     private static final ColumnMetadata MISSING_COLUMN = new ColumnMetadata("missing_column", BIGINT);
 
+    private static final RowType BOGUS_ROW_FIELD = RowType.from(ImmutableList.of(
+            new RowType.Field(Optional.of("test_field"), BogusType.BOGUS)));
+    private static final RowType NESTED_ROW_FIELD = RowType.from(ImmutableList.of(
+            new RowType.Field(Optional.of("child1"), INTEGER),
+            new RowType.Field(Optional.of("child2"), INTEGER)));
+    private static final RowType HIGHLY_NESTED_ROW_FIELD = RowType.from(ImmutableList.of(
+            new RowType.Field(Optional.of("grandparent"), RowType.from(ImmutableList.of(
+                    new RowType.Field(Optional.of("parent"), RowType.from(ImmutableList.of(
+                            new RowType.Field(Optional.of("child"), INTEGER)))))))));
+
     private static final DeltaLakeColumnHandle BOOLEAN_COLUMN_HANDLE =
-            new DeltaLakeColumnHandle("boolean_column_name", BooleanType.BOOLEAN, OptionalInt.empty(), "boolean_column_name", BooleanType.BOOLEAN, REGULAR);
+            new DeltaLakeColumnHandle("boolean_column_name", BooleanType.BOOLEAN, OptionalInt.empty(), "boolean_column_name", BooleanType.BOOLEAN, REGULAR, Optional.empty());
     private static final DeltaLakeColumnHandle DOUBLE_COLUMN_HANDLE =
-            new DeltaLakeColumnHandle("double_column_name", DoubleType.DOUBLE, OptionalInt.empty(), "double_column_name", DoubleType.DOUBLE, REGULAR);
+            new DeltaLakeColumnHandle("double_column_name", DoubleType.DOUBLE, OptionalInt.empty(), "double_column_name", DoubleType.DOUBLE, REGULAR, Optional.empty());
     private static final DeltaLakeColumnHandle BOGUS_COLUMN_HANDLE =
-            new DeltaLakeColumnHandle("bogus_column_name", BogusType.BOGUS, OptionalInt.empty(), "bogus_column_name", BogusType.BOGUS, REGULAR);
+            new DeltaLakeColumnHandle("bogus_column_name", BogusType.BOGUS, OptionalInt.empty(), "bogus_column_name", BogusType.BOGUS, REGULAR, Optional.empty());
     private static final DeltaLakeColumnHandle VARCHAR_COLUMN_HANDLE =
-            new DeltaLakeColumnHandle("varchar_column_name", VarcharType.VARCHAR, OptionalInt.empty(), "varchar_column_name", VarcharType.VARCHAR, REGULAR);
+            new DeltaLakeColumnHandle("varchar_column_name", VarcharType.VARCHAR, OptionalInt.empty(), "varchar_column_name", VarcharType.VARCHAR, REGULAR, Optional.empty());
     private static final DeltaLakeColumnHandle DATE_COLUMN_HANDLE =
-            new DeltaLakeColumnHandle("date_column_name", DateType.DATE, OptionalInt.empty(), "date_column_name", DateType.DATE, REGULAR);
+            new DeltaLakeColumnHandle("date_column_name", DateType.DATE, OptionalInt.empty(), "date_column_name", DateType.DATE, REGULAR, Optional.empty());
+    private static final DeltaLakeColumnHandle NESTED_COLUMN_HANDLE =
+            new DeltaLakeColumnHandle("nested_column_name", NESTED_ROW_FIELD, OptionalInt.empty(), "nested_column_name", NESTED_ROW_FIELD, REGULAR, Optional.empty());
+    private static final DeltaLakeColumnHandle EXPECTED_NESTED_COLUMN_HANDLE =
+            new DeltaLakeColumnHandle(
+                    "nested_column_name",
+                    NESTED_ROW_FIELD,
+                    OptionalInt.empty(),
+                    "nested_column_name",
+                    NESTED_ROW_FIELD,
+                    REGULAR,
+                    Optional.of(new DeltaLakeColumnProjectionInfo(INTEGER, ImmutableList.of(1), ImmutableList.of("child2"))));
+    private static final DeltaLakeColumnHandle NESTED_COLUMN_HANDLE_WITH_PROJECTION =
+            new DeltaLakeColumnHandle(
+                    "highly_nested_column_name",
+                    HIGHLY_NESTED_ROW_FIELD,
+                    OptionalInt.empty(),
+                    "highly_nested_column_name",
+                    HIGHLY_NESTED_ROW_FIELD,
+                    REGULAR,
+                    Optional.of(new DeltaLakeColumnProjectionInfo(INTEGER, ImmutableList.of(0, 0), ImmutableList.of("grandparent", "parent"))));
+    private static final DeltaLakeColumnHandle EXPECTED_NESTED_COLUMN_HANDLE_WITH_PROJECTION =
+            new DeltaLakeColumnHandle(
+                    "highly_nested_column_name",
+                    HIGHLY_NESTED_ROW_FIELD,
+                    OptionalInt.empty(),
+                    "highly_nested_column_name",
+                    HIGHLY_NESTED_ROW_FIELD,
+                    REGULAR,
+                    Optional.of(new DeltaLakeColumnProjectionInfo(INTEGER, ImmutableList.of(0, 0, 0), ImmutableList.of("grandparent", "parent", "child"))));
 
     private static final Map<String, ColumnHandle> SYNTHETIC_COLUMN_ASSIGNMENTS = ImmutableMap.of(
             "test_synthetic_column_name_1", BOGUS_COLUMN_HANDLE,
             "test_synthetic_column_name_2", VARCHAR_COLUMN_HANDLE);
-
-    private static final RowType BOGUS_ROW_FIELD = RowType.from(ImmutableList.of(
-            new RowType.Field(Optional.of("test_field"), BogusType.BOGUS)));
+    private static final Map<String, ColumnHandle> NESTED_COLUMN_ASSIGNMENTS = ImmutableMap.of("nested_column_name", NESTED_COLUMN_HANDLE);
+    private static final Map<String, ColumnHandle> EXPECTED_NESTED_COLUMN_ASSIGNMENTS = ImmutableMap.of("nested_column_name#child2", EXPECTED_NESTED_COLUMN_HANDLE);
+    private static final Map<String, ColumnHandle> HIGHLY_NESTED_COLUMN_ASSIGNMENTS = ImmutableMap.of("highly_nested_column_name#grandparent#parent", NESTED_COLUMN_HANDLE_WITH_PROJECTION);
+    private static final Map<String, ColumnHandle> EXPECTED_HIGHLY_NESTED_COLUMN_ASSIGNMENTS = ImmutableMap.of("highly_nested_column_name#grandparent#parent#child", EXPECTED_NESTED_COLUMN_HANDLE_WITH_PROJECTION);
 
     private static final ConnectorExpression DOUBLE_PROJECTION = new Variable("double_projection", DoubleType.DOUBLE);
     private static final ConnectorExpression BOOLEAN_PROJECTION = new Variable("boolean_projection", BooleanType.BOOLEAN);
@@ -123,11 +166,33 @@ public class TestDeltaLakeMetadata
             BOGUS_ROW_FIELD,
             new Constant(1, BOGUS_ROW_FIELD),
             0);
+    private static final ConnectorExpression NESTED_DEREFERENCE_PROJECTION = new FieldDereference(
+            INTEGER,
+            new Variable("nested_column_name", NESTED_ROW_FIELD),
+            1);
+    private static final ConnectorExpression EXPECTED_NESTED_DEREFERENCE_PROJECTION = new Variable(
+            "nested_column_name#child2",
+            INTEGER);
+    private static final ConnectorExpression HIGHLY_NESTED_DEREFERENCE_PROJECTION = new FieldDereference(
+            INTEGER,
+            new Variable("highly_nested_column_name#grandparent#parent", HIGHLY_NESTED_ROW_FIELD),
+            0);
+    private static final ConnectorExpression EXPECTED_HIGHLY_NESTED_DEREFERENCE_PROJECTION = new Variable(
+            "highly_nested_column_name#grandparent#parent#child",
+            INTEGER);
 
     private static final List<ConnectorExpression> SIMPLE_COLUMN_PROJECTIONS =
             ImmutableList.of(DOUBLE_PROJECTION, BOOLEAN_PROJECTION);
     private static final List<ConnectorExpression> DEREFERENCE_COLUMN_PROJECTIONS =
             ImmutableList.of(DOUBLE_PROJECTION, DEREFERENCE_PROJECTION, BOOLEAN_PROJECTION);
+    private static final List<ConnectorExpression> NESTED_DEREFERENCE_COLUMN_PROJECTIONS =
+            ImmutableList.of(NESTED_DEREFERENCE_PROJECTION);
+    private static final List<ConnectorExpression> EXPECTED_NESTED_DEREFERENCE_COLUMN_PROJECTIONS =
+            ImmutableList.of(EXPECTED_NESTED_DEREFERENCE_PROJECTION);
+    private static final List<ConnectorExpression> HIGHLY_NESTED_DEREFERENCE_COLUMN_PROJECTIONS =
+            ImmutableList.of(HIGHLY_NESTED_DEREFERENCE_PROJECTION);
+    private static final List<ConnectorExpression> EXPECTED_HIGHLY_NESTED_DEREFERENCE_COLUMN_PROJECTIONS =
+            ImmutableList.of(EXPECTED_HIGHLY_NESTED_DEREFERENCE_PROJECTION);
 
     private static final Set<DeltaLakeColumnHandle> PREDICATE_COLUMNS =
             ImmutableSet.of(BOOLEAN_COLUMN_HANDLE, DOUBLE_COLUMN_HANDLE);
@@ -311,7 +376,8 @@ public class TestDeltaLakeMetadata
                         SYNTHETIC_COLUMN_ASSIGNMENTS,
                         SIMPLE_COLUMN_PROJECTIONS,
                         SIMPLE_COLUMN_PROJECTIONS,
-                        ImmutableSet.of(BOGUS_COLUMN_HANDLE, VARCHAR_COLUMN_HANDLE)
+                        ImmutableSet.of(BOGUS_COLUMN_HANDLE, VARCHAR_COLUMN_HANDLE),
+                        SYNTHETIC_COLUMN_ASSIGNMENTS
                 },
                 {
                         // table handle already contains subset of expected projected columns
@@ -319,7 +385,8 @@ public class TestDeltaLakeMetadata
                         SYNTHETIC_COLUMN_ASSIGNMENTS,
                         SIMPLE_COLUMN_PROJECTIONS,
                         SIMPLE_COLUMN_PROJECTIONS,
-                        ImmutableSet.of(BOGUS_COLUMN_HANDLE, VARCHAR_COLUMN_HANDLE)
+                        ImmutableSet.of(BOGUS_COLUMN_HANDLE, VARCHAR_COLUMN_HANDLE),
+                        SYNTHETIC_COLUMN_ASSIGNMENTS
                 },
                 {
                         // table handle already contains superset of expected projected columns
@@ -327,7 +394,8 @@ public class TestDeltaLakeMetadata
                         SYNTHETIC_COLUMN_ASSIGNMENTS,
                         SIMPLE_COLUMN_PROJECTIONS,
                         SIMPLE_COLUMN_PROJECTIONS,
-                        ImmutableSet.of(BOGUS_COLUMN_HANDLE, VARCHAR_COLUMN_HANDLE)
+                        ImmutableSet.of(BOGUS_COLUMN_HANDLE, VARCHAR_COLUMN_HANDLE),
+                        SYNTHETIC_COLUMN_ASSIGNMENTS
                 },
                 {
                         // table handle has empty assignments
@@ -335,15 +403,32 @@ public class TestDeltaLakeMetadata
                         ImmutableMap.of(),
                         SIMPLE_COLUMN_PROJECTIONS,
                         SIMPLE_COLUMN_PROJECTIONS,
-                        ImmutableSet.of()
+                        ImmutableSet.of(),
+                        ImmutableMap.of()
                 },
                 {
-                        // table handle has dereference column projections (which should be filtered out)
                         ImmutableSet.of(DOUBLE_COLUMN_HANDLE, BOOLEAN_COLUMN_HANDLE, DATE_COLUMN_HANDLE, BOGUS_COLUMN_HANDLE, VARCHAR_COLUMN_HANDLE),
                         ImmutableMap.of(),
                         DEREFERENCE_COLUMN_PROJECTIONS,
-                        SIMPLE_COLUMN_PROJECTIONS,
-                        ImmutableSet.of()
+                        DEREFERENCE_COLUMN_PROJECTIONS,
+                        ImmutableSet.of(),
+                        ImmutableMap.of()
+                },
+                {
+                        ImmutableSet.of(NESTED_COLUMN_HANDLE),
+                        NESTED_COLUMN_ASSIGNMENTS,
+                        NESTED_DEREFERENCE_COLUMN_PROJECTIONS,
+                        EXPECTED_NESTED_DEREFERENCE_COLUMN_PROJECTIONS,
+                        ImmutableSet.of(EXPECTED_NESTED_COLUMN_HANDLE),
+                        EXPECTED_NESTED_COLUMN_ASSIGNMENTS
+                },
+                {
+                        ImmutableSet.of(HIGHLY_NESTED_ROW_FIELD),
+                        HIGHLY_NESTED_COLUMN_ASSIGNMENTS,
+                        HIGHLY_NESTED_DEREFERENCE_COLUMN_PROJECTIONS,
+                        EXPECTED_HIGHLY_NESTED_DEREFERENCE_COLUMN_PROJECTIONS,
+                        ImmutableSet.of(EXPECTED_NESTED_COLUMN_HANDLE_WITH_PROJECTION),
+                        EXPECTED_HIGHLY_NESTED_COLUMN_ASSIGNMENTS
                 }
         };
     }
@@ -354,7 +439,8 @@ public class TestDeltaLakeMetadata
             Map<String, ColumnHandle> inputAssignments,
             List<ConnectorExpression> inputProjections,
             List<ConnectorExpression> expectedProjections,
-            Set<ColumnHandle> expectedProjectedColumns)
+            Set<ColumnHandle> expectedProjectedColumns,
+            Map<String, ColumnHandle> expectedAssignments)
     {
         DeltaLakeMetadata deltaLakeMetadata = deltaLakeMetadataFactory.create(SESSION.getIdentity());
 
@@ -376,7 +462,7 @@ public class TestDeltaLakeMetadata
 
         assertThat(projection.getAssignments())
                 .usingRecursiveComparison()
-                .isEqualTo(createNewColumnAssignments(inputAssignments));
+                .isEqualTo(createNewColumnAssignments(expectedAssignments));
 
         assertThat(projection.isPrecalculateStatistics())
                 .isFalse();
@@ -454,7 +540,8 @@ public class TestDeltaLakeMetadata
         ImmutableMap.Builder<DeltaLakeColumnHandle, Domain> tupleBuilder = ImmutableMap.builder();
 
         constrainedColumns.forEach(column -> {
-            tupleBuilder.put(column, Domain.notNull(column.getType()));
+            verify(column.isBaseColumn(), "Unexpected dereference: %s", column);
+            tupleBuilder.put(column, Domain.notNull(column.getBaseType()));
         });
 
         return TupleDomain.withColumnDomains(tupleBuilder.buildOrThrow());
@@ -463,10 +550,14 @@ public class TestDeltaLakeMetadata
     private static List<Assignment> createNewColumnAssignments(Map<String, ColumnHandle> assignments)
     {
         return assignments.entrySet().stream()
-                .map(assignment -> new Assignment(
-                        assignment.getKey(),
-                        assignment.getValue(),
-                        ((DeltaLakeColumnHandle) assignment.getValue()).getType()))
+                .map(assignment -> {
+                    DeltaLakeColumnHandle column = ((DeltaLakeColumnHandle) assignment.getValue());
+                    Type type = column.getProjectionInfo().map(DeltaLakeColumnProjectionInfo::getType).orElse(column.getBaseType());
+                    return new Assignment(
+                            assignment.getKey(),
+                            assignment.getValue(),
+                            type);
+                })
                 .collect(toImmutableList());
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
@@ -188,7 +188,8 @@ public class TestDeltaLakePageSink
                     OptionalInt.empty(),
                     column.getColumnName(),
                     getTrinoType(column.getType()),
-                    REGULAR));
+                    REGULAR,
+                    Optional.empty()));
         }
         return handles.build();
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeProjectionPushdownPlans.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeProjectionPushdownPlans.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.Session;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.metadata.TableHandle;
+import io.trino.plugin.deltalake.metastore.TestingDeltaLakeMetastoreModule;
+import io.trino.plugin.hive.metastore.Database;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.security.PrincipalType;
+import io.trino.sql.planner.assertions.BasePushdownPlanTest;
+import io.trino.testing.LocalQueryRunner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.Predicates.equalTo;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static com.google.inject.util.Modules.EMPTY_MODULE;
+import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.any;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestDeltaLakeProjectionPushdownPlans
+        extends BasePushdownPlanTest
+{
+    private static final String CATALOG = "delta";
+    private static final String SCHEMA = "test_schema";
+
+    private File baseDir;
+
+    @Override
+    protected LocalQueryRunner createLocalQueryRunner()
+    {
+        Session session = testSessionBuilder()
+                .setCatalog(CATALOG)
+                .setSchema(SCHEMA)
+                .build();
+        try {
+            baseDir = Files.createTempDirectory("delta_lake_projection_pushdown").toFile();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        HiveMetastore metastore = createTestingFileHiveMetastore(baseDir);
+        Database database = Database.builder()
+                .setDatabaseName(SCHEMA)
+                .setOwnerName(Optional.of("public"))
+                .setOwnerType(Optional.of(PrincipalType.ROLE))
+                .build();
+
+        metastore.createDatabase(database);
+
+        LocalQueryRunner queryRunner = LocalQueryRunner.create(session);
+        queryRunner.installPlugin(new TestingDeltaLakePlugin(Optional.of(new TestingDeltaLakeMetastoreModule(metastore)), Optional.empty(), EMPTY_MODULE));
+        queryRunner.createCatalog(CATALOG, "delta_lake", ImmutableMap.of());
+
+        return queryRunner;
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanup()
+            throws Exception
+    {
+        if (baseDir != null) {
+            deleteRecursively(baseDir.toPath(), ALLOW_INSECURE);
+        }
+    }
+
+    @Test
+    public void testPushdownDisabled()
+    {
+        String testTable = "test_pushdown_disabled_" + randomNameSuffix();
+
+        Session session = Session.builder(getQueryRunner().getDefaultSession())
+                .setCatalogSessionProperty(CATALOG, "projection_pushdown_enabled", "false")
+                .build();
+
+        getQueryRunner().execute(format(
+                "CREATE TABLE %s (col0) AS SELECT CAST(row(5, 6) AS row(a bigint, b bigint)) AS col0 WHERE false",
+                testTable));
+
+        assertPlan(
+                format("SELECT col0.a expr_a, col0.b expr_b FROM %s", testTable),
+                session,
+                any(
+                        project(
+                                ImmutableMap.of("expr", expression("col0[1]"), "expr_2", expression("col0[2]")),
+                                tableScan(testTable, ImmutableMap.of("col0", "col0")))));
+    }
+
+    @Test
+    public void testDereferencePushdown()
+    {
+        String testTable = "test_simple_projection_pushdown" + randomNameSuffix();
+        QualifiedObjectName completeTableName = new QualifiedObjectName(CATALOG, SCHEMA, testTable);
+
+        getQueryRunner().execute(format(
+                "CREATE TABLE %s (col0, col1) WITH (partitioned_by = ARRAY['col1']) AS" +
+                        " SELECT CAST(row(5, 6) AS row(x bigint, y bigint)) AS col0, 5 AS col1",
+                testTable));
+
+        Session session = getQueryRunner().getDefaultSession();
+
+        Optional<TableHandle> tableHandle = getTableHandle(session, completeTableName);
+        assertThat(tableHandle).as("expected the table handle to be present").isPresent();
+
+        Map<String, ColumnHandle> columns = getColumnHandles(session, completeTableName);
+
+        DeltaLakeColumnHandle column0Handle = (DeltaLakeColumnHandle) columns.get("col0");
+        DeltaLakeColumnHandle column1Handle = (DeltaLakeColumnHandle) columns.get("col1");
+
+        DeltaLakeColumnHandle columnX = createProjectedColumnHandle(column0Handle, ImmutableList.of(0), ImmutableList.of("x"));
+        DeltaLakeColumnHandle columnY = createProjectedColumnHandle(column0Handle, ImmutableList.of(1), ImmutableList.of("y"));
+
+        // Simple Projection pushdown
+        assertPlan(
+                "SELECT col0.x expr_x, col0.y expr_y FROM " + testTable,
+                any(tableScan(
+                        equalTo(((DeltaLakeTableHandle) tableHandle.get().getConnectorHandle()).withProjectedColumns(Set.of(columnX, columnY))),
+                        TupleDomain.all(),
+                        ImmutableMap.of("col0.x", equalTo(columnX), "col0.y", equalTo(columnY)))));
+
+        // Projection and predicate pushdown
+        assertPlan(
+                format("SELECT col0.x FROM %s WHERE col0.x = col1 + 3 and col0.y = 2", testTable),
+                anyTree(
+                        filter(
+                                "y = BIGINT '2' AND (x =  CAST((col1 + 3) AS BIGINT))",
+                                tableScan(
+                                        table -> {
+                                            DeltaLakeTableHandle deltaLakeTableHandle = (DeltaLakeTableHandle) table;
+                                            TupleDomain<DeltaLakeColumnHandle> unenforcedConstraint = deltaLakeTableHandle.getNonPartitionConstraint();
+                                            return deltaLakeTableHandle.getProjectedColumns().orElseThrow().equals(ImmutableSet.of(column1Handle, columnX, columnY)) &&
+                                                    unenforcedConstraint.equals(TupleDomain.withColumnDomains(ImmutableMap.of(columnY, Domain.singleValue(BIGINT, 2L))));
+                                        },
+                                        TupleDomain.all(),
+                                        ImmutableMap.of("y", columnY::equals, "x", columnX::equals, "col1", column1Handle::equals)))));
+
+        // Projection and predicate pushdown with overlapping columns
+        assertPlan(
+                format("SELECT col0, col0.y expr_y FROM %s WHERE col0.x = 5", testTable),
+                anyTree(
+                        filter(
+                                "x = BIGINT '5'",
+                                tableScan(
+                                        table -> {
+                                            DeltaLakeTableHandle deltaLakeTableHandle = (DeltaLakeTableHandle) table;
+                                            TupleDomain<DeltaLakeColumnHandle> unenforcedConstraint = deltaLakeTableHandle.getNonPartitionConstraint();
+                                            return deltaLakeTableHandle.getProjectedColumns().orElseThrow().equals(ImmutableSet.of(column0Handle, columnX)) &&
+                                                    unenforcedConstraint.equals(TupleDomain.withColumnDomains(ImmutableMap.of(columnX, Domain.singleValue(BIGINT, 5L))));
+                                        },
+                                        TupleDomain.all(),
+                                        ImmutableMap.of("col0", equalTo(column0Handle), "x", equalTo(columnX))))));
+
+        // Projection and predicate pushdown with joins
+        assertPlan(
+                format("SELECT T.col0.x, T.col0, T.col0.y FROM %s T join %s S on T.col1 = S.col1 WHERE (T.col0.x = 2)", testTable, testTable),
+                anyTree(
+                        project(
+                                ImmutableMap.of(
+                                        "expr_0_x", expression("expr_0[1]"),
+                                        "expr_0", expression("expr_0"),
+                                        "expr_0_y", expression("expr_0[2]")),
+                                join(INNER, builder -> builder
+                                        .equiCriteria("t_expr_1", "s_expr_1")
+                                        .left(
+                                                anyTree(
+                                                        filter(
+                                                                "x = BIGINT '2'",
+                                                                tableScan(
+                                                                        table -> {
+                                                                            DeltaLakeTableHandle deltaLakeTableHandle = (DeltaLakeTableHandle) table;
+                                                                            TupleDomain<DeltaLakeColumnHandle> unenforcedConstraint = deltaLakeTableHandle.getNonPartitionConstraint();
+                                                                            Set<DeltaLakeColumnHandle> expectedProjections = ImmutableSet.of(column0Handle, column1Handle, columnX);
+                                                                            TupleDomain<DeltaLakeColumnHandle> expectedUnenforcedConstraint = TupleDomain.withColumnDomains(
+                                                                                    ImmutableMap.of(columnX, Domain.singleValue(BIGINT, 2L)));
+                                                                            return deltaLakeTableHandle.getProjectedColumns().orElseThrow().equals(expectedProjections) &&
+                                                                                    unenforcedConstraint.equals(expectedUnenforcedConstraint);
+                                                                        },
+                                                                        TupleDomain.all(),
+                                                                        ImmutableMap.of("x", equalTo(columnX), "expr_0", equalTo(column0Handle), "t_expr_1", equalTo(column1Handle))))))
+                                        .right(
+                                                anyTree(
+                                                        tableScan(
+                                                                equalTo(((DeltaLakeTableHandle) tableHandle.get().getConnectorHandle()).withProjectedColumns(Set.of(column1Handle))),
+                                                                TupleDomain.all(),
+                                                                ImmutableMap.of("s_expr_1", equalTo(column1Handle)))))))));
+    }
+
+    private DeltaLakeColumnHandle createProjectedColumnHandle(
+            DeltaLakeColumnHandle baseColumnHandle,
+            List<Integer> dereferenceIndices,
+            List<String> dereferenceNames)
+    {
+        return new DeltaLakeColumnHandle(
+                baseColumnHandle.getBaseColumnName(),
+                baseColumnHandle.getBaseType(),
+                baseColumnHandle.getBaseFieldId(),
+                baseColumnHandle.getBasePhysicalColumnName(),
+                baseColumnHandle.getBasePhysicalType(),
+                DeltaLakeColumnType.REGULAR,
+                Optional.of(new DeltaLakeColumnProjectionInfo(
+                        BIGINT,
+                        dereferenceIndices,
+                        dereferenceNames)));
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeWriter.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeWriter.java
@@ -58,7 +58,7 @@ public class TestDeltaLakeWriter
                         Statistics.getBuilderForReading(intType).withMin(getIntByteArray(-100)).withMax(getIntByteArray(250)).withNumNulls(6).build()),
                 createMetaData(columnName, intType, 10,
                         Statistics.getBuilderForReading(intType).withMin(getIntByteArray(-200)).withMax(getIntByteArray(150)).withNumNulls(7).build()));
-        DeltaLakeColumnHandle intColumn = new DeltaLakeColumnHandle(columnName, INTEGER, OptionalInt.empty(), columnName, INTEGER, REGULAR);
+        DeltaLakeColumnHandle intColumn = new DeltaLakeColumnHandle(columnName, INTEGER, OptionalInt.empty(), columnName, INTEGER, REGULAR, Optional.empty());
 
         DeltaLakeFileStatistics fileStats = mergeStats(buildMultimap(columnName, metadata), ImmutableMap.of(columnName, INTEGER), 20);
         assertEquals(fileStats.getNumRecords(), Optional.of(20L));
@@ -77,7 +77,7 @@ public class TestDeltaLakeWriter
                         Statistics.getBuilderForReading(type).withMin(getFloatByteArray(0.01f)).withMax(getFloatByteArray(1.0f)).withNumNulls(6).build()),
                 createMetaData(columnName, type, 10,
                         Statistics.getBuilderForReading(type).withMin(getFloatByteArray(-2.001f)).withMax(getFloatByteArray(0.0f)).withNumNulls(7).build()));
-        DeltaLakeColumnHandle floatColumn = new DeltaLakeColumnHandle(columnName, REAL, OptionalInt.empty(), columnName, REAL, REGULAR);
+        DeltaLakeColumnHandle floatColumn = new DeltaLakeColumnHandle(columnName, REAL, OptionalInt.empty(), columnName, REAL, REGULAR, Optional.empty());
 
         DeltaLakeFileStatistics fileStats = mergeStats(buildMultimap(columnName, metadata), ImmutableMap.of(columnName, REAL), 20);
         assertEquals(fileStats.getNumRecords(), Optional.of(20L));
@@ -98,7 +98,7 @@ public class TestDeltaLakeWriter
                         Statistics.getBuilderForReading(type).withMin(getFloatByteArray(Float.NaN)).withMax(getFloatByteArray(1.0f)).withNumNulls(6).build()),
                 createMetaData(columnName, type, 10,
                         Statistics.getBuilderForReading(type).withMin(getFloatByteArray(-2.001f)).withMax(getFloatByteArray(0.0f)).withNumNulls(7).build()));
-        DeltaLakeColumnHandle floatColumn = new DeltaLakeColumnHandle(columnName, REAL, OptionalInt.empty(), columnName, REAL, REGULAR);
+        DeltaLakeColumnHandle floatColumn = new DeltaLakeColumnHandle(columnName, REAL, OptionalInt.empty(), columnName, REAL, REGULAR, Optional.empty());
 
         DeltaLakeFileStatistics fileStats = mergeStats(buildMultimap(columnName, metadata), ImmutableMap.of(columnName, REAL), 20);
         assertEquals(fileStats.getNumRecords(), Optional.of(20L));
@@ -119,7 +119,7 @@ public class TestDeltaLakeWriter
                         Statistics.getBuilderForReading(type).withMin(getDoubleByteArray(Double.NaN)).withMax(getDoubleByteArray(1.0f)).withNumNulls(6).build()),
                 createMetaData(columnName, type, 10,
                         Statistics.getBuilderForReading(type).withMin(getDoubleByteArray(-2.001f)).withMax(getDoubleByteArray(0.0f)).withNumNulls(7).build()));
-        DeltaLakeColumnHandle doubleColumn = new DeltaLakeColumnHandle(columnName, DOUBLE, OptionalInt.empty(), columnName, DOUBLE, REGULAR);
+        DeltaLakeColumnHandle doubleColumn = new DeltaLakeColumnHandle(columnName, DOUBLE, OptionalInt.empty(), columnName, DOUBLE, REGULAR, Optional.empty());
 
         DeltaLakeFileStatistics fileStats = mergeStats(buildMultimap(columnName, metadata), ImmutableMap.of(columnName, DOUBLE), 20);
         assertEquals(fileStats.getNumRecords(), Optional.of(20L));
@@ -138,7 +138,7 @@ public class TestDeltaLakeWriter
                         Statistics.getBuilderForReading(type).withMin("aba".getBytes(UTF_8)).withMax("ab⌘".getBytes(UTF_8)).withNumNulls(6).build()),
                 createMetaData(columnName, type, 10,
                         Statistics.getBuilderForReading(type).withMin("aba".getBytes(UTF_8)).withMax("abc".getBytes(UTF_8)).withNumNulls(6).build()));
-        DeltaLakeColumnHandle varcharColumn = new DeltaLakeColumnHandle(columnName, VarcharType.createUnboundedVarcharType(), OptionalInt.empty(), columnName, VarcharType.createUnboundedVarcharType(), REGULAR);
+        DeltaLakeColumnHandle varcharColumn = new DeltaLakeColumnHandle(columnName, VarcharType.createUnboundedVarcharType(), OptionalInt.empty(), columnName, VarcharType.createUnboundedVarcharType(), REGULAR, Optional.empty());
 
         DeltaLakeFileStatistics fileStats = mergeStats(buildMultimap(columnName, metadata), ImmutableMap.of(columnName, createUnboundedVarcharType()), 20);
         assertEquals(fileStats.getNumRecords(), Optional.of(20L));
@@ -157,7 +157,7 @@ public class TestDeltaLakeWriter
                         Statistics.getBuilderForReading(type).withMin("aba".getBytes(UTF_8)).withMax("ab\uFAD8".getBytes(UTF_8)).withNumNulls(6).build()),
                 createMetaData(columnName, type, 10,
                         Statistics.getBuilderForReading(type).withMin("aba".getBytes(UTF_8)).withMax("ab\uD83D\uDD74".getBytes(UTF_8)).withNumNulls(6).build()));
-        DeltaLakeColumnHandle varcharColumn = new DeltaLakeColumnHandle(columnName, VarcharType.createUnboundedVarcharType(), OptionalInt.empty(), columnName, VarcharType.createUnboundedVarcharType(), REGULAR);
+        DeltaLakeColumnHandle varcharColumn = new DeltaLakeColumnHandle(columnName, VarcharType.createUnboundedVarcharType(), OptionalInt.empty(), columnName, VarcharType.createUnboundedVarcharType(), REGULAR, Optional.empty());
 
         DeltaLakeFileStatistics fileStats = mergeStats(buildMultimap(columnName, metadata), ImmutableMap.of(columnName, createUnboundedVarcharType()), 20);
         assertEquals(fileStats.getNumRecords(), Optional.of(20L));

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
@@ -619,10 +619,10 @@ public class TestTransactionLogAccess
             assertTrue(actual.getStats().isPresent());
 
             for (ColumnMetadata column : columns) {
-                DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(column.getName(), column.getType(), OptionalInt.empty(), column.getName(), column.getType(), REGULAR);
+                DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(column.getName(), column.getType(), OptionalInt.empty(), column.getName(), column.getType(), REGULAR, Optional.empty());
                 assertEquals(expected.getStats().get().getMinColumnValue(columnHandle), actual.getStats().get().getMinColumnValue(columnHandle));
                 assertEquals(expected.getStats().get().getMaxColumnValue(columnHandle), actual.getStats().get().getMaxColumnValue(columnHandle));
-                assertEquals(expected.getStats().get().getNullCount(columnHandle.getName()), actual.getStats().get().getNullCount(columnHandle.getName()));
+                assertEquals(expected.getStats().get().getNullCount(columnHandle.getBaseColumnName()), actual.getStats().get().getNullCount(columnHandle.getBaseColumnName()));
                 assertEquals(expected.getStats().get().getNumRecords(), actual.getStats().get().getNumRecords());
             }
         }
@@ -692,11 +692,11 @@ public class TestTransactionLogAccess
             // Types would need to be specified properly if stats were being read from JSON but are not can be ignored when reading parsed stats from parquet,
             // so it is safe to use INTEGER as a placeholder
             assertEquals(
-                    fileStats.getMinColumnValue(new DeltaLakeColumnHandle(columnName, IntegerType.INTEGER, OptionalInt.empty(), columnName, IntegerType.INTEGER, REGULAR)),
+                    fileStats.getMinColumnValue(new DeltaLakeColumnHandle(columnName, IntegerType.INTEGER, OptionalInt.empty(), columnName, IntegerType.INTEGER, REGULAR, Optional.empty())),
                     Optional.of(statsValues.get(columnName)));
 
             assertEquals(
-                    fileStats.getMaxColumnValue(new DeltaLakeColumnHandle(columnName, IntegerType.INTEGER, OptionalInt.empty(), columnName, IntegerType.INTEGER, REGULAR)),
+                    fileStats.getMaxColumnValue(new DeltaLakeColumnHandle(columnName, IntegerType.INTEGER, OptionalInt.empty(), columnName, IntegerType.INTEGER, REGULAR, Optional.empty())),
                     Optional.of(statsValues.get(columnName)));
         }
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/statistics/TestDeltaLakeFileBasedTableStatisticsProvider.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/statistics/TestDeltaLakeFileBasedTableStatisticsProvider.java
@@ -64,7 +64,7 @@ import static org.testng.Assert.assertEquals;
 
 public class TestDeltaLakeFileBasedTableStatisticsProvider
 {
-    private static final ColumnHandle COLUMN_HANDLE = new DeltaLakeColumnHandle("val", DoubleType.DOUBLE, OptionalInt.empty(), "val", DoubleType.DOUBLE, REGULAR);
+    private static final ColumnHandle COLUMN_HANDLE = new DeltaLakeColumnHandle("val", DoubleType.DOUBLE, OptionalInt.empty(), "val", DoubleType.DOUBLE, REGULAR, Optional.empty());
 
     private TransactionLogAccess transactionLogAccess;
     private CachingExtendedStatisticsAccess statistics;
@@ -315,47 +315,47 @@ public class TestDeltaLakeFileBasedTableStatisticsProvider
         assertEquals(stats.getRowCount(), Estimate.of(9));
 
         Map<ColumnHandle, ColumnStatistics> statisticsMap = stats.getColumnStatistics();
-        ColumnStatistics columnStats = statisticsMap.get(new DeltaLakeColumnHandle("dec_short", DecimalType.createDecimalType(5, 1), OptionalInt.empty(), "dec_short", DecimalType.createDecimalType(5, 1), REGULAR));
+        ColumnStatistics columnStats = statisticsMap.get(new DeltaLakeColumnHandle("dec_short", DecimalType.createDecimalType(5, 1), OptionalInt.empty(), "dec_short", DecimalType.createDecimalType(5, 1), REGULAR, Optional.empty()));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertEquals(columnStats.getRange().get().getMin(), -10.1);
         assertEquals(columnStats.getRange().get().getMax(), 10.1);
 
-        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("dec_long", DecimalType.createDecimalType(25, 3), OptionalInt.empty(), "dec_long", DecimalType.createDecimalType(25, 3), REGULAR));
+        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("dec_long", DecimalType.createDecimalType(25, 3), OptionalInt.empty(), "dec_long", DecimalType.createDecimalType(25, 3), REGULAR, Optional.empty()));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertEquals(columnStats.getRange().get().getMin(), -999999999999.123);
         assertEquals(columnStats.getRange().get().getMax(), 999999999999.123);
 
-        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("l", BIGINT, OptionalInt.empty(), "l", BIGINT, REGULAR));
+        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("l", BIGINT, OptionalInt.empty(), "l", BIGINT, REGULAR, Optional.empty()));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertEquals(columnStats.getRange().get().getMin(), -10000000.0);
         assertEquals(columnStats.getRange().get().getMax(), 10000000.0);
 
-        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("in", INTEGER, OptionalInt.empty(), "in", INTEGER, REGULAR));
+        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("in", INTEGER, OptionalInt.empty(), "in", INTEGER, REGULAR, Optional.empty()));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertEquals(columnStats.getRange().get().getMin(), -20000000.0);
         assertEquals(columnStats.getRange().get().getMax(), 20000000.0);
 
-        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("sh", SMALLINT, OptionalInt.empty(), "sh", SMALLINT, REGULAR));
+        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("sh", SMALLINT, OptionalInt.empty(), "sh", SMALLINT, REGULAR, Optional.empty()));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertEquals(columnStats.getRange().get().getMin(), -123.0);
         assertEquals(columnStats.getRange().get().getMax(), 123.0);
 
-        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("byt", TINYINT, OptionalInt.empty(), "byt", TINYINT, REGULAR));
+        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("byt", TINYINT, OptionalInt.empty(), "byt", TINYINT, REGULAR, Optional.empty()));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertEquals(columnStats.getRange().get().getMin(), -42.0);
         assertEquals(columnStats.getRange().get().getMax(), 42.0);
 
-        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("fl", REAL, OptionalInt.empty(), "fl", REAL, REGULAR));
+        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("fl", REAL, OptionalInt.empty(), "fl", REAL, REGULAR, Optional.empty()));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertEquals((float) columnStats.getRange().get().getMin(), -0.123f);
         assertEquals((float) columnStats.getRange().get().getMax(), 0.123f);
 
-        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("dou", DOUBLE, OptionalInt.empty(), "dou", DOUBLE, REGULAR));
+        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("dou", DOUBLE, OptionalInt.empty(), "dou", DOUBLE, REGULAR, Optional.empty()));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertEquals(columnStats.getRange().get().getMin(), -0.321);
         assertEquals(columnStats.getRange().get().getMax(), 0.321);
 
-        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("dat", DATE, OptionalInt.empty(), "dat", DATE, REGULAR));
+        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("dat", DATE, OptionalInt.empty(), "dat", DATE, REGULAR, Optional.empty()));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertEquals(columnStats.getRange().get().getMin(), (double) LocalDate.parse("1900-01-01").toEpochDay());
         assertEquals(columnStats.getRange().get().getMax(), (double) LocalDate.parse("5000-01-01").toEpochDay());
@@ -371,11 +371,11 @@ public class TestDeltaLakeFileBasedTableStatisticsProvider
         assertEquals(stats.getRowCount(), Estimate.of(9));
 
         Map<ColumnHandle, ColumnStatistics> statisticsMap = stats.getColumnStatistics();
-        ColumnStatistics columnStats = statisticsMap.get(new DeltaLakeColumnHandle("fl", REAL, OptionalInt.empty(), "fl", REAL, REGULAR));
+        ColumnStatistics columnStats = statisticsMap.get(new DeltaLakeColumnHandle("fl", REAL, OptionalInt.empty(), "fl", REAL, REGULAR, Optional.empty()));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertThat(columnStats.getRange()).isEmpty();
 
-        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("dou", DOUBLE, OptionalInt.empty(), "dou", DOUBLE, REGULAR));
+        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("dou", DOUBLE, OptionalInt.empty(), "dou", DOUBLE, REGULAR, Optional.empty()));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertThat(columnStats.getRange()).isEmpty();
     }
@@ -390,7 +390,7 @@ public class TestDeltaLakeFileBasedTableStatisticsProvider
         assertEquals(stats.getRowCount(), Estimate.of(9));
 
         Map<ColumnHandle, ColumnStatistics> statisticsMap = stats.getColumnStatistics();
-        ColumnStatistics columnStats = statisticsMap.get(new DeltaLakeColumnHandle("i", INTEGER, OptionalInt.empty(), "i", INTEGER, REGULAR));
+        ColumnStatistics columnStats = statisticsMap.get(new DeltaLakeColumnHandle("i", INTEGER, OptionalInt.empty(), "i", INTEGER, REGULAR, Optional.empty()));
         assertEquals(columnStats.getNullsFraction(), Estimate.of(3.0 / 9.0));
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestDeltaLakeSchemaSupport.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestDeltaLakeSchemaSupport.java
@@ -174,7 +174,8 @@ public class TestDeltaLakeSchemaSupport
                 OptionalInt.empty(),
                 "arr",
                 new ArrayType(new ArrayType(INTEGER)),
-                REGULAR);
+                REGULAR,
+                Optional.empty());
 
         DeltaLakeColumnHandle structColumn = new DeltaLakeColumnHandle(
                 "str",
@@ -190,7 +191,8 @@ public class TestDeltaLakeSchemaSupport
                         new RowType.Field(Optional.of("s2"), RowType.from(ImmutableList.of(
                                 new RowType.Field(Optional.of("i1"), INTEGER),
                                 new RowType.Field(Optional.of("d2"), DecimalType.createDecimalType(38, 0))))))),
-                REGULAR);
+                REGULAR,
+                Optional.empty());
 
         TypeOperators typeOperators = new TypeOperators();
         DeltaLakeColumnHandle mapColumn = new DeltaLakeColumnHandle(
@@ -205,7 +207,8 @@ public class TestDeltaLakeSchemaSupport
                         INTEGER,
                         new MapType(INTEGER, INTEGER, typeOperators),
                         typeOperators),
-                REGULAR);
+                REGULAR,
+                Optional.empty());
 
         URL expected = getResource("io/trino/plugin/deltalake/transactionlog/schema/nested_schema.json");
         ObjectMapper objectMapper = new ObjectMapper();
@@ -225,7 +228,7 @@ public class TestDeltaLakeSchemaSupport
                 .map(DeltaLakeColumnMetadata::getColumnMetadata)
                 .collect(toImmutableList());
         List<DeltaLakeColumnHandle> columnHandles = schema.stream()
-                .map(metadata -> new DeltaLakeColumnHandle(metadata.getName(), metadata.getType(), OptionalInt.empty(), metadata.getName(), metadata.getType(), REGULAR))
+                .map(metadata -> new DeltaLakeColumnHandle(metadata.getName(), metadata.getType(), OptionalInt.empty(), metadata.getName(), metadata.getType(), REGULAR, Optional.empty()))
                 .collect(toImmutableList());
         ObjectMapper objectMapper = new ObjectMapper();
         String jsonEncoding = serializeSchemaAsJson(columnHandles, ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of());

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/BenchmarkExtendedStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/BenchmarkExtendedStatistics.java
@@ -80,7 +80,7 @@ public class BenchmarkExtendedStatistics
         {
             columns = new ArrayList<>(columnsCount);
             for (int i = 0; i < columnsCount; i++) {
-                columns.add(new DeltaLakeColumnHandle("column_" + i, BigintType.BIGINT, OptionalInt.empty(), "column_" + i, BigintType.BIGINT, REGULAR));
+                columns.add(new DeltaLakeColumnHandle("column_" + i, BigintType.BIGINT, OptionalInt.empty(), "column_" + i, BigintType.BIGINT, REGULAR, Optional.empty()));
             }
 
             fileStatistics = new ArrayList<>(filesCount);
@@ -112,7 +112,7 @@ public class BenchmarkExtendedStatistics
         {
             Map<String, Object> map = new HashMap<>();
             for (DeltaLakeColumnHandle column : columns) {
-                map.put(column.getName(), random.nextLong());
+                map.put(column.getBaseColumnName(), random.nextLong());
             }
             return Optional.of(map);
         }
@@ -127,7 +127,7 @@ public class BenchmarkExtendedStatistics
                 DeltaLakeColumnHandle column = benchmarkData.columns.get(benchmarkData.random.nextInt(benchmarkData.columnsCount));
                 result += (long) statistics.getMaxColumnValue(column).get();
                 result += (long) statistics.getMinColumnValue(column).get();
-                result += statistics.getNullCount(column.getName()).get();
+                result += statistics.getNullCount(column.getBaseColumnName()).get();
             }
         }
         return result;

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/TestDeltaLakeFileStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/TestDeltaLakeFileStatistics.java
@@ -136,53 +136,53 @@ public class TestDeltaLakeFileStatistics
     {
         assertEquals(fileStatistics.getNumRecords(), Optional.of(1L));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("byt", TINYINT, OptionalInt.empty(), "byt", TINYINT, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("byt", TINYINT, OptionalInt.empty(), "byt", TINYINT, REGULAR, Optional.empty())),
                 Optional.of(42L));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("dat", DATE, OptionalInt.empty(), "dat", DATE, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("dat", DATE, OptionalInt.empty(), "dat", DATE, REGULAR, Optional.empty())),
                 Optional.of(LocalDate.parse("5000-01-01").toEpochDay()));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("dec_long", DecimalType.createDecimalType(25, 3), OptionalInt.empty(), "dec_long", DecimalType.createDecimalType(25, 3), REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("dec_long", DecimalType.createDecimalType(25, 3), OptionalInt.empty(), "dec_long", DecimalType.createDecimalType(25, 3), REGULAR, Optional.empty())),
                 Optional.of(encodeScaledValue(new BigDecimal("999999999999.123"), 3)));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("dec_short", DecimalType.createDecimalType(5, 1), OptionalInt.empty(), "dec_short", DecimalType.createDecimalType(5, 1), REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("dec_short", DecimalType.createDecimalType(5, 1), OptionalInt.empty(), "dec_short", DecimalType.createDecimalType(5, 1), REGULAR, Optional.empty())),
                 Optional.of(new BigDecimal("10.1").unscaledValue().longValueExact()));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("dou", DoubleType.DOUBLE, OptionalInt.empty(), "dou", DoubleType.DOUBLE, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("dou", DoubleType.DOUBLE, OptionalInt.empty(), "dou", DoubleType.DOUBLE, REGULAR, Optional.empty())),
                 Optional.of(0.321));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("fl", REAL, OptionalInt.empty(), "fl", REAL, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("fl", REAL, OptionalInt.empty(), "fl", REAL, REGULAR, Optional.empty())),
                 Optional.of((long) floatToIntBits(0.123f)));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("in", INTEGER, OptionalInt.empty(), "in", INTEGER, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("in", INTEGER, OptionalInt.empty(), "in", INTEGER, REGULAR, Optional.empty())),
                 Optional.of(20000000L));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("l", BIGINT, OptionalInt.empty(), "l", BIGINT, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("l", BIGINT, OptionalInt.empty(), "l", BIGINT, REGULAR, Optional.empty())),
                 Optional.of(10000000L));
         Type rowType = RowType.rowType(RowType.field("s1", INTEGER), RowType.field("s3", VarcharType.createUnboundedVarcharType()));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("row", rowType, OptionalInt.empty(), "row", rowType, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("row", rowType, OptionalInt.empty(), "row", rowType, REGULAR, Optional.empty())),
                 Optional.empty());
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("arr", new ArrayType(INTEGER), OptionalInt.empty(), "arr", new ArrayType(INTEGER), REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("arr", new ArrayType(INTEGER), OptionalInt.empty(), "arr", new ArrayType(INTEGER), REGULAR, Optional.empty())),
                 Optional.empty());
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("m", new MapType(INTEGER, VarcharType.createUnboundedVarcharType(), new TypeOperators()), OptionalInt.empty(), "m", new MapType(INTEGER, VarcharType.createUnboundedVarcharType(), new TypeOperators()), REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("m", new MapType(INTEGER, VarcharType.createUnboundedVarcharType(), new TypeOperators()), OptionalInt.empty(), "m", new MapType(INTEGER, VarcharType.createUnboundedVarcharType(), new TypeOperators()), REGULAR, Optional.empty())),
                 Optional.empty());
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("sh", SMALLINT, OptionalInt.empty(), "sh", SMALLINT, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("sh", SMALLINT, OptionalInt.empty(), "sh", SMALLINT, REGULAR, Optional.empty())),
                 Optional.of(123L));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("str", VarcharType.createUnboundedVarcharType(), OptionalInt.empty(), "str", VarcharType.createUnboundedVarcharType(), REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("str", VarcharType.createUnboundedVarcharType(), OptionalInt.empty(), "str", VarcharType.createUnboundedVarcharType(), REGULAR, Optional.empty())),
                 Optional.of(utf8Slice("a")));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("ts", TIMESTAMP_TZ_MILLIS, OptionalInt.empty(), "ts", TIMESTAMP_TZ_MILLIS, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("ts", TIMESTAMP_TZ_MILLIS, OptionalInt.empty(), "ts", TIMESTAMP_TZ_MILLIS, REGULAR, Optional.empty())),
                 Optional.of(packDateTimeWithZone(LocalDateTime.parse("2960-10-31T01:00:00.000").toInstant(UTC).toEpochMilli(), UTC_KEY)));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("bool", BOOLEAN, OptionalInt.empty(), "bool", BOOLEAN, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("bool", BOOLEAN, OptionalInt.empty(), "bool", BOOLEAN, REGULAR, Optional.empty())),
                 Optional.empty());
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("bin", VARBINARY, OptionalInt.empty(), "bin", VARBINARY, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("bin", VARBINARY, OptionalInt.empty(), "bin", VARBINARY, REGULAR, Optional.empty())),
                 Optional.empty());
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.hive;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
@@ -342,8 +341,7 @@ public class HivePageSourceProvider
                 HivePageSourceProvider::getProjection);
     }
 
-    @VisibleForTesting
-    static List<Integer> getProjection(ColumnHandle expected, ColumnHandle read)
+    public static List<Integer> getProjection(ColumnHandle expected, ColumnHandle read)
     {
         HiveColumnHandle expectedColumn = (HiveColumnHandle) expected;
         HiveColumnHandle readColumn = (HiveColumnHandle) read;
@@ -701,9 +699,17 @@ public class HivePageSourceProvider
     }
 
     /**
-     * Creates a mapping between the input {@param columns} and base columns if required.
+     * Creates a mapping between the input {@param columns} and base columns based on baseHiveColumnIndex if required.
      */
     public static Optional<ReaderColumns> projectBaseColumns(List<HiveColumnHandle> columns)
+    {
+        return projectBaseColumns(columns, false);
+    }
+
+    /**
+     * Creates a mapping between the input {@param columns} and base columns based on baseHiveColumnIndex or baseColumnName if required.
+     */
+    public static Optional<ReaderColumns> projectBaseColumns(List<HiveColumnHandle> columns, boolean useColumnNames)
     {
         requireNonNull(columns, "columns is null");
 
@@ -714,16 +720,16 @@ public class HivePageSourceProvider
 
         ImmutableList.Builder<ColumnHandle> projectedColumns = ImmutableList.builder();
         ImmutableList.Builder<Integer> outputColumnMapping = ImmutableList.builder();
-        Map<Integer, Integer> mappedHiveColumnIndices = new HashMap<>();
+        Map<Object, Integer> mappedHiveBaseColumnKeys = new HashMap<>();
         int projectedColumnCount = 0;
 
         for (HiveColumnHandle column : columns) {
-            int hiveColumnIndex = column.getBaseHiveColumnIndex();
-            Integer mapped = mappedHiveColumnIndices.get(hiveColumnIndex);
+            Object baseColumnKey = useColumnNames ? column.getBaseColumnName() : column.getBaseHiveColumnIndex();
+            Integer mapped = mappedHiveBaseColumnKeys.get(baseColumnKey);
 
             if (mapped == null) {
                 projectedColumns.add(column.getBaseColumn());
-                mappedHiveColumnIndices.put(hiveColumnIndex, projectedColumnCount);
+                mappedHiveBaseColumnKeys.put(baseColumnKey, projectedColumnCount);
                 outputColumnMapping.add(projectedColumnCount);
                 projectedColumnCount++;
             }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ReaderColumns.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ReaderColumns.java
@@ -26,7 +26,8 @@ import static java.util.Objects.requireNonNull;
  * - the projected columns required by a connector level pagesource and
  * -  the columns supplied by format-specific page source
  * <p>
- * Currently used in {@link HivePageSource} and {@code io.trino.plugin.iceberg.IcebergPageSource}.
+ * Currently used in {@link HivePageSource}, {@code io.trino.plugin.iceberg.IcebergPageSource},
+ * and {@code io.trino.plugin.deltalake.DeltaLakePageSource}.
  */
 public class ReaderColumns
 {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -272,7 +272,7 @@ public class ParquetPageSourceFactory
                 nextStart += block.getRowCount();
             }
 
-            Optional<ReaderColumns> readerProjections = projectBaseColumns(columns);
+            Optional<ReaderColumns> readerProjections = projectBaseColumns(columns, useColumnNames);
             List<HiveColumnHandle> baseColumns = readerProjections.map(projection ->
                             projection.get().stream()
                                     .map(HiveColumnHandle.class::cast)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR implements dereference pushdown for Delta Lake connector(similar to https://github.com/trinodb/trino/pull/8129).

This adds significant performance improvements for queries accessing nested fields inside struct/row columns. They have been optimized through the pushdown of dereference expressions. With this feature, the query execution prunes structural data eagerly, extracting the necessary fields.

**For Example:**

I have a table having a nested field `col`. When perform selecting `col.a`, we can see the difference in `Input` and `Physical Input` values in the query plan when running with and without dereference pushdown.

Table Schema as below:
```
trino:dereference_pushdown_test> SHOW COLUMNS FROM ntest;
  Column  |          Type           | Extra | Comment
----------+-------------------------+-------+---------
 orderkey | bigint                  |       |
 col      | row(a bigint, b bigint) |       |
(2 rows)

```

**Query Plan without Dereference pushdown**:

```
trino:dereference_pushdown_test> SET SESSION delta_lake.projection_pushdown_enabled=false;
SET SESSION
trino:dereference_pushdown_test> EXPLAIN ANALYZE SELECT col.a FROM ntest;
                                                                                           Query Plan
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Trino version: testversion
 Queued: 453.79us, Analysis: 306.94ms, Planning: 91.70ms, Execution: 490.10ms
 Fragment 1 [SOURCE]
     CPU: 60.38ms, Scheduled: 216.02ms, Blocked 0.00ns (Input: 0.00ns, Output: 0.00ns), Input: 1500000 rows (32.90MB); per task: avg.: 1500000.00 std.dev.: 0.00, Output: 1500000 rows (12.87MB)
     Output layout: [expr]
     Output partitioning: SINGLE []
     ScanProject[table = delta_lake:dereference_pushdown_test.ntest]
         Layout: [expr:bigint]
         Estimates: {rows: 1500000 (12.87MB), cpu: 78.68M, memory: 0B, network: 0B}/{rows: 1500000 (12.87MB), cpu: 12.87M, memory: 0B, network: 0B}
         CPU: 60.00ms (100.00%), Scheduled: 216.00ms (100.00%), Blocked: 0.00ns (?%), Output: 1500000 rows (12.87MB)
         Input avg.: 1500000.00 rows, Input std.dev.: 0.00%
         expr := "col"[1]
         col := col:row(a bigint, b bigint):REGULAR
         Input: 1500000 rows (32.90MB), Filtered: 0.00%, Physical input: 425.08kB, Physical input time: 167700000.00ns
```

**Query Plan with Dereference pushdown**:
```
trino:dereference_pushdown_test> SET SESSION delta_lake.projection_pushdown_enabled=true;
SET SESSION
trino:dereference_pushdown_test> EXPLAIN ANALYZE SELECT col.a FROM ntest;
                                                                                           Query Plan
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Trino version: testversion
 Queued: 431.92us, Analysis: 365.17ms, Planning: 105.14ms, Execution: 501.89ms
 Fragment 1 [SOURCE]
     CPU: 47.47ms, Scheduled: 208.86ms, Blocked 0.00ns (Input: 0.00ns, Output: 0.00ns), Input: 1500000 rows (12.87MB); per task: avg.: 1500000.00 std.dev.: 0.00, Output: 1500000 rows (12.87MB)
     Output layout: [col.a]
     Output partitioning: SINGLE []
     TableScan[table = delta_lake:dereference_pushdown_test.ntest]
         Layout: [col.a:bigint]
         Estimates: {rows: 1500000 (12.87MB), cpu: 12.87M, memory: 0B, network: 0B}
         CPU: 48.00ms (100.00%), Scheduled: 208.00ms (100.00%), Blocked: 0.00ns (?%), Output: 1500000 rows (12.87MB)
         Input avg.: 1500000.00 rows, Input std.dev.: 0.00%
         col.a := col.a:bigint:REGULAR
         Input: 1500000 rows (12.87MB), Physical input: 236.54kB, Physical input time: 175040000.00ns
```


More Details about dereference pushdown: https://trino.io/blog/2020/08/14/dereference-pushdown.html

## Additional context and related issues

The feature is enabled by default.

The feature can be disabled by setting `delta.projection-pushdown-enabled` configuration property or `delta.projection_pushdown_enabled` session property to `false`.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
# DeltaLake
* Add Dereference pushdown for the Delta Lake connector. ({issue}`17085`)
```
