### PR TITLE
Support for unregister table in Hive

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -837,6 +837,15 @@ The following procedures are available:
   Flush Hive metadata cache entries connected with selected partition.
   Procedure requires named parameters to be passed.
 
+* ``system.unregister_table(schema_name => ..., table_name=> ...)``
+
+  The connector can unregister existing Hive tables from the metastore.
+
+  The procedure ``system.unregister_table`` allows the caller to unregister an
+  existing Hive table from the metastore without deleting the data::
+
+    CALL example.system.unregister_table(schema_name => 'testdb', table_name => 'customer_orders')
+
 .. _hive-data-management:
 
 Data management

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -1506,7 +1506,7 @@ public class HiveMetadata
         if (metastore.getTable(handle.getSchemaName(), handle.getTableName()).isEmpty()) {
             throw new TableNotFoundException(handle.getSchemaTableName());
         }
-        metastore.dropTable(session, handle.getSchemaName(), handle.getTableName());
+        metastore.dropTable(session, handle.getSchemaName(), handle.getTableName(), true);
     }
 
     @Override
@@ -2170,7 +2170,7 @@ public class HiveMetadata
                     PrincipalPrivileges principalPrivileges = fromHivePrivilegeInfos(metastore.listTablePrivileges(handle.getSchemaName(), handle.getTableName(), Optional.empty()));
 
                     // first drop it
-                    metastore.dropTable(session, handle.getSchemaName(), handle.getTableName());
+                    metastore.dropTable(session, handle.getSchemaName(), handle.getTableName(), true);
 
                     // create the table with the new location
                     metastore.createTable(session, table, principalPrivileges, Optional.of(partitionUpdate.getWritePath()), Optional.of(partitionUpdate.getFileNames()), false, partitionStatistics, handle.isRetriesEnabled());
@@ -2680,7 +2680,7 @@ public class HiveMetadata
         }
 
         try {
-            metastore.dropTable(session, viewName.getSchemaName(), viewName.getTableName());
+            metastore.dropTable(session, viewName.getSchemaName(), viewName.getTableName(), false);
         }
         catch (TableNotFoundException e) {
             throw new ViewNotFoundException(e.getTableName());

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/HiveProcedureModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/HiveProcedureModule.java
@@ -32,6 +32,7 @@ public class HiveProcedureModule
         procedures.addBinding().toProvider(CreateEmptyPartitionProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(RegisterPartitionProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(UnregisterPartitionProcedure.class).in(Scopes.SINGLETON);
+        procedures.addBinding().toProvider(UnregisterTableProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(SyncPartitionMetadataProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(DropStatsProcedure.class).in(Scopes.SINGLETON);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/UnregisterTableProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/UnregisterTableProcedure.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.procedure;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.trino.plugin.hive.TableType;
+import io.trino.plugin.hive.TransactionalMetadata;
+import io.trino.plugin.hive.TransactionalMetadataFactory;
+import io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore;
+import io.trino.plugin.hive.metastore.Table;
+import io.trino.spi.TrinoException;
+import io.trino.spi.classloader.ThreadContextClassLoader;
+import io.trino.spi.connector.ConnectorAccessControl;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.SchemaNotFoundException;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.TableNotFoundException;
+import io.trino.spi.procedure.Procedure;
+
+import java.lang.invoke.MethodHandle;
+
+import static io.trino.plugin.base.util.Procedures.checkProcedureArgument;
+import static io.trino.spi.StandardErrorCode.UNSUPPORTED_TABLE_TYPE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.String.format;
+import static java.lang.invoke.MethodHandles.lookup;
+import static java.util.Objects.requireNonNull;
+
+public class UnregisterTableProcedure
+        implements Provider<Procedure>
+{
+    private static final MethodHandle UNREGISTER_TABLE;
+    private static final String SYSTEM_SCHEMA = "system";
+    private static final String PROCEDURE_NAME = "unregister_table";
+    private static final String SCHEMA_NAME = "SCHEMA_NAME";
+    private static final String TABLE_NAME = "TABLE_NAME";
+
+    static {
+        try {
+            UNREGISTER_TABLE = lookup().unreflect(UnregisterTableProcedure.class.getMethod("unregisterTable", ConnectorAccessControl.class, ConnectorSession.class, String.class, String.class));
+        }
+        catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private final TransactionalMetadataFactory hiveMetadataFactory;
+
+    @Inject
+    public UnregisterTableProcedure(TransactionalMetadataFactory hiveMetadataFactory)
+    {
+        this.hiveMetadataFactory = requireNonNull(hiveMetadataFactory, "hiveMetadataFactory is null");
+    }
+
+    @Override
+    public Procedure get()
+    {
+        return new Procedure(
+                SYSTEM_SCHEMA,
+                PROCEDURE_NAME,
+                ImmutableList.of(
+                        new Procedure.Argument(SCHEMA_NAME, VARCHAR),
+                        new Procedure.Argument(TABLE_NAME, VARCHAR)),
+                UNREGISTER_TABLE.bindTo(this));
+    }
+
+    public void unregisterTable(ConnectorAccessControl accessControl, ConnectorSession session, String schemaName, String tableName)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            doUnregisterTable(accessControl, session, schemaName, tableName);
+        }
+    }
+
+    private void doUnregisterTable(ConnectorAccessControl accessControl, ConnectorSession session, String schemaName, String tableName)
+    {
+        checkProcedureArgument(schemaName != null, "schema_name cannot be null");
+        checkProcedureArgument(tableName != null, "table_name cannot be null");
+        SchemaTableName schemaTableName = new SchemaTableName(schemaName, tableName);
+
+        accessControl.checkCanDropTable(null, schemaTableName);
+        TransactionalMetadata hiveMetadata = hiveMetadataFactory.create(session.getIdentity(), true);
+        SemiTransactionalHiveMetastore metastore = hiveMetadata.getMetastore();
+
+        if (metastore.getDatabase(schemaName).isEmpty()) {
+            throw new SchemaNotFoundException(schemaName);
+        }
+
+        ConnectorTableHandle tableHandle = hiveMetadata.getTableHandle(session, new SchemaTableName(schemaName, tableName));
+        if (tableHandle == null) {
+            throw new TableNotFoundException(schemaTableName);
+        }
+
+        Table table = metastore.getTable(schemaName, tableName).orElseThrow(() -> new TableNotFoundException(schemaTableName));
+        if (!isTable(table.getTableType())) {
+            throw new TrinoException(UNSUPPORTED_TABLE_TYPE, format("Not a Hive table '%s'", tableName));
+        }
+
+        metastore.dropTable(session, schemaName, tableName, false);
+        metastore.commit();
+    }
+
+    private boolean isTable(String tableType)
+    {
+        return TableType.MANAGED_TABLE.name().equals(tableType) || TableType.EXTERNAL_TABLE.name().equals(tableType);
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
@@ -612,7 +612,7 @@ public abstract class AbstractTestHiveFileSystem
     private void dropTable(SchemaTableName table)
     {
         try (Transaction transaction = newTransaction()) {
-            transaction.getMetastore().dropTable(newSession(), table.getSchemaName(), table.getTableName());
+            transaction.getMetastore().dropTable(newSession(), table.getSchemaName(), table.getTableName(), true);
             transaction.commit();
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Support for unregister table in Hive. The unregister table procedure removes the managed table from the listing. However, it does not delete the data.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Add suport for unregister table in Hive
```
