### PR TITLE
Avoid unnecessary DeterminePartitionCount work

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
@@ -625,6 +625,11 @@ public final class PlanMatchPattern
         return exchange(scope, Optional.empty(), Optional.empty(), ImmutableList.of(), ImmutableSet.of(), Optional.empty(), ImmutableList.of(), Optional.of(partitionCount), sources);
     }
 
+    public static PlanMatchPattern exchange(ExchangeNode.Scope scope, ExchangeNode.Type type, Optional<Integer> partitionCount, PlanMatchPattern... sources)
+    {
+        return exchange(scope, Optional.of(type), Optional.empty(), ImmutableList.of(), ImmutableSet.of(), Optional.empty(), ImmutableList.of(), Optional.of(partitionCount), sources);
+    }
+
     public static PlanMatchPattern exchange(ExchangeNode.Scope scope, PartitioningHandle partitioningHandle, Optional<Integer> partitionCount, PlanMatchPattern... sources)
     {
         return exchange(scope, Optional.empty(), Optional.of(partitioningHandle), ImmutableList.of(), ImmutableSet.of(), Optional.empty(), ImmutableList.of(), Optional.of(partitionCount), sources);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
@@ -132,13 +132,11 @@ public class TestDeltaLakeFileOperations
         assertFileSystemAccesses(
                 "SELECT count(*) FROM test_read_part_key WHERE key = 'p1'",
                 ImmutableMultiset.<FileOperation>builder()
-                        .addCopies(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", INPUT_FILE_NEW_STREAM), 3) // TODO (https://github.com/trinodb/trino/issues/16782) should be checked once per query
+                        .addCopies(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", INPUT_FILE_NEW_STREAM), 2) // TODO (https://github.com/trinodb/trino/issues/16782) should be checked once per query
                         .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000000.json", INPUT_FILE_NEW_STREAM), 1)
                         .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000001.json", INPUT_FILE_NEW_STREAM), 1)
                         .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000002.json", INPUT_FILE_NEW_STREAM), 1)
-                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000003.json", INPUT_FILE_NEW_STREAM), 3) // TODO (https://github.com/trinodb/trino/issues/16780) why is last transaction log accessed more times than others?
-                        .addCopies(new FileOperation(TRINO_EXTENDED_STATS_JSON, "extended_stats.json", INPUT_FILE_EXISTS), 1)
-                        .addCopies(new FileOperation(TRINO_EXTENDED_STATS_JSON, "extended_stats.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000003.json", INPUT_FILE_NEW_STREAM), 2) // TODO (https://github.com/trinodb/trino/issues/16780) why is last transaction log accessed more times than others?
                         .build());
 
         // Read partition and synthetic columns

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestHiveMetastoreAccessOperations.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestHiveMetastoreAccessOperations.java
@@ -99,7 +99,6 @@ public class TestHiveMetastoreAccessOperations
         assertMetastoreInvocations("SELECT * FROM test_select_from",
                 ImmutableMultiset.builder()
                         .add(GET_TABLE)
-                        .add(GET_TABLE_STATISTICS)
                         .build());
     }
 
@@ -113,7 +112,6 @@ public class TestHiveMetastoreAccessOperations
                         .addCopies(GET_TABLE, 2)
                         .add(GET_PARTITION_NAMES_BY_FILTER)
                         .add(GET_PARTITIONS_BY_NAMES)
-                        .add(GET_PARTITION_STATISTICS)
                         .build());
 
         assertUpdate("INSERT INTO test_select_partition SELECT 2 AS data, 20 AS part", 1);
@@ -122,7 +120,6 @@ public class TestHiveMetastoreAccessOperations
                         .addCopies(GET_TABLE, 2)
                         .add(GET_PARTITION_NAMES_BY_FILTER)
                         .add(GET_PARTITIONS_BY_NAMES)
-                        .add(GET_PARTITION_STATISTICS)
                         .build());
 
         // Specify a specific partition
@@ -142,7 +139,6 @@ public class TestHiveMetastoreAccessOperations
         assertMetastoreInvocations("SELECT * FROM test_select_from_where WHERE age = 2",
                 ImmutableMultiset.builder()
                         .add(GET_TABLE)
-                        .add(GET_TABLE_STATISTICS)
                         .build());
     }
 
@@ -155,7 +151,6 @@ public class TestHiveMetastoreAccessOperations
         assertMetastoreInvocations("SELECT * FROM test_select_view_view",
                 ImmutableMultiset.builder()
                         .addCopies(GET_TABLE, 2)
-                        .add(GET_TABLE_STATISTICS)
                         .build());
     }
 
@@ -168,7 +163,6 @@ public class TestHiveMetastoreAccessOperations
         assertMetastoreInvocations("SELECT * FROM test_select_view_where_view WHERE age = 2",
                 ImmutableMultiset.builder()
                         .addCopies(GET_TABLE, 2)
-                        .add(GET_TABLE_STATISTICS)
                         .build());
     }
 
@@ -241,7 +235,6 @@ public class TestHiveMetastoreAccessOperations
         assertMetastoreInvocations("ANALYZE test_analyze",
                 ImmutableMultiset.builder()
                         .add(GET_TABLE)
-                        .add(GET_TABLE_STATISTICS)
                         .add(UPDATE_TABLE_STATISTICS)
                         .build());
     }

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionCreation.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionCreation.java
@@ -86,7 +86,7 @@ public class TestPostgreSqlJdbcConnectionCreation
                 {"SELECT * FROM information_schema.schemata", 1, Optional.empty()},
                 {"SELECT * FROM information_schema.tables", 1, Optional.empty()},
                 {"SELECT * FROM information_schema.columns", 1, Optional.empty()},
-                {"SELECT * FROM nation", 3, Optional.empty()},
+                {"SELECT * FROM nation", 2, Optional.empty()},
                 {"SELECT * FROM TABLE (system.query(query => 'SELECT * FROM tpch.nation'))", 2, Optional.empty()},
                 {"CREATE TABLE copy_of_nation AS SELECT * FROM nation", 6, Optional.empty()},
                 {"INSERT INTO copy_of_nation SELECT * FROM nation", 6, Optional.empty()},


### PR DESCRIPTION
## Description
Modifies the `DeterminePartitionCount` optimizer rule to only attempt stats collection and dynamic partition count selection when the plan contains an eligible remote exchange. Otherwise, plan stats collection would be triggered potentially unnecessarily.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
