### PR TITLE
Implement predicate push down for parquet dereference column in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.VerifyException;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.BiMap;
@@ -85,7 +86,6 @@ import io.trino.spi.predicate.ValueSet;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.RowType;
-import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import org.apache.avro.file.DataFileStream;
@@ -149,6 +149,7 @@ import static io.trino.parquet.ParquetTypeUtils.getDescriptors;
 import static io.trino.parquet.predicate.PredicateUtils.buildPredicate;
 import static io.trino.parquet.predicate.PredicateUtils.getFilteredRowGroups;
 import static io.trino.plugin.hive.parquet.ParquetPageSourceFactory.createDataSource;
+import static io.trino.plugin.iceberg.ColumnIdentity.TypeCategory.PRIMITIVE;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.TRINO_MERGE_PARTITION_DATA;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.TRINO_MERGE_PARTITION_SPEC_ID;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_BAD_DATA;
@@ -1466,7 +1467,8 @@ public class IcebergPageSourceProvider
         return Optional.of(new GroupType(baseType.getRepetition(), baseType.getName(), ImmutableList.of(type)));
     }
 
-    private static TupleDomain<ColumnDescriptor> getParquetTupleDomain(Map<List<String>, ColumnDescriptor> descriptorsByPath, TupleDomain<IcebergColumnHandle> effectivePredicate)
+    @VisibleForTesting
+    static TupleDomain<ColumnDescriptor> getParquetTupleDomain(Map<List<String>, ColumnDescriptor> descriptorsByPath, TupleDomain<IcebergColumnHandle> effectivePredicate)
     {
         if (effectivePredicate.isNone()) {
             return TupleDomain.none();
@@ -1476,9 +1478,9 @@ public class IcebergPageSourceProvider
                 .collect(toImmutableMap(descriptor -> descriptor.getPrimitiveType().getId().intValue(), identity()));
         ImmutableMap.Builder<ColumnDescriptor, Domain> predicate = ImmutableMap.builder();
         effectivePredicate.getDomains().orElseThrow().forEach((columnHandle, domain) -> {
-            String baseType = columnHandle.getType().getTypeSignature().getBase();
+            ColumnIdentity columnIdentity = columnHandle.getColumnIdentity();
             // skip looking up predicates for complex types as Parquet only stores stats for primitives
-            if (columnHandle.isBaseColumn() && (!baseType.equals(StandardTypes.MAP) && !baseType.equals(StandardTypes.ARRAY) && !baseType.equals(StandardTypes.ROW))) {
+            if (PRIMITIVE.equals(columnIdentity.getTypeCategory())) {
                 ColumnDescriptor descriptor = descriptorsById.get(columnHandle.getId());
                 if (descriptor != null) {
                     predicate.put(descriptor, domain);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetComplexTypesPredicatePushDown.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetComplexTypesPredicatePushDown.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import io.trino.Session;
+import io.trino.testing.BaseComplexTypesPredicatePushDownTest;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.plugin.iceberg.IcebergTestUtils.withSmallRowGroups;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+
+public class TestIcebergParquetComplexTypesPredicatePushDown
+        extends BaseComplexTypesPredicatePushDownTest
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.builder()
+                .addIcebergProperty("iceberg.file-format", "PARQUET")
+                .build();
+    }
+
+    @Override
+    protected final Session getSession()
+    {
+        return withSmallRowGroups(super.getSession());
+    }
+
+    // The Iceberg table scan differs from Hive in that the coordinator also uses file statistics when generating the splits .
+    // As a result, if the predicates fall outside the bounds of the file statistics,
+    // the split is not created for the worker and worker won't call getParquetTupleDomain().
+    // The test increased the number of row groups and introduced predicates that are within the file statistics but outside the statistics of the row groups.
+    @Test
+    public void testIcebergParquetRowTypeRowGroupPruning()
+    {
+        String tableName = "test_nested_column_pruning_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (col1Row ROW(a BIGINT, b BIGINT), col2 BIGINT) WITH (sorted_by=ARRAY['col2'])");
+        assertUpdate("INSERT INTO " + tableName + " SELECT * FROM unnest(transform(SEQUENCE(1, 10000), x -> ROW(ROW(x*2, 100), x)))", 10000);
+
+        // col1Row.a only contains even numbers, in the range of [2, 20000].
+        // The test has roughly 50 rows per row group due to withSmallRowGroups, [2, 100], [102, 200], ... [19902, 20000]
+        // 101 is a value between [2, 20000] but is an odd number, so won't be discarded by Iceberg table's statistics.
+        // At the same time, 101 is not within the bound of any row group. So can be discarded by Parquet's row group statistics.
+        assertNoDataRead("SELECT * FROM " + tableName + " WHERE col1Row.a = 101");
+        assertNoDataRead("SELECT * FROM " + tableName + " WHERE col1Row.a IS NULL");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestParquetPredicates.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestParquetPredicates.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.RowType;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.parquet.ParquetTypeUtils.getDescriptors;
+import static io.trino.plugin.iceberg.ColumnIdentity.TypeCategory.PRIMITIVE;
+import static io.trino.plugin.iceberg.ColumnIdentity.TypeCategory.STRUCT;
+import static io.trino.plugin.iceberg.IcebergPageSourceProvider.getParquetTupleDomain;
+import static io.trino.spi.predicate.TupleDomain.withColumnDomains;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RowType.rowType;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestParquetPredicates
+{
+    @Test
+    public void testParquetTupleDomainStructWithPrimitiveColumnPredicate()
+    {
+        // trino type
+        RowType baseType = rowType(
+                RowType.field("a", INTEGER),
+                RowType.field("b", INTEGER),
+                RowType.field("c", INTEGER));
+
+        // iceberg type
+        ColumnIdentity fieldA = new ColumnIdentity(1, "a", PRIMITIVE, ImmutableList.of());
+        ColumnIdentity fieldB = new ColumnIdentity(2, "b", PRIMITIVE, ImmutableList.of());
+        ColumnIdentity fieldC = new ColumnIdentity(3, "c", PRIMITIVE, ImmutableList.of());
+
+        // parquet type
+        MessageType fileSchema = new MessageType("iceberg_schema",
+                new GroupType(OPTIONAL, "row_field",
+                        new PrimitiveType(OPTIONAL, INT32, "a").withId(1),
+                        new PrimitiveType(OPTIONAL, INT32, "b").withId(2),
+                        new PrimitiveType(OPTIONAL, INT32, "c").withId(3)));
+
+        // predicate domain
+        IcebergColumnHandle projectedColumn = new IcebergColumnHandle(
+                new ColumnIdentity(
+                        5,
+                        "row_field",
+                        STRUCT,
+                        ImmutableList.of(fieldA, fieldB, fieldC)),
+                baseType,
+                ImmutableList.of(2),
+                INTEGER,
+                Optional.empty());
+        Domain predicateDomain = Domain.singleValue(INTEGER, 123L);
+        TupleDomain<IcebergColumnHandle> tupleDomain = withColumnDomains(ImmutableMap.of(projectedColumn, predicateDomain));
+
+        Map<List<String>, ColumnDescriptor> descriptorsByPath = getDescriptors(fileSchema, fileSchema);
+        TupleDomain<ColumnDescriptor> calculatedTupleDomain = getParquetTupleDomain(descriptorsByPath, tupleDomain);
+
+        assertThat(calculatedTupleDomain.getDomains().orElseThrow().size()).isEqualTo(1);
+        ColumnDescriptor selectedColumnDescriptor = descriptorsByPath.get(ImmutableList.of("row_field", "b"));
+        assertThat(calculatedTupleDomain.getDomains().orElseThrow().get(selectedColumnDescriptor)).isEqualTo(predicateDomain);
+    }
+
+    @Test
+    public void testParquetTupleDomainStructWithPrimitiveColumnDifferentIdPredicate()
+    {
+        // trino type
+        RowType baseType = rowType(
+                RowType.field("a", INTEGER),
+                RowType.field("b", INTEGER),
+                RowType.field("c", INTEGER));
+
+        // iceberg type
+        ColumnIdentity fieldA = new ColumnIdentity(1, "a", PRIMITIVE, ImmutableList.of());
+        ColumnIdentity fieldB = new ColumnIdentity(2, "b", PRIMITIVE, ImmutableList.of());
+        ColumnIdentity fieldC = new ColumnIdentity(4, "c", PRIMITIVE, ImmutableList.of());
+
+        // parquet type
+        MessageType fileSchema = new MessageType("iceberg_schema",
+                new GroupType(OPTIONAL, "row_field",
+                        new PrimitiveType(OPTIONAL, INT32, "a").withId(1),
+                        new PrimitiveType(OPTIONAL, INT32, "b").withId(2),
+                        new PrimitiveType(OPTIONAL, INT32, "c").withId(3)).withId(5));
+
+        // predicate domain
+        IcebergColumnHandle projectedColumn = new IcebergColumnHandle(
+                new ColumnIdentity(
+                        5,
+                        "row_field",
+                        STRUCT,
+                        ImmutableList.of(fieldA, fieldB, fieldC)),
+                baseType,
+                ImmutableList.of(4),
+                INTEGER,
+                Optional.empty());
+        Domain predicateDomain = Domain.singleValue(INTEGER, 123L);
+        TupleDomain<IcebergColumnHandle> tupleDomain = withColumnDomains(ImmutableMap.of(projectedColumn, predicateDomain));
+
+        Map<List<String>, ColumnDescriptor> descriptorsByPath = getDescriptors(fileSchema, fileSchema);
+        TupleDomain<ColumnDescriptor> calculatedTupleDomain = getParquetTupleDomain(descriptorsByPath, tupleDomain);
+        // same name but different Id between iceberg and parquet for field c
+        assertThat(calculatedTupleDomain.isAll()).isTrue();
+    }
+
+    @Test
+    public void testParquetTupleDomainStructWithComplexColumnPredicate()
+    {
+        // trino type
+        RowType nestedType = rowType(
+                RowType.field("c1", INTEGER),
+                RowType.field("c2", INTEGER));
+        RowType baseType = rowType(
+                RowType.field("a", INTEGER),
+                RowType.field("b", INTEGER),
+                RowType.field("c", nestedType));
+
+        // iceberg type
+        ColumnIdentity fieldC11 = new ColumnIdentity(1, "c1", PRIMITIVE, ImmutableList.of());
+        ColumnIdentity fieldC12 = new ColumnIdentity(2, "c2", PRIMITIVE, ImmutableList.of());
+        ColumnIdentity fieldA = new ColumnIdentity(3, "a", PRIMITIVE, ImmutableList.of());
+        ColumnIdentity fieldB = new ColumnIdentity(4, "b", PRIMITIVE, ImmutableList.of());
+        ColumnIdentity fieldC = new ColumnIdentity(5, "c", STRUCT, ImmutableList.of(fieldC11, fieldC12));
+
+        // parquet type
+        MessageType fileSchema = new MessageType("iceberg_schema",
+                new GroupType(OPTIONAL, "row_field",
+                        new PrimitiveType(OPTIONAL, INT32, "a").withId(3),
+                        new PrimitiveType(OPTIONAL, INT32, "b").withId(4),
+                        new GroupType(OPTIONAL,
+                                "c",
+                                new PrimitiveType(OPTIONAL, INT32, "c1").withId(1),
+                                new PrimitiveType(OPTIONAL, INT32, "c2").withId(2)).withId(5)));
+        // predicate domain
+        IcebergColumnHandle projectedColumn = new IcebergColumnHandle(
+                new ColumnIdentity(
+                        6,
+                        "row_field",
+                        STRUCT,
+                        ImmutableList.of(fieldA, fieldB, fieldC)),
+                baseType,
+                ImmutableList.of(5),
+                nestedType,
+                Optional.empty());
+
+        Domain predicateDomain = Domain.onlyNull(nestedType);
+        TupleDomain<IcebergColumnHandle> tupleDomain = withColumnDomains(ImmutableMap.of(projectedColumn, predicateDomain));
+
+        Map<List<String>, ColumnDescriptor> descriptorsByPath = getDescriptors(fileSchema, fileSchema);
+        TupleDomain<ColumnDescriptor> calculatedTupleDomain = getParquetTupleDomain(descriptorsByPath, tupleDomain);
+
+        assertThat(calculatedTupleDomain.isAll()).isTrue();
+    }
+
+    @Test
+    public void testParquetTupleDomainStructWithMissingPrimitiveColumn()
+    {
+        // trino type
+        RowType baseType = rowType(
+                RowType.field("a", INTEGER),
+                RowType.field("b", INTEGER),
+                RowType.field("missing", INTEGER));
+
+        // iceberg type
+        ColumnIdentity fieldA = new ColumnIdentity(1, "a", PRIMITIVE, ImmutableList.of());
+        ColumnIdentity fieldB = new ColumnIdentity(2, "b", PRIMITIVE, ImmutableList.of());
+        ColumnIdentity fieldC = new ColumnIdentity(3, "missing", PRIMITIVE, ImmutableList.of());
+
+        // parquet type
+        MessageType fileSchema = new MessageType("iceberg_schema",
+                new GroupType(OPTIONAL, "row_field",
+                        new PrimitiveType(OPTIONAL, INT32, "a").withId(1),
+                        new PrimitiveType(OPTIONAL, INT32, "b").withId(2)));
+
+        // predicate domain
+        IcebergColumnHandle projectedColumn = new IcebergColumnHandle(
+                new ColumnIdentity(
+                        5,
+                        "row_field",
+                        STRUCT,
+                        ImmutableList.of(fieldA, fieldB, fieldC)),
+                baseType,
+                ImmutableList.of(3),
+                INTEGER,
+                Optional.empty());
+        Domain predicateDomain = Domain.singleValue(INTEGER, 123L);
+        TupleDomain<IcebergColumnHandle> tupleDomain = withColumnDomains(ImmutableMap.of(projectedColumn, predicateDomain));
+
+        Map<List<String>, ColumnDescriptor> descriptorsByPath = getDescriptors(fileSchema, fileSchema);
+        TupleDomain<ColumnDescriptor> calculatedTupleDomain = getParquetTupleDomain(descriptorsByPath, tupleDomain);
+
+        assertThat(calculatedTupleDomain.isAll()).isTrue();
+    }
+}

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -806,6 +806,8 @@ public class TestIcebergSparkCompatibility
                                 .addField("added", null)
                                 .build(),
                         1001L));
+        // make sure predicates are also ID based
+        assertThat(onTrino().executeQuery(format("SELECT keep_col FROM %s WHERE drop_and_add_col IS NULL", trinoTableName))).containsOnly(row(3L));
 
         // smoke test for dereference
         assertThat(onTrino().executeQuery(format("SELECT a_struct.renamed FROM %s", trinoTableName))).containsOnly(row(11L));
@@ -818,6 +820,7 @@ public class TestIcebergSparkCompatibility
         assertThat(onTrino().executeQuery(format("SELECT keep_col FROM %s WHERE a_struct.renamed = 11", trinoTableName))).containsOnly(row(3L));
         assertThat(onTrino().executeQuery(format("SELECT keep_col FROM %s WHERE a_struct.keep = 12", trinoTableName))).containsOnly(row(3L));
         assertThat(onTrino().executeQuery(format("SELECT keep_col FROM %s WHERE a_struct.casesensitive = 14", trinoTableName))).containsOnly(row(3L));
+        // make sure predicates are also ID based
         assertThat(onTrino().executeQuery(format("SELECT keep_col FROM %s WHERE a_struct.drop_and_add IS NULL", trinoTableName))).containsOnly(row(3L));
         assertThat(onTrino().executeQuery(format("SELECT keep_col FROM %s WHERE a_struct.added IS NULL", trinoTableName))).containsOnly(row(3L));
 


### PR DESCRIPTION
## Description

From https://trino.io/blog/2020/08/14/dereference-pushdown.html: "Another future improvement will be the pushdown of predicates on subfields for data stored in Parquet format. Although the pruning of nested fields occurs with Parquet, the predicates are not yet pushed down into the reader."

This PR enables Parquet page source to use statistics for nested fields in the iceberg connector.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Related ORC commit: https://github.com/trinodb/trino/commit/5069a55252dfc0958e68c140a4c49313096e9003
Fixes https://github.com/trinodb/trino/issues/9928
Hive change PR: https://github.com/trinodb/trino/pull/15163

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

() This is not user-visible or docs only and no release notes are required.
() Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Improve performance of queries with filters on fields in ROW type columns stored in parquet files.
```
