### PR TITLE
Load catalogs concurrently by default

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/ServerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerConfig.java
@@ -15,6 +15,7 @@ package io.trino.server;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.Duration;
 
 import javax.validation.constraints.NotNull;
@@ -26,7 +27,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 public class ServerConfig
 {
     private boolean coordinator = true;
-    private boolean concurrentStartup;
+    private boolean concurrentStartup = true;
     private boolean includeExceptionInResponse = true;
     private Duration gracePeriod = new Duration(2, MINUTES);
     private boolean queryResultsCompressionEnabled = true;
@@ -49,7 +50,8 @@ public class ServerConfig
         return concurrentStartup;
     }
 
-    @Config("experimental.concurrent-startup")
+    @LegacyConfig("experimental.concurrent-startup")
+    @Config("concurrent-startup")
     @ConfigDescription("Parallelize work during server startup")
     public ServerConfig setConcurrentStartup(boolean concurrentStartup)
     {

--- a/core/trino-main/src/test/java/io/trino/server/TestServerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestServerConfig.java
@@ -31,7 +31,7 @@ public class TestServerConfig
     {
         assertRecordedDefaults(recordDefaults(ServerConfig.class)
                 .setCoordinator(true)
-                .setConcurrentStartup(false)
+                .setConcurrentStartup(true)
                 .setIncludeExceptionInResponse(true)
                 .setGracePeriod(new Duration(2, MINUTES))
                 .setQueryResultsCompressionEnabled(true)
@@ -43,7 +43,7 @@ public class TestServerConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("coordinator", "false")
-                .put("experimental.concurrent-startup", "true")
+                .put("concurrent-startup", "false")
                 .put("http.include-exception-in-response", "false")
                 .put("shutdown.grace-period", "5m")
                 .put("query-results.compression-enabled", "false")
@@ -52,7 +52,7 @@ public class TestServerConfig
 
         ServerConfig expected = new ServerConfig()
                 .setCoordinator(false)
-                .setConcurrentStartup(true)
+                .setConcurrentStartup(false)
                 .setIncludeExceptionInResponse(false)
                 .setGracePeriod(new Duration(5, MINUTES))
                 .setQueryResultsCompressionEnabled(false)

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard-multinode/multinode-master-config.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard-multinode/multinode-master-config.properties
@@ -2,7 +2,6 @@ node.id=will-be-overwritten
 node.environment=test
 
 coordinator=true
-experimental.concurrent-startup=true
 node-scheduler.include-coordinator=false
 http-server.http.port=8080
 query.max-memory=1GB

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard-multinode/multinode-worker-config.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard-multinode/multinode-worker-config.properties
@@ -2,7 +2,6 @@ node.id=will-be-overwritten
 node.environment=test
 
 coordinator=false
-experimental.concurrent-startup=true
 http-server.http.port=8081
 query.max-memory=1GB
 query.max-memory-per-node=1GB

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard/config.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard/config.properties
@@ -2,7 +2,6 @@ node.id=will-be-overwritten
 node.environment=test
 
 coordinator=true
-experimental.concurrent-startup=true
 node-scheduler.include-coordinator=true
 http-server.http.port=8080
 query.max-memory=2GB

--- a/testing/trino-server-dev/etc/config.properties
+++ b/testing/trino-server-dev/etc/config.properties
@@ -9,7 +9,6 @@
 node.id=ffffffff-ffff-ffff-ffff-ffffffffffff
 node.environment=test
 node.internal-address=localhost
-experimental.concurrent-startup=true
 http-server.http.port=8080
 
 discovery.uri=http://localhost:8080


### PR DESCRIPTION
`experimental.concurrent-startup` was enabled in tests for quite some time. It is believed the functionality can be enabled by default.
