### PR TITLE
Make checkCanWriteSystemInformation to deny by default

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
@@ -225,7 +225,7 @@ public interface SystemAccessControl
      */
     default void checkCanWriteSystemInformation(SystemSecurityContext context)
     {
-        AccessDeniedException.denyReadSystemInformationAccess();
+        AccessDeniedException.denyWriteSystemInformationAccess();
     }
 
     /**

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/DefaultSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/DefaultSystemAccessControl.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.spi.security.AccessDeniedException.denyImpersonateUser;
+import static io.trino.spi.security.AccessDeniedException.denyWriteSystemInformationAccess;
 
 /**
  * Default system access control rules.
@@ -54,5 +55,11 @@ public class DefaultSystemAccessControl
     public void checkCanImpersonateUser(SystemSecurityContext context, String userName)
     {
         denyImpersonateUser(context.getIdentity().getUser(), userName);
+    }
+
+    @Override
+    public void checkCanWriteSystemInformation(SystemSecurityContext context)
+    {
+        denyWriteSystemInformationAccess();
     }
 }


### PR DESCRIPTION
Make checkCanWriteSystemInformation to deny by default

This is in order to prevent accidental access to modify the worker state
in case there was no configured access control on worker.
