### PR TITLE
Allow Delta flush_metadata_cache after table creation

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/QueryAssertions.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/QueryAssertions.java
@@ -507,9 +507,9 @@ public final class QueryAssertions
         long rows = (Long) queryRunner.execute(session, sql).getMaterializedRows().get(0).getField(0);
         log.info("Imported %s rows for %s in %s", rows, table.getObjectName(), nanosSince(start).convertToMostSuccinctTimeUnit());
 
-        assertThat(queryRunner.execute(session, "SELECT count(*) FROM " + table).getOnlyValue())
-                .as("Table is not loaded properly: %s", table)
-                .isEqualTo(queryRunner.execute(session, "SELECT count(*) FROM " + table.getObjectName()).getOnlyValue());
+        assertThat(queryRunner.execute(session, "SELECT count(*) FROM " + table.getObjectName()).getOnlyValue())
+                .as("Table is not loaded properly: %s", table.getObjectName())
+                .isEqualTo(queryRunner.execute(session, "SELECT count(*) FROM " + table).getOnlyValue());
     }
 
     public static RuntimeException getTrinoExceptionCause(Throwable e)


### PR DESCRIPTION
Support following scenario

- table was checked via Trino, so Delta connector knows table doesn't
  exist and cached that (`CachingMetastore` caches also misses).
- table is created externally
- `flush_metadata_cache` is used so that table becomes accessible via
  Trino
