### PR TITLE
Increase TypedSet expectedSize in DynamicFilterSourceOperator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/DynamicFilterSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DynamicFilterSourceOperator.java
@@ -58,8 +58,6 @@ import static java.util.stream.Collectors.toSet;
 public class DynamicFilterSourceOperator
         implements Operator
 {
-    private static final int EXPECTED_BLOCK_BUILDER_SIZE = 8;
-
     public static class Channel
     {
         private final DynamicFilterId filterId;
@@ -412,13 +410,14 @@ public class DynamicFilterSourceOperator
             if (collectMinMax) {
                 minMaxComparison = blockTypeOperators.getComparisonUnorderedLastOperator(type);
             }
-            blockBuilder = type.createBlockBuilder(null, EXPECTED_BLOCK_BUILDER_SIZE);
+            int expectedSize = Math.min(maxDistinctValues, 8192) * 2;
+            blockBuilder = type.createBlockBuilder(null, expectedSize);
             valueSet = createUnboundedEqualityTypedSet(
                     type,
                     blockTypeOperators.getEqualOperator(type),
                     blockTypeOperators.getHashCodeOperator(type),
                     blockBuilder,
-                    EXPECTED_BLOCK_BUILDER_SIZE,
+                    expectedSize,
                     format("DynamicFilterSourceOperator_%s_%d", planNodeId, channel.index));
         }
 


### PR DESCRIPTION
## Description

Current initial size of 8 is very small and leads to unnecessary amount of rehashing
```
Benchmark                                                  (collectionLimits)  (positionsPerPage)  Mode  Cnt  Before Score   After Score     Units
BenchmarkDynamicFilterSourceOperator.dynamicFilterCollect              5000,0                1024  avgt   45   0.663 ± 0.133  0.257 ± 0.017  ms/op
BenchmarkDynamicFilterSourceOperator.dynamicFilterCollect             50000,0                1024  avgt   45   6.420 ± 0.956  3.703 ± 0.139  ms/op
BenchmarkDynamicFilterSourceOperator.dynamicFilterCollect           1000000,0                1024  avgt   45  38.821 ± 2.883 32.224 ± 1.992  ms/op
```
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
