### PR TITLE
Improve performance of reading iceberg table with many delete files

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/EqualityDeleteFilter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/EqualityDeleteFilter.java
@@ -17,26 +17,22 @@ import io.trino.plugin.iceberg.IcebergColumnHandle;
 import io.trino.spi.Page;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.type.Type;
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
-import org.apache.iceberg.util.StructLikeSet;
-import org.apache.iceberg.util.StructProjection;
 
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
-import static io.trino.plugin.iceberg.IcebergUtil.schemaFromHandles;
 import static java.util.Objects.requireNonNull;
 
 public final class EqualityDeleteFilter
         implements DeleteFilter
 {
-    private final Schema schema;
-    private final StructLikeSet deleteSet;
+    private final Predicate<StructLike> deletedRows;
 
-    private EqualityDeleteFilter(Schema schema, StructLikeSet deleteSet)
+    public EqualityDeleteFilter(Predicate<StructLike> deletedRows)
     {
-        this.schema = requireNonNull(schema, "schema is null");
-        this.deleteSet = requireNonNull(deleteSet, "deleteSet is null");
+        this.deletedRows = requireNonNull(deletedRows, "deletedRows is null");
     }
 
     @Override
@@ -46,23 +42,17 @@ public final class EqualityDeleteFilter
                 .map(IcebergColumnHandle::getType)
                 .toArray(Type[]::new);
 
-        Schema fileSchema = schemaFromHandles(columns);
-        StructProjection projection = StructProjection.create(fileSchema, schema);
-
         return (page, position) -> {
             StructLike row = new LazyTrinoRow(types, page, position);
-            return !deleteSet.contains(projection.wrap(row));
+            return !deletedRows.test(row);
         };
     }
 
-    public static DeleteFilter readEqualityDeletes(ConnectorPageSource pageSource, List<IcebergColumnHandle> columns, Schema tableSchema)
+    public static void readEqualityDeletes(ConnectorPageSource pageSource, List<IcebergColumnHandle> columns, Consumer<StructLike> deletedRows)
     {
         Type[] types = columns.stream()
                 .map(IcebergColumnHandle::getType)
                 .toArray(Type[]::new);
-
-        Schema deleteSchema = schemaFromHandles(columns);
-        StructLikeSet deleteSet = StructLikeSet.create(deleteSchema.asStruct());
 
         while (!pageSource.isFinished()) {
             Page page = pageSource.getNextPage();
@@ -71,10 +61,8 @@ public final class EqualityDeleteFilter
             }
 
             for (int position = 0; position < page.getPositionCount(); position++) {
-                deleteSet.add(new TrinoRow(types, page, position));
+                deletedRows.accept(new TrinoRow(types, page, position));
             }
         }
-
-        return new EqualityDeleteFilter(deleteSchema, deleteSet);
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fixes #17114 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

If a split with many delete file `RowPredicate.and` will create a deep stack, this pr compact all StructLikeSet to a collection to reduce stack depth.

The stack depth is only a hidden danger. The real problem is that multiple `StructLikeSet` of a split are not merged according to the ids, resulting in too many `StructLikeSet` being generated, which makes the filtering efficiency very lowly. 

The main content is to classify delete files according to id, and only use the same `StructLikeSet` to collect deletion data. 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Improve performance of reading iceberg table with many delete files. ({issue}`17114`)
```
