### PR TITLE
Remove flaky race-prone assertions in TestDriver

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/TestDriver.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestDriver.java
@@ -206,7 +206,6 @@ public class TestDriver
 
         driver.close();
         assertTrue(driver.isFinished());
-        assertFalse(driver.getDestroyedFuture().isDone());
 
         assertThatThrownBy(() -> driverProcessFor.get(1, TimeUnit.SECONDS))
                 .isInstanceOf(ExecutionException.class)
@@ -321,7 +320,6 @@ public class TestDriver
 
         driver.close();
         assertTrue(driver.isFinished());
-        assertFalse(driver.getDestroyedFuture().isDone());
 
         assertThatThrownBy(() -> driverProcessFor.get(1, TimeUnit.SECONDS))
                 .isInstanceOf(ExecutionException.class)


### PR DESCRIPTION
## Description
Avoids asserting that driver destroyed future is not complete in `TestDriver` tests that do not block on `BrokenOperator#close()`. Otherwise the assertion is subject to a simple race condition causing sporadic test failures.

Fixes https://github.com/trinodb/trino/issues/16925

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
