### PR TITLE
Type primitives

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/ChangeOnlyUpdatedColumnsMergeProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ChangeOnlyUpdatedColumnsMergeProcessor.java
@@ -86,7 +86,7 @@ public class ChangeOnlyUpdatedColumnsMergeProcessor
 
         int defaultCaseCount = 0;
         for (int position = 0; position < positionCount; position++) {
-            if (TINYINT.getLong(operationChannelBlock, position) == DEFAULT_CASE_OPERATION_NUMBER) {
+            if (TINYINT.getByte(operationChannelBlock, position) == DEFAULT_CASE_OPERATION_NUMBER) {
                 defaultCaseCount++;
             }
         }
@@ -97,7 +97,7 @@ public class ChangeOnlyUpdatedColumnsMergeProcessor
         int usedCases = 0;
         int[] positions = new int[positionCount - defaultCaseCount];
         for (int position = 0; position < positionCount; position++) {
-            if (TINYINT.getLong(operationChannelBlock, position) != DEFAULT_CASE_OPERATION_NUMBER) {
+            if (TINYINT.getByte(operationChannelBlock, position) != DEFAULT_CASE_OPERATION_NUMBER) {
                 positions[usedCases] = position;
                 usedCases++;
             }

--- a/core/trino-main/src/main/java/io/trino/operator/DeleteAndInsertMergeProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DeleteAndInsertMergeProcessor.java
@@ -33,7 +33,6 @@ import static io.trino.spi.connector.ConnectorMergeSink.UPDATE_DELETE_OPERATION_
 import static io.trino.spi.connector.ConnectorMergeSink.UPDATE_INSERT_OPERATION_NUMBER;
 import static io.trino.spi.connector.ConnectorMergeSink.UPDATE_OPERATION_NUMBER;
 import static io.trino.spi.type.TinyintType.TINYINT;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class DeleteAndInsertMergeProcessor
@@ -108,7 +107,7 @@ public class DeleteAndInsertMergeProcessor
         int insertPositions = 0;
         int deletePositions = 0;
         for (int position = 0; position < originalPositionCount; position++) {
-            int operation = toIntExact(TINYINT.getLong(operationChannelBlock, position));
+            byte operation = TINYINT.getByte(operationChannelBlock, position);
             switch (operation) {
                 case DEFAULT_CASE_OPERATION_NUMBER -> { /* ignored */ }
                 case INSERT_OPERATION_NUMBER -> insertPositions++;
@@ -130,7 +129,7 @@ public class DeleteAndInsertMergeProcessor
 
         PageBuilder pageBuilder = new PageBuilder(totalPositions, pageTypes);
         for (int position = 0; position < originalPositionCount; position++) {
-            long operation = TINYINT.getLong(operationChannelBlock, position);
+            byte operation = TINYINT.getByte(operationChannelBlock, position);
             if (operation != DEFAULT_CASE_OPERATION_NUMBER) {
                 // Delete and Update because both create a delete row
                 if (operation == DELETE_OPERATION_NUMBER || operation == UPDATE_OPERATION_NUMBER) {

--- a/core/trino-main/src/main/java/io/trino/operator/MergeWriterOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MergeWriterOperator.java
@@ -152,7 +152,7 @@ public class MergeWriterOperator
         long insertsFromUpdates = 0;
         int positionCount = page.getPositionCount();
         for (int position = 0; position < positionCount; position++) {
-            insertsFromUpdates += TINYINT.getLong(insertFromUpdateColumn, position);
+            insertsFromUpdates += TINYINT.getByte(insertFromUpdateColumn, position);
         }
         rowCount += positionCount - insertsFromUpdates;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/PagesRTreeIndex.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesRTreeIndex.java
@@ -44,7 +44,6 @@ import static io.trino.operator.SyntheticAddress.decodeSliceIndex;
 import static io.trino.operator.join.JoinUtils.channelsToPages;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class PagesRTreeIndex
@@ -144,7 +143,7 @@ public class PagesRTreeIndex
             return EMPTY_ADDRESSES;
         }
 
-        int probePartition = probePartitionChannel.map(channel -> toIntExact(INTEGER.getLong(probe.getBlock(channel), probePosition))).orElse(-1);
+        int probePartition = probePartitionChannel.map(channel -> INTEGER.getInt(probe.getBlock(channel), probePosition)).orElse(-1);
 
         Slice slice = probeGeometryBlock.getSlice(probePosition, 0, probeGeometryBlock.getSliceLength(probePosition));
         OGCGeometry probeGeometry = deserialize(slice);

--- a/core/trino-main/src/main/java/io/trino/operator/PagesSpatialIndexSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesSpatialIndexSupplier.java
@@ -47,7 +47,6 @@ import static io.trino.operator.SyntheticAddress.decodePosition;
 import static io.trino.operator.SyntheticAddress.decodeSliceIndex;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
-import static java.lang.Math.toIntExact;
 
 public class PagesSpatialIndexSupplier
         implements Supplier<PagesSpatialIndex>
@@ -133,7 +132,7 @@ public class PagesSpatialIndexSupplier
             int partition = -1;
             if (partitionChannel.isPresent()) {
                 Block partitionBlock = channels.get(partitionChannel.get()).get(blockIndex);
-                partition = toIntExact(INTEGER.getLong(partitionBlock, blockPosition));
+                partition = INTEGER.getInt(partitionBlock, blockPosition);
             }
 
             rtree.insert(getEnvelope(ogcGeometry, radius), new GeometryWithPosition(ogcGeometry, partition, position));

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayMaxFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayMaxFunction.java
@@ -176,7 +176,7 @@ public final class ArrayMaxFunction
     @SuppressWarnings("NumericCastThatLosesPrecision")
     private static float getReal(Block block, int position)
     {
-        return intBitsToFloat((int) REAL.getLong(block, position));
+        return intBitsToFloat(REAL.getInt(block, position));
     }
 
     private static boolean floatGreater(float left, float right)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayMaxFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayMaxFunction.java
@@ -31,7 +31,6 @@ import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_FIRST;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.util.Failures.internalError;
-import static java.lang.Float.intBitsToFloat;
 
 @ScalarFunction("array_max")
 @Description("Get maximum value of array")
@@ -166,17 +165,11 @@ public final class ArrayMaxFunction
             if (block.isNull(position)) {
                 return null;
             }
-            if (selectedPosition < 0 || floatGreater(getReal(block, position), getReal(block, selectedPosition))) {
+            if (selectedPosition < 0 || floatGreater(REAL.getFloat(block, position), REAL.getFloat(block, selectedPosition))) {
                 selectedPosition = position;
             }
         }
         return REAL.getLong(block, selectedPosition);
-    }
-
-    @SuppressWarnings("NumericCastThatLosesPrecision")
-    private static float getReal(Block block, int position)
-    {
-        return intBitsToFloat(REAL.getInt(block, position));
     }
 
     private static boolean floatGreater(float left, float right)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/FormatFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/FormatFunction.java
@@ -70,7 +70,6 @@ import static io.trino.type.JsonType.JSON;
 import static io.trino.type.UnknownType.UNKNOWN;
 import static io.trino.util.Failures.internalError;
 import static io.trino.util.Reflection.methodHandle;
-import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 
@@ -199,7 +198,7 @@ public final class FormatFunction
             return (session, block) -> BIGINT.getLong(block, position);
         }
         if (type.equals(REAL)) {
-            return (session, block) -> intBitsToFloat(REAL.getInt(block, position));
+            return (session, block) -> REAL.getFloat(block, position);
         }
         if (type.equals(DOUBLE)) {
             return (session, block) -> DOUBLE.getDouble(block, position);

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/FormatFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/FormatFunction.java
@@ -184,19 +184,28 @@ public final class FormatFunction
             return (session, block) -> null;
         }
         if (type.equals(BOOLEAN)) {
-            return (session, block) -> type.getBoolean(block, position);
+            return (session, block) -> BOOLEAN.getBoolean(block, position);
         }
-        if (type.equals(TINYINT) || type.equals(SMALLINT) || type.equals(INTEGER) || type.equals(BIGINT)) {
-            return (session, block) -> type.getLong(block, position);
+        if (type.equals(TINYINT)) {
+            return (session, block) -> TINYINT.getLong(block, position);
+        }
+        if (type.equals(SMALLINT)) {
+            return (session, block) -> SMALLINT.getLong(block, position);
+        }
+        if (type.equals(INTEGER)) {
+            return (session, block) -> INTEGER.getLong(block, position);
+        }
+        if (type.equals(BIGINT)) {
+            return (session, block) -> BIGINT.getLong(block, position);
         }
         if (type.equals(REAL)) {
-            return (session, block) -> intBitsToFloat(toIntExact(type.getLong(block, position)));
+            return (session, block) -> intBitsToFloat(toIntExact(REAL.getLong(block, position)));
         }
         if (type.equals(DOUBLE)) {
-            return (session, block) -> type.getDouble(block, position);
+            return (session, block) -> DOUBLE.getDouble(block, position);
         }
         if (type.equals(DATE)) {
-            return (session, block) -> LocalDate.ofEpochDay(type.getLong(block, position));
+            return (session, block) -> LocalDate.ofEpochDay(DATE.getLong(block, position));
         }
         if (type instanceof TimestampWithTimeZoneType timestampWithTimeZoneType) {
             return (session, block) -> toZonedDateTime(timestampWithTimeZoneType, block, position);
@@ -204,8 +213,8 @@ public final class FormatFunction
         if (type instanceof TimestampType timestampType) {
             return (session, block) -> toLocalDateTime(timestampType, block, position);
         }
-        if (type instanceof TimeType) {
-            return (session, block) -> toLocalTime(type.getLong(block, position));
+        if (type instanceof TimeType timeType) {
+            return (session, block) -> toLocalTime(timeType.getLong(block, position));
         }
         // TODO: support TIME WITH TIME ZONE by https://github.com/trinodb/trino/issues/191 + mapping to java.time.OffsetTime
         if (type.equals(JSON)) {
@@ -215,15 +224,15 @@ public final class FormatFunction
         if (type instanceof DecimalType decimalType) {
             int scale = decimalType.getScale();
             if (decimalType.isShort()) {
-                return (session, block) -> BigDecimal.valueOf(type.getLong(block, position), scale);
+                return (session, block) -> BigDecimal.valueOf(decimalType.getLong(block, position), scale);
             }
-            return (session, block) -> new BigDecimal(((Int128) type.getObject(block, position)).toBigInteger(), scale);
+            return (session, block) -> new BigDecimal(((Int128) decimalType.getObject(block, position)).toBigInteger(), scale);
         }
-        if (type instanceof VarcharType) {
-            return (session, block) -> type.getSlice(block, position).toStringUtf8();
+        if (type instanceof VarcharType varcharType) {
+            return (session, block) -> varcharType.getSlice(block, position).toStringUtf8();
         }
         if (type instanceof CharType charType) {
-            return (session, block) -> padSpaces(type.getSlice(block, position), charType).toStringUtf8();
+            return (session, block) -> padSpaces(charType.getSlice(block, position), charType).toStringUtf8();
         }
 
         BiFunction<ConnectorSession, Block, Object> function;

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/FormatFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/FormatFunction.java
@@ -190,7 +190,7 @@ public final class FormatFunction
             return (session, block) -> (long) TINYINT.getByte(block, position);
         }
         if (type.equals(SMALLINT)) {
-            return (session, block) -> SMALLINT.getLong(block, position);
+            return (session, block) -> (long) SMALLINT.getShort(block, position);
         }
         if (type.equals(INTEGER)) {
             return (session, block) -> INTEGER.getLong(block, position);

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/FormatFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/FormatFunction.java
@@ -193,19 +193,19 @@ public final class FormatFunction
             return (session, block) -> (long) SMALLINT.getShort(block, position);
         }
         if (type.equals(INTEGER)) {
-            return (session, block) -> INTEGER.getLong(block, position);
+            return (session, block) -> (long) INTEGER.getInt(block, position);
         }
         if (type.equals(BIGINT)) {
             return (session, block) -> BIGINT.getLong(block, position);
         }
         if (type.equals(REAL)) {
-            return (session, block) -> intBitsToFloat(toIntExact(REAL.getLong(block, position)));
+            return (session, block) -> intBitsToFloat(REAL.getInt(block, position));
         }
         if (type.equals(DOUBLE)) {
             return (session, block) -> DOUBLE.getDouble(block, position);
         }
         if (type.equals(DATE)) {
-            return (session, block) -> LocalDate.ofEpochDay(DATE.getLong(block, position));
+            return (session, block) -> LocalDate.ofEpochDay(DATE.getInt(block, position));
         }
         if (type instanceof TimestampWithTimeZoneType timestampWithTimeZoneType) {
             return (session, block) -> toZonedDateTime(timestampWithTimeZoneType, block, position);

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/FormatFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/FormatFunction.java
@@ -187,7 +187,7 @@ public final class FormatFunction
             return (session, block) -> BOOLEAN.getBoolean(block, position);
         }
         if (type.equals(TINYINT)) {
-            return (session, block) -> TINYINT.getLong(block, position);
+            return (session, block) -> (long) TINYINT.getByte(block, position);
         }
         if (type.equals(SMALLINT)) {
             return (session, block) -> SMALLINT.getLong(block, position);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/MergePartitioningHandle.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/MergePartitioningHandle.java
@@ -43,7 +43,6 @@ import static io.trino.spi.connector.ConnectorMergeSink.UPDATE_DELETE_OPERATION_
 import static io.trino.spi.connector.ConnectorMergeSink.UPDATE_INSERT_OPERATION_NUMBER;
 import static io.trino.spi.connector.ConnectorMergeSink.UPDATE_OPERATION_NUMBER;
 import static io.trino.spi.type.TinyintType.TINYINT;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public final class MergePartitioningHandle
@@ -213,7 +212,7 @@ public final class MergePartitioningHandle
         public int getPartition(Page page, int position)
         {
             Block operationBlock = page.getBlock(0);
-            int operation = toIntExact(TINYINT.getLong(operationBlock, position));
+            byte operation = TINYINT.getByte(operationBlock, position);
             return switch (operation) {
                 case INSERT_OPERATION_NUMBER, UPDATE_INSERT_OPERATION_NUMBER -> insertFunction.getPartition(page.getColumns(insertColumns), position);
                 case UPDATE_OPERATION_NUMBER, DELETE_OPERATION_NUMBER, UPDATE_DELETE_OPERATION_NUMBER -> updateFunction.getPartition(page.getColumns(updateColumns), position);

--- a/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
@@ -65,6 +65,7 @@ import static io.trino.util.JsonUtil.createJsonGenerator;
 import static io.trino.util.JsonUtil.createJsonParser;
 import static io.trino.util.JsonUtil.currentTokenAsLongDecimal;
 import static io.trino.util.JsonUtil.currentTokenAsShortDecimal;
+import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.multiplyExact;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
@@ -467,13 +468,15 @@ public final class DecimalCasts
     @UsedByGeneratedCode
     public static long realToShortDecimal(long value, long precision, long scale, long tenToScale)
     {
-        return DecimalConversions.realToShortDecimal(value, precision, scale);
+        float floatValue = intBitsToFloat((int) value);
+        return DecimalConversions.realToShortDecimal(floatValue, precision, scale);
     }
 
     @UsedByGeneratedCode
     public static Int128 realToLongDecimal(long value, long precision, long scale, Int128 tenToScale)
     {
-        return DecimalConversions.realToLongDecimal(value, precision, scale);
+        float floatValue = intBitsToFloat((int) value);
+        return DecimalConversions.realToLongDecimal(floatValue, precision, scale);
     }
 
     @UsedByGeneratedCode

--- a/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
+++ b/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
@@ -94,7 +94,6 @@ import static io.trino.type.UnknownType.UNKNOWN;
 import static io.trino.util.DateTimeUtils.printDate;
 import static io.trino.util.JsonUtil.ObjectKeyProvider.createObjectKeyProvider;
 import static java.lang.Float.floatToRawIntBits;
-import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.math.RoundingMode.HALF_UP;
@@ -232,7 +231,7 @@ public final class JsonUtil
                 return (block, position) -> String.valueOf(BIGINT.getLong(block, position));
             }
             if (type.equals(REAL)) {
-                return (block, position) -> String.valueOf(intBitsToFloat(REAL.getInt(block, position)));
+                return (block, position) -> String.valueOf(REAL.getFloat(block, position));
             }
             if (type.equals(DOUBLE)) {
                 return (block, position) -> String.valueOf(DOUBLE.getDouble(block, position));
@@ -382,7 +381,7 @@ public final class JsonUtil
                 jsonGenerator.writeNull();
             }
             else {
-                float value = intBitsToFloat(REAL.getInt(block, position));
+                float value = REAL.getFloat(block, position);
                 jsonGenerator.writeNumber(value);
             }
         }

--- a/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
+++ b/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
@@ -226,13 +226,13 @@ public final class JsonUtil
                 return (block, position) -> String.valueOf(SMALLINT.getShort(block, position));
             }
             if (type.equals(INTEGER)) {
-                return (block, position) -> String.valueOf(INTEGER.getLong(block, position));
+                return (block, position) -> String.valueOf(INTEGER.getInt(block, position));
             }
             if (type.equals(BIGINT)) {
                 return (block, position) -> String.valueOf(BIGINT.getLong(block, position));
             }
             if (type.equals(REAL)) {
-                return (block, position) -> String.valueOf(intBitsToFloat(toIntExact(REAL.getLong(block, position))));
+                return (block, position) -> String.valueOf(intBitsToFloat(REAL.getInt(block, position)));
             }
             if (type.equals(DOUBLE)) {
                 return (block, position) -> String.valueOf(DOUBLE.getDouble(block, position));
@@ -382,7 +382,7 @@ public final class JsonUtil
                 jsonGenerator.writeNull();
             }
             else {
-                float value = intBitsToFloat(toIntExact(REAL.getLong(block, position)));
+                float value = intBitsToFloat(REAL.getInt(block, position));
                 jsonGenerator.writeNumber(value);
             }
         }
@@ -543,7 +543,7 @@ public final class JsonUtil
                 jsonGenerator.writeNull();
             }
             else {
-                int value = toIntExact(DATE.getLong(block, position));
+                int value = DATE.getInt(block, position);
                 jsonGenerator.writeString(printDate(value));
             }
         }

--- a/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
+++ b/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
@@ -223,7 +223,7 @@ public final class JsonUtil
                 return (block, position) -> String.valueOf(TINYINT.getByte(block, position));
             }
             if (type.equals(SMALLINT)) {
-                return (block, position) -> String.valueOf(SMALLINT.getLong(block, position));
+                return (block, position) -> String.valueOf(SMALLINT.getShort(block, position));
             }
             if (type.equals(INTEGER)) {
                 return (block, position) -> String.valueOf(INTEGER.getLong(block, position));

--- a/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
+++ b/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
@@ -220,7 +220,7 @@ public final class JsonUtil
                 return (block, position) -> BOOLEAN.getBoolean(block, position) ? "true" : "false";
             }
             if (type.equals(TINYINT)) {
-                return (block, position) -> String.valueOf(TINYINT.getLong(block, position));
+                return (block, position) -> String.valueOf(TINYINT.getByte(block, position));
             }
             if (type.equals(SMALLINT)) {
                 return (block, position) -> String.valueOf(SMALLINT.getLong(block, position));

--- a/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
+++ b/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
@@ -90,6 +90,7 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.UNBOUNDED_LENGTH;
 import static io.trino.type.DateTimes.formatTimestamp;
 import static io.trino.type.JsonType.JSON;
+import static io.trino.type.UnknownType.UNKNOWN;
 import static io.trino.util.DateTimeUtils.printDate;
 import static io.trino.util.JsonUtil.ObjectKeyProvider.createObjectKeyProvider;
 import static java.lang.Float.floatToRawIntBits;
@@ -212,31 +213,40 @@ public final class JsonUtil
 
         static ObjectKeyProvider createObjectKeyProvider(Type type)
         {
-            if (type instanceof UnknownType) {
+            if (type.equals(UNKNOWN)) {
                 return (block, position) -> null;
             }
-            if (type instanceof BooleanType) {
-                return (block, position) -> type.getBoolean(block, position) ? "true" : "false";
+            if (type.equals(BOOLEAN)) {
+                return (block, position) -> BOOLEAN.getBoolean(block, position) ? "true" : "false";
             }
-            if (type instanceof TinyintType || type instanceof SmallintType || type instanceof IntegerType || type instanceof BigintType) {
-                return (block, position) -> String.valueOf(type.getLong(block, position));
+            if (type.equals(TINYINT)) {
+                return (block, position) -> String.valueOf(TINYINT.getLong(block, position));
             }
-            if (type instanceof RealType) {
-                return (block, position) -> String.valueOf(intBitsToFloat(toIntExact(type.getLong(block, position))));
+            if (type.equals(SMALLINT)) {
+                return (block, position) -> String.valueOf(SMALLINT.getLong(block, position));
             }
-            if (type instanceof DoubleType) {
-                return (block, position) -> String.valueOf(type.getDouble(block, position));
+            if (type.equals(INTEGER)) {
+                return (block, position) -> String.valueOf(INTEGER.getLong(block, position));
+            }
+            if (type.equals(BIGINT)) {
+                return (block, position) -> String.valueOf(BIGINT.getLong(block, position));
+            }
+            if (type.equals(REAL)) {
+                return (block, position) -> String.valueOf(intBitsToFloat(toIntExact(REAL.getLong(block, position))));
+            }
+            if (type.equals(DOUBLE)) {
+                return (block, position) -> String.valueOf(DOUBLE.getDouble(block, position));
             }
             if (type instanceof DecimalType decimalType) {
                 if (decimalType.isShort()) {
                     return (block, position) -> Decimals.toString(decimalType.getLong(block, position), decimalType.getScale());
                 }
                 return (block, position) -> Decimals.toString(
-                        ((Int128) type.getObject(block, position)).toBigInteger(),
+                        ((Int128) decimalType.getObject(block, position)).toBigInteger(),
                         decimalType.getScale());
             }
-            if (type instanceof VarcharType) {
-                return (block, position) -> type.getSlice(block, position).toStringUtf8();
+            if (type instanceof VarcharType varcharType) {
+                return (block, position) -> varcharType.getSlice(block, position).toStringUtf8();
             }
 
             throw new TrinoException(INVALID_FUNCTION_ARGUMENT, format("Unsupported type: %s", type));

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDeleteAndInsertMergeProcessor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDeleteAndInsertMergeProcessor.java
@@ -76,7 +76,7 @@ public class TestDeleteAndInsertMergeProcessor
         assertThat(outputPage.getPositionCount()).isEqualTo(1);
 
         // The single operation is a delete
-        assertThat(TINYINT.getLong(outputPage.getBlock(3), 0)).isEqualTo(DELETE_OPERATION_NUMBER);
+        assertThat((int) TINYINT.getByte(outputPage.getBlock(3), 0)).isEqualTo(DELETE_OPERATION_NUMBER);
 
         // Show that the row to be deleted is rowId 0, e.g. ('Dave', 11, 'Devon')
         Block rowIdRow = outputPage.getBlock(4).getObject(0, Block.class);

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDeleteAndInsertMergeProcessor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDeleteAndInsertMergeProcessor.java
@@ -80,7 +80,7 @@ public class TestDeleteAndInsertMergeProcessor
 
         // Show that the row to be deleted is rowId 0, e.g. ('Dave', 11, 'Devon')
         Block rowIdRow = outputPage.getBlock(4).getObject(0, Block.class);
-        assertThat(INTEGER.getLong(rowIdRow, 1)).isEqualTo(0);
+        assertThat(INTEGER.getInt(rowIdRow, 1)).isEqualTo(0);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestConventionDependencies.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestConventionDependencies.java
@@ -155,7 +155,7 @@ public class TestConventionDependencies
                 @BlockPosition @SqlType(value = StandardTypes.INTEGER, nativeContainerType = long.class) Block block,
                 @BlockIndex int position)
         {
-            return Math.addExact((int) first, (int) INTEGER.getLong(block, position));
+            return Math.addExact((int) first, INTEGER.getInt(block, position));
         }
     }
 }

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -263,6 +263,10 @@
                                     <old>class io.trino.spi.block.Int96ArrayBlockEncoding</old>
                                     <justification>Int96Array renamed to Fixed12 since this is never used as a number</justification>
                                 </item>
+                                <item>
+                                    <code>java.method.finalMethodAddedToNonFinalClass</code>
+                                    <new>method int io.trino.spi.type.AbstractIntType::getInt(io.trino.spi.block.Block, int)</new>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/MergePage.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/MergePage.java
@@ -24,7 +24,6 @@ import static io.trino.spi.connector.ConnectorMergeSink.INSERT_OPERATION_NUMBER;
 import static io.trino.spi.connector.ConnectorMergeSink.UPDATE_DELETE_OPERATION_NUMBER;
 import static io.trino.spi.connector.ConnectorMergeSink.UPDATE_INSERT_OPERATION_NUMBER;
 import static io.trino.spi.type.TinyintType.TINYINT;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -79,7 +78,7 @@ public final class MergePage
         int insertPositionCount = 0;
 
         for (int position = 0; position < positionCount; position++) {
-            int operation = toIntExact(TINYINT.getLong(operationBlock, position));
+            byte operation = TINYINT.getByte(operationBlock, position);
             switch (operation) {
                 case DELETE_OPERATION_NUMBER, UPDATE_DELETE_OPERATION_NUMBER:
                     deletePositions[deletePositionCount] = position;

--- a/core/trino-spi/src/main/java/io/trino/spi/type/AbstractIntType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/AbstractIntType.java
@@ -72,6 +72,11 @@ public abstract class AbstractIntType
     @Override
     public final long getLong(Block block, int position)
     {
+        return getInt(block, position);
+    }
+
+    public final int getInt(Block block, int position)
+    {
         return block.getInt(position, 0);
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/type/DecimalConversions.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/DecimalConversions.java
@@ -122,7 +122,17 @@ public final class DecimalConversions
         }
     }
 
+    /**
+     * @deprecated Use {@link #realToShortDecimal(float, long, long)} instead
+     */
+    @Deprecated(forRemoval = true)
     public static long realToShortDecimal(long value, long precision, long scale)
+    {
+        float floatValue = intBitsToFloat(intScale(value));
+        return realToShortDecimal(floatValue, precision, scale);
+    }
+
+    public static long realToShortDecimal(float value, long precision, long scale)
     {
         // TODO: implement specialized version for short decimals
         Int128 decimal = realToLongDecimal(value, precision, scale);
@@ -135,9 +145,18 @@ public final class DecimalConversions
         return low;
     }
 
+    /**
+     * @deprecated Use {@link #realToLongDecimal(float, long, long)} instead
+     */
+    @Deprecated(forRemoval = true)
     public static Int128 realToLongDecimal(long value, long precision, long scale)
     {
         float floatValue = intBitsToFloat(intScale(value));
+        return realToLongDecimal(floatValue, precision, scale);
+    }
+
+    public static Int128 realToLongDecimal(float floatValue, long precision, long scale)
+    {
         if (Float.isInfinite(floatValue) || Float.isNaN(floatValue)) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast REAL '%s' to DECIMAL(%s, %s)", floatValue, precision, scale));
         }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/RealType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/RealType.java
@@ -63,6 +63,11 @@ public final class RealType
         if (block.isNull(position)) {
             return null;
         }
+        return getFloat(block, position);
+    }
+
+    public float getFloat(Block block, int position)
+    {
         return intBitsToFloat(block.getInt(position, 0));
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/type/SmallintType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/SmallintType.java
@@ -160,6 +160,11 @@ public final class SmallintType
     @Override
     public long getLong(Block block, int position)
     {
+        return getShort(block, position);
+    }
+
+    public short getShort(Block block, int position)
+    {
         return block.getShort(position, 0);
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TinyintType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TinyintType.java
@@ -160,6 +160,11 @@ public final class TinyintType
     @Override
     public long getLong(Block block, int position)
     {
+        return getByte(block, position);
+    }
+
+    public byte getByte(Block block, int position)
+    {
         return block.getByte(position, 0);
     }
 

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/HiveFormatUtils.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/HiveFormatUtils.java
@@ -301,13 +301,13 @@ public final class HiveFormatUtils
 
     public static String formatHiveDate(Block block, int position)
     {
-        LocalDate localDate = LocalDate.ofEpochDay(DATE.getLong(block, position));
+        LocalDate localDate = LocalDate.ofEpochDay(DATE.getInt(block, position));
         return localDate.format(DATE_FORMATTER);
     }
 
     public static void formatHiveDate(Block block, int position, StringBuilder builder)
     {
-        LocalDate localDate = LocalDate.ofEpochDay(DATE.getLong(block, position));
+        LocalDate localDate = LocalDate.ofEpochDay(DATE.getInt(block, position));
         DATE_FORMATTER.formatTo(localDate, builder);
     }
 

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonSerializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonSerializer.java
@@ -51,7 +51,6 @@ import static io.trino.spi.type.RowType.field;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
-import static java.lang.Float.intBitsToFloat;
 
 /**
  * Deserializer that is bug for bug compatible with Hive JsonSerDe.
@@ -128,7 +127,7 @@ public class JsonSerializer
             generator.writeNumber(value.toBigDecimal().toString());
         }
         else if (REAL.equals(type)) {
-            generator.writeNumber(intBitsToFloat(REAL.getInt(block, position)));
+            generator.writeNumber(REAL.getFloat(block, position));
         }
         else if (DOUBLE.equals(type)) {
             generator.writeNumber(DOUBLE.getDouble(block, position));
@@ -212,7 +211,7 @@ public class JsonSerializer
             return type.getObjectValue(null, block, position).toString();
         }
         else if (REAL.equals(type)) {
-            return String.valueOf(intBitsToFloat(REAL.getInt(block, position)));
+            return String.valueOf(REAL.getFloat(block, position));
         }
         else if (DOUBLE.equals(type)) {
             return String.valueOf(DOUBLE.getDouble(block, position));

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonSerializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonSerializer.java
@@ -115,7 +115,7 @@ public class JsonSerializer
             generator.writeNumber(BIGINT.getLong(block, position));
         }
         else if (INTEGER.equals(type)) {
-            generator.writeNumber(INTEGER.getLong(block, position));
+            generator.writeNumber(INTEGER.getInt(block, position));
         }
         else if (SMALLINT.equals(type)) {
             generator.writeNumber(SMALLINT.getShort(block, position));
@@ -128,7 +128,7 @@ public class JsonSerializer
             generator.writeNumber(value.toBigDecimal().toString());
         }
         else if (REAL.equals(type)) {
-            generator.writeNumber(intBitsToFloat((int) REAL.getLong(block, position)));
+            generator.writeNumber(intBitsToFloat(REAL.getInt(block, position)));
         }
         else if (DOUBLE.equals(type)) {
             generator.writeNumber(DOUBLE.getDouble(block, position));
@@ -200,7 +200,7 @@ public class JsonSerializer
             return String.valueOf(BIGINT.getLong(block, position));
         }
         else if (INTEGER.equals(type)) {
-            return String.valueOf(INTEGER.getLong(block, position));
+            return String.valueOf(INTEGER.getInt(block, position));
         }
         else if (SMALLINT.equals(type)) {
             return String.valueOf(SMALLINT.getShort(block, position));
@@ -212,7 +212,7 @@ public class JsonSerializer
             return type.getObjectValue(null, block, position).toString();
         }
         else if (REAL.equals(type)) {
-            return String.valueOf(intBitsToFloat((int) REAL.getLong(block, position)));
+            return String.valueOf(intBitsToFloat(REAL.getInt(block, position)));
         }
         else if (DOUBLE.equals(type)) {
             return String.valueOf(DOUBLE.getDouble(block, position));

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonSerializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonSerializer.java
@@ -118,7 +118,7 @@ public class JsonSerializer
             generator.writeNumber(INTEGER.getLong(block, position));
         }
         else if (SMALLINT.equals(type)) {
-            generator.writeNumber(SMALLINT.getLong(block, position));
+            generator.writeNumber(SMALLINT.getShort(block, position));
         }
         else if (TINYINT.equals(type)) {
             generator.writeNumber(TINYINT.getByte(block, position));
@@ -203,7 +203,7 @@ public class JsonSerializer
             return String.valueOf(INTEGER.getLong(block, position));
         }
         else if (SMALLINT.equals(type)) {
-            return String.valueOf(SMALLINT.getLong(block, position));
+            return String.valueOf(SMALLINT.getShort(block, position));
         }
         else if (TINYINT.equals(type)) {
             return String.valueOf(TINYINT.getByte(block, position));

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonSerializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonSerializer.java
@@ -121,7 +121,7 @@ public class JsonSerializer
             generator.writeNumber(SMALLINT.getLong(block, position));
         }
         else if (TINYINT.equals(type)) {
-            generator.writeNumber(TINYINT.getLong(block, position));
+            generator.writeNumber(TINYINT.getByte(block, position));
         }
         else if (type instanceof DecimalType) {
             SqlDecimal value = (SqlDecimal) type.getObjectValue(null, block, position);
@@ -206,7 +206,7 @@ public class JsonSerializer
             return String.valueOf(SMALLINT.getLong(block, position));
         }
         else if (TINYINT.equals(type)) {
-            return String.valueOf(TINYINT.getLong(block, position));
+            return String.valueOf(TINYINT.getByte(block, position));
         }
         else if (type instanceof DecimalType) {
             return type.getObjectValue(null, block, position).toString();

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/openxjson/OpenXJsonSerializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/openxjson/OpenXJsonSerializer.java
@@ -141,7 +141,7 @@ public class OpenXJsonSerializer
             return BIGINT.getLong(block, position);
         }
         else if (INTEGER.equals(type)) {
-            return INTEGER.getLong(block, position);
+            return INTEGER.getInt(block, position);
         }
         else if (SMALLINT.equals(type)) {
             return SMALLINT.getShort(block, position);
@@ -155,7 +155,7 @@ public class OpenXJsonSerializer
             return value.toBigDecimal().toString();
         }
         else if (REAL.equals(type)) {
-            return intBitsToFloat((int) REAL.getLong(block, position));
+            return intBitsToFloat(REAL.getInt(block, position));
         }
         else if (DOUBLE.equals(type)) {
             return DOUBLE.getDouble(block, position);

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/openxjson/OpenXJsonSerializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/openxjson/OpenXJsonSerializer.java
@@ -147,7 +147,7 @@ public class OpenXJsonSerializer
             return SMALLINT.getLong(block, position);
         }
         else if (TINYINT.equals(type)) {
-            return TINYINT.getLong(block, position);
+            return TINYINT.getByte(block, position);
         }
         else if (type instanceof DecimalType) {
             // decimal type is read-only in Hive, but we support it

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/openxjson/OpenXJsonSerializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/openxjson/OpenXJsonSerializer.java
@@ -144,7 +144,7 @@ public class OpenXJsonSerializer
             return INTEGER.getLong(block, position);
         }
         else if (SMALLINT.equals(type)) {
-            return SMALLINT.getLong(block, position);
+            return SMALLINT.getShort(block, position);
         }
         else if (TINYINT.equals(type)) {
             return TINYINT.getByte(block, position);

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/openxjson/OpenXJsonSerializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/openxjson/OpenXJsonSerializer.java
@@ -57,7 +57,6 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
-import static java.lang.Float.intBitsToFloat;
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
 import static java.time.temporal.ChronoField.HOUR_OF_DAY;
 import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
@@ -155,7 +154,7 @@ public class OpenXJsonSerializer
             return value.toBigDecimal().toString();
         }
         else if (REAL.equals(type)) {
-            return intBitsToFloat(REAL.getInt(block, position));
+            return REAL.getFloat(block, position);
         }
         else if (DOUBLE.equals(type)) {
             return DOUBLE.getDouble(block, position);

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/rcfile/TestRcFileReaderManual.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/rcfile/TestRcFileReaderManual.java
@@ -245,7 +245,7 @@ public class TestRcFileReaderManual
         while (reader.advance() >= 0) {
             Block block = reader.readBlock(0);
             for (int position = 0; position < block.getPositionCount(); position++) {
-                values.add((int) SMALLINT.getLong(block, position));
+                values.add((int) SMALLINT.getShort(block, position));
             }
         }
 

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestOrcLz4.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestOrcLz4.java
@@ -74,7 +74,7 @@ public class TestOrcLz4
 
                 for (int position = 0; position < page.getPositionCount(); position++) {
                     BIGINT.getLong(xBlock, position);
-                    INTEGER.getLong(yBlock, position);
+                    INTEGER.getInt(yBlock, position);
                     BIGINT.getLong(zBlock, position);
                 }
             }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/DateValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/DateValueWriter.java
@@ -36,7 +36,7 @@ public class DateValueWriter
     {
         for (int position = 0; position < block.getPositionCount(); position++) {
             if (!block.isNull(position)) {
-                int value = (int) DATE.getLong(block, position);
+                int value = DATE.getInt(block, position);
                 valuesWriter.writeInteger(value);
                 getStatistics().updateStats(value);
             }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/RealValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/RealValueWriter.java
@@ -19,7 +19,6 @@ import org.apache.parquet.schema.PrimitiveType;
 
 import static io.trino.spi.type.RealType.REAL;
 import static java.lang.Float.intBitsToFloat;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class RealValueWriter
@@ -38,7 +37,7 @@ public class RealValueWriter
     {
         for (int i = 0; i < block.getPositionCount(); i++) {
             if (!block.isNull(i)) {
-                float value = intBitsToFloat(toIntExact(REAL.getLong(block, i)));
+                float value = intBitsToFloat(REAL.getInt(block, i));
                 valuesWriter.writeFloat(value);
                 getStatistics().updateStats(value);
             }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/RealValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/RealValueWriter.java
@@ -18,7 +18,6 @@ import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
 import static io.trino.spi.type.RealType.REAL;
-import static java.lang.Float.intBitsToFloat;
 import static java.util.Objects.requireNonNull;
 
 public class RealValueWriter
@@ -37,7 +36,7 @@ public class RealValueWriter
     {
         for (int i = 0; i < block.getPositionCount(); i++) {
             if (!block.isNull(i)) {
-                float value = intBitsToFloat(REAL.getInt(block, i));
+                float value = REAL.getFloat(block, i);
                 valuesWriter.writeFloat(value);
                 getStatistics().updateStats(value);
             }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTypeUtils.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTypeUtils.java
@@ -48,7 +48,6 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
-import static java.lang.Math.toIntExact;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Collections.unmodifiableMap;
 
@@ -77,7 +76,7 @@ public final class BigQueryTypeUtils
             return SMALLINT.getShort(block, position);
         }
         if (type.equals(INTEGER)) {
-            return toIntExact(INTEGER.getLong(block, position));
+            return INTEGER.getInt(block, position);
         }
         if (type.equals(BIGINT)) {
             return BIGINT.getLong(block, position);
@@ -95,7 +94,7 @@ public final class BigQueryTypeUtils
             return Base64.getEncoder().encodeToString(VARBINARY.getSlice(block, position).getBytes());
         }
         if (type.equals(DATE)) {
-            long days = DATE.getLong(block, position);
+            int days = DATE.getInt(block, position);
             return DATE_FORMATTER.format(LocalDate.ofEpochDay(days));
         }
         if (type.equals(TIMESTAMP_MICROS)) {

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTypeUtils.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTypeUtils.java
@@ -70,38 +70,38 @@ public final class BigQueryTypeUtils
 
         // TODO https://github.com/trinodb/trino/issues/13741 Add support for time, timestamp with time zone, geography, map type
         if (type.equals(BOOLEAN)) {
-            return type.getBoolean(block, position);
+            return BOOLEAN.getBoolean(block, position);
         }
         if (type.equals(TINYINT)) {
-            return SignedBytes.checkedCast(type.getLong(block, position));
+            return SignedBytes.checkedCast(TINYINT.getLong(block, position));
         }
         if (type.equals(SMALLINT)) {
-            return Shorts.checkedCast(type.getLong(block, position));
+            return Shorts.checkedCast(SMALLINT.getLong(block, position));
         }
         if (type.equals(INTEGER)) {
-            return toIntExact(type.getLong(block, position));
+            return toIntExact(INTEGER.getLong(block, position));
         }
         if (type.equals(BIGINT)) {
-            return type.getLong(block, position);
+            return BIGINT.getLong(block, position);
         }
         if (type.equals(DOUBLE)) {
-            return type.getDouble(block, position);
+            return DOUBLE.getDouble(block, position);
         }
         if (type instanceof DecimalType) {
             return readBigDecimal((DecimalType) type, block, position).toString();
         }
-        if (type instanceof VarcharType) {
-            return type.getSlice(block, position).toStringUtf8();
+        if (type instanceof VarcharType varcharType) {
+            return varcharType.getSlice(block, position).toStringUtf8();
         }
         if (type.equals(VARBINARY)) {
-            return Base64.getEncoder().encodeToString(type.getSlice(block, position).getBytes());
+            return Base64.getEncoder().encodeToString(VARBINARY.getSlice(block, position).getBytes());
         }
         if (type.equals(DATE)) {
-            long days = type.getLong(block, position);
+            long days = DATE.getLong(block, position);
             return DATE_FORMATTER.format(LocalDate.ofEpochDay(days));
         }
         if (type.equals(TIMESTAMP_MICROS)) {
-            long epochMicros = type.getLong(block, position);
+            long epochMicros = TIMESTAMP_MICROS.getLong(block, position);
             long epochSeconds = floorDiv(epochMicros, MICROSECONDS_PER_SECOND);
             int nanoAdjustment = floorMod(epochMicros, MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND;
             return DATETIME_FORMATTER.format(toZonedDateTime(epochSeconds, nanoAdjustment, UTC));
@@ -121,7 +121,7 @@ public final class BigQueryTypeUtils
         if (type instanceof RowType rowType) {
             Block rowBlock = block.getObject(position, Block.class);
 
-            List<Type> fieldTypes = type.getTypeParameters();
+            List<Type> fieldTypes = rowType.getTypeParameters();
             if (fieldTypes.size() != rowBlock.getPositionCount()) {
                 throw new TrinoException(GENERIC_INTERNAL_ERROR, "Expected row value field count does not match type field count");
             }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTypeUtils.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTypeUtils.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.bigquery;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.primitives.Shorts;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.ArrayType;
@@ -75,7 +74,7 @@ public final class BigQueryTypeUtils
             return TINYINT.getByte(block, position);
         }
         if (type.equals(SMALLINT)) {
-            return Shorts.checkedCast(SMALLINT.getLong(block, position));
+            return SMALLINT.getShort(block, position);
         }
         if (type.equals(INTEGER)) {
             return toIntExact(INTEGER.getLong(block, position));

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTypeUtils.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTypeUtils.java
@@ -15,7 +15,6 @@ package io.trino.plugin.bigquery;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Shorts;
-import com.google.common.primitives.SignedBytes;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.ArrayType;
@@ -73,7 +72,7 @@ public final class BigQueryTypeUtils
             return BOOLEAN.getBoolean(block, position);
         }
         if (type.equals(TINYINT)) {
-            return SignedBytes.checkedCast(TINYINT.getLong(block, position));
+            return TINYINT.getByte(block, position);
         }
         if (type.equals(SMALLINT)) {
             return Shorts.checkedCast(SMALLINT.getLong(block, position));

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPageSink.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPageSink.java
@@ -159,44 +159,44 @@ public class CassandraPageSink
             values.add(null);
         }
         else if (BOOLEAN.equals(type)) {
-            values.add(type.getBoolean(block, position));
+            values.add(BOOLEAN.getBoolean(block, position));
         }
         else if (BIGINT.equals(type)) {
-            values.add(type.getLong(block, position));
+            values.add(BIGINT.getLong(block, position));
         }
         else if (INTEGER.equals(type)) {
-            values.add(toIntExact(type.getLong(block, position)));
+            values.add(toIntExact(INTEGER.getLong(block, position)));
         }
         else if (SMALLINT.equals(type)) {
-            values.add(Shorts.checkedCast(type.getLong(block, position)));
+            values.add(Shorts.checkedCast(SMALLINT.getLong(block, position)));
         }
         else if (TINYINT.equals(type)) {
-            values.add(SignedBytes.checkedCast(type.getLong(block, position)));
+            values.add(SignedBytes.checkedCast(TINYINT.getLong(block, position)));
         }
         else if (DOUBLE.equals(type)) {
-            values.add(type.getDouble(block, position));
+            values.add(DOUBLE.getDouble(block, position));
         }
         else if (REAL.equals(type)) {
-            values.add(intBitsToFloat(toIntExact(type.getLong(block, position))));
+            values.add(intBitsToFloat(toIntExact(REAL.getLong(block, position))));
         }
         else if (DATE.equals(type)) {
-            values.add(toCassandraDate.apply(type.getLong(block, position)));
+            values.add(toCassandraDate.apply(DATE.getLong(block, position)));
         }
         else if (TIME_NANOS.equals(type)) {
             long value = type.getLong(block, position);
             values.add(LocalTime.ofNanoOfDay(roundDiv(value, PICOSECONDS_PER_NANOSECOND) % NANOSECONDS_PER_DAY));
         }
         else if (TIMESTAMP_TZ_MILLIS.equals(type)) {
-            values.add(Instant.ofEpochMilli(unpackMillisUtc(type.getLong(block, position))));
+            values.add(Instant.ofEpochMilli(unpackMillisUtc(TIMESTAMP_TZ_MILLIS.getLong(block, position))));
         }
-        else if (type instanceof VarcharType) {
-            values.add(type.getSlice(block, position).toStringUtf8());
+        else if (type instanceof VarcharType varcharType) {
+            values.add(varcharType.getSlice(block, position).toStringUtf8());
         }
         else if (VARBINARY.equals(type)) {
-            values.add(type.getSlice(block, position).toByteBuffer());
+            values.add(VARBINARY.getSlice(block, position).toByteBuffer());
         }
         else if (UuidType.UUID.equals(type)) {
-            values.add(trinoUuidToJavaUuid(type.getSlice(block, position)));
+            values.add(trinoUuidToJavaUuid(UuidType.UUID.getSlice(block, position)));
         }
         else if (cassandraTypeManager.isIpAddressType(type)) {
             values.add(InetAddresses.forString((String) type.getObjectValue(null, block, position)));

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPageSink.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPageSink.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.InetAddresses;
 import com.google.common.primitives.Shorts;
-import com.google.common.primitives.SignedBytes;
 import io.airlift.slice.Slice;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
@@ -171,7 +170,7 @@ public class CassandraPageSink
             values.add(Shorts.checkedCast(SMALLINT.getLong(block, position)));
         }
         else if (TINYINT.equals(type)) {
-            values.add(SignedBytes.checkedCast(TINYINT.getLong(block, position)));
+            values.add(TINYINT.getByte(block, position));
         }
         else if (DOUBLE.equals(type)) {
             values.add(DOUBLE.getDouble(block, position));

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPageSink.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPageSink.java
@@ -67,7 +67,6 @@ import static io.trino.spi.type.Timestamps.roundDiv;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.UuidType.trinoUuidToJavaUuid;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
-import static java.lang.Float.intBitsToFloat;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
@@ -174,7 +173,7 @@ public class CassandraPageSink
             values.add(DOUBLE.getDouble(block, position));
         }
         else if (REAL.equals(type)) {
-            values.add(intBitsToFloat(REAL.getInt(block, position)));
+            values.add(REAL.getFloat(block, position));
         }
         else if (DATE.equals(type)) {
             values.add(toCassandraDate.apply(DATE.getInt(block, position)));

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPageSink.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPageSink.java
@@ -23,7 +23,6 @@ import com.datastax.oss.driver.api.querybuilder.term.Term;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.InetAddresses;
-import com.google.common.primitives.Shorts;
 import io.airlift.slice.Slice;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
@@ -167,7 +166,7 @@ public class CassandraPageSink
             values.add(toIntExact(INTEGER.getLong(block, position)));
         }
         else if (SMALLINT.equals(type)) {
-            values.add(Shorts.checkedCast(SMALLINT.getLong(block, position)));
+            values.add(SMALLINT.getShort(block, position));
         }
         else if (TINYINT.equals(type)) {
             values.add(TINYINT.getByte(block, position));

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnector.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnector.java
@@ -338,7 +338,7 @@ public class TestCassandraConnector
                     assertEquals(keyValue, "key");
                     assertEquals(VARCHAR.getSlice(udtValue, 0).toStringUtf8(), "text");
                     assertEquals(trinoUuidToJavaUuid(UUID.getSlice(udtValue, 1)).toString(), "01234567-0123-0123-0123-0123456789ab");
-                    assertEquals(INTEGER.getLong(udtValue, 2), -2147483648);
+                    assertEquals(INTEGER.getInt(udtValue, 2), -2147483648);
                     assertEquals(BIGINT.getLong(udtValue, 3), -9223372036854775808L);
                     assertEquals(VARBINARY.getSlice(udtValue, 4).toStringUtf8(), "01234");
                     assertEquals(TIMESTAMP_MILLIS.getLong(udtValue, 5), 117964800000L);
@@ -356,10 +356,10 @@ public class TestCassandraConnector
                     assertEquals(VARCHAR.getSlice(udtValue, 17).toStringUtf8(), "[true]");
                     SingleRowBlock tupleValueBlock = (SingleRowBlock) udtValue.getObject(18, Block.class);
                     assertThat(tupleValueBlock.getPositionCount()).isEqualTo(1);
-                    assertThat(INTEGER.getLong(tupleValueBlock, 0)).isEqualTo(123);
+                    assertThat(INTEGER.getInt(tupleValueBlock, 0)).isEqualTo(123);
                     SingleRowBlock udtValueBlock = (SingleRowBlock) udtValue.getObject(19, Block.class);
                     assertThat(udtValueBlock.getPositionCount()).isEqualTo(1);
-                    assertThat(INTEGER.getLong(udtValueBlock, 0)).isEqualTo(999);
+                    assertThat(INTEGER.getInt(udtValueBlock, 0)).isEqualTo(999);
 
                     long newCompletedBytes = cursor.getCompletedBytes();
                     assertTrue(newCompletedBytes >= completedBytes);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -78,7 +78,6 @@ import static io.trino.spi.predicate.Utils.nativeValueToBlock;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
@@ -239,7 +238,7 @@ public class DeltaLakeMergeSink
         int updateDeletePositionCount = 0;
 
         for (int position = 0; position < positionCount; position++) {
-            int operation = toIntExact(TINYINT.getLong(operationBlock, position));
+            byte operation = TINYINT.getByte(operationBlock, position);
             switch (operation) {
                 case DELETE_OPERATION_NUMBER:
                     deletePositions[deletePositionCount] = position;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSink.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSink.java
@@ -403,7 +403,7 @@ public class HivePageSink
 
             OptionalInt bucketNumber = OptionalInt.empty();
             if (bucketBlock != null) {
-                bucketNumber = OptionalInt.of((int) INTEGER.getLong(bucketBlock, position));
+                bucketNumber = OptionalInt.of(INTEGER.getInt(bucketBlock, position));
             }
 
             writer = writerFactory.createWriter(partitionColumns, position, bucketNumber);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdateBucketFunction.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdateBucketFunction.java
@@ -34,7 +34,7 @@ public class HiveUpdateBucketFunction
     public int getBucket(Page page, int position)
     {
         Block bucketBlock = page.getBlock(0).getObject(position, Block.class);
-        long value = INTEGER.getLong(bucketBlock, BUCKET_CHANNEL);
+        long value = INTEGER.getInt(bucketBlock, BUCKET_CHANNEL);
         return (int) (value & Integer.MAX_VALUE) % bucketCount;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/DecimalCoercers.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/DecimalCoercers.java
@@ -348,7 +348,7 @@ public final class DecimalCoercers
         protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
         {
             toType.writeLong(blockBuilder,
-                    realToShortDecimal(fromType.getInt(block, position), toType.getPrecision(), toType.getScale()));
+                    realToShortDecimal(fromType.getFloat(block, position), toType.getPrecision(), toType.getScale()));
         }
     }
 
@@ -364,7 +364,7 @@ public final class DecimalCoercers
         protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
         {
             toType.writeObject(blockBuilder,
-                    realToLongDecimal(fromType.getInt(block, position), toType.getPrecision(), toType.getScale()));
+                    realToLongDecimal(fromType.getFloat(block, position), toType.getPrecision(), toType.getScale()));
         }
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/DecimalCoercers.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/DecimalCoercers.java
@@ -348,7 +348,7 @@ public final class DecimalCoercers
         protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
         {
             toType.writeLong(blockBuilder,
-                    realToShortDecimal(fromType.getLong(block, position), toType.getPrecision(), toType.getScale()));
+                    realToShortDecimal(fromType.getInt(block, position), toType.getPrecision(), toType.getScale()));
         }
     }
 
@@ -364,7 +364,7 @@ public final class DecimalCoercers
         protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
         {
             toType.writeObject(blockBuilder,
-                    realToLongDecimal(fromType.getLong(block, position), toType.getPrecision(), toType.getScale()));
+                    realToLongDecimal(fromType.getInt(block, position), toType.getPrecision(), toType.getScale()));
         }
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/FloatToDoubleCoercer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/FloatToDoubleCoercer.java
@@ -34,6 +34,6 @@ public class FloatToDoubleCoercer
     @Override
     protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
     {
-        DOUBLE.writeDouble(blockBuilder, intBitsToFloat((int) REAL.getLong(block, position)));
+        DOUBLE.writeDouble(blockBuilder, intBitsToFloat(REAL.getInt(block, position)));
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/FloatToDoubleCoercer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/FloatToDoubleCoercer.java
@@ -21,7 +21,6 @@ import io.trino.spi.type.RealType;
 
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.RealType.REAL;
-import static java.lang.Float.intBitsToFloat;
 
 public class FloatToDoubleCoercer
         extends TypeCoercer<RealType, DoubleType>
@@ -34,6 +33,6 @@ public class FloatToDoubleCoercer
     @Override
     protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
     {
-        DOUBLE.writeDouble(blockBuilder, intBitsToFloat(REAL.getInt(block, position)));
+        DOUBLE.writeDouble(blockBuilder, REAL.getFloat(block, position));
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcDeletedRows.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcDeletedRows.java
@@ -53,7 +53,6 @@ import static io.trino.plugin.hive.HiveErrorCode.HIVE_CURSOR_ERROR;
 import static io.trino.plugin.hive.util.AcidTables.bucketFileName;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 @NotThreadSafe
@@ -222,7 +221,7 @@ public class OrcDeletedRows
             }
             else {
                 originalTransaction = BIGINT.getLong(sourcePage.getBlock(ORIGINAL_TRANSACTION_INDEX), position);
-                int encodedBucketValue = toIntExact(INTEGER.getLong(sourcePage.getBlock(BUCKET_ID_INDEX), position));
+                int encodedBucketValue = INTEGER.getInt(sourcePage.getBlock(BUCKET_ID_INDEX), position);
                 AcidBucketCodec bucketCodec = AcidBucketCodec.forBucket(encodedBucketValue);
                 bucket = bucketCodec.decodeWriterId(encodedBucketValue);
                 statementId = bucketCodec.decodeStatementId(encodedBucketValue);
@@ -333,7 +332,7 @@ public class OrcDeletedRows
 
                             while (currentPagePosition < currentPage.getPositionCount()) {
                                 long originalTransaction = BIGINT.getLong(currentPage.getBlock(ORIGINAL_TRANSACTION_INDEX), currentPagePosition);
-                                int encodedBucketValue = toIntExact(INTEGER.getLong(currentPage.getBlock(BUCKET_ID_INDEX), currentPagePosition));
+                                int encodedBucketValue = INTEGER.getInt(currentPage.getBlock(BUCKET_ID_INDEX), currentPagePosition);
                                 AcidBucketCodec bucketCodec = AcidBucketCodec.forBucket(encodedBucketValue);
                                 int bucket = bucketCodec.decodeWriterId(encodedBucketValue);
                                 int statement = bucketCodec.decodeStatementId(encodedBucketValue);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/FieldSetterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/FieldSetterFactory.java
@@ -194,7 +194,7 @@ public final class FieldSetterFactory
         @Override
         public void setField(Block block, int position)
         {
-            value.set(toIntExact(INTEGER.getLong(block, position)));
+            value.set(INTEGER.getInt(block, position));
             rowInspector.setStructFieldData(row, field, value);
         }
     }
@@ -266,7 +266,7 @@ public final class FieldSetterFactory
         @Override
         public void setField(Block block, int position)
         {
-            value.set(intBitsToFloat((int) REAL.getLong(block, position)));
+            value.set(intBitsToFloat(REAL.getInt(block, position)));
             rowInspector.setStructFieldData(row, field, value);
         }
     }
@@ -343,7 +343,7 @@ public final class FieldSetterFactory
         @Override
         public void setField(Block block, int position)
         {
-            value.set(toIntExact(DATE.getLong(block, position)));
+            value.set(DATE.getInt(block, position));
             rowInspector.setStructFieldData(row, field, value);
         }
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/FieldSetterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/FieldSetterFactory.java
@@ -61,7 +61,6 @@ import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
-import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
 import static java.lang.Math.toIntExact;
@@ -266,7 +265,7 @@ public final class FieldSetterFactory
         @Override
         public void setField(Block block, int position)
         {
-            value.set(intBitsToFloat(REAL.getInt(block, position)));
+            value.set(REAL.getFloat(block, position));
             rowInspector.setStructFieldData(row, field, value);
         }
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/FieldSetterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/FieldSetterFactory.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.hive.util;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.primitives.Shorts;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.CharType;
@@ -213,7 +212,7 @@ public final class FieldSetterFactory
         @Override
         public void setField(Block block, int position)
         {
-            value.set(Shorts.checkedCast(SMALLINT.getLong(block, position)));
+            value.set(SMALLINT.getShort(block, position));
             rowInspector.setStructFieldData(row, field, value);
         }
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/FieldSetterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/FieldSetterFactory.java
@@ -15,7 +15,6 @@ package io.trino.plugin.hive.util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Shorts;
-import com.google.common.primitives.SignedBytes;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.CharType;
@@ -232,7 +231,7 @@ public final class FieldSetterFactory
         @Override
         public void setField(Block block, int position)
         {
-            value.set(SignedBytes.checkedCast(TINYINT.getLong(block, position)));
+            value.set(TINYINT.getByte(block, position));
             rowInspector.setStructFieldData(row, field, value);
         }
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV1.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV1.java
@@ -90,7 +90,7 @@ final class HiveBucketingV1
                     return BOOLEAN.getBoolean(block, position) ? 1 : 0;
                 }
                 if (trinoType.equals(TINYINT)) {
-                    return SignedBytes.checkedCast(TINYINT.getLong(block, position));
+                    return TINYINT.getByte(block, position);
                 }
                 if (trinoType.equals(SMALLINT)) {
                     return Shorts.checkedCast(SMALLINT.getLong(block, position));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV1.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV1.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.hive.util;
 
+import com.google.common.base.VerifyException;
 import com.google.common.primitives.Shorts;
 import com.google.common.primitives.SignedBytes;
 import io.airlift.slice.Slice;
@@ -24,10 +25,19 @@ import io.trino.plugin.hive.type.TypeInfo;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
 
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
 import static java.lang.Double.doubleToLongBits;
 import static java.lang.Float.floatToIntBits;
 import static java.lang.Float.intBitsToFloat;
@@ -76,46 +86,45 @@ final class HiveBucketingV1
                 PrimitiveTypeInfo typeInfo = (PrimitiveTypeInfo) type;
                 PrimitiveCategory primitiveCategory = typeInfo.getPrimitiveCategory();
                 Type trinoType = requireNonNull(HiveTypeTranslator.fromPrimitiveType(typeInfo));
-                switch (primitiveCategory) {
-                    case BOOLEAN:
-                        return trinoType.getBoolean(block, position) ? 1 : 0;
-                    case BYTE:
-                        return SignedBytes.checkedCast(trinoType.getLong(block, position));
-                    case SHORT:
-                        return Shorts.checkedCast(trinoType.getLong(block, position));
-                    case INT:
-                        return toIntExact(trinoType.getLong(block, position));
-                    case LONG:
-                        long bigintValue = trinoType.getLong(block, position);
-                        return (int) ((bigintValue >>> 32) ^ bigintValue);
-                    case FLOAT:
-                        // convert to canonical NaN if necessary
-                        return floatToIntBits(intBitsToFloat(toIntExact(trinoType.getLong(block, position))));
-                    case DOUBLE:
-                        long doubleValue = doubleToLongBits(trinoType.getDouble(block, position));
-                        return (int) ((doubleValue >>> 32) ^ doubleValue);
-                    case STRING:
-                        return hashBytes(0, trinoType.getSlice(block, position));
-                    case VARCHAR:
-                        return hashBytes(1, trinoType.getSlice(block, position));
-                    case DATE:
-                        // day offset from 1970-01-01
-                        return toIntExact(trinoType.getLong(block, position));
-                    case TIMESTAMP:
-                        // We do not support bucketing on timestamp
-                        break;
-                    case DECIMAL:
-                    case CHAR:
-                    case BINARY:
-                    case TIMESTAMPLOCALTZ:
-                    case INTERVAL_YEAR_MONTH:
-                    case INTERVAL_DAY_TIME:
-                        // TODO
-                        break;
-                    case VOID:
-                    case UNKNOWN:
-                        break;
+                if (trinoType.equals(BOOLEAN)) {
+                    return BOOLEAN.getBoolean(block, position) ? 1 : 0;
                 }
+                if (trinoType.equals(TINYINT)) {
+                    return SignedBytes.checkedCast(TINYINT.getLong(block, position));
+                }
+                if (trinoType.equals(SMALLINT)) {
+                    return Shorts.checkedCast(SMALLINT.getLong(block, position));
+                }
+                if (trinoType.equals(INTEGER)) {
+                    return toIntExact(INTEGER.getLong(block, position));
+                }
+                if (trinoType.equals(BIGINT)) {
+                    long bigintValue = BIGINT.getLong(block, position);
+                    return (int) ((bigintValue >>> 32) ^ bigintValue);
+                }
+                if (trinoType.equals(REAL)) {
+                    // convert to canonical NaN if necessary
+                    return floatToIntBits(intBitsToFloat(toIntExact(REAL.getLong(block, position))));
+                }
+                if (trinoType.equals(DOUBLE)) {
+                    long doubleValue = doubleToLongBits(DOUBLE.getDouble(block, position));
+                    return (int) ((doubleValue >>> 32) ^ doubleValue);
+                }
+                if (trinoType instanceof VarcharType varcharType) {
+                    int initial = switch (primitiveCategory) {
+                        case STRING -> 0;
+                        case VARCHAR -> 1;
+                        default -> throw new VerifyException("Unexpected category: " + primitiveCategory);
+                    };
+                    return hashBytes(initial, varcharType.getSlice(block, position));
+                }
+                if (trinoType.equals(DATE)) {
+                    // day offset from 1970-01-01
+                    return toIntExact(DATE.getLong(block, position));
+                }
+
+                // We do not support bucketing on the following:
+                // TIMESTAMP DECIMAL CHAR BINARY TIMESTAMPLOCALTZ INTERVAL_YEAR_MONTH INTERVAL_DAY_TIME VOID UNKNOWN
                 throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive primitive category: " + primitiveCategory);
             case LIST:
                 return hashOfList((ListTypeInfo) type, block.getObject(position, Block.class));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV1.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV1.java
@@ -104,7 +104,7 @@ final class HiveBucketingV1
                 }
                 if (trinoType.equals(REAL)) {
                     // convert to canonical NaN if necessary
-                    return floatToIntBits(intBitsToFloat(REAL.getInt(block, position)));
+                    return floatToIntBits(REAL.getFloat(block, position));
                 }
                 if (trinoType.equals(DOUBLE)) {
                     long doubleValue = doubleToLongBits(DOUBLE.getDouble(block, position));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV1.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV1.java
@@ -93,7 +93,7 @@ final class HiveBucketingV1
                     return TINYINT.getByte(block, position);
                 }
                 if (trinoType.equals(SMALLINT)) {
-                    return Shorts.checkedCast(SMALLINT.getLong(block, position));
+                    return SMALLINT.getShort(block, position);
                 }
                 if (trinoType.equals(INTEGER)) {
                     return toIntExact(INTEGER.getLong(block, position));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV1.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV1.java
@@ -96,7 +96,7 @@ final class HiveBucketingV1
                     return SMALLINT.getShort(block, position);
                 }
                 if (trinoType.equals(INTEGER)) {
-                    return toIntExact(INTEGER.getLong(block, position));
+                    return INTEGER.getInt(block, position);
                 }
                 if (trinoType.equals(BIGINT)) {
                     long bigintValue = BIGINT.getLong(block, position);
@@ -104,7 +104,7 @@ final class HiveBucketingV1
                 }
                 if (trinoType.equals(REAL)) {
                     // convert to canonical NaN if necessary
-                    return floatToIntBits(intBitsToFloat(toIntExact(REAL.getLong(block, position))));
+                    return floatToIntBits(intBitsToFloat(REAL.getInt(block, position)));
                 }
                 if (trinoType.equals(DOUBLE)) {
                     long doubleValue = doubleToLongBits(DOUBLE.getDouble(block, position));
@@ -120,7 +120,7 @@ final class HiveBucketingV1
                 }
                 if (trinoType.equals(DATE)) {
                     // day offset from 1970-01-01
-                    return toIntExact(DATE.getLong(block, position));
+                    return DATE.getInt(block, position);
                 }
 
                 // We do not support bucketing on the following:

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV2.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV2.java
@@ -25,10 +25,19 @@ import io.trino.plugin.hive.type.TypeInfo;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
 
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
 import static java.lang.Double.doubleToLongBits;
 import static java.lang.Double.doubleToRawLongBits;
 import static java.lang.Float.floatToIntBits;
@@ -79,48 +88,42 @@ final class HiveBucketingV2
                 PrimitiveTypeInfo typeInfo = (PrimitiveTypeInfo) type;
                 PrimitiveCategory primitiveCategory = typeInfo.getPrimitiveCategory();
                 Type trinoType = requireNonNull(HiveTypeTranslator.fromPrimitiveType(typeInfo));
-                switch (primitiveCategory) {
-                    case BOOLEAN:
-                        return trinoType.getBoolean(block, position) ? 1 : 0;
-                    case BYTE:
-                        return SignedBytes.checkedCast(trinoType.getLong(block, position));
-                    case SHORT:
-                        return murmur3(bytes(Shorts.checkedCast(trinoType.getLong(block, position))));
-                    case INT:
-                        return murmur3(bytes(toIntExact(trinoType.getLong(block, position))));
-                    case LONG:
-                        return murmur3(bytes(trinoType.getLong(block, position)));
-                    case FLOAT:
-                        // convert to canonical NaN if necessary
-                        // Sic! we're `floatToIntBits -> cast to float -> floatToRawIntBits` just as it is (implicitly) done in
-                        // https://github.com/apache/hive/blob/7dc47faddba9f079bbe2698aaa4d8712e7654f87/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java#L830
-                        return murmur3(bytes(floatToRawIntBits(floatToIntBits(intBitsToFloat(toIntExact(trinoType.getLong(block, position)))))));
-                    case DOUBLE:
-                        // Sic! we're `doubleToLongBits -> cast to double -> doubleToRawLongBits` just as it is (implicitly) done in
-                        // https://github.com/apache/hive/blob/7dc47faddba9f079bbe2698aaa4d8712e7654f87/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java#L836
-                        return murmur3(bytes(doubleToRawLongBits(doubleToLongBits(trinoType.getDouble(block, position)))));
-                    case STRING:
-                        return murmur3(trinoType.getSlice(block, position).getBytes());
-                    case VARCHAR:
-                        return murmur3(trinoType.getSlice(block, position).getBytes());
-                    case DATE:
-                        // day offset from 1970-01-01
-                        return murmur3(bytes(toIntExact(trinoType.getLong(block, position))));
-                    case TIMESTAMP:
-                        // We do not support bucketing on timestamp
-                        break;
-                    case DECIMAL:
-                    case CHAR:
-                    case BINARY:
-                    case TIMESTAMPLOCALTZ:
-                    case INTERVAL_YEAR_MONTH:
-                    case INTERVAL_DAY_TIME:
-                        // TODO
-                        break;
-                    case VOID:
-                    case UNKNOWN:
-                        break;
+                if (trinoType.equals(BOOLEAN)) {
+                    return BOOLEAN.getBoolean(block, position) ? 1 : 0;
                 }
+                if (trinoType.equals(TINYINT)) {
+                    return SignedBytes.checkedCast(TINYINT.getLong(block, position));
+                }
+                if (trinoType.equals(SMALLINT)) {
+                    return murmur3(bytes(Shorts.checkedCast(SMALLINT.getLong(block, position))));
+                }
+                if (trinoType.equals(INTEGER)) {
+                    return murmur3(bytes(toIntExact(INTEGER.getLong(block, position))));
+                }
+                if (trinoType.equals(BIGINT)) {
+                    return murmur3(bytes(BIGINT.getLong(block, position)));
+                }
+                if (trinoType.equals(REAL)) {
+                    // convert to canonical NaN if necessary
+                    // Sic! we're `floatToIntBits -> cast to float -> floatToRawIntBits` just as it is (implicitly) done in
+                    // https://github.com/apache/hive/blob/7dc47faddba9f079bbe2698aaa4d8712e7654f87/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java#L830
+                    return murmur3(bytes(floatToRawIntBits(floatToIntBits(intBitsToFloat(toIntExact(REAL.getLong(block, position)))))));
+                }
+                if (trinoType.equals(DOUBLE)) {
+                    // Sic! we're `doubleToLongBits -> cast to double -> doubleToRawLongBits` just as it is (implicitly) done in
+                    // https://github.com/apache/hive/blob/7dc47faddba9f079bbe2698aaa4d8712e7654f87/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java#L836
+                    return murmur3(bytes(doubleToRawLongBits(doubleToLongBits(DOUBLE.getDouble(block, position)))));
+                }
+                if (trinoType instanceof VarcharType varcharType) {
+                    return murmur3(varcharType.getSlice(block, position).getBytes());
+                }
+                if (trinoType.equals(DATE)) {
+                    // day offset from 1970-01-01
+                    return murmur3(bytes(toIntExact(DATE.getLong(block, position))));
+                }
+
+                // We do not support bucketing on the following:
+                // TIMESTAMP DECIMAL CHAR BINARY TIMESTAMPLOCALTZ INTERVAL_YEAR_MONTH INTERVAL_DAY_TIME VOID UNKNOWN
                 throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive primitive category: " + primitiveCategory);
             case LIST:
                 return hashOfList((ListTypeInfo) type, block.getObject(position, Block.class));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV2.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV2.java
@@ -98,7 +98,7 @@ final class HiveBucketingV2
                     return murmur3(bytes(SMALLINT.getShort(block, position)));
                 }
                 if (trinoType.equals(INTEGER)) {
-                    return murmur3(bytes(toIntExact(INTEGER.getLong(block, position))));
+                    return murmur3(bytes(INTEGER.getInt(block, position)));
                 }
                 if (trinoType.equals(BIGINT)) {
                     return murmur3(bytes(BIGINT.getLong(block, position)));
@@ -107,7 +107,7 @@ final class HiveBucketingV2
                     // convert to canonical NaN if necessary
                     // Sic! we're `floatToIntBits -> cast to float -> floatToRawIntBits` just as it is (implicitly) done in
                     // https://github.com/apache/hive/blob/7dc47faddba9f079bbe2698aaa4d8712e7654f87/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java#L830
-                    return murmur3(bytes(floatToRawIntBits(floatToIntBits(intBitsToFloat(toIntExact(REAL.getLong(block, position)))))));
+                    return murmur3(bytes(floatToRawIntBits(floatToIntBits(intBitsToFloat(REAL.getInt(block, position))))));
                 }
                 if (trinoType.equals(DOUBLE)) {
                     // Sic! we're `doubleToLongBits -> cast to double -> doubleToRawLongBits` just as it is (implicitly) done in
@@ -119,7 +119,7 @@ final class HiveBucketingV2
                 }
                 if (trinoType.equals(DATE)) {
                     // day offset from 1970-01-01
-                    return murmur3(bytes(toIntExact(DATE.getLong(block, position))));
+                    return murmur3(bytes(DATE.getInt(block, position)));
                 }
 
                 // We do not support bucketing on the following:

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV2.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV2.java
@@ -92,7 +92,7 @@ final class HiveBucketingV2
                     return BOOLEAN.getBoolean(block, position) ? 1 : 0;
                 }
                 if (trinoType.equals(TINYINT)) {
-                    return SignedBytes.checkedCast(TINYINT.getLong(block, position));
+                    return TINYINT.getByte(block, position);
                 }
                 if (trinoType.equals(SMALLINT)) {
                     return murmur3(bytes(Shorts.checkedCast(SMALLINT.getLong(block, position))));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV2.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV2.java
@@ -95,7 +95,7 @@ final class HiveBucketingV2
                     return TINYINT.getByte(block, position);
                 }
                 if (trinoType.equals(SMALLINT)) {
-                    return murmur3(bytes(Shorts.checkedCast(SMALLINT.getLong(block, position))));
+                    return murmur3(bytes(SMALLINT.getShort(block, position)));
                 }
                 if (trinoType.equals(INTEGER)) {
                     return murmur3(bytes(toIntExact(INTEGER.getLong(block, position))));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV2.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV2.java
@@ -107,7 +107,7 @@ final class HiveBucketingV2
                     // convert to canonical NaN if necessary
                     // Sic! we're `floatToIntBits -> cast to float -> floatToRawIntBits` just as it is (implicitly) done in
                     // https://github.com/apache/hive/blob/7dc47faddba9f079bbe2698aaa4d8712e7654f87/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java#L830
-                    return murmur3(bytes(floatToRawIntBits(floatToIntBits(intBitsToFloat(REAL.getInt(block, position))))));
+                    return murmur3(bytes(floatToRawIntBits(floatToIntBits(REAL.getFloat(block, position)))));
                 }
                 if (trinoType.equals(DOUBLE)) {
                     // Sic! we're `doubleToLongBits -> cast to double -> doubleToRawLongBits` just as it is (implicitly) done in

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
@@ -15,7 +15,6 @@ package io.trino.plugin.hive.util;
 
 import com.google.common.base.CharMatcher;
 import com.google.common.collect.ImmutableList;
-import com.google.common.primitives.Shorts;
 import io.trino.hdfs.HdfsContext;
 import io.trino.hdfs.HdfsEnvironment;
 import io.trino.plugin.hive.HiveReadOnlyException;
@@ -310,7 +309,7 @@ public final class HiveWriteUtils
             return toIntExact(INTEGER.getLong(block, position));
         }
         if (SMALLINT.equals(type)) {
-            return Shorts.checkedCast(SMALLINT.getLong(block, position));
+            return SMALLINT.getShort(block, position);
         }
         if (TINYINT.equals(type)) {
             return TINYINT.getByte(block, position);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
@@ -124,7 +124,6 @@ import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
-import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
 import static java.lang.String.format;
@@ -314,7 +313,7 @@ public final class HiveWriteUtils
             return TINYINT.getByte(block, position);
         }
         if (REAL.equals(type)) {
-            return intBitsToFloat(REAL.getInt(block, position));
+            return REAL.getFloat(block, position);
         }
         if (DOUBLE.equals(type)) {
             return DOUBLE.getDouble(block, position);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
@@ -16,7 +16,6 @@ package io.trino.plugin.hive.util;
 import com.google.common.base.CharMatcher;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Shorts;
-import com.google.common.primitives.SignedBytes;
 import io.trino.hdfs.HdfsContext;
 import io.trino.hdfs.HdfsEnvironment;
 import io.trino.plugin.hive.HiveReadOnlyException;
@@ -314,7 +313,7 @@ public final class HiveWriteUtils
             return Shorts.checkedCast(SMALLINT.getLong(block, position));
         }
         if (TINYINT.equals(type)) {
-            return SignedBytes.checkedCast(TINYINT.getLong(block, position));
+            return TINYINT.getByte(block, position);
         }
         if (REAL.equals(type)) {
             return intBitsToFloat((int) REAL.getLong(block, position));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
@@ -302,46 +302,46 @@ public final class HiveWriteUtils
             return null;
         }
         if (BOOLEAN.equals(type)) {
-            return type.getBoolean(block, position);
+            return BOOLEAN.getBoolean(block, position);
         }
         if (BIGINT.equals(type)) {
-            return type.getLong(block, position);
+            return BIGINT.getLong(block, position);
         }
         if (INTEGER.equals(type)) {
-            return toIntExact(type.getLong(block, position));
+            return toIntExact(INTEGER.getLong(block, position));
         }
         if (SMALLINT.equals(type)) {
-            return Shorts.checkedCast(type.getLong(block, position));
+            return Shorts.checkedCast(SMALLINT.getLong(block, position));
         }
         if (TINYINT.equals(type)) {
-            return SignedBytes.checkedCast(type.getLong(block, position));
+            return SignedBytes.checkedCast(TINYINT.getLong(block, position));
         }
         if (REAL.equals(type)) {
-            return intBitsToFloat((int) type.getLong(block, position));
+            return intBitsToFloat((int) REAL.getLong(block, position));
         }
         if (DOUBLE.equals(type)) {
-            return type.getDouble(block, position);
+            return DOUBLE.getDouble(block, position);
         }
-        if (type instanceof VarcharType) {
-            return new Text(type.getSlice(block, position).getBytes());
+        if (type instanceof VarcharType varcharType) {
+            return new Text(varcharType.getSlice(block, position).getBytes());
         }
         if (type instanceof CharType charType) {
-            return new Text(padSpaces(type.getSlice(block, position), charType).toStringUtf8());
+            return new Text(padSpaces(charType.getSlice(block, position), charType).toStringUtf8());
         }
         if (VARBINARY.equals(type)) {
-            return type.getSlice(block, position).getBytes();
+            return VARBINARY.getSlice(block, position).getBytes();
         }
         if (DATE.equals(type)) {
-            return Date.ofEpochDay(toIntExact(type.getLong(block, position)));
+            return Date.ofEpochDay(toIntExact(DATE.getLong(block, position)));
         }
-        if (type instanceof TimestampType) {
-            return getHiveTimestamp(localZone, (TimestampType) type, block, position);
+        if (type instanceof TimestampType timestampType) {
+            return getHiveTimestamp(localZone, timestampType, block, position);
         }
         if (type instanceof DecimalType decimalType) {
             return getHiveDecimal(decimalType, block, position);
         }
-        if (type instanceof ArrayType) {
-            Type elementType = ((ArrayType) type).getElementType();
+        if (type instanceof ArrayType arrayType) {
+            Type elementType = arrayType.getElementType();
             Block arrayBlock = block.getObject(position, Block.class);
 
             List<Object> list = new ArrayList<>(arrayBlock.getPositionCount());
@@ -350,9 +350,9 @@ public final class HiveWriteUtils
             }
             return unmodifiableList(list);
         }
-        if (type instanceof MapType) {
-            Type keyType = ((MapType) type).getKeyType();
-            Type valueType = ((MapType) type).getValueType();
+        if (type instanceof MapType mapType) {
+            Type keyType = mapType.getKeyType();
+            Type valueType = mapType.getValueType();
             Block mapBlock = block.getObject(position, Block.class);
 
             Map<Object, Object> map = new HashMap<>();
@@ -363,8 +363,8 @@ public final class HiveWriteUtils
             }
             return unmodifiableMap(map);
         }
-        if (type instanceof RowType) {
-            List<Type> fieldTypes = type.getTypeParameters();
+        if (type instanceof RowType rowType) {
+            List<Type> fieldTypes = rowType.getTypeParameters();
             Block rowBlock = block.getObject(position, Block.class);
             checkCondition(
                     fieldTypes.size() == rowBlock.getPositionCount(),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
@@ -127,7 +127,6 @@ import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.unmodifiableList;
@@ -306,7 +305,7 @@ public final class HiveWriteUtils
             return BIGINT.getLong(block, position);
         }
         if (INTEGER.equals(type)) {
-            return toIntExact(INTEGER.getLong(block, position));
+            return INTEGER.getInt(block, position);
         }
         if (SMALLINT.equals(type)) {
             return SMALLINT.getShort(block, position);
@@ -315,7 +314,7 @@ public final class HiveWriteUtils
             return TINYINT.getByte(block, position);
         }
         if (REAL.equals(type)) {
-            return intBitsToFloat((int) REAL.getLong(block, position));
+            return intBitsToFloat(REAL.getInt(block, position));
         }
         if (DOUBLE.equals(type)) {
             return DOUBLE.getDouble(block, position);
@@ -330,7 +329,7 @@ public final class HiveWriteUtils
             return VARBINARY.getSlice(block, position).getBytes();
         }
         if (DATE.equals(type)) {
-            return Date.ofEpochDay(toIntExact(DATE.getLong(block, position)));
+            return Date.ofEpochDay(DATE.getInt(block, position));
         }
         if (type instanceof TimestampType timestampType) {
             return getHiveTimestamp(localZone, timestampType, block, position);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestMergingPageIterator.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestMergingPageIterator.java
@@ -80,7 +80,7 @@ public class TestMergingPageIterator
                 .collect(toList());
         Iterator<Page> iterator = new MergingPageIterator(pages, types, sortIndexes, sortOrders, new TypeOperators());
 
-        List<Long> values = new ArrayList<>();
+        List<Integer> values = new ArrayList<>();
         while (iterator.hasNext()) {
             Page page = iterator.next();
             for (int i = 0; i < page.getPositionCount(); i++) {
@@ -89,8 +89,8 @@ public class TestMergingPageIterator
                     values.add(null);
                 }
                 else {
-                    long x = INTEGER.getLong(page.getBlock(0), i);
-                    long y = INTEGER.getLong(page.getBlock(1), i);
+                    int x = INTEGER.getInt(page.getBlock(0), i);
+                    int y = INTEGER.getInt(page.getBlock(1), i);
                     assertEquals(y, x * 22);
                     values.add(x);
                 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroDataConversion.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroDataConversion.java
@@ -74,7 +74,6 @@ import static io.trino.spi.type.UuidType.javaUuidToTrinoUuid;
 import static io.trino.spi.type.UuidType.trinoUuidToJavaUuid;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.Float.floatToRawIntBits;
-import static java.lang.Float.intBitsToFloat;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.types.Type.TypeID.FIXED;
 import static org.apache.iceberg.util.DateTimeUtil.microsFromTimestamp;
@@ -153,7 +152,7 @@ public final class IcebergAvroDataConversion
             return BIGINT.getLong(block, position);
         }
         if (type.equals(REAL)) {
-            return intBitsToFloat(REAL.getInt(block, position));
+            return REAL.getFloat(block, position);
         }
         if (type.equals(DOUBLE)) {
             return DOUBLE.getDouble(block, position);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroDataConversion.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroDataConversion.java
@@ -75,7 +75,6 @@ import static io.trino.spi.type.UuidType.trinoUuidToJavaUuid;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.types.Type.TypeID.FIXED;
 import static org.apache.iceberg.util.DateTimeUtil.microsFromTimestamp;
@@ -148,13 +147,13 @@ public final class IcebergAvroDataConversion
             return BOOLEAN.getBoolean(block, position);
         }
         if (type.equals(INTEGER)) {
-            return toIntExact(INTEGER.getLong(block, position));
+            return INTEGER.getInt(block, position);
         }
         if (type.equals(BIGINT)) {
             return BIGINT.getLong(block, position);
         }
         if (type.equals(REAL)) {
-            return intBitsToFloat((int) REAL.getLong(block, position));
+            return intBitsToFloat(REAL.getInt(block, position));
         }
         if (type.equals(DOUBLE)) {
             return DOUBLE.getDouble(block, position);
@@ -172,7 +171,7 @@ public final class IcebergAvroDataConversion
             return ByteBuffer.wrap(varbinaryType.getSlice(block, position).getBytes());
         }
         if (type.equals(DATE)) {
-            long epochDays = DATE.getLong(block, position);
+            int epochDays = DATE.getInt(block, position);
             return LocalDate.ofEpochDay(epochDays);
         }
         if (type.equals(TIME_MICROS)) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMergeSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMergeSink.java
@@ -48,7 +48,6 @@ import static io.trino.spi.block.ColumnarRow.toColumnarRow;
 import static io.trino.spi.connector.MergePage.createDeleteAndInsertPages;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
@@ -111,7 +110,7 @@ public class IcebergMergeSink
                 int index = position;
                 FileDeletion deletion = fileDeletions.computeIfAbsent(filePath, ignored -> {
                     long fileRecordCount = BIGINT.getLong(rowIdRow.getField(2), index);
-                    int partitionSpecId = toIntExact(INTEGER.getLong(rowIdRow.getField(3), index));
+                    int partitionSpecId = INTEGER.getInt(rowIdRow.getField(3), index);
                     String partitionData = VarcharType.VARCHAR.getSlice(rowIdRow.getField(4), index).toStringUtf8();
                     return new FileDeletion(partitionSpecId, partitionData, fileRecordCount);
                 });

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
@@ -81,7 +81,6 @@ import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.UuidType.UUID;
 import static io.trino.spi.type.UuidType.trinoUuidToJavaUuid;
-import static java.lang.Float.intBitsToFloat;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
@@ -471,7 +470,7 @@ public class IcebergPageSink
             return readBigDecimal(decimalType, block, position);
         }
         if (type.equals(REAL)) {
-            return intBitsToFloat(REAL.getInt(block, position));
+            return REAL.getFloat(block, position);
         }
         if (type.equals(DOUBLE)) {
             return DOUBLE.getDouble(block, position);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
@@ -29,18 +29,9 @@ import io.trino.spi.block.Block;
 import io.trino.spi.connector.ConnectorPageSink;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SortOrder;
-import io.trino.spi.type.BigintType;
-import io.trino.spi.type.BooleanType;
-import io.trino.spi.type.DateType;
 import io.trino.spi.type.DecimalType;
-import io.trino.spi.type.DoubleType;
-import io.trino.spi.type.IntegerType;
-import io.trino.spi.type.RealType;
-import io.trino.spi.type.SmallintType;
-import io.trino.spi.type.TinyintType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
-import io.trino.spi.type.UuidType;
 import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
 import org.apache.iceberg.MetricsConfig;
@@ -75,11 +66,20 @@ import static io.trino.plugin.iceberg.IcebergUtil.getColumns;
 import static io.trino.plugin.iceberg.PartitionTransforms.getColumnTransform;
 import static io.trino.plugin.iceberg.util.Timestamps.getTimestampTz;
 import static io.trino.plugin.iceberg.util.Timestamps.timestampTzToMicros;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.Decimals.readBigDecimal;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimeType.TIME_MICROS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.UuidType.UUID;
 import static io.trino.spi.type.UuidType.trinoUuidToJavaUuid;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
@@ -450,41 +450,50 @@ public class IcebergPageSink
         if (block.isNull(position)) {
             return null;
         }
-        if (type instanceof BigintType) {
-            return type.getLong(block, position);
+        if (type.equals(BIGINT)) {
+            return BIGINT.getLong(block, position);
         }
-        if (type instanceof IntegerType || type instanceof SmallintType || type instanceof TinyintType || type instanceof DateType) {
-            return toIntExact(type.getLong(block, position));
+        if (type.equals(TINYINT)) {
+            return toIntExact(TINYINT.getLong(block, position));
         }
-        if (type instanceof BooleanType) {
-            return type.getBoolean(block, position);
+        if (type.equals(SMALLINT)) {
+            return toIntExact(SMALLINT.getLong(block, position));
         }
-        if (type instanceof DecimalType) {
-            return readBigDecimal((DecimalType) type, block, position);
+        if (type.equals(INTEGER)) {
+            return toIntExact(INTEGER.getLong(block, position));
         }
-        if (type instanceof RealType) {
-            return intBitsToFloat(toIntExact(type.getLong(block, position)));
+        if (type.equals(DATE)) {
+            return toIntExact(DATE.getLong(block, position));
         }
-        if (type instanceof DoubleType) {
-            return type.getDouble(block, position);
+        if (type.equals(BOOLEAN)) {
+            return BOOLEAN.getBoolean(block, position);
+        }
+        if (type instanceof DecimalType decimalType) {
+            return readBigDecimal(decimalType, block, position);
+        }
+        if (type.equals(REAL)) {
+            return intBitsToFloat(toIntExact(REAL.getLong(block, position)));
+        }
+        if (type.equals(DOUBLE)) {
+            return DOUBLE.getDouble(block, position);
         }
         if (type.equals(TIME_MICROS)) {
-            return type.getLong(block, position) / PICOSECONDS_PER_MICROSECOND;
+            return TIME_MICROS.getLong(block, position) / PICOSECONDS_PER_MICROSECOND;
         }
         if (type.equals(TIMESTAMP_MICROS)) {
-            return type.getLong(block, position);
+            return TIMESTAMP_MICROS.getLong(block, position);
         }
         if (type.equals(TIMESTAMP_TZ_MICROS)) {
             return timestampTzToMicros(getTimestampTz(block, position));
         }
-        if (type instanceof VarbinaryType) {
-            return type.getSlice(block, position).getBytes();
+        if (type instanceof VarbinaryType varbinaryType) {
+            return varbinaryType.getSlice(block, position).getBytes();
         }
-        if (type instanceof VarcharType) {
-            return type.getSlice(block, position).toStringUtf8();
+        if (type instanceof VarcharType varcharType) {
+            return varcharType.getSlice(block, position).toStringUtf8();
         }
-        if (type instanceof UuidType) {
-            return trinoUuidToJavaUuid(type.getSlice(block, position));
+        if (type.equals(UUID)) {
+            return trinoUuidToJavaUuid(UUID.getSlice(block, position));
         }
         throw new UnsupportedOperationException("Type not supported as partition column: " + type.getDisplayName());
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
@@ -457,7 +457,7 @@ public class IcebergPageSink
             return (int) TINYINT.getByte(block, position);
         }
         if (type.equals(SMALLINT)) {
-            return toIntExact(SMALLINT.getLong(block, position));
+            return (int) SMALLINT.getShort(block, position);
         }
         if (type.equals(INTEGER)) {
             return toIntExact(INTEGER.getLong(block, position));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
@@ -82,7 +82,6 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.UuidType.UUID;
 import static io.trino.spi.type.UuidType.trinoUuidToJavaUuid;
 import static java.lang.Float.intBitsToFloat;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
@@ -460,10 +459,10 @@ public class IcebergPageSink
             return (int) SMALLINT.getShort(block, position);
         }
         if (type.equals(INTEGER)) {
-            return toIntExact(INTEGER.getLong(block, position));
+            return INTEGER.getInt(block, position);
         }
         if (type.equals(DATE)) {
-            return toIntExact(DATE.getLong(block, position));
+            return DATE.getInt(block, position);
         }
         if (type.equals(BOOLEAN)) {
             return BOOLEAN.getBoolean(block, position);
@@ -472,7 +471,7 @@ public class IcebergPageSink
             return readBigDecimal(decimalType, block, position);
         }
         if (type.equals(REAL)) {
-            return intBitsToFloat(toIntExact(REAL.getLong(block, position)));
+            return intBitsToFloat(REAL.getInt(block, position));
         }
         if (type.equals(DOUBLE)) {
             return DOUBLE.getDouble(block, position);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
@@ -454,7 +454,7 @@ public class IcebergPageSink
             return BIGINT.getLong(block, position);
         }
         if (type.equals(TINYINT)) {
-            return toIntExact(TINYINT.getLong(block, position));
+            return (int) TINYINT.getByte(block, position);
         }
         if (type.equals(SMALLINT)) {
             return toIntExact(SMALLINT.getLong(block, position));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTransforms.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTransforms.java
@@ -372,7 +372,7 @@ public final class PartitionTransforms
 
     private static int hashInteger(Block block, int position)
     {
-        return bucketHash(INTEGER.getLong(block, position));
+        return bucketHash(INTEGER.getInt(block, position));
     }
 
     private static int hashBigint(Block block, int position)
@@ -400,7 +400,7 @@ public final class PartitionTransforms
 
     private static int hashDate(Block block, int position)
     {
-        return bucketHash(DATE.getLong(block, position));
+        return bucketHash(DATE.getInt(block, position));
     }
 
     private static int hashTime(Block block, int position)
@@ -490,7 +490,7 @@ public final class PartitionTransforms
 
     private static long truncateInteger(Block block, int position, int width)
     {
-        long value = INTEGER.getLong(block, position);
+        long value = INTEGER.getInt(block, position);
         return value - ((value % width) + width) % width;
     }
 

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/AbstractRowEncoder.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/AbstractRowEncoder.java
@@ -81,34 +81,34 @@ public abstract class AbstractRowEncoder
             appendNullValue();
         }
         else if (type == BOOLEAN) {
-            appendBoolean(type.getBoolean(block, position));
+            appendBoolean(BOOLEAN.getBoolean(block, position));
         }
         else if (type == BIGINT) {
-            appendLong(type.getLong(block, position));
+            appendLong(BIGINT.getLong(block, position));
         }
         else if (type == INTEGER) {
-            appendInt(toIntExact(type.getLong(block, position)));
+            appendInt(toIntExact(INTEGER.getLong(block, position)));
         }
         else if (type == SMALLINT) {
-            appendShort(Shorts.checkedCast(type.getLong(block, position)));
+            appendShort(Shorts.checkedCast(SMALLINT.getLong(block, position)));
         }
         else if (type == TINYINT) {
-            appendByte(SignedBytes.checkedCast(type.getLong(block, position)));
+            appendByte(SignedBytes.checkedCast(TINYINT.getLong(block, position)));
         }
         else if (type == DOUBLE) {
-            appendDouble(type.getDouble(block, position));
+            appendDouble(DOUBLE.getDouble(block, position));
         }
         else if (type == REAL) {
-            appendFloat(intBitsToFloat(toIntExact(type.getLong(block, position))));
+            appendFloat(intBitsToFloat(toIntExact(REAL.getLong(block, position))));
         }
-        else if (type instanceof VarcharType) {
-            appendString(type.getSlice(block, position).toStringUtf8());
+        else if (type instanceof VarcharType varcharType) {
+            appendString(varcharType.getSlice(block, position).toStringUtf8());
         }
-        else if (type instanceof VarbinaryType) {
-            appendByteBuffer(type.getSlice(block, position).toByteBuffer());
+        else if (type instanceof VarbinaryType varbinaryType) {
+            appendByteBuffer(varbinaryType.getSlice(block, position).toByteBuffer());
         }
         else if (type == DATE) {
-            appendSqlDate((SqlDate) type.getObjectValue(session, block, position));
+            appendSqlDate((SqlDate) DATE.getObjectValue(session, block, position));
         }
         else if (type instanceof TimeType) {
             appendSqlTime((SqlTime) type.getObjectValue(session, block, position));

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/AbstractRowEncoder.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/AbstractRowEncoder.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.kafka.encoder;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.primitives.Shorts;
 import io.trino.spi.block.Block;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.ArrayType;
@@ -89,7 +88,7 @@ public abstract class AbstractRowEncoder
             appendInt(toIntExact(INTEGER.getLong(block, position)));
         }
         else if (type == SMALLINT) {
-            appendShort(Shorts.checkedCast(SMALLINT.getLong(block, position)));
+            appendShort(SMALLINT.getShort(block, position));
         }
         else if (type == TINYINT) {
             appendByte(TINYINT.getByte(block, position));

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/AbstractRowEncoder.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/AbstractRowEncoder.java
@@ -15,7 +15,6 @@ package io.trino.plugin.kafka.encoder;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Shorts;
-import com.google.common.primitives.SignedBytes;
 import io.trino.spi.block.Block;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.ArrayType;
@@ -93,7 +92,7 @@ public abstract class AbstractRowEncoder
             appendShort(Shorts.checkedCast(SMALLINT.getLong(block, position)));
         }
         else if (type == TINYINT) {
-            appendByte(SignedBytes.checkedCast(TINYINT.getLong(block, position)));
+            appendByte(TINYINT.getByte(block, position));
         }
         else if (type == DOUBLE) {
             appendDouble(DOUBLE.getDouble(block, position));

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/AbstractRowEncoder.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/AbstractRowEncoder.java
@@ -45,7 +45,6 @@ import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
-import static java.lang.Float.intBitsToFloat;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -96,7 +95,7 @@ public abstract class AbstractRowEncoder
             appendDouble(DOUBLE.getDouble(block, position));
         }
         else if (type == REAL) {
-            appendFloat(intBitsToFloat(REAL.getInt(block, position)));
+            appendFloat(REAL.getFloat(block, position));
         }
         else if (type instanceof VarcharType varcharType) {
             appendString(varcharType.getSlice(block, position).toStringUtf8());

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/AbstractRowEncoder.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/AbstractRowEncoder.java
@@ -46,7 +46,6 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static java.lang.Float.intBitsToFloat;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -85,7 +84,7 @@ public abstract class AbstractRowEncoder
             appendLong(BIGINT.getLong(block, position));
         }
         else if (type == INTEGER) {
-            appendInt(toIntExact(INTEGER.getLong(block, position)));
+            appendInt(INTEGER.getInt(block, position));
         }
         else if (type == SMALLINT) {
             appendShort(SMALLINT.getShort(block, position));
@@ -97,7 +96,7 @@ public abstract class AbstractRowEncoder
             appendDouble(DOUBLE.getDouble(block, position));
         }
         else if (type == REAL) {
-            appendFloat(intBitsToFloat(toIntExact(REAL.getLong(block, position))));
+            appendFloat(intBitsToFloat(REAL.getInt(block, position)));
         }
         else if (type instanceof VarcharType varcharType) {
             appendString(varcharType.getSlice(block, position).toStringUtf8());

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
@@ -155,30 +155,30 @@ public class KuduPageSink
             row.setNull(destChannel);
         }
         else if (TIMESTAMP_MILLIS.equals(type)) {
-            row.addLong(destChannel, truncateEpochMicrosToMillis(type.getLong(block, position)));
+            row.addLong(destChannel, truncateEpochMicrosToMillis(TIMESTAMP_MILLIS.getLong(block, position)));
         }
         else if (REAL.equals(type)) {
-            row.addFloat(destChannel, intBitsToFloat(toIntExact(type.getLong(block, position))));
+            row.addFloat(destChannel, intBitsToFloat(toIntExact(REAL.getLong(block, position))));
         }
         else if (BIGINT.equals(type)) {
-            row.addLong(destChannel, type.getLong(block, position));
+            row.addLong(destChannel, BIGINT.getLong(block, position));
         }
         else if (INTEGER.equals(type)) {
-            row.addInt(destChannel, toIntExact(type.getLong(block, position)));
+            row.addInt(destChannel, toIntExact(INTEGER.getLong(block, position)));
         }
         else if (SMALLINT.equals(type)) {
-            row.addShort(destChannel, Shorts.checkedCast(type.getLong(block, position)));
+            row.addShort(destChannel, Shorts.checkedCast(SMALLINT.getLong(block, position)));
         }
         else if (TINYINT.equals(type)) {
-            row.addByte(destChannel, SignedBytes.checkedCast(type.getLong(block, position)));
+            row.addByte(destChannel, SignedBytes.checkedCast(TINYINT.getLong(block, position)));
         }
         else if (BOOLEAN.equals(type)) {
-            row.addBoolean(destChannel, type.getBoolean(block, position));
+            row.addBoolean(destChannel, BOOLEAN.getBoolean(block, position));
         }
         else if (DOUBLE.equals(type)) {
-            row.addDouble(destChannel, type.getDouble(block, position));
+            row.addDouble(destChannel, DOUBLE.getDouble(block, position));
         }
-        else if (type instanceof VarcharType) {
+        else if (type instanceof VarcharType varcharType) {
             Type originalType = originalColumnTypes.get(destChannel);
             if (DATE.equals(originalType)) {
                 SqlDate date = (SqlDate) originalType.getObjectValue(connectorSession, block, position);
@@ -187,14 +187,14 @@ public class KuduPageSink
                 row.addStringUtf8(destChannel, bytes);
             }
             else {
-                row.addString(destChannel, type.getSlice(block, position).toStringUtf8());
+                row.addString(destChannel, varcharType.getSlice(block, position).toStringUtf8());
             }
         }
         else if (VARBINARY.equals(type)) {
-            row.addBinary(destChannel, type.getSlice(block, position).toByteBuffer());
+            row.addBinary(destChannel, VARBINARY.getSlice(block, position).toByteBuffer());
         }
-        else if (type instanceof DecimalType) {
-            SqlDecimal sqlDecimal = (SqlDecimal) type.getObjectValue(connectorSession, block, position);
+        else if (type instanceof DecimalType decimalType) {
+            SqlDecimal sqlDecimal = (SqlDecimal) decimalType.getObjectValue(connectorSession, block, position);
             row.addDecimal(destChannel, sqlDecimal.toBigDecimal());
         }
         else {

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
@@ -58,7 +58,6 @@ import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.Timestamps.truncateEpochMicrosToMillis;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
-import static java.lang.Float.intBitsToFloat;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -155,7 +154,7 @@ public class KuduPageSink
             row.addLong(destChannel, truncateEpochMicrosToMillis(TIMESTAMP_MILLIS.getLong(block, position)));
         }
         else if (REAL.equals(type)) {
-            row.addFloat(destChannel, intBitsToFloat(REAL.getInt(block, position)));
+            row.addFloat(destChannel, REAL.getFloat(block, position));
         }
         else if (BIGINT.equals(type)) {
             row.addLong(destChannel, BIGINT.getLong(block, position));

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
@@ -15,7 +15,6 @@ package io.trino.plugin.kudu;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Shorts;
-import com.google.common.primitives.SignedBytes;
 import io.airlift.slice.Slice;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
@@ -170,7 +169,7 @@ public class KuduPageSink
             row.addShort(destChannel, Shorts.checkedCast(SMALLINT.getLong(block, position)));
         }
         else if (TINYINT.equals(type)) {
-            row.addByte(destChannel, SignedBytes.checkedCast(TINYINT.getLong(block, position)));
+            row.addByte(destChannel, TINYINT.getByte(block, position));
         }
         else if (BOOLEAN.equals(type)) {
             row.addBoolean(destChannel, BOOLEAN.getBoolean(block, position));
@@ -214,7 +213,7 @@ public class KuduPageSink
         Schema schema = table.getSchema();
         try (KuduOperationApplier operationApplier = KuduOperationApplier.fromKuduClientSession(session)) {
             for (int position = 0; position < page.getPositionCount(); position++) {
-                long operation = TINYINT.getLong(operationBlock, position);
+                byte operation = TINYINT.getByte(operationBlock, position);
 
                 checkState(operation == UPDATE_OPERATION_NUMBER ||
                                 operation == INSERT_OPERATION_NUMBER ||

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
@@ -59,7 +59,6 @@ import static io.trino.spi.type.Timestamps.truncateEpochMicrosToMillis;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.Float.intBitsToFloat;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -156,13 +155,13 @@ public class KuduPageSink
             row.addLong(destChannel, truncateEpochMicrosToMillis(TIMESTAMP_MILLIS.getLong(block, position)));
         }
         else if (REAL.equals(type)) {
-            row.addFloat(destChannel, intBitsToFloat(toIntExact(REAL.getLong(block, position))));
+            row.addFloat(destChannel, intBitsToFloat(REAL.getInt(block, position)));
         }
         else if (BIGINT.equals(type)) {
             row.addLong(destChannel, BIGINT.getLong(block, position));
         }
         else if (INTEGER.equals(type)) {
-            row.addInt(destChannel, toIntExact(INTEGER.getLong(block, position)));
+            row.addInt(destChannel, INTEGER.getInt(block, position));
         }
         else if (SMALLINT.equals(type)) {
             row.addShort(destChannel, SMALLINT.getShort(block, position));

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.kudu;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.primitives.Shorts;
 import io.airlift.slice.Slice;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
@@ -166,7 +165,7 @@ public class KuduPageSink
             row.addInt(destChannel, toIntExact(INTEGER.getLong(block, position)));
         }
         else if (SMALLINT.equals(type)) {
-            row.addShort(destChannel, Shorts.checkedCast(SMALLINT.getLong(block, position)));
+            row.addShort(destChannel, SMALLINT.getShort(block, position));
         }
         else if (TINYINT.equals(type)) {
             row.addByte(destChannel, TINYINT.getByte(block, position));

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSink.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSink.java
@@ -71,7 +71,6 @@ import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
 import static io.trino.spi.type.Timestamps.roundDiv;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
-import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.floorDiv;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Collections.unmodifiableList;
@@ -154,7 +153,7 @@ public class MongoPageSink
             return TINYINT.getByte(block, position);
         }
         if (type.equals(REAL)) {
-            return intBitsToFloat(REAL.getInt(block, position));
+            return REAL.getFloat(block, position);
         }
         if (type.equals(DOUBLE)) {
             return DOUBLE.getDouble(block, position);

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSink.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSink.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.mongodb;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.primitives.Shorts;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.InsertManyOptions;
 import io.airlift.slice.Slice;
@@ -150,7 +149,7 @@ public class MongoPageSink
             return toIntExact(INTEGER.getLong(block, position));
         }
         if (type.equals(SMALLINT)) {
-            return Shorts.checkedCast(SMALLINT.getLong(block, position));
+            return SMALLINT.getShort(block, position);
         }
         if (type.equals(TINYINT)) {
             return TINYINT.getByte(block, position);

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSink.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSink.java
@@ -73,7 +73,6 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.floorDiv;
-import static java.lang.Math.toIntExact;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
@@ -146,7 +145,7 @@ public class MongoPageSink
             return BIGINT.getLong(block, position);
         }
         if (type.equals(INTEGER)) {
-            return toIntExact(INTEGER.getLong(block, position));
+            return INTEGER.getInt(block, position);
         }
         if (type.equals(SMALLINT)) {
             return SMALLINT.getShort(block, position);
@@ -155,7 +154,7 @@ public class MongoPageSink
             return TINYINT.getByte(block, position);
         }
         if (type.equals(REAL)) {
-            return intBitsToFloat(toIntExact(REAL.getLong(block, position)));
+            return intBitsToFloat(REAL.getInt(block, position));
         }
         if (type.equals(DOUBLE)) {
             return DOUBLE.getDouble(block, position);
@@ -170,7 +169,7 @@ public class MongoPageSink
             return new Binary(VARBINARY.getSlice(block, position).getBytes());
         }
         if (type.equals(DATE)) {
-            long days = DATE.getLong(block, position);
+            int days = DATE.getInt(block, position);
             return LocalDate.ofEpochDay(days);
         }
         if (type.equals(TIME_MILLIS)) {

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSink.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSink.java
@@ -15,7 +15,6 @@ package io.trino.plugin.mongodb;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Shorts;
-import com.google.common.primitives.SignedBytes;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.InsertManyOptions;
 import io.airlift.slice.Slice;
@@ -154,7 +153,7 @@ public class MongoPageSink
             return Shorts.checkedCast(SMALLINT.getLong(block, position));
         }
         if (type.equals(TINYINT)) {
-            return SignedBytes.checkedCast(TINYINT.getLong(block, position));
+            return TINYINT.getByte(block, position);
         }
         if (type.equals(REAL)) {
             return intBitsToFloat(toIntExact(REAL.getLong(block, position)));

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSink.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSink.java
@@ -26,22 +26,14 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.connector.ConnectorPageSink;
 import io.trino.spi.connector.ConnectorPageSinkId;
-import io.trino.spi.type.BigintType;
-import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.CharType;
-import io.trino.spi.type.DateType;
 import io.trino.spi.type.DecimalType;
-import io.trino.spi.type.DoubleType;
-import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.MapType;
 import io.trino.spi.type.NamedTypeSignature;
-import io.trino.spi.type.RealType;
-import io.trino.spi.type.SmallintType;
-import io.trino.spi.type.TimeType;
-import io.trino.spi.type.TimestampWithTimeZoneType;
-import io.trino.spi.type.TinyintType;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeSignatureParameter;
-import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
 import org.bson.BsonInvalidOperationException;
 import org.bson.Document;
@@ -61,18 +53,26 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static io.trino.plugin.mongodb.ObjectIdType.OBJECT_ID;
-import static io.trino.plugin.mongodb.TypeUtils.isArrayType;
 import static io.trino.plugin.mongodb.TypeUtils.isJsonType;
-import static io.trino.plugin.mongodb.TypeUtils.isMapType;
-import static io.trino.plugin.mongodb.TypeUtils.isRowType;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.Chars.padSpaces;
 import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
+import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.Decimals.readBigDecimal;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeType.TIME_MILLIS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
 import static io.trino.spi.type.Timestamps.roundDiv;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.floorDiv;
 import static java.lang.Math.toIntExact;
@@ -141,56 +141,56 @@ public class MongoPageSink
         if (type.equals(OBJECT_ID)) {
             return new ObjectId(block.getSlice(position, 0, block.getSliceLength(position)).getBytes());
         }
-        if (type.equals(BooleanType.BOOLEAN)) {
-            return type.getBoolean(block, position);
+        if (type.equals(BOOLEAN)) {
+            return BOOLEAN.getBoolean(block, position);
         }
-        if (type.equals(BigintType.BIGINT)) {
-            return type.getLong(block, position);
+        if (type.equals(BIGINT)) {
+            return BIGINT.getLong(block, position);
         }
-        if (type.equals(IntegerType.INTEGER)) {
-            return toIntExact(type.getLong(block, position));
+        if (type.equals(INTEGER)) {
+            return toIntExact(INTEGER.getLong(block, position));
         }
-        if (type.equals(SmallintType.SMALLINT)) {
-            return Shorts.checkedCast(type.getLong(block, position));
+        if (type.equals(SMALLINT)) {
+            return Shorts.checkedCast(SMALLINT.getLong(block, position));
         }
-        if (type.equals(TinyintType.TINYINT)) {
-            return SignedBytes.checkedCast(type.getLong(block, position));
+        if (type.equals(TINYINT)) {
+            return SignedBytes.checkedCast(TINYINT.getLong(block, position));
         }
-        if (type.equals(RealType.REAL)) {
-            return intBitsToFloat(toIntExact(type.getLong(block, position)));
+        if (type.equals(REAL)) {
+            return intBitsToFloat(toIntExact(REAL.getLong(block, position)));
         }
-        if (type.equals(DoubleType.DOUBLE)) {
-            return type.getDouble(block, position);
+        if (type.equals(DOUBLE)) {
+            return DOUBLE.getDouble(block, position);
         }
-        if (type instanceof VarcharType) {
-            return type.getSlice(block, position).toStringUtf8();
+        if (type instanceof VarcharType varcharType) {
+            return varcharType.getSlice(block, position).toStringUtf8();
         }
-        if (type instanceof CharType) {
-            return padSpaces(type.getSlice(block, position), ((CharType) type)).toStringUtf8();
+        if (type instanceof CharType charType) {
+            return padSpaces(charType.getSlice(block, position), charType).toStringUtf8();
         }
-        if (type.equals(VarbinaryType.VARBINARY)) {
-            return new Binary(type.getSlice(block, position).getBytes());
+        if (type.equals(VARBINARY)) {
+            return new Binary(VARBINARY.getSlice(block, position).getBytes());
         }
-        if (type.equals(DateType.DATE)) {
-            long days = type.getLong(block, position);
+        if (type.equals(DATE)) {
+            long days = DATE.getLong(block, position);
             return LocalDate.ofEpochDay(days);
         }
-        if (type.equals(TimeType.TIME_MILLIS)) {
-            long picos = type.getLong(block, position);
+        if (type.equals(TIME_MILLIS)) {
+            long picos = TIME_MILLIS.getLong(block, position);
             return LocalTime.ofNanoOfDay(roundDiv(picos, PICOSECONDS_PER_NANOSECOND));
         }
         if (type.equals(TIMESTAMP_MILLIS)) {
-            long millisUtc = floorDiv(type.getLong(block, position), MICROSECONDS_PER_MILLISECOND);
+            long millisUtc = floorDiv(TIMESTAMP_MILLIS.getLong(block, position), MICROSECONDS_PER_MILLISECOND);
             Instant instant = Instant.ofEpochMilli(millisUtc);
             return LocalDateTime.ofInstant(instant, UTC);
         }
-        if (type.equals(TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS)) {
-            long millisUtc = unpackMillisUtc(type.getLong(block, position));
+        if (type.equals(TIMESTAMP_TZ_MILLIS)) {
+            long millisUtc = unpackMillisUtc(TIMESTAMP_TZ_MILLIS.getLong(block, position));
             Instant instant = Instant.ofEpochMilli(millisUtc);
             return LocalDateTime.ofInstant(instant, UTC);
         }
-        if (type instanceof DecimalType) {
-            return readBigDecimal((DecimalType) type, block, position);
+        if (type instanceof DecimalType decimalType) {
+            return readBigDecimal(decimalType, block, position);
         }
         if (isJsonType(type)) {
             String json = type.getSlice(block, position).toStringUtf8();
@@ -201,8 +201,8 @@ public class MongoPageSink
                 throw new TrinoException(NOT_SUPPORTED, "Can't convert json to MongoDB Document: " + json, e);
             }
         }
-        if (isArrayType(type)) {
-            Type elementType = type.getTypeParameters().get(0);
+        if (type instanceof ArrayType arrayType) {
+            Type elementType = arrayType.getElementType();
 
             Block arrayBlock = block.getObject(position, Block.class);
 
@@ -214,9 +214,9 @@ public class MongoPageSink
 
             return unmodifiableList(list);
         }
-        if (isMapType(type)) {
-            Type keyType = type.getTypeParameters().get(0);
-            Type valueType = type.getTypeParameters().get(1);
+        if (type instanceof MapType mapType) {
+            Type keyType = mapType.getKeyType();
+            Type valueType = mapType.getValueType();
 
             Block mapBlock = block.getObject(position, Block.class);
 
@@ -231,15 +231,15 @@ public class MongoPageSink
 
             return unmodifiableList(values);
         }
-        if (isRowType(type)) {
+        if (type instanceof RowType rowType) {
             Block rowBlock = block.getObject(position, Block.class);
 
-            List<Type> fieldTypes = type.getTypeParameters();
+            List<Type> fieldTypes = rowType.getTypeParameters();
             if (fieldTypes.size() != rowBlock.getPositionCount()) {
                 throw new TrinoException(StandardErrorCode.GENERIC_INTERNAL_ERROR, "Expected row value field count does not match type field count");
             }
 
-            if (isImplicitRowType(type)) {
+            if (isImplicitRowType(rowType)) {
                 List<Object> rowValue = new ArrayList<>();
                 for (int i = 0; i < rowBlock.getPositionCount(); i++) {
                     Object element = getObjectValue(fieldTypes.get(i), rowBlock, i);
@@ -251,7 +251,7 @@ public class MongoPageSink
             Map<String, Object> rowValue = new HashMap<>();
             for (int i = 0; i < rowBlock.getPositionCount(); i++) {
                 rowValue.put(
-                        type.getTypeSignature().getParameters().get(i).getNamedTypeSignature().getName().orElse("field" + i),
+                        rowType.getTypeSignature().getParameters().get(i).getNamedTypeSignature().getName().orElse("field" + i),
                         getObjectValue(fieldTypes.get(i), rowBlock, i));
             }
             return unmodifiableMap(rowValue);

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMergeSink.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMergeSink.java
@@ -176,7 +176,7 @@ public class PhoenixMergeSink
         int rowIdUpdatePositionCount = 0;
 
         for (int position = 0; position < positionCount; position++) {
-            int operation = (int) TINYINT.getLong(operationBlock, position);
+            int operation = TINYINT.getByte(operationBlock, position);
             switch (operation) {
                 case INSERT_OPERATION_NUMBER -> {
                     insertPositions[insertPositionCount] = position;

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorBucketFunction.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorBucketFunction.java
@@ -83,7 +83,7 @@ public class RaptorBucketFunction
 
     private static HashFunction intHashFunction()
     {
-        return (block, position) -> XxHash64.hash(INTEGER.getLong(block, position));
+        return (block, position) -> XxHash64.hash(INTEGER.getInt(block, position));
     }
 
     private static HashFunction varcharHashFunction()

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorBucketedUpdateFunction.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorBucketedUpdateFunction.java
@@ -18,7 +18,6 @@ import io.trino.spi.block.Block;
 import io.trino.spi.connector.BucketFunction;
 
 import static io.trino.spi.type.IntegerType.INTEGER;
-import static java.lang.Math.toIntExact;
 
 public class RaptorBucketedUpdateFunction
         implements BucketFunction
@@ -27,6 +26,6 @@ public class RaptorBucketedUpdateFunction
     public int getBucket(Page page, int position)
     {
         Block row = page.getBlock(0).getObject(position, Block.class);
-        return toIntExact(INTEGER.getLong(row, 0)); // bucket field of row ID
+        return INTEGER.getInt(row, 0); // bucket field of row ID
     }
 }

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorMergeSink.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorMergeSink.java
@@ -89,7 +89,7 @@ public class RaptorMergeSink
             for (int position = 0; position < rowIdRow.getPositionCount(); position++) {
                 OptionalInt bucketNumber = shardBucketBlock.isNull(position)
                         ? OptionalInt.empty()
-                        : OptionalInt.of(toIntExact(INTEGER.getLong(shardBucketBlock, position)));
+                        : OptionalInt.of(INTEGER.getInt(shardBucketBlock, position));
                 UUID uuid = trinoUuidToJavaUuid(UuidType.UUID.getSlice(shardUuidBlock, position));
                 int rowId = toIntExact(BIGINT.getLong(shardRowIdBlock, position));
                 Entry<OptionalInt, BitSet> entry = rowsToDelete.computeIfAbsent(uuid, ignored -> Map.entry(bucketNumber, new BitSet()));

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/storage/organization/TemporalFunction.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/storage/organization/TemporalFunction.java
@@ -33,7 +33,7 @@ public final class TemporalFunction
     public static int getDay(Type type, Block block, int position)
     {
         if (type.equals(DATE)) {
-            return toIntExact(DATE.getLong(block, position));
+            return DATE.getInt(block, position);
         }
 
         if (type.equals(TIMESTAMP_MILLIS)) {

--- a/plugin/trino-thrift-api/src/test/java/io/trino/plugin/thrift/api/TestReadWrite.java
+++ b/plugin/trino-thrift-api/src/test/java/io/trino/plugin/thrift/api/TestReadWrite.java
@@ -284,7 +284,7 @@ public class TestReadWrite
         @Override
         Object extractValue(Block block, int position)
         {
-            return INTEGER.getLong(block, position);
+            return INTEGER.getInt(block, position);
         }
 
         @Override
@@ -392,7 +392,7 @@ public class TestReadWrite
         @Override
         Object extractValue(Block block, int position)
         {
-            return DATE.getLong(block, position);
+            return DATE.getInt(block, position);
         }
 
         @Override

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/HandTpchQuery1.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/HandTpchQuery1.java
@@ -42,7 +42,6 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.VarcharType.VARCHAR;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class HandTpchQuery1
@@ -249,7 +248,7 @@ public class HandTpchQuery1
                     continue;
                 }
 
-                int shipDate = toIntExact(DATE.getLong(shipDateBlock, position));
+                int shipDate = DATE.getInt(shipDateBlock, position);
 
                 // where
                 //     shipdate <= '1998-09-02'

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/HandTpchQuery6.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/HandTpchQuery6.java
@@ -123,8 +123,8 @@ public class HandTpchQuery6
             Block discountBlock = page.getBlock(0);
             Block shipDateBlock = page.getBlock(1);
             Block quantityBlock = page.getBlock(2);
-            return !shipDateBlock.isNull(position) && DATE.getLong(shipDateBlock, position) >= MIN_SHIP_DATE &&
-                    !shipDateBlock.isNull(position) && DATE.getLong(shipDateBlock, position) < MAX_SHIP_DATE &&
+            return !shipDateBlock.isNull(position) && DATE.getInt(shipDateBlock, position) >= MIN_SHIP_DATE &&
+                    !shipDateBlock.isNull(position) && DATE.getInt(shipDateBlock, position) < MAX_SHIP_DATE &&
                     !discountBlock.isNull(position) && DOUBLE.getDouble(discountBlock, position) >= 0.05 &&
                     !discountBlock.isNull(position) && DOUBLE.getDouble(discountBlock, position) <= 0.07 &&
                     !quantityBlock.isNull(position) && BIGINT.getLong(quantityBlock, position) < 24;


### PR DESCRIPTION
## Description
When exact type is known use specialized methods on type to fetch value directly.  Also, add methods to get `byte`, `short`, `int`, and `float` values directly from type to avoid converting to long and then back to smaller primitives.

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
