### PR TITLE
Move planning CPU time to resource utilization summary

### DIFF
--- a/core/trino-main/src/main/resources/webapp/src/components/QueryDetail.jsx
+++ b/core/trino-main/src/main/resources/webapp/src/components/QueryDetail.jsx
@@ -1336,14 +1336,6 @@ export class QueryDetail extends React.Component {
                             </tr>
                             <tr>
                                 <td className="info-title">
-                                    Planning CPU Time
-                                </td>
-                                <td className="info-text">
-                                    {query.queryStats.planningCpuTime}
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="info-title">
                                     Execution Time
                                 </td>
                                 <td className="info-text">
@@ -1374,6 +1366,14 @@ export class QueryDetail extends React.Component {
                                             {query.queryStats.failedCpuTime}
                                         </td>
                                         }
+                                    </tr>
+                                    <tr>
+                                        <td className="info-title">
+                                            Planning CPU Time
+                                        </td>
+                                        <td className="info-text">
+                                            {query.queryStats.planningCpuTime}
+                                        </td>
                                     </tr>
                                     <tr>
                                         <td className="info-title">


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
A Follow-up to #15318 . Looking back at the UI it seems a CPU time stat should be placed in the `Resource Utilization Summary` section.

Example screenshot:
![Screenshot 2023-04-21 at 3 03 34 PM](https://user-images.githubusercontent.com/92953539/233741492-56f3437c-3c26-4858-b69d-449eea4476d3.png)


(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
