### PR TITLE
Manually instrument okhttp with OTEL in trino-jdbc

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/QueryRunner.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/QueryRunner.java
@@ -24,6 +24,7 @@ import io.trino.client.auth.external.HttpTokenPoller;
 import io.trino.client.auth.external.KnownToken;
 import io.trino.client.auth.external.RedirectHandler;
 import io.trino.client.auth.external.TokenPoller;
+import okhttp3.Call;
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
 
@@ -156,7 +157,7 @@ public class QueryRunner
         sslSetup.accept(builder);
         OkHttpClient client = builder.build();
 
-        return newStatementClient(client, session, query);
+        return newStatementClient((Call.Factory) client, session, query);
     }
 
     @Override

--- a/client/trino-client/src/main/java/io/trino/client/JsonResponse.java
+++ b/client/trino-client/src/main/java/io/trino/client/JsonResponse.java
@@ -15,9 +15,9 @@ package io.trino.client;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import jakarta.annotation.Nullable;
+import okhttp3.Call;
 import okhttp3.Headers;
 import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
@@ -108,7 +108,7 @@ public final class JsonResponse<T>
                 .toString();
     }
 
-    public static <T> JsonResponse<T> execute(JsonCodec<T> codec, OkHttpClient client, Request request, OptionalLong materializedJsonSizeLimit)
+    public static <T> JsonResponse<T> execute(JsonCodec<T> codec, Call.Factory client, Request request, OptionalLong materializedJsonSizeLimit)
     {
         try (Response response = client.newCall(request).execute()) {
             ResponseBody responseBody = requireNonNull(response.body());

--- a/client/trino-client/src/main/java/io/trino/client/StatementClientFactory.java
+++ b/client/trino-client/src/main/java/io/trino/client/StatementClientFactory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.client;
 
+import okhttp3.Call;
 import okhttp3.OkHttpClient;
 
 import java.util.Optional;
@@ -22,13 +23,13 @@ public final class StatementClientFactory
 {
     private StatementClientFactory() {}
 
-    public static StatementClient newStatementClient(OkHttpClient httpClient, ClientSession session, String query)
+    public static StatementClient newStatementClient(Call.Factory httpCallFactory, ClientSession session, String query)
     {
-        return new StatementClientV1(httpClient, session, query, Optional.empty());
+        return new StatementClientV1(httpCallFactory, session, query, Optional.empty());
     }
 
     public static StatementClient newStatementClient(OkHttpClient httpClient, ClientSession session, String query, Optional<Set<String>> clientCapabilities)
     {
-        return new StatementClientV1(httpClient, session, query, clientCapabilities);
+        return new StatementClientV1((Call.Factory) httpClient, session, query, clientCapabilities);
     }
 }

--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -65,6 +65,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-okhttp-3.0</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-client</artifactId>
         </dependency>
@@ -77,6 +82,12 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -371,6 +382,10 @@
                                     <shadedPattern>${shadeBase}.okhttp3</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>io.opentelemetry.instrumentation</pattern>
+                                    <shadedPattern>${shadeBase}.opentelemetry.instrumentation</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>okio</pattern>
                                     <shadedPattern>${shadeBase}.okio</shadedPattern>
                                 </relocation>
@@ -406,6 +421,9 @@
                                         <exclude>META-INF/*-NOTICE</exclude>
                                         <exclude>META-INF/*-LICENSE</exclude>
                                         <exclude>META-INF/LICENSE**</exclude>
+                                        <exclude>META-INF/io/opentelemetry/**</exclude>
+                                        <exclude>io/opentelemetry/semconv/**</exclude>
+                                        <exclude>META-INF/native-image/**</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestFinalQueryInfo.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestFinalQueryInfo.java
@@ -21,6 +21,7 @@ import io.trino.client.StatementClient;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.spi.QueryId;
 import io.trino.testing.DistributedQueryRunner;
+import okhttp3.Call;
 import okhttp3.OkHttpClient;
 import org.testng.annotations.Test;
 
@@ -73,7 +74,7 @@ public class TestFinalQueryInfo
                     .build();
 
             // start query
-            StatementClient client = newStatementClient(httpClient, clientSession, sql);
+            StatementClient client = newStatementClient((Call.Factory) httpClient, clientSession, sql);
 
             // wait for query to be fully scheduled
             while (client.isRunning() && !client.currentStatusInfo().getStats().isScheduled()) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Because trino-jdbc is using a shaded version of okhttp, it does not get automatically instrumented when using an OTEL Java agent.

Thanks to this, both client and server traces can be correlated, with JDBC traces as the root.

This is a follow-up to #16950.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
