### PR TITLE
Fetch all table/view names across schemas with one Hive metastore call (when Hive views enabled)

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
@@ -152,6 +152,11 @@ public class HiveMetastoreClosure
         return delegate.getAllTables(databaseName);
     }
 
+    public Optional<List<SchemaTableName>> getAllTables()
+    {
+        return delegate.getAllTables();
+    }
+
     public List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
     {
         return delegate.getTablesWithParameter(databaseName, parameterKey, parameterValue);
@@ -160,6 +165,11 @@ public class HiveMetastoreClosure
     public List<String> getAllViews(String databaseName)
     {
         return delegate.getAllViews(databaseName);
+    }
+
+    public Optional<List<SchemaTableName>> getAllViews()
+    {
+        return delegate.getAllViews();
     }
 
     public void createDatabase(Database database)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/ForwardingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/ForwardingHiveMetastore.java
@@ -115,6 +115,12 @@ public abstract class ForwardingHiveMetastore
     }
 
     @Override
+    public Optional<List<SchemaTableName>> getAllTables()
+    {
+        return delegate.getAllTables();
+    }
+
+    @Override
     public List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
     {
         return delegate.getTablesWithParameter(databaseName, parameterKey, parameterValue);
@@ -124,6 +130,12 @@ public abstract class ForwardingHiveMetastore
     public List<String> getAllViews(String databaseName)
     {
         return delegate.getAllViews(databaseName);
+    }
+
+    @Override
+    public Optional<List<SchemaTableName>> getAllViews()
+    {
+        return delegate.getAllViews();
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
@@ -62,9 +62,19 @@ public interface HiveMetastore
 
     List<String> getAllTables(String databaseName);
 
+    /**
+     * @return List of tables, views and materialized views names from all schemas or Optional.empty if operation is not supported
+     */
+    Optional<List<SchemaTableName>> getAllTables();
+
     List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue);
 
     List<String> getAllViews(String databaseName);
+
+    /**
+     * @return List of views including materialized views names from all schemas or Optional.empty if operation is not supported
+     */
+    Optional<List<SchemaTableName>> getAllViews();
 
     void createDatabase(Database database);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -245,6 +245,15 @@ public class SemiTransactionalHiveMetastore
         return delegate.getAllTables(databaseName);
     }
 
+    public synchronized Optional<List<SchemaTableName>> getAllTables()
+    {
+        checkReadable();
+        if (!tableActions.isEmpty()) {
+            throw new UnsupportedOperationException("Listing all tables after adding/dropping/altering tables/views in a transaction is not supported");
+        }
+        return delegate.getAllTables();
+    }
+
     public synchronized Optional<Table> getTable(String databaseName, String tableName)
     {
         checkReadable();
@@ -417,6 +426,15 @@ public class SemiTransactionalHiveMetastore
             throw new UnsupportedOperationException("Listing all tables after adding/dropping/altering tables/views in a transaction is not supported");
         }
         return delegate.getAllViews(databaseName);
+    }
+
+    public synchronized Optional<List<SchemaTableName>> getAllViews()
+    {
+        checkReadable();
+        if (!tableActions.isEmpty()) {
+            throw new UnsupportedOperationException("Listing all tables after adding/dropping/altering tables/views in a transaction is not supported");
+        }
+        return delegate.getAllViews();
     }
 
     public synchronized void createDatabase(ConnectorSession session, Database database)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/alluxio/AlluxioHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/alluxio/AlluxioHiveMetastore.java
@@ -41,6 +41,7 @@ import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.security.RoleGrant;
 import io.trino.spi.type.Type;
@@ -213,6 +214,12 @@ public class AlluxioHiveMetastore
     }
 
     @Override
+    public Optional<List<SchemaTableName>> getAllTables()
+    {
+        return Optional.empty();
+    }
+
+    @Override
     public List<String> getTablesWithParameter(
             String databaseName,
             String parameterKey,
@@ -246,6 +253,12 @@ public class AlluxioHiveMetastore
     {
         // TODO: Add views on the server side
         return Collections.emptyList();
+    }
+
+    @Override
+    public Optional<List<SchemaTableName>> getAllViews()
+    {
+        return Optional.empty();
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/SharedHiveMetastoreCache.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/SharedHiveMetastoreCache.java
@@ -257,6 +257,13 @@ public class SharedHiveMetastoreCache
 
         @Managed
         @Nested
+        public AggregateCacheStatsMBean getAllTableNamesStats()
+        {
+            return new AggregateCacheStatsMBean(CachingHiveMetastore::getAllTableNamesCache);
+        }
+
+        @Managed
+        @Nested
         public AggregateCacheStatsMBean getTableWithParameterStats()
         {
             return new AggregateCacheStatsMBean(CachingHiveMetastore::getTablesWithParameterCache);
@@ -281,6 +288,13 @@ public class SharedHiveMetastoreCache
         public AggregateCacheStatsMBean getViewNamesStats()
         {
             return new AggregateCacheStatsMBean(CachingHiveMetastore::getViewNamesCache);
+        }
+
+        @Managed
+        @Nested
+        public AggregateCacheStatsMBean getAllViewNamesStats()
+        {
+            return new AggregateCacheStatsMBean(CachingHiveMetastore::getAllViewNamesCache);
         }
 
         @Managed

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -491,6 +491,12 @@ public class FileHiveMetastore
     }
 
     @Override
+    public Optional<List<SchemaTableName>> getAllTables()
+    {
+        return Optional.empty();
+    }
+
+    @Override
     public synchronized List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
     {
         requireNonNull(parameterKey, "parameterKey is null");
@@ -540,6 +546,12 @@ public class FileHiveMetastore
                 .filter(table -> table.getTableType().equals(VIRTUAL_VIEW.name()))
                 .map(Table::getTableName)
                 .collect(toImmutableList());
+    }
+
+    @Override
+    public Optional<List<SchemaTableName>> getAllViews()
+    {
+        return Optional.empty();
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -440,6 +440,12 @@ public class GlueHiveMetastore
     }
 
     @Override
+    public Optional<List<SchemaTableName>> getAllTables()
+    {
+        return Optional.empty();
+    }
+
+    @Override
     public synchronized List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
     {
         return getAllViews(databaseName, table -> parameterValue.equals(getTableParameters(table).get(parameterKey)));
@@ -449,6 +455,12 @@ public class GlueHiveMetastore
     public List<String> getAllViews(String databaseName)
     {
         return getAllViews(databaseName, table -> true);
+    }
+
+    @Override
+    public Optional<List<SchemaTableName>> getAllViews()
+    {
+        return Optional.empty();
     }
 
     private List<String> getAllViews(String databaseName, Predicate<com.amazonaws.services.glue.model.Table> additionalFilter)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/recording/HiveMetastoreRecording.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/recording/HiveMetastoreRecording.java
@@ -71,9 +71,9 @@ public class HiveMetastoreRecording
     private final NonEvictableCache<HiveTableName, Optional<Table>> tableCache;
     private final NonEvictableCache<HiveTableName, PartitionStatistics> tableStatisticsCache;
     private final NonEvictableCache<HivePartitionName, PartitionStatistics> partitionStatisticsCache;
-    private final NonEvictableCache<String, List<String>> allTablesCache;
+    private final NonEvictableCache<String, List<String>> tableNamesCache;
     private final NonEvictableCache<TablesWithParameterCacheKey, List<String>> tablesWithParameterCache;
-    private final NonEvictableCache<String, List<String>> allViewsCache;
+    private final NonEvictableCache<String, List<String>> viewNamesCache;
     private final NonEvictableCache<HivePartitionName, Optional<Partition>> partitionCache;
     private final NonEvictableCache<HiveTableName, Optional<List<String>>> partitionNamesCache;
     private final NonEvictableCache<PartitionFilter, Optional<List<String>>> partitionNamesByPartsCache;
@@ -95,9 +95,9 @@ public class HiveMetastoreRecording
         tableCache = createCache(replay, recordingDuration);
         tableStatisticsCache = createCache(replay, recordingDuration);
         partitionStatisticsCache = createCache(replay, recordingDuration);
-        allTablesCache = createCache(replay, recordingDuration);
+        tableNamesCache = createCache(replay, recordingDuration);
         tablesWithParameterCache = createCache(replay, recordingDuration);
-        allViewsCache = createCache(replay, recordingDuration);
+        viewNamesCache = createCache(replay, recordingDuration);
         partitionCache = createCache(replay, recordingDuration);
         partitionNamesCache = createCache(replay, recordingDuration);
         partitionNamesByPartsCache = createCache(replay, recordingDuration);
@@ -126,9 +126,9 @@ public class HiveMetastoreRecording
         tableCache.putAll(toMap(recording.getTables()));
         tableStatisticsCache.putAll(toMap(recording.getTableStatistics()));
         partitionStatisticsCache.putAll(toMap(recording.getPartitionStatistics()));
-        allTablesCache.putAll(toMap(recording.getAllTables()));
+        tableNamesCache.putAll(toMap(recording.getAllTables()));
         tablesWithParameterCache.putAll(toMap(recording.getTablesWithParameter()));
-        allViewsCache.putAll(toMap(recording.getAllViews()));
+        viewNamesCache.putAll(toMap(recording.getAllViews()));
         partitionCache.putAll(toMap(recording.getPartitions()));
         partitionNamesCache.putAll(toMap(recording.getPartitionNames()));
         partitionNamesByPartsCache.putAll(toMap(recording.getPartitionNamesByParts()));
@@ -176,7 +176,7 @@ public class HiveMetastoreRecording
 
     public List<String> getAllTables(String databaseName, Supplier<List<String>> valueSupplier)
     {
-        return loadValue(allTablesCache, databaseName, valueSupplier);
+        return loadValue(tableNamesCache, databaseName, valueSupplier);
     }
 
     public List<String> getTablesWithParameter(TablesWithParameterCacheKey tablesWithParameterCacheKey, Supplier<List<String>> valueSupplier)
@@ -186,7 +186,7 @@ public class HiveMetastoreRecording
 
     public List<String> getAllViews(String databaseName, Supplier<List<String>> valueSupplier)
     {
-        return loadValue(allViewsCache, databaseName, valueSupplier);
+        return loadValue(viewNamesCache, databaseName, valueSupplier);
     }
 
     public Optional<Partition> getPartition(HivePartitionName hivePartitionName, Supplier<Optional<Partition>> valueSupplier)
@@ -255,9 +255,9 @@ public class HiveMetastoreRecording
                 toPairs(tableCache),
                 toPairs(tableStatisticsCache),
                 toPairs(partitionStatisticsCache),
-                toPairs(allTablesCache),
+                toPairs(tableNamesCache),
                 toPairs(tablesWithParameterCache),
-                toPairs(allViewsCache),
+                toPairs(viewNamesCache),
                 toPairs(partitionCache),
                 toPairs(partitionNamesCache),
                 toPairs(partitionNamesByPartsCache),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/recording/RecordingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/recording/RecordingHiveMetastore.java
@@ -28,6 +28,7 @@ import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hive.metastore.TablesWithParameterCacheKey;
 import io.trino.plugin.hive.metastore.UserTableKey;
+import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.security.RoleGrant;
 import io.trino.spi.type.Type;
@@ -141,6 +142,18 @@ public class RecordingHiveMetastore
     public List<String> getAllViews(String databaseName)
     {
         return recording.getAllViews(databaseName, () -> delegate.getAllViews(databaseName));
+    }
+
+    @Override
+    public Optional<List<SchemaTableName>> getAllTables()
+    {
+        return recording.getAllTables(delegate::getAllTables);
+    }
+
+    @Override
+    public Optional<List<SchemaTableName>> getAllViews()
+    {
+        return recording.getAllViews(delegate::getAllViews);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -155,6 +155,18 @@ public class BridgingHiveMetastore
     }
 
     @Override
+    public Optional<List<SchemaTableName>> getAllTables()
+    {
+        return delegate.getAllTables();
+    }
+
+    @Override
+    public Optional<List<SchemaTableName>> getAllViews()
+    {
+        return delegate.getAllViews();
+    }
+
+    @Override
     public void createDatabase(Database database)
     {
         delegate.createDatabase(toMetastoreApiDatabase(database));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/DefaultThriftMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/DefaultThriftMetastoreClientFactory.java
@@ -61,7 +61,7 @@ public class DefaultThriftMetastoreClientFactory
     private final MetastoreSupportsDateStatistics metastoreSupportsDateStatistics = new MetastoreSupportsDateStatistics();
     private final AtomicInteger chosenGetTableAlternative = new AtomicInteger(Integer.MAX_VALUE);
     private final AtomicInteger chosenTableParamAlternative = new AtomicInteger(Integer.MAX_VALUE);
-    private final AtomicInteger chosenGetAllViewsAlternative = new AtomicInteger(Integer.MAX_VALUE);
+    private final AtomicInteger chosenGetAllViewsPerDatabaseAlternative = new AtomicInteger(Integer.MAX_VALUE);
     private final AtomicInteger chosenAlterTransactionalTableAlternative = new AtomicInteger(Integer.MAX_VALUE);
     private final AtomicInteger chosenAlterPartitionsAlternative = new AtomicInteger(Integer.MAX_VALUE);
 
@@ -114,7 +114,7 @@ public class DefaultThriftMetastoreClientFactory
                 metastoreSupportsDateStatistics,
                 chosenGetTableAlternative,
                 chosenTableParamAlternative,
-                chosenGetAllViewsAlternative,
+                chosenGetAllViewsPerDatabaseAlternative,
                 chosenAlterTransactionalTableAlternative,
                 chosenAlterPartitionsAlternative);
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/DefaultThriftMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/DefaultThriftMetastoreClientFactory.java
@@ -64,6 +64,8 @@ public class DefaultThriftMetastoreClientFactory
     private final AtomicInteger chosenGetAllViewsPerDatabaseAlternative = new AtomicInteger(Integer.MAX_VALUE);
     private final AtomicInteger chosenAlterTransactionalTableAlternative = new AtomicInteger(Integer.MAX_VALUE);
     private final AtomicInteger chosenAlterPartitionsAlternative = new AtomicInteger(Integer.MAX_VALUE);
+    private final AtomicInteger chosenGetAllTablesAlternative = new AtomicInteger(Integer.MAX_VALUE);
+    private final AtomicInteger chosenGetAllViewsAlternative = new AtomicInteger(Integer.MAX_VALUE);
 
     public DefaultThriftMetastoreClientFactory(
             Optional<SSLContext> sslContext,
@@ -114,7 +116,9 @@ public class DefaultThriftMetastoreClientFactory
                 metastoreSupportsDateStatistics,
                 chosenGetTableAlternative,
                 chosenTableParamAlternative,
+                chosenGetAllTablesAlternative,
                 chosenGetAllViewsPerDatabaseAlternative,
+                chosenGetAllViewsAlternative,
                 chosenAlterTransactionalTableAlternative,
                 chosenAlterPartitionsAlternative);
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/FailureAwareThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/FailureAwareThriftMetastoreClient.java
@@ -30,10 +30,12 @@ import io.trino.hive.thrift.metastore.RolePrincipalGrant;
 import io.trino.hive.thrift.metastore.Table;
 import io.trino.hive.thrift.metastore.TxnToWriteId;
 import io.trino.plugin.hive.acid.AcidOperation;
+import io.trino.spi.connector.SchemaTableName;
 import org.apache.thrift.TException;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -90,10 +92,24 @@ public class FailureAwareThriftMetastoreClient
     }
 
     @Override
+    public Optional<List<SchemaTableName>> getAllTables()
+            throws TException
+    {
+        return runWithHandle(() -> delegate.getAllTables());
+    }
+
+    @Override
     public List<String> getAllViews(String databaseName)
             throws TException
     {
         return runWithHandle(() -> delegate.getAllViews(databaseName));
+    }
+
+    @Override
+    public Optional<List<SchemaTableName>> getAllViews()
+            throws TException
+    {
+        return runWithHandle(() -> delegate.getAllViews());
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -864,6 +864,54 @@ public class ThriftHiveMetastore
     }
 
     @Override
+    public Optional<List<SchemaTableName>> getAllTables()
+    {
+        try {
+            return retry()
+                    .stopOn(UnknownDBException.class)
+                    .stopOnIllegalExceptions()
+                    .run("getAllTables", stats.getGetAllTables().wrap(() -> {
+                        try (ThriftMetastoreClient client = createMetastoreClient()) {
+                            return client.getAllTables();
+                        }
+                    }));
+        }
+        catch (TException e) {
+            throw new TrinoException(HIVE_METASTORE_ERROR, e);
+        }
+        catch (Exception e) {
+            throw propagate(e);
+        }
+    }
+
+    @Override
+    public Optional<List<SchemaTableName>> getAllViews()
+    {
+        // Without translateHiveViews, Hive views are represented as tables in Trino,
+        // and they should not be returned from ThriftHiveMetastore.getAllViews() call
+        if (!translateHiveViews) {
+            return Optional.empty();
+        }
+
+        try {
+            return retry()
+                    .stopOn(UnknownDBException.class)
+                    .stopOnIllegalExceptions()
+                    .run("getAllViews", stats.getGetAllViews().wrap(() -> {
+                        try (ThriftMetastoreClient client = createMetastoreClient()) {
+                            return client.getAllViews();
+                        }
+                    }));
+        }
+        catch (TException e) {
+            throw new TrinoException(HIVE_METASTORE_ERROR, e);
+        }
+        catch (Exception e) {
+            throw propagate(e);
+        }
+    }
+
+    @Override
     public void createDatabase(Database database)
     {
         try {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -114,7 +114,7 @@ public class ThriftHiveMetastoreClient
     private final MetastoreSupportsDateStatistics metastoreSupportsDateStatistics;
     private final AtomicInteger chosenGetTableAlternative;
     private final AtomicInteger chosenTableParamAlternative;
-    private final AtomicInteger chosenGetAllViewsAlternative;
+    private final AtomicInteger chosenGetAllViewsPerDatabaseAlternative;
     private final AtomicInteger chosenAlterTransactionalTableAlternative;
     private final AtomicInteger chosenAlterPartitionsAlternative;
 
@@ -124,7 +124,7 @@ public class ThriftHiveMetastoreClient
             MetastoreSupportsDateStatistics metastoreSupportsDateStatistics,
             AtomicInteger chosenGetTableAlternative,
             AtomicInteger chosenTableParamAlternative,
-            AtomicInteger chosenGetAllViewsAlternative,
+            AtomicInteger chosenGetAllViewsPerDatabaseAlternative,
             AtomicInteger chosenAlterTransactionalTableAlternative,
             AtomicInteger chosenAlterPartitionsAlternative)
             throws TTransportException
@@ -134,7 +134,7 @@ public class ThriftHiveMetastoreClient
         this.metastoreSupportsDateStatistics = requireNonNull(metastoreSupportsDateStatistics, "metastoreSupportsDateStatistics is null");
         this.chosenGetTableAlternative = requireNonNull(chosenGetTableAlternative, "chosenGetTableAlternative is null");
         this.chosenTableParamAlternative = requireNonNull(chosenTableParamAlternative, "chosenTableParamAlternative is null");
-        this.chosenGetAllViewsAlternative = requireNonNull(chosenGetAllViewsAlternative, "chosenGetAllViewsAlternative is null");
+        this.chosenGetAllViewsPerDatabaseAlternative = requireNonNull(chosenGetAllViewsPerDatabaseAlternative, "chosenGetAllViewsPerDatabaseAlternative is null");
         this.chosenAlterTransactionalTableAlternative = requireNonNull(chosenAlterTransactionalTableAlternative, "chosenAlterTransactionalTableAlternative is null");
         this.chosenAlterPartitionsAlternative = requireNonNull(chosenAlterPartitionsAlternative, "chosenAlterPartitionsAlternative is null");
 
@@ -190,7 +190,7 @@ public class ThriftHiveMetastoreClient
     {
         return alternativeCall(
                 exception -> !isUnknownMethodExceptionalResponse(exception),
-                chosenGetAllViewsAlternative,
+                chosenGetAllViewsPerDatabaseAlternative,
                 () -> client.getTablesByType(databaseName, ".*", VIRTUAL_VIEW.name()),
                 // fallback to enumerating Presto views only (Hive views can still be executed, but will be listed as tables and not views)
                 () -> getTablesWithParameter(databaseName, PRESTO_VIEW_FLAG, "true"));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastore.java
@@ -65,9 +65,13 @@ public interface ThriftMetastore
 
     List<String> getAllTables(String databaseName);
 
+    Optional<List<SchemaTableName>> getAllTables();
+
     List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue);
 
     List<String> getAllViews(String databaseName);
+
+    Optional<List<SchemaTableName>> getAllViews();
 
     Optional<Database> getDatabase(String databaseName);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
@@ -29,11 +29,13 @@ import io.trino.hive.thrift.metastore.RolePrincipalGrant;
 import io.trino.hive.thrift.metastore.Table;
 import io.trino.hive.thrift.metastore.TxnToWriteId;
 import io.trino.plugin.hive.acid.AcidOperation;
+import io.trino.spi.connector.SchemaTableName;
 import org.apache.thrift.TException;
 
 import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public interface ThriftMetastoreClient
         extends Closeable
@@ -50,7 +52,13 @@ public interface ThriftMetastoreClient
     List<String> getAllTables(String databaseName)
             throws TException;
 
+    Optional<List<SchemaTableName>> getAllTables()
+            throws TException;
+
     List<String> getAllViews(String databaseName)
+            throws TException;
+
+    Optional<List<SchemaTableName>> getAllViews()
             throws TException;
 
     List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/CountingAccessHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/CountingAccessHiveMetastore.java
@@ -21,6 +21,7 @@ import io.trino.plugin.hive.HiveType;
 import io.trino.plugin.hive.PartitionStatistics;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege;
+import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.security.RoleGrant;
 import io.trino.spi.type.Type;
@@ -33,6 +34,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
+import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_TABLES;
+import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_VIEWS;
+
 @ThreadSafe
 public class CountingAccessHiveMetastore
         implements HiveMetastore
@@ -44,9 +48,11 @@ public class CountingAccessHiveMetastore
         GET_ALL_DATABASES,
         GET_DATABASE,
         GET_TABLE,
+        GET_ALL_TABLES,
         GET_ALL_TABLES_FROM_DATABASE,
         GET_TABLE_WITH_PARAMETER,
         GET_TABLE_STATISTICS,
+        GET_ALL_VIEWS,
         GET_ALL_VIEWS_FROM_DATABASE,
         UPDATE_TABLE_STATISTICS,
         ADD_PARTITIONS,
@@ -117,6 +123,16 @@ public class CountingAccessHiveMetastore
     {
         methodInvocations.add(Method.GET_ALL_VIEWS_FROM_DATABASE);
         return delegate.getAllViews(databaseName);
+    }
+
+    @Override
+    public Optional<List<SchemaTableName>> getAllViews()
+    {
+        Optional<List<SchemaTableName>> allViews = delegate.getAllViews();
+        if (allViews.isPresent()) {
+            methodInvocations.add(GET_ALL_VIEWS);
+        }
+        return allViews;
     }
 
     @Override
@@ -346,5 +362,15 @@ public class CountingAccessHiveMetastore
     {
         methodInvocations.add(Method.GET_ALL_TABLES_FROM_DATABASE);
         return delegate.getAllTables(databaseName);
+    }
+
+    @Override
+    public Optional<List<SchemaTableName>> getAllTables()
+    {
+        Optional<List<SchemaTableName>> allTables = delegate.getAllTables();
+        if (allTables.isPresent()) {
+            methodInvocations.add(GET_ALL_TABLES);
+        }
+        return allTables;
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/UnimplementedHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/UnimplementedHiveMetastore.java
@@ -18,6 +18,7 @@ import io.trino.plugin.hive.HiveType;
 import io.trino.plugin.hive.PartitionStatistics;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege;
+import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.security.RoleGrant;
 import io.trino.spi.type.Type;
@@ -89,6 +90,12 @@ public class UnimplementedHiveMetastore
     }
 
     @Override
+    public Optional<List<SchemaTableName>> getAllTables()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
     {
         throw new UnsupportedOperationException();
@@ -96,6 +103,12 @@ public class UnimplementedHiveMetastore
 
     @Override
     public List<String> getAllViews(String databaseName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<List<SchemaTableName>> getAllViews()
     {
         throw new UnsupportedOperationException();
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
@@ -327,6 +327,18 @@ public class InMemoryThriftMetastore
     }
 
     @Override
+    public synchronized Optional<List<SchemaTableName>> getAllTables()
+    {
+        return Optional.of(ImmutableList.copyOf(relations.keySet()));
+    }
+
+    @Override
+    public synchronized Optional<List<SchemaTableName>> getAllViews()
+    {
+        return Optional.of(ImmutableList.copyOf(views.keySet()));
+    }
+
+    @Override
     public synchronized Optional<Database> getDatabase(String databaseName)
     {
         return Optional.ofNullable(databases.get(databaseName));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
@@ -47,6 +47,7 @@ import org.apache.thrift.TException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -180,7 +181,24 @@ public class MockThriftMetastoreClient
     }
 
     @Override
+    public Optional<List<SchemaTableName>> getAllTables()
+            throws TException
+    {
+        accessCount.incrementAndGet();
+        if (throwException) {
+            throw new RuntimeException();
+        }
+        return Optional.of(ImmutableList.of(new SchemaTableName(TEST_DATABASE, TEST_TABLE)));
+    }
+
+    @Override
     public List<String> getAllViews(String databaseName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<List<SchemaTableName>> getAllViews()
     {
         throw new UnsupportedOperationException();
     }
@@ -384,13 +402,13 @@ public class MockThriftMetastoreClient
     @Override
     public void createDatabase(Database database)
     {
-        throw new UnsupportedOperationException();
+        // No-op, make sure the cache invalidation logic in CachingHiveMetastore will be passed through
     }
 
     @Override
     public void dropDatabase(String databaseName, boolean deleteData, boolean cascade)
     {
-        throw new UnsupportedOperationException();
+        // No-op, make sure the cache invalidation logic in CachingHiveMetastore will be passed through
     }
 
     @Override
@@ -402,7 +420,7 @@ public class MockThriftMetastoreClient
     @Override
     public void createTable(Table table)
     {
-        throw new UnsupportedOperationException();
+        // No-op, make sure the cache invalidation logic in CachingHiveMetastore will be passed through
     }
 
     @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestHiveMetastoreMetadataQueriesAccessOperations.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestHiveMetastoreMetadataQueriesAccessOperations.java
@@ -27,6 +27,7 @@ import io.trino.plugin.hive.metastore.CountingAccessHiveMetastoreUtil;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hive.metastore.UnimplementedHiveMetastore;
 import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DataProviders;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
 import org.intellij.lang.annotations.Language;
@@ -98,17 +99,29 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
         assertMetastoreInvocations("SELECT * FROM system.jdbc.schemas WHERE table_schem LIKE 'test%'", ImmutableMultiset.of(GET_ALL_DATABASES));
     }
 
-    @Test
-    public void testSelectTablesWithoutPredicate()
+    @Test(dataProviderClass = DataProviders.class, dataProvider = "trueFalse")
+    public void testSelectTablesWithoutPredicate(boolean allTablesViewsImplemented)
     {
         assertMetastoreInvocations("SELECT * FROM information_schema.tables",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .build());
         assertMetastoreInvocations("SELECT * FROM system.jdbc.tables",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
@@ -137,79 +150,138 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                         .build());
     }
 
-    @Test
-    public void testSelectTablesWithLikeOverSchema()
+    @Test(dataProviderClass = DataProviders.class, dataProvider = "trueFalse")
+    public void testSelectTablesWithLikeOverSchema(boolean allTablesViewsImplemented)
     {
         assertMetastoreInvocations("SELECT * FROM information_schema.tables WHERE table_schema LIKE 'test%'",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .build());
         assertMetastoreInvocations("SELECT * FROM system.jdbc.tables WHERE table_schem LIKE 'test%'",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .build());
     }
 
-    @Test
-    public void testSelectTablesWithFilterByTableName()
+    @Test(dataProviderClass = DataProviders.class, dataProvider = "trueFalse")
+    public void testSelectTablesWithFilterByTableName(boolean allTablesViewsImplemented)
     {
         assertMetastoreInvocations("SELECT * FROM information_schema.tables WHERE table_name = 'test_table_0'",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .build());
         assertMetastoreInvocations("SELECT * FROM system.jdbc.tables WHERE table_name = 'test_table_0'",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .build());
         assertMetastoreInvocations("SELECT * FROM system.jdbc.tables WHERE table_name LIKE 'test\\_table\\_0' ESCAPE '\\'",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .build());
         assertMetastoreInvocations("SELECT * FROM system.jdbc.tables WHERE table_name LIKE 'test_table_0' ESCAPE '\\'",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .build());
     }
 
-    @Test
-    public void testSelectTablesWithLikeOverTableName()
+    @Test(dataProviderClass = DataProviders.class, dataProvider = "trueFalse")
+    public void testSelectTablesWithLikeOverTableName(boolean allTablesViewsImplemented)
     {
         assertMetastoreInvocations("SELECT * FROM information_schema.tables WHERE table_name LIKE 'test%'",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .build());
         assertMetastoreInvocations("SELECT * FROM system.jdbc.tables WHERE table_name LIKE 'test%'",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .build());
     }
 
-    @Test
-    public void testSelectViewsWithoutPredicate()
+    @Test(dataProviderClass = DataProviders.class, dataProvider = "trueFalse")
+    public void testSelectViewsWithoutPredicate(boolean allTablesViewsImplemented)
     {
         assertMetastoreInvocations("SELECT * FROM information_schema.views",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .build());
         assertMetastoreInvocations("SELECT * FROM system.jdbc.tables WHERE table_type = 'VIEW'",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
@@ -234,66 +306,113 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                         .build());
     }
 
-    @Test
-    public void testSelectViewsWithLikeOverSchema()
+    @Test(dataProviderClass = DataProviders.class, dataProvider = "trueFalse")
+    public void testSelectViewsWithLikeOverSchema(boolean allTablesViewsImplemented)
     {
         assertMetastoreInvocations("SELECT * FROM information_schema.views WHERE table_schema LIKE 'test%'",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .build());
         assertMetastoreInvocations("SELECT * FROM system.jdbc.tables WHERE table_type = 'VIEW' AND table_schem LIKE 'test%'",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .build());
     }
 
-    @Test
-    public void testSelectViewsWithFilterByTableName()
+    @Test(dataProviderClass = DataProviders.class, dataProvider = "trueFalse")
+    public void testSelectViewsWithFilterByTableName(boolean allTablesViewsImplemented)
     {
         assertMetastoreInvocations("SELECT * FROM information_schema.views WHERE table_name = 'test_table_0'",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .build());
         assertMetastoreInvocations("SELECT * FROM system.jdbc.tables WHERE table_type = 'VIEW' AND table_name = 'test_table_0'",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .build());
     }
 
-    @Test
-    public void testSelectViewsWithLikeOverTableName()
+    @Test(dataProviderClass = DataProviders.class, dataProvider = "trueFalse")
+    public void testSelectViewsWithLikeOverTableName(boolean allTablesViewsImplemented)
     {
         assertMetastoreInvocations("SELECT * FROM information_schema.views WHERE table_name LIKE 'test%'",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .build());
         assertMetastoreInvocations("SELECT * FROM system.jdbc.tables WHERE table_type = 'VIEW' AND table_name LIKE 'test%'",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .build());
     }
 
-    @Test
-    public void testSelectColumnsWithoutPredicate()
+    @Test(dataProviderClass = DataProviders.class, dataProvider = "trueFalse")
+    public void testSelectColumnsWithoutPredicate(boolean allTablesViewsImplemented)
     {
         assertMetastoreInvocations("SELECT * FROM information_schema.columns",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
         assertMetastoreInvocations("SELECT * FROM system.jdbc.columns",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
@@ -338,11 +457,18 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                         .build());
     }
 
-    @Test
-    public void testSelectColumnsWithLikeOverSchema()
+    @Test(dataProviderClass = DataProviders.class, dataProvider = "trueFalse")
+    public void testSelectColumnsWithLikeOverSchema(boolean allTablesViewsImplemented)
     {
         assertMetastoreInvocations("SELECT * FROM information_schema.columns WHERE table_schema LIKE 'test%'",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
@@ -356,8 +482,8 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                         .build());
     }
 
-    @Test
-    public void testSelectColumnsFilterByTableName()
+    @Test(dataProviderClass = DataProviders.class, dataProvider = "trueFalse")
+    public void testSelectColumnsFilterByTableName(boolean allTablesViewsImplemented)
     {
         metastore.resetCounters();
         computeActual("SELECT * FROM information_schema.columns WHERE table_name = 'test_table_0'");
@@ -372,7 +498,13 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
         invocations.elementSet().remove(GET_TABLE);
 
         assertThat(invocations).as("invocations except of GET_TABLE")
-                .isEqualTo(ImmutableMultiset.builder()
+                .isEqualTo(allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
@@ -396,11 +528,18 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                         .build());
     }
 
-    @Test
-    public void testSelectColumnsWithLikeOverTableName()
+    @Test(dataProviderClass = DataProviders.class, dataProvider = "trueFalse")
+    public void testSelectColumnsWithLikeOverTableName(boolean allTablesViewsImplemented)
     {
         assertMetastoreInvocations("SELECT * FROM information_schema.columns WHERE table_name LIKE 'test%'",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
@@ -414,18 +553,32 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                         .build());
     }
 
-    @Test
-    public void testSelectColumnsFilterByColumn()
+    @Test(dataProviderClass = DataProviders.class, dataProvider = "trueFalse")
+    public void testSelectColumnsFilterByColumn(boolean allTablesViewsImplemented)
     {
         assertMetastoreInvocations("SELECT * FROM information_schema.columns WHERE column_name = 'name'",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
         assertMetastoreInvocations("SELECT * FROM system.jdbc.columns WHERE column_name = 'name'",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
@@ -433,18 +586,32 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                         .build());
     }
 
-    @Test
-    public void testSelectColumnsWithLikeOverColumn()
+    @Test(dataProviderClass = DataProviders.class, dataProvider = "trueFalse")
+    public void testSelectColumnsWithLikeOverColumn(boolean allTablesViewsImplemented)
     {
         assertMetastoreInvocations("SELECT * FROM information_schema.columns WHERE column_name LIKE 'n%'",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
         assertMetastoreInvocations("SELECT * FROM system.jdbc.columns WHERE column_name LIKE 'n%'",
-                ImmutableMultiset.builder()
+                allTablesViewsImplemented
+                        ? ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
+                        .build()
+                        : ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftHiveMetastoreClient.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftHiveMetastoreClient.java
@@ -49,6 +49,8 @@ public class TestThriftHiveMetastoreClient
                 new AtomicInteger(),
                 new AtomicInteger(),
                 new AtomicInteger(),
+                new AtomicInteger(),
+                new AtomicInteger(),
                 new AtomicInteger());
         assertThat(connectionCount.get()).isEqualTo(1);
 


### PR DESCRIPTION
## Description
This PR replaces https://github.com/trinodb/trino/pull/16847 but drops last commits because of a regression - I will try to reintroduce that with a fix in separate PR.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix some things. ({issue}`issuenumber`)
```
