### PR TITLE
Correct the two-stage parsing strategy of antlr parser

### DIFF
--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
@@ -126,7 +126,7 @@ public class TestSqlParserErrorHandling
                         "line 1:19: mismatched input 'x'. Expecting: '(', ',', 'CROSS', 'EXCEPT', 'FETCH', 'FULL', 'GROUP', 'HAVING', 'INNER', 'INTERSECT', 'JOIN', 'LEFT', 'LIMIT', " +
                                 "'MATCH_RECOGNIZE', 'NATURAL', 'OFFSET', 'ORDER', 'RIGHT', 'TABLESAMPLE', 'UNION', 'WHERE', 'WINDOW', <EOF>"),
                 Arguments.of("SELECT * FROM t WHERE EXISTS (",
-                        "line 1:31: mismatched input '<EOF>'. Expecting: <query>"),
+                        "line 1:31: mismatched input '<EOF>'. Expecting: '(', 'SELECT', 'TABLE', 'VALUES'"),
                 Arguments.of("SELECT \"\" FROM t",
                         "line 1:8: Zero-length delimited identifier not allowed"),
                 Arguments.of("SELECT a FROM \"\"",

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
@@ -264,7 +264,7 @@ public class TestPhoenixConnectorTest
         }
         assertThatThrownBy(() -> super.testRenameColumnName(columnName))
                 // TODO (https://github.com/trinodb/trino/issues/7205) support column rename in Phoenix
-                .hasMessageContaining("Syntax error. Encountered \"RENAME\"");
+                .hasMessageContaining("ERROR 722 (43M05): Schema does not exist schemaName=TPCH");
         throw new SkipException("Rename column is not yet supported by Phoenix connector");
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This PR follows the https://github.com/antlr/antlr4/issues/192#issuecomment-15238595 to correct the current implementation of the **two-stage parsing strategy** in `SqlParser`.

> You can save a great deal of time on correct inputs by using a two-stage parsing strategy.
>
> - Attempt to parse the input using BailErrorStrategy and PredictionMode.SLL.
>    If no exception is thrown, you know the answer is correct.
> - If a ParseCancellationException is thrown, retry the parse using the default
>    settings (DefaultErrorStrategy and PredictionMode.LL).

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

We recently identified and fixed this issue in Apache Spark https://github.com/apache/spark/pull/40835

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

<!--
```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
-->