### PR TITLE
Showcase dereference pushdown limited effectiveness in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -4941,11 +4941,16 @@ public abstract class BaseIcebergConnectorTest
                 getSession(),
                 selectQuery,
                 statsWithPushdown -> {
+                    DataSize physicalDataSizeWithPushdown = statsWithPushdown.getPhysicalInputDataSize();
                     DataSize processedDataSizeWithPushdown = statsWithPushdown.getProcessedInputDataSize();
                     assertQueryStats(
                             sessionWithoutPushdown,
                             selectQuery,
-                            statsWithoutPushdown -> assertThat(statsWithoutPushdown.getProcessedInputDataSize()).isGreaterThan(processedDataSizeWithPushdown),
+                            statsWithoutPushdown -> {
+                                //TODO (https://github.com/trinodb/trino/issues/17156) add dereference pushdown on the physical layer
+                                assertThat(statsWithoutPushdown.getPhysicalInputDataSize()).isEqualTo(physicalDataSizeWithPushdown);
+                                assertThat(statsWithoutPushdown.getProcessedInputDataSize()).isGreaterThan(processedDataSizeWithPushdown);
+                            },
                             results -> assertEquals(results.getOnlyColumnAsSet(), expected));
                 },
                 results -> assertEquals(results.getOnlyColumnAsSet(), expected));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

As can be seen in the snippets below:

- the physical input is the same for both queries `Physical input: 1.20kB` 
- the query selecting a nested field has `Input: 1 row (5B)` which is much less than the query doing the selection of the whole row `Input: 1 row (50B)`

```
trino:tiny> explain analyze select b.c3.d2.e2.f2 from iceberg.tiny.itest2;
                                                                             Query Plan                                       >
------------------------------------------------------------------------------------------------------------------------------>
 Trino version: dev                                                                                                           >
 Queued: 761.02us, Analysis: 27.10ms, Planning: 33.96ms, Execution: 536.67ms                                                  >
 Fragment 1 [SOURCE]                                                                                                          >
     CPU: 303.10ms, Scheduled: 372.58ms, Blocked 0.00ns (Input: 0.00ns, Output: 0.00ns), Input: 1 row (5B); per task: avg.: 1.>
     Output layout: [b.c3.d2.e2.f2]                                                                                           >
     Output partitioning: SINGLE []                                                                                           >
     TableScan[table = iceberg:tiny.itest2$data@700374889882065389]                                                           >
         Layout: [b.c3.d2.e2.f2:integer]                                                                                      >
         Estimates: {rows: 1 (5B), cpu: 5, memory: 0B, network: 0B}                                                           >
         CPU: 303.00ms (100.00%), Scheduled: 372.00ms (100.00%), Blocked: 0.00ns (?%), Output: 1 row (5B)                     >
         Input avg.: 1.00 rows, Input std.dev.: 0.00%                                                                         >
         b.c3.d2.e2.f2 := 11:f2:integer                                                                                       >
         Input: 1 row (5B), Physical input: 1.20kB, Physical input time: 10120000.00ns                                        >
                                                                                                                              >
                                                                                                                              >
(1 row)
```

```
trino:tiny> explain analyze select b  from iceberg.tiny.itest2;
                                                                            Query Plan                                        >
------------------------------------------------------------------------------------------------------------------------------>
 Trino version: dev                                                                                                           >
 Queued: 211.84us, Analysis: 25.14ms, Planning: 27.73ms, Execution: 167.99ms                                                  >
 Fragment 1 [SOURCE]                                                                                                          >
     CPU: 7.18ms, Scheduled: 12.43ms, Blocked 0.00ns (Input: 0.00ns, Output: 0.00ns), Input: 1 row (50B); per task: avg.: 1.00>
     Output layout: [b]                                                                                                       >
     Output partitioning: SINGLE []                                                                                           >
     TableScan[table = iceberg:tiny.itest2$data@700374889882065389]                                                           >
         Layout: [b:row(c1 integer, c2 integer, c3 row(d1 integer, d2 row(e1 integer, e2 row(f1 integer, f2 integer))))]      >
         Estimates: {rows: 1 (55B), cpu: 55, memory: 0B, network: 0B}                                                         >
         CPU: 7.00ms (100.00%), Scheduled: 12.00ms (100.00%), Blocked: 0.00ns (?%), Output: 1 row (50B)                       >
         Input avg.: 1.00 rows, Input std.dev.: 0.00%                                                                         >
         b := 2:b:row(c1 integer, c2 integer, c3 row(d1 integer, d2 row(e1 integer, e2 row(f1 integer, f2 integer))))         >
         Input: 1 row (50B), Physical input: 1.20kB, Physical input time: 7950000.00ns                                        >
                                                                                                                              >
                                                                                                                              >
(1 row)
```

This PR proves that the dereference pushdown in Iceberg is not effective.

The logic for building a stripped file schema `MessageType`  (see https://github.com/trinodb/trino/blob/a524709bc7df1655250fd130d6f4d9d79065bc4c/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java#L316-L358) seems to be missing from `IcebergPageSourceFactory`
https://github.com/trinodb/trino/blob/a524709bc7df1655250fd130d6f4d9d79065bc4c/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java#L905-L918

For this reason, the `ParquetReader` reads always all the primitive fields of the nested columns selected in the Iceberg connector.


**tldr;** In Iceberg, the Parquet file schema is built from base columns, while on Hive is built out of adaptation of the original base columns which contain Optional.empty() for what is not being read.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
