### PR TITLE
Include exception when failed to parse filter in MongoDB

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/ptf/Query.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/ptf/Query.java
@@ -152,7 +152,7 @@ public class Query
             return Document.parse(filter);
         }
         catch (JsonParseException e) {
-            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Can't parse 'filter' argument as json");
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Can't parse 'filter' argument as json", e);
         }
     }
 


### PR DESCRIPTION
## Description

Include exception when failed to parse filter in MongoDB so that we can realize the wrong place of the argument. 

## Release notes

(x) This is not user-visible or docs only and no release notes are required.