### PR TITLE
Update and pin json-smart to 2.4.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1674,6 +1674,13 @@
             </dependency>
 
             <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <!-- not vulnerable to CVE-2023-1370 -->
+                <version>2.4.10</version>
+            </dependency>
+
+            <dependency>
                 <groupId>net.sf.opencsv</groupId>
                 <artifactId>opencsv</artifactId>
                 <version>2.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1676,7 +1676,6 @@
             <dependency>
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>
-                <!-- not vulnerable to CVE-2023-1370 -->
                 <version>2.4.10</version>
             </dependency>
 


### PR DESCRIPTION
json-smart <= 2.4.9 is affected by CVE-2023-1370

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
