### PR TITLE
Support migrating Delta Lake tables to Iceberg

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/CorruptedDeltaLakeTableHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/CorruptedDeltaLakeTableHandle.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 
 public record CorruptedDeltaLakeTableHandle(
         SchemaTableName schemaTableName,
+        boolean managed,
         String location,
         TrinoException originalException)
         implements ConnectorTableHandle

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/CorruptedDeltaLakeTableHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/CorruptedDeltaLakeTableHandle.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.deltalake;
 
 import io.trino.spi.TrinoException;
-import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.SchemaTableName;
 
 import static java.util.Objects.requireNonNull;
@@ -24,7 +23,7 @@ public record CorruptedDeltaLakeTableHandle(
         boolean managed,
         String location,
         TrinoException originalException)
-        implements ConnectorTableHandle
+        implements LocatedTableHandle
 {
     public CorruptedDeltaLakeTableHandle
     {

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/CorruptedDeltaLakeTableHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/CorruptedDeltaLakeTableHandle.java
@@ -21,12 +21,14 @@ import static java.util.Objects.requireNonNull;
 
 public record CorruptedDeltaLakeTableHandle(
         SchemaTableName schemaTableName,
+        String location,
         TrinoException originalException)
         implements ConnectorTableHandle
 {
     public CorruptedDeltaLakeTableHandle
     {
         requireNonNull(schemaTableName, "schemaTableName is null");
+        requireNonNull(location, "location is null");
         requireNonNull(originalException, "originalException is null");
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -421,7 +421,7 @@ public class DeltaLakeMetadata
     }
 
     @Override
-    public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
+    public LocatedTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
     {
         requireNonNull(tableName, "tableName is null");
         if (!DeltaLakeTableName.isDataTable(tableName.getTableName())) {
@@ -1885,22 +1885,8 @@ public class DeltaLakeMetadata
     @Override
     public void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        SchemaTableName schemaTableName;
-        boolean managed;
-        String tableLocation;
-        if (tableHandle instanceof CorruptedDeltaLakeTableHandle corruptedTableHandle) {
-            schemaTableName = corruptedTableHandle.schemaTableName();
-            tableLocation = corruptedTableHandle.location();
-            managed = corruptedTableHandle.managed();
-        }
-        else {
-            DeltaLakeTableHandle handle = (DeltaLakeTableHandle) tableHandle;
-            schemaTableName = handle.getSchemaTableName();
-            tableLocation = handle.getLocation();
-            managed = handle.isManaged();
-        }
-
-        metastore.dropTable(session, schemaTableName.getSchemaName(), schemaTableName.getTableName(), tableLocation, managed);
+        LocatedTableHandle handle = (LocatedTableHandle) tableHandle;
+        metastore.dropTable(session, handle.schemaTableName(), handle.location(), handle.managed());
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -52,6 +52,7 @@ import io.trino.plugin.deltalake.transactionlog.MetadataEntry.Format;
 import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
 import io.trino.plugin.deltalake.transactionlog.RemoveFileEntry;
 import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
+import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointWriterManager;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.TransactionLogTail;
 import io.trino.plugin.deltalake.transactionlog.statistics.DeltaLakeFileStatistics;
@@ -310,6 +311,7 @@ public class DeltaLakeMetadata
     private static final String CHECK_CONSTRAINT_CONVERT_FAIL_EXPRESSION = "CAST(fail('Failed to convert Delta check constraints to Trino expression') AS boolean)";
 
     private final DeltaLakeMetastore metastore;
+    private final TransactionLogAccess transactionLogAccess;
     private final TrinoFileSystemFactory fileSystemFactory;
     private final TypeManager typeManager;
     private final AccessControlMetadata accessControlMetadata;
@@ -332,6 +334,7 @@ public class DeltaLakeMetadata
 
     public DeltaLakeMetadata(
             DeltaLakeMetastore metastore,
+            TransactionLogAccess transactionLogAccess,
             TrinoFileSystemFactory fileSystemFactory,
             TypeManager typeManager,
             AccessControlMetadata accessControlMetadata,
@@ -351,6 +354,7 @@ public class DeltaLakeMetadata
             boolean allowManagedTableRename)
     {
         this.metastore = requireNonNull(metastore, "metastore is null");
+        this.transactionLogAccess = requireNonNull(transactionLogAccess, "transactionLogAccess is null");
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.accessControlMetadata = requireNonNull(accessControlMetadata, "accessControlMetadata is null");
@@ -1167,7 +1171,7 @@ public class DeltaLakeMetadata
             throw new TrinoException(NOT_SUPPORTED, "Column name %s is forbidden when change data feed is enabled".formatted(newColumnMetadata.getName()));
         }
 
-        if (!newColumnMetadata.isNullable() && !metastore.getValidDataFiles(handle.getSchemaTableName(), session).isEmpty()) {
+        if (!newColumnMetadata.isNullable() && !transactionLogAccess.getActiveFiles(metastore.getSnapshot(handle.getSchemaTableName(), session), session).isEmpty()) {
             throw new TrinoException(DELTA_LAKE_BAD_WRITE, format("Unable to add NOT NULL column '%s' for non-empty table: %s.%s", newColumnMetadata.getName(), handle.getSchemaName(), handle.getTableName()));
         }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -445,7 +445,7 @@ public class DeltaLakeMetadata
             }
             throw e;
         }
-        ProtocolEntry protocolEntry = metastore.getProtocol(session, tableSnapshot);
+        ProtocolEntry protocolEntry = getProtocolEntry(session, tableSnapshot);
         if (protocolEntry.getMinReaderVersion() > MAX_READER_VERSION) {
             LOG.debug("Skip %s because the reader version is unsupported: %d", dataTableName, protocolEntry.getMinReaderVersion());
             return null;
@@ -1808,7 +1808,14 @@ public class DeltaLakeMetadata
 
     private ProtocolEntry getProtocolEntry(ConnectorSession session, DeltaLakeTableHandle handle)
     {
-        return metastore.getProtocol(session, metastore.getSnapshot(handle.getSchemaTableName(), session));
+        return getProtocolEntry(session, metastore.getSnapshot(handle.getSchemaTableName(), session));
+    }
+
+    private ProtocolEntry getProtocolEntry(ConnectorSession session, TableSnapshot tableSnapshot)
+    {
+        return transactionLogAccess.getProtocolEntries(tableSnapshot, session)
+                .reduce((first, second) -> second)
+                .orElseThrow(() -> new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Protocol entry not found in transaction log for table " + tableSnapshot.getTable()));
     }
 
     private ProtocolEntry protocolEntryForNewTable(Map<String, Object> properties)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -41,6 +41,7 @@ import io.trino.plugin.deltalake.procedure.DeltaLakeTableExecuteHandle;
 import io.trino.plugin.deltalake.procedure.DeltaLakeTableProcedureId;
 import io.trino.plugin.deltalake.procedure.DeltaTableOptimizeHandle;
 import io.trino.plugin.deltalake.statistics.DeltaLakeColumnStatistics;
+import io.trino.plugin.deltalake.statistics.DeltaLakeTableStatisticsProvider;
 import io.trino.plugin.deltalake.statistics.ExtendedStatistics;
 import io.trino.plugin.deltalake.statistics.ExtendedStatisticsAccess;
 import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
@@ -313,6 +314,7 @@ public class DeltaLakeMetadata
 
     private final DeltaLakeMetastore metastore;
     private final TransactionLogAccess transactionLogAccess;
+    private final DeltaLakeTableStatisticsProvider tableStatisticsProvider;
     private final TrinoFileSystemFactory fileSystemFactory;
     private final TypeManager typeManager;
     private final AccessControlMetadata accessControlMetadata;
@@ -336,6 +338,7 @@ public class DeltaLakeMetadata
     public DeltaLakeMetadata(
             DeltaLakeMetastore metastore,
             TransactionLogAccess transactionLogAccess,
+            DeltaLakeTableStatisticsProvider tableStatisticsProvider,
             TrinoFileSystemFactory fileSystemFactory,
             TypeManager typeManager,
             AccessControlMetadata accessControlMetadata,
@@ -356,6 +359,7 @@ public class DeltaLakeMetadata
     {
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.transactionLogAccess = requireNonNull(transactionLogAccess, "transactionLogAccess is null");
+        this.tableStatisticsProvider = requireNonNull(tableStatisticsProvider, "tableStatisticsProvider is null");
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.accessControlMetadata = requireNonNull(accessControlMetadata, "accessControlMetadata is null");
@@ -660,7 +664,7 @@ public class DeltaLakeMetadata
         if (!isTableStatisticsEnabled(session)) {
             return TableStatistics.empty();
         }
-        return metastore.getTableStatistics(session, handle);
+        return tableStatisticsProvider.getTableStatistics(session, handle, metastore.getSnapshot(handle.getSchemaTableName(), handle.getLocation(), session));
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -434,6 +434,7 @@ public class DeltaLakeMetadata
             return null;
         }
 
+        String tableLocation = metastore.getTableLocation(dataTableName);
         TableSnapshot tableSnapshot = metastore.getSnapshot(dataTableName, session);
         MetadataEntry metadataEntry;
         try {
@@ -441,7 +442,7 @@ public class DeltaLakeMetadata
         }
         catch (TrinoException e) {
             if (e.getErrorCode().equals(DELTA_LAKE_INVALID_SCHEMA.toErrorCode())) {
-                return new CorruptedDeltaLakeTableHandle(dataTableName, e);
+                return new CorruptedDeltaLakeTableHandle(dataTableName, tableLocation, e);
             }
             throw e;
         }
@@ -459,7 +460,7 @@ public class DeltaLakeMetadata
         return new DeltaLakeTableHandle(
                 dataTableName.getSchemaName(),
                 dataTableName.getTableName(),
-                metastore.getTableLocation(dataTableName),
+                tableLocation,
                 metadataEntry,
                 TupleDomain.all(),
                 TupleDomain.all(),
@@ -486,7 +487,6 @@ public class DeltaLakeMetadata
     public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
     {
         DeltaLakeTableHandle tableHandle = checkValidTableHandle(table);
-        String location = metastore.getTableLocation(tableHandle.getSchemaTableName());
         MetadataEntry metadataEntry = tableHandle.getMetadataEntry();
         Map<String, String> columnComments = getColumnComments(metadataEntry);
         Map<String, Boolean> columnsNullability = getColumnsNullability(metadataEntry);
@@ -500,7 +500,7 @@ public class DeltaLakeMetadata
                 .collect(toImmutableList());
 
         ImmutableMap.Builder<String, Object> properties = ImmutableMap.<String, Object>builder()
-                .put(LOCATION_PROPERTY, location);
+                .put(LOCATION_PROPERTY, tableHandle.getLocation());
         List<String> partitionColumnNames = metadataEntry.getCanonicalPartitionColumns();
         if (!partitionColumnNames.isEmpty()) {
             properties.put(PARTITIONED_BY_PROPERTY, partitionColumnNames);
@@ -1512,8 +1512,7 @@ public class DeltaLakeMetadata
 
         Optional<Long> checkpointInterval = handle.getMetadataEntry().getCheckpointInterval();
 
-        String tableLocation = metastore.getTableLocation(handle.getSchemaTableName());
-
+        String tableLocation = handle.getLocation();
         boolean writeCommitted = false;
         try {
             TransactionLogWriter transactionLogWriter = transactionLogWriterFactory.newWriter(session, tableLocation);
@@ -1764,8 +1763,7 @@ public class DeltaLakeMetadata
     private boolean allowWrite(ConnectorSession session, DeltaLakeTableHandle tableHandle)
     {
         try {
-            String tableLocation = metastore.getTableLocation(tableHandle.getSchemaTableName());
-            String tableMetadataDirectory = appendPath(getParent(tableLocation), tableHandle.getTableName());
+            String tableMetadataDirectory = appendPath(getParent(tableHandle.getLocation()), tableHandle.getTableName());
             boolean requiresOptIn = transactionLogWriterFactory.newWriter(session, tableMetadataDirectory).isUnsafe();
             return !requiresOptIn || unsafeWritesEnabled;
         }
@@ -1886,18 +1884,21 @@ public class DeltaLakeMetadata
     public void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         SchemaTableName schemaTableName;
+        String tableLocation;
         if (tableHandle instanceof CorruptedDeltaLakeTableHandle corruptedTableHandle) {
             schemaTableName = corruptedTableHandle.schemaTableName();
+            tableLocation = corruptedTableHandle.location();
         }
         else {
             DeltaLakeTableHandle handle = (DeltaLakeTableHandle) tableHandle;
             schemaTableName = handle.getSchemaTableName();
+            tableLocation = handle.getLocation();
         }
 
         Table table = metastore.getTable(schemaTableName.getSchemaName(), schemaTableName.getTableName())
                 .orElseThrow(() -> new TableNotFoundException(schemaTableName));
 
-        metastore.dropTable(session, schemaTableName.getSchemaName(), schemaTableName.getTableName(), table.getTableType().equals(MANAGED_TABLE.toString()));
+        metastore.dropTable(session, schemaTableName.getSchemaName(), schemaTableName.getTableName(), tableLocation, table.getTableType().equals(MANAGED_TABLE.toString()));
     }
 
     @Override
@@ -2383,14 +2384,13 @@ public class DeltaLakeMetadata
     {
         DeltaLakeTableHandle tableHandle = (DeltaLakeTableHandle) table;
         AnalyzeHandle analyzeHandle = tableHandle.getAnalyzeHandle().orElseThrow(() -> new IllegalArgumentException("analyzeHandle not set"));
-        String location = metastore.getTableLocation(tableHandle.getSchemaTableName());
         Optional<Instant> maxFileModificationTime = getMaxFileModificationTime(computedStatistics);
         Map<String, String> physicalColumnNameMapping = extractSchema(tableHandle.getMetadataEntry(), typeManager).stream()
                         .collect(toImmutableMap(DeltaLakeColumnMetadata::getName, DeltaLakeColumnMetadata::getPhysicalName));
         updateTableStatistics(
                 session,
                 Optional.of(analyzeHandle),
-                location,
+                tableHandle.getLocation(),
                 maxFileModificationTime,
                 computedStatistics,
                 Optional.of(physicalColumnNameMapping));
@@ -2605,6 +2605,7 @@ public class DeltaLakeMetadata
         if (tableHandle instanceof CorruptedDeltaLakeTableHandle) {
             return Optional.empty();
         }
+        DeltaLakeTableHandle handle = (DeltaLakeTableHandle) tableHandle;
 
         Optional<DeltaLakeTableType> tableType = DeltaLakeTableName.tableTypeFrom(tableName.getTableName());
         if (tableType.isEmpty()) {
@@ -2615,7 +2616,7 @@ public class DeltaLakeMetadata
             case DATA -> throw new VerifyException("Unexpected DATA table type"); // Handled above.
             case HISTORY -> Optional.of(new DeltaLakeHistoryTable(
                     systemTableName,
-                    getCommitInfoEntries(((DeltaLakeTableHandle) tableHandle).getSchemaTableName(), session),
+                    getCommitInfoEntries(handle.getSchemaTableName(), handle.getLocation(), session),
                     typeManager));
         };
     }
@@ -2696,11 +2697,11 @@ public class DeltaLakeMetadata
         return metastore;
     }
 
-    private List<CommitInfoEntry> getCommitInfoEntries(SchemaTableName table, ConnectorSession session)
+    private List<CommitInfoEntry> getCommitInfoEntries(SchemaTableName table, String tableLocation, ConnectorSession session)
     {
         TrinoFileSystem fileSystem = fileSystemFactory.create(session);
         try {
-            return TransactionLogTail.loadNewTail(fileSystem, metastore.getTableLocation(table), Optional.empty()).getFileEntries().stream()
+            return TransactionLogTail.loadNewTail(fileSystem, tableLocation, Optional.empty()).getFileEntries().stream()
                     .map(DeltaLakeTransactionLogEntry::getCommitInfo)
                     .filter(Objects::nonNull)
                     .collect(toImmutableList());

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -179,6 +179,7 @@ import static io.trino.plugin.deltalake.DeltaLakeColumnType.PARTITION_KEY;
 import static io.trino.plugin.deltalake.DeltaLakeColumnType.REGULAR;
 import static io.trino.plugin.deltalake.DeltaLakeColumnType.SYNTHESIZED;
 import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_BAD_WRITE;
+import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_FILESYSTEM_ERROR;
 import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_INVALID_SCHEMA;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getHiveCatalogName;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.isCollectExtendedStatisticsColumnStatisticsOnWrite;
@@ -1911,7 +1912,16 @@ public class DeltaLakeMetadata
     public void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         LocatedTableHandle handle = (LocatedTableHandle) tableHandle;
-        metastore.dropTable(session, handle.schemaTableName(), handle.location(), handle.managed());
+        boolean deleteData = handle.managed();
+        metastore.dropTable(session, handle.schemaTableName(), handle.location(), deleteData);
+        if (deleteData) {
+            try {
+                fileSystemFactory.create(session).deleteDirectory(handle.location());
+            }
+            catch (IOException e) {
+                throw new TrinoException(DELTA_LAKE_FILESYSTEM_ERROR, format("Failed to delete directory %s of the table %s", handle.location(), handle.schemaTableName()), e);
+            }
+        }
         // As a precaution, clear the caches
         statisticsAccess.invalidateCache(handle.location());
         transactionLogAccess.invalidateCaches(handle.location());

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -433,7 +433,7 @@ public class DeltaLakeMetadata
         if (table.isEmpty()) {
             return null;
         }
-        boolean managed = table.get().getTableType().equals(MANAGED_TABLE.toString());
+        boolean managed = table.get().getTableType().equals(MANAGED_TABLE.name());
 
         String tableLocation = metastore.getTableLocation(dataTableName);
         TableSnapshot tableSnapshot = metastore.getSnapshot(dataTableName, tableLocation, session);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -437,7 +437,7 @@ public class DeltaLakeMetadata
         TableSnapshot tableSnapshot = metastore.getSnapshot(dataTableName, session);
         MetadataEntry metadataEntry;
         try {
-            metadataEntry = metastore.getMetadata(tableSnapshot, session);
+            metadataEntry = transactionLogAccess.getMetadataEntry(tableSnapshot, session);
         }
         catch (TrinoException e) {
             if (e.getErrorCode().equals(DELTA_LAKE_INVALID_SCHEMA.toErrorCode())) {
@@ -612,7 +612,7 @@ public class DeltaLakeMetadata
                             return Stream.of(TableColumnsMetadata.forRedirectedTable(table));
                         }
 
-                        MetadataEntry metadata = metastore.getMetadata(metastore.getSnapshot(table, session), session);
+                        MetadataEntry metadata = transactionLogAccess.getMetadataEntry(metastore.getSnapshot(table, session), session);
                         Map<String, String> columnComments = getColumnComments(metadata);
                         Map<String, Boolean> columnsNullability = getColumnsNullability(metadata);
                         Map<String, String> columnGenerations = getGeneratedColumnExpressions(metadata);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -439,7 +439,7 @@ public class DeltaLakeMetadata
         boolean managed = table.get().managed();
 
         String tableLocation = table.get().location();
-        TableSnapshot tableSnapshot = metastore.getSnapshot(dataTableName, tableLocation, session);
+        TableSnapshot tableSnapshot = getSnapshot(dataTableName, tableLocation, session);
         MetadataEntry metadataEntry;
         try {
             metadataEntry = transactionLogAccess.getMetadataEntry(tableSnapshot, session);
@@ -623,7 +623,7 @@ public class DeltaLakeMetadata
                             return Stream.of();
                         }
                         String tableLocation = metastoreTable.get().location();
-                        MetadataEntry metadata = transactionLogAccess.getMetadataEntry(metastore.getSnapshot(table, tableLocation, session), session);
+                        MetadataEntry metadata = transactionLogAccess.getMetadataEntry(getSnapshot(table, tableLocation, session), session);
                         Map<String, String> columnComments = getColumnComments(metadata);
                         Map<String, Boolean> columnsNullability = getColumnsNullability(metadata);
                         Map<String, String> columnGenerations = getGeneratedColumnExpressions(metadata);
@@ -664,7 +664,7 @@ public class DeltaLakeMetadata
         if (!isTableStatisticsEnabled(session)) {
             return TableStatistics.empty();
         }
-        return tableStatisticsProvider.getTableStatistics(session, handle, metastore.getSnapshot(handle.getSchemaTableName(), handle.getLocation(), session));
+        return tableStatisticsProvider.getTableStatistics(session, handle, getSnapshot(handle.getSchemaTableName(), handle.getLocation(), session));
     }
 
     @Override
@@ -1182,7 +1182,7 @@ public class DeltaLakeMetadata
             throw new TrinoException(NOT_SUPPORTED, "Column name %s is forbidden when change data feed is enabled".formatted(newColumnMetadata.getName()));
         }
 
-        if (!newColumnMetadata.isNullable() && !transactionLogAccess.getActiveFiles(metastore.getSnapshot(handle.getSchemaTableName(), handle.getLocation(), session), session).isEmpty()) {
+        if (!newColumnMetadata.isNullable() && !transactionLogAccess.getActiveFiles(getSnapshot(handle.getSchemaTableName(), handle.getLocation(), session), session).isEmpty()) {
             throw new TrinoException(DELTA_LAKE_BAD_WRITE, format("Unable to add NOT NULL column '%s' for non-empty table: %s.%s", newColumnMetadata.getName(), handle.getSchemaName(), handle.getTableName()));
         }
 
@@ -1817,7 +1817,7 @@ public class DeltaLakeMetadata
 
     private ProtocolEntry getProtocolEntry(ConnectorSession session, DeltaLakeTableHandle handle)
     {
-        return getProtocolEntry(session, metastore.getSnapshot(handle.getSchemaTableName(), handle.getLocation(), session));
+        return getProtocolEntry(session, getSnapshot(handle.getSchemaTableName(), handle.getLocation(), session));
     }
 
     private ProtocolEntry getProtocolEntry(ConnectorSession session, TableSnapshot tableSnapshot)
@@ -1825,6 +1825,16 @@ public class DeltaLakeMetadata
         return transactionLogAccess.getProtocolEntries(tableSnapshot, session)
                 .reduce((first, second) -> second)
                 .orElseThrow(() -> new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Protocol entry not found in transaction log for table " + tableSnapshot.getTable()));
+    }
+
+    private TableSnapshot getSnapshot(SchemaTableName schemaTableName, String tableLocation, ConnectorSession session)
+    {
+        try {
+            return transactionLogAccess.loadSnapshot(schemaTableName, tableLocation, session);
+        }
+        catch (IOException | RuntimeException e) {
+            throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Error getting snapshot for " + schemaTableName, e);
+        }
     }
 
     private ProtocolEntry protocolEntryForNewTable(Map<String, Object> properties)
@@ -1843,7 +1853,7 @@ public class DeltaLakeMetadata
         try {
             // We are writing checkpoint synchronously. It should not be long lasting operation for tables where transaction log is not humongous.
             // Tables with really huge transaction logs would behave poorly in read flow already.
-            TableSnapshot snapshot = metastore.getSnapshot(table, tableLocation, session);
+            TableSnapshot snapshot = getSnapshot(table, tableLocation, session);
             long lastCheckpointVersion = snapshot.getLastCheckpointVersion().orElse(0L);
             if (newVersion - lastCheckpointVersion < checkpointInterval.orElse(defaultCheckpointInterval)) {
                 return;

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
@@ -17,6 +17,7 @@ import io.airlift.json.JsonCodec;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.plugin.deltalake.metastore.HiveMetastoreBackedDeltaLakeMetastore;
 import io.trino.plugin.deltalake.statistics.CachingExtendedStatisticsAccess;
+import io.trino.plugin.deltalake.statistics.FileBasedTableStatisticsProvider;
 import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointWriterManager;
 import io.trino.plugin.deltalake.transactionlog.writer.TransactionLogWriterFactory;
@@ -110,9 +111,12 @@ public class DeltaLakeMetadataFactory
         HiveMetastoreBackedDeltaLakeMetastore deltaLakeMetastore = new HiveMetastoreBackedDeltaLakeMetastore(
                 cachingHiveMetastore,
                 transactionLogAccess,
-                typeManager,
                 statisticsAccess,
                 fileSystemFactory);
+        FileBasedTableStatisticsProvider tableStatisticsProvider = new FileBasedTableStatisticsProvider(
+                typeManager,
+                transactionLogAccess,
+                statisticsAccess);
         TrinoViewHiveMetastore trinoViewHiveMetastore = new TrinoViewHiveMetastore(
                 cachingHiveMetastore,
                 accessControlMetadata.isUsingSystemSecurity(),
@@ -121,6 +125,7 @@ public class DeltaLakeMetadataFactory
         return new DeltaLakeMetadata(
                 deltaLakeMetastore,
                 transactionLogAccess,
+                tableStatisticsProvider,
                 fileSystemFactory,
                 typeManager,
                 accessControlMetadata,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
@@ -120,6 +120,7 @@ public class DeltaLakeMetadataFactory
                 "Trino Delta Lake connector");
         return new DeltaLakeMetadata(
                 deltaLakeMetastore,
+                transactionLogAccess,
                 fileSystemFactory,
                 typeManager,
                 accessControlMetadata,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
@@ -110,7 +110,6 @@ public class DeltaLakeMetadataFactory
         AccessControlMetadata accessControlMetadata = accessControlMetadataFactory.create(cachingHiveMetastore);
         HiveMetastoreBackedDeltaLakeMetastore deltaLakeMetastore = new HiveMetastoreBackedDeltaLakeMetastore(
                 cachingHiveMetastore,
-                transactionLogAccess,
                 fileSystemFactory);
         FileBasedTableStatisticsProvider tableStatisticsProvider = new FileBasedTableStatisticsProvider(
                 typeManager,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
@@ -111,7 +111,6 @@ public class DeltaLakeMetadataFactory
         HiveMetastoreBackedDeltaLakeMetastore deltaLakeMetastore = new HiveMetastoreBackedDeltaLakeMetastore(
                 cachingHiveMetastore,
                 transactionLogAccess,
-                statisticsAccess,
                 fileSystemFactory);
         FileBasedTableStatisticsProvider tableStatisticsProvider = new FileBasedTableStatisticsProvider(
                 typeManager,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
@@ -108,9 +108,7 @@ public class DeltaLakeMetadataFactory
                 hiveMetastoreFactory.createMetastore(Optional.of(identity)),
                 perTransactionMetastoreCacheMaximumSize);
         AccessControlMetadata accessControlMetadata = accessControlMetadataFactory.create(cachingHiveMetastore);
-        HiveMetastoreBackedDeltaLakeMetastore deltaLakeMetastore = new HiveMetastoreBackedDeltaLakeMetastore(
-                cachingHiveMetastore,
-                fileSystemFactory);
+        HiveMetastoreBackedDeltaLakeMetastore deltaLakeMetastore = new HiveMetastoreBackedDeltaLakeMetastore(cachingHiveMetastore);
         FileBasedTableStatisticsProvider tableStatisticsProvider = new FileBasedTableStatisticsProvider(
                 typeManager,
                 transactionLogAccess,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeModule.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeModule.java
@@ -53,7 +53,6 @@ import io.trino.plugin.hive.SystemTableProvider;
 import io.trino.plugin.hive.TransactionalMetadata;
 import io.trino.plugin.hive.TransactionalMetadataFactory;
 import io.trino.plugin.hive.fs.DirectoryLister;
-import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore;
 import io.trino.plugin.hive.metastore.thrift.TranslateHiveViews;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
@@ -65,7 +64,6 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.TableProcedureMetadata;
 import io.trino.spi.procedure.Procedure;
-import io.trino.spi.security.ConnectorIdentity;
 
 import javax.inject.Singleton;
 
@@ -152,14 +150,6 @@ public class DeltaLakeModule
 
         Multibinder<TableProcedureMetadata> tableProcedures = newSetBinder(binder, TableProcedureMetadata.class);
         tableProcedures.addBinding().toProvider(OptimizeTableProcedure.class).in(Scopes.SINGLETON);
-    }
-
-    @Singleton
-    @Provides
-    public BiFunction<ConnectorIdentity, HiveTransactionHandle, HiveMetastore> createHiveMetastoreGetter(DeltaLakeTransactionManager transactionManager)
-    {
-        return (identity, transactionHandle) ->
-                transactionManager.get(transactionHandle, identity).getMetastore().getHiveMetastore();
     }
 
     @Singleton

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeModule.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeModule.java
@@ -23,7 +23,6 @@ import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.plugin.base.CatalogName;
 import io.trino.plugin.base.security.ConnectorAccessControlModule;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
-import io.trino.plugin.deltalake.metastore.DeltaLakeMetastore;
 import io.trino.plugin.deltalake.procedure.DropExtendedStatsProcedure;
 import io.trino.plugin.deltalake.procedure.FlushMetadataCacheProcedure;
 import io.trino.plugin.deltalake.procedure.OptimizeTableProcedure;
@@ -45,7 +44,6 @@ import io.trino.plugin.deltalake.transactionlog.writer.TransactionLogSynchronize
 import io.trino.plugin.deltalake.transactionlog.writer.TransactionLogWriterFactory;
 import io.trino.plugin.hive.FileFormatDataSourceStats;
 import io.trino.plugin.hive.HiveLocationService;
-import io.trino.plugin.hive.HiveTransactionHandle;
 import io.trino.plugin.hive.HiveTransactionManager;
 import io.trino.plugin.hive.LocationService;
 import io.trino.plugin.hive.PropertiesSystemTableProvider;
@@ -60,7 +58,6 @@ import io.trino.plugin.hive.parquet.ParquetWriterConfig;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
-import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.TableProcedureMetadata;
 import io.trino.spi.procedure.Procedure;
@@ -68,7 +65,6 @@ import io.trino.spi.procedure.Procedure;
 import javax.inject.Singleton;
 
 import java.util.concurrent.ExecutorService;
-import java.util.function.BiFunction;
 
 import static com.google.inject.multibindings.MapBinder.newMapBinder;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
@@ -150,14 +146,6 @@ public class DeltaLakeModule
 
         Multibinder<TableProcedureMetadata> tableProcedures = newSetBinder(binder, TableProcedureMetadata.class);
         tableProcedures.addBinding().toProvider(OptimizeTableProcedure.class).in(Scopes.SINGLETON);
-    }
-
-    @Singleton
-    @Provides
-    public BiFunction<ConnectorSession, HiveTransactionHandle, DeltaLakeMetastore> createMetastoreGetter(DeltaLakeTransactionManager transactionManager)
-    {
-        return (connectorSession, transactionHandle) ->
-                transactionManager.get(transactionHandle, connectorSession.getIdentity()).getMetastore();
     }
 
     @Singleton

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
@@ -135,7 +135,6 @@ public class DeltaLakeSplitManager
             Constraint constraint)
     {
         DeltaLakeMetastore metastore = getMetastore(session, transaction);
-        String tableLocation = metastore.getTableLocation(tableHandle.getSchemaTableName());
         List<AddFileEntry> validDataFiles = transactionLogAccess.getActiveFiles(metastore.getSnapshot(tableHandle.getSchemaTableName(), session), session);
         TupleDomain<DeltaLakeColumnHandle> enforcedPartitionConstraint = tableHandle.getEnforcedPartitionConstraint();
         TupleDomain<DeltaLakeColumnHandle> nonPartitionConstraint = tableHandle.getNonPartitionConstraint();
@@ -169,7 +168,7 @@ public class DeltaLakeSplitManager
                         return Stream.empty();
                     }
 
-                    String splitPath = buildSplitPath(tableLocation, addAction);
+                    String splitPath = buildSplitPath(tableHandle.getLocation(), addAction);
                     if (!pathMatchesPredicate(pathDomain, splitPath)) {
                         return Stream.empty();
                     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
@@ -310,7 +310,7 @@ public class DeltaLakeSplitManager
         return splits.build();
     }
 
-    private static String buildSplitPath(String tableLocation, AddFileEntry addAction)
+    public static String buildSplitPath(String tableLocation, AddFileEntry addAction)
     {
         // paths are relative to the table location and are RFC 2396 URIs
         // https://github.com/delta-io/delta/blob/master/PROTOCOL.md#add-file-and-remove-file

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
@@ -135,7 +135,7 @@ public class DeltaLakeSplitManager
             Constraint constraint)
     {
         DeltaLakeMetastore metastore = getMetastore(session, transaction);
-        List<AddFileEntry> validDataFiles = transactionLogAccess.getActiveFiles(metastore.getSnapshot(tableHandle.getSchemaTableName(), session), session);
+        List<AddFileEntry> validDataFiles = transactionLogAccess.getActiveFiles(metastore.getSnapshot(tableHandle.getSchemaTableName(), tableHandle.getLocation(), session), session);
         TupleDomain<DeltaLakeColumnHandle> enforcedPartitionConstraint = tableHandle.getEnforcedPartitionConstraint();
         TupleDomain<DeltaLakeColumnHandle> nonPartitionConstraint = tableHandle.getNonPartitionConstraint();
         Domain pathDomain = getPathDomain(nonPartitionConstraint);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
@@ -16,11 +16,10 @@ package io.trino.plugin.deltalake;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorSplitSource;
-import io.trino.plugin.deltalake.metastore.DeltaLakeMetastore;
 import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
+import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
 import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
 import io.trino.plugin.deltalake.transactionlog.statistics.DeltaLakeFileStatistics;
-import io.trino.plugin.hive.HiveTransactionHandle;
 import io.trino.spi.SplitWeight;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
@@ -38,6 +37,7 @@ import io.trino.spi.type.TypeManager;
 
 import javax.inject.Inject;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.time.Instant;
@@ -47,7 +47,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -72,7 +71,6 @@ public class DeltaLakeSplitManager
 {
     private final TypeManager typeManager;
     private final TransactionLogAccess transactionLogAccess;
-    private final BiFunction<ConnectorSession, HiveTransactionHandle, DeltaLakeMetastore> metastoreProvider;
     private final ExecutorService executor;
     private final int maxInitialSplits;
     private final int maxSplitsPerSecond;
@@ -83,13 +81,11 @@ public class DeltaLakeSplitManager
     public DeltaLakeSplitManager(
             TypeManager typeManager,
             TransactionLogAccess transactionLogAccess,
-            BiFunction<ConnectorSession, HiveTransactionHandle, DeltaLakeMetastore> metastoreProvider,
             ExecutorService executor,
             DeltaLakeConfig config)
     {
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.transactionLogAccess = requireNonNull(transactionLogAccess, "transactionLogAccess is null");
-        this.metastoreProvider = requireNonNull(metastoreProvider, "metastoreProvider is null");
         this.executor = requireNonNull(executor, "executor is null");
         this.maxInitialSplits = config.getMaxInitialSplits();
         this.maxSplitsPerSecond = config.getMaxSplitsPerSecond();
@@ -115,7 +111,7 @@ public class DeltaLakeSplitManager
 
         DeltaLakeSplitSource splitSource = new DeltaLakeSplitSource(
                 deltaLakeTableHandle.getSchemaTableName(),
-                getSplits(transaction, deltaLakeTableHandle, session, deltaLakeTableHandle.getMaxScannedFileSize(), dynamicFilter.getColumnsCovered(), constraint),
+                getSplits(deltaLakeTableHandle, session, deltaLakeTableHandle.getMaxScannedFileSize(), dynamicFilter.getColumnsCovered(), constraint),
                 executor,
                 maxSplitsPerSecond,
                 maxOutstandingSplits,
@@ -127,15 +123,20 @@ public class DeltaLakeSplitManager
     }
 
     private Stream<DeltaLakeSplit> getSplits(
-            ConnectorTransactionHandle transaction,
             DeltaLakeTableHandle tableHandle,
             ConnectorSession session,
             Optional<DataSize> maxScannedFileSize,
             Set<ColumnHandle> columnsCoveredByDynamicFilter,
             Constraint constraint)
     {
-        DeltaLakeMetastore metastore = getMetastore(session, transaction);
-        List<AddFileEntry> validDataFiles = transactionLogAccess.getActiveFiles(metastore.getSnapshot(tableHandle.getSchemaTableName(), tableHandle.getLocation(), session), session);
+        TableSnapshot tableSnapshot;
+        try {
+            tableSnapshot = transactionLogAccess.loadSnapshot(tableHandle.getSchemaTableName(), tableHandle.getLocation(), session);
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        List<AddFileEntry> validDataFiles = transactionLogAccess.getActiveFiles(tableSnapshot, session);
         TupleDomain<DeltaLakeColumnHandle> enforcedPartitionConstraint = tableHandle.getEnforcedPartitionConstraint();
         TupleDomain<DeltaLakeColumnHandle> nonPartitionConstraint = tableHandle.getNonPartitionConstraint();
         Domain pathDomain = getPathDomain(nonPartitionConstraint);
@@ -326,10 +327,5 @@ public class DeltaLakeSplitManager
             return tableLocation + path;
         }
         return tableLocation + "/" + path;
-    }
-
-    private DeltaLakeMetastore getMetastore(ConnectorSession session, ConnectorTransactionHandle transactionHandle)
-    {
-        return metastoreProvider.apply(session, (HiveTransactionHandle) transactionHandle);
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableHandle.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.airlift.units.DataSize;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.spi.connector.ColumnHandle;
-import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 
@@ -33,7 +32,7 @@ import static io.trino.plugin.deltalake.DeltaLakeTableHandle.WriteType.UPDATE;
 import static java.util.Objects.requireNonNull;
 
 public class DeltaLakeTableHandle
-        implements ConnectorTableHandle
+        implements LocatedTableHandle
 {
     // Insert is not included here because it uses a separate TableHandle type
     public enum WriteType
@@ -173,6 +172,17 @@ public class DeltaLakeTableHandle
                 readVersion);
     }
 
+    @Override
+    public SchemaTableName schemaTableName()
+    {
+        return getSchemaTableName();
+    }
+
+    public SchemaTableName getSchemaTableName()
+    {
+        return new SchemaTableName(schemaName, tableName);
+    }
+
     @JsonProperty
     public String getSchemaName()
     {
@@ -185,10 +195,22 @@ public class DeltaLakeTableHandle
         return tableName;
     }
 
+    @Override
+    public boolean managed()
+    {
+        return isManaged();
+    }
+
     @JsonProperty
     public boolean isManaged()
     {
         return managed;
+    }
+
+    @Override
+    public String location()
+    {
+        return getLocation();
     }
 
     @JsonProperty
@@ -262,11 +284,6 @@ public class DeltaLakeTableHandle
     public long getReadVersion()
     {
         return readVersion;
-    }
-
-    public SchemaTableName getSchemaTableName()
-    {
-        return new SchemaTableName(schemaName, tableName);
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableHandle.java
@@ -44,6 +44,7 @@ public class DeltaLakeTableHandle
 
     private final String schemaName;
     private final String tableName;
+    private final boolean managed;
     private final String location;
     private final MetadataEntry metadataEntry;
     private final TupleDomain<DeltaLakeColumnHandle> enforcedPartitionConstraint;
@@ -68,6 +69,7 @@ public class DeltaLakeTableHandle
     public DeltaLakeTableHandle(
             @JsonProperty("schemaName") String schemaName,
             @JsonProperty("tableName") String tableName,
+            @JsonProperty("managed") boolean managed,
             @JsonProperty("location") String location,
             @JsonProperty("metadataEntry") MetadataEntry metadataEntry,
             @JsonProperty("enforcedPartitionConstraint") TupleDomain<DeltaLakeColumnHandle> enforcedPartitionConstraint,
@@ -82,6 +84,7 @@ public class DeltaLakeTableHandle
         this(
                 schemaName,
                 tableName,
+                managed,
                 location,
                 metadataEntry,
                 enforcedPartitionConstraint,
@@ -99,6 +102,7 @@ public class DeltaLakeTableHandle
     public DeltaLakeTableHandle(
             String schemaName,
             String tableName,
+            boolean managed,
             String location,
             MetadataEntry metadataEntry,
             TupleDomain<DeltaLakeColumnHandle> enforcedPartitionConstraint,
@@ -114,6 +118,7 @@ public class DeltaLakeTableHandle
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
+        this.managed = managed;
         this.location = requireNonNull(location, "location is null");
         this.metadataEntry = requireNonNull(metadataEntry, "metadataEntry is null");
         this.enforcedPartitionConstraint = requireNonNull(enforcedPartitionConstraint, "enforcedPartitionConstraint is null");
@@ -135,6 +140,7 @@ public class DeltaLakeTableHandle
         return new DeltaLakeTableHandle(
                 schemaName,
                 tableName,
+                managed,
                 location,
                 metadataEntry,
                 enforcedPartitionConstraint,
@@ -152,6 +158,7 @@ public class DeltaLakeTableHandle
         return new DeltaLakeTableHandle(
                 schemaName,
                 tableName,
+                managed,
                 location,
                 metadataEntry,
                 enforcedPartitionConstraint,
@@ -176,6 +183,12 @@ public class DeltaLakeTableHandle
     public String getTableName()
     {
         return tableName;
+    }
+
+    @JsonProperty
+    public boolean isManaged()
+    {
+        return managed;
     }
 
     @JsonProperty
@@ -276,6 +289,7 @@ public class DeltaLakeTableHandle
         return recordScannedFiles == that.recordScannedFiles &&
                 Objects.equals(schemaName, that.schemaName) &&
                 Objects.equals(tableName, that.tableName) &&
+                managed == that.managed &&
                 Objects.equals(location, that.location) &&
                 Objects.equals(metadataEntry, that.metadataEntry) &&
                 Objects.equals(enforcedPartitionConstraint, that.enforcedPartitionConstraint) &&
@@ -295,6 +309,7 @@ public class DeltaLakeTableHandle
         return Objects.hash(
                 schemaName,
                 tableName,
+                managed,
                 location,
                 metadataEntry,
                 enforcedPartitionConstraint,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/LocatedTableHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/LocatedTableHandle.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.SchemaTableName;
+
+public interface LocatedTableHandle
+        extends ConnectorTableHandle
+{
+    SchemaTableName schemaTableName();
+
+    boolean managed();
+
+    String location();
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
@@ -42,7 +42,7 @@ public interface DeltaLakeMetastore
 
     void createTable(ConnectorSession session, Table table, PrincipalPrivileges principalPrivileges);
 
-    void dropTable(ConnectorSession session, String databaseName, String tableName, String tableLocation, boolean deleteData);
+    void dropTable(ConnectorSession session, SchemaTableName schemaTableName, String tableLocation, boolean deleteData);
 
     void renameTable(ConnectorSession session, SchemaTableName from, SchemaTableName to);
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.deltalake.metastore;
 
-import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
 import io.trino.plugin.hive.metastore.Database;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
@@ -44,6 +43,4 @@ public interface DeltaLakeMetastore
     void dropTable(ConnectorSession session, SchemaTableName schemaTableName, String tableLocation, boolean deleteData);
 
     void renameTable(ConnectorSession session, SchemaTableName from, SchemaTableName to);
-
-    TableSnapshot getSnapshot(SchemaTableName table, String tableLocation, ConnectorSession session);
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
@@ -42,7 +42,7 @@ public interface DeltaLakeMetastore
 
     void createTable(ConnectorSession session, Table table, PrincipalPrivileges principalPrivileges);
 
-    void dropTable(ConnectorSession session, String databaseName, String tableName, boolean deleteData);
+    void dropTable(ConnectorSession session, String databaseName, String tableName, String tableLocation, boolean deleteData);
 
     void renameTable(ConnectorSession session, SchemaTableName from, SchemaTableName to);
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
@@ -16,7 +16,6 @@ package io.trino.plugin.deltalake.metastore;
 import io.trino.plugin.deltalake.DeltaLakeTableHandle;
 import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
 import io.trino.plugin.hive.metastore.Database;
-import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.spi.connector.ConnectorSession;
@@ -34,7 +33,9 @@ public interface DeltaLakeMetastore
 
     List<String> getAllTables(String databaseName);
 
-    Optional<Table> getTable(String databaseName, String tableName);
+    Optional<Table> getRawMetastoreTable(String databaseName, String tableName);
+
+    Optional<DeltaMetastoreTable> getTable(String databaseName, String tableName);
 
     void createDatabase(Database database);
 
@@ -46,11 +47,7 @@ public interface DeltaLakeMetastore
 
     void renameTable(ConnectorSession session, SchemaTableName from, SchemaTableName to);
 
-    String getTableLocation(SchemaTableName table);
-
     TableSnapshot getSnapshot(SchemaTableName table, String tableLocation, ConnectorSession session);
 
     TableStatistics getTableStatistics(ConnectorSession session, DeltaLakeTableHandle tableHandle);
-
-    HiveMetastore getHiveMetastore();
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
@@ -13,14 +13,12 @@
  */
 package io.trino.plugin.deltalake.metastore;
 
-import io.trino.plugin.deltalake.DeltaLakeTableHandle;
 import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
 import io.trino.plugin.hive.metastore.Database;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.statistics.TableStatistics;
 
 import java.util.List;
 import java.util.Optional;
@@ -48,6 +46,4 @@ public interface DeltaLakeMetastore
     void renameTable(ConnectorSession session, SchemaTableName from, SchemaTableName to);
 
     TableSnapshot getSnapshot(SchemaTableName table, String tableLocation, ConnectorSession session);
-
-    TableStatistics getTableStatistics(ConnectorSession session, DeltaLakeTableHandle tableHandle);
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
@@ -48,7 +48,7 @@ public interface DeltaLakeMetastore
 
     String getTableLocation(SchemaTableName table);
 
-    TableSnapshot getSnapshot(SchemaTableName table, ConnectorSession session);
+    TableSnapshot getSnapshot(SchemaTableName table, String tableLocation, ConnectorSession session);
 
     TableStatistics getTableStatistics(ConnectorSession session, DeltaLakeTableHandle tableHandle);
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.deltalake.metastore;
 
 import io.trino.plugin.deltalake.DeltaLakeTableHandle;
-import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
 import io.trino.plugin.hive.metastore.Database;
 import io.trino.plugin.hive.metastore.HiveMetastore;
@@ -46,8 +45,6 @@ public interface DeltaLakeMetastore
     void dropTable(ConnectorSession session, String databaseName, String tableName, boolean deleteData);
 
     void renameTable(ConnectorSession session, SchemaTableName from, SchemaTableName to);
-
-    MetadataEntry getMetadata(TableSnapshot tableSnapshot, ConnectorSession session);
 
     String getTableLocation(SchemaTableName table);
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
@@ -15,7 +15,6 @@ package io.trino.plugin.deltalake.metastore;
 
 import io.trino.plugin.deltalake.DeltaLakeTableHandle;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
-import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
 import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
 import io.trino.plugin.hive.metastore.Database;
 import io.trino.plugin.hive.metastore.HiveMetastore;
@@ -49,8 +48,6 @@ public interface DeltaLakeMetastore
     void renameTable(ConnectorSession session, SchemaTableName from, SchemaTableName to);
 
     MetadataEntry getMetadata(TableSnapshot tableSnapshot, ConnectorSession session);
-
-    ProtocolEntry getProtocol(ConnectorSession session, TableSnapshot table);
 
     String getTableLocation(SchemaTableName table);
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.deltalake.metastore;
 
 import io.trino.plugin.deltalake.DeltaLakeTableHandle;
-import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
 import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
@@ -56,8 +55,6 @@ public interface DeltaLakeMetastore
     String getTableLocation(SchemaTableName table);
 
     TableSnapshot getSnapshot(SchemaTableName table, ConnectorSession session);
-
-    List<AddFileEntry> getValidDataFiles(SchemaTableName table, ConnectorSession session);
 
     TableStatistics getTableStatistics(ConnectorSession session, DeltaLakeTableHandle tableHandle);
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaMetastoreTable.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaMetastoreTable.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.metastore;
+
+import io.trino.spi.connector.SchemaTableName;
+
+import static java.util.Objects.requireNonNull;
+
+public record DeltaMetastoreTable(
+        SchemaTableName schemaTableName,
+        boolean managed,
+        String location)
+{
+    public DeltaMetastoreTable
+    {
+        requireNonNull(schemaTableName, "schemaTableName is null");
+        requireNonNull(location, "location is null");
+    }
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -171,15 +171,4 @@ public class HiveMetastoreBackedDeltaLakeMetastore
         }
         return location;
     }
-
-    @Override
-    public TableSnapshot getSnapshot(SchemaTableName table, String tableLocation, ConnectorSession session)
-    {
-        try {
-            return transactionLogAccess.loadSnapshot(table, tableLocation, session);
-        }
-        catch (IOException | RuntimeException e) {
-            throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Error getting snapshot for " + table, e);
-        }
-    }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -204,10 +204,10 @@ public class HiveMetastoreBackedDeltaLakeMetastore
     }
 
     @Override
-    public TableSnapshot getSnapshot(SchemaTableName table, ConnectorSession session)
+    public TableSnapshot getSnapshot(SchemaTableName table, String tableLocation, ConnectorSession session)
     {
         try {
-            return transactionLogAccess.loadSnapshot(table, getTableLocation(table), session);
+            return transactionLogAccess.loadSnapshot(table, tableLocation, session);
         }
         catch (NotADeltaLakeTableException e) {
             throw e;
@@ -220,7 +220,7 @@ public class HiveMetastoreBackedDeltaLakeMetastore
     @Override
     public TableStatistics getTableStatistics(ConnectorSession session, DeltaLakeTableHandle tableHandle)
     {
-        TableSnapshot tableSnapshot = getSnapshot(tableHandle.getSchemaTableName(), session);
+        TableSnapshot tableSnapshot = getSnapshot(tableHandle.getSchemaTableName(), tableHandle.getLocation(), session);
 
         double numRecords = 0L;
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -23,7 +23,6 @@ import io.trino.plugin.deltalake.statistics.ExtendedStatistics;
 import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
 import io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
-import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
 import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
 import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
 import io.trino.plugin.deltalake.transactionlog.statistics.DeltaLakeFileStatistics;
@@ -191,14 +190,6 @@ public class HiveMetastoreBackedDeltaLakeMetastore
     public MetadataEntry getMetadata(TableSnapshot tableSnapshot, ConnectorSession session)
     {
         return transactionLogAccess.getMetadataEntry(tableSnapshot, session);
-    }
-
-    @Override
-    public ProtocolEntry getProtocol(ConnectorSession session, TableSnapshot tableSnapshot)
-    {
-        return transactionLogAccess.getProtocolEntries(tableSnapshot, session)
-                .reduce((first, second) -> second)
-                .orElseThrow(() -> new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Protocol entry not found in transaction log for table " + tableSnapshot.getTable()));
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -246,7 +246,7 @@ public class HiveMetastoreBackedDeltaLakeMetastore
 
         double numRecords = 0L;
 
-        MetadataEntry metadata = transactionLogAccess.getMetadataEntry(tableSnapshot, session);
+        MetadataEntry metadata = tableHandle.getMetadataEntry();
         List<DeltaLakeColumnMetadata> columnMetadata = DeltaLakeSchemaSupport.extractSchema(metadata, typeManager);
         List<DeltaLakeColumnHandle> columns = columnMetadata.stream()
                 .map(columnMeta -> new DeltaLakeColumnHandle(

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -178,9 +178,6 @@ public class HiveMetastoreBackedDeltaLakeMetastore
         try {
             return transactionLogAccess.loadSnapshot(table, tableLocation, session);
         }
-        catch (NotADeltaLakeTableException e) {
-            throw e;
-        }
         catch (IOException | RuntimeException e) {
             throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Error getting snapshot for " + table, e);
         }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -14,18 +14,9 @@
 package io.trino.plugin.deltalake.metastore;
 
 import io.trino.filesystem.TrinoFileSystemFactory;
-import io.trino.plugin.deltalake.DeltaLakeColumnHandle;
-import io.trino.plugin.deltalake.DeltaLakeColumnMetadata;
-import io.trino.plugin.deltalake.DeltaLakeTableHandle;
 import io.trino.plugin.deltalake.statistics.CachingExtendedStatisticsAccess;
-import io.trino.plugin.deltalake.statistics.DeltaLakeColumnStatistics;
-import io.trino.plugin.deltalake.statistics.ExtendedStatistics;
-import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
-import io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport;
-import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
 import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
-import io.trino.plugin.deltalake.transactionlog.statistics.DeltaLakeFileStatistics;
 import io.trino.plugin.hive.metastore.Database;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
@@ -33,39 +24,18 @@ import io.trino.plugin.hive.metastore.Table;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.predicate.TupleDomain;
-import io.trino.spi.statistics.ColumnStatistics;
-import io.trino.spi.statistics.DoubleRange;
-import io.trino.spi.statistics.Estimate;
-import io.trino.spi.statistics.TableStatistics;
-import io.trino.spi.type.TypeManager;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalDouble;
-import java.util.Set;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static io.trino.plugin.deltalake.DeltaLakeColumnType.PARTITION_KEY;
-import static io.trino.plugin.deltalake.DeltaLakeColumnType.REGULAR;
 import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_FILESYSTEM_ERROR;
 import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_INVALID_SCHEMA;
 import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_INVALID_TABLE;
 import static io.trino.plugin.deltalake.DeltaLakeMetadata.PATH_PROPERTY;
-import static io.trino.plugin.deltalake.DeltaLakeMetadata.createStatisticsPredicate;
-import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.isExtendedStatisticsEnabled;
-import static io.trino.plugin.deltalake.DeltaLakeSplitManager.partitionMatchesPredicate;
 import static io.trino.plugin.hive.TableType.MANAGED_TABLE;
 import static io.trino.plugin.hive.ViewReaderUtil.isHiveOrPrestoView;
-import static io.trino.spi.statistics.StatsUtil.toStatsRepresentation;
-import static java.lang.Double.NEGATIVE_INFINITY;
-import static java.lang.Double.NaN;
-import static java.lang.Double.POSITIVE_INFINITY;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -77,20 +47,17 @@ public class HiveMetastoreBackedDeltaLakeMetastore
 
     private final HiveMetastore delegate;
     private final TransactionLogAccess transactionLogAccess;
-    private final TypeManager typeManager;
     private final CachingExtendedStatisticsAccess statisticsAccess;
     private final TrinoFileSystemFactory fileSystemFactory;
 
     public HiveMetastoreBackedDeltaLakeMetastore(
             HiveMetastore delegate,
             TransactionLogAccess transactionLogAccess,
-            TypeManager typeManager,
             CachingExtendedStatisticsAccess statisticsAccess,
             TrinoFileSystemFactory fileSystemFactory)
     {
         this.delegate = requireNonNull(delegate, "delegate is null");
         this.transactionLogAccess = requireNonNull(transactionLogAccess, "transactionLogSupport is null");
-        this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.statisticsAccess = requireNonNull(statisticsAccess, "statisticsAccess is null");
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
     }
@@ -217,173 +184,5 @@ public class HiveMetastoreBackedDeltaLakeMetastore
         catch (IOException | RuntimeException e) {
             throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Error getting snapshot for " + table, e);
         }
-    }
-
-    @Override
-    public TableStatistics getTableStatistics(ConnectorSession session, DeltaLakeTableHandle tableHandle)
-    {
-        TableSnapshot tableSnapshot = getSnapshot(tableHandle.getSchemaTableName(), tableHandle.getLocation(), session);
-
-        double numRecords = 0L;
-
-        MetadataEntry metadata = tableHandle.getMetadataEntry();
-        List<DeltaLakeColumnMetadata> columnMetadata = DeltaLakeSchemaSupport.extractSchema(metadata, typeManager);
-        List<DeltaLakeColumnHandle> columns = columnMetadata.stream()
-                .map(columnMeta -> new DeltaLakeColumnHandle(
-                        columnMeta.getName(),
-                        columnMeta.getType(),
-                        columnMeta.getFieldId(),
-                        columnMeta.getPhysicalName(),
-                        columnMeta.getPhysicalColumnType(),
-                        metadata.getCanonicalPartitionColumns().contains(columnMeta.getName()) ? PARTITION_KEY : REGULAR))
-                .collect(toImmutableList());
-
-        Map<DeltaLakeColumnHandle, Double> nullCounts = new HashMap<>();
-        columns.forEach(column -> nullCounts.put(column, 0.0));
-        Map<DeltaLakeColumnHandle, Double> minValues = new HashMap<>();
-        Map<DeltaLakeColumnHandle, Double> maxValues = new HashMap<>();
-        Map<DeltaLakeColumnHandle, Set<String>> partitioningColumnsDistinctValues = new HashMap<>();
-        columns.stream()
-                .filter(column -> column.getColumnType() == PARTITION_KEY)
-                .forEach(column -> partitioningColumnsDistinctValues.put(column, new HashSet<>()));
-
-        if (tableHandle.getEnforcedPartitionConstraint().isNone() || tableHandle.getNonPartitionConstraint().isNone()) {
-            return createZeroStatistics(columns);
-        }
-
-        Set<String> predicatedColumnNames = tableHandle.getNonPartitionConstraint().getDomains().orElseThrow().keySet().stream()
-                .map(DeltaLakeColumnHandle::getName)
-                .collect(toImmutableSet());
-        List<DeltaLakeColumnMetadata> predicatedColumns = columnMetadata.stream()
-                .filter(column -> predicatedColumnNames.contains(column.getName()))
-                .collect(toImmutableList());
-
-        for (AddFileEntry addEntry : transactionLogAccess.getActiveFiles(tableSnapshot, session)) {
-            Optional<? extends DeltaLakeFileStatistics> fileStatistics = addEntry.getStats();
-            if (fileStatistics.isEmpty()) {
-                // Open source Delta Lake does not collect stats
-                return TableStatistics.empty();
-            }
-            DeltaLakeFileStatistics stats = fileStatistics.get();
-            if (!partitionMatchesPredicate(addEntry.getCanonicalPartitionValues(), tableHandle.getEnforcedPartitionConstraint().getDomains().orElseThrow())) {
-                continue;
-            }
-
-            TupleDomain<DeltaLakeColumnHandle> statisticsPredicate = createStatisticsPredicate(
-                    addEntry,
-                    predicatedColumns,
-                    tableHandle.getMetadataEntry().getCanonicalPartitionColumns());
-            if (!tableHandle.getNonPartitionConstraint().overlaps(statisticsPredicate)) {
-                continue;
-            }
-
-            if (stats.getNumRecords().isEmpty()) {
-                // Not clear if it's possible for stats to be present with no row count, but bail out if that happens
-                return TableStatistics.empty();
-            }
-            numRecords += stats.getNumRecords().get();
-            for (DeltaLakeColumnHandle column : columns) {
-                if (column.getColumnType() == PARTITION_KEY) {
-                    Optional<String> partitionValue = addEntry.getCanonicalPartitionValues().get(column.getPhysicalName());
-                    if (partitionValue.isEmpty()) {
-                        nullCounts.merge(column, (double) stats.getNumRecords().get(), Double::sum);
-                    }
-                    else {
-                        // NULL is not counted as a distinct value
-                        // Code below assumes that values returned by addEntry.getCanonicalPartitionValues() are normalized,
-                        // it may not be true in case of real, doubles, timestamps etc
-                        partitioningColumnsDistinctValues.get(column).add(partitionValue.get());
-                    }
-                }
-                else {
-                    Optional<Long> maybeNullCount = stats.getNullCount(column.getPhysicalName());
-                    if (maybeNullCount.isPresent()) {
-                        nullCounts.put(column, nullCounts.get(column) + maybeNullCount.get());
-                    }
-                    else {
-                        // If any individual file fails to report null counts, fail to calculate the total for the table
-                        nullCounts.put(column, NaN);
-                    }
-                }
-
-                // Math.min returns NaN if any operand is NaN
-                stats.getMinColumnValue(column)
-                        .map(parsedValue -> toStatsRepresentation(column.getType(), parsedValue))
-                        .filter(OptionalDouble::isPresent)
-                        .map(OptionalDouble::getAsDouble)
-                        .ifPresent(parsedValueAsDouble -> minValues.merge(column, parsedValueAsDouble, Math::min));
-
-                stats.getMaxColumnValue(column)
-                        .map(parsedValue -> toStatsRepresentation(column.getType(), parsedValue))
-                        .filter(OptionalDouble::isPresent)
-                        .map(OptionalDouble::getAsDouble)
-                        .ifPresent(parsedValueAsDouble -> maxValues.merge(column, parsedValueAsDouble, Math::max));
-            }
-        }
-
-        if (numRecords == 0) {
-            return createZeroStatistics(columns);
-        }
-
-        TableStatistics.Builder statsBuilder = new TableStatistics.Builder().setRowCount(Estimate.of(numRecords));
-
-        Optional<ExtendedStatistics> statistics = Optional.empty();
-        if (isExtendedStatisticsEnabled(session)) {
-            statistics = statisticsAccess.readExtendedStatistics(session, tableHandle.getLocation());
-        }
-
-        for (DeltaLakeColumnHandle column : columns) {
-            ColumnStatistics.Builder columnStatsBuilder = new ColumnStatistics.Builder();
-            Double nullCount = nullCounts.get(column);
-            columnStatsBuilder.setNullsFraction(nullCount.isNaN() ? Estimate.unknown() : Estimate.of(nullCount / numRecords));
-
-            Double maxValue = maxValues.get(column);
-            Double minValue = minValues.get(column);
-
-            if (isValidInRange(maxValue) && isValidInRange(minValue)) {
-                columnStatsBuilder.setRange(new DoubleRange(minValue, maxValue));
-            }
-            else if (isValidInRange(maxValue)) {
-                columnStatsBuilder.setRange(new DoubleRange(NEGATIVE_INFINITY, maxValue));
-            }
-            else if (isValidInRange(minValue)) {
-                columnStatsBuilder.setRange(new DoubleRange(minValue, POSITIVE_INFINITY));
-            }
-
-            // extend statistics with NDV
-            if (column.getColumnType() == PARTITION_KEY) {
-                columnStatsBuilder.setDistinctValuesCount(Estimate.of(partitioningColumnsDistinctValues.get(column).size()));
-            }
-            if (statistics.isPresent()) {
-                DeltaLakeColumnStatistics deltaLakeColumnStatistics = statistics.get().getColumnStatistics().get(column.getPhysicalName());
-                if (deltaLakeColumnStatistics != null && column.getColumnType() != PARTITION_KEY) {
-                    deltaLakeColumnStatistics.getTotalSizeInBytes().ifPresent(size -> columnStatsBuilder.setDataSize(Estimate.of(size)));
-                    columnStatsBuilder.setDistinctValuesCount(Estimate.of(deltaLakeColumnStatistics.getNdvSummary().cardinality()));
-                }
-            }
-
-            statsBuilder.setColumnStatistics(column, columnStatsBuilder.build());
-        }
-
-        return statsBuilder.build();
-    }
-
-    private TableStatistics createZeroStatistics(List<DeltaLakeColumnHandle> columns)
-    {
-        TableStatistics.Builder statsBuilder = new TableStatistics.Builder().setRowCount(Estimate.of(0));
-        for (DeltaLakeColumnHandle column : columns) {
-            ColumnStatistics.Builder columnStatistics = ColumnStatistics.builder();
-            columnStatistics.setNullsFraction(Estimate.of(0));
-            columnStatistics.setDistinctValuesCount(Estimate.of(0));
-            statsBuilder.setColumnStatistics(column, columnStatistics.build());
-        }
-
-        return statsBuilder.build();
-    }
-
-    private boolean isValidInRange(Double d)
-    {
-        // Delta considers NaN a valid min/max value but Trino does not
-        return d != null && !d.isNaN();
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -234,12 +234,6 @@ public class HiveMetastoreBackedDeltaLakeMetastore
     }
 
     @Override
-    public List<AddFileEntry> getValidDataFiles(SchemaTableName table, ConnectorSession session)
-    {
-        return transactionLogAccess.getActiveFiles(getSnapshot(table, session), session);
-    }
-
-    @Override
     public TableStatistics getTableStatistics(ConnectorSession session, DeltaLakeTableHandle tableHandle)
     {
         TableSnapshot tableSnapshot = getSnapshot(tableHandle.getSchemaTableName(), session);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -164,9 +164,8 @@ public class HiveMetastoreBackedDeltaLakeMetastore
     }
 
     @Override
-    public void dropTable(ConnectorSession session, String databaseName, String tableName, boolean deleteData)
+    public void dropTable(ConnectorSession session, String databaseName, String tableName, String tableLocation, boolean deleteData)
     {
-        String tableLocation = getTableLocation(new SchemaTableName(databaseName, tableName));
         delegate.dropTable(databaseName, tableName, deleteData);
         statisticsAccess.invalidateCache(tableLocation);
         transactionLogAccess.invalidateCaches(tableLocation);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -187,12 +187,6 @@ public class HiveMetastoreBackedDeltaLakeMetastore
     }
 
     @Override
-    public MetadataEntry getMetadata(TableSnapshot tableSnapshot, ConnectorSession session)
-    {
-        return transactionLogAccess.getMetadataEntry(tableSnapshot, session);
-    }
-
-    @Override
     public String getTableLocation(SchemaTableName tableName)
     {
         Table table = getTable(tableName.getSchemaName(), tableName.getTableName())

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -164,9 +164,9 @@ public class HiveMetastoreBackedDeltaLakeMetastore
     }
 
     @Override
-    public void dropTable(ConnectorSession session, String databaseName, String tableName, String tableLocation, boolean deleteData)
+    public void dropTable(ConnectorSession session, SchemaTableName schemaTableName, String tableLocation, boolean deleteData)
     {
-        delegate.dropTable(databaseName, tableName, deleteData);
+        delegate.dropTable(schemaTableName.getSchemaName(), schemaTableName.getTableName(), deleteData);
         statisticsAccess.invalidateCache(tableLocation);
         transactionLogAccess.invalidateCaches(tableLocation);
         if (deleteData) {
@@ -174,7 +174,7 @@ public class HiveMetastoreBackedDeltaLakeMetastore
                 fileSystemFactory.create(session).deleteDirectory(tableLocation);
             }
             catch (IOException e) {
-                throw new TrinoException(DELTA_LAKE_FILESYSTEM_ERROR, format("Failed to delete directory %s of the table %s", tableLocation, tableName), e);
+                throw new TrinoException(DELTA_LAKE_FILESYSTEM_ERROR, format("Failed to delete directory %s of the table %s", tableLocation, schemaTableName), e);
             }
         }
     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/FlushMetadataCacheProcedure.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/FlushMetadataCacheProcedure.java
@@ -14,15 +14,18 @@
 package io.trino.plugin.deltalake.procedure;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.plugin.deltalake.CorruptedDeltaLakeTableHandle;
+import io.trino.plugin.deltalake.DeltaLakeMetadata;
+import io.trino.plugin.deltalake.DeltaLakeMetadataFactory;
+import io.trino.plugin.deltalake.DeltaLakeTableHandle;
 import io.trino.plugin.deltalake.statistics.CachingExtendedStatisticsAccess;
 import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
-import io.trino.plugin.hive.metastore.HiveMetastore;
-import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
-import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hive.metastore.cache.CachingHiveMetastore;
 import io.trino.spi.TrinoException;
 import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.procedure.Procedure;
 
 import javax.inject.Inject;
@@ -31,8 +34,6 @@ import javax.inject.Provider;
 import java.lang.invoke.MethodHandle;
 import java.util.Optional;
 
-import static io.trino.plugin.deltalake.metastore.HiveMetastoreBackedDeltaLakeMetastore.getTableLocation;
-import static io.trino.plugin.deltalake.metastore.HiveMetastoreBackedDeltaLakeMetastore.verifyDeltaLakeTable;
 import static io.trino.spi.StandardErrorCode.INVALID_PROCEDURE_ARGUMENT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.invoke.MethodHandles.lookup;
@@ -57,19 +58,19 @@ public class FlushMetadataCacheProcedure
         }
     }
 
-    private final HiveMetastoreFactory metastoreFactory;
+    private final DeltaLakeMetadataFactory metadataFactory;
     private final Optional<CachingHiveMetastore> cachingHiveMetastore;
     private final TransactionLogAccess transactionLogAccess;
     private final CachingExtendedStatisticsAccess extendedStatisticsAccess;
 
     @Inject
     public FlushMetadataCacheProcedure(
-            HiveMetastoreFactory metastoreFactory,
+            DeltaLakeMetadataFactory metadataFactory,
             Optional<CachingHiveMetastore> cachingHiveMetastore,
             TransactionLogAccess transactionLogAccess,
             CachingExtendedStatisticsAccess extendedStatisticsAccess)
     {
-        this.metastoreFactory = requireNonNull(metastoreFactory, "metastoreFactory is null");
+        this.metadataFactory = requireNonNull(metadataFactory, "metadataFactory is null");
         this.cachingHiveMetastore = requireNonNull(cachingHiveMetastore, "cachingHiveMetastore is null");
         this.transactionLogAccess = requireNonNull(transactionLogAccess, "transactionLogAccess is null");
         this.extendedStatisticsAccess = requireNonNull(extendedStatisticsAccess, "extendedStatisticsAccess is null");
@@ -103,14 +104,17 @@ public class FlushMetadataCacheProcedure
             extendedStatisticsAccess.invalidateCache();
         }
         else if (schemaName.isPresent() && tableName.isPresent()) {
-            HiveMetastore metastore = metastoreFactory.createMetastore(Optional.of(session.getIdentity()));
+            DeltaLakeMetadata metadata = metadataFactory.create(session.getIdentity());
+            SchemaTableName schemaTableName = new SchemaTableName(schemaName.get(), tableName.get());
             // This may insert into a cache, but this will get invalidated below. TODO fix Delta so that flush_metadata_cache doesn't have to read from metastore
-            Optional<Table> tableBeforeFlush = metastore.getTable(schemaName.get(), tableName.get());
+            ConnectorTableHandle tableHandle = metadata.getTableHandle(session, schemaTableName);
             cachingHiveMetastore.ifPresent(caching -> caching.invalidateTable(schemaName.get(), tableName.get()));
 
-            Optional<String> tableLocation = tableBeforeFlush.map(table -> {
-                verifyDeltaLakeTable(table);
-                return getTableLocation(table);
+            Optional<String> tableLocation = Optional.ofNullable(tableHandle).map(table -> {
+                if (tableHandle instanceof CorruptedDeltaLakeTableHandle corruptedTableHandle) {
+                    return corruptedTableHandle.location();
+                }
+                return ((DeltaLakeTableHandle) tableHandle).getLocation();
             });
             tableLocation.ifPresent(transactionLogAccess::invalidateCaches);
             tableLocation.ifPresent(extendedStatisticsAccess::invalidateCache);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/RegisterTableProcedure.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/RegisterTableProcedure.java
@@ -19,6 +19,8 @@ import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.plugin.deltalake.DeltaLakeConfig;
 import io.trino.plugin.deltalake.DeltaLakeMetadataFactory;
 import io.trino.plugin.deltalake.metastore.DeltaLakeMetastore;
+import io.trino.plugin.deltalake.statistics.CachingExtendedStatisticsAccess;
+import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.spi.TrinoException;
@@ -69,13 +71,22 @@ public class RegisterTableProcedure
     }
 
     private final DeltaLakeMetadataFactory metadataFactory;
+    private final TransactionLogAccess transactionLogAccess;
+    private final CachingExtendedStatisticsAccess statisticsAccess;
     private final TrinoFileSystemFactory fileSystemFactory;
     private final boolean registerTableProcedureEnabled;
 
     @Inject
-    public RegisterTableProcedure(DeltaLakeMetadataFactory metadataFactory, TrinoFileSystemFactory fileSystemFactory, DeltaLakeConfig deltaLakeConfig)
+    public RegisterTableProcedure(
+            DeltaLakeMetadataFactory metadataFactory,
+            TransactionLogAccess transactionLogAccess,
+            CachingExtendedStatisticsAccess statisticsAccess,
+            TrinoFileSystemFactory fileSystemFactory,
+            DeltaLakeConfig deltaLakeConfig)
     {
         this.metadataFactory = requireNonNull(metadataFactory, "metadataFactory is null");
+        this.transactionLogAccess = requireNonNull(transactionLogAccess, "transactionLogAccess is null");
+        this.statisticsAccess = requireNonNull(statisticsAccess, "statisticsAccess is null");
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.registerTableProcedureEnabled = deltaLakeConfig.isRegisterTableProcedureEnabled();
     }
@@ -142,6 +153,9 @@ public class RegisterTableProcedure
         Table table = buildTable(session, schemaTableName, tableLocation, true);
 
         PrincipalPrivileges principalPrivileges = buildInitialPrivilegeSet(table.getOwner().orElseThrow());
+        // Clear the caches so that createTable verifies we're registering a location with a valid table
+        statisticsAccess.invalidateCache(tableLocation);
+        transactionLogAccess.invalidateCaches(tableLocation);
         metastore.createTable(
                 session,
                 table,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/RegisterTableProcedure.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/RegisterTableProcedure.java
@@ -20,6 +20,7 @@ import io.trino.plugin.deltalake.DeltaLakeConfig;
 import io.trino.plugin.deltalake.DeltaLakeMetadataFactory;
 import io.trino.plugin.deltalake.metastore.DeltaLakeMetastore;
 import io.trino.plugin.deltalake.statistics.CachingExtendedStatisticsAccess;
+import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
 import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
@@ -39,6 +40,7 @@ import java.lang.invoke.MethodHandle;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static io.trino.plugin.base.util.Procedures.checkProcedureArgument;
 import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_FILESYSTEM_ERROR;
+import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_INVALID_TABLE;
 import static io.trino.plugin.deltalake.DeltaLakeMetadata.buildTable;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.getTransactionLogDir;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.buildInitialPrivilegeSet;
@@ -153,9 +155,16 @@ public class RegisterTableProcedure
         Table table = buildTable(session, schemaTableName, tableLocation, true);
 
         PrincipalPrivileges principalPrivileges = buildInitialPrivilegeSet(table.getOwner().orElseThrow());
-        // Clear the caches so that createTable verifies we're registering a location with a valid table
         statisticsAccess.invalidateCache(tableLocation);
         transactionLogAccess.invalidateCaches(tableLocation);
+        // Verify we're registering a location with a valid table
+        try {
+            TableSnapshot tableSnapshot = transactionLogAccess.loadSnapshot(table.getSchemaTableName(), tableLocation, session);
+            transactionLogAccess.getMetadataEntry(tableSnapshot, session); // verify metadata exists
+        }
+        catch (IOException | RuntimeException e) {
+            throw new TrinoException(DELTA_LAKE_INVALID_TABLE, "Failed to access table location: " + tableLocation, e);
+        }
         metastore.createTable(
                 session,
                 table,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/statistics/DeltaLakeTableStatisticsProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/statistics/DeltaLakeTableStatisticsProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.statistics;
+
+import io.trino.plugin.deltalake.DeltaLakeTableHandle;
+import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.statistics.TableStatistics;
+
+public interface DeltaLakeTableStatisticsProvider
+{
+    TableStatistics getTableStatistics(ConnectorSession session, DeltaLakeTableHandle tableHandle, TableSnapshot tableSnapshot);
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/statistics/FileBasedTableStatisticsProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/statistics/FileBasedTableStatisticsProvider.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.statistics;
+
+import io.trino.plugin.deltalake.DeltaLakeColumnHandle;
+import io.trino.plugin.deltalake.DeltaLakeColumnMetadata;
+import io.trino.plugin.deltalake.DeltaLakeTableHandle;
+import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
+import io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport;
+import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
+import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
+import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
+import io.trino.plugin.deltalake.transactionlog.statistics.DeltaLakeFileStatistics;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.statistics.ColumnStatistics;
+import io.trino.spi.statistics.DoubleRange;
+import io.trino.spi.statistics.Estimate;
+import io.trino.spi.statistics.TableStatistics;
+import io.trino.spi.type.TypeManager;
+
+import javax.inject.Inject;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.plugin.deltalake.DeltaLakeColumnType.PARTITION_KEY;
+import static io.trino.plugin.deltalake.DeltaLakeColumnType.REGULAR;
+import static io.trino.plugin.deltalake.DeltaLakeMetadata.createStatisticsPredicate;
+import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.isExtendedStatisticsEnabled;
+import static io.trino.plugin.deltalake.DeltaLakeSplitManager.partitionMatchesPredicate;
+import static io.trino.spi.statistics.StatsUtil.toStatsRepresentation;
+import static java.lang.Double.NEGATIVE_INFINITY;
+import static java.lang.Double.NaN;
+import static java.lang.Double.POSITIVE_INFINITY;
+import static java.util.Objects.requireNonNull;
+
+public class FileBasedTableStatisticsProvider
+        implements DeltaLakeTableStatisticsProvider
+{
+    private final TypeManager typeManager;
+    private final TransactionLogAccess transactionLogAccess;
+    private final CachingExtendedStatisticsAccess statisticsAccess;
+
+    @Inject
+    public FileBasedTableStatisticsProvider(
+            TypeManager typeManager,
+            TransactionLogAccess transactionLogAccess,
+            CachingExtendedStatisticsAccess statisticsAccess)
+    {
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.transactionLogAccess = requireNonNull(transactionLogAccess, "transactionLogAccess is null");
+        this.statisticsAccess = requireNonNull(statisticsAccess, "statisticsAccess is null");
+    }
+
+    @Override
+    public TableStatistics getTableStatistics(ConnectorSession session, DeltaLakeTableHandle tableHandle, TableSnapshot tableSnapshot)
+    {
+        double numRecords = 0L;
+
+        MetadataEntry metadata = tableHandle.getMetadataEntry();
+        List<DeltaLakeColumnMetadata> columnMetadata = DeltaLakeSchemaSupport.extractSchema(metadata, typeManager);
+        List<DeltaLakeColumnHandle> columns = columnMetadata.stream()
+                .map(columnMeta -> new DeltaLakeColumnHandle(
+                        columnMeta.getName(),
+                        columnMeta.getType(),
+                        columnMeta.getFieldId(),
+                        columnMeta.getPhysicalName(),
+                        columnMeta.getPhysicalColumnType(),
+                        metadata.getCanonicalPartitionColumns().contains(columnMeta.getName()) ? PARTITION_KEY : REGULAR))
+                .collect(toImmutableList());
+
+        Map<DeltaLakeColumnHandle, Double> nullCounts = new HashMap<>();
+        columns.forEach(column -> nullCounts.put(column, 0.0));
+        Map<DeltaLakeColumnHandle, Double> minValues = new HashMap<>();
+        Map<DeltaLakeColumnHandle, Double> maxValues = new HashMap<>();
+        Map<DeltaLakeColumnHandle, Set<String>> partitioningColumnsDistinctValues = new HashMap<>();
+        columns.stream()
+                .filter(column -> column.getColumnType() == PARTITION_KEY)
+                .forEach(column -> partitioningColumnsDistinctValues.put(column, new HashSet<>()));
+
+        if (tableHandle.getEnforcedPartitionConstraint().isNone() || tableHandle.getNonPartitionConstraint().isNone()) {
+            return createZeroStatistics(columns);
+        }
+
+        Set<String> predicatedColumnNames = tableHandle.getNonPartitionConstraint().getDomains().orElseThrow().keySet().stream()
+                .map(DeltaLakeColumnHandle::getName)
+                .collect(toImmutableSet());
+        List<DeltaLakeColumnMetadata> predicatedColumns = columnMetadata.stream()
+                .filter(column -> predicatedColumnNames.contains(column.getName()))
+                .collect(toImmutableList());
+
+        for (AddFileEntry addEntry : transactionLogAccess.getActiveFiles(tableSnapshot, session)) {
+            Optional<? extends DeltaLakeFileStatistics> fileStatistics = addEntry.getStats();
+            if (fileStatistics.isEmpty()) {
+                // Open source Delta Lake does not collect stats
+                return TableStatistics.empty();
+            }
+            DeltaLakeFileStatistics stats = fileStatistics.get();
+            if (!partitionMatchesPredicate(addEntry.getCanonicalPartitionValues(), tableHandle.getEnforcedPartitionConstraint().getDomains().orElseThrow())) {
+                continue;
+            }
+
+            TupleDomain<DeltaLakeColumnHandle> statisticsPredicate = createStatisticsPredicate(
+                    addEntry,
+                    predicatedColumns,
+                    tableHandle.getMetadataEntry().getCanonicalPartitionColumns());
+            if (!tableHandle.getNonPartitionConstraint().overlaps(statisticsPredicate)) {
+                continue;
+            }
+
+            if (stats.getNumRecords().isEmpty()) {
+                // Not clear if it's possible for stats to be present with no row count, but bail out if that happens
+                return TableStatistics.empty();
+            }
+            numRecords += stats.getNumRecords().get();
+            for (DeltaLakeColumnHandle column : columns) {
+                if (column.getColumnType() == PARTITION_KEY) {
+                    Optional<String> partitionValue = addEntry.getCanonicalPartitionValues().get(column.getPhysicalName());
+                    if (partitionValue.isEmpty()) {
+                        nullCounts.merge(column, (double) stats.getNumRecords().get(), Double::sum);
+                    }
+                    else {
+                        // NULL is not counted as a distinct value
+                        // Code below assumes that values returned by addEntry.getCanonicalPartitionValues() are normalized,
+                        // it may not be true in case of real, doubles, timestamps etc
+                        partitioningColumnsDistinctValues.get(column).add(partitionValue.get());
+                    }
+                }
+                else {
+                    Optional<Long> maybeNullCount = stats.getNullCount(column.getPhysicalName());
+                    if (maybeNullCount.isPresent()) {
+                        nullCounts.put(column, nullCounts.get(column) + maybeNullCount.get());
+                    }
+                    else {
+                        // If any individual file fails to report null counts, fail to calculate the total for the table
+                        nullCounts.put(column, NaN);
+                    }
+                }
+
+                // Math.min returns NaN if any operand is NaN
+                stats.getMinColumnValue(column)
+                        .map(parsedValue -> toStatsRepresentation(column.getType(), parsedValue))
+                        .filter(OptionalDouble::isPresent)
+                        .map(OptionalDouble::getAsDouble)
+                        .ifPresent(parsedValueAsDouble -> minValues.merge(column, parsedValueAsDouble, Math::min));
+
+                stats.getMaxColumnValue(column)
+                        .map(parsedValue -> toStatsRepresentation(column.getType(), parsedValue))
+                        .filter(OptionalDouble::isPresent)
+                        .map(OptionalDouble::getAsDouble)
+                        .ifPresent(parsedValueAsDouble -> maxValues.merge(column, parsedValueAsDouble, Math::max));
+            }
+        }
+
+        if (numRecords == 0) {
+            return createZeroStatistics(columns);
+        }
+
+        TableStatistics.Builder statsBuilder = new TableStatistics.Builder().setRowCount(Estimate.of(numRecords));
+
+        Optional<ExtendedStatistics> statistics = Optional.empty();
+        if (isExtendedStatisticsEnabled(session)) {
+            statistics = statisticsAccess.readExtendedStatistics(session, tableHandle.getLocation());
+        }
+
+        for (DeltaLakeColumnHandle column : columns) {
+            ColumnStatistics.Builder columnStatsBuilder = new ColumnStatistics.Builder();
+            Double nullCount = nullCounts.get(column);
+            columnStatsBuilder.setNullsFraction(nullCount.isNaN() ? Estimate.unknown() : Estimate.of(nullCount / numRecords));
+
+            Double maxValue = maxValues.get(column);
+            Double minValue = minValues.get(column);
+
+            if (isValidInRange(maxValue) && isValidInRange(minValue)) {
+                columnStatsBuilder.setRange(new DoubleRange(minValue, maxValue));
+            }
+            else if (isValidInRange(maxValue)) {
+                columnStatsBuilder.setRange(new DoubleRange(NEGATIVE_INFINITY, maxValue));
+            }
+            else if (isValidInRange(minValue)) {
+                columnStatsBuilder.setRange(new DoubleRange(minValue, POSITIVE_INFINITY));
+            }
+
+            // extend statistics with NDV
+            if (column.getColumnType() == PARTITION_KEY) {
+                columnStatsBuilder.setDistinctValuesCount(Estimate.of(partitioningColumnsDistinctValues.get(column).size()));
+            }
+            if (statistics.isPresent()) {
+                DeltaLakeColumnStatistics deltaLakeColumnStatistics = statistics.get().getColumnStatistics().get(column.getPhysicalName());
+                if (deltaLakeColumnStatistics != null && column.getColumnType() != PARTITION_KEY) {
+                    deltaLakeColumnStatistics.getTotalSizeInBytes().ifPresent(size -> columnStatsBuilder.setDataSize(Estimate.of(size)));
+                    columnStatsBuilder.setDistinctValuesCount(Estimate.of(deltaLakeColumnStatistics.getNdvSummary().cardinality()));
+                }
+            }
+
+            statsBuilder.setColumnStatistics(column, columnStatsBuilder.build());
+        }
+
+        return statsBuilder.build();
+    }
+
+    private TableStatistics createZeroStatistics(List<DeltaLakeColumnHandle> columns)
+    {
+        TableStatistics.Builder statsBuilder = new TableStatistics.Builder().setRowCount(Estimate.of(0));
+        for (DeltaLakeColumnHandle column : columns) {
+            ColumnStatistics.Builder columnStatistics = ColumnStatistics.builder();
+            columnStatistics.setNullsFraction(Estimate.of(0));
+            columnStatistics.setDistinctValuesCount(Estimate.of(0));
+            statsBuilder.setColumnStatistics(column, columnStatistics.build());
+        }
+
+        return statsBuilder.build();
+    }
+
+    private boolean isValidInRange(Double d)
+    {
+        // Delta considers NaN a valid min/max value but Trino does not
+        return d != null && !d.isNaN();
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -1965,7 +1965,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
         String schemaName = "test_unregister_table_not_existing_schema_" + randomNameSuffix();
         assertQueryFails(
                 "CALL system.unregister_table('" + schemaName + "', 'non_existent_table')",
-                "Schema " + schemaName + " not found");
+                "Table \\Q'" + schemaName + ".non_existent_table' not found");
     }
 
     @Test

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
@@ -30,7 +30,6 @@ import io.trino.plugin.deltalake.metastore.DeltaLakeMetastore;
 import io.trino.plugin.deltalake.metastore.DeltaLakeMetastoreModule;
 import io.trino.plugin.deltalake.metastore.HiveMetastoreBackedDeltaLakeMetastore;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
-import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
 import io.trino.plugin.hive.NodeVersion;
 import io.trino.plugin.hive.metastore.Database;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
@@ -168,13 +167,10 @@ public class TestDeltaLakeMetadata
                 new AbstractModule()
                 {
                     @Provides
-                    public DeltaLakeMetastore getDeltaLakeMetastore(
-                            @RawHiveMetastoreFactory HiveMetastoreFactory hiveMetastoreFactory,
-                            TransactionLogAccess transactionLogAccess)
+                    public DeltaLakeMetastore getDeltaLakeMetastore(@RawHiveMetastoreFactory HiveMetastoreFactory hiveMetastoreFactory)
                     {
                         return new HiveMetastoreBackedDeltaLakeMetastore(
                                 hiveMetastoreFactory.createMetastore(Optional.empty()),
-                                transactionLogAccess,
                                 new HdfsFileSystemFactory(HDFS_ENVIRONMENT));
                     }
                 });

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
@@ -172,13 +172,11 @@ public class TestDeltaLakeMetadata
                     public DeltaLakeMetastore getDeltaLakeMetastore(
                             @RawHiveMetastoreFactory HiveMetastoreFactory hiveMetastoreFactory,
                             TransactionLogAccess transactionLogAccess,
-                            TypeManager typeManager,
                             CachingExtendedStatisticsAccess statistics)
                     {
                         return new HiveMetastoreBackedDeltaLakeMetastore(
                                 hiveMetastoreFactory.createMetastore(Optional.empty()),
                                 transactionLogAccess,
-                                typeManager,
                                 statistics,
                                 new HdfsFileSystemFactory(HDFS_ENVIRONMENT));
                     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
@@ -169,9 +169,7 @@ public class TestDeltaLakeMetadata
                     @Provides
                     public DeltaLakeMetastore getDeltaLakeMetastore(@RawHiveMetastoreFactory HiveMetastoreFactory hiveMetastoreFactory)
                     {
-                        return new HiveMetastoreBackedDeltaLakeMetastore(
-                                hiveMetastoreFactory.createMetastore(Optional.empty()),
-                                new HdfsFileSystemFactory(HDFS_ENVIRONMENT));
+                        return new HiveMetastoreBackedDeltaLakeMetastore(hiveMetastoreFactory.createMetastore(Optional.empty()));
                     }
                 });
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
@@ -446,6 +446,7 @@ public class TestDeltaLakeMetadata
         return new DeltaLakeTableHandle(
                 "test_schema_name",
                 "test_table_name",
+                true,
                 "test_location",
                 createMetadataEntry(),
                 createConstrainedColumnsTuple(constrainedColumns),

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
@@ -29,7 +29,6 @@ import io.trino.plugin.base.CatalogName;
 import io.trino.plugin.deltalake.metastore.DeltaLakeMetastore;
 import io.trino.plugin.deltalake.metastore.DeltaLakeMetastoreModule;
 import io.trino.plugin.deltalake.metastore.HiveMetastoreBackedDeltaLakeMetastore;
-import io.trino.plugin.deltalake.statistics.CachingExtendedStatisticsAccess;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
 import io.trino.plugin.hive.NodeVersion;
@@ -171,13 +170,11 @@ public class TestDeltaLakeMetadata
                     @Provides
                     public DeltaLakeMetastore getDeltaLakeMetastore(
                             @RawHiveMetastoreFactory HiveMetastoreFactory hiveMetastoreFactory,
-                            TransactionLogAccess transactionLogAccess,
-                            CachingExtendedStatisticsAccess statistics)
+                            TransactionLogAccess transactionLogAccess)
                     {
                         return new HiveMetastoreBackedDeltaLakeMetastore(
                                 hiveMetastoreFactory.createMetastore(Optional.empty()),
                                 transactionLogAccess,
-                                statistics,
                                 new HdfsFileSystemFactory(HDFS_ENVIRONMENT));
                     }
                 });

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePerTransactionMetastoreCache.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePerTransactionMetastoreCache.java
@@ -140,12 +140,9 @@ public class TestDeltaLakePerTransactionMetastoreCache
             throws Exception
     {
         try (DistributedQueryRunner queryRunner = createQueryRunner(false)) {
-            // Sanity check that getTable call is done more than twice if per-transaction cache is disabled.
-            // This is to be sure that `testPerTransactionHiveMetastoreCachingEnabled` passes because of per-transaction
-            // caching and not because of caching done by some other layer.
             assertMetastoreInvocations(queryRunner, "SELECT * FROM nation JOIN region ON nation.regionkey = region.regionkey",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 6)
+                            .addCopies(GET_TABLE, 2)
                             .build());
         }
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePerTransactionMetastoreCache.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePerTransactionMetastoreCache.java
@@ -145,7 +145,7 @@ public class TestDeltaLakePerTransactionMetastoreCache
             // caching and not because of caching done by some other layer.
             assertMetastoreInvocations(queryRunner, "SELECT * FROM nation JOIN region ON nation.regionkey = region.regionkey",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 12)
+                            .addCopies(GET_TABLE, 6)
                             .build());
         }
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePerTransactionMetastoreCache.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePerTransactionMetastoreCache.java
@@ -16,96 +16,89 @@ package io.trino.plugin.deltalake;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Multiset;
+import com.google.common.reflect.ClassPath;
 import com.google.inject.Binder;
 import com.google.inject.Key;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
-import io.airlift.units.Duration;
 import io.trino.Session;
-import io.trino.plugin.hive.containers.HiveMinioDataLake;
+import io.trino.plugin.base.util.Closables;
 import io.trino.plugin.hive.metastore.CountingAccessHiveMetastore;
 import io.trino.plugin.hive.metastore.CountingAccessHiveMetastoreUtil;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
 import io.trino.plugin.hive.metastore.RawHiveMetastoreFactory;
-import io.trino.plugin.hive.metastore.thrift.BridgingHiveMetastore;
-import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreConfig;
+import io.trino.plugin.hive.metastore.file.FileHiveMetastore;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
+import io.trino.testing.minio.MinioClient;
 import io.trino.tpch.TpchEntity;
 import io.trino.tpch.TpchTable;
 import org.intellij.lang.annotations.Language;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
-import static io.trino.plugin.hive.TestingThriftHiveMetastoreBuilder.testingThriftHiveMetastoreBuilder;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Methods.GET_TABLE;
+import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
 import static java.lang.String.format;
+import static java.nio.file.Files.createDirectories;
+import static java.nio.file.Files.write;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.MINUTES;
 
 @Test(singleThreaded = true) // tests use shared invocation counter map
 public class TestDeltaLakePerTransactionMetastoreCache
 {
-    private static final String BUCKET_NAME = "delta-lake-per-transaction-metastore-cache";
-    private HiveMinioDataLake hiveMinioDataLake;
     private CountingAccessHiveMetastore metastore;
 
     private DistributedQueryRunner createQueryRunner(boolean enablePerTransactionHiveMetastoreCaching)
             throws Exception
     {
-        boolean createdDeltaLake = false;
-        if (hiveMinioDataLake == null) {
-            // share environment between testcases to speed things up
-            hiveMinioDataLake = new HiveMinioDataLake(BUCKET_NAME);
-            hiveMinioDataLake.start();
-            createdDeltaLake = true;
-        }
         Session session = testSessionBuilder()
                 .setCatalog(DELTA_CATALOG)
                 .setSchema("default")
                 .build();
 
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
+        try {
+            FileHiveMetastore fileMetastore = createTestingFileHiveMetastore(queryRunner.getCoordinator().getBaseDataDir().resolve("file-metastore").toFile());
+            metastore = new CountingAccessHiveMetastore(fileMetastore);
+            queryRunner.installPlugin(new TestingDeltaLakePlugin(Optional.empty(), Optional.empty(), new CountingAccessMetastoreModule(metastore)));
 
-        metastore = new CountingAccessHiveMetastore(new BridgingHiveMetastore(testingThriftHiveMetastoreBuilder()
-                .metastoreClient(hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint())
-                .thriftMetastoreConfig(new ThriftMetastoreConfig()
-                        .setMetastoreTimeout(new Duration(1, MINUTES))) // read timed out sometimes happens with the default timeout
-                .build()));
+            ImmutableMap.Builder<String, String> deltaLakeProperties = ImmutableMap.builder();
+            deltaLakeProperties.put("hive.metastore", "test"); // use test value so we do not get clash with default bindings)
+            deltaLakeProperties.put("delta.register-table-procedure.enabled", "true");
+            if (!enablePerTransactionHiveMetastoreCaching) {
+                // almost disable the cache; 0 is not allowed as config property value
+                deltaLakeProperties.put("delta.per-transaction-metastore-cache-maximum-size", "1");
+            }
 
-        queryRunner.installPlugin(new TestingDeltaLakePlugin(Optional.empty(), Optional.empty(), new CountingAccessMetastoreModule(metastore)));
+            queryRunner.createCatalog(DELTA_CATALOG, "delta_lake", deltaLakeProperties.buildOrThrow());
+            queryRunner.execute("CREATE SCHEMA " + session.getSchema().orElseThrow());
 
-        ImmutableMap.Builder<String, String> deltaLakeProperties = ImmutableMap.builder();
-        deltaLakeProperties.put("hive.s3.aws-access-key", MINIO_ACCESS_KEY);
-        deltaLakeProperties.put("hive.s3.aws-secret-key", MINIO_SECRET_KEY);
-        deltaLakeProperties.put("hive.s3.endpoint", hiveMinioDataLake.getMinio().getMinioAddress());
-        deltaLakeProperties.put("hive.s3.path-style-access", "true");
-        deltaLakeProperties.put("hive.metastore", "test"); // use test value so we do not get clash with default bindings)
-        deltaLakeProperties.put("delta.register-table-procedure.enabled", "true");
-        if (!enablePerTransactionHiveMetastoreCaching) {
-            // almost disable the cache; 0 is not allowed as config property value
-            deltaLakeProperties.put("delta.per-transaction-metastore-cache-maximum-size", "1");
-        }
-
-        queryRunner.createCatalog(DELTA_CATALOG, "delta_lake", deltaLakeProperties.buildOrThrow());
-
-        if (createdDeltaLake) {
-            List<TpchTable<? extends TpchEntity>> tpchTables = List.of(TpchTable.NATION, TpchTable.REGION);
-            tpchTables.forEach(table -> {
+            for (TpchTable<? extends TpchEntity> table : List.of(TpchTable.NATION, TpchTable.REGION)) {
                 String tableName = table.getTableName();
-                hiveMinioDataLake.copyResources("io/trino/plugin/deltalake/testing/resources/databricks/" + tableName, tableName);
-                queryRunner.execute(format("CALL %1$s.system.register_table('%2$s', '%3$s', 's3://%4$s/%3$s')",
-                        DELTA_CATALOG,
-                        "default",
-                        tableName,
-                        BUCKET_NAME));
-            });
+                String resourcePath = "io/trino/plugin/deltalake/testing/resources/databricks/" + tableName + "/";
+                Path tableDirectory = queryRunner.getCoordinator().getBaseDataDir().resolve("%s-%s".formatted(tableName, randomNameSuffix()));
+
+                for (ClassPath.ResourceInfo resourceInfo : ClassPath.from(MinioClient.class.getClassLoader())
+                        .getResources()) {
+                    if (resourceInfo.getResourceName().startsWith(resourcePath)) {
+                        Path targetFile = tableDirectory.resolve(resourceInfo.getResourceName().substring(resourcePath.length()));
+                        createDirectories(targetFile.getParent());
+                        write(targetFile, resourceInfo.asByteSource().read());
+                    }
+                }
+
+                queryRunner.execute(format("CALL system.register_table(CURRENT_SCHEMA, '%s', '%s')", tableName, tableDirectory));
+            }
+        }
+        catch (Throwable e) {
+            Closables.closeAllSuppress(e, queryRunner);
+            throw e;
         }
 
         return queryRunner;
@@ -126,16 +119,6 @@ public class TestDeltaLakePerTransactionMetastoreCache
         {
             binder.bind(HiveMetastoreFactory.class).annotatedWith(RawHiveMetastoreFactory.class).toInstance(HiveMetastoreFactory.ofInstance(metastore));
             binder.bind(Key.get(boolean.class, AllowDeltaLakeManagedTableRename.class)).toInstance(false);
-        }
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void tearDown()
-            throws Exception
-    {
-        if (hiveMinioDataLake != null) {
-            hiveMinioDataLake.close();
-            hiveMinioDataLake = null;
         }
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
@@ -18,8 +18,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.airlift.units.DataSize;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
-import io.trino.plugin.deltalake.metastore.DeltaLakeMetastore;
-import io.trino.plugin.deltalake.metastore.DeltaMetastoreTable;
 import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
@@ -27,9 +25,6 @@ import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointSchemaManager;
 import io.trino.plugin.hive.FileFormatDataSourceStats;
 import io.trino.plugin.hive.HiveTransactionHandle;
-import io.trino.plugin.hive.metastore.Database;
-import io.trino.plugin.hive.metastore.PrincipalPrivileges;
-import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.plugin.hive.parquet.ParquetWriterConfig;
 import io.trino.spi.SplitWeight;
@@ -38,7 +33,6 @@ import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.DynamicFilter;
-import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.TypeManager;
 import io.trino.testing.TestingConnectorContext;
@@ -162,7 +156,6 @@ public class TestDeltaLakeSplitManager
         TestingConnectorContext context = new TestingConnectorContext();
         TypeManager typeManager = context.getTypeManager();
 
-        MockDeltaLakeMetastore metastore = new MockDeltaLakeMetastore();
         return new DeltaLakeSplitManager(
                 typeManager,
                 new TransactionLogAccess(
@@ -179,7 +172,6 @@ public class TestDeltaLakeSplitManager
                         return addFileEntries;
                     }
                 },
-                (session, transaction) -> metastore,
                 MoreExecutors.newDirectExecutorService(),
                 deltaLakeConfig);
     }
@@ -221,75 +213,5 @@ public class TestDeltaLakeSplitManager
         return TestingConnectorSession.builder()
                 .setPropertyMetadata(sessionProperties.getSessionProperties())
                 .build();
-    }
-
-    private static class MockDeltaLakeMetastore
-            implements DeltaLakeMetastore
-    {
-        @Override
-        public List<String> getAllDatabases()
-        {
-            throw new UnsupportedOperationException("Unimplemented");
-        }
-
-        @Override
-        public Optional<Database> getDatabase(String databaseName)
-        {
-            throw new UnsupportedOperationException("Unimplemented");
-        }
-
-        @Override
-        public List<String> getAllTables(String databaseName)
-        {
-            throw new UnsupportedOperationException("Unimplemented");
-        }
-
-        @Override
-        public Optional<Table> getRawMetastoreTable(String databaseName, String tableName)
-        {
-            throw new UnsupportedOperationException("Unimplemented");
-        }
-
-        @Override
-        public Optional<DeltaMetastoreTable> getTable(String databaseName, String tableName)
-        {
-            throw new UnsupportedOperationException("Unimplemented");
-        }
-
-        @Override
-        public void createDatabase(Database database)
-        {
-            throw new UnsupportedOperationException("Unimplemented");
-        }
-
-        @Override
-        public void dropDatabase(String databaseName, boolean deleteData)
-        {
-            throw new UnsupportedOperationException("Unimplemented");
-        }
-
-        @Override
-        public void createTable(ConnectorSession session, Table table, PrincipalPrivileges principalPrivileges)
-        {
-            throw new UnsupportedOperationException("Unimplemented");
-        }
-
-        @Override
-        public void dropTable(ConnectorSession session, SchemaTableName schemaTableName, String tableLocation, boolean deleteData)
-        {
-            throw new UnsupportedOperationException("Unimplemented");
-        }
-
-        @Override
-        public void renameTable(ConnectorSession session, SchemaTableName from, SchemaTableName to)
-        {
-            throw new UnsupportedOperationException("Unimplemented");
-        }
-
-        @Override
-        public TableSnapshot getSnapshot(SchemaTableName table, String tableLocation, ConnectorSession session)
-        {
-            return null; // hack, unused
-        }
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
@@ -21,7 +21,6 @@ import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
 import io.trino.plugin.deltalake.metastore.DeltaLakeMetastore;
 import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
-import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
 import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
 import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointSchemaManager;
@@ -283,12 +282,6 @@ public class TestDeltaLakeSplitManager
 
         @Override
         public MetadataEntry getMetadata(TableSnapshot tableSnapshot, ConnectorSession session)
-        {
-            throw new UnsupportedOperationException("Unimplemented");
-        }
-
-        @Override
-        public ProtocolEntry getProtocol(ConnectorSession session, TableSnapshot tableSnapshot)
         {
             throw new UnsupportedOperationException("Unimplemented");
         }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
@@ -71,7 +71,7 @@ public class TestDeltaLakeSplitManager
     private static final DeltaLakeTableHandle tableHandle = new DeltaLakeTableHandle(
             "schema",
             "table",
-            "location",
+            TABLE_PATH,
             metadataEntry,
             TupleDomain.all(),
             TupleDomain.all(),
@@ -269,7 +269,7 @@ public class TestDeltaLakeSplitManager
         }
 
         @Override
-        public void dropTable(ConnectorSession session, String databaseName, String tableName, boolean deleteData)
+        public void dropTable(ConnectorSession session, String databaseName, String tableName, String tableLocation, boolean deleteData)
         {
             throw new UnsupportedOperationException("Unimplemented");
         }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
@@ -40,7 +40,6 @@ import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
-import io.trino.spi.statistics.TableStatistics;
 import io.trino.spi.type.TypeManager;
 import io.trino.testing.TestingConnectorContext;
 import io.trino.testing.TestingConnectorSession;
@@ -291,12 +290,6 @@ public class TestDeltaLakeSplitManager
         public TableSnapshot getSnapshot(SchemaTableName table, String tableLocation, ConnectorSession session)
         {
             return null; // hack, unused
-        }
-
-        @Override
-        public TableStatistics getTableStatistics(ConnectorSession session, DeltaLakeTableHandle tableHandle)
-        {
-            throw new UnsupportedOperationException("Unimplemented");
         }
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
@@ -19,6 +19,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import io.airlift.units.DataSize;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
 import io.trino.plugin.deltalake.metastore.DeltaLakeMetastore;
+import io.trino.plugin.deltalake.metastore.DeltaMetastoreTable;
 import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
@@ -27,7 +28,6 @@ import io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointSchemaManag
 import io.trino.plugin.hive.FileFormatDataSourceStats;
 import io.trino.plugin.hive.HiveTransactionHandle;
 import io.trino.plugin.hive.metastore.Database;
-import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
@@ -246,7 +246,13 @@ public class TestDeltaLakeSplitManager
         }
 
         @Override
-        public Optional<Table> getTable(String databaseName, String tableName)
+        public Optional<Table> getRawMetastoreTable(String databaseName, String tableName)
+        {
+            throw new UnsupportedOperationException("Unimplemented");
+        }
+
+        @Override
+        public Optional<DeltaMetastoreTable> getTable(String databaseName, String tableName)
         {
             throw new UnsupportedOperationException("Unimplemented");
         }
@@ -282,12 +288,6 @@ public class TestDeltaLakeSplitManager
         }
 
         @Override
-        public String getTableLocation(SchemaTableName table)
-        {
-            return TABLE_PATH;
-        }
-
-        @Override
         public TableSnapshot getSnapshot(SchemaTableName table, String tableLocation, ConnectorSession session)
         {
             return null; // hack, unused
@@ -295,12 +295,6 @@ public class TestDeltaLakeSplitManager
 
         @Override
         public TableStatistics getTableStatistics(ConnectorSession session, DeltaLakeTableHandle tableHandle)
-        {
-            throw new UnsupportedOperationException("Unimplemented");
-        }
-
-        @Override
-        public HiveMetastore getHiveMetastore()
         {
             throw new UnsupportedOperationException("Unimplemented");
         }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
@@ -270,7 +270,7 @@ public class TestDeltaLakeSplitManager
         }
 
         @Override
-        public void dropTable(ConnectorSession session, String databaseName, String tableName, String tableLocation, boolean deleteData)
+        public void dropTable(ConnectorSession session, SchemaTableName schemaTableName, String tableLocation, boolean deleteData)
         {
             throw new UnsupportedOperationException("Unimplemented");
         }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
@@ -288,7 +288,7 @@ public class TestDeltaLakeSplitManager
         }
 
         @Override
-        public TableSnapshot getSnapshot(SchemaTableName table, ConnectorSession session)
+        public TableSnapshot getSnapshot(SchemaTableName table, String tableLocation, ConnectorSession session)
         {
             return null; // hack, unused
         }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
@@ -71,6 +71,7 @@ public class TestDeltaLakeSplitManager
     private static final DeltaLakeTableHandle tableHandle = new DeltaLakeTableHandle(
             "schema",
             "table",
+            true,
             TABLE_PATH,
             metadataEntry,
             TupleDomain.all(),

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
@@ -281,12 +281,6 @@ public class TestDeltaLakeSplitManager
         }
 
         @Override
-        public MetadataEntry getMetadata(TableSnapshot tableSnapshot, ConnectorSession session)
-        {
-            throw new UnsupportedOperationException("Unimplemented");
-        }
-
-        @Override
         public String getTableLocation(SchemaTableName table)
         {
             return TABLE_PATH;

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
@@ -144,6 +144,7 @@ public class TestTransactionLogAccess
         DeltaLakeTableHandle tableHandle = new DeltaLakeTableHandle(
                 "schema",
                 tableName,
+                true,
                 "location",
                 new MetadataEntry("id", "test", "description", null, "", ImmutableList.of(), ImmutableMap.of(), 0),
                 TupleDomain.none(),

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreAccessOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreAccessOperations.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.util.Optional;
 
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Methods.CREATE_TABLE;
+import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Methods.DROP_TABLE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Methods.GET_DATABASE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Methods.GET_TABLE;
 import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
@@ -236,6 +237,18 @@ public class TestDeltaLakeMetastoreAccessOperations
         assertMetastoreInvocations("SHOW STATS FOR (SELECT * FROM test_show_stats_with_filter where age >= 2)",
                 ImmutableMultiset.builder()
                         .add(GET_TABLE)
+                        .build());
+    }
+
+    @Test
+    public void testDropTable()
+    {
+        assertUpdate("CREATE TABLE test_drop_table AS SELECT 20050910 as a_number", 1);
+
+        assertMetastoreInvocations("DROP TABLE test_drop_table",
+                ImmutableMultiset.builder()
+                        .add(GET_TABLE)
+                        .add(DROP_TABLE)
                         .build());
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreStatistics.java
@@ -165,7 +165,7 @@ public class TestDeltaLakeMetastoreStatistics
                 schemaTableName.getSchemaName(),
                 schemaTableName.getTableName(),
                 true,
-                "location",
+                tableLocation,
                 metadataEntry,
                 TupleDomain.all(),
                 TupleDomain.all(),

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreStatistics.java
@@ -164,7 +164,7 @@ public class TestDeltaLakeMetastoreStatistics
         return new DeltaLakeTableHandle(
                 schemaTableName.getSchemaName(),
                 schemaTableName.getTableName(),
-                true,
+                false,
                 tableLocation,
                 metadataEntry,
                 TupleDomain.all(),

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreStatistics.java
@@ -164,6 +164,7 @@ public class TestDeltaLakeMetastoreStatistics
         return new DeltaLakeTableHandle(
                 schemaTableName.getSchemaName(),
                 schemaTableName.getTableName(),
+                true,
                 "location",
                 metadataEntry,
                 TupleDomain.all(),
@@ -293,6 +294,7 @@ public class TestDeltaLakeMetastoreStatistics
         DeltaLakeTableHandle tableHandleWithUnenforcedConstraint = new DeltaLakeTableHandle(
                 tableHandle.getSchemaName(),
                 tableHandle.getTableName(),
+                tableHandle.isManaged(),
                 tableHandle.getLocation(),
                 tableHandle.getMetadataEntry(),
                 TupleDomain.all(),
@@ -316,6 +318,7 @@ public class TestDeltaLakeMetastoreStatistics
         DeltaLakeTableHandle tableHandleWithNoneEnforcedConstraint = new DeltaLakeTableHandle(
                 tableHandle.getSchemaName(),
                 tableHandle.getTableName(),
+                tableHandle.isManaged(),
                 tableHandle.getLocation(),
                 tableHandle.getMetadataEntry(),
                 TupleDomain.none(),
@@ -329,6 +332,7 @@ public class TestDeltaLakeMetastoreStatistics
         DeltaLakeTableHandle tableHandleWithNoneUnenforcedConstraint = new DeltaLakeTableHandle(
                 tableHandle.getSchemaName(),
                 tableHandle.getTableName(),
+                tableHandle.isManaged(),
                 tableHandle.getLocation(),
                 tableHandle.getMetadataEntry(),
                 TupleDomain.all(),

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/statistics/TestDeltaLakeFileBasedTableStatisticsProvider.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/statistics/TestDeltaLakeFileBasedTableStatisticsProvider.java
@@ -11,39 +11,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.deltalake.metastore;
+package io.trino.plugin.deltalake.statistics;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
 import io.airlift.json.JsonCodecFactory;
 import io.trino.plugin.deltalake.DeltaLakeColumnHandle;
 import io.trino.plugin.deltalake.DeltaLakeConfig;
 import io.trino.plugin.deltalake.DeltaLakeTableHandle;
-import io.trino.plugin.deltalake.statistics.CachingExtendedStatisticsAccess;
-import io.trino.plugin.deltalake.statistics.DeltaLakeColumnStatistics;
-import io.trino.plugin.deltalake.statistics.ExtendedStatistics;
-import io.trino.plugin.deltalake.statistics.MetaDirStatisticsAccess;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
 import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointSchemaManager;
 import io.trino.plugin.hive.FileFormatDataSourceStats;
-import io.trino.plugin.hive.HiveType;
-import io.trino.plugin.hive.metastore.Column;
-import io.trino.plugin.hive.metastore.Database;
-import io.trino.plugin.hive.metastore.HiveMetastore;
-import io.trino.plugin.hive.metastore.PrincipalPrivileges;
-import io.trino.plugin.hive.metastore.Storage;
-import io.trino.plugin.hive.metastore.StorageFormat;
-import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
-import io.trino.spi.security.PrincipalType;
 import io.trino.spi.statistics.ColumnStatistics;
 import io.trino.spi.statistics.Estimate;
 import io.trino.spi.statistics.TableStatistics;
@@ -54,9 +40,7 @@ import io.trino.testing.TestingConnectorContext;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.time.LocalDate;
 import java.util.Map;
 import java.util.Optional;
@@ -64,12 +48,8 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 
 import static io.trino.plugin.deltalake.DeltaLakeColumnType.REGULAR;
-import static io.trino.plugin.deltalake.DeltaLakeMetadata.PATH_PROPERTY;
 import static io.trino.plugin.deltalake.DeltaTestingConnectorSession.SESSION;
-import static io.trino.plugin.deltalake.metastore.HiveMetastoreBackedDeltaLakeMetastore.TABLE_PROVIDER_PROPERTY;
-import static io.trino.plugin.deltalake.metastore.HiveMetastoreBackedDeltaLakeMetastore.TABLE_PROVIDER_VALUE;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_FILE_SYSTEM_FACTORY;
-import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
@@ -82,18 +62,16 @@ import static java.lang.Double.POSITIVE_INFINITY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
-public class TestDeltaLakeMetastoreStatistics
+public class TestDeltaLakeFileBasedTableStatisticsProvider
 {
     private static final ColumnHandle COLUMN_HANDLE = new DeltaLakeColumnHandle("val", DoubleType.DOUBLE, OptionalInt.empty(), "val", DoubleType.DOUBLE, REGULAR);
 
     private TransactionLogAccess transactionLogAccess;
-    private DeltaLakeMetastore deltaLakeMetastore;
-    private HiveMetastore hiveMetastore;
     private CachingExtendedStatisticsAccess statistics;
+    private DeltaLakeTableStatisticsProvider tableStatisticsProvider;
 
     @BeforeClass
     public void setupMetastore()
-            throws Exception
     {
         TestingConnectorContext context = new TestingConnectorContext();
         TypeManager typeManager = context.getTypeManager();
@@ -109,19 +87,11 @@ public class TestDeltaLakeMetastoreStatistics
                 HDFS_FILE_SYSTEM_FACTORY,
                 new ParquetReaderConfig());
 
-        File tmpDir = Files.createTempDirectory(null).toFile();
-        File metastoreDir = new File(tmpDir, "metastore");
-        hiveMetastore = createTestingFileHiveMetastore(metastoreDir);
-
-        hiveMetastore.createDatabase(new Database("db_name", Optional.empty(), Optional.of("test"), Optional.of(PrincipalType.USER), Optional.empty(), ImmutableMap.of()));
-
         statistics = new CachingExtendedStatisticsAccess(new MetaDirStatisticsAccess(HDFS_FILE_SYSTEM_FACTORY, new JsonCodecFactory().jsonCodec(ExtendedStatistics.class)));
-        deltaLakeMetastore = new HiveMetastoreBackedDeltaLakeMetastore(
-                hiveMetastore,
-                transactionLogAccess,
+        tableStatisticsProvider = new FileBasedTableStatisticsProvider(
                 typeManager,
-                statistics,
-                HDFS_FILE_SYSTEM_FACTORY);
+                transactionLogAccess,
+                statistics);
     }
 
     private DeltaLakeTableHandle registerTable(String tableName)
@@ -132,26 +102,7 @@ public class TestDeltaLakeMetastoreStatistics
     private DeltaLakeTableHandle registerTable(String tableName, String directoryName)
     {
         String tableLocation = Resources.getResource("statistics/" + directoryName).toExternalForm();
-
-        Storage tableStorage = new Storage(
-                StorageFormat.create("serde", "input", "output"), Optional.of(tableLocation), Optional.empty(), true, ImmutableMap.of(PATH_PROPERTY, tableLocation));
-
         SchemaTableName schemaTableName = new SchemaTableName("db_name", tableName);
-        hiveMetastore.createTable(
-                new Table(
-                        schemaTableName.getSchemaName(),
-                        schemaTableName.getTableName(),
-                        Optional.of("test"),
-                        "EXTERNAL_TABLE",
-                        tableStorage,
-                        ImmutableList.of(new Column("val", HiveType.HIVE_DOUBLE, Optional.empty())),
-                        ImmutableList.of(),
-                        ImmutableMap.of(TABLE_PROVIDER_PROPERTY, TABLE_PROVIDER_VALUE),
-                        Optional.empty(),
-                        Optional.empty(),
-                        OptionalLong.empty()),
-                PrincipalPrivileges.fromHivePrivilegeInfos(ImmutableSet.of()));
-
         TableSnapshot tableSnapshot;
         try {
             tableSnapshot = transactionLogAccess.loadSnapshot(schemaTableName, tableLocation, SESSION);
@@ -160,7 +111,6 @@ public class TestDeltaLakeMetastoreStatistics
             throw new RuntimeException(e);
         }
         MetadataEntry metadataEntry = transactionLogAccess.getMetadataEntry(tableSnapshot, SESSION);
-
         return new DeltaLakeTableHandle(
                 schemaTableName.getSchemaName(),
                 schemaTableName.getTableName(),
@@ -181,7 +131,7 @@ public class TestDeltaLakeMetastoreStatistics
     public void testStatisticsNaN()
     {
         DeltaLakeTableHandle tableHandle = registerTable("nan");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
+        TableStatistics stats = getTableStatistics(SESSION, tableHandle);
         assertEquals(stats.getRowCount(), Estimate.of(1));
         assertEquals(stats.getColumnStatistics().size(), 1);
 
@@ -193,7 +143,7 @@ public class TestDeltaLakeMetastoreStatistics
     public void testStatisticsInf()
     {
         DeltaLakeTableHandle tableHandle = registerTable("positive_infinity");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
+        TableStatistics stats = getTableStatistics(SESSION, tableHandle);
         ColumnStatistics columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange().get().getMin(), POSITIVE_INFINITY);
         assertEquals(columnStatistics.getRange().get().getMax(), POSITIVE_INFINITY);
@@ -203,7 +153,7 @@ public class TestDeltaLakeMetastoreStatistics
     public void testStatisticsNegInf()
     {
         DeltaLakeTableHandle tableHandle = registerTable("negative_infinity");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
+        TableStatistics stats = getTableStatistics(SESSION, tableHandle);
         ColumnStatistics columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange().get().getMin(), NEGATIVE_INFINITY);
         assertEquals(columnStatistics.getRange().get().getMax(), NEGATIVE_INFINITY);
@@ -213,7 +163,7 @@ public class TestDeltaLakeMetastoreStatistics
     public void testStatisticsNegZero()
     {
         DeltaLakeTableHandle tableHandle = registerTable("negative_zero");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
+        TableStatistics stats = getTableStatistics(SESSION, tableHandle);
         ColumnStatistics columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange().get().getMin(), -0.0d);
         assertEquals(columnStatistics.getRange().get().getMax(), -0.0d);
@@ -224,7 +174,7 @@ public class TestDeltaLakeMetastoreStatistics
     {
         // Stats with NaN values cannot be used
         DeltaLakeTableHandle tableHandle = registerTable("infinity_nan");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
+        TableStatistics stats = getTableStatistics(SESSION, tableHandle);
         ColumnStatistics columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange().get().getMin(), POSITIVE_INFINITY);
         assertEquals(columnStatistics.getRange().get().getMax(), POSITIVE_INFINITY);
@@ -235,7 +185,7 @@ public class TestDeltaLakeMetastoreStatistics
     {
         // Stats with NaN values cannot be used
         DeltaLakeTableHandle tableHandle = registerTable("negative_infinity_nan");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
+        TableStatistics stats = getTableStatistics(SESSION, tableHandle);
         ColumnStatistics columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange().get().getMin(), NEGATIVE_INFINITY);
         assertEquals(columnStatistics.getRange().get().getMax(), POSITIVE_INFINITY);
@@ -246,7 +196,7 @@ public class TestDeltaLakeMetastoreStatistics
     {
         // Stats with NaN values cannot be used
         DeltaLakeTableHandle tableHandle = registerTable("zero_nan");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
+        TableStatistics stats = getTableStatistics(SESSION, tableHandle);
         ColumnStatistics columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange().get().getMin(), 0.0);
         assertEquals(columnStatistics.getRange().get().getMax(), POSITIVE_INFINITY);
@@ -256,7 +206,7 @@ public class TestDeltaLakeMetastoreStatistics
     public void testStatisticsZeroAndInfinity()
     {
         DeltaLakeTableHandle tableHandle = registerTable("zero_infinity");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
+        TableStatistics stats = getTableStatistics(SESSION, tableHandle);
         ColumnStatistics columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange().get().getMin(), 0.0);
         assertEquals(columnStatistics.getRange().get().getMax(), POSITIVE_INFINITY);
@@ -266,7 +216,7 @@ public class TestDeltaLakeMetastoreStatistics
     public void testStatisticsZeroAndNegativeInfinity()
     {
         DeltaLakeTableHandle tableHandle = registerTable("zero_negative_infinity");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
+        TableStatistics stats = getTableStatistics(SESSION, tableHandle);
         ColumnStatistics columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange().get().getMin(), NEGATIVE_INFINITY);
         assertEquals(columnStatistics.getRange().get().getMax(), 0.0);
@@ -277,7 +227,7 @@ public class TestDeltaLakeMetastoreStatistics
     {
         // Stats with NaN values cannot be used. This transaction combines a file with NaN min/max values with one with 0.0 min/max values
         DeltaLakeTableHandle tableHandle = registerTable("nan_multi_file");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
+        TableStatistics stats = getTableStatistics(SESSION, tableHandle);
         ColumnStatistics columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange(), Optional.empty());
     }
@@ -286,7 +236,7 @@ public class TestDeltaLakeMetastoreStatistics
     public void testStatisticsMultipleFiles()
     {
         DeltaLakeTableHandle tableHandle = registerTable("basic_multi_file");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
+        TableStatistics stats = getTableStatistics(SESSION, tableHandle);
         ColumnStatistics columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange().get().getMin(), -42.0);
         assertEquals(columnStatistics.getRange().get().getMax(), 42.0);
@@ -305,7 +255,7 @@ public class TestDeltaLakeMetastoreStatistics
                 tableHandle.getUpdateRowIdColumns(),
                 tableHandle.getAnalyzeHandle(),
                 0);
-        stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandleWithUnenforcedConstraint);
+        stats = getTableStatistics(SESSION, tableHandleWithUnenforcedConstraint);
         columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange().get().getMin(), 0.0);
         assertEquals(columnStatistics.getRange().get().getMax(), 42.0);
@@ -344,8 +294,8 @@ public class TestDeltaLakeMetastoreStatistics
                 tableHandle.getAnalyzeHandle(),
                 0);
         // If either the table handle's constraint or the provided Constraint are none, it will cause a 0 record count to be reported
-        assertEmptyStats(deltaLakeMetastore.getTableStatistics(SESSION, tableHandleWithNoneEnforcedConstraint));
-        assertEmptyStats(deltaLakeMetastore.getTableStatistics(SESSION, tableHandleWithNoneUnenforcedConstraint));
+        assertEmptyStats(getTableStatistics(SESSION, tableHandleWithNoneEnforcedConstraint));
+        assertEmptyStats(getTableStatistics(SESSION, tableHandleWithNoneUnenforcedConstraint));
     }
 
     private void assertEmptyStats(TableStatistics tableStatistics)
@@ -361,7 +311,7 @@ public class TestDeltaLakeMetastoreStatistics
     {
         // The transaction log for this table was created so that the checkpoints only write struct statistics, not json statistics
         DeltaLakeTableHandle tableHandle = registerTable("parquet_struct_statistics");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
+        TableStatistics stats = getTableStatistics(SESSION, tableHandle);
         assertEquals(stats.getRowCount(), Estimate.of(9));
 
         Map<ColumnHandle, ColumnStatistics> statisticsMap = stats.getColumnStatistics();
@@ -417,7 +367,7 @@ public class TestDeltaLakeMetastoreStatistics
         // The transaction log for this table was created so that the checkpoints only write struct statistics, not json statistics
         // The table has a REAL and DOUBLE columns each with 9 values, one of them being NaN
         DeltaLakeTableHandle tableHandle = registerTable("parquet_struct_statistics_nan");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
+        TableStatistics stats = getTableStatistics(SESSION, tableHandle);
         assertEquals(stats.getRowCount(), Estimate.of(9));
 
         Map<ColumnHandle, ColumnStatistics> statisticsMap = stats.getColumnStatistics();
@@ -436,7 +386,7 @@ public class TestDeltaLakeMetastoreStatistics
         // The transaction log for this table was created so that the checkpoints only write struct statistics, not json statistics
         // The table has one INTEGER column 'i' where 3 of the 9 values are null
         DeltaLakeTableHandle tableHandle = registerTable("parquet_struct_statistics_null_count");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
+        TableStatistics stats = getTableStatistics(SESSION, tableHandle);
         assertEquals(stats.getRowCount(), Estimate.of(9));
 
         Map<ColumnHandle, ColumnStatistics> statisticsMap = stats.getColumnStatistics();
@@ -492,5 +442,17 @@ public class TestDeltaLakeMetastoreStatistics
         DeltaLakeColumnStatistics mergedComment = columnStatisticsWithoutDataSize.get("comment").update(columnStatisticsWithDataSize.get("comment"));
         assertEquals(mergedComment.getTotalSizeInBytes(), OptionalLong.empty());
         assertEquals(mergedComment.getNdvSummary().cardinality(), 5);
+    }
+
+    private TableStatistics getTableStatistics(ConnectorSession session, DeltaLakeTableHandle tableHandle)
+    {
+        TableSnapshot tableSnapshot;
+        try {
+            tableSnapshot = transactionLogAccess.loadSnapshot(tableHandle.getSchemaTableName(), tableHandle.getLocation(), SESSION);
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return tableStatisticsProvider.getTableStatistics(session, tableHandle, tableSnapshot);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -723,7 +723,7 @@ public class SemiTransactionalHiveMetastore
         SchemaTableName schemaTableName = new SchemaTableName(databaseName, tableName);
         Table table = getTable(databaseName, tableName)
                 .orElseThrow(() -> new TableNotFoundException(schemaTableName));
-        if (!table.getTableType().equals(MANAGED_TABLE.toString())) {
+        if (!table.getTableType().equals(MANAGED_TABLE.name())) {
             throw new TrinoException(NOT_SUPPORTED, "Cannot delete from non-managed Hive table");
         }
         if (!table.getPartitionColumns().isEmpty()) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
@@ -377,11 +377,11 @@ public final class HiveWriteUtils
 
     public static void checkTableIsWritable(Table table, boolean writesToNonManagedTablesEnabled)
     {
-        if (table.getTableType().equals(MATERIALIZED_VIEW.toString())) {
+        if (table.getTableType().equals(MATERIALIZED_VIEW.name())) {
             throw new TrinoException(NOT_SUPPORTED, "Cannot write to Hive materialized view");
         }
 
-        if (!writesToNonManagedTablesEnabled && !table.getTableType().equals(MANAGED_TABLE.toString())) {
+        if (!writesToNonManagedTablesEnabled && !table.getTableType().equals(MANAGED_TABLE.name())) {
             throw new TrinoException(NOT_SUPPORTED, "Cannot write to non-managed Hive table");
         }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -1363,7 +1363,7 @@ public class TestBackgroundHiveSplitLoader
                 .setDatabaseName("test_dbname")
                 .setOwner(Optional.of("testOwner"))
                 .setTableName("test_table")
-                .setTableType(TableType.MANAGED_TABLE.toString())
+                .setTableType(TableType.MANAGED_TABLE.name())
                 .setDataColumns(ImmutableList.of(new Column("col1", HIVE_STRING, Optional.empty())))
                 .setParameters(tableParameters)
                 .setPartitionColumns(partitionColumns)

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -29,6 +29,11 @@
     <dependencies>
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-delta-lake</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-filesystem</artifactId>
         </dependency>
 
@@ -355,6 +360,13 @@
         </dependency>
 
         <!-- for testing -->
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-delta-lake</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-exchange-filesystem</artifactId>

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
@@ -19,6 +19,9 @@ import com.google.inject.Module;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
+import io.trino.plugin.deltalake.DeltaLakeConfig;
+import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
+import io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointSchemaManager;
 import io.trino.plugin.hive.FileFormatDataSourceStats;
 import io.trino.plugin.hive.SortingFileWriterConfig;
 import io.trino.plugin.hive.metastore.thrift.TranslateHiveViews;
@@ -93,5 +96,10 @@ public class IcebergModule
         tableProcedures.addBinding().toProvider(DropExtendedStatsTableProcedure.class).in(Scopes.SINGLETON);
         tableProcedures.addBinding().toProvider(ExpireSnapshotsTableProcedure.class).in(Scopes.SINGLETON);
         tableProcedures.addBinding().toProvider(RemoveOrphanFilesTableProcedure.class).in(Scopes.SINGLETON);
+
+        // Used for migrating Delta Lake tables to Iceberg. Intentionally not exposing Delta Lake config via configBinder
+        binder.bind(DeltaLakeConfig.class).in(Scopes.SINGLETON);
+        binder.bind(TransactionLogAccess.class).in(Scopes.SINGLETON);
+        binder.bind(CheckpointSchemaManager.class).in(Scopes.SINGLETON);
     }
 }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/AbstractSinglenodeDeltaLakeDatabricks.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/AbstractSinglenodeDeltaLakeDatabricks.java
@@ -63,6 +63,10 @@ public abstract class AbstractSinglenodeDeltaLakeDatabricks
                 "delta_lake",
                 forHostPath(configDir.getPath("delta.properties")),
                 CONTAINER_TRINO_ETC + "/catalog/delta.properties");
+        builder.addConnector(
+                "iceberg",
+                forHostPath(configDir.getPath("iceberg.properties")),
+                CONTAINER_TRINO_ETC + "/catalog/iceberg.properties");
 
         builder.configureContainer(TESTS, container -> exportAWSCredentials(container)
                 .withEnv("S3_BUCKET", s3Bucket)

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeDeltaLakeOss.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeDeltaLakeOss.java
@@ -99,6 +99,10 @@ public class EnvSinglenodeDeltaLakeOss
                 "delta_lake",
                 forHostPath(configDir.getPath("delta.properties")),
                 CONTAINER_TRINO_ETC + "/catalog/delta.properties");
+        builder.addConnector(
+                "iceberg",
+                forHostPath(configDir.getPath("iceberg.properties")),
+                CONTAINER_TRINO_ETC + "/catalog/iceberg.properties");
 
         builder.configureContainer(TESTS, dockerContainer -> {
             dockerContainer.withEnv("S3_BUCKET", s3Bucket)

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeDatabricks104.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeDatabricks104.java
@@ -31,7 +31,7 @@ public class SuiteDeltaLakeDatabricks104
     {
         return ImmutableList.of(
                 testOnEnvironment(EnvSinglenodeDeltaLakeDatabricks104.class)
-                        .withGroups("configured_features", "delta-lake-databricks")
+                        .withGroups("configured_features", "delta-lake-databricks", "iceberg_delta_lake_migration")
                         .withExcludedGroups("delta-lake-exclude-104")
                         .withExcludedTests(getExcludedTests())
                         .build());

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeDatabricks113.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeDatabricks113.java
@@ -31,7 +31,7 @@ public class SuiteDeltaLakeDatabricks113
     {
         return ImmutableList.of(
                 testOnEnvironment(EnvSinglenodeDeltaLakeDatabricks113.class)
-                        .withGroups("configured_features", "delta-lake-databricks")
+                        .withGroups("configured_features", "delta-lake-databricks", "iceberg_delta_lake_migration")
                         .withExcludedGroups("delta-lake-exclude-113")
                         .withExcludedTests(getExcludedTests())
                         .build());

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeDatabricks122.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeDatabricks122.java
@@ -31,7 +31,7 @@ public class SuiteDeltaLakeDatabricks122
     {
         return ImmutableList.of(
                 testOnEnvironment(EnvSinglenodeDeltaLakeDatabricks122.class)
-                        .withGroups("configured_features", "delta-lake-databricks")
+                        .withGroups("configured_features", "delta-lake-databricks", "iceberg_delta_lake_migration")
                         .withExcludedGroups("delta-lake-exclude-122")
                         .withExcludedTests(getExcludedTests())
                         .build());

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeDatabricks73.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeDatabricks73.java
@@ -31,7 +31,7 @@ public class SuiteDeltaLakeDatabricks73
     {
         return ImmutableList.of(
                 testOnEnvironment(EnvSinglenodeDeltaLakeDatabricks73.class)
-                        .withGroups("configured_features", "delta-lake-databricks")
+                        .withGroups("configured_features", "delta-lake-databricks", "iceberg_delta_lake_migration")
                         .withExcludedGroups("delta-lake-exclude-73")
                         .withExcludedTests(getExcludedTests())
                         .build());

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeDatabricks91.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeDatabricks91.java
@@ -31,7 +31,7 @@ public class SuiteDeltaLakeDatabricks91
     {
         return ImmutableList.of(
                 testOnEnvironment(EnvSinglenodeDeltaLakeDatabricks91.class)
-                        .withGroups("configured_features", "delta-lake-databricks")
+                        .withGroups("configured_features", "delta-lake-databricks", "iceberg_delta_lake_migration")
                         .withExcludedGroups("delta-lake-exclude-91")
                         .withExcludedTests(getExcludedTests())
                         .build());

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeOss.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeOss.java
@@ -43,7 +43,7 @@ public class SuiteDeltaLakeOss
                 testOnEnvironment(EnvSinglenodeDeltaLakeOss.class)
                         // TODO: make the list of tests run here as close to those run on SinglenodeDeltaLakeDatabricks
                         //  e.g. replace `delta-lake-oss` group with `delta-lake-databricks` + any exclusions, of needed
-                        .withGroups("configured_features", "delta-lake-oss")
+                        .withGroups("configured_features", "delta-lake-oss", "iceberg_delta_lake_migration")
                         .build());
     }
 }

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-delta-lake-databricks/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-delta-lake-databricks/iceberg.properties
@@ -1,0 +1,5 @@
+connector.name=iceberg
+iceberg.catalog.type=glue
+hive.metastore.glue.region=${ENV:AWS_REGION}
+# We need to give access to bucket owner (the AWS account integrated with Databricks), otherwise files won't be readable from Databricks
+hive.s3.upload-acl-type=BUCKET_OWNER_FULL_CONTROL

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-delta-lake-oss/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-delta-lake-oss/iceberg.properties
@@ -1,0 +1,7 @@
+connector.name=iceberg
+hive.metastore.uri=thrift://hadoop-master:9083
+hive.s3.aws-access-key=minio-access-key
+hive.s3.aws-secret-key=minio-secret-key
+hive.s3.endpoint=http://minio:9080/
+hive.s3.path-style-access=true
+hive.s3.ssl.enabled=false

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestGroups.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestGroups.java
@@ -71,6 +71,7 @@ public final class TestGroups
     public static final String KAFKA = "kafka";
     public static final String TWO_HIVES = "two_hives";
     public static final String ICEBERG = "iceberg";
+    public static final String ICEBERG_DELTA_LAKE_MIGRATION = "iceberg_delta_lake_migration";
     public static final String ICEBERG_FORMAT_VERSION_COMPATIBILITY = "iceberg_format_version_compatibility";
     public static final String ICEBERG_REST = "iceberg_rest";
     public static final String ICEBERG_JDBC = "iceberg_jdbc";

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergDeltaLakeMigration.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergDeltaLakeMigration.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.tests.product.deltalake.BaseTestDeltaLakeS3Storage;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.time.LocalDate;
+
+import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
+import static io.trino.tempto.assertions.QueryAssert.assertThat;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.tests.product.TestGroups.ICEBERG_DELTA_LAKE_MIGRATION;
+import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.utils.QueryExecutors.onDelta;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+import static java.lang.String.format;
+
+public class TestIcebergDeltaLakeMigration
+        extends BaseTestDeltaLakeS3Storage
+{
+    @Test(groups = {ICEBERG_DELTA_LAKE_MIGRATION, PROFILE_SPECIFIC_TESTS})
+    public void testMigrateDeltaLakeTable()
+    {
+        String tableName = "test_migrate_delta_lake_" + randomNameSuffix();
+        String icebergTableName = "iceberg.default." + tableName;
+        String sparkTableName = "default." + tableName;
+
+        onDelta().executeQuery(format("CREATE TABLE " + sparkTableName + " USING DELTA LOCATION 's3://%s/%s' AS SELECT " +
+                "    true a_boolean," +
+                "     67 a_tinyint," +
+                "     35 a_smallint," +
+                "    CAST(-1546831166 AS INT) an_integer," +
+                "    1544323431676534245 a_bigint," +
+                "    12345.67F a_real," +
+                "    12345.678901234D a_double," +
+                "    CAST('1234567.8901' AS decimal(11, 4)) a_short_decimal," +
+                "    CAST('1234567890123456789.0123456' AS decimal(26, 7)) a_long_decimal," +
+                "    'some longer string' an_unbounded_varchar," +
+                "    X'65683F' a_varbinary," +
+                "    DATE '2005-09-10' a_date," +
+                "    ARRAY(1, 10, 100, 1000) an_array_of_ints," +
+                "    map('map_key', ARRAY(1, 2, 3)) a_map_with_int_array," +
+                "    named_struct('struct_name', 42) a_row_with_int", bucketName, tableName));
+
+        onTrino().executeQuery("CALL iceberg.system.migrate('default', '" + tableName + "')");
+        assertThat(onTrino().executeQuery("SELECT * FROM " + icebergTableName))
+                .containsOnly(row(
+                        true,
+                        67,
+                        35,
+                        -1546831166,
+                        1544323431676534245L,
+                        12345.67F,
+                        12345.678901234D,
+                        new BigDecimal("1234567.8901"),
+                        new BigDecimal("1234567890123456789.0123456"),
+                        "some longer string",
+                        new byte[]{(byte) 0x65, (byte) 0x68, (byte) 0x3F},
+                        Date.valueOf(LocalDate.of(2005, 9, 10)),
+                        ImmutableList.of(1, 10, 100, 1000),
+                        ImmutableMap.of("map_key", ImmutableList.of(1, 2, 3)),
+                        io.trino.jdbc.Row.builder().addField("struct_name", 42).build()));
+
+        onTrino().executeQuery("DROP TABLE IF EXISTS " + icebergTableName);
+    }
+
+    @Test(groups = {ICEBERG_DELTA_LAKE_MIGRATION, PROFILE_SPECIFIC_TESTS})
+    public void testMigratePartitionedDeltaLakeTable()
+    {
+        String tableName = "test_migrate_partitioned_delta_lake_" + randomNameSuffix();
+        String icebergTableName = "iceberg.default." + tableName;
+        String sparkTableName = "default." + tableName;
+
+        onDelta().executeQuery(format("CREATE TABLE " + sparkTableName + " USING DELTA LOCATION 's3://%s/%s' PARTITIONED BY " +
+                "   (a_boolean, a_tinyint, a_smallint, an_integer, a_bigint, a_real, a_double, a_short_decimal, a_long_decimal, an_unbounded_varchar, a_date)" +
+                " AS SELECT " +
+                "    true a_boolean," +
+                "     67 a_tinyint," +
+                "     35 a_smallint," +
+                "    CAST(-1546831166 AS INT) an_integer," +
+                "    1544323431676534245 a_bigint," +
+                "    12345.67F a_real," +
+                "    12345.678901234D a_double," +
+                "    CAST('1234567.8901' AS decimal(11, 4)) a_short_decimal," +
+                "    CAST('1234567890123456789.0123456' AS decimal(26, 7)) a_long_decimal," +
+                "    'some longer string' an_unbounded_varchar," +
+                "    X'65683F' a_varbinary," +
+                "    DATE '2005-09-10' a_date," +
+                "    ARRAY(1, 10, 100, 1000) an_array_of_ints," +
+                "    map('map_key', ARRAY(1, 2, 3)) a_map_with_int_array," +
+                "    named_struct('struct_name', 42) a_row_with_int", bucketName, tableName));
+
+        onTrino().executeQuery("CALL iceberg.system.migrate('default', '" + tableName + "')");
+        assertThat(onTrino().executeQuery("SELECT * FROM " + icebergTableName))
+                .containsOnly(row(
+                        true,
+                        67,
+                        35,
+                        -1546831166,
+                        1544323431676534245L,
+                        12345.67F,
+                        12345.678901234D,
+                        new BigDecimal("1234567.8901"),
+                        new BigDecimal("1234567890123456789.0123456"),
+                        "some longer string",
+                        new byte[]{(byte) 0x65, (byte) 0x68, (byte) 0x3F},
+                        Date.valueOf(LocalDate.of(2005, 9, 10)),
+                        ImmutableList.of(1, 10, 100, 1000),
+                        ImmutableMap.of("map_key", ImmutableList.of(1, 2, 3)),
+                        io.trino.jdbc.Row.builder().addField("struct_name", 42).build()));
+
+        onTrino().executeQuery("DROP TABLE IF EXISTS " + icebergTableName);
+    }
+
+    @Test(groups = {ICEBERG_DELTA_LAKE_MIGRATION, PROFILE_SPECIFIC_TESTS})
+    public void testMigratedTableStats()
+    {
+        String tableName = "test_migrate_table_stats_" + randomNameSuffix();
+        String sparkTableName = "default." + tableName;
+        String deltaTableName = "delta.default." + tableName;
+        String icebergTableName = "iceberg.default." + tableName;
+
+        onDelta().executeQuery(format("CREATE TABLE " + sparkTableName + "(id INT, a_double DOUBLE) USING DELTA LOCATION 's3://%s/%s'", bucketName, tableName));
+        onDelta().executeQuery("INSERT INTO " + sparkTableName + " VALUES (1, 1.0), (10, 10.123), (3, null)");
+        onDelta().executeQuery("OPTIMIZE " + sparkTableName);
+
+        onTrino().executeQuery("ANALYZE " + deltaTableName);
+
+        assertThat(onTrino().executeQuery("SHOW STATS FOR " + deltaTableName))
+                .containsOnly(
+                        row("id", null, 3.0, 0.0, null, "1", "10"),
+                        row("a_double", null, 2.0, 1.0 / 3, null, "1.0", "10.123"),
+                        row(null, null, null, null, 3.0, null, null));
+
+        onTrino().executeQuery("CALL iceberg.system.migrate('default', '" + tableName + "')");
+        // Migrating NDV stats is not yet supported
+        assertThat(onTrino().executeQuery("SHOW STATS FOR " + icebergTableName))
+                .containsOnly(
+                        row("id", null, null, 0.0, null, "1", "10"),
+                        row("a_double", null, null, 1.0 / 3, null, "1.0", "10.123"),
+                        row(null, null, null, null, 3.0, null, null));
+
+        String icebergFilesTable = "iceberg.default.\"" + tableName + "$files\"";
+        assertThat(onTrino().executeQuery("SELECT record_count, value_counts, null_value_counts, nan_value_counts, lower_bounds, upper_bounds FROM " + icebergFilesTable))
+                .contains(row(
+                        3,
+                        ImmutableMap.of(1, 3L, 2, 3L),
+                        ImmutableMap.of(1, 0L, 2, 1L),
+                        ImmutableMap.of(),
+                        ImmutableMap.of(1, "1", 2, "1.0"),
+                        ImmutableMap.of(1, "10", 2, "10.123")));
+    }
+
+    @Test(groups = {ICEBERG_DELTA_LAKE_MIGRATION, PROFILE_SPECIFIC_TESTS})
+    public void testMigrateUnsupportedWriterVersion()
+    {
+        String tableName = "test_migrate_unsupported_writer_version_" + randomNameSuffix();
+        onDelta().executeQuery(format("CREATE TABLE default." + tableName + " USING DELTA LOCATION 's3://%s/%s' TBLPROPERTIES ('delta.minWriterVersion' = 3) AS SELECT 1 x", bucketName, tableName));
+        assertQueryFailure(() -> onTrino().executeQuery("CALL iceberg.system.migrate('default', '" + tableName + "')"))
+                .hasMessageContaining("Migration of Delta Lake tables using writer versions above 2 is not supported");
+        onTrino().executeQuery("DROP TABLE IF EXISTS delta.default." + tableName);
+    }
+
+    @Test(groups = {ICEBERG_DELTA_LAKE_MIGRATION, PROFILE_SPECIFIC_TESTS})
+    public void testMigrateUnsupportedReaderVersion()
+    {
+        String tableName = "test_migrate_unsupported_reader_version_" + randomNameSuffix();
+        onDelta().executeQuery(format("CREATE TABLE default." + tableName + " USING DELTA LOCATION 's3://%s/%s' TBLPROPERTIES ('delta.minReaderVersion' = 2) AS SELECT 1 x", bucketName, tableName));
+        assertQueryFailure(() -> onTrino().executeQuery("CALL iceberg.system.migrate('default', '" + tableName + "')"))
+                .hasMessageContaining("Migration of Delta Lake tables using reader versions above 1 is not supported");
+        onTrino().executeQuery("DROP TABLE IF EXISTS delta.default." + tableName);
+    }
+}


### PR DESCRIPTION
## Description

Support migrating Delta Lake tables to Iceberg

Still a draft because it is based on https://github.com/trinodb/trino/pull/17092

TODO:
- Additional testing
- See if metrics can be created based on existing Delta Lake stats rather than re-reading the data file
- Support for tables with column mapping modes

## Additional context and related issues

Fixes: https://github.com/trinodb/trino/issues/16572

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Add support to the migrate procedure to convert Delta Lake tables to Iceberg.
```
